### PR TITLE
SDXL BH support fix

### DIFF
--- a/models/demos/stable_diffusion_xl_base/conftest.py
+++ b/models/demos/stable_diffusion_xl_base/conftest.py
@@ -326,7 +326,7 @@ def get_device_name():
         ttnn.cluster.ClusterType.N300_2x2: "n300_2x2",
         ttnn.cluster.ClusterType.T3K: "t3k",
         ttnn.cluster.ClusterType.GALAXY: "galaxy",
-        ttnn.cluster.ClusterType.BLACKHOLE_GALAXY: "blackhole_galaxy",
+        ttnn.cluster.ClusterType.BLACKHOLE_GALAXY: "bh_galaxy",
         ttnn.cluster.ClusterType.P100: "p100",
         ttnn.cluster.ClusterType.P150: "p150",
         ttnn.cluster.ClusterType.P150_X2: "p150x2",

--- a/models/demos/stable_diffusion_xl_base/conftest.py
+++ b/models/demos/stable_diffusion_xl_base/conftest.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pytest
 from loguru import logger
 
-from conftest import is_galaxy
 from models.common.utility_functions import is_wormhole_b0
 from models.demos.stable_diffusion_xl_base.lora.config import TEST_LORA_FILENAME, TEST_LORA_REPO_ID
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE, SDXL_L1_SMALL_SIZE_BH
@@ -308,20 +307,35 @@ def reset_config(request):
     return reset_bool, reset_period
 
 
+def is_galaxy():
+    import ttnn
+
+    return (
+        ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
+        or ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.BLACKHOLE_GALAXY
+    )
+
+
 def get_device_name():
     import ttnn
 
-    num_devices = ttnn.GetNumAvailableDevices()
-    if is_galaxy():
-        return "galaxy"
-    elif num_devices == 0:
-        return "cpu"
-    elif num_devices == 1:
-        return "n150"
-    elif num_devices == 2:
-        return "n300"
-    elif num_devices == 8:
-        return "t3k"
+    cluster_type = ttnn.cluster.get_cluster_type()
+    cluster_type_to_name = {
+        ttnn.cluster.ClusterType.N150: "n150",
+        ttnn.cluster.ClusterType.N300: "n300",
+        ttnn.cluster.ClusterType.N300_2x2: "n300_2x2",
+        ttnn.cluster.ClusterType.T3K: "t3k",
+        ttnn.cluster.ClusterType.GALAXY: "galaxy",
+        ttnn.cluster.ClusterType.BLACKHOLE_GALAXY: "blackhole_galaxy",
+        ttnn.cluster.ClusterType.P100: "p100",
+        ttnn.cluster.ClusterType.P150: "p150",
+        ttnn.cluster.ClusterType.P150_X2: "p150x2",
+        ttnn.cluster.ClusterType.P150_X4: "p150x4",
+        ttnn.cluster.ClusterType.P150_X8: "p150x8",
+        ttnn.cluster.ClusterType.P300: "p300",
+        ttnn.cluster.ClusterType.P300_X2: "p300x2",
+    }
+    return cluster_type_to_name.get(cluster_type, "unknown")
 
 
 @pytest.fixture

--- a/models/demos/stable_diffusion_xl_base/demo/demo.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo.py
@@ -11,8 +11,8 @@ from diffusers import DiffusionPipeline
 from loguru import logger
 from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
-from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
+from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
     MAX_SEQUENCE_LENGTH,

--- a/models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -10,8 +10,8 @@ import torch
 from diffusers import DiffusionPipeline, StableDiffusionXLImg2ImgPipeline
 from loguru import logger
 
-from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
+from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     SDXL_FABRIC_CONFIG,
     determinate_min_batch_size,

--- a/models/demos/stable_diffusion_xl_base/demo/demo_img2img.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_img2img.py
@@ -12,8 +12,8 @@ from loguru import logger
 from PIL import Image
 from transformers import CLIPTextModelWithProjection
 
-from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
+from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER,
     MAX_SEQUENCE_LENGTH,

--- a/models/demos/stable_diffusion_xl_base/demo/demo_inpainting.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_inpainting.py
@@ -12,8 +12,8 @@ from diffusers.utils import load_image
 from loguru import logger
 from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
-from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
+from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
     MAX_SEQUENCE_LENGTH,

--- a/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
@@ -49,8 +49,8 @@ def run_demo_inference(
     sigmas=None,
     lora_path=None,
 ):
-    if vae_on_device and is_blackhole():
-        pytest.skip("Device VAE not supported on Blackhole")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
 
     batch_size = determinate_min_batch_size(ttnn_device, use_cfg_parallel)
 

--- a/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
@@ -12,8 +12,8 @@ from loguru import logger
 from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
 import ttnn
-from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
+from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
     MAX_SEQUENCE_LENGTH,

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
@@ -10,8 +10,7 @@ from diffusers import DiffusionPipeline
 from loguru import logger
 
 import ttnn
-from conftest import is_galaxy
-from models.demos.stable_diffusion_xl_base.conftest import get_device_name
+from models.demos.stable_diffusion_xl_base.conftest import get_device_name, is_galaxy
 from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
 from tests.ttnn.utils_for_testing import assert_allclose, assert_with_pcc
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_rollback.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_rollback.py
@@ -8,7 +8,7 @@ from diffusers import DiffusionPipeline
 from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
 import ttnn
-from conftest import is_galaxy
+from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
     MAX_SEQUENCE_LENGTH,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -132,8 +132,8 @@ def test_accuracy_sdxl(
     refiner_aesthetic_score,
     refiner_negative_aesthetic_score,
 ):
-    if vae_on_device and is_blackhole():
-        pytest.skip("Device VAE not supported on Blackhole")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
 

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
@@ -126,8 +126,8 @@ def test_accuracy_sdxl_img2img(
     timesteps,
     sigmas,
 ):
-    if vae_on_device and is_blackhole():
-        pytest.skip("Device VAE not supported on Blackhole")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
 

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
@@ -108,8 +108,8 @@ def test_accuracy_sdxl_inpaint(
     use_cfg_parallel,
     strength,
 ):
-    if vae_on_device and is_blackhole():
-        pytest.skip("Device VAE not supported on Blackhole")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
     input_images, input_masks, prompts = get_dataset_for_inpainting_accuracy(num_prompts)

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
@@ -120,8 +120,8 @@ def test_accuracy_sdxl_lora(
     sigmas,
     lora_path,
 ):
-    if vae_on_device and is_blackhole():
-        pytest.skip("Device VAE not supported on Blackhole")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
 

--- a/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -97,10 +97,12 @@ class TtSDXLPipeline(LightweightModule):
         if is_wormhole_b0():
             os.environ["TT_MM_THROTTLE_PERF"] = "5"
         if pipeline_config.is_galaxy:
-            logger.info("Setting TT_MM_THROTTLE_PERF for Galaxy")
+            grid_override = os.environ.get("TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE")
+            logger.info(f"Checking TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE for Galaxy, current value: {grid_override}")
+            expected = "7,7" if is_wormhole_b0() else "10,9"
             assert (
-                os.environ["TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE"] == "7,7"
-            ), "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE is not set to 7,7, and it needs to be set for Galaxy"
+                grid_override == expected
+            ), f"TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE is not set to {expected}, and it needs to be set for Galaxy"
 
         logger.info("Loading TT components...")
         self.__load_tt_components(pipeline_config, tt_scheduler)


### PR DESCRIPTION
### Ticket
SDXL on galaxy bug #41569

### Problem description
- BH not considered (device_name, is_galaxy, pyskip)

### What's changed
- new get_device_name function
- new is_galaxy function in local conftest
- added assert for `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE` for galaxy
- pyskip condition fixed

### Checklist
- [x] [T3K accuracy](https://github.com/tenstorrent/tt-shield/actions/runs/24088986238) passed✅
- [x] [n150 accuracy](https://github.com/tenstorrent/tt-shield/actions/runs/24088963344) passed✅


