### PR TITLE
Convert Blitz `pipeline_stage_sync` CCL op to Neighbour Exchange

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp
@@ -20,6 +20,7 @@ void kernel_main() {
     using CTArgs = PipelineStageSync::ReaderCTArgs<
         get_named_compile_time_arg_val("run_stalling_logic_on_ncrisc"),
         get_named_compile_time_arg_val("run_signalling_logic_on_ncrisc"),
+        get_named_compile_time_arg_val("is_intermediate_signaller"),
         get_named_compile_time_arg_val("stalling_device_semaphore_noc_x_addr"),
         get_named_compile_time_arg_val("stalling_device_semaphore_noc_y_addr"),
         get_named_compile_time_arg_val("stalling_device_semaphore_l1_addr"),
@@ -35,6 +36,7 @@ void kernel_main() {
     using CTArgs = PipelineStageSync::WriterCTArgs<
         get_named_compile_time_arg_val("run_stalling_logic_on_brisc"),
         get_named_compile_time_arg_val("run_signalling_logic_on_brisc"),
+        get_named_compile_time_arg_val("is_intermediate_signaller"),
         get_named_compile_time_arg_val("stalling_device_semaphore_noc_x_addr"),
         get_named_compile_time_arg_val("stalling_device_semaphore_noc_y_addr"),
         get_named_compile_time_arg_val("stalling_device_semaphore_l1_addr"),

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp
@@ -22,10 +22,10 @@ void kernel_main() {
         get_named_compile_time_arg_val("run_signalling_logic_on_ncrisc"),
         get_named_compile_time_arg_val("is_intermediate_signaller"),
         get_named_compile_time_arg_val("is_signalling_to_intermediate_signaller"),
-        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
-        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
         get_named_compile_time_arg_val("signalling_core_noc_x_addr"),
         get_named_compile_time_arg_val("signalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
         get_named_compile_time_arg_val("semaphore_l1_addr"),
         get_named_compile_time_arg_val("fabric_arg_base")>;
 
@@ -39,10 +39,10 @@ void kernel_main() {
         get_named_compile_time_arg_val("run_signalling_logic_on_brisc"),
         get_named_compile_time_arg_val("is_intermediate_signaller"),
         get_named_compile_time_arg_val("is_signalling_to_intermediate_signaller"),
-        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
-        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
         get_named_compile_time_arg_val("signalling_core_noc_x_addr"),
         get_named_compile_time_arg_val("signalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
         get_named_compile_time_arg_val("semaphore_l1_addr"),
         get_named_compile_time_arg_val("fabric_arg_base")>;
 

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp
@@ -21,11 +21,12 @@ void kernel_main() {
         get_named_compile_time_arg_val("run_stalling_logic_on_ncrisc"),
         get_named_compile_time_arg_val("run_signalling_logic_on_ncrisc"),
         get_named_compile_time_arg_val("is_intermediate_signaller"),
-        get_named_compile_time_arg_val("stalling_device_semaphore_noc_x_addr"),
-        get_named_compile_time_arg_val("stalling_device_semaphore_noc_y_addr"),
-        get_named_compile_time_arg_val("stalling_device_semaphore_l1_addr"),
-        get_named_compile_time_arg_val("stalling_device_chip_id"),
-        get_named_compile_time_arg_val("stalling_device_mesh_id"),
+        get_named_compile_time_arg_val("is_signalling_to_intermediate_signaller"),
+        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("signalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("signalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("semaphore_l1_addr"),
         get_named_compile_time_arg_val("fabric_arg_base")>;
 
     // Reader runtime args
@@ -37,11 +38,12 @@ void kernel_main() {
         get_named_compile_time_arg_val("run_stalling_logic_on_brisc"),
         get_named_compile_time_arg_val("run_signalling_logic_on_brisc"),
         get_named_compile_time_arg_val("is_intermediate_signaller"),
-        get_named_compile_time_arg_val("stalling_device_semaphore_noc_x_addr"),
-        get_named_compile_time_arg_val("stalling_device_semaphore_noc_y_addr"),
-        get_named_compile_time_arg_val("stalling_device_semaphore_l1_addr"),
-        get_named_compile_time_arg_val("stalling_device_chip_id"),
-        get_named_compile_time_arg_val("stalling_device_mesh_id"),
+        get_named_compile_time_arg_val("is_signalling_to_intermediate_signaller"),
+        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("signalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("signalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("semaphore_l1_addr"),
         get_named_compile_time_arg_val("fabric_arg_base")>;
 
     // Writer runtime args

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp
@@ -20,34 +20,30 @@ void kernel_main() {
     using CTArgs = PipelineStageSync::ReaderCTArgs<
         get_named_compile_time_arg_val("run_stalling_logic_on_ncrisc"),
         get_named_compile_time_arg_val("run_signalling_logic_on_ncrisc"),
-        get_named_compile_time_arg_val("is_stalling_device_equal_signalling_device"),
+        get_named_compile_time_arg_val("stalling_device_semaphore_noc_x_addr"),
+        get_named_compile_time_arg_val("stalling_device_semaphore_noc_y_addr"),
+        get_named_compile_time_arg_val("stalling_device_semaphore_l1_addr"),
         get_named_compile_time_arg_val("stalling_device_chip_id"),
         get_named_compile_time_arg_val("stalling_device_mesh_id"),
         get_named_compile_time_arg_val("fabric_arg_base")>;
 
-    // Reader runtime args (from common args)
-    PipelineStageSync::ReaderArgs rt_args = {
-        get_common_arg_val<uint32_t>(0),  // stalling_device_semaphore_noc_x_addr
-        get_common_arg_val<uint32_t>(1),  // stalling_device_semaphore_noc_y_addr
-        get_common_arg_val<uint32_t>(2),  // stalling_device_semaphore_l1_addr
-    };
+    // Reader runtime args
+    PipelineStageSync::ReaderArgs rt_args = {};
 
 #elif defined(COMPILE_FOR_BRISC)
     // Writer CTArgs
     using CTArgs = PipelineStageSync::WriterCTArgs<
         get_named_compile_time_arg_val("run_stalling_logic_on_brisc"),
         get_named_compile_time_arg_val("run_signalling_logic_on_brisc"),
-        get_named_compile_time_arg_val("is_stalling_device_equal_signalling_device"),
+        get_named_compile_time_arg_val("stalling_device_semaphore_noc_x_addr"),
+        get_named_compile_time_arg_val("stalling_device_semaphore_noc_y_addr"),
+        get_named_compile_time_arg_val("stalling_device_semaphore_l1_addr"),
         get_named_compile_time_arg_val("stalling_device_chip_id"),
         get_named_compile_time_arg_val("stalling_device_mesh_id"),
         get_named_compile_time_arg_val("fabric_arg_base")>;
 
-    // Writer runtime args (from common args)
-    PipelineStageSync::WriterArgs rt_args = {
-        get_common_arg_val<uint32_t>(0),  // stalling_device_semaphore_noc_x_addr
-        get_common_arg_val<uint32_t>(1),  // stalling_device_semaphore_noc_y_addr
-        get_common_arg_val<uint32_t>(2),  // stalling_device_semaphore_l1_addr
-    };
+    // Writer runtime args
+    PipelineStageSync::WriterArgs rt_args = {};
 
 #elif defined(COMPILE_FOR_TRISC)
     // Compute CTArgs

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -68,6 +68,7 @@ class PipelineStageSync:
         pseudo_input_tensor: ttnn.Tensor,
         pseudo_output_tensor: ttnn.Tensor,
         mesh_device: ttnn.MeshDevice,
+        semaphore,
         src_device_mesh_coord: ttnn.MeshCoordinate,
         signalling_core: ttnn.CoreCoord,
         run_signalling_kernel_on_ncrisc: bool,
@@ -126,8 +127,7 @@ class PipelineStageSync:
         stalling_core_noc_y_addr = stalling_core_phys.y
 
         # semaphores
-        global_semaphore = ttnn.create_global_semaphore(mesh_device, all_cores_core_range_set, 0)
-        semaphore_l1_addr = ttnn.get_global_semaphore_address(global_semaphore)
+        semaphore_l1_addr = ttnn.get_global_semaphore_address(semaphore)
 
         # construct path
         signalling_devices, intermediate_signalling_devices, signaller_device_mapping = build_signalling_path(

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -83,7 +83,7 @@ class PipelineStageSync:
             mesh_device: mesh_device micro op operates on
             src_device_mesh_coord: src mesh coordinate
             signalling_core: core that signalling logic is executed on
-            run_signalling_kernel_on_ncrisc: whether to run the signalling kernel on ncrsic or brisc
+            run_signalling_kernel_on_ncrisc: whether to run the signalling kernel on ncrisc or brisc
             dst_device_mesh_coord: dst mesh coordinate
             stalling_core: core that stalling logic is executed on
             run_stalling_kernel_on_ncrisc: whether to run the stalling kernel on ncrisc or brisc

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -117,6 +117,14 @@ class PipelineStageSync:
                 ]
             )
 
+        signalling_core_phys = mesh_device.worker_core_from_logical_core(signalling_core)
+        signalling_core_noc_x_addr = signalling_core_phys.x
+        signalling_core_noc_y_addr = signalling_core_phys.y
+
+        stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
+        stalling_core_noc_x_addr = stalling_core_phys.x
+        stalling_core_noc_y_addr = stalling_core_phys.y
+
         # semaphores
         global_semaphore = ttnn.create_global_semaphore(mesh_device, all_cores_core_range_set, 0)
         semaphore_l1_addr = ttnn.get_global_semaphore_address(global_semaphore)
@@ -138,14 +146,6 @@ class PipelineStageSync:
                 is_signalling_to_intermediate_signaller = (
                     mesh_coord in signalling_devices and target_device in intermediate_signalling_devices
                 )
-
-                signalling_core_phys = mesh_device.worker_core_from_logical_core(signalling_core)
-                signalling_core_noc_x_addr = signalling_core_phys.x
-                signalling_core_noc_y_addr = signalling_core_phys.y
-
-                stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
-                stalling_core_noc_x_addr = stalling_core_phys.x
-                stalling_core_noc_y_addr = stalling_core_phys.y
 
                 fabric_arg_base = 0
                 reader_named_ct_args = [

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -67,26 +67,40 @@ class PipelineStageSync:
             stalling_device_mesh_coord == signalling_device_mesh_coord
         ), f"Stalling and signalling device cannot be the same"
 
-        global_semaphore = ttnn.create_global_semaphore(
-            mesh_device, ttnn.CoreRangeSet([ttnn.CoreRange(stalling_core, stalling_core)]), 0
-        )
-        global_semaphore_addr = ttnn.get_global_semaphore_address(global_semaphore)
+        # cores
+        if stalling_core == signalling_core:
+            all_cores_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(stalling_core, stalling_core)])
+        else:
+            all_cores_core_range_set = ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(stalling_core, stalling_core),
+                    ttnn.CoreRange(signalling_core, signalling_core),
+                ]
+            )
 
+        # semaphores
+        global_semaphore = ttnn.create_global_semaphore(mesh_device, all_cores_core_range_set, 0)
+        semaphore_l1_addr = ttnn.get_global_semaphore_address(global_semaphore)
+
+        # construct path
         mesh_shape = mesh_device.shape
         mesh_rows = mesh_shape[0]
         mesh_cols = mesh_shape[1]
+
         for row in range(mesh_rows):
             for col in range(mesh_cols):
                 mesh_coord = ttnn.MeshCoordinate(row, col)
-                # device = mesh_device.get_device(row, col)
 
                 # === Compile-time args ===
 
                 # Reader (NCRISC) and Writer (BRISC) compile-time args
                 stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
-                stalling_device_semaphore_noc_x_addr = stalling_core_phys.x
-                stalling_device_semaphore_noc_y_addr = stalling_core_phys.y
-                stalling_device_semaphore_l1_addr = global_semaphore_addr
+                stalling_core_noc_x_addr = stalling_core_phys.x
+                stalling_core_noc_y_addr = stalling_core_phys.y
+
+                signalling_core_phys = mesh_device.worker_core_from_logical_core(signalling_core)
+                signalling_core_noc_x_addr = signalling_core_phys.x
+                signalling_core_noc_y_addr = signalling_core_phys.y
 
                 stalling_device_fabric_node_id = mesh_device.get_fabric_node_id(stalling_device_mesh_coord)
                 stalling_device_chip_id = int(stalling_device_fabric_node_id.chip_id)
@@ -95,11 +109,12 @@ class PipelineStageSync:
 
                 reader_named_ct_args = [
                     ("is_intermediate_signaller", False),  # TODO: (GR)
-                    ("stalling_device_semaphore_noc_x_addr", stalling_device_semaphore_noc_x_addr),
-                    ("stalling_device_semaphore_noc_y_addr", stalling_device_semaphore_noc_y_addr),
-                    ("stalling_device_semaphore_l1_addr", stalling_device_semaphore_l1_addr),
-                    ("stalling_device_chip_id", stalling_device_chip_id),
-                    ("stalling_device_mesh_id", stalling_device_mesh_id),
+                    ("is_signalling_to_intermediate_signaller", False),  # TODO: (GR)
+                    ("stalling_core_noc_x_addr", stalling_core_noc_x_addr),
+                    ("stalling_core_noc_y_addr", stalling_core_noc_y_addr),
+                    ("signalling_core_noc_x_addr", signalling_core_noc_x_addr),
+                    ("signalling_core_noc_y_addr", signalling_core_noc_y_addr),
+                    ("semaphore_l1_addr", semaphore_l1_addr),
                     ("fabric_arg_base", fabric_arg_base),
                     ("num_iterations", num_iterations),
                 ]
@@ -118,18 +133,9 @@ class PipelineStageSync:
                     mesh_coord == signalling_device_mesh_coord and run_signalling_kernel_on_brisc
                 )
 
-                if stalling_core == signalling_core:
-                    core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(stalling_core, stalling_core)])
-                else:
-                    core_ranges = ttnn.CoreRangeSet(
-                        [
-                            ttnn.CoreRange(stalling_core, stalling_core),
-                            ttnn.CoreRange(signalling_core, signalling_core),
-                        ]
-                    )
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source=kernel_path,
-                    core_ranges=core_ranges,
+                    core_ranges=all_cores_core_range_set,
                     ncrisc_named_compile_time_args=reader_named_ct_args,
                     trisc_named_compile_time_args=compute_name_ct_args,
                     brisc_named_compile_time_args=writer_named_ct_args,

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -94,6 +94,7 @@ class PipelineStageSync:
                 fabric_arg_base = 0
 
                 reader_named_ct_args = [
+                    ("is_intermediate_signaller", False),  # TODO: (GR)
                     ("stalling_device_semaphore_noc_x_addr", stalling_device_semaphore_noc_x_addr),
                     ("stalling_device_semaphore_noc_y_addr", stalling_device_semaphore_noc_y_addr),
                     ("stalling_device_semaphore_l1_addr", stalling_device_semaphore_l1_addr),

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -63,16 +63,9 @@ class PipelineStageSync:
         # kernel path
         kernel_path = "models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp"
 
-        is_stalling_device_equal_signalling_device = stalling_device_mesh_coord == signalling_device_mesh_coord
-        is_stalling_core_equal_signalling_core = stalling_core == signalling_core
-        is_stalling_kernel_and_signalling_kernel_on_same_risc = (
-            run_stalling_kernel_on_brisc == run_signalling_kernel_on_brisc
-        )
         assert not (
-            is_stalling_device_equal_signalling_device
-            and is_stalling_core_equal_signalling_core
-            and is_stalling_kernel_and_signalling_kernel_on_same_risc
-        ), f"If the stalling device is the same as the signalling device, and the stalling core is the same as the signalling core, then the stalling kernel must run on a different risc than the signalling kernel"
+            stalling_device_mesh_coord == signalling_device_mesh_coord
+        ), f"Stalling and signalling device cannot be the same"
 
         global_semaphore = ttnn.create_global_semaphore(
             mesh_device, ttnn.CoreRangeSet([ttnn.CoreRange(stalling_core, stalling_core)]), 0
@@ -90,13 +83,20 @@ class PipelineStageSync:
                 # === Compile-time args ===
 
                 # Reader (NCRISC) and Writer (BRISC) compile-time args
+                stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
+                stalling_device_semaphore_noc_x_addr = stalling_core_phys.x
+                stalling_device_semaphore_noc_y_addr = stalling_core_phys.y
+                stalling_device_semaphore_l1_addr = global_semaphore_addr
+
                 stalling_device_fabric_node_id = mesh_device.get_fabric_node_id(stalling_device_mesh_coord)
                 stalling_device_chip_id = int(stalling_device_fabric_node_id.chip_id)
                 stalling_device_mesh_id = int(stalling_device_fabric_node_id.mesh_id)
                 fabric_arg_base = 0
 
                 reader_named_ct_args = [
-                    ("is_stalling_device_equal_signalling_device", is_stalling_device_equal_signalling_device),
+                    ("stalling_device_semaphore_noc_x_addr", stalling_device_semaphore_noc_x_addr),
+                    ("stalling_device_semaphore_noc_y_addr", stalling_device_semaphore_noc_y_addr),
+                    ("stalling_device_semaphore_l1_addr", stalling_device_semaphore_l1_addr),
                     ("stalling_device_chip_id", stalling_device_chip_id),
                     ("stalling_device_mesh_id", stalling_device_mesh_id),
                     ("fabric_arg_base", fabric_arg_base),
@@ -104,20 +104,6 @@ class PipelineStageSync:
                 ]
                 writer_named_ct_args = reader_named_ct_args
                 compute_name_ct_args = [("num_iterations", num_iterations)]
-
-                # === Common Runtime Args ===
-                stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
-                stalling_device_semaphore_noc_x_addr = stalling_core_phys.x
-                stalling_device_semaphore_noc_y_addr = stalling_core_phys.y
-                stalling_device_semaphore_l1_addr = global_semaphore_addr
-
-                # Reader (NCRISC) and Writer (BRISC) common runtime args
-                reader_common_rt_args = [
-                    stalling_device_semaphore_noc_x_addr,
-                    stalling_device_semaphore_noc_y_addr,
-                    stalling_device_semaphore_l1_addr,
-                ]
-                writer_common_rt_args = reader_common_rt_args
 
                 # === Unified Kernel Descriptor ===
                 run_stalling_logic_on_ncrisc = (
@@ -146,8 +132,8 @@ class PipelineStageSync:
                     ncrisc_named_compile_time_args=reader_named_ct_args,
                     trisc_named_compile_time_args=compute_name_ct_args,
                     brisc_named_compile_time_args=writer_named_ct_args,
-                    ncrisc_common_runtime_args=reader_common_rt_args,
-                    brisc_common_runtime_args=writer_common_rt_args,
+                    ncrisc_common_runtime_args=[],
+                    brisc_common_runtime_args=[],
                     per_core_compile_time_descriptors=[
                         PerCoreCompileTimeDescriptor(
                             named_compile_time_arg="run_stalling_logic_on_ncrisc",

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -82,6 +82,7 @@ class PipelineStageSync:
 
         Args:
             mesh_device: mesh_device micro op operates on
+            semaphore: global semaphore used in op
             src_device_mesh_coord: src mesh coordinate
             signalling_core: core that signalling logic is executed on
             run_signalling_kernel_on_ncrisc: whether to run the signalling kernel on ncrisc or brisc
@@ -105,7 +106,8 @@ class PipelineStageSync:
         # kernel path
         kernel_path = "models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp"
 
-        assert not (src_device_mesh_coord == dst_device_mesh_coord), f"src and dst device cannot be the same"
+        if src_device_mesh_coord == dst_device_mesh_coord:
+            raise ValueError("src and dst device cannot be the same")
 
         # cores
         if stalling_core == signalling_core:

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -7,14 +7,50 @@ PipelineStageSync Operation using ttnn.generic_op
 
 This module implements a multi-device synchronization on an arbitrary mesh.
 
-Stalling device waits until a signal from the signalling device.
-
-Stalling device and signalling device can be the same, as long as the stalling core and signalling core are not the same.
 """
 
 
 import ttnn
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import PerCoreCompileTimeDescriptor, UnifiedKernelDescriptor
+
+
+def build_signalling_path(src_device_mesh_coord, dst_device_mesh_coord, mesh_rows, mesh_cols):
+    src_row, src_col = src_device_mesh_coord[0], src_device_mesh_coord[1]
+    dst_row, dst_col = dst_device_mesh_coord[0], dst_device_mesh_coord[1]
+
+    path = [ttnn.MeshCoordinate(src_row, src_col)]
+    current_row, current_col = src_row, src_col
+
+    # traverse across rows first (wrap around present)
+    positive_row_distance = (dst_row - src_row) % mesh_rows
+    negative_row_distance = (src_row - dst_row) % mesh_rows
+
+    if positive_row_distance <= negative_row_distance:
+        row_step = 1
+        row_num_hops = positive_row_distance
+    else:
+        row_step = -1
+        row_num_hops = negative_row_distance
+
+    for _ in range(row_num_hops):
+        current_row = (current_row + row_step) % mesh_rows
+        path.append(ttnn.MeshCoordinate(current_row, current_col))
+
+    # traverse across cols second (wrap around not present)
+    while current_col != dst_col:
+        current_col += 1 if dst_col > current_col else -1
+        path.append(ttnn.MeshCoordinate(current_row, current_col))
+
+    # signalling and intermediate signalling sets
+    signalling_devices = set(path[0:-1])
+    intermediate_signalling_devices = set(path[1:-1])
+
+    # build signalling device to target device mapping
+    signaller_device_mapping = {}
+    for i in range(len(path) - 1):
+        signaller_device_mapping[path[i]] = path[i + 1]
+
+    return signalling_devices, intermediate_signalling_devices, signaller_device_mapping
 
 
 class PipelineStageSync:
@@ -45,17 +81,22 @@ class PipelineStageSync:
 
         Args:
             mesh_device: mesh_device micro op operates on
-            dst_device_mesh_coord: mesh coordinate on which the stalling_core stalls
-            stalling_core: core that the stalling device stalls on
-            run_stalling_kernel_on_ncrisc: whether to run the stalling kernel on ncrisc or brisc
-            src_device_mesh_coord: mesh coordinate on which the signalling_core signals
-            signalling_core: core that the signalling device signals on
+            src_device_mesh_coord: src mesh coordinate
+            signalling_core: core that signalling logic is executed on
             run_signalling_kernel_on_ncrisc: whether to run the signalling kernel on ncrsic or brisc
+            dst_device_mesh_coord: dst mesh coordinate
+            stalling_core: core that stalling logic is executed on
+            run_stalling_kernel_on_ncrisc: whether to run the stalling kernel on ncrisc or brisc
             num_iterations: Number of iterations to run inside the kernel
 
         Returns:
             None
         """
+
+        # mesh details
+        mesh_shape = mesh_device.shape
+        mesh_rows = mesh_shape[0]
+        mesh_cols = mesh_shape[1]
 
         # create mesh program descriptor
         mesh_program_descriptor = ttnn.MeshProgramDescriptor()
@@ -63,7 +104,7 @@ class PipelineStageSync:
         # kernel path
         kernel_path = "models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp"
 
-        assert not (dst_device_mesh_coord == src_device_mesh_coord), f"Src and dst device cannot be the same"
+        assert not (src_device_mesh_coord == dst_device_mesh_coord), f"src and dst device cannot be the same"
 
         # cores
         if stalling_core == signalling_core:
@@ -81,57 +122,21 @@ class PipelineStageSync:
         semaphore_l1_addr = ttnn.get_global_semaphore_address(global_semaphore)
 
         # construct path
-        mesh_shape = mesh_device.shape
-        mesh_rows = mesh_shape[0]
-        mesh_cols = mesh_shape[1]
-
-        src_row, src_col = src_device_mesh_coord[0], src_device_mesh_coord[1]
-        dst_row, dst_col = dst_device_mesh_coord[0], dst_device_mesh_coord[1]
-
-        path = []
-        row, col = src_row, src_col
-        path.append(ttnn.MeshCoordinate(row, col))
-
-        forward_distance = (dst_row - src_row) % mesh_rows  # hops going +1
-        backward_distance = (src_row - dst_row) % mesh_rows  # hops going -1
-
-        if forward_distance <= backward_distance:
-            row_step = 1
-            row_hops = forward_distance
-        else:
-            row_step = -1
-            row_hops = backward_distance
-
-        print(row_step)
-
-        for _ in range(row_hops):
-            row = (row + row_step) % mesh_rows
-            path.append(ttnn.MeshCoordinate(row, col))
-
-        # Column dimension: no wrap, just step linearly
-        while col != dst_col:
-            col += 1 if dst_col > col else -1
-            path.append(ttnn.MeshCoordinate(row, col))
-
-        # Build lookup structures (same as before)
-        signaller_devices_mapping = {}
-        for i in range(len(path) - 1):
-            signaller_devices_mapping[path[i]] = path[i + 1]
-
-        signaller_devices = set(path[0:-1])
-        intermediate_signaller_devices = set(path[1:-1])
+        signalling_devices, intermediate_signalling_devices, signaller_device_mapping = build_signalling_path(
+            src_device_mesh_coord, dst_device_mesh_coord, mesh_rows, mesh_cols
+        )
 
         for row in range(mesh_rows):
             for col in range(mesh_cols):
                 mesh_coord = ttnn.MeshCoordinate(row, col)
-                target_device = signaller_devices_mapping.get(mesh_coord, None)
+                target_device = signaller_device_mapping.get(mesh_coord, None)
 
                 # === Compile-time args ===
 
                 # Reader (NCRISC) and Writer (BRISC) compile-time args
-                is_intermediate_signaller = mesh_coord in intermediate_signaller_devices
+                is_intermediate_signaller = mesh_coord in intermediate_signalling_devices
                 is_signalling_to_intermediate_signaller = (
-                    mesh_coord in signaller_devices and target_device in intermediate_signaller_devices
+                    mesh_coord in signalling_devices and target_device in intermediate_signalling_devices
                 )
 
                 signalling_core_phys = mesh_device.worker_core_from_logical_core(signalling_core)
@@ -160,7 +165,7 @@ class PipelineStageSync:
                 # === Unified Kernel Descriptor ===
 
                 # select risc for signalling cores
-                if mesh_coord in signaller_devices:
+                if mesh_coord in signalling_devices:
                     if run_signalling_kernel_on_ncrisc:
                         run_signalling_logic_on_ncrisc = True
                         run_signalling_logic_on_brisc = False
@@ -223,7 +228,8 @@ class PipelineStageSync:
                     cbs=[],
                 )
 
-                if mesh_coord in signaller_devices:
+                # Setup fabric
+                if mesh_coord in signalling_devices:
                     if run_signalling_kernel_on_ncrisc:
                         kernel_idx = kernel_result.get_group_by_arg(
                             "run_signalling_logic_on_ncrisc", 1

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -199,11 +199,12 @@ class PipelineStageSync:
 
                     signalling_fabric_node_id = mesh_device.get_fabric_node_id(signalling_device_mesh_coord)
                     link_index = 0
-                    fabric_args = ttnn.setup_fabric_connection(
+                    fabric_args = ttnn.setup_routing_plane_connection(
                         signalling_fabric_node_id,
-                        stalling_device_fabric_node_id,
-                        link_index,
+                        [stalling_device_fabric_node_id],
+                        [link_index],
                         program,
+                        kernel_idx,
                         signalling_core,
                     )
                     per_core_rt_args_ref.extend(fabric_args)

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -32,12 +32,12 @@ class PipelineStageSync:
         pseudo_input_tensor: ttnn.Tensor,
         pseudo_output_tensor: ttnn.Tensor,
         mesh_device: ttnn.MeshDevice,
-        stalling_device_mesh_coord: ttnn.MeshCoordinate,
+        dst_device_mesh_coord: ttnn.MeshCoordinate,
         stalling_core: ttnn.CoreCoord,
-        run_stalling_kernel_on_brisc: bool,
-        signalling_device_mesh_coord: ttnn.MeshCoordinate,
+        run_stalling_kernel_on_ncrisc: bool,
+        src_device_mesh_coord: ttnn.MeshCoordinate,
         signalling_core: ttnn.CoreCoord,
-        run_signalling_kernel_on_brisc: bool,
+        run_signalling_kernel_on_ncrisc: bool,
         num_iterations: int = 1,
     ) -> None:
         """
@@ -45,12 +45,12 @@ class PipelineStageSync:
 
         Args:
             mesh_device: mesh_device micro op operates on
-            stalling_device_mesh_coord: mesh coordinate on which the stalling_core stalls
+            dst_device_mesh_coord: mesh coordinate on which the stalling_core stalls
             stalling_core: core that the stalling device stalls on
-            run_stalling_kernel_on_brisc: whether to run the stalling kernel on brisc, if false runs on ncrisc
-            signalling_device_mesh_coord: mesh coordinate on which the signalling_core signals
+            run_stalling_kernel_on_ncrisc: whether to run the stalling kernel on ncrisc or brisc
+            src_device_mesh_coord: mesh coordinate on which the signalling_core signals
             signalling_core: core that the signalling device signals on
-            run_signalling_kernel_on_brisc: whether to run the signalling kernel on brisc, if false runs on ncrisc
+            run_signalling_kernel_on_ncrisc: whether to run the signalling kernel on ncrsic or brisc
             num_iterations: Number of iterations to run inside the kernel
 
         Returns:
@@ -63,9 +63,7 @@ class PipelineStageSync:
         # kernel path
         kernel_path = "models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp"
 
-        assert not (
-            stalling_device_mesh_coord == signalling_device_mesh_coord
-        ), f"Stalling and signalling device cannot be the same"
+        assert not (dst_device_mesh_coord == src_device_mesh_coord), f"Src and dst device cannot be the same"
 
         # cores
         if stalling_core == signalling_core:
@@ -82,18 +80,58 @@ class PipelineStageSync:
         global_semaphore = ttnn.create_global_semaphore(mesh_device, all_cores_core_range_set, 0)
         semaphore_l1_addr = ttnn.get_global_semaphore_address(global_semaphore)
 
-        # construct path
+        # construct path - horizontal then vertical
         mesh_shape = mesh_device.shape
         mesh_rows = mesh_shape[0]
         mesh_cols = mesh_shape[1]
 
+        src_row, src_col = src_device_mesh_coord[0], src_device_mesh_coord[1]
+        dst_row, dst_col = dst_device_mesh_coord[0], dst_device_mesh_coord[1]
+
+        path = []
+        row, col = src_row, src_col
+        path.append(ttnn.MeshCoordinate(row, col))
+
+        forward_distance = (dst_row - src_row) % mesh_rows  # hops going +1
+        backward_distance = (src_row - dst_row) % mesh_rows  # hops going -1
+
+        if forward_distance <= backward_distance:
+            row_step = 1
+            row_hops = forward_distance
+        else:
+            row_step = -1
+            row_hops = backward_distance
+
+        for _ in range(row_hops):
+            row = (row + row_step) % mesh_rows
+            path.append(ttnn.MeshCoordinate(row, col))
+
+        # Column dimension: no wrap, just step linearly
+        while col != dst_col:
+            col += 1 if dst_col > col else -1
+            path.append(ttnn.MeshCoordinate(row, col))
+
+        # Build lookup structures (same as before)
+        signaller_devices_mapping = {}
+        for i in range(len(path) - 1):
+            signaller_devices_mapping[path[i]] = path[i + 1]
+
+        signaller_devices = set(path[0:-1])
+        intermediate_signaller_devices = set(path[1:-1])
+
         for row in range(mesh_rows):
             for col in range(mesh_cols):
                 mesh_coord = ttnn.MeshCoordinate(row, col)
+                target_device = signaller_devices_mapping.get(mesh_coord, None)
 
                 # === Compile-time args ===
 
                 # Reader (NCRISC) and Writer (BRISC) compile-time args
+                is_intermediate_signaller = mesh_coord in intermediate_signaller_devices
+                is_signalling_to_intermediate_signaller = (
+                    mesh_coord in signaller_devices and target_device in intermediate_signaller_devices
+                )
+
                 stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
                 stalling_core_noc_x_addr = stalling_core_phys.x
                 stalling_core_noc_y_addr = stalling_core_phys.y
@@ -102,14 +140,10 @@ class PipelineStageSync:
                 signalling_core_noc_x_addr = signalling_core_phys.x
                 signalling_core_noc_y_addr = signalling_core_phys.y
 
-                stalling_device_fabric_node_id = mesh_device.get_fabric_node_id(stalling_device_mesh_coord)
-                stalling_device_chip_id = int(stalling_device_fabric_node_id.chip_id)
-                stalling_device_mesh_id = int(stalling_device_fabric_node_id.mesh_id)
                 fabric_arg_base = 0
-
                 reader_named_ct_args = [
-                    ("is_intermediate_signaller", False),  # TODO: (GR)
-                    ("is_signalling_to_intermediate_signaller", False),  # TODO: (GR)
+                    ("is_intermediate_signaller", is_intermediate_signaller),
+                    ("is_signalling_to_intermediate_signaller", is_signalling_to_intermediate_signaller),
                     ("stalling_core_noc_x_addr", stalling_core_noc_x_addr),
                     ("stalling_core_noc_y_addr", stalling_core_noc_y_addr),
                     ("signalling_core_noc_x_addr", signalling_core_noc_x_addr),
@@ -122,16 +156,30 @@ class PipelineStageSync:
                 compute_name_ct_args = [("num_iterations", num_iterations)]
 
                 # === Unified Kernel Descriptor ===
-                run_stalling_logic_on_ncrisc = (
-                    mesh_coord == stalling_device_mesh_coord and not run_stalling_kernel_on_brisc
-                )
-                run_stalling_logic_on_brisc = mesh_coord == stalling_device_mesh_coord and run_stalling_kernel_on_brisc
-                run_signalling_logic_on_ncrisc = (
-                    mesh_coord == signalling_device_mesh_coord and not run_signalling_kernel_on_brisc
-                )
-                run_signalling_logic_on_brisc = (
-                    mesh_coord == signalling_device_mesh_coord and run_signalling_kernel_on_brisc
-                )
+
+                # select risc for stalling cores
+                if mesh_coord == dst_device_mesh_coord:
+                    if run_stalling_kernel_on_ncrisc:
+                        run_stalling_logic_on_ncrisc = True
+                        run_stalling_logic_on_brisc = False
+                    else:
+                        run_stalling_logic_on_ncrisc = False
+                        run_stalling_logic_on_brisc = True
+                else:
+                    run_stalling_logic_on_ncrisc = False
+                    run_stalling_logic_on_brisc = False
+
+                # select risc for signalling cores
+                if mesh_coord in signaller_devices:
+                    if run_signalling_kernel_on_ncrisc:
+                        run_signalling_logic_on_ncrisc = True
+                        run_signalling_logic_on_brisc = False
+                    else:
+                        run_signalling_logic_on_ncrisc = False
+                        run_signalling_logic_on_brisc = True
+                else:
+                    run_signalling_logic_on_ncrisc = False
+                    run_signalling_logic_on_brisc = False
 
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source=kernel_path,
@@ -173,11 +221,9 @@ class PipelineStageSync:
                     cbs=[],
                 )
 
-                if (
-                    mesh_coord == signalling_device_mesh_coord
-                    and not stalling_device_mesh_coord == signalling_device_mesh_coord
-                ):
-                    if not run_signalling_kernel_on_brisc:
+                # TODO: (GR)
+                if mesh_coord in signaller_devices:
+                    if run_signalling_kernel_on_ncrisc:
                         kernel_idx = kernel_result.get_group_by_arg(
                             "run_signalling_logic_on_ncrisc", 1
                         ).ncrisc_kernel_index
@@ -190,11 +236,16 @@ class PipelineStageSync:
                         signalling_core.y
                     ]
 
-                    signalling_fabric_node_id = mesh_device.get_fabric_node_id(signalling_device_mesh_coord)
+                    # signalling_fabric_node_id = mesh_device.get_fabric_node_id(src_device_mesh_coord)
+                    # stalling_device_fabric_node_id = mesh_device.get_fabric_node_id(dst_device_mesh_coord)
+
+                    fabric_src_node_id = mesh_device.get_fabric_node_id(mesh_coord)
+                    fabric_dst_node_id = mesh_device.get_fabric_node_id(target_device)
+
                     link_index = 0
                     fabric_args = ttnn.setup_routing_plane_connection(
-                        signalling_fabric_node_id,
-                        [stalling_device_fabric_node_id],
+                        fabric_src_node_id,
+                        [fabric_dst_node_id],
                         [link_index],
                         program,
                         kernel_idx,

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -32,12 +32,12 @@ class PipelineStageSync:
         pseudo_input_tensor: ttnn.Tensor,
         pseudo_output_tensor: ttnn.Tensor,
         mesh_device: ttnn.MeshDevice,
-        dst_device_mesh_coord: ttnn.MeshCoordinate,
-        stalling_core: ttnn.CoreCoord,
-        run_stalling_kernel_on_ncrisc: bool,
         src_device_mesh_coord: ttnn.MeshCoordinate,
         signalling_core: ttnn.CoreCoord,
         run_signalling_kernel_on_ncrisc: bool,
+        dst_device_mesh_coord: ttnn.MeshCoordinate,
+        stalling_core: ttnn.CoreCoord,
+        run_stalling_kernel_on_ncrisc: bool,
         num_iterations: int = 1,
     ) -> None:
         """
@@ -80,7 +80,7 @@ class PipelineStageSync:
         global_semaphore = ttnn.create_global_semaphore(mesh_device, all_cores_core_range_set, 0)
         semaphore_l1_addr = ttnn.get_global_semaphore_address(global_semaphore)
 
-        # construct path - horizontal then vertical
+        # construct path
         mesh_shape = mesh_device.shape
         mesh_rows = mesh_shape[0]
         mesh_cols = mesh_shape[1]
@@ -101,6 +101,8 @@ class PipelineStageSync:
         else:
             row_step = -1
             row_hops = backward_distance
+
+        print(row_step)
 
         for _ in range(row_hops):
             row = (row + row_step) % mesh_rows
@@ -132,22 +134,22 @@ class PipelineStageSync:
                     mesh_coord in signaller_devices and target_device in intermediate_signaller_devices
                 )
 
-                stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
-                stalling_core_noc_x_addr = stalling_core_phys.x
-                stalling_core_noc_y_addr = stalling_core_phys.y
-
                 signalling_core_phys = mesh_device.worker_core_from_logical_core(signalling_core)
                 signalling_core_noc_x_addr = signalling_core_phys.x
                 signalling_core_noc_y_addr = signalling_core_phys.y
+
+                stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
+                stalling_core_noc_x_addr = stalling_core_phys.x
+                stalling_core_noc_y_addr = stalling_core_phys.y
 
                 fabric_arg_base = 0
                 reader_named_ct_args = [
                     ("is_intermediate_signaller", is_intermediate_signaller),
                     ("is_signalling_to_intermediate_signaller", is_signalling_to_intermediate_signaller),
-                    ("stalling_core_noc_x_addr", stalling_core_noc_x_addr),
-                    ("stalling_core_noc_y_addr", stalling_core_noc_y_addr),
                     ("signalling_core_noc_x_addr", signalling_core_noc_x_addr),
                     ("signalling_core_noc_y_addr", signalling_core_noc_y_addr),
+                    ("stalling_core_noc_x_addr", stalling_core_noc_x_addr),
+                    ("stalling_core_noc_y_addr", stalling_core_noc_y_addr),
                     ("semaphore_l1_addr", semaphore_l1_addr),
                     ("fabric_arg_base", fabric_arg_base),
                     ("num_iterations", num_iterations),
@@ -156,18 +158,6 @@ class PipelineStageSync:
                 compute_name_ct_args = [("num_iterations", num_iterations)]
 
                 # === Unified Kernel Descriptor ===
-
-                # select risc for stalling cores
-                if mesh_coord == dst_device_mesh_coord:
-                    if run_stalling_kernel_on_ncrisc:
-                        run_stalling_logic_on_ncrisc = True
-                        run_stalling_logic_on_brisc = False
-                    else:
-                        run_stalling_logic_on_ncrisc = False
-                        run_stalling_logic_on_brisc = True
-                else:
-                    run_stalling_logic_on_ncrisc = False
-                    run_stalling_logic_on_brisc = False
 
                 # select risc for signalling cores
                 if mesh_coord in signaller_devices:
@@ -181,6 +171,18 @@ class PipelineStageSync:
                     run_signalling_logic_on_ncrisc = False
                     run_signalling_logic_on_brisc = False
 
+                # select risc for stalling cores
+                if mesh_coord == dst_device_mesh_coord:
+                    if run_stalling_kernel_on_ncrisc:
+                        run_stalling_logic_on_ncrisc = True
+                        run_stalling_logic_on_brisc = False
+                    else:
+                        run_stalling_logic_on_ncrisc = False
+                        run_stalling_logic_on_brisc = True
+                else:
+                    run_stalling_logic_on_ncrisc = False
+                    run_stalling_logic_on_brisc = False
+
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source=kernel_path,
                     core_ranges=all_cores_core_range_set,
@@ -191,16 +193,6 @@ class PipelineStageSync:
                     brisc_common_runtime_args=[],
                     per_core_compile_time_descriptors=[
                         PerCoreCompileTimeDescriptor(
-                            named_compile_time_arg="run_stalling_logic_on_ncrisc",
-                            core_values=[(stalling_core, run_stalling_logic_on_ncrisc)],
-                            other_value=0,
-                        ),
-                        PerCoreCompileTimeDescriptor(
-                            named_compile_time_arg="run_stalling_logic_on_brisc",
-                            core_values=[(stalling_core, run_stalling_logic_on_brisc)],
-                            other_value=0,
-                        ),
-                        PerCoreCompileTimeDescriptor(
                             named_compile_time_arg="run_signalling_logic_on_ncrisc",
                             core_values=[(signalling_core, run_signalling_logic_on_ncrisc)],
                             other_value=0,
@@ -208,6 +200,16 @@ class PipelineStageSync:
                         PerCoreCompileTimeDescriptor(
                             named_compile_time_arg="run_signalling_logic_on_brisc",
                             core_values=[(signalling_core, run_signalling_logic_on_brisc)],
+                            other_value=0,
+                        ),
+                        PerCoreCompileTimeDescriptor(
+                            named_compile_time_arg="run_stalling_logic_on_ncrisc",
+                            core_values=[(stalling_core, run_stalling_logic_on_ncrisc)],
+                            other_value=0,
+                        ),
+                        PerCoreCompileTimeDescriptor(
+                            named_compile_time_arg="run_stalling_logic_on_brisc",
+                            core_values=[(stalling_core, run_stalling_logic_on_brisc)],
                             other_value=0,
                         ),
                     ],
@@ -221,7 +223,6 @@ class PipelineStageSync:
                     cbs=[],
                 )
 
-                # TODO: (GR)
                 if mesh_coord in signaller_devices:
                     if run_signalling_kernel_on_ncrisc:
                         kernel_idx = kernel_result.get_group_by_arg(
@@ -235,9 +236,6 @@ class PipelineStageSync:
                     per_core_rt_args_ref = program.kernels[kernel_idx].runtime_args[signalling_core.x][
                         signalling_core.y
                     ]
-
-                    # signalling_fabric_node_id = mesh_device.get_fabric_node_id(src_device_mesh_coord)
-                    # stalling_device_fabric_node_id = mesh_device.get_fabric_node_id(dst_device_mesh_coord)
 
                     fabric_src_node_id = mesh_device.get_fabric_node_id(mesh_coord)
                     fabric_dst_node_id = mesh_device.get_fabric_node_id(target_device)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
@@ -142,7 +142,7 @@ def test_pipeline_stage_sync_2d(
 
     submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
 
-    logger.info(f"\n=== Testing pipeline_stage_sync (num_iterations={num_iterations}) ===")
+    logger.info(f"=== Testing pipeline_stage_sync (num_iterations={num_iterations}) ===")
 
     # Pseudo input/output tensors
     pseudo_input_tensor = ttnn.from_torch(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
@@ -98,7 +98,7 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
             ttnn.MeshCoordinate((0, 0)),
             ttnn.CoreCoord(1, 1),
             False,
-        ),  # backwards
+        ),  # backwards across rows
     ],
 )
 @pytest.mark.parametrize("num_iterations", [50])

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
@@ -168,11 +168,18 @@ def test_pipeline_stage_sync_2d(
         ),
     )
 
+    compute_grid_size = submesh_device.compute_with_storage_grid_size()
+    num_cores = compute_grid_size.x * compute_grid_size.y
+    available_cores = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, row_wise=True)
+    semaphore = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
+
     # Run pipeline_stage_sync with looping inside the kernel
+    ttnn.synchronize_device(submesh_device)
     PipelineStageSync.op(
         pseudo_input_tensor=pseudo_input_tensor,
         pseudo_output_tensor=pseudo_output_tensor,
         mesh_device=submesh_device,
+        semaphore=semaphore,
         src_device_mesh_coord=src_device_mesh_coord,
         signalling_core=signalling_core,
         run_signalling_kernel_on_ncrisc=run_signalling_kernel_on_ncrisc,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
@@ -99,6 +99,22 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
             ttnn.CoreCoord(1, 1),
             False,
         ),  # backwards across rows
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((0, 1)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # just col traversal, left to right
+        (
+            ttnn.MeshCoordinate((0, 1)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # just col traversal, right to left
     ],
 )
 @pytest.mark.parametrize("num_iterations", [50])

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
@@ -17,7 +17,7 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
 
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
-    "stalling_device_mesh_coord, stalling_core, run_stalling_kernel_on_brisc, signalling_device_mesh_coord, signalling_core, run_signalling_kernel_on_brisc",
+    "src_device_mesh_coord, signalling_core, run_signalling_kernel_on_ncrisc, dst_device_mesh_coord, stalling_core, run_stalling_kernel_on_ncrisc",
     [
         (
             ttnn.MeshCoordinate((0, 0)),
@@ -26,7 +26,7 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
             ttnn.MeshCoordinate((1, 1)),
             ttnn.CoreCoord(1, 1),
             False,
-        ),
+        ),  # nc signaller, b staller
         (
             ttnn.MeshCoordinate((0, 0)),
             ttnn.CoreCoord(0, 0),
@@ -34,7 +34,7 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
             ttnn.MeshCoordinate((1, 1)),
             ttnn.CoreCoord(1, 1),
             True,
-        ),
+        ),  # b signaller, nc staller
         (
             ttnn.MeshCoordinate((0, 0)),
             ttnn.CoreCoord(0, 0),
@@ -42,7 +42,7 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
             ttnn.MeshCoordinate((1, 1)),
             ttnn.CoreCoord(1, 1),
             True,
-        ),
+        ),  # nc signaller, nc staller
         (
             ttnn.MeshCoordinate((0, 0)),
             ttnn.CoreCoord(0, 0),
@@ -50,31 +50,55 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
             ttnn.MeshCoordinate((1, 1)),
             ttnn.CoreCoord(1, 1),
             False,
-        ),
+        ),  # b signaller, b staller
         (
             ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((1, 1)),
+            ttnn.CoreCoord(0, 0),
+            False,
+        ),  # same core, different risc
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((1, 1)),
+            ttnn.CoreCoord(0, 0),
+            True,
+        ),  # same core, same risc
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((2, 1)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # multiple intermediate, first col to second col
+        (
+            ttnn.MeshCoordinate((2, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((0, 1)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # multiple intermediate, second col to first col
+        (
+            ttnn.MeshCoordinate((3, 0)),
             ttnn.CoreCoord(0, 0),
             True,
             ttnn.MeshCoordinate((0, 0)),
             ttnn.CoreCoord(1, 1),
-            True,
-        ),
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
             False,
-        ),
+        ),  # wrap around
         (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            False,
-            ttnn.MeshCoordinate((0, 0)),
+            ttnn.MeshCoordinate((1, 0)),
             ttnn.CoreCoord(0, 0),
             True,
-        ),
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # backwards
     ],
 )
 @pytest.mark.parametrize("num_iterations", [50])
@@ -86,12 +110,12 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
 )
 def test_pipeline_stage_sync_2d(
     bh_2d_mesh_device,
-    stalling_device_mesh_coord,
-    stalling_core,
-    run_stalling_kernel_on_brisc,
-    signalling_device_mesh_coord,
+    src_device_mesh_coord,
     signalling_core,
-    run_signalling_kernel_on_brisc,
+    run_signalling_kernel_on_ncrisc,
+    dst_device_mesh_coord,
+    stalling_core,
+    run_stalling_kernel_on_ncrisc,
     num_iterations,
     num_devices,
 ):
@@ -133,12 +157,12 @@ def test_pipeline_stage_sync_2d(
         pseudo_input_tensor=pseudo_input_tensor,
         pseudo_output_tensor=pseudo_output_tensor,
         mesh_device=submesh_device,
-        stalling_device_mesh_coord=stalling_device_mesh_coord,
-        stalling_core=stalling_core,
-        run_stalling_kernel_on_brisc=run_stalling_kernel_on_brisc,
-        signalling_device_mesh_coord=signalling_device_mesh_coord,
+        src_device_mesh_coord=src_device_mesh_coord,
         signalling_core=signalling_core,
-        run_signalling_kernel_on_brisc=run_signalling_kernel_on_brisc,
+        run_signalling_kernel_on_ncrisc=run_signalling_kernel_on_ncrisc,
+        dst_device_mesh_coord=dst_device_mesh_coord,
+        stalling_core=stalling_core,
+        run_stalling_kernel_on_ncrisc=run_stalling_kernel_on_ncrisc,
         num_iterations=num_iterations,
     )
     ttnn.synchronize_device(submesh_device)

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -35,10 +35,10 @@ struct PipelineStageSync {
         uint32_t runSignallingLogicOnNCRISC,
         uint32_t isIntermediateSignaller,
         uint32_t isSignallingToIntermediateSignaller,
-        uint32_t stallingCoreNocXAddr,
-        uint32_t stallingCoreNocYAddr,
         uint32_t signallingCoreNocXAddr,
         uint32_t signallingCoreNocYAddr,
+        uint32_t stallingCoreNocXAddr,
+        uint32_t stallingCoreNocYAddr,
         uint32_t semaphoreL1Addr,
         uint32_t fabricArgBase>
     struct ReaderCTArgs {
@@ -46,10 +46,10 @@ struct PipelineStageSync {
         static constexpr bool run_signalling_logic_on_ncrisc = runSignallingLogicOnNCRISC == 1;
         static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
         static constexpr bool is_signalling_to_intermediate_signaller = isSignallingToIntermediateSignaller == 1;
-        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
-        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
         static constexpr uint32_t signalling_core_noc_x_addr = signallingCoreNocXAddr;
         static constexpr uint32_t signalling_core_noc_y_addr = signallingCoreNocYAddr;
+        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
+        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
         static constexpr uint32_t semaphore_l1_addr = semaphoreL1Addr;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
     };
@@ -63,10 +63,10 @@ struct PipelineStageSync {
         uint32_t runSignallingLogicOnBRISC,
         uint32_t isIntermediateSignaller,
         uint32_t isSignallingToIntermediateSignaller,
-        uint32_t stallingCoreNocXAddr,
-        uint32_t stallingCoreNocYAddr,
         uint32_t signallingCoreNocXAddr,
         uint32_t signallingCoreNocYAddr,
+        uint32_t stallingCoreNocXAddr,
+        uint32_t stallingCoreNocYAddr,
         uint32_t semaphoreL1Addr,
         uint32_t fabricArgBase>
     struct WriterCTArgs {
@@ -74,10 +74,10 @@ struct PipelineStageSync {
         static constexpr bool run_signalling_logic_on_brisc = runSignallingLogicOnBRISC == 1;
         static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
         static constexpr bool is_signalling_to_intermediate_signaller = isSignallingToIntermediateSignaller == 1;
-        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
-        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
         static constexpr uint32_t signalling_core_noc_x_addr = signallingCoreNocXAddr;
         static constexpr uint32_t signalling_core_noc_y_addr = signallingCoreNocYAddr;
+        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
+        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
         static constexpr uint32_t semaphore_l1_addr = semaphoreL1Addr;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
     };
@@ -124,10 +124,10 @@ struct PipelineStageSync {
         static FORCE_INLINE void signalling_impl(
             bool is_intermediate_signaller,
             bool is_signalling_to_intermediate_signaller,
-            uint32_t stalling_core_noc_x_addr,
-            uint32_t stalling_core_noc_y_addr,
             uint32_t signalling_core_noc_x_addr,
             uint32_t signalling_core_noc_y_addr,
+            uint32_t stalling_core_noc_x_addr,
+            uint32_t stalling_core_noc_y_addr,
             uint32_t semaphore_l1_addr,
             size_t fabric_arg_base) {
             // Remote semaphore noc address
@@ -183,10 +183,10 @@ struct PipelineStageSync {
                 signalling_impl(
                     CTArgs::is_intermediate_signaller,
                     CTArgs::is_signalling_to_intermediate_signaller,
-                    CTArgs::stalling_core_noc_x_addr,
-                    CTArgs::stalling_core_noc_y_addr,
                     CTArgs::signalling_core_noc_x_addr,
                     CTArgs::signalling_core_noc_y_addr,
+                    CTArgs::stalling_core_noc_x_addr,
+                    CTArgs::stalling_core_noc_y_addr,
                     CTArgs::semaphore_l1_addr,
                     CTArgs::fabric_arg_base);
             }
@@ -206,10 +206,10 @@ struct PipelineStageSync {
                 signalling_impl(
                     CTArgs::is_intermediate_signaller,
                     CTArgs::is_signalling_to_intermediate_signaller,
-                    CTArgs::stalling_core_noc_x_addr,
-                    CTArgs::stalling_core_noc_y_addr,
                     CTArgs::signalling_core_noc_x_addr,
                     CTArgs::signalling_core_noc_y_addr,
+                    CTArgs::stalling_core_noc_x_addr,
+                    CTArgs::stalling_core_noc_y_addr,
                     CTArgs::semaphore_l1_addr,
                     CTArgs::fabric_arg_base);
             }

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -130,13 +130,7 @@ struct PipelineStageSync {
             uint32_t signalling_core_noc_y_addr,
             uint32_t semaphore_l1_addr,
             size_t fabric_arg_base) {
-            if (is_intermediate_signaller) {
-                auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
-                noc_semaphore_wait_min(semaphore_l1_ptr, 1);
-                unified_kernels::semaphore_dec(semaphore_l1_ptr);
-                invalidate_l1_cache();
-            }
-
+            // Remote semaphore noc address
             uint64_t remote_semaphore_noc_addr;
             if (is_signalling_to_intermediate_signaller) {
                 remote_semaphore_noc_addr =
@@ -146,6 +140,7 @@ struct PipelineStageSync {
                     get_noc_addr(stalling_core_noc_x_addr, stalling_core_noc_y_addr, semaphore_l1_addr);
             }
 
+            // Setup fabric while waiting for signal (speeds things up for intermediate signallers)
             constexpr uint32_t num_connections = 1;
             tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
             open_connections(fabric_connection, num_connections, fabric_arg_base);
@@ -159,6 +154,15 @@ struct PipelineStageSync {
             packet_header_ptr->to_noc_unicast_atomic_inc(
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{remote_semaphore_noc_addr, 1});
 
+            // Wait for signal (if intermediate signaller)
+            if (is_intermediate_signaller) {
+                auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
+                noc_semaphore_wait_min(semaphore_l1_ptr, 1);
+                unified_kernels::semaphore_dec(semaphore_l1_ptr);
+                invalidate_l1_cache();
+            }
+
+            // Send semaphore increment over fabric
             auto& connection = fabric_connection.get(0).sender;
             connection.wait_for_empty_write_slot();
             connection.send_payload_flush_blocking_from_address(

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -33,14 +33,18 @@ struct PipelineStageSync {
     template <
         uint32_t runStallingLogicOnNCRISC,
         uint32_t runSignallingLogicOnNCRISC,
-        uint32_t isStallingDeviceEqualSignallingDevice,
+        uint32_t stallingDeviceSemaphoreNocXAddr,
+        uint32_t stallingDeviceSemaphoreNocYAddr,
+        uint32_t stallingDeviceSemaphoreL1Addr,
         uint32_t stallingDeviceChipID,
         uint32_t stallingDeviceMeshID,
         uint32_t fabricArgBase>
     struct ReaderCTArgs {
         static constexpr bool run_stalling_logic_on_ncrisc = runStallingLogicOnNCRISC == 1;
         static constexpr bool run_signalling_logic_on_ncrisc = runSignallingLogicOnNCRISC == 1;
-        static constexpr bool is_stalling_device_equal_signalling_device = isStallingDeviceEqualSignallingDevice == 1;
+        static constexpr uint32_t stalling_device_semaphore_noc_x_addr = stallingDeviceSemaphoreNocXAddr;
+        static constexpr uint32_t stalling_device_semaphore_noc_y_addr = stallingDeviceSemaphoreNocYAddr;
+        static constexpr uint32_t stalling_device_semaphore_l1_addr = stallingDeviceSemaphoreL1Addr;
         static constexpr uint32_t stalling_device_chip_id = stallingDeviceChipID;
         static constexpr uint32_t stalling_device_mesh_id = stallingDeviceMeshID;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
@@ -53,14 +57,18 @@ struct PipelineStageSync {
     template <
         uint32_t runStallingLogicOnBRISC,
         uint32_t runSignallingLogicOnBRISC,
-        uint32_t isStallingDeviceEqualSignallingDevice,
+        uint32_t stallingDeviceSemaphoreNocXAddr,
+        uint32_t stallingDeviceSemaphoreNocYAddr,
+        uint32_t stallingDeviceSemaphoreL1Addr,
         uint32_t stallingDeviceChipID,
         uint32_t stallingDeviceMeshID,
         uint32_t fabricArgBase>
     struct WriterCTArgs {
         static constexpr bool run_stalling_logic_on_brisc = runStallingLogicOnBRISC == 1;
         static constexpr bool run_signalling_logic_on_brisc = runSignallingLogicOnBRISC == 1;
-        static constexpr bool is_stalling_device_equal_signalling_device = isStallingDeviceEqualSignallingDevice == 1;
+        static constexpr uint32_t stalling_device_semaphore_noc_x_addr = stallingDeviceSemaphoreNocXAddr;
+        static constexpr uint32_t stalling_device_semaphore_noc_y_addr = stallingDeviceSemaphoreNocYAddr;
+        static constexpr uint32_t stalling_device_semaphore_l1_addr = stallingDeviceSemaphoreL1Addr;
         static constexpr uint32_t stalling_device_chip_id = stallingDeviceChipID;
         static constexpr uint32_t stalling_device_mesh_id = stallingDeviceMeshID;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
@@ -71,21 +79,13 @@ struct PipelineStageSync {
     // ========================================================================
 
     // NCRISC reader args
-    struct ReaderArgs {
-        uint32_t stalling_device_semaphore_noc_x_addr;
-        uint32_t stalling_device_semaphore_noc_y_addr;
-        uint32_t stalling_device_semaphore_l1_addr;
-    };
+    struct ReaderArgs {};
 
     // TRISC compute args (no-op)
     struct ComputeArgs {};
 
     // BRISC writer args
-    struct WriterArgs {
-        uint32_t stalling_device_semaphore_noc_x_addr;
-        uint32_t stalling_device_semaphore_noc_y_addr;
-        uint32_t stalling_device_semaphore_l1_addr;
-    };
+    struct WriterArgs {};
 
     // Select args type based on current RISC
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
@@ -119,42 +119,40 @@ struct PipelineStageSync {
             uint32_t stalling_device_semaphore_l1_addr,
             uint32_t stalling_device_chip_id,
             uint32_t stalling_device_mesh_id,
-            bool is_stalling_device_equal_signalling_device,
             size_t fabric_arg_base) {
+            bool is_intermediate_signaller = false;  // TODO: (GR)
+            if (is_intermediate_signaller) {
+                auto stalling_device_semaphore_l1_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stalling_device_semaphore_l1_addr);
+                noc_semaphore_wait_min(stalling_device_semaphore_l1_ptr, 1);
+                unified_kernels::semaphore_dec(stalling_device_semaphore_l1_ptr);
+                invalidate_l1_cache();
+            }
+
+            // TODO: (GR) convert to constexpr
             const uint64_t stalling_device_semaphore_noc_addr = get_noc_addr(
                 stalling_device_semaphore_noc_x_addr,
                 stalling_device_semaphore_noc_y_addr,
                 stalling_device_semaphore_l1_addr);
 
-            /*
-             * - If stalling and signalling devices are the same, use a pure NoC semaphore inc
-             * - Otherwise, must use a fabric + NoC semaphore inc
-             */
-            if (is_stalling_device_equal_signalling_device) {
-                // pure NoC
-                noc_semaphore_inc(stalling_device_semaphore_noc_addr, 1);
-            } else {
-                // fabric + NoC
-                uint32_t num_connections = 1;  // TODO: (GR)
-                tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
-                open_connections(fabric_connection, num_connections, fabric_arg_base);
+            constexpr uint32_t num_connections = 1;
+            tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
+            open_connections(fabric_connection, num_connections, fabric_arg_base);
 
-                PacketHeaderPool::reset();
-                auto* packet_header_ptr = PacketHeaderPool::allocate_header(1);
-                fabric_set_unicast_route(fabric_connection, packet_header_ptr, 0);
+            PacketHeaderPool::reset();
+            auto* packet_header_ptr = PacketHeaderPool::allocate_header(1);
+            fabric_set_unicast_route(fabric_connection, packet_header_ptr, 0);
 
-                uint32_t num_hops = 1;  // TODO: (GR)
-                packet_header_ptr->to_chip_unicast(num_hops);
-                packet_header_ptr->to_noc_unicast_atomic_inc(
-                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{stalling_device_semaphore_noc_addr, 1});
+            constexpr uint32_t num_hops = 1;
+            packet_header_ptr->to_chip_unicast(num_hops);
+            packet_header_ptr->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{stalling_device_semaphore_noc_addr, 1});
 
-                auto& connection = fabric_connection.get(0).sender;
-                connection.wait_for_empty_write_slot();
-                connection.send_payload_flush_blocking_from_address(
-                    (uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
-                close_connections(fabric_connection);
-            }
-            noc_async_atomic_barrier();
+            auto& connection = fabric_connection.get(0).sender;
+            connection.wait_for_empty_write_slot();
+            connection.send_payload_flush_blocking_from_address(
+                (uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
+            close_connections(fabric_connection);
         }
 #endif
 
@@ -164,15 +162,14 @@ struct PipelineStageSync {
             // NCRISC (Reader)
             // ================================================================
             if constexpr (CTArgs::run_stalling_logic_on_ncrisc) {
-                stalling_impl(args.stalling_device_semaphore_l1_addr);
+                stalling_impl(CTArgs::stalling_device_semaphore_l1_addr);
             } else if constexpr (CTArgs::run_signalling_logic_on_ncrisc) {
                 signalling_impl(
-                    args.stalling_device_semaphore_noc_x_addr,
-                    args.stalling_device_semaphore_noc_y_addr,
-                    args.stalling_device_semaphore_l1_addr,
+                    CTArgs::stalling_device_semaphore_noc_x_addr,
+                    CTArgs::stalling_device_semaphore_noc_y_addr,
+                    CTArgs::stalling_device_semaphore_l1_addr,
                     CTArgs::stalling_device_chip_id,
                     CTArgs::stalling_device_mesh_id,
-                    CTArgs::is_stalling_device_equal_signalling_device,
                     CTArgs::fabric_arg_base);
             }
 
@@ -186,15 +183,14 @@ struct PipelineStageSync {
             // BRISC (Writer)
             // ================================================================
             if constexpr (CTArgs::run_stalling_logic_on_brisc) {
-                stalling_impl(args.stalling_device_semaphore_l1_addr);
+                stalling_impl(CTArgs::stalling_device_semaphore_l1_addr);
             } else if constexpr (CTArgs::run_signalling_logic_on_brisc) {
                 signalling_impl(
-                    args.stalling_device_semaphore_noc_x_addr,
-                    args.stalling_device_semaphore_noc_y_addr,
-                    args.stalling_device_semaphore_l1_addr,
+                    CTArgs::stalling_device_semaphore_noc_x_addr,
+                    CTArgs::stalling_device_semaphore_noc_y_addr,
+                    CTArgs::stalling_device_semaphore_l1_addr,
                     CTArgs::stalling_device_chip_id,
                     CTArgs::stalling_device_mesh_id,
-                    CTArgs::is_stalling_device_equal_signalling_device,
                     CTArgs::fabric_arg_base);
             }
 #endif

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -135,25 +135,24 @@ struct PipelineStageSync {
                 noc_semaphore_inc(stalling_device_semaphore_noc_addr, 1);
             } else {
                 // fabric + NoC
+                uint32_t num_connections = 1;  // TODO: (GR)
+                tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
+                open_connections(fabric_connection, num_connections, fabric_arg_base);
+
                 PacketHeaderPool::reset();
-                constexpr uint32_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
-                auto route_id = PacketHeaderPool::allocate_header_n(1);
-                volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header = PacketHeaderPool::header_table[route_id].first;
-                fabric_set_unicast_route(
-                    packet_header,
-                    static_cast<uint16_t>(stalling_device_chip_id),
-                    static_cast<uint16_t>(stalling_device_mesh_id));
-                packet_header->to_noc_unicast_atomic_inc(
+                auto* packet_header_ptr = PacketHeaderPool::allocate_header(1);
+                fabric_set_unicast_route(fabric_connection, packet_header_ptr, 0);
+
+                uint32_t num_hops = 1;  // TODO: (GR)
+                packet_header_ptr->to_chip_unicast(num_hops);
+                packet_header_ptr->to_noc_unicast_atomic_inc(
                     tt::tt_fabric::NocUnicastAtomicIncCommandHeader{stalling_device_semaphore_noc_addr, 1});
 
-                auto fabric_sender =
-                    tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(
-                        fabric_arg_base);
-                fabric_sender.open();
-                fabric_sender.wait_for_empty_write_slot();
-                fabric_sender.send_payload_flush_blocking_from_address(
-                    reinterpret_cast<uint32_t>(packet_header), packet_header_size_bytes);
-                fabric_sender.close();
+                auto& connection = fabric_connection.get(0).sender;
+                connection.wait_for_empty_write_slot();
+                connection.send_payload_flush_blocking_from_address(
+                    (uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
+                close_connections(fabric_connection);
             }
             noc_async_atomic_barrier();
         }

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -12,13 +12,8 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
-#include "tt_metal/fabric/hw/inc/noc_addr.h"
-#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
-#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
-#include "tt_metal/fabric/hw/inc/api_common.h"
 
 using namespace tt::tt_fabric::linear::experimental;
-using namespace tt::tt_fabric::common::experimental;
 
 #endif
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -34,21 +34,23 @@ struct PipelineStageSync {
         uint32_t runStallingLogicOnNCRISC,
         uint32_t runSignallingLogicOnNCRISC,
         uint32_t isIntermediateSignaller,
-        uint32_t stallingDeviceSemaphoreNocXAddr,
-        uint32_t stallingDeviceSemaphoreNocYAddr,
-        uint32_t stallingDeviceSemaphoreL1Addr,
-        uint32_t stallingDeviceChipID,
-        uint32_t stallingDeviceMeshID,
+        uint32_t isSignallingToIntermediateSignaller,
+        uint32_t stallingCoreNocXAddr,
+        uint32_t stallingCoreNocYAddr,
+        uint32_t signallingCoreNocXAddr,
+        uint32_t signallingCoreNocYAddr,
+        uint32_t semaphoreL1Addr,
         uint32_t fabricArgBase>
     struct ReaderCTArgs {
         static constexpr bool run_stalling_logic_on_ncrisc = runStallingLogicOnNCRISC == 1;
         static constexpr bool run_signalling_logic_on_ncrisc = runSignallingLogicOnNCRISC == 1;
         static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
-        static constexpr uint32_t stalling_device_semaphore_noc_x_addr = stallingDeviceSemaphoreNocXAddr;
-        static constexpr uint32_t stalling_device_semaphore_noc_y_addr = stallingDeviceSemaphoreNocYAddr;
-        static constexpr uint32_t stalling_device_semaphore_l1_addr = stallingDeviceSemaphoreL1Addr;
-        static constexpr uint32_t stalling_device_chip_id = stallingDeviceChipID;
-        static constexpr uint32_t stalling_device_mesh_id = stallingDeviceMeshID;
+        static constexpr bool is_signalling_to_intermediate_signaller = isSignallingToIntermediateSignaller == 1;
+        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
+        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
+        static constexpr uint32_t signalling_core_noc_x_addr = signallingCoreNocXAddr;
+        static constexpr uint32_t signalling_core_noc_y_addr = signallingCoreNocYAddr;
+        static constexpr uint32_t semaphore_l1_addr = semaphoreL1Addr;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
     };
 
@@ -60,21 +62,23 @@ struct PipelineStageSync {
         uint32_t runStallingLogicOnBRISC,
         uint32_t runSignallingLogicOnBRISC,
         uint32_t isIntermediateSignaller,
-        uint32_t stallingDeviceSemaphoreNocXAddr,
-        uint32_t stallingDeviceSemaphoreNocYAddr,
-        uint32_t stallingDeviceSemaphoreL1Addr,
-        uint32_t stallingDeviceChipID,
-        uint32_t stallingDeviceMeshID,
+        uint32_t isSignallingToIntermediateSignaller,
+        uint32_t stallingCoreNocXAddr,
+        uint32_t stallingCoreNocYAddr,
+        uint32_t signallingCoreNocXAddr,
+        uint32_t signallingCoreNocYAddr,
+        uint32_t semaphoreL1Addr,
         uint32_t fabricArgBase>
     struct WriterCTArgs {
         static constexpr bool run_stalling_logic_on_brisc = runStallingLogicOnBRISC == 1;
         static constexpr bool run_signalling_logic_on_brisc = runSignallingLogicOnBRISC == 1;
         static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
-        static constexpr uint32_t stalling_device_semaphore_noc_x_addr = stallingDeviceSemaphoreNocXAddr;
-        static constexpr uint32_t stalling_device_semaphore_noc_y_addr = stallingDeviceSemaphoreNocYAddr;
-        static constexpr uint32_t stalling_device_semaphore_l1_addr = stallingDeviceSemaphoreL1Addr;
-        static constexpr uint32_t stalling_device_chip_id = stallingDeviceChipID;
-        static constexpr uint32_t stalling_device_mesh_id = stallingDeviceMeshID;
+        static constexpr bool is_signalling_to_intermediate_signaller = isSignallingToIntermediateSignaller == 1;
+        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
+        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
+        static constexpr uint32_t signalling_core_noc_x_addr = signallingCoreNocXAddr;
+        static constexpr uint32_t signalling_core_noc_y_addr = signallingCoreNocYAddr;
+        static constexpr uint32_t semaphore_l1_addr = semaphoreL1Addr;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
     };
 
@@ -104,39 +108,43 @@ struct PipelineStageSync {
 
     private:
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
-        static FORCE_INLINE void stalling_impl(uint32_t stalling_device_semaphore_l1_addr) {
+        static FORCE_INLINE void stalling_impl(uint32_t semaphore_l1_addr) {
             /*
              * - Wait min as multiple signals may have been received before testing semaphore value
              * - Decrement by one (instead of set to 0), so further signals aren't erased
-             * - Invalidate cache to ensure value is decremented before proceeding
+             * - Invalidate cache to ensure value is decremented before proceeding (to prevent wrap around reading same
+             * value)
              */
-            auto stalling_device_semaphore_l1_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stalling_device_semaphore_l1_addr);
-            noc_semaphore_wait_min(stalling_device_semaphore_l1_ptr, 1);
-            unified_kernels::semaphore_dec(stalling_device_semaphore_l1_ptr);
+            auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
+            noc_semaphore_wait_min(semaphore_l1_ptr, 1);
+            unified_kernels::semaphore_dec(semaphore_l1_ptr);
             invalidate_l1_cache();
         }
 
         static FORCE_INLINE void signalling_impl(
             bool is_intermediate_signaller,
-            uint32_t stalling_device_semaphore_noc_x_addr,
-            uint32_t stalling_device_semaphore_noc_y_addr,
-            uint32_t stalling_device_semaphore_l1_addr,
-            uint32_t stalling_device_chip_id,
-            uint32_t stalling_device_mesh_id,
+            bool is_signalling_to_intermediate_signaller,
+            uint32_t stalling_core_noc_x_addr,
+            uint32_t stalling_core_noc_y_addr,
+            uint32_t signalling_core_noc_x_addr,
+            uint32_t signalling_core_noc_y_addr,
+            uint32_t semaphore_l1_addr,
             size_t fabric_arg_base) {
             if (is_intermediate_signaller) {
-                auto stalling_device_semaphore_l1_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stalling_device_semaphore_l1_addr);
-                noc_semaphore_wait_min(stalling_device_semaphore_l1_ptr, 1);
-                unified_kernels::semaphore_dec(stalling_device_semaphore_l1_ptr);
+                auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
+                noc_semaphore_wait_min(semaphore_l1_ptr, 1);
+                unified_kernels::semaphore_dec(semaphore_l1_ptr);
                 invalidate_l1_cache();
             }
 
-            const uint64_t stalling_device_semaphore_noc_addr = get_noc_addr(
-                stalling_device_semaphore_noc_x_addr,
-                stalling_device_semaphore_noc_y_addr,
-                stalling_device_semaphore_l1_addr);
+            uint64_t remote_semaphore_noc_addr;
+            if (is_signalling_to_intermediate_signaller) {
+                remote_semaphore_noc_addr =
+                    get_noc_addr(signalling_core_noc_x_addr, signalling_core_noc_y_addr, semaphore_l1_addr);
+            } else {
+                remote_semaphore_noc_addr =
+                    get_noc_addr(stalling_core_noc_x_addr, stalling_core_noc_y_addr, semaphore_l1_addr);
+            }
 
             constexpr uint32_t num_connections = 1;
             tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
@@ -149,13 +157,14 @@ struct PipelineStageSync {
             constexpr uint32_t num_hops = 1;
             packet_header_ptr->to_chip_unicast(num_hops);
             packet_header_ptr->to_noc_unicast_atomic_inc(
-                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{stalling_device_semaphore_noc_addr, 1});
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{remote_semaphore_noc_addr, 1});
 
             auto& connection = fabric_connection.get(0).sender;
             connection.wait_for_empty_write_slot();
             connection.send_payload_flush_blocking_from_address(
                 (uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
             close_connections(fabric_connection);
+            noc_async_write_barrier();
         }
 #endif
 
@@ -165,15 +174,16 @@ struct PipelineStageSync {
             // NCRISC (Reader)
             // ================================================================
             if constexpr (CTArgs::run_stalling_logic_on_ncrisc) {
-                stalling_impl(CTArgs::stalling_device_semaphore_l1_addr);
+                stalling_impl(CTArgs::semaphore_l1_addr);
             } else if constexpr (CTArgs::run_signalling_logic_on_ncrisc) {
                 signalling_impl(
                     CTArgs::is_intermediate_signaller,
-                    CTArgs::stalling_device_semaphore_noc_x_addr,
-                    CTArgs::stalling_device_semaphore_noc_y_addr,
-                    CTArgs::stalling_device_semaphore_l1_addr,
-                    CTArgs::stalling_device_chip_id,
-                    CTArgs::stalling_device_mesh_id,
+                    CTArgs::is_signalling_to_intermediate_signaller,
+                    CTArgs::stalling_core_noc_x_addr,
+                    CTArgs::stalling_core_noc_y_addr,
+                    CTArgs::signalling_core_noc_x_addr,
+                    CTArgs::signalling_core_noc_y_addr,
+                    CTArgs::semaphore_l1_addr,
                     CTArgs::fabric_arg_base);
             }
 
@@ -187,15 +197,16 @@ struct PipelineStageSync {
             // BRISC (Writer)
             // ================================================================
             if constexpr (CTArgs::run_stalling_logic_on_brisc) {
-                stalling_impl(CTArgs::stalling_device_semaphore_l1_addr);
+                stalling_impl(CTArgs::semaphore_l1_addr);
             } else if constexpr (CTArgs::run_signalling_logic_on_brisc) {
                 signalling_impl(
                     CTArgs::is_intermediate_signaller,
-                    CTArgs::stalling_device_semaphore_noc_x_addr,
-                    CTArgs::stalling_device_semaphore_noc_y_addr,
-                    CTArgs::stalling_device_semaphore_l1_addr,
-                    CTArgs::stalling_device_chip_id,
-                    CTArgs::stalling_device_mesh_id,
+                    CTArgs::is_signalling_to_intermediate_signaller,
+                    CTArgs::stalling_core_noc_x_addr,
+                    CTArgs::stalling_core_noc_y_addr,
+                    CTArgs::signalling_core_noc_x_addr,
+                    CTArgs::signalling_core_noc_y_addr,
+                    CTArgs::semaphore_l1_addr,
                     CTArgs::fabric_arg_base);
             }
 #endif

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -33,6 +33,7 @@ struct PipelineStageSync {
     template <
         uint32_t runStallingLogicOnNCRISC,
         uint32_t runSignallingLogicOnNCRISC,
+        uint32_t isIntermediateSignaller,
         uint32_t stallingDeviceSemaphoreNocXAddr,
         uint32_t stallingDeviceSemaphoreNocYAddr,
         uint32_t stallingDeviceSemaphoreL1Addr,
@@ -42,6 +43,7 @@ struct PipelineStageSync {
     struct ReaderCTArgs {
         static constexpr bool run_stalling_logic_on_ncrisc = runStallingLogicOnNCRISC == 1;
         static constexpr bool run_signalling_logic_on_ncrisc = runSignallingLogicOnNCRISC == 1;
+        static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
         static constexpr uint32_t stalling_device_semaphore_noc_x_addr = stallingDeviceSemaphoreNocXAddr;
         static constexpr uint32_t stalling_device_semaphore_noc_y_addr = stallingDeviceSemaphoreNocYAddr;
         static constexpr uint32_t stalling_device_semaphore_l1_addr = stallingDeviceSemaphoreL1Addr;
@@ -57,6 +59,7 @@ struct PipelineStageSync {
     template <
         uint32_t runStallingLogicOnBRISC,
         uint32_t runSignallingLogicOnBRISC,
+        uint32_t isIntermediateSignaller,
         uint32_t stallingDeviceSemaphoreNocXAddr,
         uint32_t stallingDeviceSemaphoreNocYAddr,
         uint32_t stallingDeviceSemaphoreL1Addr,
@@ -66,6 +69,7 @@ struct PipelineStageSync {
     struct WriterCTArgs {
         static constexpr bool run_stalling_logic_on_brisc = runStallingLogicOnBRISC == 1;
         static constexpr bool run_signalling_logic_on_brisc = runSignallingLogicOnBRISC == 1;
+        static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
         static constexpr uint32_t stalling_device_semaphore_noc_x_addr = stallingDeviceSemaphoreNocXAddr;
         static constexpr uint32_t stalling_device_semaphore_noc_y_addr = stallingDeviceSemaphoreNocYAddr;
         static constexpr uint32_t stalling_device_semaphore_l1_addr = stallingDeviceSemaphoreL1Addr;
@@ -114,13 +118,13 @@ struct PipelineStageSync {
         }
 
         static FORCE_INLINE void signalling_impl(
+            bool is_intermediate_signaller,
             uint32_t stalling_device_semaphore_noc_x_addr,
             uint32_t stalling_device_semaphore_noc_y_addr,
             uint32_t stalling_device_semaphore_l1_addr,
             uint32_t stalling_device_chip_id,
             uint32_t stalling_device_mesh_id,
             size_t fabric_arg_base) {
-            bool is_intermediate_signaller = false;  // TODO: (GR)
             if (is_intermediate_signaller) {
                 auto stalling_device_semaphore_l1_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stalling_device_semaphore_l1_addr);
@@ -129,7 +133,6 @@ struct PipelineStageSync {
                 invalidate_l1_cache();
             }
 
-            // TODO: (GR) convert to constexpr
             const uint64_t stalling_device_semaphore_noc_addr = get_noc_addr(
                 stalling_device_semaphore_noc_x_addr,
                 stalling_device_semaphore_noc_y_addr,
@@ -165,6 +168,7 @@ struct PipelineStageSync {
                 stalling_impl(CTArgs::stalling_device_semaphore_l1_addr);
             } else if constexpr (CTArgs::run_signalling_logic_on_ncrisc) {
                 signalling_impl(
+                    CTArgs::is_intermediate_signaller,
                     CTArgs::stalling_device_semaphore_noc_x_addr,
                     CTArgs::stalling_device_semaphore_noc_y_addr,
                     CTArgs::stalling_device_semaphore_l1_addr,
@@ -186,6 +190,7 @@ struct PipelineStageSync {
                 stalling_impl(CTArgs::stalling_device_semaphore_l1_addr);
             } else if constexpr (CTArgs::run_signalling_logic_on_brisc) {
                 signalling_impl(
+                    CTArgs::is_intermediate_signaller,
                     CTArgs::stalling_device_semaphore_noc_x_addr,
                     CTArgs::stalling_device_semaphore_noc_y_addr,
                     CTArgs::stalling_device_semaphore_l1_addr,


### PR DESCRIPTION
### Ticket
Part of [issue](https://github.com/tenstorrent/tt-metal/issues/41317)

### Problem description
- Op is used to synchronize release of a new token into a stage, not yet integrated into model itself
- Future fabric optimizations require neighbour-exchange algorithms, this PR converts this op to use neighbour-exchange instead of direct sends

BH APC: https://github.com/tenstorrent/tt-metal/actions/runs/24046379585

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=grechsteiner/convert_pipeline_sync_to_neighbour)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:grechsteiner/convert_pipeline_sync_to_neighbour)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/convert_pipeline_sync_to_neighbour)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/convert_pipeline_sync_to_neighbour)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/convert_pipeline_sync_to_neighbour)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/convert_pipeline_sync_to_neighbour)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/convert_pipeline_sync_to_neighbour)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/convert_pipeline_sync_to_neighbour)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/convert_pipeline_sync_to_neighbour)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/convert_pipeline_sync_to_neighbour)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/convert_pipeline_sync_to_neighbour)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/convert_pipeline_sync_to_neighbour)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
