### PR TITLE
Patch for output tensor alignment ttnn::copy

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_copy_point_to_point.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy_point_to_point.py
@@ -1,12 +1,16 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 import torch
 
 import ttnn
 
+
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [(1, 2)], indirect=True)
-@pytest.mark.parametrize("shape", [(30, 60), (10, 10, 30, 60), (16, 64) ])
+@pytest.mark.parametrize("shape", [(30, 60), (10, 10, 30, 60), (16, 64)])
 def test_copy_output_as_point_to_point_preallocated(mesh_device, shape):
     coord0 = ttnn.MeshCoordinate(0, 0)
     coord1 = ttnn.MeshCoordinate(0, 1)

--- a/tests/ttnn/unit_tests/base_functionality/test_copy_point_to_point.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy_point_to_point.py
@@ -1,11 +1,12 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
-
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
 # SPDX-License-Identifier: Apache-2.0
+
 import pytest
-
 import torch
-
 import ttnn
+
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
@@ -28,10 +29,14 @@ def test_copy_output_as_point_to_point_preallocated(mesh_device, shape):
 
     copy_output = ttnn.assign(clone_output, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
-    ttnn.point_to_point(
+    final = ttnn.point_to_point(
         clone_output,
         coord0,
         coord1,
         topology=ttnn.Topology.Linear,
         output_tensor=copy_output,
     )
+
+    final_torch = ttnn.to_torch(final, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+    input_torch = ttnn.to_torch(input_tensor, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+    assert torch.equal(final_torch, input_torch), "point_to_point output does not match input"

--- a/tests/ttnn/unit_tests/base_functionality/test_copy_point_to_point.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy_point_to_point.py
@@ -1,0 +1,33 @@
+import pytest
+
+import torch
+
+import ttnn
+
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(1, 2)], indirect=True)
+@pytest.mark.parametrize("shape", [(30, 60), (10, 10, 30, 60), (16, 64) ])
+def test_copy_output_as_point_to_point_preallocated(mesh_device, shape):
+    coord0 = ttnn.MeshCoordinate(0, 0)
+    coord1 = ttnn.MeshCoordinate(0, 1)
+
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    clone_output = ttnn.clone(input_tensor)
+
+    copy_output = ttnn.assign(clone_output, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    ttnn.point_to_point(
+        clone_output,
+        coord0,
+        coord1,
+        topology=ttnn.Topology.Linear,
+        output_tensor=copy_output,
+    )

--- a/tests/ttnn/unit_tests/base_functionality/test_copy_point_to_point.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy_point_to_point.py
@@ -6,8 +6,6 @@ import pytest
 import torch
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_equal
-
 
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [(1, 2)], indirect=True)

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -153,12 +153,19 @@ CopyDeviceOperation::spec_return_value_t CopyDeviceOperation::compute_output_spe
     }
 
     const Tensor& input_tensor = tensor_args.input;
-    return tt::tt_metal::TensorSpec(
+    auto output_layout = TensorLayout(
+        operation_attributes.output_dtype, PageConfig(input_tensor.layout()), operation_attributes.output_mem_config);
+    auto output_padded_shape = output_layout.compute_padded_shape(
+        input_tensor.logical_shape());  // We need to account for the fact that the output tensor may have a different
+                                        // padded_shape due to having a differrent shard_spec.
+    return {TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout(
+        TensorLayout::fromPaddedShape(
             operation_attributes.output_dtype,
-            tt::tt_metal::PageConfig(input_tensor.layout()),
-            operation_attributes.output_mem_config));
+            PageConfig(input_tensor.layout()),
+            operation_attributes.output_mem_config,
+            input_tensor.logical_shape(),
+            output_padded_shape))};
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -153,6 +153,7 @@ CopyDeviceOperation::spec_return_value_t CopyDeviceOperation::compute_output_spe
     }
 
     const Tensor& input_tensor = tensor_args.input;
+
     auto output_layout = TensorLayout(
         operation_attributes.output_dtype, PageConfig(input_tensor.layout()), operation_attributes.output_mem_config);
     auto output_padded_shape = output_layout.compute_padded_shape(
@@ -160,9 +161,9 @@ CopyDeviceOperation::spec_return_value_t CopyDeviceOperation::compute_output_spe
                                         // padded_shape due to having a differrent shard_spec.
     return {TensorSpec(
         input_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tt::tt_metal::TensorLayout::fromPaddedShape(
             operation_attributes.output_dtype,
-            PageConfig(input_tensor.layout()),
+            tt::tt_metal::PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,
             input_tensor.logical_shape(),
             output_padded_shape))};

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -158,7 +158,7 @@ CopyDeviceOperation::spec_return_value_t CopyDeviceOperation::compute_output_spe
         operation_attributes.output_dtype, PageConfig(input_tensor.layout()), operation_attributes.output_mem_config);
     auto output_padded_shape = output_layout.compute_padded_shape(
         input_tensor.logical_shape());  // We need to account for the fact that the output tensor may have a different
-                                        // padded_shape due to having a differrent shard_spec.
+                                        // padded_shape due to having a different shard_spec.
     return {TensorSpec(
         input_tensor.logical_shape(),
         tt::tt_metal::TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -154,8 +154,10 @@ CopyDeviceOperation::spec_return_value_t CopyDeviceOperation::compute_output_spe
 
     const Tensor& input_tensor = tensor_args.input;
 
-    auto output_layout = TensorLayout(
-        operation_attributes.output_dtype, PageConfig(input_tensor.layout()), operation_attributes.output_mem_config);
+    auto output_layout = tt::tt_metal::TensorLayout(
+        operation_attributes.output_dtype,
+        tt::tt_metal::PageConfig(input_tensor.layout()),
+        operation_attributes.output_mem_config);
     auto output_padded_shape = output_layout.compute_padded_shape(
         input_tensor.logical_shape());  // We need to account for the fact that the output tensor may have a different
                                         // padded_shape due to having a different shard_spec.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There is an inconsistency with the output tensor spec alignment due to the change in compute_output_spec introduced in commit https://github.com/tenstorrent/tt-metal/commit/2ee6b1315ac5669edd9e3eaea2b3daaf661273a7 causing CI failure in tt-mlir: https://github.com/tenstorrent/tt-mlir/actions/runs/24045592443/job/70134775629?pr=7805.
### What's changed
`fromPaddedShape` is used as a patch to deal with output alignment to unblock MLIR and ttnn::to_memory_config ND sharding. However, this all instances of `fromPaddedShape` will be replaced in a future PR (next step: https://github.com/tenstorrent/tt-metal/issues/41554), since this is a problematic deprecated API and it needs to be removed.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/patch_ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/patch_ttnn_copy)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/patch_ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/patch_ttnn_copy)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/patch_ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/patch_ttnn_copy)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/runs/24087430940) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/patch_ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/patch_ttnn_copy)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/patch_ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/patch_ttnn_copy)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/patch_ttnn_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/patch_ttnn_copy)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
