### PR TITLE
[skip ci] vllm nightly pipeline: update galaxy tests to run on pipeline-perf (aus colo) instead of UF

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -329,6 +329,7 @@ jobs:
       - ${{ matrix.test-group.runner-label }}
       - ${{ matrix.test-group.arch }}
       - in-service
+      # topology-6u tag is used for WH galaxies. Currently pipeline-perf machines have mlperf access and pipeline-functional machines do not.
       - ${{ ((matrix.test-group.runner-label == 'BH-QB-GE' || matrix.test-group.runner-label == 'topology-6u') && 'pipeline-perf') || 'pipeline-functional' }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -329,7 +329,7 @@ jobs:
       - ${{ matrix.test-group.runner-label }}
       - ${{ matrix.test-group.arch }}
       - in-service
-      - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && 'pipeline-perf') || 'pipeline-functional' }}
+      - ${{ ((matrix.test-group.runner-label == 'BH-QB-GE' || matrix.test-group.runner-label == 'topology-6u') && 'pipeline-perf') || 'pipeline-functional' }}
     container:
       image: ${{ inputs.docker-image }}
       env:


### PR DESCRIPTION
Recently there was an effort to reduce demand on WH galaxies in AUS colo with weka mounts (model weights) by moving tests that do not need model weights to machines in Unsung Fields. https://github.com/tenstorrent/tt-metal/commit/100b241106aee88762204b238c549e2d20b37785 vllm nightly tests still need model weights - force tests to run on AUS colo machines with `pipeline-perf` tag

Additional context https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1775029860567249