### PR TITLE
[QSR] Enabled eltwise_binary w/ dest_reuse

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -561,9 +561,6 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse) {
-    if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "DestReuse test support will be added with DestReuse bring-up";
-    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -579,14 +576,14 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse) {
-    if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "DestReuse test support will be added with DestReuse bring-up";
-    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -602,14 +599,14 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse) {
-    if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "DestReuse test support will be added with DestReuse bring-up";
-    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -625,6 +622,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -178,10 +178,14 @@ bool single_core_binary(
             .tile = test_config.tile,
         };
 
-        inp0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
-        inp1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
-        inp2_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
-        out_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_output_dfb_config);
+        inp0_dfb =
+            tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
+        inp1_dfb =
+            tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
+        inp2_dfb =
+            tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
+        out_dfb =
+            tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_output_dfb_config);
 
     } else {
         tt_metal::CircularBufferConfig l1_input0_cb_config =
@@ -241,7 +245,8 @@ bool single_core_binary(
             program_,
             "tt_metal/kernels/dataflow/writer_unary.cpp",
             test_config.core,
-            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = writer_cta});
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = writer_cta});
 
         compute_cta = {inp0_dfb, inp1_dfb, inp2_dfb, out_dfb};
         binary_kernel = tt_metal::experimental::quasar::CreateKernel(
@@ -311,7 +316,8 @@ bool single_core_binary(
     uint16_t srcb_fid_mask = 0xFFFF;
 
     // Quasar has 8x8 mantissa multipliers so fidelity has no effect on bfloat16 multiplications.
-    // Only set FID masks for non-Quasar to ensure we are testing the effect of reduced math fidelity on the binary compute results.
+    // Only set FID masks for non-Quasar to ensure we are testing the effect of reduced math fidelity on the binary
+    // compute results.
     // TODO: If the tests are extended to FP32, then the FID masks should also be applied for Quasar.
     if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
         set_math_fid_masks(srca_fid_mask, srcb_fid_mask, test_config.math_fidelity);
@@ -576,6 +582,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -599,6 +606,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -622,6 +630,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -66,7 +66,8 @@ inline void llk_math_eltwise_binary_init_with_operands(
  * @brief Perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
  * SrcA/SrcB contain 1 tile each, and output is 1 tile in the destination register.
  * Assumes default tile shape (32x32) or 4 faces.
- * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>. Unused tparam; only for API compatibiliy.
+ * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>. Unused tparam; only for API
+ * compatibiliy.
  * @tparam src_b_bcast_type: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
  * @tparam is_fp32_dest_acc_en: Unused tparam; only for API compatibiliy.
  * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
@@ -76,7 +77,7 @@ inline void llk_math_eltwise_binary_init_with_operands(
  * @param dst_index: Tile index into the destination register
  * If dest reg in float16 mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in full mode
  * If dest reg in float32 mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
- * @param clear_fp32_dst_acc: Unused param; only for API compatibiliy.
+ * @param clear_fp32_dst_acc: Determines if FP32 clear should be used before dest-reuse.
  */
 template <
     EltwiseBinaryType eltwise_binary_type,
@@ -84,12 +85,14 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_eltwise_binary(uint dst_index, [[maybe_unused]] const bool clear_fp32_dst_acc = true) {
+inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
     static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
-    // TODO: Once runtime asserts are added for Quasar, assert that clear_fp32_dst_acc is unused
+    const bool clear_in_fp32_mode = is_fp32_dest_acc_en && clear_fp32_dst_acc;
+
     WAYPOINT("MBIW");
-    _llk_math_eltwise_binary_<binary_reuse_dest>(dst_index);
+    _llk_math_eltwise_binary_<eltwise_binary_type, binary_reuse_dest>(
+        dst_index, ckernel::DEFAULT_TENSOR_SHAPE, clear_in_fp32_mode);
     WAYPOINT("MBID");
 }
 
@@ -97,7 +100,8 @@ inline void llk_math_eltwise_binary(uint dst_index, [[maybe_unused]] const bool 
  * @brief Perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
  * SrcA/SrcB contain 1 tile each, and output is 1 tile in the destination register.
  * Derives num_faces from operand_A to support non-default tile dimensions.
- * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>. Unused tparam; only for API compatibiliy.
+ * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>. Unused tparam; only for API
+ * compatibiliy.
  * @tparam src_b_bcast_type: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
  * @tparam is_fp32_dest_acc_en: Unused tparam; only for API compatibiliy.
  * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
@@ -109,7 +113,7 @@ inline void llk_math_eltwise_binary(uint dst_index, [[maybe_unused]] const bool 
  * @param dst_index: Tile index into the destination register
  * If dest reg in float16 mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in full mode
  * If dest reg in float32 mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
- * @param clear_fp32_dst_acc: Unused param; only for API compatibiliy.
+ * @param clear_fp32_dst_acc: Determines if FP32 clear should be used before dest-reuse.
  */
 template <
     EltwiseBinaryType eltwise_binary_type,
@@ -118,14 +122,18 @@ template <
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
-    const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, uint dst_index, [[maybe_unused]] const bool clear_fp32_dst_acc) {
+    const std::uint32_t operand_A,
+    [[maybe_unused]] const std::uint32_t operand_B,
+    uint dst_index,
+    const bool clear_fp32_dst_acc) {
     static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
-    // TODO: Once runtime asserts are added for Quasar, assert that clear_fp32_dst_acc is unused
     const std::uint32_t operand_id = get_operand_id(operand_A);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    const ckernel::TensorShape tensor_shape_A = get_operand_tensor_shape(operand_id);
+
+    const bool clear_in_fp32_mode = is_fp32_dest_acc_en && clear_fp32_dst_acc;
 
     WAYPOINT("MBIW");
-    _llk_math_eltwise_binary_<binary_reuse_dest>(dst_index, num_faces);
+    _llk_math_eltwise_binary_<eltwise_binary_type, binary_reuse_dest>(dst_index, tensor_shape_A, clear_in_fp32_mode);
     WAYPOINT("MBID");
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -26,11 +26,12 @@ inline void llk_unpack_AB_init(
     const std::uint32_t operandA, const std::uint32_t operandB, [[maybe_unused]] const std::uint32_t transpose = 0) {
     static_assert(BType == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
-    // TODO: Once runtime asserts are added for Quasar, assert that transpose is unused
+    // TODO (tt-metal #42916): Once runtime asserts are added for Quasar, assert that transpose is unused
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    // num_tiles set to 1 for back-compatibility with existing APIs, can be increased in the future for better performance.
+    // num_tiles set to 1 for back-compatibility with existing APIs, can be increased in the future for better
+    // performance.
     _llk_unpack_binary_operands_init_(operandA_id, operandB_id, 1);
 }
 
@@ -50,9 +51,8 @@ inline void llk_unpack_AB(
     const std::uint32_t tile_index_a,
     const std::uint32_t tile_index_b,
     [[maybe_unused]] const std::uint32_t bcast_row_idx = 0) {
-
     static_assert(BType == BroadcastType::NONE, "Broadcast types will be added in a future update");
-    // TODO: Once runtime asserts are added for Quasar, assert that bcast_row_idx is unused
+    // TODO (tt-metal #42916): Once runtime asserts are added for Quasar, assert that bcast_row_idx is unused
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -50,10 +50,15 @@ inline void llk_unpack_A_init(
     static_assert(acc_to_dest == false, "acc_to_dest is not yet supported on Quasar");
     static_assert(BType == BroadcastType::NONE, "Only BroadcastType::NONE is supported on Quasar right now");
 
-    // Once runtime asserts are added, add asserts for unsupported features above and for valid transpose_of_faces and within_face_16x16_transpose values
+    // TODO (tt-metal #42916): Once runtime asserts are added, add asserts for unsupported features above and for valid
+    // transpose_of_faces and within_face_16x16_transpose values
 
     // For Quasar, the unp_sel field is ignored if binary_reuse_dest != EltwiseBinaryReuseDestType::NONE
-    _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /* TRANSPOSE_EN */, false /* IS_32b_DEST_EN */, binary_reuse_dest>(operand_id);
+    _llk_unpack_unary_operand_init_<
+        p_unpacr::UNP_A,
+        false /* TRANSPOSE_EN */,
+        false /* IS_32b_DEST_EN */,
+        binary_reuse_dest>(operand_id);
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -41,8 +41,8 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A_init(
-    const std::uint32_t transpose_of_faces = 0,
-    const std::uint32_t within_face_16x16_transpose = 0,
+    [[maybe_unused]] const std::uint32_t transpose_of_faces = 0,
+    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
@@ -51,6 +51,8 @@ inline void llk_unpack_A_init(
     static_assert(BType == BroadcastType::NONE, "Only BroadcastType::NONE is supported on Quasar right now");
 
     // Once runtime asserts are added, add asserts for unsupported features above and for valid transpose_of_faces and within_face_16x16_transpose values
+    
+    // For Quasar, the unp_sel field is ignored if binary_reuse_dest != EltwiseBinaryReuseDestType::NONE
     _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /* TRANSPOSE_EN */, false /* IS_32b_DEST_EN */, binary_reuse_dest>(operand_id);
 }
 
@@ -94,6 +96,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     static_assert(BType == BroadcastType::NONE, "Only BroadcastType::NONE is supported on Quasar right now");
 
     WAYPOINT("UPAW");
+    // For Quasar, the unp_sel field is ignored if binary_reuse_dest != EltwiseBinaryReuseDestType::NONE
     _llk_unpack_unary_operand_<p_unpacr::UNP_A, binary_reuse_dest>(l1_tile_index);
     WAYPOINT("UPAD");
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -45,11 +45,11 @@ inline void llk_unpack_A_init(
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    
+
     static_assert(unpack_to_dest == false, "unpack_to_dest is not yet supported on Quasar");
     static_assert(acc_to_dest == false, "acc_to_dest is not yet supported on Quasar");
     static_assert(BType == BroadcastType::NONE, "Only BroadcastType::NONE is supported on Quasar right now");
-    
+
     // Once runtime asserts are added, add asserts for unsupported features above and for valid transpose_of_faces and within_face_16x16_transpose values
     _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /* TRANSPOSE_EN */, false /* IS_32b_DEST_EN */, binary_reuse_dest>(operand_id);
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -31,6 +31,31 @@ inline void llk_unpack_A_init(const std::uint32_t operand) {
 
 /**
  *
+ * @brief Initialize unpacker0 with dest reuse support
+ *
+ * Overload matching Blackhole/Wormhole API signature to support binary dest reuse operations.
+ */
+template <
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_unpack_A_init(
+    const std::uint32_t transpose_of_faces = 0,
+    const std::uint32_t within_face_16x16_transpose = 0,
+    const std::uint32_t operand = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    
+    static_assert(unpack_to_dest == false, "unpack_to_dest is not yet supported on Quasar");
+    static_assert(acc_to_dest == false, "acc_to_dest is not yet supported on Quasar");
+    static_assert(BType == BroadcastType::NONE, "Only BroadcastType::NONE is supported on Quasar right now");
+    
+    // Once runtime asserts are added, add asserts for unsupported features above and for valid transpose_of_faces and within_face_16x16_transpose values
+    _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /* TRANSPOSE_EN */, false /* IS_32b_DEST_EN */, binary_reuse_dest>(operand_id);
+}
+
+/**
+ *
  * @brief Unpacks a single operand, unpacker0 is used
  *
  * @param operand: The logical dataflow buffer id
@@ -46,6 +71,30 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
 
     WAYPOINT("UPAW");
     _llk_unpack_unary_operand_<p_unpacr::UNP_A>(l1_tile_index);
+    WAYPOINT("UPAD");
+}
+
+/**
+ *
+ * @brief Unpacks a single operand with dest reuse support
+ *
+ * Overload matching Blackhole/Wormhole API signature to support binary dest reuse operations.
+ */
+template <
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t l1_tile_index = g_dfb_interface[operand_id].rd_entry_idx + tile_index;
+
+    static_assert(unpack_to_dest == false, "unpack_to_dest is not yet supported on Quasar");
+    static_assert(acc_to_dest == false, "acc_to_dest is not yet supported on Quasar");
+    static_assert(BType == BroadcastType::NONE, "Only BroadcastType::NONE is supported on Quasar right now");
+
+    WAYPOINT("UPAW");
+    _llk_unpack_unary_operand_<p_unpacr::UNP_A, binary_reuse_dest>(l1_tile_index);
     WAYPOINT("UPAD");
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -51,7 +51,7 @@ inline void llk_unpack_A_init(
     static_assert(BType == BroadcastType::NONE, "Only BroadcastType::NONE is supported on Quasar right now");
 
     // Once runtime asserts are added, add asserts for unsupported features above and for valid transpose_of_faces and within_face_16x16_transpose values
-    
+
     // For Quasar, the unp_sel field is ignored if binary_reuse_dest != EltwiseBinaryReuseDestType::NONE
     _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /* TRANSPOSE_EN */, false /* IS_32b_DEST_EN */, binary_reuse_dest>(operand_id);
 }
@@ -89,7 +89,8 @@ template <
     bool unpack_to_dest = false>
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t l1_tile_index = g_dfb_interface[operand_id].rd_entry_idx + tile_index;
+    const std::uint32_t l1_tile_index =
+        g_dfb_interface[operand_id].tc_slots[g_dfb_interface[operand_id].tc_idx].rd_entry_idx + tile_index;
 
     static_assert(unpack_to_dest == false, "unpack_to_dest is not yet supported on Quasar");
     static_assert(acc_to_dest == false, "acc_to_dest is not yet supported on Quasar");

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -238,7 +238,12 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 ALWI void binary_dest_reuse_tiles_init(uint32_t icb0, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, call_line);
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, binary_reuse_dest>(false, false, icb0)));
+    #ifndef ARCH_QUASAR
+        constexpr bool acc_to_dest = true;
+    #else
+        constexpr bool acc_to_dest = false;
+    #endif
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, acc_to_dest, binary_reuse_dest>(false, false, icb0)));
     if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL) {
         MATH((llk_math_eltwise_binary_init<eltwise_binary_type, BroadcastType::NONE, MATH_FIDELITY, binary_reuse_dest>(false)));
     } else {
@@ -274,8 +279,12 @@ template <
     EltwiseBinaryType eltwise_binary_type = EltwiseBinaryType::ELWADD,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 ALWI void binary_dest_reuse_tiles(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index) {
-#ifndef ARCH_QUASAR
-    UNPACK((llk_unpack_A<BroadcastType::NONE, true, binary_reuse_dest>(in_cb_id, in_tile_index)));
+    #ifndef ARCH_QUASAR
+        constexpr bool acc_to_dest = true;
+    #else
+        constexpr bool acc_to_dest = false;
+    #endif
+    UNPACK((llk_unpack_A<BroadcastType::NONE, acc_to_dest, binary_reuse_dest>(in_cb_id, in_tile_index)));
     if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL) {
         MATH((llk_math_eltwise_binary<eltwise_binary_type, BroadcastType::NONE, DST_ACCUM_MODE, MATH_FIDELITY, binary_reuse_dest>(
             in_cb_id, in_cb_id, dst_tile_index, true)));
@@ -283,7 +292,6 @@ ALWI void binary_dest_reuse_tiles(uint32_t in_cb_id, uint32_t in_tile_index, uin
         MATH((llk_math_eltwise_binary<eltwise_binary_type, BroadcastType::NONE, DST_ACCUM_MODE, MathFidelity::LoFi, binary_reuse_dest>(
             in_cb_id, in_cb_id, dst_tile_index, true)));
     }
-#endif  // TODO (GS): Add Quasar dest reuse implementation
 }
 
 }  // namespace ckernel

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -77,7 +77,12 @@ TILE_DIMENSIONS = [32, 32]
         EltwiseBinaryReuseDestType.DEST_TO_SRCA,
         EltwiseBinaryReuseDestType.DEST_TO_SRCB,
     ],
-    math_fidelity=[MathFidelity.LoFi],
+    math_fidelity=[
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ],
     dest_sync_mode=[DestSync.Half, DestSync.Full],
     input_dimensions=INPUT_DIMENSIONS,
     output_dimensions=OUTPUT_DIMENSIONS,
@@ -92,8 +97,8 @@ def test_eltwise_binary_reuse_dest_quasar(
     output_dimensions,
     boot_mode=BootMode.DEFAULT,
 ):
-    if math_fidelity != MathFidelity.LoFi:
-        pytest.skip("Quasar reuse_dest eltwise binary supports LoFi only")
+    if mathop != MathOperation.Elwmul and math_fidelity != MathFidelity.LoFi:
+        pytest.skip("elwadd/elwsub only supports LoFi mode")
 
     if mathop == MathOperation.Elwmul and formats.input_format.is_mx_format():
         pytest.skip(
@@ -234,9 +239,9 @@ def test_eltwise_binary_reuse_dest_quasar(
                         .to(srcA_m.dtype)
                         .to(internal_dtype)
                     )
-                    dest = dest + product
+                    dest = product
                 else:
-                    dest = dest + srcA * srcB
+                    dest = srcA * srcB
 
         if formats.output_format.is_mx_format():
             dest = quantize_mx_tensor_chunked(dest, formats.output_format)

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -126,7 +126,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             for (int tile = 0; tile < tiles_in_block; tile++)
             {
                 const int global_tile_idx = block * tiles_in_block + tile;
-                _llk_math_eltwise_binary_<REUSE_DEST_TYPE>(global_tile_idx, params.num_faces);
+                _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(
+                    global_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE, is_fp32_dest_acc_en /*clear_fp32_mode*/);
             }
         }
         _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -111,7 +111,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         const std::uint32_t num_tiles_in_block = std::min(remaining_tiles, params.NUM_TILES_IN_BLOCK);
         for (std::uint32_t tile = 0; tile < num_tiles_in_block; ++tile)
         {
-            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(dest_idx, ckernel::DEFAULT_TENSOR_SHAPE);
+            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP>(dest_idx, ckernel::DEFAULT_TENSOR_SHAPE);
         }
         ++dest_idx;
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -111,7 +111,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         const std::uint32_t num_tiles_in_block = std::min(remaining_tiles, params.NUM_TILES_IN_BLOCK);
         for (std::uint32_t tile = 0; tile < num_tiles_in_block; ++tile)
         {
-            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(dest_idx);
+            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(dest_idx, ckernel::DEFAULT_TENSOR_SHAPE);
         }
         ++dest_idx;
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -111,7 +111,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         const std::uint32_t num_tiles_in_block = std::min(remaining_tiles, params.NUM_TILES_IN_BLOCK);
         for (std::uint32_t tile = 0; tile < num_tiles_in_block; ++tile)
         {
-            _llk_math_eltwise_binary_(dest_idx);
+            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(dest_idx);
         }
         ++dest_idx;
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
@@ -77,41 +77,27 @@ inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& ten
     // For reuse_dest + Elwmul we need dest accumulation (dest = old_dest + srcA*srcB) ; LoFi alone sets EN_DST_ACC=0.
     const std::uint32_t EN_DST_ACC =
         acc_to_dest ? 1u
-                    : ((reuse_dest != EltwiseBinaryReuseDestType::NONE && ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWMUL) ? 1u : (high_fidelity ? 1u : 0u));
+                    : (high_fidelity ? 1u : 0u);
 
     constexpr std::uint8_t addrmod_fid    = high_fidelity ? ADDR_MOD_2 : ADDR_MOD_0;
     const std::uint32_t eltwise_binary_op = eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, p_elwise::SRCB_NO_BCAST, addrmod_fid>(EN_DST_ACC);
 
-    if constexpr (reuse_dest != EltwiseBinaryReuseDestType::NONE)
+    const std::uint32_t MOP_OUTER_LOOP     = (rows_per_mop_run >> math_rows_log2(ELTWISE_MATH_ROWS));
+    constexpr std::uint32_t MOP_INNER_LOOP = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
+
+    const std::uint32_t eltwise_binary_op_clr_valid =
+        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_setrwc::CLR_AB, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1>(EN_DST_ACC);
+    ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, eltwise_binary_op);
+    temp.set_last_outer_loop_instr(eltwise_binary_op_clr_valid);
+
+    if (high_fidelity)
     {
-        // For reuse_dest: all iterations use the same instruction (ADDR_MOD_0, no CLR).
-        // CLR_AB is handled by end_op after the MOP completes
-        // This avoids the last-iteration instruction replacement changing the addr_mod
-        // for the second inner iteration, which would corrupt the source counter state.
-        const std::uint32_t MOP_INNER_LOOP = (rows_per_mop_run >> math_rows_log2(ELTWISE_MATH_ROWS));
-        ckernel_template temp(1, MOP_INNER_LOOP, eltwise_binary_op);
-        temp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, p_setrwc::SET_AB_F));
-        temp.program_bank0_sw_cntl(instrn_buffer);
+        const std::uint32_t eltwise_binary_op_clr_fidelity =
+            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, p_elwise::SRCB_NO_BCAST, ADDR_MOD_0>(EN_DST_ACC);
+        temp.set_last_inner_loop_instr(eltwise_binary_op_clr_fidelity); // clear math fidelity
     }
-    else
-    {
-        const std::uint32_t MOP_OUTER_LOOP     = (rows_per_mop_run >> math_rows_log2(ELTWISE_MATH_ROWS));
-        constexpr std::uint32_t MOP_INNER_LOOP = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
 
-        const std::uint32_t eltwise_binary_op_clr_valid =
-            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_setrwc::CLR_AB, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1>(EN_DST_ACC);
-        ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, eltwise_binary_op);
-        temp.set_last_outer_loop_instr(eltwise_binary_op_clr_valid);
-
-        if (high_fidelity)
-        {
-            const std::uint32_t eltwise_binary_op_clr_fidelity =
-                eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, p_elwise::SRCB_NO_BCAST, ADDR_MOD_0>(EN_DST_ACC);
-            temp.set_last_inner_loop_instr(eltwise_binary_op_clr_fidelity); // clear math fidelity
-        }
-
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
+    temp.program_bank0_sw_cntl(instrn_buffer);
 }
 
 //----------------------
@@ -271,16 +257,22 @@ inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape& tensor_sh
  * If dest reg in float16 mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in full mode
  * If dest reg in float32 mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
  */
-template <EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_(const std::uint32_t tile_idx, const std::uint32_t num_faces = NUM_FACES)
+template <EltwiseBinaryType ELTWISE_BINARY_TYPE, EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void _llk_math_eltwise_binary_(const std::uint32_t tile_idx, const ckernel::TensorShape& tensor_shape, const bool clear_in_fp32_mode = false)
 {
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
 
     if constexpr (reuse_dest != EltwiseBinaryReuseDestType::NONE)
     {
-        for (std::uint32_t face_num = 0; face_num < num_faces; face_num++)
+        [[maybe_unused]] auto tile_start = tile_idx * tensor_shape.total_num_faces();
+        for (std::uint32_t face_num = 0; face_num < tensor_shape.total_num_faces(); face_num++)
         {
             eltwise_binary_reuse_dest_as_src<reuse_dest>();
+            if constexpr (ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWMUL)
+            {
+                // ELWMUL always accumulates. Clear dest face-by-face when reusing dest as srcA/B
+                TT_ZEROACC(p_zeroacc::CLR_16, clear_in_fp32_mode, 0, ADDR_MOD_3, tile_start + face_num);
+            }
             ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
         }
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
@@ -75,9 +75,7 @@ inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& ten
     constexpr bool high_fidelity = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
     static_assert(!(high_fidelity && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
     // For reuse_dest + Elwmul we need dest accumulation (dest = old_dest + srcA*srcB) ; LoFi alone sets EN_DST_ACC=0.
-    const std::uint32_t EN_DST_ACC =
-        acc_to_dest ? 1u
-                    : (high_fidelity ? 1u : 0u);
+    const std::uint32_t EN_DST_ACC = acc_to_dest ? 1u : (high_fidelity ? 1u : 0u);
 
     constexpr std::uint8_t addrmod_fid    = high_fidelity ? ADDR_MOD_2 : ADDR_MOD_0;
     const std::uint32_t eltwise_binary_op = eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, p_elwise::SRCB_NO_BCAST, addrmod_fid>(EN_DST_ACC);
@@ -270,7 +268,7 @@ inline void _llk_math_eltwise_binary_(const std::uint32_t tile_idx, const ckerne
             eltwise_binary_reuse_dest_as_src<reuse_dest>();
             if constexpr (ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWMUL)
             {
-                // ELWMUL always accumulates. Clear dest face-by-face when reusing dest as srcA/B
+                // ELWMUL needs HiFi (therefore dest_acc). Clear dest face-by-face when reusing dest as srcA/B
                 TT_ZEROACC(p_zeroacc::CLR_16, clear_in_fp32_mode, 0, ADDR_MOD_3, tile_start + face_num);
             }
             ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39753

### Problem description
Need to propagate LLK implementations for Eltwise Binary + Dest Reuse for Quasar to metal.


### What's changed
Propagated LLK implementations for Eltwise Binary for Quasar to metal

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gdsingh/qsr-eltwise-dest-reuse)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gdsingh/qsr-eltwise-dest-reuse)