### PR TITLE
[DCAMP-205] Gracefully abort and report hung devices in fabric tests instead of hanging forever

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -267,6 +267,14 @@ int main(int argc, char** argv) {
 
                 log_info(tt::LogTest, "Waiting for programs");
                 test_context.wait_for_programs_with_progress();
+
+                if (test_context.did_last_test_hang()) {
+                    log_error(tt::LogTest, "Test {} HUNG - skipping to next test.", built_test.parametrized_name);
+                    test_context.record_hung_test(built_test.parametrized_name);
+                    test_context.reset_devices();
+                    continue;
+                }
+
                 log_info(tt::LogTest, "Test {} Finished.", built_test.parametrized_name);
 
                 test_context.process_telemetry_data(built_test);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -91,7 +91,6 @@ int main(int argc, char** argv) {
         progress_config.enabled = true;
         progress_config.poll_interval_seconds = cmdline_parser.get_progress_interval();
         progress_config.hung_threshold_seconds = cmdline_parser.get_hung_threshold();
-
         test_context.enable_progress_monitoring(progress_config);
     }
 
@@ -269,10 +268,13 @@ int main(int argc, char** argv) {
                 test_context.wait_for_programs_with_progress();
 
                 if (test_context.did_last_test_hang()) {
-                    log_error(tt::LogTest, "Test {} HUNG - skipping to next test.", built_test.parametrized_name);
+                    log_error(
+                        tt::LogTest,
+                        "Test {} HUNG - aborting test suite. System may be in a bad state.",
+                        built_test.parametrized_name);
                     test_context.record_hung_test(built_test.parametrized_name);
                     test_context.reset_devices();
-                    continue;
+                    break;
                 }
 
                 log_info(tt::LogTest, "Test {} Finished.", built_test.parametrized_name);
@@ -305,6 +307,12 @@ int main(int argc, char** argv) {
                 fixture->barrier();
                 test_context.reset_devices();
             }
+            if (test_context.did_last_test_hang()) {
+                break;
+            }
+        }
+        if (test_context.did_last_test_hang()) {
+            break;
         }
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -79,6 +79,8 @@ void TestContext::add_sync_traffic_to_devices(const TestConfig& config) {
 }
 
 void TestContext::wait_for_programs_with_progress() {
+    last_test_hung_ = false;
+
     if (!progress_config_.enabled) {
         fixture_->wait_for_programs();
         return;
@@ -94,8 +96,6 @@ void TestContext::wait_for_programs_with_progress() {
         "Progress monitoring started (poll interval: {}s, hung threshold: {}s)",
         progress_config_.poll_interval_seconds,
         progress_config_.hung_threshold_seconds);
-
-    last_test_hung_ = false;
     bool completed = monitor.poll_until_complete();
 
     if (!completed) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -95,10 +95,17 @@ void TestContext::wait_for_programs_with_progress() {
         progress_config_.poll_interval_seconds,
         progress_config_.hung_threshold_seconds);
 
-    monitor.poll_until_complete();
-    log_info(tt::LogTest, "Progress monitoring complete, waiting for programs to finish...");
+    last_test_hung_ = false;
+    bool completed = monitor.poll_until_complete();
 
-    // Now call wait_for_programs() to ensure proper cleanup
+    if (!completed) {
+        last_test_hung_ = true;
+        has_test_failures_ = true;
+        log_error(tt::LogTest, "Skipping remaining steps for this test due to hang.");
+        return;
+    }
+
+    log_info(tt::LogTest, "Progress monitoring complete, waiting for programs to finish...");
     fixture_->wait_for_programs();
 }
 
@@ -190,6 +197,7 @@ void TestContext::generate_latency_summary() {
 std::vector<std::string> TestContext::get_all_failed_tests() const {
     std::vector<std::string> combined;
     combined.insert(combined.end(), all_failed_bandwidth_tests_.begin(), all_failed_bandwidth_tests_.end());
+    combined.insert(combined.end(), hung_tests_.begin(), hung_tests_.end());
     if (latency_test_manager_) {
         const auto failed = latency_test_manager_->get_failed_tests();
         combined.insert(combined.end(), failed.begin(), failed.end());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -139,6 +139,10 @@ public:
 
     void wait_for_programs_with_progress();
 
+    bool did_last_test_hang() const { return last_test_hung_; }
+
+    void record_hung_test(const std::string& test_name) { hung_tests_.push_back(test_name); }
+
     // Accessors for progress monitor
     const std::unordered_map<MeshCoordinate, TestDevice>& get_test_devices() const { return test_devices_; }
 
@@ -273,7 +277,9 @@ private:
     std::filesystem::path raw_telemetry_csv_path_;
 
     std::vector<std::string> all_failed_bandwidth_tests_;  // Accumulates failed bandwidth tests
-    bool has_test_failures_ = false;  // Track if any tests failed validation
+    std::vector<std::string> hung_tests_;
+    bool has_test_failures_ = false;
+    bool last_test_hung_ = false;
 
     // Ethernet core buffer readback helper
     std::unique_ptr<EthCoreBufferReadback> eth_readback_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -28,7 +28,7 @@ TestProgressMonitor::TestProgressMonitor(::TestContext* ctx, const ProgressMonit
 
 TestProgressMonitor::~TestProgressMonitor() = default;
 
-void TestProgressMonitor::poll_until_complete() {
+bool TestProgressMonitor::poll_until_complete() {
     start_time_ = std::chrono::steady_clock::now();
     last_poll_time_ = start_time_;
 
@@ -40,7 +40,7 @@ void TestProgressMonitor::poll_until_complete() {
 
         auto progress = poll_devices();
 
-        check_for_hung_devices(progress);
+        bool all_hung = check_for_hung_devices(progress);
 
         programs_complete = true;
         for (const auto& [device_id, prog] : progress) {
@@ -69,13 +69,19 @@ void TestProgressMonitor::poll_until_complete() {
         display_progress(progress, elapsed);
         last_poll_time_ = now;
 
+        if (all_hung && !programs_complete) {
+            std::cout << std::endl;
+            generate_hung_report(progress);
+            return false;
+        }
+
         if (!programs_complete) {
             std::this_thread::sleep_for(std::chrono::seconds(config_.poll_interval_seconds));
         }
     }
 
-    // Always print newline after final progress update
     std::cout << std::endl;
+    return true;
 }
 
 std::unordered_map<tt::tt_fabric::FabricNodeId, DeviceProgress> TestProgressMonitor::poll_devices() {
@@ -153,25 +159,29 @@ bool TestProgressMonitor::is_device_hung(tt::tt_fabric::FabricNodeId device_id, 
     return elapsed >= hung_threshold_;
 }
 
-void TestProgressMonitor::check_for_hung_devices(
+bool TestProgressMonitor::check_for_hung_devices(
     const std::unordered_map<tt::tt_fabric::FabricNodeId, DeviceProgress>& progress) {
+    uint32_t incomplete_count = 0;
+    uint32_t hung_count = 0;
+
     for (const auto& [device_id, prog] : progress) {
-        // Skip devices that have already completed
-        if (prog.current_packets >= prog.total_packets) {
+        if (prog.num_senders == 0 || prog.current_packets >= prog.total_packets) {
             continue;
         }
 
+        incomplete_count++;
+
         if (is_device_hung(device_id, prog.current_packets)) {
+            hung_count++;
             auto& state = device_states_[device_id];
 
-            // Only warn once per device
             if (!state.warned) {
                 auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
                     std::chrono::steady_clock::now() - state.last_progress_time);
 
                 log_warning(
                     tt::LogTest,
-                    "⚠️  Device {} may be HUNG: no progress for {} seconds (packets: {}/{})",
+                    "Device {} may be HUNG: no progress for {} seconds (packets: {}/{})",
                     format_device_label(device_id),
                     elapsed.count(),
                     prog.current_packets,
@@ -181,6 +191,42 @@ void TestProgressMonitor::check_for_hung_devices(
             }
         }
     }
+
+    return incomplete_count > 0 && hung_count == incomplete_count;
+}
+
+void TestProgressMonitor::generate_hung_report(
+    const std::unordered_map<tt::tt_fabric::FabricNodeId, DeviceProgress>& progress) {
+    const auto total_elapsed =
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start_time_);
+
+    log_error(tt::LogTest, "============ FABRIC TEST HUNG - ABORTING ============");
+    log_error(tt::LogTest, "Test ran for {} seconds before all remaining devices stalled.", total_elapsed.count());
+
+    for (const auto& [device_id, prog] : progress) {
+        if (prog.num_senders == 0) {
+            continue;
+        }
+
+        const bool is_complete = prog.current_packets >= prog.total_packets && prog.total_packets > 0;
+        const bool is_hung = device_states_.contains(device_id) && device_states_.at(device_id).warned;
+        const char* status = is_complete ? "COMPLETED" : (is_hung ? "HUNG" : "IN PROGRESS");
+        const double pct =
+            prog.total_packets > 0 ? 100.0 * static_cast<double>(prog.current_packets) / prog.total_packets : 0.0;
+
+        log_error(
+            tt::LogTest,
+            "  {} | {} | {}/{} packets ({:.1f}%) | {} sender(s)",
+            format_device_label(device_id),
+            status,
+            format_count(prog.current_packets),
+            format_count(prog.total_packets),
+            pct,
+            prog.num_senders);
+    }
+
+    log_error(tt::LogTest, "Devices completed: {}/{}", completed_devices_.size(), total_active_devices_);
+    log_error(tt::LogTest, "=====================================================");
 }
 
 void TestProgressMonitor::display_progress(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -211,7 +211,13 @@ void TestProgressMonitor::generate_hung_report(
 
         const bool is_complete = prog.current_packets >= prog.total_packets && prog.total_packets > 0;
         const bool is_hung = device_states_.contains(device_id) && device_states_.at(device_id).warned;
-        const char* status = is_complete ? "COMPLETED" : (is_hung ? "HUNG" : "IN PROGRESS");
+
+        const char* status = "IN PROGRESS";
+        if (is_complete) {
+            status = "COMPLETED";
+        } else if (is_hung) {
+            status = "HUNG";
+        }
         const double pct =
             prog.total_packets > 0 ? 100.0 * static_cast<double>(prog.current_packets) / prog.total_packets : 0.0;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -165,7 +165,8 @@ bool TestProgressMonitor::check_for_hung_devices(
     uint32_t hung_count = 0;
 
     for (const auto& [device_id, prog] : progress) {
-        if (prog.num_senders == 0 || prog.current_packets >= prog.total_packets) {
+        const bool device_complete = prog.total_packets > 0 && prog.current_packets >= prog.total_packets;
+        if (prog.num_senders == 0 || device_complete) {
             continue;
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.hpp
@@ -60,8 +60,9 @@ public:
     TestProgressMonitor(TestProgressMonitor&&) = delete;
     TestProgressMonitor& operator=(TestProgressMonitor&&) = delete;
 
-    // Poll until programs complete (runs in calling thread)
-    void poll_until_complete();
+    // Poll until programs complete or all remaining devices are hung.
+    // Returns true if all devices completed normally, false if aborted due to hang.
+    bool poll_until_complete();
 
 private:
     // Poll all devices and collect progress
@@ -70,8 +71,11 @@ private:
     // Poll a single device's senders
     DeviceProgress poll_device_senders(const MeshCoordinate& coord, const TestDevice& test_device);
 
-    // Check for hung devices and display warnings
-    void check_for_hung_devices(const std::unordered_map<tt::tt_fabric::FabricNodeId, DeviceProgress>& progress);
+    // Check for hung devices and display warnings. Returns true if all remaining devices are hung.
+    bool check_for_hung_devices(const std::unordered_map<tt::tt_fabric::FabricNodeId, DeviceProgress>& progress);
+
+    // Generate a detailed report of all device states at abort time
+    void generate_hung_report(const std::unordered_map<tt::tt_fabric::FabricNodeId, DeviceProgress>& progress);
 
     // Display progress (single line summary)
     void display_progress(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

- `test_tt_fabric` hangs indefinitely when devices stall during fabric testing (seen at Rev C Galaxy customer install), with no diagnostic output and no way to recover without an external kill.
- The existing `--show-progress` monitor detects hung devices and logs a one-time warning, but never breaks out of its polling loop; the subsequent `Finish()` call also blocks forever on a condvar with no timeout.
- A single hung test blocks the entire test suite — no subsequent tests run, and the operator gets no report of which physical device/ASIC is responsible.

### What's changed

- `poll_until_complete()` now returns `false` when all remaining devices are flagged as hung, emitting a per-device status report with physical Tray/ASIC labels (hostname, rank, packet progress) before breaking the loop.
- `wait_for_programs_with_progress()` skips the blocking `Finish()` on hang, records the failure, and the main test loop doesn't continue and the test suite exits
- Hung test summary is printed alongside other failures, so the process exits non-zero with a complete report instead of hanging silently.

### Testing
- Temporarily added code to the progress monitor to force a device to report zero progress, simulating a device-level stall without faulty hardware. Verified the full abort-and-continue path
- Also verified using `benchmark_mode: true` with 100M packets and `--hung-threshold 5`, which suppresses kernel progress writes and triggers the same abort path.


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/fabric_hang_detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/fabric_hang_detection)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/fabric_hang_detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/fabric_hang_detection)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/fabric_hang_detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/fabric_hang_detection)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

https://github.com/tenstorrent/tt-metal/actions/runs/24186416377 <- (TM-Fabric) Fabric Tests 
