### PR TITLE
Reverting commit 389a3674096be72e0c35b56dc066f48c3795e432

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_readers>();
     uint32_t barrier_count = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -19,10 +19,11 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
-    constexpr uint32_t num_trids = get_compile_time_arg_val(2);
-    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr uint32_t stick_size = get_compile_time_arg_val(2);
+    constexpr uint32_t num_trids = get_compile_time_arg_val(3);
+    constexpr auto src_args = TensorAccessorArgs<4>();
 
-    const auto s0 = TensorAccessor(src_args, src_addr + aligned_input_width_offset_bytes);
+    const auto s0 = TensorAccessor(src_args, src_addr + aligned_input_width_offset_bytes, stick_size);
     uint32_t stick_id = start_id;
     cb_reserve_back(cb_id_in0, block_height);
     uint32_t dest_write_addr = get_write_ptr(cb_id_in0);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_interleaved_start_id.cpp
@@ -22,7 +22,7 @@ void kernel_main() {
     // single-tile ublocks
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
 
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     const uint32_t padded_width_diff = (block_width_tiles - unpadded_block_width_tiles) * tile_bytes;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -14,9 +14,10 @@ void kernel_main() {
     const uint32_t start_id = get_arg_val<uint32_t>(6);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    constexpr uint32_t stick_size = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
 
-    const auto s0 = TensorAccessor(dst_args, dst_addr + input_width_offset_bytes);
+    const auto s0 = TensorAccessor(dst_args, dst_addr + input_width_offset_bytes, stick_size);
 
     uint32_t stick_id = start_id;
     cb_wait_front(cb_id_out0, block_height);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -61,10 +61,12 @@ InterleavedToShardedDeviceOperation::spec_return_value_t InterleavedToShardedDev
     const auto& input_tensor = tensor_args.input_tensor;
     return TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout(
+        tt::tt_metal::TensorLayout::fromPaddedShape(
             operation_attributes.output_dtype,
             tt::tt_metal::PageConfig(input_tensor.layout()),
-            operation_attributes.output_mem_config));
+            operation_attributes.output_mem_config,
+            input_tensor.logical_shape(),
+            input_tensor.padded_shape()));
 }
 
 InterleavedToShardedDeviceOperation::tensor_return_value_t InterleavedToShardedDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -74,7 +74,7 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
         num_units_per_row = input.padded_shape()[-1] / TILE_WIDTH;
         num_units_offset = num_units_per_row;
-        uint32_t num_units_height = (input.physical_volume() / input.padded_shape()[-1])/ TILE_HEIGHT;
+        uint32_t num_units_height = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT / num_slices;
         num_units_per_shard_height_last =
             num_units_per_shard_height -
             (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
@@ -88,9 +88,9 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.logical_shape()[-1] * input.element_size();
+        num_units_per_row = input.padded_shape()[-1] * input.element_size();
         num_units_offset = 1;
-        uint32_t num_units_height = input.logical_volume() / input.logical_shape()[-1];
+        uint32_t num_units_height = input.physical_volume() / input.padded_shape()[-1];
         num_units_per_shard_height_last =
             num_units_per_shard_height -
             (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
@@ -156,7 +156,7 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
             all_cores,
             tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
     } else {
-        std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_trids};
+        std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_units_per_row, num_trids};
         tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
         unary_reader_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp
@@ -35,8 +35,8 @@ void kernel_main() {
 
     const uint32_t first_shard_id = get_arg_val<uint32_t>(0);
 
-    auto accessor_src = TensorAccessor(args_src, bank_base_address_src);
-    auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst);
+    auto accessor_src = TensorAccessor(args_src, bank_base_address_src, src_page_size);
+    auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst, dst_page_size);
 
     for (uint32_t shard_id = first_shard_id; shard_id < num_shards; shard_id += shard_id_stride) {
         if constexpr (is_reader) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
@@ -19,7 +19,7 @@ void kernel_main() {
     const uint32_t start_page = get_arg_val<uint32_t>(0);
     const uint32_t end_page = get_arg_val<uint32_t>(1);
 
-    auto accessor_src = TensorAccessor(args_src, bank_base_address_src);
+    auto accessor_src = TensorAccessor(args_src, bank_base_address_src, page_size);
 
     constexpr uint32_t one_tile = 1;
     uint32_t cb_addr = get_write_ptr(cb_id);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
@@ -19,7 +19,7 @@ void kernel_main() {
     const uint32_t start_page = get_arg_val<uint32_t>(0);
     const uint32_t end_page = get_arg_val<uint32_t>(1);
 
-    auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst);
+    auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst, page_size);
 
     constexpr uint32_t one_tile = 1;
     uint32_t cb_addr = get_write_ptr(cb_id);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
@@ -178,10 +178,14 @@ TensorSpec ReshardDeviceOperation::compute_output_specs(
     }
 
     const auto& input_tensor = tensor_args.input;
-    return tt::tt_metal::TensorSpec(
+    return TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout(
-            input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), args.output_mem_config));
+        TensorLayout::fromPaddedShape(
+            input_tensor.dtype(),
+            PageConfig(input_tensor.layout()),
+            args.output_mem_config,
+            input_tensor.logical_shape(),
+            input_tensor.padded_shape()));
 }
 
 Tensor ReshardDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -57,10 +57,14 @@ TensorSpec ShardedToInterleavedDeviceOperation::compute_output_specs(
     }
 
     const auto& input_tensor = tensor_args.input_tensor;
-    return tt::tt_metal::TensorSpec(
+    return TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout(
-            args.output_dtype, tt::tt_metal::PageConfig(input_tensor.layout()), args.output_mem_config));
+        TensorLayout::fromPaddedShape(
+            args.output_dtype,
+            PageConfig(input_tensor.layout()),
+            args.output_mem_config,
+            input_tensor.logical_shape(),
+            input_tensor.padded_shape()));
 }
 
 Tensor ShardedToInterleavedDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -52,9 +52,9 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
         num_units_per_shard_height = shard_spec.shape[0] / TILE_HEIGHT;
         num_units_per_shard_width = shard_spec.shape[1] / TILE_WIDTH;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.padded_shape()[-1] / TILE_WIDTH;
+        num_units_per_row = output.padded_shape()[-1] / TILE_WIDTH;
         num_units_offset = num_units_per_row;
-        num_units_height = (input.physical_volume() / input.padded_shape()[-1])/ TILE_HEIGHT;
+        num_units_height = output.physical_volume() / output.padded_shape()[-1] / TILE_HEIGHT / num_slices;
         num_units_per_shard_height_last =
             num_units_per_shard_height - (round_up(num_units_height, num_units_per_shard_height) - num_units_height);
         num_units_per_shard_width_last =
@@ -65,9 +65,9 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.logical_shape()[-1] * input.element_size();
+        num_units_per_row = output.padded_shape()[-1] * output.element_size();
         num_units_offset = 1;
-        num_units_height = input.logical_volume() / input.logical_shape()[-1];
+        num_units_height = input.physical_volume() / input.padded_shape()[-1];
         num_units_per_shard_height_last =
             num_units_per_shard_height - (round_up(num_units_height, num_units_per_shard_height) - num_units_height);
         num_units_per_shard_width_last =
@@ -136,7 +136,7 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
             used_cores,
             tt_metal::WriterDataMovementConfig(writer_compile_time_args));
     } else {
-        std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
+        std::vector<uint32_t> writer_compile_time_args = {out_cb_index, num_units_per_row};
         TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
         unary_writer_kernel_id = tt_metal::CreateKernel(
@@ -251,7 +251,7 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
                  num_units_per_row,
                  shard_height,
                  shard_width,
-                 padded_shard_width,
+                 (is_blackhole) ? shard_width : padded_shard_width,
                  curr_idx_w,
                  curr_idx_h});
             curr_idx_w += output_unit_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -149,7 +149,8 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
             all_cores,
             tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
     } else {
-        std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_trids};
+        std::vector<uint32_t> reader_compile_time_args = {
+            input_cb_index, scratch_cb_index, num_units_per_row, num_trids};
         tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
         unary_reader_kernel_id = tt::tt_metal::CreateKernel(


### PR DESCRIPTION
### Ticket
N/A
### Problem description
Revert as a precautionary measure due to the revert [41540](https://github.com/tenstorrent/tt-metal/pull/41540)
### What's changed
Revert as a precautionary measure due to the revert [41540](https://github.com/tenstorrent/tt-metal/pull/41540)


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/Revert_sharded_fromPaddedShape_deletion)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/Revert_sharded_fromPaddedShape_deletion)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/Revert_sharded_fromPaddedShape_deletion)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/Revert_sharded_fromPaddedShape_deletion)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/Revert_sharded_fromPaddedShape_deletion)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/Revert_sharded_fromPaddedShape_deletion)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/Revert_sharded_fromPaddedShape_deletion)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/Revert_sharded_fromPaddedShape_deletion)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/Revert_sharded_fromPaddedShape_deletion)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/Revert_sharded_fromPaddedShape_deletion)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/Revert_sharded_fromPaddedShape_deletion)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/Revert_sharded_fromPaddedShape_deletion)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
