### PR TITLE
#0: Optimize kv cache nope path by splitting work onto 16 cores

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -312,6 +312,16 @@ void kernel_main() {
                 get_named_compile_time_arg_val("mla_sender_noc_y_6"),
                 get_named_compile_time_arg_val("mla_sender_noc_y_7"),
             },
+        .knope_core_index = get_named_compile_time_arg_val("knope_core_index"),
+        .nope_mcast_dest_noc_start_x = get_named_compile_time_arg_val("nope_mcast_dest_noc_start_x"),
+        .nope_mcast_dest_noc_start_y = get_named_compile_time_arg_val("nope_mcast_dest_noc_start_y"),
+        .nope_mcast_dest_noc_end_x = get_named_compile_time_arg_val("nope_mcast_dest_noc_end_x"),
+        .nope_mcast_dest_noc_end_y = get_named_compile_time_arg_val("nope_mcast_dest_noc_end_y"),
+        .nope_mcast_sender_semaphore_addr = get_named_compile_time_arg_val("nope_mcast_sender_semaphore_addr"),
+        .nope_mcast_receiver_semaphore_addr = get_named_compile_time_arg_val("nope_mcast_receiver_semaphore_addr"),
+        .nope_mcast_data_size_bytes = get_named_compile_time_arg_val("nope_mcast_data_size_bytes"),
+        .nope_mcast_num_dests = get_named_compile_time_arg_val("nope_mcast_num_dests"),
+        .kv_rmsnorm_num_tiles = get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
@@ -669,6 +679,7 @@ void kernel_main() {
         .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+        .knope_core_index = get_named_compile_time_arg_val("knope_core_index"),
     };
 
     deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
@@ -1364,7 +1375,8 @@ void kernel_main() {
             // Non-owning SP devices skip the entire branch and just signal the
             // KV-cache-ready semaphore so FlashMLA can proceed.
             // ====================================================================
-            deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_krope_core> kv_cache_update;
+            deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_knope_core, Core::is_krope_core>
+                kv_cache_update;
             kv_cache_update.set_local_cur_pos(kv_cache_update_args, local_cur_pos);
             if (!skip_kv_cache_update) {
                 DeviceZoneScopedN("KV CACHE");

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -456,7 +456,6 @@ class AttentionBlock:
             }
         )
 
-        kv_cache_update_grid = dkv_rmsnorm_grid.merge(krope_grid)
         # Use the merged grids for certain shared CBs between Q rope and K rope
         qkv_grid = qrope_grid.merge(krope_grid)
 
@@ -1363,6 +1362,7 @@ class AttentionBlock:
         # KV Cache Branch: RMSNorm
         # RMSNorm compute compile-time args (named args for TRISC)
         kv_rmsnorm_num_tiles = kv_numel // (16 * 32)  # 512 / 512 = 1 tile (16x32)
+        kv_rmsnorm_page_size = TILE_16x32.get_tile_size(data_format)
         kv_rmsnorm_brisc_named_compile_time_args = [
             ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
             ("kv_rmsnorm_num_tiles", kv_rmsnorm_num_tiles),
@@ -1387,7 +1387,7 @@ class AttentionBlock:
         # ========================================================================
         dkv_gather_receiver_core = dkv_rmsnorm_gamma_tensor.core_range_set.ranges()[0].start
         dkv_gather_sender_grid = dkv_matmul_weights_core_grid.subtract(krope_grid)
-
+        kv_cache_update_grid = dkv_matmul_weights_core_grid
         # Get NOC coordinates for gather destination (receiver core)
         dkv_gather_dest_noc_core = device.worker_core_from_logical_core(dkv_gather_receiver_core)
 
@@ -1470,6 +1470,15 @@ class AttentionBlock:
         # KVCacheUpdate compile-time args split across NCRISC (patch + writeback) and BRISC (DRAM read)
         # k_chunk_size and num_cores_per_head are shared with MLA args (set in mla_ncrisc section)
         # mla_sender_noc_x/y args are appended after MLA core group is built (depends on num_s_blocks)
+        knope_grid_range = dkv_gather_sender_grid.ranges()[0]
+        nope_mcast_dest_start_core = device.worker_core_from_logical_core(knope_grid_range.start)
+        nope_mcast_dest_end_core = device.worker_core_from_logical_core(knope_grid_range.end)
+        nope_mcast_num_cores = knope_grid_range.grid_size().x * knope_grid_range.grid_size().y
+        nope_mcast_num_dests = nope_mcast_num_cores - 1
+        nope_mcast_data_size_bytes = kv_rmsnorm_num_tiles * kv_rmsnorm_page_size
+        # Reuse existing global semaphores for nope mcast sender/receiver
+        nope_mcast_sender_semaphore_addr = mcast_data_sender_semaphore_addr
+        nope_mcast_receiver_semaphore_addr = mcast_data_receiver_semaphore_addr
         kv_cache_ncrisc_named_compile_time_args = [
             ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
             ("krope_output_cb", krope_output_cb),
@@ -1478,6 +1487,15 @@ class AttentionBlock:
             ("kv_cache_output_cb", kv_cache_output_cb),
             ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
             ("kv_cache_cur_pos_ready_semaphore_addr", mla_kv_cache_cur_pos_ready_semaphore_addr),
+            ("nope_mcast_dest_noc_start_x", nope_mcast_dest_start_core.x),
+            ("nope_mcast_dest_noc_start_y", nope_mcast_dest_start_core.y),
+            ("nope_mcast_dest_noc_end_x", nope_mcast_dest_end_core.x),
+            ("nope_mcast_dest_noc_end_y", nope_mcast_dest_end_core.y),
+            ("nope_mcast_sender_semaphore_addr", nope_mcast_sender_semaphore_addr),
+            ("nope_mcast_receiver_semaphore_addr", nope_mcast_receiver_semaphore_addr),
+            ("nope_mcast_data_size_bytes", nope_mcast_data_size_bytes),
+            ("nope_mcast_num_dests", nope_mcast_num_dests),
+            ("kv_rmsnorm_num_tiles", kv_rmsnorm_num_tiles),
         ]
         kv_cache_brisc_named_compile_time_args = [
             ("kv_cache_input_cb", kv_cache_input_cb),
@@ -2375,7 +2393,7 @@ class AttentionBlock:
             ref_attention_block_output_tensor,
             address_offset=attn_block_output_kv_cache_update_nope_running_offset,
             total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
-            core_ranges=dkv_gather_receiver_core_grid,  # Only the nope core (BRISC) reads kv_rmsnorm_output_cb
+            core_ranges=dkv_rmsnorm_grid.merge(dkv_gather_sender_grid),
         )
         kv_rmsnorm_output_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2432,7 +2450,7 @@ class AttentionBlock:
 
         TILE_32x32 = ttnn.Tile((32, 32))
         kv_cache_page_size = TILE_32x32.get_tile_size(k_df)
-        kv_cache_num_tiles = 16
+        kv_cache_num_tiles = 1
         kv_cache_input_cb_format = ttnn.CBFormatDescriptor(
             buffer_index=kv_cache_input_cb,
             data_format=k_df,
@@ -3246,7 +3264,20 @@ class AttentionBlock:
             ),
         ]
 
+        knope_grid_width = knope_grid_range.grid_size().x
         per_core_compile_time_descriptors = [
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="knope_core_index",
+                core_values=[
+                    (
+                        ttnn.CoreCoord(x, y),
+                        (y - knope_grid_range.start.y) * knope_grid_width + (x - knope_grid_range.start.x),
+                    )
+                    for y in range(knope_grid_range.start.y, knope_grid_range.end.y + 1)
+                    for x in range(knope_grid_range.start.x, knope_grid_range.end.x + 1)
+                ],
+                other_value=0,
+            ),
             PerCoreCompileTimeDescriptor(
                 named_compile_time_arg="qrope_start_tile_offset",
                 core_values=qrope_start_tile_offset_core_values,

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -351,6 +351,16 @@ void kernel_main() {
                 get_named_compile_time_arg_val("mla_sender_noc_y_6"),
                 get_named_compile_time_arg_val("mla_sender_noc_y_7"),
             },
+        .knope_core_index = get_named_compile_time_arg_val("knope_core_index"),
+        .nope_mcast_dest_noc_start_x = get_named_compile_time_arg_val("nope_mcast_dest_noc_start_x"),
+        .nope_mcast_dest_noc_start_y = get_named_compile_time_arg_val("nope_mcast_dest_noc_start_y"),
+        .nope_mcast_dest_noc_end_x = get_named_compile_time_arg_val("nope_mcast_dest_noc_end_x"),
+        .nope_mcast_dest_noc_end_y = get_named_compile_time_arg_val("nope_mcast_dest_noc_end_y"),
+        .nope_mcast_sender_semaphore_addr = get_named_compile_time_arg_val("nope_mcast_sender_semaphore_addr"),
+        .nope_mcast_receiver_semaphore_addr = get_named_compile_time_arg_val("nope_mcast_receiver_semaphore_addr"),
+        .nope_mcast_data_size_bytes = get_named_compile_time_arg_val("nope_mcast_data_size_bytes"),
+        .nope_mcast_num_dests = get_named_compile_time_arg_val("nope_mcast_num_dests"),
+        .kv_rmsnorm_num_tiles = get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
@@ -708,6 +718,7 @@ void kernel_main() {
         .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+        .knope_core_index = get_named_compile_time_arg_val("knope_core_index"),
     };
 
     deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
@@ -2197,7 +2208,8 @@ void kernel_main() {
             // Non-owning SP devices skip the entire branch and just signal the
             // KV-cache-ready semaphore so FlashMLA can proceed.
             // ====================================================================
-            deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_krope_core> kv_cache_update;
+            deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_knope_core, Core::is_krope_core>
+                kv_cache_update;
             kv_cache_update.set_local_cur_pos(kv_cache_update_args, local_cur_pos);
             if (!skip_kv_cache_update) {
                 DeviceZoneScopedN("KV CACHE");

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -316,6 +316,16 @@ if constexpr (!Core::skip_ccl) {
                 get_named_compile_time_arg_val("mla_sender_noc_y_6"),
                 get_named_compile_time_arg_val("mla_sender_noc_y_7"),
             },
+        .knope_core_index = get_named_compile_time_arg_val("knope_core_index"),
+        .nope_mcast_dest_noc_start_x = get_named_compile_time_arg_val("nope_mcast_dest_noc_start_x"),
+        .nope_mcast_dest_noc_start_y = get_named_compile_time_arg_val("nope_mcast_dest_noc_start_y"),
+        .nope_mcast_dest_noc_end_x = get_named_compile_time_arg_val("nope_mcast_dest_noc_end_x"),
+        .nope_mcast_dest_noc_end_y = get_named_compile_time_arg_val("nope_mcast_dest_noc_end_y"),
+        .nope_mcast_sender_semaphore_addr = get_named_compile_time_arg_val("nope_mcast_sender_semaphore_addr"),
+        .nope_mcast_receiver_semaphore_addr = get_named_compile_time_arg_val("nope_mcast_receiver_semaphore_addr"),
+        .nope_mcast_data_size_bytes = get_named_compile_time_arg_val("nope_mcast_data_size_bytes"),
+        .nope_mcast_num_dests = get_named_compile_time_arg_val("nope_mcast_num_dests"),
+        .kv_rmsnorm_num_tiles = get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
@@ -504,6 +514,7 @@ if constexpr (!Core::skip_ccl) {
         .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+        .knope_core_index = get_named_compile_time_arg_val("knope_core_index"),
     };
 
     deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
@@ -998,7 +1009,8 @@ if constexpr (!Core::skip_ccl) {
         // Non-owning SP devices skip the entire branch and just signal the
         // KV-cache-ready semaphore so FlashMLA can proceed.
         // ====================================================================
-        deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_krope_core> kv_cache_update;
+        deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_knope_core, Core::is_krope_core>
+            kv_cache_update;
         kv_cache_update.set_local_cur_pos(kv_cache_update_args, local_cur_pos);
         if (!skip_kv_cache_update) {
             DeviceZoneScopedN("KV CACHE");
@@ -1042,8 +1054,7 @@ if constexpr (!Core::skip_ccl) {
             }
 
             // ================================================================
-            // KV Cache Update: Write results to DRAM interleaved tensor
-            // BRISC handles writing from output CBs to DRAM
+            // KV Cache Update: NOPE mcast + write results to DRAM
             // ================================================================
             {
                 DeviceZoneScopedN("KV_CACHE_UPDATE");

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -401,7 +401,6 @@ class PreSDPA:
             }
         )
 
-        kv_cache_update_grid = dkv_rmsnorm_grid.merge(krope_grid)
         # Use the merged grids for certain shared CBs between Q rope and K rope
         qkv_grid = qrope_grid.merge(krope_grid)
 
@@ -441,6 +440,7 @@ class PreSDPA:
         # KV Cache Branch grid configuration
         # DKV Matmul (9x2)
         dkv_matmul_weights_core_grid = dkv_matmul_weights_tensor.core_range_set
+        kv_cache_update_grid = dkv_matmul_weights_core_grid
 
         # Calculate per-core width in tiles for dkv matmul (from overlapped tensor shard spec)
         dkv_matmul_weights_shard_shape = dkv_matmul_weights_tensor.shard_shape
@@ -490,6 +490,10 @@ class PreSDPA:
         # Gather-reduce for matmul path reuses gather semaphore IDs
         gather_reduce_noc0_receiver_semaphore_addr = gather_noc0_receiver_semaphore_addr
         gather_reduce_noc1_receiver_semaphore_addr = gather_noc1_receiver_semaphore_addr
+
+        # NOPE mcast semaphore IDs (reuse gather semaphores since gather is done before this mcast)
+        nope_mcast_data_sender_semaphore_addr = gather_noc0_receiver_semaphore_addr
+        nope_mcast_data_receiver_semaphore_addr = gather_noc1_receiver_semaphore_addr
 
         # CreateQHeads 3-phase semaphore IDs (reuse existing IDs, safe since prior ops have completed)
         # Phase 1: QNOPE first halves, Phase 2: QNOPE second halves, Phase 3: QROPE
@@ -969,6 +973,7 @@ class PreSDPA:
         # KV Cache Branch: RMSNorm
         # RMSNorm compute compile-time args (named args for TRISC)
         kv_rmsnorm_num_tiles = kv_numel // (16 * 32)  # 512 / 512 = 1 tile (16x32)
+        kv_rmsnorm_page_size = TILE_16x32.get_tile_size(data_format)
         kv_rmsnorm_brisc_named_compile_time_args = [
             ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
             ("kv_rmsnorm_num_tiles", kv_rmsnorm_num_tiles),
@@ -1078,13 +1083,32 @@ class PreSDPA:
         device_chunk_size = flash_mla_program_config.device_chunk_size
         # k_chunk_size and num_cores_per_head are shared with MLA args (set in mla_ncrisc section)
         # mla_sender_noc_x/y args are appended after MLA core group is built (depends on num_s_blocks)
+        # NOPE mcast: rmsnorm core -> knope grid
+        nope_mcast_knope_grid_range = dkv_gather_sender_grid.ranges()[0]
+
+        # Get NOC coordinates for NOPE mcast destination (knope grid)
+        nope_mcast_dest_start_core = device.worker_core_from_logical_core(nope_mcast_knope_grid_range.start)
+        nope_mcast_dest_end_core = device.worker_core_from_logical_core(nope_mcast_knope_grid_range.end)
+        nope_mcast_num_cores = nope_mcast_knope_grid_range.grid_size().x * nope_mcast_knope_grid_range.grid_size().y
+        nope_mcast_num_dests = nope_mcast_num_cores - 1
+
         kv_cache_ncrisc_named_compile_time_args = [
             ("kv_cache_intermed_cb", kv_cache_intermed_cb),
             ("kv_cache_intermed_sync_cb", kv_cache_intermed_sync_cb),
             ("kv_cache_output_cb", kv_cache_output_cb),
             ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
             ("kv_cache_cur_pos_ready_semaphore_addr", mla_kv_cache_cur_pos_ready_semaphore_addr),
+            ("nope_mcast_dest_noc_start_x", nope_mcast_dest_start_core.x),
+            ("nope_mcast_dest_noc_start_y", nope_mcast_dest_start_core.y),
+            ("nope_mcast_dest_noc_end_x", nope_mcast_dest_end_core.x),
+            ("nope_mcast_dest_noc_end_y", nope_mcast_dest_end_core.y),
+            ("nope_mcast_sender_semaphore_addr", nope_mcast_data_sender_semaphore_addr),
+            ("nope_mcast_receiver_semaphore_addr", nope_mcast_data_receiver_semaphore_addr),
+            ("nope_mcast_data_size_bytes", kv_rmsnorm_num_tiles * kv_rmsnorm_page_size),
+            ("nope_mcast_num_dests", nope_mcast_num_dests),
+            ("kv_rmsnorm_num_tiles", kv_rmsnorm_num_tiles),
         ]
+
         kv_cache_brisc_named_compile_time_args = [
             ("kv_cache_input_cb", kv_cache_input_cb),
             ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
@@ -1721,11 +1745,13 @@ class PreSDPA:
 
                 # CB 27: KV RMSNorm output buffer — overlap with sdpa_out_interm L1 buffer
                 # This CB is consumed before SDPA runs.
+                # Expand rmsnorm output CB to knope grid for NOPE mcast receive
                 kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     kv_rmsnorm_output_cb,
                     sdpa_out_interm_buffer_device,
                     address_offset=sdpa_out_interm_running_offset,
                     total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
+                    core_ranges=dkv_rmsnorm_grid.merge(dkv_gather_sender_grid),
                 )
                 kv_rmsnorm_output_cb_descriptor.format_descriptors = [
                     ttnn.CBFormatDescriptor(
@@ -1770,7 +1796,7 @@ class PreSDPA:
                 sdpa_out_interm_running_offset += krope_output_cb_descriptor.total_size
                 TILE_32x32 = ttnn.Tile((32, 32))
                 kv_cache_page_size = TILE_32x32.get_tile_size(ttnn.bfloat8_b)
-                kv_cache_num_tiles = 16
+                kv_cache_num_tiles = 1  # Each knope/krope core handles 1 tile
                 kv_cache_input_cb_format = ttnn.CBFormatDescriptor(
                     buffer_index=kv_cache_input_cb,
                     data_format=ttnn.bfloat8_b,
@@ -2222,7 +2248,21 @@ class PreSDPA:
                     ),
                 ]
 
+                knope_grid_width = nope_mcast_knope_grid_range.grid_size().x
                 per_core_compile_time_descriptors = [
+                    PerCoreCompileTimeDescriptor(
+                        named_compile_time_arg="knope_core_index",
+                        core_values=[
+                            (
+                                ttnn.CoreCoord(x, y),
+                                (y - nope_mcast_knope_grid_range.start.y) * knope_grid_width
+                                + (x - nope_mcast_knope_grid_range.start.x),
+                            )
+                            for y in range(nope_mcast_knope_grid_range.start.y, nope_mcast_knope_grid_range.end.y + 1)
+                            for x in range(nope_mcast_knope_grid_range.start.x, nope_mcast_knope_grid_range.end.x + 1)
+                        ],
+                        other_value=0,
+                    ),
                     PerCoreCompileTimeDescriptor(
                         named_compile_time_arg="qrope_start_tile_offset",
                         core_values=qrope_start_tile_offset_core_values,

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
@@ -3,30 +3,40 @@
 
 // KV Cache Update kernel: uses KVCacheUpdate Op from kv_cache_update.hpp
 //
-// BRISC: Stream existing KV cache pages from DRAM into kv_cache_input_cb
-// NCRISC: Wait on compute, patch new data, wait on compute, write back to DRAM
-// TRISC: Untilize input_cb -> intermed_cb, tilize intermed_cb -> output_cb
+// NOPE path:
+//   nope_cache_tensor lives on a single "nope sender" core.
+//   NCRISC on that core multicasts the data to a 2x8 "knope" grid (16 cores).
+//   Each knope core then independently handles 1 DRAM tile (1x32).
+//   BRISC starts DRAM reads in parallel with the mcast.
+//
+// ROPE path:
+//   rope_cache_tensor is already split across 2 cores (1x32 each).
+//   Each core independently handles its own tile.
+//
+// BRISC: DRAM read (knope/krope cores)
+// NCRISC: Mcast sender/receiver (knope cores) + patch + DRAM write
+// TRISC: Untilize + tilize
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
 #include "../../../unified_kernels/kv_cache_update.hpp"
-
 struct Core {
+    static constexpr bool is_nope_sender_core = get_named_compile_time_arg_val("is_nope_sender_core") == 1;
     static constexpr bool is_nope_core = get_named_compile_time_arg_val("is_nope_core") == 1;
     static constexpr bool is_rope_core = get_named_compile_time_arg_val("is_rope_core") == 1;
 };
 
 void kernel_main() {
 #if defined(COMPILE_FOR_NCRISC)
-    if (Core::is_nope_core) {
+    if constexpr (Core::is_nope_sender_core) {
         uint32_t kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb");
         unified_kernels::setup_sharded_buffer(kv_rmsnorm_output_cb, 1);
     }
-    if (Core::is_rope_core) {
+    if constexpr (Core::is_rope_core) {
         uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
         unified_kernels::setup_sharded_buffer(krope_output_cb, 1);
     }
-    deepseek_b1_ops::KVCacheUpdate::WriterArgs args{
+    deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_args{
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
         .local_cur_pos = 0,
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
@@ -41,16 +51,31 @@ void kernel_main() {
         .num_cores_per_head = 0,
         .mla_sender_noc_x = {},
         .mla_sender_noc_y = {},
+        .knope_core_index = get_named_compile_time_arg_val("knope_core_index"),
+        .nope_mcast_dest_noc_start_x = get_named_compile_time_arg_val("nope_mcast_dest_noc_start_x"),
+        .nope_mcast_dest_noc_start_y = get_named_compile_time_arg_val("nope_mcast_dest_noc_start_y"),
+        .nope_mcast_dest_noc_end_x = get_named_compile_time_arg_val("nope_mcast_dest_noc_end_x"),
+        .nope_mcast_dest_noc_end_y = get_named_compile_time_arg_val("nope_mcast_dest_noc_end_y"),
+        .nope_mcast_sender_semaphore_addr =
+            get_semaphore(get_named_compile_time_arg_val("nope_mcast_sender_semaphore_id")),
+        .nope_mcast_receiver_semaphore_addr =
+            get_semaphore(get_named_compile_time_arg_val("nope_mcast_receiver_semaphore_id")),
+        .nope_mcast_data_size_bytes = get_named_compile_time_arg_val("nope_mcast_data_size_bytes"),
+        .nope_mcast_num_dests = get_named_compile_time_arg_val("nope_mcast_num_dests"),
+        .kv_rmsnorm_num_tiles = get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
     };
+
 #elif defined(COMPILE_FOR_BRISC)
-    deepseek_b1_ops::KVCacheUpdate::ReaderArgs args{
+    deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_args{
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
         .local_cur_pos = 0,
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+        .knope_core_index = get_named_compile_time_arg_val("knope_core_index"),
     };
+
 #elif defined(COMPILE_FOR_TRISC)
-    deepseek_b1_ops::KVCacheUpdate::ComputeArgs args{
+    deepseek_b1_ops::KVCacheUpdate::ComputeArgs kv_cache_args{
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
@@ -60,13 +85,14 @@ void kernel_main() {
     deepseek_compute_kernel_init();
 #endif
 
-    deepseek_b1_ops::KVCacheUpdate::Op<Core::is_nope_core, Core::is_rope_core> op;
+    deepseek_b1_ops::KVCacheUpdate::Op<Core::is_nope_sender_core, Core::is_nope_core, Core::is_rope_core>
+        kv_cache_update;
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
     {
         uint32_t pos_addr = get_common_arg_val<uint32_t>(1);
         volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pos_addr);
-        op.set_local_cur_pos(args, pos_ptr[0]);
+        kv_cache_update.set_local_cur_pos(kv_cache_args, pos_ptr[0]);
     }
 #endif
-    op(args);
+    kv_cache_update(kv_cache_args);
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/op.py
@@ -1,15 +1,25 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 """
 KV Cache Update micro op.
 
-Reads 16 BFP8 tiles from DRAM into L1, untilize (BFP8->bfloat16), tilize (bfloat16->BFP8).
-Runs on a grid with nope cores (kv_rmsnorm) and rope cores (krope). Uses kv_cache_update.hpp Op.
+Updates 1x576 KV cache in DRAM with new NOPE (512) and ROPE (64) data.
+
+Input expectations:
+  NOPE: Single-core L1 tensor (1x512 on one core).
+        The op multicasts this to a 2x8 knope grid (16 cores), then each
+        knope core reads 1 DRAM page (1x32), patches its 32-element slice,
+        and writes back.
+  ROPE: Split across 2 cores (1x32 each, WIDTH_SHARDED).
+        Each rope core independently reads 1 DRAM page, patches, writes back.
+
+Uses unified_kernels/kv_cache_update.hpp Op and unified_kernels/mcast.hpp Op.
 """
 
 import ttnn
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreCompileTimeDescriptor,
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
 )
@@ -21,7 +31,7 @@ KV_CACHE_INTERMED_CB = 29
 KV_CACHE_INTERMED_SYNC_CB = 28
 KV_RMSNORM_OUTPUT_CB = 26
 KROPE_OUTPUT_CB = 27
-KV_CACHE_NUM_TILES = 16
+KV_CACHE_NUM_TILES = 1
 KROPE_WT = 1
 OUTPUT_CB = 0
 
@@ -29,10 +39,13 @@ TILE_32x32 = ttnn.Tile((32, 32))
 TILE_16x32 = ttnn.Tile((16, 32))
 TILE_1x32 = ttnn.Tile((1, 32))
 
+# NOPE rmsnorm output: 1 tile of 16x32 = 512 elements
+KV_RMSNORM_NUM_TILES = 1
+
 
 class KVCacheUpdate:
     """
-    KV Cache Update: read DRAM -> untilize -> tilize. Uses unified_kernels/kv_cache_update.hpp.
+    KV Cache Update: mcast nope data -> read DRAM -> untilize -> patch -> tilize -> write DRAM.
     """
 
     @staticmethod
@@ -41,30 +54,49 @@ class KVCacheUpdate:
         rope_cache_tensor,
         full_kv_cache_tensor,
         position_ids_tensor: ttnn.Tensor,
-        output_tensor,  # not used
+        output_tensor,
+        knope_grid,
     ):
         """
         Run KV cache update as a standalone program.
 
         Args:
-            nope_cache_tensor: L1 tensor backing NOPE_CACHE_CB (tilized BFP8 input).
-            rope_cache_tensor: DRAM tensor for rope cache (buffer address + tensor accessor).
-            full_kv_cache_tensor: DRAM tensor for full KV cache (buffer address + tensor accessor).
-            position_id: Write position index.
-            output_tensor: not used, validation is read back from full_kv_cache_tensor
+            nope_cache_tensor: L1 tensor on a SINGLE core containing the rmsnorm output
+                               (1x512 bfloat16). This is the mcast source.
+            rope_cache_tensor: L1 tensor split across 2 rope cores (1x32 each, WIDTH_SHARDED).
+            full_kv_cache_tensor: DRAM tensor for full KV cache (ND-sharded, BFP8).
+            position_ids_tensor: L1 tensor with write position index (replicated across all cores).
+            output_tensor: Not used for readback; validation reads from full_kv_cache_tensor.
+            knope_grid: CoreRangeSet for the 16 knope receiver cores (e.g. 2x8 grid).
 
         Returns:
-            Output of generic_op (includes output_tensor when provided).
+            Output of generic_op.
         """
-        nope_core_grid = nope_cache_tensor.memory_config().shard_spec.grid
+        device = nope_cache_tensor.device()
+        nope_sender_grid = nope_cache_tensor.memory_config().shard_spec.grid
         rope_core_grid = rope_cache_tensor.memory_config().shard_spec.grid
-        kv_cache_core_grid = nope_core_grid.merge(rope_core_grid)
+
+        # Full grid: nope sender + knope receivers + rope cores
+        full_grid = nope_sender_grid.merge(knope_grid).merge(rope_core_grid)
+        # KV cache update grid: knope + rope (cores that do DRAM read/write)
+        kv_cache_core_grid = knope_grid.merge(rope_core_grid)
 
         tensor_accessor_args = ttnn.TensorAccessorArgs(full_kv_cache_tensor)
         ncrisc_compile_time_args = tensor_accessor_args.get_compile_time_args()
         brisc_compile_time_args = tensor_accessor_args.get_compile_time_args()
 
-        # CB indices passed as named compile-time args; kernel uses get_named_compile_time_arg_val
+        # Compute mcast NOC coordinates
+        knope_grid_range = list(knope_grid.ranges())[0]
+        nope_mcast_dest_start_core = device.worker_core_from_logical_core(knope_grid_range.start)
+        nope_mcast_dest_end_core = device.worker_core_from_logical_core(knope_grid_range.end)
+        nope_mcast_num_cores = knope_grid_range.grid_size().x * knope_grid_range.grid_size().y
+        nope_mcast_num_dests = (
+            nope_mcast_num_cores - 1 if knope_grid_range.contains(nope_sender_grid) else nope_mcast_num_cores
+        )
+
+        kv_rmsnorm_page_size = TILE_16x32.get_tile_size(ttnn.bfloat16)
+        nope_mcast_data_size_bytes = KV_RMSNORM_NUM_TILES * kv_rmsnorm_page_size
+
         ncrisc_named = [
             ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
             ("krope_output_cb", KROPE_OUTPUT_CB),
@@ -73,10 +105,20 @@ class KVCacheUpdate:
             ("kv_cache_output_cb", KV_CACHE_OUTPUT_CB),
             ("kv_cache_grid_start_y", list(rope_core_grid.ranges())[0].start.y),
             ("kv_cache_cur_pos_ready_semaphore_id", 0),
+            ("nope_mcast_dest_noc_start_x", nope_mcast_dest_start_core.x),
+            ("nope_mcast_dest_noc_start_y", nope_mcast_dest_start_core.y),
+            ("nope_mcast_dest_noc_end_x", nope_mcast_dest_end_core.x),
+            ("nope_mcast_dest_noc_end_y", nope_mcast_dest_end_core.y),
+            ("nope_mcast_sender_semaphore_id", 1),
+            ("nope_mcast_receiver_semaphore_id", 2),
+            ("nope_mcast_data_size_bytes", nope_mcast_data_size_bytes),
+            ("nope_mcast_num_dests", nope_mcast_num_dests),
+            ("kv_rmsnorm_num_tiles", KV_RMSNORM_NUM_TILES),
         ]
         brisc_named = [
             ("kv_cache_input_cb", KV_CACHE_INPUT_CB),
             ("kv_cache_grid_start_y", list(rope_core_grid.ranges())[0].start.y),
+            ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
         ]
         trisc_named = [
             ("kv_cache_input_cb", KV_CACHE_INPUT_CB),
@@ -115,11 +157,15 @@ class KVCacheUpdate:
             tile=ttnn.TileDescriptor(TILE_32x32),
         )
 
-        kv_rmsnorm_output_cb_format = ttnn.cb_descriptor_from_sharded_tensor(KV_RMSNORM_OUTPUT_CB, nope_cache_tensor)
+        # Expand kv_rmsnorm_output_cb to cover nope sender + knope grid
+        kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            KV_RMSNORM_OUTPUT_CB,
+            nope_cache_tensor,
+            core_ranges=nope_sender_grid.merge(knope_grid),
+        )
 
-        # Output CB: tensor-backed on nope core when output_tensor provided, else L1-only
         cbs = [
-            kv_rmsnorm_output_cb_format,
+            kv_rmsnorm_output_cb_descriptor,
             ttnn.cb_descriptor_from_sharded_tensor(KROPE_OUTPUT_CB, rope_cache_tensor),
             ttnn.cb_descriptor_from_sharded_tensor(OUTPUT_CB, output_tensor),
             ttnn.CBDescriptor(
@@ -139,19 +185,44 @@ class KVCacheUpdate:
             ),
         ]
 
-        # not used in unit test, but needed for fused sdpa to wait on kv cache update
         mla_kv_cache_cur_pos_ready_semaphore_descriptor = ttnn.SemaphoreDescriptor(
             id=0,
             core_ranges=kv_cache_core_grid,
             initial_value=0,
         )
+
+        # Mcast semaphores: sender (BRISC) and receiver (NCRISC)
+        nope_mcast_sender_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=1,
+            core_ranges=full_grid,
+            initial_value=0,
+        )
+        nope_mcast_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=2,
+            core_ranges=full_grid,
+            initial_value=0,
+        )
+
         pos_addr = position_ids_tensor.buffer_address()
         ncrisc_common_runtime_args = [full_kv_cache_tensor.buffer_address(), pos_addr]
         brisc_common_runtime_args = [full_kv_cache_tensor.buffer_address(), pos_addr]
 
+        knope_grid_width = knope_grid_range.grid_size().x
+        knope_core_index_desc = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="knope_core_index",
+            core_values=[
+                (
+                    ttnn.CoreCoord(x, y),
+                    (y - knope_grid_range.start.y) * knope_grid_width + (x - knope_grid_range.start.x),
+                )
+                for y in range(knope_grid_range.start.y, knope_grid_range.end.y + 1)
+                for x in range(knope_grid_range.start.x, knope_grid_range.end.x + 1)
+            ],
+            other_value=0,
+        )
         kernel_desc = UnifiedKernelDescriptor(
             kernel_source="models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp",
-            core_ranges=kv_cache_core_grid,
+            core_ranges=full_grid,
             ncrisc_compile_time_args=ncrisc_compile_time_args,
             brisc_compile_time_args=brisc_compile_time_args,
             ncrisc_named_compile_time_args=ncrisc_named,
@@ -159,10 +230,17 @@ class KVCacheUpdate:
             trisc_named_compile_time_args=trisc_named,
             ncrisc_common_runtime_args=ncrisc_common_runtime_args,
             brisc_common_runtime_args=brisc_common_runtime_args,
+            per_core_compile_time_descriptors=[knope_core_index_desc],
             unified_compile_time_core_descriptors=[
                 UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_nope_sender_core",
+                    core_range=nope_sender_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
                     named_compile_time_arg="is_nope_core",
-                    core_range=nope_core_grid,
+                    core_range=knope_grid,
                     value=1,
                     other_value=0,
                 ),
@@ -179,7 +257,11 @@ class KVCacheUpdate:
         program_descriptor = ttnn.ProgramDescriptor(
             kernels=kernel_result.kernels,
             cbs=cbs,
-            semaphores=[mla_kv_cache_cur_pos_ready_semaphore_descriptor],
+            semaphores=[
+                mla_kv_cache_cur_pos_ready_semaphore_descriptor,
+                nope_mcast_sender_semaphore_descriptor,
+                nope_mcast_receiver_semaphore_descriptor,
+            ],
         )
         io_tensors = [nope_cache_tensor, rope_cache_tensor, position_ids_tensor, output_tensor]
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
@@ -344,21 +344,20 @@ def test_kv_cache_dram_shard(device, position_id):
     torch.manual_seed(0)
     max_seq_len = 1136
 
-    nope_core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(0, 8))})
-    rope_core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(8, 8), ttnn.CoreCoord(8, 9))})
+    # NOPE: single-core input (the op will mcast to nope_worker_grid)
+    nope_input_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(0, 8))})
+    nope_worker_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(7, 9))})
+    rope_input_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(8, 8), ttnn.CoreCoord(8, 9))})
 
-    # Input to nope kcache core
-    #    torch_nope_cache = torch.randn(16, 32, dtype=torch.bfloat16)
     torch_nope_cache = torch.arange(512, dtype=torch.bfloat16)
     input_shard_spec = ttnn.ShardSpec(
-        nope_core_grid,
+        nope_input_grid,
         (1, 512),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
 
     tile = ttnn.Tile([1, 32])
-    # Create TTNN input tensor with WIDTH_SHARDED memory and tiny tile
     ttnn_nope_cache = ttnn.from_torch(
         torch_nope_cache,
         dtype=ttnn.bfloat16,
@@ -371,7 +370,7 @@ def test_kv_cache_dram_shard(device, position_id):
     # Input to rope cores: 1 to 64 over the whole tensor
     torch_rope_cache = torch.randn(1, 64, dtype=torch.bfloat16) * 100
     rope_input_shard_spec = ttnn.ShardSpec(
-        rope_core_grid,
+        rope_input_grid,
         (1, 32),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
@@ -408,7 +407,6 @@ def test_kv_cache_dram_shard(device, position_id):
         memory_config=pos_mem_config,
     )
 
-    # Create TTNN input tensor with WIDTH_SHARDED memory and tiny tile
     ttnn_output = ttnn.from_torch(
         torch_nope_cache,
         dtype=ttnn.bfloat16,
@@ -459,7 +457,14 @@ def test_kv_cache_dram_shard(device, position_id):
 
     kv_cache_bfp8_before_op = ttnn.to_torch(ttnn_kv_cache)
 
-    _ = KVCacheUpdate.op(ttnn_nope_cache, ttnn_rope_cache, ttnn_kv_cache, ttnn_position_ids, output_tensor=ttnn_output)
+    _ = KVCacheUpdate.op(
+        ttnn_nope_cache,
+        ttnn_rope_cache,
+        ttnn_kv_cache,
+        ttnn_position_ids,
+        output_tensor=ttnn_output,
+        knope_grid=nope_worker_grid,
+    )
 
     torch_kv_cache_output = ttnn.to_torch(ttnn_kv_cache)
     # check that kv cache for 0 to pos_id -  1 is identical to kv cache before op

--- a/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
@@ -4,12 +4,13 @@
 #pragma once
 
 #include "kernel_op_api.hpp"
+#include "kernel_utils.hpp"
+#include "mcast.hpp"
 
 #if defined(COMPILE_FOR_BRISC)
 #include "api/dataflow/dataflow_api.h"
 #elif defined(COMPILE_FOR_NCRISC)
 #include "api/dataflow/dataflow_api.h"
-#include "mcast.hpp"
 #elif defined(COMPILE_FOR_TRISC)
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/pack_untilize.h"
@@ -23,11 +24,20 @@ namespace deepseek_b1_ops {
 // KVCacheUpdate micro-op
 //
 // Computes: Update existing KV Cache with 1x576 new cache
-// assumes one core with 1x512 NOPE cache and 2 cores each with 1x32 ROPE cache
+// NOPE cache: 16 cores (2x8 knope grid), each handles 1 tile (1x32 BFP8 page)
+// ROPE cache: 2 cores each with 1x32
 //
-// BRISC: streams existing KV cache pages from DRAM into kv_cache_input_cb
-// NCRISC: waits on compute (untilize), patches new data, waits on compute
-//         (tilize), writes updated pages back to DRAM, signals cache ready
+// Input expectations:
+//   NOPE: Input is on a single "nope sender" core. NCRISC on that core
+//         multicasts the data to the full knope grid, then each core
+//         independently reads/patches/writes 1 DRAM page.
+//         BRISC can start the DRAM read in parallel with the mcast.
+//   ROPE: Input is already split across 2 cores. Each core handles
+//         its own tile independently.
+//
+// BRISC: DRAM read (all knope/rope cores)
+// NCRISC: mcast sender (nope sender core) + mcast receiver (knope non-sender
+//         cores) + patch + DRAM write
 // TRISC: untilize input_cb -> intermed_cb, tilize intermed_cb -> output_cb
 // ============================================================================
 struct KVCacheUpdate {
@@ -64,12 +74,24 @@ struct KVCacheUpdate {
         uint32_t num_cores_per_head;
         uint32_t mla_sender_noc_x[MAX_MLA_CORES_PER_HEAD];
         uint32_t mla_sender_noc_y[MAX_MLA_CORES_PER_HEAD];
+        uint32_t knope_core_index;
+        // NOPE mcast fields (NCRISC handles both send and receive)
+        uint32_t nope_mcast_dest_noc_start_x;
+        uint32_t nope_mcast_dest_noc_start_y;
+        uint32_t nope_mcast_dest_noc_end_x;
+        uint32_t nope_mcast_dest_noc_end_y;
+        uint32_t nope_mcast_sender_semaphore_addr;
+        uint32_t nope_mcast_receiver_semaphore_addr;
+        uint32_t nope_mcast_data_size_bytes;
+        uint32_t nope_mcast_num_dests;
+        uint32_t kv_rmsnorm_num_tiles;
     };
     struct ReaderArgs {
         uint32_t kv_cache_buffer_base_addr;
         uint32_t local_cur_pos;
         uint32_t kv_cache_input_cb;
         uint32_t grid_start_y;
+        uint32_t knope_core_index;
     };
     struct ComputeArgs {
         uint32_t kv_cache_input_cb;
@@ -83,7 +105,7 @@ struct KVCacheUpdate {
     // ========================================================================
     // Op - full KV cache update (owning device)
     // ========================================================================
-    template <bool IsNopeCore, bool IsRopeCore>
+    template <bool IsNopeSenderCore, bool IsNopeCore, bool IsRopeCore>
     class Op {
     public:
         void operator()([[maybe_unused]] const RTArgs& args) { impl(args); }
@@ -113,14 +135,71 @@ struct KVCacheUpdate {
 
     private:
         void impl([[maybe_unused]] const RTArgs& args) {
+            // ============================================================
+            // NOPE mcast on NCRISC: sender broadcasts rmsnorm output to
+            // knope grid, receivers wait for semaphore.
+            // BRISC is free to start DRAM reads in parallel.
+            // ============================================================
+#if defined(COMPILE_FOR_NCRISC)
+            if constexpr (IsNopeSenderCore) {
+                cb_wait_front(args.kv_rmsnorm_output_cb, args.kv_rmsnorm_num_tiles);
+
+                {
+                    DeviceZoneScopedN("MCAST_RMSNORM");
+                    uint32_t data_addr = get_read_ptr(args.kv_rmsnorm_output_cb);
+
+                    volatile tt_l1_ptr uint32_t* sender_sem_ptr =
+                        (volatile tt_l1_ptr uint32_t*)args.nope_mcast_sender_semaphore_addr;
+                    noc_semaphore_set(sender_sem_ptr, VALID);
+
+                    uint64_t mcast_noc_addr = get_noc_multicast_addr<0>(
+                        args.nope_mcast_dest_noc_start_x,
+                        args.nope_mcast_dest_noc_start_y,
+                        args.nope_mcast_dest_noc_end_x,
+                        args.nope_mcast_dest_noc_end_y,
+                        0);
+                    noc_async_write_multicast(
+                        data_addr,
+                        mcast_noc_addr | data_addr,
+                        args.nope_mcast_data_size_bytes,
+                        args.nope_mcast_num_dests,
+                        false,
+                        0,
+                        NOC_DISPATCH_MULTICAST_WRITE_VC);
+                    noc_semaphore_set_multicast(
+                        args.nope_mcast_sender_semaphore_addr,
+                        mcast_noc_addr | args.nope_mcast_receiver_semaphore_addr,
+                        args.nope_mcast_num_dests,
+                        false,
+                        0,
+                        NOC_DISPATCH_MULTICAST_WRITE_VC);
+
+                    noc_async_write_barrier();
+                }
+            } else if constexpr (IsNopeCore) {
+                {
+                    DeviceZoneScopedN("RECEIVE_RMSNORM");
+                    volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
+                        (volatile tt_l1_ptr uint32_t*)args.nope_mcast_receiver_semaphore_addr;
+                    cb_reserve_back(args.kv_rmsnorm_output_cb, args.kv_rmsnorm_num_tiles);
+                    noc_semaphore_wait(receiver_sem_ptr, VALID);
+                    noc_semaphore_set(receiver_sem_ptr, INVALID);
+                    cb_push_back(args.kv_rmsnorm_output_cb, args.kv_rmsnorm_num_tiles);
+                }
+            }
+#endif
+
+            // ============================================================
+            // KV cache DRAM read / patch / write
+            // ============================================================
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
             if constexpr (IsRopeCore || IsNopeCore) {
                 constexpr uint32_t PAGE_SIZE = 1088;
                 constexpr uint32_t PAGES_PER_BLOCK = 18;
                 constexpr uint32_t CACHES_PER_BLOCK = 32;
                 constexpr uint32_t nope_num_pages = 16;
-                constexpr uint32_t CHUNK_SIZE = IsRopeCore ? 1 : 8;
-                constexpr uint32_t NUM_CHUNKS = IsRopeCore ? 1 : 2;
+                constexpr uint32_t CHUNK_SIZE = 1;
+                constexpr uint32_t NUM_CHUNKS = 1;
 
                 uint32_t cur_pos = args.local_cur_pos;
 
@@ -132,6 +211,8 @@ struct KVCacheUpdate {
                     uint32_t grid_offset_pages = 1 * (get_absolute_logical_y() - args.grid_start_y);
                     kv_cache_page_id_start += grid_offset_pages;
                     kv_cache_page_id_start += nope_num_pages;
+                } else {
+                    kv_cache_page_id_start += args.knope_core_index;
                 }
 
 #if defined(COMPILE_FOR_BRISC)
@@ -156,10 +237,18 @@ struct KVCacheUpdate {
                 uint32_t new_cache_cb = IsRopeCore ? args.krope_output_cb : args.kv_rmsnorm_output_cb;
                 uint32_t offset_in_page = cur_pos % CACHES_PER_BLOCK;
 
-                constexpr uint32_t num_bytes_per_chunk = IsRopeCore ? 64 : (CHUNK_SIZE * 32 * 2);
+                constexpr uint32_t num_bytes_per_chunk = 32 * 2;
 
+                // For NOPESenderCore, this wait is redundant as the mcast sender will have already waited for
+                // args.kv_rmsnorm_output_cb.
                 cb_wait_front(new_cache_cb, 1);
                 uint32_t src_addr = get_read_ptr(new_cache_cb);
+                // RMSNorm output is [1, 512] row-major (treated as a 16x32 tile during
+                // compute, but the data is still a contiguous 512-element row).
+                // Each knope core owns a 32-element chunk, so linear indexing works.
+                if constexpr (IsNopeCore) {
+                    src_addr += args.knope_core_index * num_bytes_per_chunk;
+                }
                 uint32_t write_addr_offset = offset_in_page * num_bytes_per_chunk;
 
                 for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
@@ -184,7 +273,6 @@ struct KVCacheUpdate {
 
                 cb_pop_front(new_cache_cb, 1);
 
-                // Phase 2: Wait for tilize to complete, write to DRAM
                 for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
                     {
                         DeviceZoneScopedN("WAIT_TILIZE");
@@ -211,8 +299,8 @@ struct KVCacheUpdate {
                 uint32_t kv_cache_intermed_sync_cb = args.kv_cache_intermed_sync_cb;
                 uint32_t kv_cache_input_cb = args.kv_cache_input_cb;
                 uint32_t kv_cache_output_cb = args.kv_cache_output_cb;
-                constexpr uint32_t kv_cache_num_tiles = IsRopeCore ? 1 : 16;
-                constexpr uint32_t CHUNK_SIZE = IsRopeCore ? 1 : 8;
+                constexpr uint32_t kv_cache_num_tiles = 1;
+                constexpr uint32_t CHUNK_SIZE = 1;
                 constexpr uint32_t NUM_CHUNKS = kv_cache_num_tiles / CHUNK_SIZE;
 
                 // Phase 1: Untilize into intermed_cb, pushing each chunk of CHUNK_SIZE

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -929,15 +929,10 @@ inline void noc_async_write_multicast(
     uint32_t size,
     uint32_t num_dests,
     bool linked = false,
-    uint8_t noc = noc_index) {
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_MULTICAST_WRITE_VC) {
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::WRITE_MULTICAST,
-        src_local_l1_addr,
-        dst_noc_addr_multicast,
-        size,
-        NOC_MULTICAST_WRITE_VC,
-        false,
-        noc);
+        NocEventType::WRITE_MULTICAST, src_local_l1_addr, dst_noc_addr_multicast, size, vc, false, noc);
 
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
         noc_async_write_multicast_one_packet<false>(
@@ -952,7 +947,7 @@ inline void noc_async_write_multicast(
             src_local_l1_addr,
             dst_noc_addr_multicast,
             size,
-            NOC_MULTICAST_WRITE_VC,
+            vc,
             true /* mcast */,
             linked,
             num_dests,
@@ -1570,19 +1565,20 @@ inline void noc_semaphore_set_multicast(
     uint64_t dst_noc_addr_multicast,
     uint32_t num_dests,
     bool linked = false,
-    uint8_t noc = noc_index) {
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_MULTICAST_WRITE_VC) {
     WAYPOINT("NSNW");
 
     constexpr uint32_t size_bytes = 4;
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size_bytes);
 
-    NOC_TRACE_QUICK_PUSH_IF_LINKED(NOC_MULTICAST_WRITE_VC, linked);
+    NOC_TRACE_QUICK_PUSH_IF_LINKED(vc, linked);
     RECORD_NOC_EVENT_WITH_ADDR(
         NocEventType::SEMAPHORE_SET_MULTICAST,
         src_local_l1_addr,
         dst_noc_addr_multicast,
         size_bytes,
-        NOC_MULTICAST_WRITE_VC,
+        vc,
         /*posted=*/false,
         noc);
     ncrisc_noc_fast_write_any_len<noc_mode>(
@@ -1591,7 +1587,7 @@ inline void noc_semaphore_set_multicast(
         src_local_l1_addr,
         dst_noc_addr_multicast,
         size_bytes,
-        NOC_MULTICAST_WRITE_VC,
+        vc,
         true,
         linked,
         num_dests,


### PR DESCRIPTION
### Ticket
None

### Problem description
KV cache path is very close to being on the critical path for MLA (~0.5us of margin). Optimizing this path will allow to see optimizations for Q path in the future. Currently, NOPE kv cache update is bottleneck because it uses single-core to update [1, 512] in kv cache. This PR splits up to work to 16 cores to keep it more in line with ROPE path (each core does [1, 32] update).

### What's changed
- RMSNorm core mcasts output to 16 cores and each core does [1, 32] of [1, 512]
  * Mcast overlaps with kv cache read + mcast in FlashMLA, so need to use separate VC
    ** WARNING: Currently, hardcoded to use Fast Dispatch VC
  * Perf is now 1.7us compared to 4.8us

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bliu/main)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/main): https://github.com/tenstorrent/tt-metal/actions/runs/24151797867
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/main)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
