### PR TITLE
#0 Fix a few tests failing when watcher enabled

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
@@ -1814,6 +1814,7 @@ void kernel_main() {
         local_cb.pop_front(1);
     }
     remote_cb.commit();
+    noc_async_atomic_barrier();
 }
 """
 
@@ -1839,6 +1840,7 @@ void kernel_main() {
         remote_cb.pop_front(noc, 1);
     }
     remote_cb.commit();
+    noc_async_atomic_barrier();
 }
 """
 

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
@@ -35,7 +35,7 @@ import pytest
 import torch
 import ttnn
 
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, is_watcher_enabled
 from models.experimental.ops.descriptors.op_descriptor import OpDescriptor
 from models.experimental.ops.descriptors.fusion import clear_build_cache
 
@@ -2140,6 +2140,9 @@ def _barrier_bench_setup(device, num_phases, num_cores):
     return [_build_noop_op(core_ranges, dummy) for _ in range(num_phases)]
 
 
+@pytest.mark.skipif(
+    is_watcher_enabled(), reason="pytest-timeout plugin interacts with watcher on device reopen (noop kernels)"
+)
 @pytest.mark.parametrize("perf_mode", ["cold_start", "e2e", "device_fw"])
 @pytest.mark.parametrize("num_cores", [1, 8, 16, 64])
 @pytest.mark.parametrize("num_phases", [2, 3, 4, 5, 6])

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential_global_cb.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential_global_cb.py
@@ -117,6 +117,7 @@ void kernel_main() {
         local_cb.pop_front(1);
     }
     remote_cb.commit();
+    noc_async_atomic_barrier();
 }
 """
 


### PR DESCRIPTION
### Ticket
#0

### Problem description
There were a few tests failing on BH with watcher enabled:

`test_parallel_sequential_global_cb.py`
`test_fused_demo.py::test_global_circular_buffer_fused`
`test_fused_demo.py::test_barrier_overhead`

The first two were fixed by adding noc atomic barriers as watcher suggested. The third is now skipped when watcher is enabled, as it is some strange interaction between watcher and the pytest-timeout plugin (the test passes if you unload the plugin with `-p no:timeout`). The test is a demo does not test any critical behavior, so it's ok to skip it when watcher is on.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/global_cb_tests_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/global_cb_tests_par_seq)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/global_cb_tests_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/global_cb_tests_par_seq)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/global_cb_tests_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/global_cb_tests_par_seq)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/global_cb_tests_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/global_cb_tests_par_seq)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/global_cb_tests_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/global_cb_tests_par_seq)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/global_cb_tests_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/global_cb_tests_par_seq)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
