### PR TITLE
Fix clang-static-analyzer workflow: inline container image reference

### DIFF
--- a/.github/workflows/clang-static-analyzer.yaml
+++ b/.github/workflows/clang-static-analyzer.yaml
@@ -14,11 +14,6 @@ on:
         type: string
         default: ""
 
-env:
-  # Always use the latest ci-build image — CSA runs on main HEAD and
-  # is unlikely to be paired with container changes.
-  CSA_IMAGE: harbor.ci.tenstorrent.net/ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-24.04-ci-build-amd64:latest
-
 jobs:
   clang-static-analyzer:
     name: 🔬 Clang Static Analyzer
@@ -26,7 +21,9 @@ jobs:
     timeout-minutes: 300
     runs-on: tt-ubuntu-2204-xlarge-stable
     container:
-      image: ${{ env.CSA_IMAGE }}
+      # Always use the latest ci-build image — CSA runs on main HEAD and
+      # is unlikely to be paired with container changes.
+      image: harbor.ci.tenstorrent.net/ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-24.04-ci-build-amd64:latest
       volumes:
         - ${{ github.workspace }}:/work
         # HACK: make actions available inside container


### PR DESCRIPTION
### Problem description
The clang-static-analyzer workflow fails validation with:
```
Invalid workflow file: .github/workflows/clang-static-analyzer.yaml#L1
(Line: 29, Col: 14): Unrecognized named-value: 'env'. Located at position 1 within expression: env.CSA_IMAGE
```

The `env` context is [not available](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#context-availability) in `jobs.<job_id>.container.image`. It's only available inside step-level expressions (`jobs.<job_id>.steps`).

### What's changed
- Removed the top-level `env.CSA_IMAGE` variable
- Inlined the image URL directly in `container.image` where `env` context is not supported
- Moved the explanatory comment to the inline location

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw-patch-3-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw-patch-3-1)