### PR TITLE
Fix per-core batch calculation in sharded untilize_with_unpadding

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -53,7 +53,11 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
     auto all_cores = shard_spec.grid;
     uint32_t ntiles_per_block = shard_spec.shape[1] / TILE_WIDTH;
     uint32_t nblocks_per_core = shard_spec.shape[0] / TILE_HEIGHT;
-    uint32_t batch = a.physical_volume() / (a.padded_shape()[-2] * a.padded_shape()[-1]);
+    uint32_t global_batch = a.physical_volume() / (a.padded_shape()[-2] * a.padded_shape()[-1]);
+    uint32_t batch =
+        a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED
+            ? std::max(1u, (shard_spec.shape[0] * shard_spec.shape[1]) / (a.padded_shape()[-2] * a.padded_shape()[-1]))
+            : global_batch;
     uint32_t ntiles_per_batch = ntiles_per_block * nblocks_per_core / batch;
 
     num_rows_block = out_shard_spec.shape[0];


### PR DESCRIPTION
## Summary
- Fixes device hang in `UntilizeWithUnpaddingDeviceOperation` on HEIGHT_SHARDED tensors with non-tile-aligned dimensions (#41504)
- Root cause: `batch` was computed from global tensor volume instead of per-core shard volume, causing `ntiles_per_batch` to truncate to 0 via integer division — CB semaphore mismatch between compute/writer kernels → deadlock
- Fix: compute per-core batch for HEIGHT_SHARDED by dividing shard volume by slice volume. WIDTH_SHARDED is unaffected (each core holds all rows, so global batch = per-core batch)

## Test plan
- [x] Reproduced hang on unmodified code (timeout after 30s)
- [x] Verified fix resolves the original reproducer from #41504
- [x] Verified both `ttnn.concat` path and direct `ttnn.untilize_with_unpadding` path work
- [x] All 80 existing `test_untilize_with_unpadding` unit tests pass (HEIGHT_SHARDED, WIDTH_SHARDED, BLOCK_SHARDED, ND_SHARDED, interleaved)
- [x] [(TM-DM) Data Movement Test Suite](https://github.com/tenstorrent/tt-metal/actions/runs/24050073661 )

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rpavlovic/fix-untilize-with-unpadding-sharded-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rpavlovic/fix-untilize-with-unpadding-sharded-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rpavlovic/fix-untilize-with-unpadding-sharded-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rpavlovic/fix-untilize-with-unpadding-sharded-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rpavlovic/fix-untilize-with-unpadding-sharded-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rpavlovic/fix-untilize-with-unpadding-sharded-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/fix-untilize-with-unpadding-sharded-deadlock) |