### PR TITLE
[Test]: MultiCoreKernelUniqueRuntimeArgs was specifying incorrect numof cta for compute kernel

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -50,15 +50,17 @@ void execute_program_and_verify(
     bool verify_output = true) {
     distributed::WriteShard(mesh_device->mesh_command_queue(), in_buffer, input, zero_coord, true);
 
-    // TODO #38042: Need to wait for data to be written, the barrier needs to be uplifted for Quasar
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    if (mesh_device->get_devices()[0]->arch() == ARCH::QUASAR) {
+        // TODO #38042: Need to wait for data to be written, the barrier needs to be uplifted for Quasar
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    std::vector<uint32_t> rdback_dram;
-    distributed::ReadShard(mesh_device->mesh_command_queue(), rdback_dram, in_buffer, zero_coord, true);
+        std::vector<uint32_t> rdback_dram;
+        distributed::ReadShard(mesh_device->mesh_command_queue(), rdback_dram, in_buffer, zero_coord, true);
 
-    tt_driver_atomics::mfence();
+        tt_driver_atomics::mfence();
 
-    EXPECT_EQ(rdback_dram, input);
+        EXPECT_EQ(rdback_dram, input);
+    }
 
     // Execute using slow dispatch (DFBs not yet supported in MeshWorkload path)
     IDevice* device = mesh_device->get_devices()[0];
@@ -406,7 +408,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx1S) {
         .enable_implicit_sync = GetParam()};
 
     uint32_t num_entries_in_buffer = 18;
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, {}, num_entries_in_buffer);
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set, num_entries_in_buffer);
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx1S) {
@@ -622,7 +625,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx4S) {
         .enable_implicit_sync = GetParam()};
 
     uint32_t num_entries_in_buffer = 29;
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, {}, num_entries_in_buffer);
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set, num_entries_in_buffer);
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx4S) {
@@ -670,7 +674,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB2Sx4S) {
         .enable_implicit_sync = GetParam()};
 
     uint32_t num_entries_in_buffer = 21;
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, {}, num_entries_in_buffer);
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set, num_entries_in_buffer);
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB2Sx4S) {

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
@@ -283,7 +283,7 @@ static DramBuffer prepare_reader(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt_metal::NOC::RISCV_1_default,
-            .compile_args = {DEFAULT_INPUT_CB_INDEX, 0}});
+            .compile_args = {DEFAULT_INPUT_CB_INDEX, /*use_dfbs=*/false}});
 
     // Set runtime arguments for the reader kernel
     tt_metal::SetRuntimeArgs(
@@ -315,7 +315,7 @@ static DramBuffer prepare_writer(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = {DEFAULT_OUTPUT_CB_INDEX, 0}});
+            .compile_args = {DEFAULT_OUTPUT_CB_INDEX, /*use_dfbs=*/false}});
 
     // Set runtime arguments for the writer kernel
     tt_metal::SetRuntimeArgs(

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -25,9 +25,13 @@ void kernel_main() {
     experimental::Noc noc;
 
     // TODO: Replace with get_thread_idx() kernel API when available
+#ifdef ARCH_QUASAR
     std::uint64_t hartid;
     asm volatile("csrr %0, mhartid" : "=r"(hartid));
     uint32_t consumer_idx = static_cast<uint32_t>(__builtin_popcount(consumer_mask & ((1u << hartid) - 1u)));
+#else
+    uint32_t consumer_idx = 0;
+#endif
 
     DPRINT << "consumer_idx: " << consumer_idx << " num_entries_per_consumer: " << num_entries_per_consumer << ENDL();
     DEVICE_PRINT("consumer_idx: {} num_entries_per_consumer: {}\n", consumer_idx, num_entries_per_consumer);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -29,9 +29,13 @@ void kernel_main() {
     experimental::Noc noc;
 
     // TODO: Replace with get_thread_idx() kernel API when available
+#ifdef ARCH_QUASAR
     std::uint64_t hartid;
     asm volatile("csrr %0, mhartid" : "=r"(hartid));
     uint32_t producer_idx = static_cast<uint32_t>(__builtin_popcount(producer_mask & ((1u << hartid) - 1u)));
+#else
+    uint32_t producer_idx = 0;
+#endif
 
     // DPRINT << "producer_idx: " << producer_idx << " num_entries_per_producer: " << num_entries_per_producer <<
     // ENDL(); DEVICE_PRINT("producer_idx: {} num_entries_per_producer: {}\n", producer_idx, num_entries_per_producer);

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -146,7 +146,7 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelUniqueRuntimeArgs) {
     auto dst_dram_buffer_2 = CreateBuffer(dram_config);
     auto dst_dram_buffer_3 = CreateBuffer(dram_config);
 
-    vector<uint32_t> compute_kernel_args = {uint(num_tiles)};
+    vector<uint32_t> compute_kernel_args = {uint(num_tiles), /*use_dfbs=*/false};
 
     auto [program, reader_kernel_id, writer_kernel_id] =
         create_program(dev, single_tile_size, all_cores, compute_kernel_args);


### PR DESCRIPTION

### Ticket
https://github.com/tenstorrent/tt-metal/issues/41620

### Problem description
https://github.com/tenstorrent/tt-metal/actions/runs/24067681397/job/70199214658. Changes to enable dfb on wh/pr updated test kernel CTA but this usage wasn't updated 

### Checklist

- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/l2-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/l2-fix)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

