### PR TITLE
Dgomez/remove create output tensors boilerplate

### DIFF
--- a/.cursor/commands/ttnn/migrate-device-operation.md
+++ b/.cursor/commands/ttnn/migrate-device-operation.md
@@ -27,7 +27,7 @@ See the comprehensive guide for detailed examples and the complete 15-step check
 1. **Forgetting to register the prim**: Always register in `ttnn::prim` namespace and use it instead of direct calls
 2. **Including runtime-only values in hash**: Only hash compile-time constants that affect program structure
 3. **Not including values that affect the program structure in hash**: Every parameter that affects program structure must be in the hash
-4. **Redundant tensors in tensor_args_t**: Do not add redundant arguments like `preallocated_output`, if legacy operation did not handle that explicitly in `create_output_tensors`
+4. **Implementing `create_output_tensors` unnecessarily**: The framework provides a default that calls `compute_output_specs` and `create_device_tensor` for simple single-output operations. You must implement it for preallocated outputs, in-place ops, attribute-conditional, multi-output, or no-input ops.
 5. **tensor_args_t must NOT contain references** - no `const &` or `&`
 
 ## Example Reference

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -441,7 +441,21 @@ typename device_operation_t::tensor_return_value_t launch(
         TT_FATAL(is_device_tensor(input_tensors.front().get()), "Device Operations expect tensor with Device storage in inputs");
     }
 
-    auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);
+    auto tensor_return_value = [&]() -> typename device_operation_t::tensor_return_value_t {
+        if constexpr (HasCreateOutputTensors<device_operation_t>) {
+            return device_operation_t::create_output_tensors(operation_attributes, tensor_args);
+        } else {
+            static_assert(
+                std::is_same_v<typename device_operation_t::tensor_return_value_t, Tensor>,
+                "Default create_output_tensors only supports tensor_return_value_t = Tensor. "
+                "Provide a custom create_output_tensors for multi-output operations.");
+            TT_FATAL(
+                !input_tensors.empty(),
+                "Default create_output_tensors requires at least one input tensor to determine the device");
+            auto specs = device_operation_t::compute_output_specs(operation_attributes, tensor_args);
+            return create_device_tensor(specs, input_tensors.front().get().device());
+        }
+    }();
 
     ttnn::MeshDevice* mesh_device = detail::get_mesh_device<device_operation_t>(operation_attributes, tensor_args);
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -92,7 +92,20 @@ struct MeshDeviceOperationAdapter {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        return DeviceOperation::create_output_tensors(attrs, tensor_args);
+        if constexpr (HasCreateOutputTensors<DeviceOperation>) {
+            return DeviceOperation::create_output_tensors(attrs, tensor_args);
+        } else {
+            static_assert(
+                std::is_same_v<tensor_return_value_t, Tensor>,
+                "Default create_output_tensors only supports tensor_return_value_t = Tensor. "
+                "Provide a custom create_output_tensors for multi-output operations.");
+            auto specs = DeviceOperation::compute_output_specs(attrs, tensor_args);
+            auto first_tensor = ttsl::reflection::get_first_object_of_type<Tensor>(tensor_args);
+            TT_FATAL(
+                first_tensor.has_value(),
+                "Default create_output_tensors requires at least one input tensor to determine the device");
+            return create_device_tensor(specs, first_tensor.value().device());
+        }
     }
 
     static ttsl::hash::hash_t compute_program_hash(

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -98,18 +98,25 @@ template <typename Variant>
 concept AllFactoriesValid =
     detail::all_factories_valid<Variant>(std::make_index_sequence<std::variant_size_v<Variant>>{});
 
+// Detect if operation provides a custom create_output_tensors.
+// If not provided, the framework creates output tensors from compute_output_specs automatically.
+template <typename device_operation_t>
+concept HasCreateOutputTensors = requires(
+    const typename device_operation_t::operation_attributes_t& attrs,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    {
+        device_operation_t::create_output_tensors(attrs, tensor_args)
+    } -> std::same_as<typename device_operation_t::tensor_return_value_t>;
+};
+
 template <typename device_operation_t>
 concept DeviceOperationConcept = requires {
     typename device_operation_t::program_factory_t;
+    typename device_operation_t::tensor_return_value_t;
 
     [](const typename device_operation_t::operation_attributes_t& operation_attributes,
        const typename device_operation_t::tensor_args_t& tensor_args) {
         device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
-
-        using tensor_return_value_t = typename device_operation_t::tensor_return_value_t;
-        static_assert(std::same_as<
-                      decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_args)),
-                      tensor_return_value_t>);
     };
 } && HasComputeOutputSpecs<device_operation_t> && AllFactoriesValid<typename device_operation_t::program_factory_t>;
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
@@ -150,13 +150,6 @@ AllToAllCombineDeviceOperation::spec_return_value_t AllToAllCombineDeviceOperati
         TensorLayout(tensor_args.input_tensor.dtype(), PageConfig(tensor_args.input_tensor.layout()), mem_config));
 }
 
-AllToAllCombineDeviceOperation::tensor_return_value_t AllToAllCombineDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return tensor_args.optional_output_tensor.value_or(
-        create_device_tensor(output_spec, tensor_args.input_tensor.device()));
-}
-
 }  // namespace ttnn::operations::ccl
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
@@ -96,9 +96,6 @@ struct AllToAllCombineDeviceOperation {
 
     // Compute the output shapes based on the operation attributes and tensor args
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    // Create the output tensors based on the operation attributes and tensor args
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::ccl
 

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.cpp
@@ -46,12 +46,6 @@ TensorSpec BroadcastDeviceOperation::compute_output_specs(
             input_tensor.dtype(), input_tensor.tensor_spec().page_config(), operation_attributes.output_mem_config));
 }
 
-Tensor BroadcastDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(spec, tensor_args.input_tensor.device());
-}
-
 ttsl::hash::hash_t BroadcastDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "BroadcastDeviceOperation::compute_program_hash is called");

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
@@ -26,7 +26,6 @@ struct BroadcastDeviceOperation {
     using program_factory_t = std::variant<BroadcastProgramFactory>;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -83,18 +83,6 @@ MeshPartitionDeviceOperation::spec_return_value_t MeshPartitionDeviceOperation::
             operation_attributes.output_mem_config))};
 }
 
-MeshPartitionDeviceOperation::tensor_return_value_t MeshPartitionDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.optional_output_tensor.has_value()) {
-        return tensor_args.optional_output_tensor.value();
-    }
-
-    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-
-    auto tensor = create_device_tensor(output_spec, tensor_args.input_tensor.device());
-    return tensor;
-}
-
 }  // namespace ttnn::operations::ccl
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
@@ -82,9 +82,6 @@ struct MeshPartitionDeviceOperation {
 
     // Compute the output shapes based on the operation attributes and tensor args
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    // Create the output tensors based on the operation attributes and tensor args
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 namespace detail {

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -61,12 +61,6 @@ CloneOperation::spec_return_value_t CloneOperation::compute_output_specs(
             input.padded_shape()));
 };
 
-CloneOperation::tensor_return_value_t CloneOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(spec, tensor_args.input.device());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<CloneOperation::tensor_return_value_t>
 CloneOperation::create_op_performance_model(
     const operation_attributes_t& /*op_attr*/, const tensor_args_t& inputs, const Tensor& output) {

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
@@ -51,7 +51,6 @@ struct CloneOperation {
     static void validate_inputs(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -155,12 +155,6 @@ TensorSpec ConcatDeviceOperation::compute_output_specs(
         shape_out, TensorLayout(ref_in_tensor.dtype(), PageConfig(ref_in_tensor.layout()), args.output_mem_config));
 }
 
-Tensor ConcatDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input_tensors[0].device());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>
 ConcatDeviceOperation::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -37,9 +37,6 @@ struct ConcatDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.cpp
@@ -49,12 +49,6 @@ TensorSpec FillRMDeviceOperation::compute_output_specs(
     return TensorSpec(shape, TensorLayout(input_tensor.dtype(), PageConfig(Layout::ROW_MAJOR), args.output_mem_config));
 }
 
-Tensor FillRMDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const Tensor& input_tensor = tensor_args.input;
-    return create_device_tensor(compute_output_specs(args, tensor_args), input_tensor.device());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<FillRMDeviceOperation::tensor_return_value_t>
 FillRMDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*operation_attributes*/,

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.hpp
@@ -23,8 +23,6 @@ struct FillRMDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -95,11 +95,6 @@ Fold::spec_return_value_t Fold::compute_output_specs(
             output_dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), input_tensor.memory_config()))};
 }
 
-Fold::tensor_return_value_t Fold::create_output_tensors(
-    const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    return create_device_tensor(compute_output_specs(op_attr, tensors), tensors.input_tensor.device());
-}
-
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -76,7 +76,6 @@ struct Fold {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.cpp
@@ -47,11 +47,6 @@ IndexedFillDeviceOperation::spec_return_value_t IndexedFillDeviceOperation::comp
         TensorLayout(input_tensor.dtype(), PageConfig(input_tensor.layout()), args.output_mem_config));
 }
 
-IndexedFillDeviceOperation::tensor_return_value_t IndexedFillDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor_a.device());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<IndexedFillDeviceOperation::tensor_return_value_t>
 IndexedFillDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args, tensor_return_value_t& output) {

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp
@@ -22,8 +22,6 @@ struct IndexedFillDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
@@ -57,13 +57,6 @@ MoeRoutingRemapDeviceOperation::spec_return_value_t MoeRoutingRemapDeviceOperati
     return routing_weights.tensor_spec().with_memory_config(mem_config);
 }
 
-MoeRoutingRemapDeviceOperation::tensor_return_value_t MoeRoutingRemapDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-
-    return tensor_args.optional_output_routing_weights.value_or(
-        create_device_tensor(output_spec, tensor_args.input_routing_weights.device()));
-}
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.hpp
@@ -77,9 +77,6 @@ struct MoeRoutingRemapDeviceOperation {
 
     // Compute the output shapes based on the operation attributes and tensor args
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    // Create the output tensors based on the operation attributes and tensor args
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::data_movement
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -62,12 +62,6 @@ RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output
             input_tensor_a.dtype(), tt::tt_metal::PageConfig(input_tensor_a.layout()), mem_config));
 }
 
-RepeatDeviceOperation::tensor_return_value_t RepeatDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& input_tensors) {
-    return create_device_tensor(
-        compute_output_specs(operation_attributes, input_tensors), input_tensors.input.device());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> RepeatDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
@@ -27,8 +27,6 @@ struct RepeatDeviceOperation {
 
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const tensor_args_t& input_tensors);
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& input_tensors);
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -75,12 +75,6 @@ ReshapeDeviceOperation::spec_return_value_t ReshapeDeviceOperation::compute_outp
             operation_attributes.padded_output_shape));
 }
 
-ReshapeDeviceOperation::tensor_return_value_t ReshapeDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(
-        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
-}
-
 ttsl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
@@ -28,9 +28,6 @@ struct ReshapeDeviceOperation {
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -40,11 +40,6 @@ ReshapeViewDeviceOperation::spec_return_value_t ReshapeViewDeviceOperation::comp
             operation_attributes.padded_output_shape));
 }
 
-tt::tt_metal::Tensor ReshapeViewDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
-}
-
 ttsl::hash::hash_t ReshapeViewDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "ReshapeViewDeviceOperation::compute_program_hash is called");

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
@@ -27,9 +27,6 @@ struct ReshapeViewDeviceOperation {
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
@@ -63,11 +63,6 @@ ScatterDeviceOperation::spec_return_value_t ScatterDeviceOperation::compute_outp
         TensorLayout{tensor_args.input_tensor.dtype(), PageConfig{Layout::ROW_MAJOR}, args.output_memory_config}};
 }
 
-ScatterDeviceOperation::tensor_return_value_t ScatterDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<ScatterDeviceOperation::tensor_return_value_t>
 ScatterDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*op_attr*/, const tensor_args_t& inputs, const Tensor& output) {

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
@@ -36,7 +36,6 @@ struct ScatterDeviceOperation {
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -65,12 +65,6 @@ TensorSpec InterleavedToShardedPartialDeviceOperation::compute_output_specs(
             operation_attributes.output_dtype, tt::tt_metal::PageConfig(input_tensor.layout()), mem_config));
 }
 
-Tensor InterleavedToShardedPartialDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const Tensor& input_tensor) {
-    auto output_spec = compute_output_specs(operation_attributes, input_tensor);
-    return create_device_tensor(output_spec, input_tensor.device());
-}
-
 ttsl::hash::hash_t InterleavedToShardedPartialDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const Tensor& input_tensor) {
     return tt::tt_metal::operation::hash_operation<InterleavedToShardedPartialDeviceOperation>(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
@@ -22,9 +22,6 @@ struct InterleavedToShardedPartialDeviceOperation {
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
-
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -188,11 +188,6 @@ TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_specs(
             operation_attributes.output_padded_shape));
 }
 
-Tensor TilizeWithValPaddingDeviceOperation::create_output_tensors(
-    const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor) {
-    return create_device_tensor(compute_output_specs(operation_attributes, input_tensor), input_tensor.device());
-}
-
 Tensor tilize_with_val_padding(
     const Tensor& input_tensor,
     const ttnn::Shape& output_padded_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.hpp
@@ -35,9 +35,6 @@ struct TilizeWithValPaddingDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
 };
 
 Tensor tilize_with_val_padding(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -164,11 +164,6 @@ TensorSpec TransposeDeviceOperation::compute_output_specs(
             output_padded_shape));
 }
 
-Tensor TransposeDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> TransposeDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args, const Tensor& output) {
     const auto& input_tensor = tensor_args.input;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.hpp
@@ -47,9 +47,6 @@ struct TransposeDeviceOperation {
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, const Tensor& output);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -277,11 +277,6 @@ UntilizeDeviceOperation::spec_return_value_t UntilizeDeviceOperation::compute_ou
             input_tensor.padded_shape()))};
 }
 
-UntilizeDeviceOperation::tensor_return_value_t UntilizeDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
-}
-
 UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
@@ -54,9 +54,6 @@ struct UntilizeDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,
         tt::tt_metal::MemoryConfig output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -235,12 +235,6 @@ TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_specs(
         TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), operation_attributes.output_mem_config));
 }
 
-Tensor UntilizeWithUnpaddingDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& input) {
-    auto output_spec = compute_output_specs(operation_attributes, input);
-    return create_device_tensor(output_spec, input.device());
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor>
 UntilizeWithUnpaddingDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*operation_attributes*/,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
@@ -38,9 +38,6 @@ struct UntilizeWithUnpaddingDeviceOperation {
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const Tensor& input);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const Tensor& input);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes, const Tensor& input, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
@@ -29,12 +29,6 @@ ExampleDeviceOperation::spec_return_value_t ExampleDeviceOperation::compute_outp
             input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), MemoryConfig{}));
 }
 
-ExampleDeviceOperation::tensor_return_value_t ExampleDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input_tensor.device());
-}
-
 }  // namespace ttnn::operations::examples
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -119,9 +119,6 @@ struct ExampleDeviceOperation {
 
     // Compute the output specs based on the operation attributes and tensor args
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    // Create the output tensors based on the operation attributes and tensor args
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.cpp
@@ -72,12 +72,6 @@ AllGatherConcatDeviceOperation::spec_return_value_t AllGatherConcatDeviceOperati
         tt::tt_metal::TensorLayout(input_tensor.dtype(), tt::tt_metal::Layout::TILE, args.output_mem_config));
 }
 
-AllGatherConcatDeviceOperation::tensor_return_value_t AllGatherConcatDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(spec, tensor_args.input_tensor.device());
-}
-
 ttsl::hash::hash_t AllGatherConcatDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllGatherConcatDeviceOperation::compute_program_hash is called");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.hpp
@@ -25,9 +25,6 @@ struct AllGatherConcatDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.cpp
@@ -80,12 +80,6 @@ AllReduceAsyncDeviceOperation::spec_return_value_t AllReduceAsyncDeviceOperation
     return TensorSpec(shape, output_tensor_layout);
 }
 
-AllReduceAsyncDeviceOperation::tensor_return_value_t AllReduceAsyncDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(args, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input_tensor.device());
-}
-
 ttsl::hash::hash_t AllReduceAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllReduceAsyncDeviceOperation::compute_program_hash is called");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.hpp
@@ -20,8 +20,6 @@ struct AllReduceAsyncDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
@@ -69,14 +69,6 @@ SelectiveReduceCombineDeviceOperation::spec_return_value_t SelectiveReduceCombin
         Shape(output_shape), TensorLayout(input_tensor.dtype(), PageConfig(Layout::ROW_MAJOR), mem_config));
 }
 
-SelectiveReduceCombineDeviceOperation::tensor_return_value_t
-SelectiveReduceCombineDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return tensor_args.optional_output_tensor.value_or(
-        create_device_tensor(output_spec, tensor_args.dense_input_tensor.device()));
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.hpp
@@ -35,9 +35,6 @@ struct SelectiveReduceCombineDeviceOperation {
 
     // Compute the output shapes based on the operation attributes and tensor args
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    // Create the output tensors based on the operation attributes and tensor args
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::experimental::prim
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
@@ -39,11 +39,6 @@ TensorSpec SliceReshardAsyncDeviceOperation::compute_output_specs(
         shape, TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), args.output_mem_config));
 }
 
-Tensor SliceReshardAsyncDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.device());
-}
-
 ttsl::hash::hash_t SliceReshardAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "SliceReshardAsyncDeviceOperation::compute_program_hash is called");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.hpp
@@ -31,7 +31,6 @@ struct SliceReshardAsyncDeviceOperation {
     using shared_variables_t = SliceReshardAsyncProgramFactory::shared_variables_t;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
@@ -49,11 +49,6 @@ TensorSpec ConvertToCHWDeviceOperation::compute_output_specs(
             args.dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR), args.memory_config));
 }
 
-Tensor ConvertToCHWDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.device());
-}
-
 ttsl::hash::hash_t ConvertToCHWDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args;

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.hpp
@@ -22,7 +22,6 @@ struct ConvertToCHWDeviceOperation {
     using program_factory_t = std::variant<ConvertToCHWProgramFactory>;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
@@ -51,11 +51,6 @@ TensorSpec ConvertToHWCDeviceOperation::compute_output_specs(
         TensorLayout(args.dtype, PageConfig(Layout::ROW_MAJOR), args.memory_config));
 }
 
-Tensor ConvertToHWCDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
-}
-
 ttsl::hash::hash_t ConvertToHWCDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return ttsl::hash::hash_objects_with_default_seed(

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.hpp
@@ -26,9 +26,6 @@ struct ConvertToHWCDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize/device/deepseek_moe_post_combine_tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize/device/deepseek_moe_post_combine_tilize_device_operation.cpp
@@ -96,13 +96,6 @@ ttnn::TensorSpec DeepseekMoEPostCombineTilizeDeviceOperation::compute_output_spe
         operations::TensorLayout(input_tensor.dtype(), tt::tt_metal::PageConfig(Layout::TILE), output_memory_config));
 }
 
-ttnn::Tensor DeepseekMoEPostCombineTilizeDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const ttnn::TensorSpec& output_tensor_spec = compute_output_specs(operation_attributes, tensor_args);
-
-    return create_device_tensor(output_tensor_spec, tensor_args.input_tensor.device());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize/device/deepseek_moe_post_combine_tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize/device/deepseek_moe_post_combine_tilize_device_operation.hpp
@@ -24,7 +24,6 @@ struct DeepseekMoEPostCombineTilizeDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
@@ -94,12 +94,6 @@ CombineDeviceOperation::spec_return_value_t CombineDeviceOperation::compute_outp
     return output_spec;
 }
 
-CombineDeviceOperation::tensor_return_value_t CombineDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.dispatched_buffer.device());
-}
-
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.hpp
@@ -22,7 +22,6 @@ struct CombineDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
@@ -60,11 +60,6 @@ tt::stl::hash::hash_t MaskedBincountDeviceOperation::compute_program_hash(
     return hash;
 }
 
-MaskedBincountDeviceOperation::tensor_return_value_t MaskedBincountDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.hpp
@@ -20,7 +20,6 @@ struct MaskedBincountDeviceOperation {
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.cpp
@@ -42,17 +42,6 @@ IsInDeviceOperation::spec_return_value_t IsInDeviceOperation::compute_output_spe
     };
 }
 
-IsInDeviceOperation::tensor_return_value_t IsInDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    if (tensor_args.optional_out) {
-        TT_FATAL(
-            tensor_args.optional_out->dtype() == OUTPUT_TENSOR_DATA_TYPE,
-            "Preallocated output should be of uint32 dtype");
-        return *tensor_args.optional_out;
-    }
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.elements_tensor.device());
-}
-
 ttsl::hash::hash_t IsInDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_memory_layout = tensor_args.elements_tensor.layout();

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.hpp
@@ -19,7 +19,6 @@ struct IsInDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.cpp
@@ -33,11 +33,6 @@ IntImgDeviceOperation::spec_return_value_t IntImgDeviceOperation::compute_output
     return TensorSpec{output_shape, TensorLayout{input_tensor.dtype(), output_layout, input_tensor.memory_config()}};
 }
 
-IntImgDeviceOperation::tensor_return_value_t IntImgDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.device());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.hpp
@@ -34,8 +34,6 @@ struct IntImgDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.cpp
@@ -54,11 +54,6 @@ TensorSpec HCSumReduceDeviceOperation::compute_output_specs(
     return TensorSpec(output_shape, TensorLayout(args.dtype, PageConfig(Layout::TILE), args.memory_config));
 }
 
-Tensor HCSumReduceDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
-}
-
 ttsl::hash::hash_t HCSumReduceDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.hpp
@@ -25,9 +25,6 @@ struct HCSumReduceDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -56,11 +56,6 @@ TensorSpec PrefixScanDeviceOperation::compute_output_specs(
             args.dtype, PageConfig(Layout::TILE), args.memory_config, a.logical_shape(), a.padded_shape()));
 }
 
-Tensor PrefixScanDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.a.device());
-}
-
 ttsl::hash::hash_t PrefixScanDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& a = tensor_args.a;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
@@ -26,9 +26,6 @@ struct PrefixScanDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.cpp
@@ -24,12 +24,6 @@ ExecuteTestHangDeviceOperation::spec_return_value_t ExecuteTestHangDeviceOperati
             tensor_args.tensor.dtype(), tt::tt_metal::PageConfig(tensor_args.tensor.layout()), MemoryConfig{}));
 }
 
-ExecuteTestHangDeviceOperation::tensor_return_value_t ExecuteTestHangDeviceOperation::create_output_tensors(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(attributes, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.tensor.device());
-}
-
 std::tuple<ExecuteTestHangDeviceOperation::operation_attributes_t, ExecuteTestHangDeviceOperation::tensor_args_t>
 ExecuteTestHangDeviceOperation::invoke(const Tensor& input_tensor) {
     return {operation_attributes_t{}, tensor_args_t{input_tensor}};

--- a/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.hpp
@@ -42,8 +42,6 @@ struct ExecuteTestHangDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_device_operation.cpp
@@ -39,11 +39,6 @@ PreAllGatherDeviceOperation::spec_return_value_t PreAllGatherDeviceOperation::co
     return TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::TILE), args.memory_config));
 }
 
-PreAllGatherDeviceOperation::tensor_return_value_t PreAllGatherDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_device_operation.hpp
@@ -24,8 +24,6 @@ struct PreAllGatherDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_pre_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_pre_all_gather_device_operation.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fused_rmsnorm_pre_all_gather_device_operation.hpp"
-#include "ttnn/tensor/tensor_ops.hpp"
 
 #include <tt-metalium/constants.hpp>
 
@@ -40,11 +39,6 @@ TensorSpec FusedRMSNormPreAllGatherDeviceOperation::compute_output_specs(
     output_shape[-1] = num_tiles_w * TILE_WIDTH;
 
     return TensorSpec(output_shape, TensorLayout(args.dtype, PageConfig(Layout::TILE), input_tensor.memory_config()));
-}
-
-Tensor FusedRMSNormPreAllGatherDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_pre_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_pre_all_gather_device_operation.hpp
@@ -23,8 +23,6 @@ struct FusedRMSNormPreAllGatherDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
@@ -87,12 +87,6 @@ NLPConcatHeadsDeviceOperation::spec_return_value_t NLPConcatHeadsDeviceOperation
             input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), args.output_mem_config));
 }
 
-NLPConcatHeadsDeviceOperation::tensor_return_value_t NLPConcatHeadsDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args;
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), input_tensor.device());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.hpp
@@ -26,8 +26,6 @@ struct NLPConcatHeadsDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rotary_embedding_device_operation.hpp"
-#include "ttnn/tensor/tensor_ops.hpp"
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -124,11 +123,6 @@ TensorSpec RotaryEmbeddingDeviceOperation::compute_output_specs(
         shape,
         tt::tt_metal::TensorLayout(
             input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), args.output_mem_config));
-}
-
-Tensor RotaryEmbeddingDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
 ttsl::hash::hash_t RotaryEmbeddingDeviceOperation::compute_program_hash(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
@@ -22,8 +22,6 @@ struct RotaryEmbeddingDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
@@ -41,12 +41,6 @@ TensorSpec RotateHalfDeviceOperation::compute_output_specs(
             input_tensor.padded_shape()));
 }
 
-Tensor RotateHalfDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const TensorSpec spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(spec, tensor_args.device());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.hpp
@@ -23,9 +23,6 @@ struct RotateHalfDeviceOperation {
 
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "index_fill_device_operation.hpp"
-#include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
@@ -66,11 +65,6 @@ IndexFillOperation::spec_return_value_t IndexFillOperation::compute_output_specs
     return TensorSpec(
         tensor_args.input.logical_shape(),
         tensor_args.input.tensor_spec().tensor_layout().with_memory_config(operation_attributes.memory_config));
-}
-IndexFillOperation::tensor_return_value_t IndexFillOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input.device());
 }
 }  // namespace ttnn::operations::index_fill
 

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
@@ -45,7 +45,6 @@ struct IndexFillOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::index_fill
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp"
-#include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 
@@ -303,12 +302,6 @@ TensorSpec GridSampleOperation::compute_output_specs(
             output_memory_config,
             output_logical_shape,
             output_padded_shape));
-}
-
-Tensor GridSampleOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
 ttnn::Tensor grid_sample(

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp
@@ -30,7 +30,6 @@ struct GridSampleOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
@@ -118,11 +118,6 @@ RotateDeviceOperation::spec_return_value_t RotateDeviceOperation::compute_output
             output_padded));
 }
 
-RotateDeviceOperation::tensor_return_value_t RotateDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
-}
-
 ttsl::hash::hash_t RotateDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return ttsl::hash::hash_objects_with_default_seed(

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.hpp
@@ -87,7 +87,6 @@ struct RotateDeviceOperation {
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/pool/upsample/device/upsample_device_operation.hpp"
-#include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/operations/pool/upsample/device/upsample_common.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.hpp"
@@ -134,11 +133,6 @@ UpsampleOperation::spec_return_value_t UpsampleOperation::compute_output_specs(
     }
 
     return make_spec(operations::pool::upsample::compute_float_output_mem_config(input_mc, out_n, out_h, out_w));
-}
-
-UpsampleOperation::tensor_return_value_t UpsampleOperation::create_output_tensors(
-    const operation_attributes_t& args, const Tensor& input) {
-    return create_device_tensor(compute_output_specs(args, input), input.device());
 }
 
 ttnn::Tensor upsample(

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp
@@ -33,7 +33,6 @@ struct UpsampleOperation {
     static program_factory_t select_program_factory(const operation_attributes_t& args, const Tensor& input);
     static void validate_on_program_cache_miss(const operation_attributes_t& args, const Tensor& input);
     static spec_return_value_t compute_output_specs(const operation_attributes_t& args, const Tensor& input);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const Tensor& input);
 };
 
 ttnn::Tensor upsample(

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
@@ -82,12 +82,6 @@ TensorSpec DramPrefetcherOperation::compute_output_specs(
             MemoryConfig{}));
 }
 
-DramPrefetcherOperation::tensor_return_value_t DramPrefetcherOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(args, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input_tensors[0].device());
-}
-
 ttnn::Tensor dram_prefetcher(
     std::vector<ttnn::Tensor>& tensors,
     const uint32_t num_layers,

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.hpp
@@ -23,7 +23,6 @@ struct DramPrefetcherOperation {
     using program_factory_t = std::variant<DramPrefetcherProgramFactory>;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 ttnn::Tensor dram_prefetcher(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce_op_device_operation.hpp"
-#include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/reduction/generic/device/common.hpp"
 
@@ -77,11 +76,6 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
     }
 
     return tensor_spec;
-}
-
-ReduceDeviceOperation::tensor_return_value_t ReduceDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.device());
 }
 
 ttsl::hash::hash_t ReduceDeviceOperation::compute_program_hash(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
@@ -34,9 +34,6 @@ struct ReduceDeviceOperation {
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
@@ -36,11 +36,6 @@ ProdAllDeviceOperation::spec_return_value_t ProdAllDeviceOperation::compute_outp
             input.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), args.output_mem_config));
 }
 
-ProdAllDeviceOperation::tensor_return_value_t ProdAllDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
-}
-
 ttnn::Tensor prod_all(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
     using OperationType = ProdAllDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
@@ -18,9 +18,6 @@ struct ProdAllDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t&);
 };
 
 ttnn::Tensor prod_all(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -87,12 +87,6 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
             output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, output_shape, padded_output_shape));
 }
 
-HaloDeviceOperation::tensor_return_value_t HaloDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(args, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.device());
-}
-
 Tensor halo(
     const Tensor& input_tensor,
     const ttnn::operations::sliding_window::SlidingWindowConfig& config,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -26,8 +26,6 @@ struct HaloDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args);
 };
 
 Tensor halo(

--- a/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
+++ b/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
@@ -101,9 +101,13 @@ struct UnaryDeviceOperation {
         const operation_attributes_t&,
         const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t&);
+    // Optional: only needed for custom allocation logic (preallocated outputs,
+    // in-place ops, attribute-conditional allocation, multi-output, etc.).
+    // When omitted, the framework creates output tensors automatically from
+    // compute_output_specs.
+    // static tensor_return_value_t create_output_tensors(
+    //     const operation_attributes_t& operation_attributes,
+    //     const tensor_args_t&);
 
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t&,
@@ -661,7 +665,7 @@ Use this checklist to ensure all steps are completed:
 - [ ] **Step 2**: Created `tensor_args_t` struct with all Tensor parameters from invoke signature
 - [ ] **Step 3**: Defined `tensor_return_value_t` and `spec_return_value_t` appropriately
 - [ ] **Step 4**: Implemented `compute_output_specs`
-- [ ] **Step 5**: [Optional] Implemented `create_output_tensors` (if legacy had it)
+- [ ] **Step 5**: [Optional] Implemented `create_output_tensors` (only needed for preallocated outputs, in-place ops, attribute-conditional allocation, multi-output, or no-input ops — the framework handles standard single-output allocation automatically)
 - [ ] **Step 6**: [If multi-variant] Implemented `select_program_factory` returning correct variant type (not needed for single-variant `program_factory_t`)
 - [ ] **Step 6a**: [If needed] Created separate mesh workload factory for `mesh_coords` filtering support
 - [ ] **Step 7**: Implemented `validate_on_program_cache_miss`
@@ -684,7 +688,7 @@ Use this checklist to ensure all steps are completed:
 1. **Forgetting to register the prim**: Always register in `ttnn::prim` namespace and use it instead of direct calls
 2. **Including runtime-only values in hash**: Only hash compile-time constants that affect program structure
 3. **Not including values that affect the program structure in hash**: Every parameter that has an effect on program structure must be taken into account in the hash
-4. **Redundant tensors in tensor_args_t**: Do not add redundant arguments like `preallocated_output`, if legacy operation did not handle that explicitly in `create_output_tensors`
+4. **Implementing `create_output_tensors` unnecessarily**: The framework provides a default that calls `compute_output_specs` and `create_device_tensor` for simple single-output operations. You must implement `create_output_tensors` if your operation has preallocated output tensors (`std::optional<Tensor>` output fields), custom logic (in-place, attribute-conditional, multi-output, or no-input ops).
 5. **Mesh workload factories not working with `mesh_coords`**: If your operation supports `mesh_coords` filtering, you MUST create a separate mesh workload factory. The infrastructure's `MeshWorkloadFactoryAdapter` will create programs for ALL tensor coordinates, ignoring `mesh_coords`. Only factories that implement `MeshWorkloadFactoryConcept` (and NOT `ProgramFactoryConcept`) will use the direct path that allows coordinate filtering.
 
 ---


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Nearly every device operation implements a `create_output_tensors` static method that follows one of two patterns:

- **Pattern A** (unconditional allocation): `return create_device_tensor(compute_output_specs(...), input.device())`
- **Pattern B** (optional preallocated output): `if (optional_output.has_value()) return optional_output.value(); else return create_device_tensor(compute_output_specs(...), input.device())`

This is pure boilerplate — ~120 operations repeat the same logic, totaling over 1,100 lines of code that add no value. Every new operation must copy-paste it. The framework already has `compute_output_specs` which fully describes the output tensor; `create_output_tensors` just mechanically translates specs into tensors.



### What's changed
**Framework** (`operation_concepts.hpp`, `device_operation.hpp`, `mesh_device_operation_adapter.hpp`)

`create_output_tensors` is no longer a required method in `DeviceOperationConcept`. A new concept `HasCreateOutputTensors` detects whether an operation provides its own implementation. When an operation omits it, the framework calls `compute_output_specs()` and allocates a new tensor on the first input tensor's device. This is resolved at compile time with zero runtime cost.

A `static_assert` enforces that the default path only applies to operations with `tensor_return_value_t = Tensor` (single-output). Multi-output operations must provide a custom implementation.

**Operations** (~44 ops, 121 files, −313 net lines)

Removed `create_output_tensors` from every Pattern A operation — those that unconditionally create a device tensor from specs with no conditional logic. No field names were changed; operations keep their original struct layouts.

~164 operations retain custom `create_output_tensors` because they have genuinely different semantics: preallocated optional outputs, multi-output, no-input, in-place, attribute-conditional logic, `std::optional<Tensor>` fields that are inputs rather than outputs, or external callers that invoke it directly.

**Documentation** (`DEVICE_OPERATION_MIGRATION_GUIDE.md`, `migrate-device-operation.md`)

Updated to reflect that `create_output_tensors` is optional. The example operation struct shows it commented out with guidance on when it's actually needed. The migration checklist and common pitfalls were updated accordingly.


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/remove-create-output-tensors-boilerplate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/remove-create-output-tensors-boilerplate)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/remove-create-output-tensors-boilerplate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/remove-create-output-tensors-boilerplate)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/remove-create-output-tensors-boilerplate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/remove-create-output-tensors-boilerplate)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/remove-create-output-tensors-boilerplate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/remove-create-output-tensors-boilerplate)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/remove-create-output-tensors-boilerplate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/remove-create-output-tensors-boilerplate)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/remove-create-output-tensors-boilerplate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/remove-create-output-tensors-boilerplate)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)