### PR TITLE
#40916: add ability of group_norm to choose a core grid itself

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -2,13 +2,15 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-def test_group_norm_large_ex_external_cb(device):
+@pytest.mark.parametrize("specify_grid", [True, False])
+def test_group_norm_large_ex_external_cb(device, specify_grid):
     torch.manual_seed(0)
     shape = (1, 1, 1280 * 720, 256)  # [N, 1, H*W, C]
     num_groups = 32
@@ -31,14 +33,16 @@ def test_group_norm_large_ex_external_cb(device):
     w_tt = ttnn.from_torch(weight_4d, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
     b_tt = ttnn.from_torch(bias_4d, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
 
-    sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
-        device=device,
-        num_channels=c,
-        num_groups=num_groups,
-        input_nhw=1280 * 720,
-        is_height_sharded=False,
-        is_row_major=False,
-    )
+    grid_size = None
+    if specify_grid:
+        sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
+            device=device,
+            num_channels=c,
+            num_groups=num_groups,
+            input_nhw=1280 * 720,
+            is_height_sharded=False,
+            is_row_major=False,
+        )
     output_tensor_tt = ttnn.group_norm(
         input_tensor_tt,
         num_groups=num_groups,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -2,15 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("specify_grid", [True, False])
-def test_group_norm_large_ex_external_cb(device, specify_grid):
+def test_group_norm_large_ex_external_cb(device):
     torch.manual_seed(0)
     shape = (1, 1, 1280 * 720, 256)  # [N, 1, H*W, C]
     num_groups = 32
@@ -33,16 +31,14 @@ def test_group_norm_large_ex_external_cb(device, specify_grid):
     w_tt = ttnn.from_torch(weight_4d, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
     b_tt = ttnn.from_torch(bias_4d, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
 
-    grid_size = None
-    if specify_grid:
-        sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
-            device=device,
-            num_channels=c,
-            num_groups=num_groups,
-            input_nhw=1280 * 720,
-            is_height_sharded=False,
-            is_row_major=False,
-        )
+    sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
+        device=device,
+        num_channels=c,
+        num_groups=num_groups,
+        input_nhw=1280 * 720,
+        is_height_sharded=False,
+        is_row_major=False,
+    )
     output_tensor_tt = ttnn.group_norm(
         input_tensor_tt,
         num_groups=num_groups,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -226,7 +226,8 @@ def test_group_norm_with_block_sharded_v2_8x4_grid(device, N, C, H, W, num_group
     ],
 )
 @pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
-def test_group_norm_with_block_sharded_v2_8x8_grid(device, N, C, H, W, num_groups, use_welford):
+@pytest.mark.parametrize("specify_grid", [True, False])
+def test_group_norm_with_block_sharded_v2_8x8_grid(device, N, C, H, W, num_groups, use_welford, specify_grid):
     torch.manual_seed(0)
     if device.core_grid.y == 7:
         pytest.skip()
@@ -293,7 +294,7 @@ def test_group_norm_with_block_sharded_v2_8x8_grid(device, N, C, H, W, num_group
         weight=gamma_t,
         bias=beta_t,
         memory_config=sharded_mem_config,
-        core_grid=grid_size,
+        core_grid=grid_size if specify_grid else None,
         use_welford=use_welford,
     )
 
@@ -1007,7 +1008,8 @@ def test_group_norm_negative_tests(
         (1, 1280, 16, 16, 32),
     ],
 )
-def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups):
+@pytest.mark.parametrize("specify_grid", [True, False])
+def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups, specify_grid):
     """Use determine_expected_group_norm_dram_grid_size to pick a grid, then
     run DRAM-interleaved group norm and compare against torch."""
     torch.manual_seed(0)
@@ -1051,7 +1053,7 @@ def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups):
         weight=gamma_t,
         bias=beta_t,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        core_grid=grid_size,
+        core_grid=grid_size if specify_grid else None,
         inplace=False,
         num_out_blocks=1,
         use_welford=True,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -60,6 +60,24 @@ void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht
     }
 }
 
+int64_t get_group_norm_cores_across_channel(
+    tt::tt_metal::TensorMemoryLayout memory_layout,
+    const ttnn::CoreGrid& core_grid,
+    const std::optional<tt::tt_metal::ShardOrientation>& shard_orientation) {
+    using tt::tt_metal::ShardOrientation;
+    using tt::tt_metal::TensorMemoryLayout;
+    if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        if (shard_orientation == ShardOrientation::ROW_MAJOR) {
+            return static_cast<int64_t>(core_grid.x);
+        }
+        return static_cast<int64_t>(core_grid.y);
+    }
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        return 1;
+    }
+    return static_cast<int64_t>(core_grid.x * core_grid.y);
+}
+
 }  // namespace
 
 namespace ttnn::operations::normalization {
@@ -68,7 +86,7 @@ ttnn::Tensor get_mask_tensor(
     const ttnn::Tensor& input_tensor,
     const std::optional<ttnn::Tensor>& input_mask,
     const std::optional<ttnn::Tensor>& negative_mask,
-    std::optional<CoreGrid> core_grid,
+    const CoreGrid& core_grid,
     const int num_groups) {
     ttnn::Tensor mask = input_mask.value_or(ttnn::Tensor());
     if (!input_mask.has_value() and !negative_mask.has_value()) {
@@ -76,25 +94,22 @@ ttnn::Tensor get_mask_tensor(
         int64_t num_channel = input_tensor.padded_shape()[-1];
         int64_t num_cores_across_channel;
         if (input_tensor.memory_config().buffer_type() == BufferType::L1) {
-            auto mem_layout = input_tensor.memory_config().memory_layout();
-            if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-                num_cores_across_channel = 1;
-            } else if (mem_layout == TensorMemoryLayout::BLOCK_SHARDED && core_grid.has_value()) {
-                auto shard_spec = input_tensor.memory_config().shard_spec();
-                bool is_row_major = shard_spec.has_value() && shard_spec->orientation == ShardOrientation::ROW_MAJOR;
-                num_cores_across_channel = is_row_major ? core_grid.value().x : core_grid.value().y;
-            } else {
-                num_cores_across_channel = core_grid.has_value() ? core_grid.value().y : 1;
+            const auto mem_layout = input_tensor.memory_config().memory_layout();
+            const auto shard_spec = input_tensor.memory_config().shard_spec();
+            std::optional<ShardOrientation> shard_orientation = std::nullopt;
+            if (shard_spec.has_value()) {
+                shard_orientation = shard_spec->orientation;
             }
+            num_cores_across_channel = get_group_norm_cores_across_channel(mem_layout, core_grid, shard_orientation);
         } else {
             uint32_t num_virtual_cols =
-                compute_num_virtual_cols(core_grid.value().x, num_groups, static_cast<uint32_t>(num_channel));
+                compute_num_virtual_cols(core_grid.x, num_groups, static_cast<uint32_t>(num_channel));
             TT_FATAL(
                 num_virtual_cols > 0,
                 "group_norm: Cannot determine num_virtual_cols for core_grid x={}, num_groups={}, "
                 "num_channels={}. num_virtual_cols must satisfy (num_channels / nvc) % TILE_SIZE == 0 "
                 "and num_groups % nvc == 0.",
-                core_grid.value().x,
+                core_grid.x,
                 num_groups,
                 num_channel);
             num_cores_across_channel = static_cast<int64_t>(num_virtual_cols);
@@ -151,10 +166,6 @@ Tensor group_norm(
     }
 
     TT_FATAL(
-        core_grid.has_value(),
-        "Automatic grid size determination is not supported. Please specify the grid size explicitly.");
-
-    TT_FATAL(
         input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
         "Unsupported memory layout: Input tensor cannot be width-sharded.");
 
@@ -202,6 +213,39 @@ Tensor group_norm(
     auto kernel_config_val =
         init_device_compute_kernel_config(arch, compute_kernel_config, math_fidelity, approx_mode, fp32_acc);
 
+    if (!core_grid.has_value()) {
+        if (input_tensor.is_sharded()) {
+            const auto& shard_spec_opt = input_tensor.shard_spec();
+            TT_FATAL(
+                shard_spec_opt.has_value(),
+                "group_norm: Sharded input must have a shard spec when core_grid is not provided.");
+            const auto mem_layout = input_tensor.memory_config().memory_layout();
+            const bool is_height_sharded = mem_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+            const bool is_row_major = is_height_sharded || (shard_spec_opt->orientation == ShardOrientation::ROW_MAJOR);
+            const auto gn_sharded =
+                ttnn::operations::normalization::determine_expected_group_norm_sharded_config_and_grid_size(
+                    input_tensor.device()->compute_with_storage_grid_size(),
+                    input_padded_shape[3],
+                    num_groups,
+                    nhw,
+                    is_height_sharded,
+                    is_row_major);
+            core_grid = gn_sharded.core_grid;
+        } else {
+            const auto dev_grid = input_tensor.device()->compute_with_storage_grid_size();
+            auto dram_grid = ttnn::operations::normalization::find_expected_dram_grid(
+                dev_grid.x, dev_grid.y, input_padded_shape[3], num_groups, nhw);
+            TT_FATAL(
+                dram_grid.has_value(),
+                "group_norm: Could not determine a valid DRAM core grid for channels={}, num_groups={}, nhw={}. "
+                "Specify core_grid explicitly or adjust configuration.",
+                input_padded_shape[3],
+                num_groups,
+                nhw);
+            core_grid = dram_grid.value();
+        }
+    }
+
     // For non-sharded DRAM tensors, validate that the requested core grid is not too
     // large for the input spatial dimensions. The constraint is Ht >= num_virtual_rows,
     // where num_virtual_rows = (grid_x / num_virtual_cols) * grid_y and Ht = NHW / TILE_SIZE.
@@ -213,8 +257,8 @@ Tensor group_norm(
     }
 
     // auto generate mask tensor if both input_mask and negative_mask are not provided
-    ttnn::Tensor mask =
-        operations::normalization::get_mask_tensor(input_tensor, input_mask, negative_mask, core_grid, num_groups);
+    ttnn::Tensor mask = operations::normalization::get_mask_tensor(
+        input_tensor, input_mask, negative_mask, core_grid.value(), num_groups);
 
     if (input_tensor.is_sharded()) {
         const ttnn::prim::GroupNormShardedMultiCoreProgramConfig program_config = {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
@@ -41,6 +41,8 @@ GroupNormShardedConfigAndGridSize determine_expected_group_norm_sharded_config_a
     using tt::tt_metal::ShardSpec;
     using tt::tt_metal::TensorMemoryLayout;
 
+    TT_FATAL(num_groups > 0, "num_groups needs to be greater than 0");
+    TT_FATAL(num_channels > 0, "num_channels needs to be greater than 0");
     TT_FATAL(
         num_channels % static_cast<uint32_t>(num_groups) == 0,
         "group_norm: num_channels ({}) must be divisible by num_groups ({}).",

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
@@ -5,9 +5,136 @@
 #include "groupnorm_grid_utils.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/math.hpp>
+
 namespace ttnn::operations::normalization {
+
+namespace {
+
+uint32_t find_closest_largest_divisor(uint32_t num, uint32_t start_divisor) {
+    uint32_t divisor = start_divisor;
+    while (divisor > 0 && num % divisor != 0) {
+        divisor -= 1;
+    }
+    return divisor;
+}
+
+}  // namespace
+
+GroupNormShardedConfigAndGridSize determine_expected_group_norm_sharded_config_and_grid_size(
+    tt::tt_metal::CoreCoord device_compute_grid,
+    uint32_t num_channels,
+    int num_groups,
+    uint32_t input_nhw,
+    bool is_height_sharded,
+    bool is_row_major) {
+    using tt::tt_metal::BufferType;
+    using tt::tt_metal::CoreCoord;
+    using tt::tt_metal::CoreRange;
+    using tt::tt_metal::CoreRangeSet;
+    using tt::tt_metal::MemoryConfig;
+    using tt::tt_metal::ShardOrientation;
+    using tt::tt_metal::ShardSpec;
+    using tt::tt_metal::TensorMemoryLayout;
+
+    TT_FATAL(
+        num_channels % static_cast<uint32_t>(num_groups) == 0,
+        "group_norm: num_channels ({}) must be divisible by num_groups ({}).",
+        num_channels,
+        num_groups);
+    TT_FATAL(
+        num_channels % ttnn::types::TILE_SIZE == 0,
+        "group_norm: num_channels ({}) must be divisible by tile width ({}).",
+        num_channels,
+        ttnn::types::TILE_SIZE);
+
+    const uint32_t group_size = num_channels / static_cast<uint32_t>(num_groups);
+    uint32_t dg0 = static_cast<uint32_t>(device_compute_grid.x);
+    uint32_t dg1 = static_cast<uint32_t>(device_compute_grid.y);
+    if (is_row_major) {
+        std::swap(dg0, dg1);
+    }
+    const uint32_t max_num_cores = dg0 * dg1;
+
+    const uint32_t input_nhw_padded_to32 = tt::div_up(input_nhw, ttnn::types::TILE_SIZE) * ttnn::types::TILE_SIZE;
+    const uint32_t ht_padded = input_nhw_padded_to32 / ttnn::types::TILE_SIZE;
+    const uint32_t start_divisor = is_height_sharded ? max_num_cores : dg0;
+    uint32_t num_cores_nhw = find_closest_largest_divisor(ht_padded, start_divisor);
+    TT_FATAL(
+        num_cores_nhw > 0,
+        "group_norm: Could not find num_cores_nhw for sharded config (Ht_padded={}, start_divisor={}).",
+        ht_padded,
+        start_divisor);
+
+    uint32_t num_cores_channels = 1;
+    if (!is_height_sharded) {
+        num_cores_channels = dg1;
+        const uint32_t num_channels_tiles = num_channels / 8;
+        while (num_cores_channels > 0 &&
+               ((num_channels_tiles % num_cores_channels != 0) ||
+                ((num_channels / num_cores_channels) % group_size != 0) || (num_channels / num_cores_channels < 32))) {
+            num_cores_channels -= 1;
+        }
+        TT_FATAL(
+            num_cores_channels > 0,
+            "group_norm: Could not find num_cores_channels for block-sharded group norm (C={}, G={}).",
+            num_channels,
+            num_groups);
+    }
+
+    const uint32_t input_nhw_padded_to_ncores =
+        tt::div_up(input_nhw, num_cores_nhw * ttnn::types::TILE_SIZE) * (num_cores_nhw * ttnn::types::TILE_SIZE);
+    const uint32_t gn_in_channels_per_core = num_channels / num_cores_channels;
+    TT_FATAL(
+        gn_in_channels_per_core % 8 == 0,
+        "group_norm: gn_in_channels_per_core ({}) must be divisible by 8.",
+        gn_in_channels_per_core);
+    const uint32_t gn_nhw_per_core = input_nhw_padded_to_ncores / num_cores_nhw;
+
+    uint32_t grid_x = 0;
+    uint32_t grid_y = 0;
+    if (is_height_sharded) {
+        grid_x = (num_cores_nhw >= dg0) ? dg0 : num_cores_nhw;
+        grid_y = tt::div_up(num_cores_nhw, dg0);
+        TT_FATAL(
+            num_cores_nhw <= grid_x * grid_y,
+            "group_norm: num_cores_nhw ({}) exceeds grid capacity ({}x{}={}).",
+            num_cores_nhw,
+            grid_x,
+            grid_y,
+            grid_x * grid_y);
+    } else {
+        grid_x = is_row_major ? num_cores_channels : num_cores_nhw;
+        grid_y = is_row_major ? num_cores_nhw : num_cores_channels;
+    }
+
+    const ShardOrientation shard_orientation =
+        (is_height_sharded || is_row_major) ? ShardOrientation::ROW_MAJOR : ShardOrientation::COL_MAJOR;
+
+    std::array<uint32_t, 2> shard_shape{};
+    if (shard_orientation == ShardOrientation::ROW_MAJOR) {
+        shard_shape = {gn_nhw_per_core, gn_in_channels_per_core};
+    } else {
+        shard_shape = {gn_in_channels_per_core, gn_nhw_per_core};
+    }
+
+    const CoreCoord grid_end{static_cast<int>(grid_x) - 1, static_cast<int>(grid_y) - 1};
+    const CoreRangeSet shard_grid(CoreRange(CoreCoord{0, 0}, grid_end));
+
+    const TensorMemoryLayout tensor_memory_layout =
+        is_height_sharded ? TensorMemoryLayout::HEIGHT_SHARDED : TensorMemoryLayout::BLOCK_SHARDED;
+    const ShardSpec shard_spec(shard_grid, shard_shape, shard_orientation);
+    MemoryConfig memory_config(tensor_memory_layout, BufferType::L1, shard_spec);
+
+    return GroupNormShardedConfigAndGridSize{
+        .memory_config = std::move(memory_config),
+        .core_grid = ttnn::CoreGrid(grid_x, grid_y),
+    };
+}
 
 uint32_t compute_num_virtual_cols(uint32_t grid_x, int num_groups, uint32_t num_channels) {
     uint32_t nvc = std::min<uint32_t>(grid_x, num_groups);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp
@@ -6,9 +6,26 @@
 
 #include <cstdint>
 #include <optional>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include "ttnn/types.hpp"
 
 namespace ttnn::operations::normalization {
+
+struct GroupNormShardedConfigAndGridSize {
+    ttnn::MemoryConfig memory_config;
+    ttnn::CoreGrid core_grid;
+};
+
+// Port of Python ``determine_expected_group_norm_sharded_config_and_grid_size`` (L1 shard spec + CoreGrid).
+GroupNormShardedConfigAndGridSize determine_expected_group_norm_sharded_config_and_grid_size(
+    tt::tt_metal::CoreCoord device_compute_grid,
+    uint32_t num_channels,
+    int num_groups,
+    uint32_t input_nhw,
+    bool is_height_sharded,
+    bool is_row_major);
 
 // Compute the number of virtual columns for DRAM group-norm.
 // Finds the largest nvc <= min(grid_x, num_groups) such that:

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -8,6 +8,11 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/tuple.h>
+
+#include <tuple>
+
+#include <tt-metalium/core_coord.hpp>
 
 #include "ttnn-nanobind/bind_function.hpp"
 #include "groupnorm.hpp"
@@ -209,6 +214,35 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         R"doc(
             Find the largest valid CoreGrid within (max_x, max_y) bounds
             for DRAM interleaved group-norm. Raises if no valid grid exists.
+        )doc");
+    mod.def(
+        "determine_expected_group_norm_sharded_config_and_grid_size",
+        [](int32_t device_grid_x,
+           int32_t device_grid_y,
+           uint32_t num_channels,
+           int num_groups,
+           uint32_t input_nhw,
+           bool is_height_sharded,
+           bool is_row_major) {
+            auto result = ttnn::operations::normalization::determine_expected_group_norm_sharded_config_and_grid_size(
+                tt::tt_metal::CoreCoord{device_grid_x, device_grid_y},
+                num_channels,
+                num_groups,
+                input_nhw,
+                is_height_sharded,
+                is_row_major);
+            return std::make_tuple(result.memory_config, result.core_grid);
+        },
+        nb::arg("device_grid_x"),
+        nb::arg("device_grid_y"),
+        nb::arg("num_channels"),
+        nb::arg("num_groups"),
+        nb::arg("input_nhw"),
+        nb::arg("is_height_sharded"),
+        nb::arg("is_row_major") = false,
+        R"doc(
+            C++ implementation matching Python ``determine_expected_group_norm_sharded_config_and_grid_size``:
+            returns ``(MemoryConfig, CoreGrid)`` for L1 height- or block-sharded group norm, given device grid extents.
         )doc");
 }
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -59,7 +59,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 bias (ttnn.Tensor, optional): Beta (shift) parameter for the affine transformation. When omitted, no shift is applied. Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (ttnn.DataType, optional): Defaults to `None`.
-                core_grid (CoreGrid, optional): Must be provided (see limitations). Defaults to `None`.
+                core_grid (CoreGrid, optional): Defaults to `None`.
                 inplace (bool, optional): Defaults to `True`.
                 output_layout (ttnn.Layout, optional): Defaults to `None`.
                 num_out_blocks (int, optional): Allows the output to be processed in multiple smaller chunks, to reduce the amount of L1 required at a time. Should only be used if needed to relieve L1 pressure, as this negatively impacts performance. Defaults to `None`.
@@ -108,7 +108,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
               - For the :attr:`input_tensor`, H*W must be a multiple of the tile size (32) and C must be a multiple of the tile size and divide evenly into :attr:`num_groups`.
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
-              - :attr:`core_grid` must be provided
+              - If :attr:`core_grid` is not provided, it will be inferred using helper functions such as :func:`ttnn.determine_expected_group_norm_dram_grid_size` and :func:`ttnn.determine_expected_group_norm_sharded_config_and_grid_size`. This grid may not be optimal.
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.
               - When generating inputs (e.g. weight, bias) for block sharded tensors, the number of cores in a column should draw upon core.x rather than core.y.
               - When generating inputs (e.g. weight, bias) for height sharded tensors, the number of cores in a column should be 1 rather than core.y.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -12,8 +12,7 @@
 
 #include <tuple>
 
-#include <tt-metalium/core_coord.hpp>
-
+#include "ttnn/device.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
 #include "groupnorm.hpp"
 #include "groupnorm_grid_utils.hpp"
@@ -217,32 +216,39 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         )doc");
     mod.def(
         "determine_expected_group_norm_sharded_config_and_grid_size",
-        [](int32_t device_grid_x,
-           int32_t device_grid_y,
+        [](ttnn::MeshDevice* device,
            uint32_t num_channels,
            int num_groups,
            uint32_t input_nhw,
            bool is_height_sharded,
            bool is_row_major) {
+            TT_FATAL(
+                device != nullptr,
+                "determine_expected_group_norm_sharded_config_and_grid_size: device must not be null.");
+            const auto grid = device->compute_with_storage_grid_size();
             auto result = ttnn::operations::normalization::determine_expected_group_norm_sharded_config_and_grid_size(
-                tt::tt_metal::CoreCoord{device_grid_x, device_grid_y},
-                num_channels,
-                num_groups,
-                input_nhw,
-                is_height_sharded,
-                is_row_major);
+                grid, num_channels, num_groups, input_nhw, is_height_sharded, is_row_major);
             return std::make_tuple(result.memory_config, result.core_grid);
         },
-        nb::arg("device_grid_x"),
-        nb::arg("device_grid_y"),
+        nb::kw_only(),
+        nb::arg("device"),
         nb::arg("num_channels"),
         nb::arg("num_groups"),
         nb::arg("input_nhw"),
         nb::arg("is_height_sharded"),
         nb::arg("is_row_major") = false,
         R"doc(
-            C++ implementation matching Python ``determine_expected_group_norm_sharded_config_and_grid_size``:
-            returns ``(MemoryConfig, CoreGrid)`` for L1 height- or block-sharded group norm, given device grid extents.
+    Derive sharded memory config and grid for group norm.
+
+    - num_channels must be divisible by num_groups and 32 (tile width).
+    - input_nhw is N*H*W in logical units; padded to core multiples.
+    - If is_height_sharded: shard along NHW only; channels per core is all C.
+      Otherwise: shard across channels and NHW (BLOCK_SHARDED).
+    - is_row_major toggles shard shape orientation.
+
+    Keyword-only arguments. Uses ``device.compute_with_storage_grid_size()``.
+
+    Returns: ``(MemoryConfig, CoreGrid)`` for L1 height- or block-sharded group norm.
         )doc");
 }
 }  // namespace

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -12,6 +12,7 @@ import math
 from ttnn._ttnn.operations.normalization import (
     create_group_norm_input_mask,
     create_group_norm_input_negative_mask,
+    determine_expected_group_norm_sharded_config_and_grid_size,
     _compute_num_virtual_cols,
     _find_expected_dram_grid,
 )
@@ -211,76 +212,6 @@ def create_layer_norm_reciprocals(device: ttnn.Device, core_range_set: ttnn.Core
 
 
 # group norm helper function
-def determine_expected_group_norm_sharded_config_and_grid_size(
-    *, device, num_channels, num_groups, input_nhw, is_height_sharded, is_row_major=False
-):
-    """Derive sharded memory config and grid for group norm.
-
-    - num_channels must be divisible by num_groups and 32 (tile width).
-    - input_nhw is N*H*W in logical units; padded to core multiples.
-    - If is_height_sharded: shard along NHW only; channels per core is all C.
-      Otherwise: shard across channels and NHW (BLOCK_SHARDED).
-    - is_row_major toggles shard shape orientation.
-
-    Returns: (MemoryConfig, CoreGrid)
-    """
-    assert num_channels % num_groups == 0
-    assert num_channels % 32 == 0
-    group_size = num_channels // num_groups
-    compute_with_storage_grid_size = device.compute_with_storage_grid_size()
-    device_grid_size = [compute_with_storage_grid_size.x, compute_with_storage_grid_size.y]
-    if is_row_major:
-        device_grid_size = [compute_with_storage_grid_size.y, compute_with_storage_grid_size.x]
-
-    max_num_cores = device_grid_size[0] * device_grid_size[1]
-    input_nhw_paddedto32 = math.ceil(input_nhw / 32) * 32
-    num_cores_nhw = find_closest_largest_divisor(
-        input_nhw_paddedto32 // 32, max_num_cores if is_height_sharded else device_grid_size[0]
-    )
-    if is_height_sharded:
-        num_cores_channels = 1
-    else:
-        num_cores_channels = device_grid_size[1]
-        # num_channels_tiles = num_channels // 16
-        num_channels_tiles = num_channels // 8
-        while (
-            (num_channels_tiles % num_cores_channels != 0)
-            or ((num_channels // num_cores_channels) % group_size != 0)
-            or (num_channels // num_cores_channels < 32)
-        ):
-            num_cores_channels -= 1
-            assert num_cores_channels > 0
-    input_nhw_padded_to_ncores = math.ceil(input_nhw / (num_cores_nhw * 32)) * (num_cores_nhw * 32)
-    gn_in_channels_per_core = num_channels // num_cores_channels
-    # assert gn_in_channels_per_core % 16 == 0
-    assert gn_in_channels_per_core % 8 == 0
-    gn_nhw_per_core = input_nhw_padded_to_ncores // num_cores_nhw
-    if is_height_sharded:
-        grid_size = [
-            device_grid_size[0] if num_cores_nhw >= device_grid_size[0] else num_cores_nhw,
-            math.ceil(num_cores_nhw / device_grid_size[0]),
-        ]  # for 1d systolic array, grid size is the tightest bound of num_cores_nhw as a rectangle (x,y)
-        assert (
-            num_cores_nhw <= grid_size[0] * grid_size[1]
-        ), "Error: For height sharding, num_cores_nhw must be <= grid size"
-    else:
-        grid_size = [num_cores_channels, num_cores_nhw] if is_row_major else [num_cores_nhw, num_cores_channels]
-    shard_shape = (
-        (1, 1, gn_nhw_per_core, gn_in_channels_per_core)
-        if is_row_major
-        else (1, 1, gn_in_channels_per_core, gn_nhw_per_core)
-    )
-    shard_strategy = ttnn.ShardStrategy.HEIGHT if is_height_sharded else ttnn.ShardStrategy.BLOCK
-    shard_orientation = (
-        ttnn.ShardOrientation.ROW_MAJOR if is_height_sharded or is_row_major else ttnn.ShardOrientation.COL_MAJOR
-    )
-    return ttnn.create_sharded_memory_config(
-        shard_shape,
-        ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
-        shard_strategy,
-        shard_orientation,
-        use_height_and_width_as_shard_shape=True,
-    ), ttnn.CoreGrid(y=grid_size[1], x=grid_size[0])
 
 
 def determine_expected_group_norm_dram_grid_size(*, device, num_channels, num_groups, input_nhw):


### PR DESCRIPTION
### Ticket
Link to Github Issue #40916

### Problem description
group_norm() requires a core grid even though it's optional. That is causing problems for upstream users.

### What's changed
- add ability to identify the core grid from within group_norm()
- AI insisted on creating a C++ version of determine_expected_group_norm_sharded_config_and_grid_size()
- therefore added the C++ version to nanobind and removed the python version
- modify some tests, at least one for sharded and one for dram, to test without a core grid being passed in (some tests fail if the grid is not passed in, probably the utility functions need more information and dealing with this will be done in future PRs)

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-40916_gn_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-40916_gn_grid)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-40916_gn_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-40916_gn_grid)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-40916_gn_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-40916_gn_grid)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-40916_gn_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-40916_gn_grid)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-40916_gn_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-40916_gn_grid)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-40916_gn_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-40916_gn_grid)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
