### PR TITLE
[Refactor] Minor refactoring to kernel.cpp

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -676,6 +676,7 @@ void Kernel::set_binaries(uint64_t build_key, std::vector<const ll_api::memory*>
 void DataMovementKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<const ll_api::memory*> binaries;
+    auto paths = this->file_paths(*device);
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indices
     // TODO(pgk): consolidate read_binaries where possible
@@ -683,12 +684,9 @@ void DataMovementKernel::read_binaries(IDevice* device) {
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->config_.processor);
-    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
     auto load_type =
         MetalContext::instance().hal().get_jit_build_config(tensix_core_type, dm_class_idx, riscv_id).memory_load;
-    const ll_api::memory& binary_mem =
-        llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
+    const ll_api::memory& binary_mem = llrt::get_risc_binary(paths[0], load_type);
     binaries.push_back(&binary_mem);
     [[maybe_unused]] uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC={}, name={}, size={} (bytes)", riscv_id, this->name(), binary_size);
@@ -700,17 +698,16 @@ void EthernetKernel::read_binaries(IDevice* device) {
     // untested
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<const ll_api::memory*> binaries;
+    auto paths = this->file_paths(*device);
     uint32_t erisc_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     constexpr auto k_EthDmClassIndex = enchantum::to_underlying(HalProcessorClassType::DM);
     int erisc_id = enchantum::to_underlying(this->config_.processor);
-    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device->build_id(), erisc_core_type, k_EthDmClassIndex, erisc_id);
     // TODO: fix when active eth supports relo
     auto load_type =
         MetalContext::instance().hal().get_jit_build_config(erisc_core_type, k_EthDmClassIndex, erisc_id).memory_load;
-    const ll_api::memory& binary_mem = llrt::get_risc_binary(
-        build_state.get_target_out_path(this->kernel_full_name_), load_type, [this](ll_api::memory& binary_mem) {
+    const ll_api::memory& binary_mem =
+        llrt::get_risc_binary(paths[0], load_type, [this](ll_api::memory& binary_mem) {
             if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
                 this->config_.eth_mode != Eth::IDLE) {
                 // text_addr and some of span's addr point to IRAM base address.
@@ -734,18 +731,16 @@ void EthernetKernel::read_binaries(IDevice* device) {
 void ComputeKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<const ll_api::memory*> binaries;
+    auto paths = this->file_paths(*device);
     uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
-        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, compute_class_idx, trisc_id);
         auto load_type = MetalContext::instance()
                              .hal()
                              .get_jit_build_config(tensix_core_type, compute_class_idx, trisc_id)
                              .memory_load;
-        const ll_api::memory& binary_mem =
-            llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
+        const ll_api::memory& binary_mem = llrt::get_risc_binary(paths[trisc_id], load_type);
         binaries.push_back(&binary_mem);
     }
     this->set_binaries(
@@ -878,31 +873,26 @@ void QuasarDataMovementKernel::generate_binaries(IDevice* device, JitBuildOption
 void QuasarDataMovementKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<const ll_api::memory*> binaries;
+    auto paths = this->file_paths(*device);
     const uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     if (config_.is_legacy_kernel) {
-        for (const DataMovementProcessor& processor : this->dm_processors_) {
+        for (int i = 0; i < this->dm_processors_.size(); ++i) {
+            const DataMovementProcessor& processor = this->dm_processors_[i];
             const int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(processor);
-            const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-                device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
             auto load_type =
                 MetalContext::instance().hal().get_jit_build_config(tensix_core_type, dm_class_idx, riscv_id)
                     .memory_load;
-            const ll_api::memory& binary_mem =
-                llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
+            const ll_api::memory& binary_mem = llrt::get_risc_binary(paths[i], load_type);
             binaries.push_back(&binary_mem);
         }
     } else {
-        const int canonical_id =
-            static_cast<std::underlying_type_t<DataMovementProcessor>>(this->dm_processors_[0]);
-        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, dm_class_idx, canonical_id);
+        const int canonical_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->dm_processors_[0]);
         auto load_type =
             MetalContext::instance().hal().get_jit_build_config(tensix_core_type, dm_class_idx, canonical_id)
                 .memory_load;
-        const ll_api::memory& binary_mem =
-            llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
+        const ll_api::memory& binary_mem = llrt::get_risc_binary(paths[0], load_type);
         binaries.push_back(&binary_mem);
     }
     this->set_binaries(
@@ -980,19 +970,18 @@ void QuasarComputeKernel::generate_binaries(IDevice* device, JitBuildOptions&) c
 void QuasarComputeKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<const ll_api::memory*> binaries;
+    auto paths = this->file_paths(*device);
     const uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
-    for (const QuasarComputeProcessor& processor : this->compute_processors_) {
+    for (int i = 0; i < this->compute_processors_.size(); ++i) {
+        const QuasarComputeProcessor& processor = this->compute_processors_[i];
         const int trisc_id = static_cast<std::underlying_type_t<QuasarComputeProcessor>>(processor);
-        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, compute_class_idx, trisc_id);
         auto load_type = MetalContext::instance()
                              .hal()
                              .get_jit_build_config(tensix_core_type, compute_class_idx, trisc_id)
                              .memory_load;
-        const ll_api::memory& binary_mem =
-            llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
+        const ll_api::memory& binary_mem = llrt::get_risc_binary(paths[i], load_type);
         binaries.push_back(&binary_mem);
     }
     this->set_binaries(

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -878,7 +878,7 @@ void QuasarDataMovementKernel::read_binaries(IDevice* device) {
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     if (config_.is_legacy_kernel) {
-        for (int i = 0; i < this->dm_processors_.size(); ++i) {
+        for (std::size_t i = 0; i < this->dm_processors_.size(); ++i) {
             const DataMovementProcessor& processor = this->dm_processors_[i];
             const int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(processor);
             auto load_type =
@@ -974,7 +974,7 @@ void QuasarComputeKernel::read_binaries(IDevice* device) {
     const uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
-    for (int i = 0; i < this->compute_processors_.size(); ++i) {
+    for (std::size_t i = 0; i < this->compute_processors_.size(); ++i) {
         const QuasarComputeProcessor& processor = this->compute_processors_[i];
         const int trisc_id = static_cast<std::underlying_type_t<QuasarComputeProcessor>>(processor);
         auto load_type = MetalContext::instance()

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -5,10 +5,7 @@
 #pragma once
 
 #include <umd/device/types/core_coordinates.hpp>
-#include <fstream>
-#include <sstream>
 #include <string>
-#include <tt_stl/unreachable.hpp>
 
 #include "api/tt-metalium/kernel_types.hpp"
 #include "api/tt-metalium/runtime_args_data.hpp"
@@ -20,6 +17,7 @@
 #include "jit_build/jit_build_settings.hpp"
 #include "jit_build/jit_build_options.hpp"
 #include "impl/program/program_impl.hpp"
+#include "impl/kernels/kernel_source.hpp"
 #include <enchantum/enchantum.hpp>
 #include "tt_cluster.hpp"
 
@@ -64,49 +62,6 @@ KernelHandle CreateKernelFromString(
     const std::string& kernel_src_code,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const EthernetConfig& config);
-
-struct KernelSource {
-    enum SourceType { FILE_PATH, SOURCE_CODE };
-
-    std::string source_;
-    SourceType source_type_;
-    // if source_type_ is FILE_PATH, file pointed by path_ exists at time of construction
-    std::filesystem::path path_;
-
-    KernelSource(const std::string& source, const SourceType& source_type);
-
-    std::string name() const {
-        std::string name;
-        if (this->source_type_ == SourceType::FILE_PATH) {
-            const std::size_t start_pos_of_name = this->source_.rfind('/') + 1;
-            const std::size_t pos_of_dot = this->source_.rfind('.');
-            name = this->source_.substr(start_pos_of_name, (pos_of_dot - start_pos_of_name));
-        } else {
-            name = "Kernel_Source_Code";
-        }
-        return name;
-    }
-
-    // Returns the actual source code (file content or source string)
-    std::string get_content() const {
-        switch (source_type_) {
-            case SourceType::FILE_PATH: {
-                std::ifstream file(path_);
-                if (!file.is_open()) {
-                    throw std::runtime_error("Cannot open kernel source file: " + path_.string());
-                }
-                std::stringstream buffer;
-                buffer << file.rdbuf();
-                if (file.fail() && !file.eof()) {
-                    throw std::runtime_error("Failed to read kernel source file: " + path_.string());
-                }
-                return buffer.str();
-            }
-            case SourceType::SOURCE_CODE: return source_;
-        }
-        ttsl::unreachable();
-    }
-};
 
 class Kernel : public JitBuildSettings {
 public:

--- a/tt_metal/impl/kernels/kernel_source.hpp
+++ b/tt_metal/impl/kernels/kernel_source.hpp
@@ -24,15 +24,10 @@ struct KernelSource {
     KernelSource(const std::string& source, const SourceType& source_type);
 
     std::string name() const {
-        std::string name;
         if (this->source_type_ == SourceType::FILE_PATH) {
-            const std::size_t start_pos_of_name = this->source_.rfind('/') + 1;
-            const std::size_t pos_of_dot = this->source_.rfind('.');
-            name = this->source_.substr(start_pos_of_name, (pos_of_dot - start_pos_of_name));
-        } else {
-            name = "Kernel_Source_Code";
+            return this->path_.stem().string();
         }
-        return name;
+        return "Kernel_Source_Code";
     }
 
     // Returns the actual source code (file content or source string)

--- a/tt_metal/impl/kernels/kernel_source.hpp
+++ b/tt_metal/impl/kernels/kernel_source.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/kernels/kernel_source.hpp
+++ b/tt_metal/impl/kernels/kernel_source.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <tt_stl/unreachable.hpp>
+
+namespace tt::tt_metal {
+
+struct KernelSource {
+    enum SourceType { FILE_PATH, SOURCE_CODE };
+
+    std::string source_;
+    SourceType source_type_;
+    // if source_type_ is FILE_PATH, file pointed by path_ exists at time of construction
+    std::filesystem::path path_;
+
+    KernelSource(const std::string& source, const SourceType& source_type);
+
+    std::string name() const {
+        std::string name;
+        if (this->source_type_ == SourceType::FILE_PATH) {
+            const std::size_t start_pos_of_name = this->source_.rfind('/') + 1;
+            const std::size_t pos_of_dot = this->source_.rfind('.');
+            name = this->source_.substr(start_pos_of_name, (pos_of_dot - start_pos_of_name));
+        } else {
+            name = "Kernel_Source_Code";
+        }
+        return name;
+    }
+
+    // Returns the actual source code (file content or source string)
+    std::string get_content() const {
+        switch (source_type_) {
+            case SourceType::FILE_PATH: {
+                std::ifstream file(path_);
+                if (!file.is_open()) {
+                    throw std::runtime_error("Cannot open kernel source file: " + path_.string());
+                }
+                std::stringstream buffer;
+                buffer << file.rdbuf();
+                if (file.fail() && !file.eof()) {
+                    throw std::runtime_error("Failed to read kernel source file: " + path_.string());
+                }
+                return buffer.str();
+            }
+            case SourceType::SOURCE_CODE: return source_;
+        }
+        ttsl::unreachable();
+    }
+};
+
+}  // namespace tt::tt_metal


### PR DESCRIPTION


### Ticket
https://github.com/tenstorrent/tt-metal/issues/41527

### Problem description
These changes turned out to be helpful when implementing the compile server. Extracting them into a refactor PR.


### What's changed

- Split KernelSource to a separate header
- Make use of file_paths when reading binaries

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/kernel-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/kernel-refactor)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/kernel-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/kernel-refactor)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/kernel-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/kernel-refactor)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/kernel-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/kernel-refactor)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/kernel-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/kernel-refactor)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/kernel-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/kernel-refactor)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
