### PR TITLE
#41176: Lookup table definition for 100k single/multi host prefills

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 
 import pytest
+import torch
 from loguru import logger
 from transformers import AutoConfig
 
@@ -434,3 +435,61 @@ def pretrained_weights(model_path, hf_config, state_dict):
     logger.info(f"Loaded {len(dequantized_weights)} pretrained weight tensors")
 
     return hf_config, dequantized_weights
+
+
+@pytest.fixture
+def random_weights(config_only):
+    """
+    Generate random weights for testing using the config.
+
+    Args:
+        config_only: HuggingFace config (only downloads config files, not weight shards)
+
+    Returns:
+        Tuple of (config, weights_dict) in bfloat16
+    """
+    config = config_only
+
+    torch.manual_seed(42)  # this is tied to already cached reference results, so keep it consistent for now
+
+    # Use proper initialization scale from config (typically 0.02)
+    std = config.initializer_range
+
+    # Generate random weights matching MLA architecture using actual config
+    # Generate in float32 first, then convert to bfloat16 for better numerical properties
+    weights = {
+        "q_a_proj.weight": (torch.randn(config.q_lora_rank, config.hidden_size) * std).to(torch.bfloat16),
+        "q_a_layernorm.weight": torch.ones(config.q_lora_rank, dtype=torch.bfloat16),
+        "q_b_proj.weight": (
+            torch.randn(
+                config.num_attention_heads * (config.qk_nope_head_dim + config.qk_rope_head_dim),
+                config.q_lora_rank,
+            )
+            * std
+        ).to(torch.bfloat16),
+        "kv_a_proj_with_mqa.weight": (
+            torch.randn(
+                config.kv_lora_rank + config.qk_rope_head_dim,
+                config.hidden_size,
+            )
+            * std
+        ).to(torch.bfloat16),
+        "kv_a_layernorm.weight": torch.ones(config.kv_lora_rank, dtype=torch.bfloat16),
+        "kv_b_proj.weight": (
+            torch.randn(
+                config.num_attention_heads * (config.qk_nope_head_dim + config.v_head_dim),
+                config.kv_lora_rank,
+            )
+            * std
+        ).to(torch.bfloat16),
+        "o_proj.weight": (
+            torch.randn(
+                config.hidden_size,
+                config.num_attention_heads * config.v_head_dim,
+            )
+            * std
+        ).to(torch.bfloat16),
+    }
+
+    logger.info(f"Generated {len(weights)} random weight tensors using config dimensions")
+    return config, weights

--- a/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test for KvChunkAddressTable Python bindings.
+This test verifies that the disaggregation APIs are accessible from Python
+and work correctly.
+"""
+
+import socket
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    ids=["8x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        }
+    ],
+    indirect=True,
+)
+def test_kv_chunk_address_table(mesh_device):
+    """Test KvChunkAddressTable Python bindings"""
+
+    logger.info("Testing KvChunkAddressTable Python bindings")
+
+    # 1. Create configuration
+    config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+    config.num_layers = 1
+    config.max_sequence_length = 8192
+    config.num_slots = 8
+    config.chunk_n_tokens = 32
+    config.chunk_size_bytes = 19584
+
+    logger.info(
+        f"Config: layers={config.num_layers}, seq_len={config.max_sequence_length}, "
+        f"slots={config.num_slots}, chunk_tokens={config.chunk_n_tokens}"
+    )
+
+    # 2. Initialize table
+    table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
+
+    logger.info(
+        f"Table created: {table.num_position_chunks()} position chunks, " f"{table.total_entries()} total entries"
+    )
+
+    # 3. Add device groups using FabricNodeIds from mesh
+    mesh_shape = list(mesh_device.shape)
+    device_groups = []
+
+    # Create one device group per mesh column
+    for col in range(mesh_shape[1]):
+        fabric_node_ids = []
+        for row in range(mesh_shape[0]):
+            coord = ttnn.MeshCoordinate(row, col)
+            fabric_node_id = mesh_device.get_fabric_node_id(coord)
+            fabric_node_ids.append(fabric_node_id)
+
+        group_idx = table.add_device_group(fabric_node_ids)
+        device_groups.append(group_idx)
+        logger.info(f"Device group {int(group_idx)}: {len(fabric_node_ids)} nodes")
+
+    logger.info(f"Total device groups: {table.num_device_groups()}")
+
+    # 4. Set KV cache locations
+    layer = 0
+    slot = 0
+    position = 0  # Must be chunk-aligned
+
+    location = ttnn.experimental.disaggregation.KvCacheLocation()
+    location.noc_addr = 0xDEADBEEF
+    location.size_bytes = 19584
+    location.device_group_index = device_groups[0]
+
+    table.set(layer, position, slot, location)
+    logger.info(f"Set location for (layer={layer}, pos={position}, slot={slot})")
+
+    # 5. Lookup the location
+    retrieved = table.lookup(layer, position, slot)
+    logger.info(
+        f"Retrieved: noc_addr=0x{retrieved.noc_addr:X}, "
+        f"size={retrieved.size_bytes}, group_idx={int(retrieved.device_group_index)}"
+    )
+
+    assert retrieved.noc_addr == 0xDEADBEEF
+    assert retrieved.size_bytes == 19584
+    assert int(retrieved.device_group_index) == int(device_groups[0])
+
+    # 6. Test range lookup
+    start_pos = 0
+    end_pos = 64  # 2 chunks
+    locations = table.lookup_range(layer, start_pos, end_pos, slot)
+    logger.info(f"Range lookup [{start_pos}, {end_pos}): {len(locations)} entries")
+
+    # 7. Test device group retrieval
+    group = table.get_device_group(device_groups[0])
+    logger.info(f"Device group 0 has {len(group.fabric_node_ids)} fabric nodes")
+
+    # 8. Print fabric node IDs in the first group
+    for idx, fid in enumerate(group.fabric_node_ids):
+        mesh_id = int(fid.mesh_id)
+        chip_id = int(fid.chip_id)
+        logger.info(f"  Node {idx}: mesh_id={mesh_id}, chip_id={chip_id}")
+
+    logger.success("KvChunkAddressTable bindings test passed!")
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(32, 4), (8, 4), (1, 2)],
+    ids=["32x4", "8x4", "1x2"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", [3 * 1024, 4 * 3 * 1024, 100 * 1024], ids=["seq3k", "seq12k", "seq100k"])
+def test_kv_cache_address_table(mesh_device, seq_len):
+    sp_axis = 0
+    kvpe_cache_head_dim = 576
+
+    mesh_shape = list(mesh_device.shape)
+    if mesh_shape[0] == 32 and mesh_shape[1] == 4 and seq_len == 3 * 1024:
+        pytest.skip("Skipping test for 32x4 mesh and seq3k")
+    seq_len_local = seq_len // mesh_shape[sp_axis]
+
+    torch_kvpe_cache = torch.zeros(1, 1, seq_len_local, kvpe_cache_head_dim)
+
+    BH_NUM_DRAM_BANKS = 8
+    core_ranges = [
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
+    ]
+    grid = ttnn.CoreRangeSet(core_ranges)
+
+    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32  # this is a predefined constant
+    kv_nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim],
+        grid=grid,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    kv_mem_config = ttnn.MemoryConfig(
+        buffer_type=ttnn.BufferType.DRAM,
+        nd_shard_spec=kv_nd_shard_spec,
+    )
+
+    tt_kvpe_cache = ttnn.from_torch(
+        torch_kvpe_cache,
+        dtype=ttnn.bfloat8_b,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=kv_mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    CHUNK_SIZE_BYTES = 19584  # [1, 1, 32, 576] bfp8
+    config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+    config.num_layers = 1
+    config.max_sequence_length = seq_len
+    config.num_slots = 1
+    config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+    config.chunk_size_bytes = CHUNK_SIZE_BYTES
+
+    lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
+
+    host_name = socket.gethostname()
+    logger.info(f"Host name: {host_name}")
+
+    # Create device groups that contain replicated data
+    # Data is replicated on each column of the mesh
+    device_group_idx_per_row = []
+
+    rank = ttnn.distributed_context_get_rank()
+    size = ttnn.distributed_context_get_size()
+
+    total_rows = mesh_shape[0]
+    rank_row_start = int(rank) * total_rows // int(size)
+    rank_row_end = rank_row_start + total_rows // int(size)
+
+    logger.info(f"Rank: {rank}, Size: {size}, Row start: {rank_row_start}, Row end: {rank_row_end}")
+
+    all_fabric_node_ids = []
+    for row in range(rank_row_start, rank_row_end):
+        fabric_node_ids = []
+        for col in range(mesh_shape[1]):
+            coord = ttnn.MeshCoordinate(row, col)
+            fabric_node_id = mesh_device.get_fabric_node_id(coord)
+            fabric_node_ids.append(fabric_node_id)
+
+        all_fabric_node_ids.extend(fabric_node_ids)
+        group_idx = lookup_table.add_device_group(fabric_node_ids)
+        logger.info(f"Device group {int(group_idx)}: {len(fabric_node_ids)} nodes")
+        for idx, fid in enumerate(fabric_node_ids):
+            mesh_id = int(fid.mesh_id)
+            chip_id = int(fid.chip_id)
+            logger.info(f"  Node {idx}: mesh_id={mesh_id}, chip_id={chip_id}")
+
+        device_group_idx_per_row.append(group_idx)
+
+    for fid in all_fabric_node_ids:
+        lookup_table.set_fabric_node_host(fid, host_name=host_name)
+        logger.info(
+            f"Set host name for fabric node id: mesh_id={int(fid.mesh_id)}, chip_id={int(fid.chip_id)} to {host_name}"
+        )
+
+    num_tokens_in_strip = seq_len // (mesh_shape[sp_axis] * 2)
+    num_chunks_in_strip = num_tokens_in_strip // NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+    logger.info(f"Num tokens in strip is: {num_tokens_in_strip} num_chunks in strip is: {num_chunks_in_strip}")
+
+    # describes high and low sequence length per rank
+    seq_len_per_rank = seq_len // (int(size) * 2)
+
+    device_position_indices_low_strip = []
+    device_position_indices_high_strip = []
+    low_strip_start_idx = seq_len_per_rank * int(rank)
+    high_strip_end_idx = seq_len_per_rank * (int(size) - int(rank)) - 1 + seq_len // 2
+    for row in range(len(device_group_idx_per_row)):
+        low_strip_end_idx = low_strip_start_idx + num_chunks_in_strip * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK - 1
+        device_position_indices_low_strip.append((low_strip_start_idx, low_strip_end_idx))
+        high_strip_start_idx = high_strip_end_idx - (num_chunks_in_strip * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK - 1)
+        device_position_indices_high_strip.append((high_strip_start_idx, high_strip_end_idx))
+
+        low_strip_start_idx = low_strip_end_idx + 1
+        high_strip_end_idx = high_strip_start_idx - 1
+        logger.info(
+            f"Token positions for device group index: Rank = {rank}, Device group index = {device_group_idx_per_row[row]} are {device_position_indices_low_strip[row]} and {device_position_indices_high_strip[row]}"
+        )
+
+    layer = 0
+    slot = 0
+    current_position = 0  # Must be chunk-aligned
+    chunks_per_device_group = num_chunks_in_strip * 2
+    logger.info("chunks_per_device_group = ", chunks_per_device_group)
+
+    dram_bank_0_addr = tt_kvpe_cache.buffer_address()
+    for row in range(len(device_group_idx_per_row)):
+        group_idx = device_group_idx_per_row[row]
+        curr_bank_id = 0
+        curr_bank_offset = 0
+
+        logger.info(
+            f"Rank: {rank} Populating device_group_index: {group_idx} with positions: {device_position_indices_low_strip[row]} and {device_position_indices_high_strip[row]}"
+        )
+        (current_position, max_position) = device_position_indices_low_strip[row]
+        for chunk in range(chunks_per_device_group):
+            location = ttnn.experimental.disaggregation.KvCacheLocation()
+
+            # This needs proper handling in KvCacheLocation(), just add it up atm
+            noc_addr = dram_bank_0_addr + curr_bank_id + curr_bank_offset
+            location.noc_addr = noc_addr
+            location.size_bytes = CHUNK_SIZE_BYTES
+            location.device_group_index = group_idx
+            lookup_table.set(layer, current_position, slot, location)
+            logger.info(
+                f"Rank: {rank} Set location for (layer={layer}, pos={current_position}, slot={slot}, bank_id={curr_bank_id}, curr_bank_offset = {curr_bank_offset} noc_addr = 0x{noc_addr:X})"
+            )
+
+            curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
+            # move to next chunk offset
+            if curr_bank_id == 0:
+                curr_bank_offset += CHUNK_SIZE_BYTES
+            current_position += NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+            if chunk == num_chunks_in_strip - 1:
+                # switch to high chunk
+                assert (
+                    current_position == max_position + 1
+                ), f"Missmatch in position calculation. Expected current_position to be {max_position + 1}, but it is: {current_position}"
+                (current_position, max_position) = device_position_indices_high_strip[row]
+
+    for position in range(low_strip_start_idx, high_strip_end_idx, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+        retrieved = lookup_table.lookup(layer, position, slot)
+        logger.info(
+            f"Rank: {rank} Retrieved: position={position}, noc_addr=0x{retrieved.noc_addr:X}, "
+            f"size={retrieved.size_bytes}, group_idx={int(retrieved.device_group_index)}"
+        )
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(32, 4), (8, 4), (1, 2)],
+    ids=["32x4", "8x4", "1x2"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        }
+    ],
+    indirect=True,
+)
+def test_fnids(mesh_device):
+    mesh_shape = list(mesh_device.shape)
+
+    host_name = socket.gethostname()
+    logger.info(f"Host name: {host_name}")
+
+    rank = ttnn.distributed_context_get_rank()
+    size = ttnn.distributed_context_get_size()
+
+    total_rows = mesh_shape[0]
+    rank_row_start = int(rank) * total_rows // int(size)
+    rank_row_end = rank_row_start + total_rows // int(size)
+
+    logger.info(f"Rank: {rank}, Size: {size}, Row start: {rank_row_start}, Row end: {rank_row_end}")
+
+    all_fabric_node_ids = []
+    for row in range(rank_row_start, rank_row_end):
+        fabric_node_ids = []
+        for col in range(mesh_shape[1]):
+            coord = ttnn.MeshCoordinate(row, col)
+            fabric_node_id = mesh_device.get_fabric_node_id(coord)
+            fabric_node_ids.append(fabric_node_id)
+
+        all_fabric_node_ids.extend(fabric_node_ids)
+        for idx, fid in enumerate(fabric_node_ids):
+            mesh_id = int(fid.mesh_id)
+            chip_id = int(fid.chip_id)
+            logger.info(
+                f"  Node {idx} row={row}, col={col}: mesh_id={mesh_id},  chip_id={chip_id} host_name={host_name}"
+            )

--- a/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
@@ -10,111 +10,14 @@ and work correctly.
 import socket
 
 import pytest
-import torch
 from loguru import logger
 
 import ttnn
-
-
-@pytest.mark.parametrize(
-    "mesh_device",
-    [(8, 4)],
-    ids=["8x4"],
-    indirect=True,
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
+    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
+    create_kv_chunk_address_table,
+    init_kvpe_cache,
 )
-@pytest.mark.parametrize(
-    "device_params",
-    [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        }
-    ],
-    indirect=True,
-)
-def test_kv_chunk_address_table(mesh_device):
-    """Test KvChunkAddressTable Python bindings"""
-
-    logger.info("Testing KvChunkAddressTable Python bindings")
-
-    # 1. Create configuration
-    config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
-    config.num_layers = 1
-    config.max_sequence_length = 8192
-    config.num_slots = 8
-    config.chunk_n_tokens = 32
-    config.chunk_size_bytes = 19584
-
-    logger.info(
-        f"Config: layers={config.num_layers}, seq_len={config.max_sequence_length}, "
-        f"slots={config.num_slots}, chunk_tokens={config.chunk_n_tokens}"
-    )
-
-    # 2. Initialize table
-    table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
-
-    logger.info(
-        f"Table created: {table.num_position_chunks()} position chunks, " f"{table.total_entries()} total entries"
-    )
-
-    # 3. Add device groups using FabricNodeIds from mesh
-    mesh_shape = list(mesh_device.shape)
-    device_groups = []
-
-    # Create one device group per mesh column
-    for col in range(mesh_shape[1]):
-        fabric_node_ids = []
-        for row in range(mesh_shape[0]):
-            coord = ttnn.MeshCoordinate(row, col)
-            fabric_node_id = mesh_device.get_fabric_node_id(coord)
-            fabric_node_ids.append(fabric_node_id)
-
-        group_idx = table.add_device_group(fabric_node_ids)
-        device_groups.append(group_idx)
-        logger.info(f"Device group {int(group_idx)}: {len(fabric_node_ids)} nodes")
-
-    logger.info(f"Total device groups: {table.num_device_groups()}")
-
-    # 4. Set KV cache locations
-    layer = 0
-    slot = 0
-    position = 0  # Must be chunk-aligned
-
-    location = ttnn.experimental.disaggregation.KvCacheLocation()
-    location.noc_addr = 0xDEADBEEF
-    location.size_bytes = 19584
-    location.device_group_index = device_groups[0]
-
-    table.set(layer, position, slot, location)
-    logger.info(f"Set location for (layer={layer}, pos={position}, slot={slot})")
-
-    # 5. Lookup the location
-    retrieved = table.lookup(layer, position, slot)
-    logger.info(
-        f"Retrieved: noc_addr=0x{retrieved.noc_addr:X}, "
-        f"size={retrieved.size_bytes}, group_idx={int(retrieved.device_group_index)}"
-    )
-
-    assert retrieved.noc_addr == 0xDEADBEEF
-    assert retrieved.size_bytes == 19584
-    assert int(retrieved.device_group_index) == int(device_groups[0])
-
-    # 6. Test range lookup
-    start_pos = 0
-    end_pos = 64  # 2 chunks
-    locations = table.lookup_range(layer, start_pos, end_pos, slot)
-    logger.info(f"Range lookup [{start_pos}, {end_pos}): {len(locations)} entries")
-
-    # 7. Test device group retrieval
-    group = table.get_device_group(device_groups[0])
-    logger.info(f"Device group 0 has {len(group.fabric_node_ids)} fabric nodes")
-
-    # 8. Print fabric node IDs in the first group
-    for idx, fid in enumerate(group.fabric_node_ids):
-        mesh_id = int(fid.mesh_id)
-        chip_id = int(fid.chip_id)
-        logger.info(f"  Node {idx}: mesh_id={mesh_id}, chip_id={chip_id}")
-
-    logger.success("KvChunkAddressTable bindings test passed!")
 
 
 @pytest.mark.parametrize(
@@ -140,157 +43,53 @@ def test_kv_cache_address_table(mesh_device, seq_len):
     mesh_shape = list(mesh_device.shape)
     if mesh_shape[0] == 32 and mesh_shape[1] == 4 and seq_len == 3 * 1024:
         pytest.skip("Skipping test for 32x4 mesh and seq3k")
-    seq_len_local = seq_len // mesh_shape[sp_axis]
 
-    torch_kvpe_cache = torch.zeros(1, 1, seq_len_local, kvpe_cache_head_dim)
-
-    BH_NUM_DRAM_BANKS = 8
-    core_ranges = [
-        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
-    ]
-    grid = ttnn.CoreRangeSet(core_ranges)
-
-    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32  # this is a predefined constant
-    kv_nd_shard_spec = ttnn.NdShardSpec(
-        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim],
-        grid=grid,
-        orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
-    )
-    kv_mem_config = ttnn.MemoryConfig(
-        buffer_type=ttnn.BufferType.DRAM,
-        nd_shard_spec=kv_nd_shard_spec,
+    num_kvpe_cache_layers = 2
+    # Initialize KVPE cache using utility function
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=kvpe_cache_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_kvpe_cache_layers,
     )
 
-    tt_kvpe_cache = ttnn.from_torch(
-        torch_kvpe_cache,
-        dtype=ttnn.bfloat8_b,
-        device=mesh_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=kv_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-    )
-
+    # Create and populate KV chunk address table using utility function
     CHUNK_SIZE_BYTES = 19584  # [1, 1, 32, 576] bfp8
     config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
-    config.num_layers = 1
+    config.num_layers = num_kvpe_cache_layers
     config.max_sequence_length = seq_len
     config.num_slots = 1
     config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     config.chunk_size_bytes = CHUNK_SIZE_BYTES
 
-    lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
+    lookup_table = create_kv_chunk_address_table(
+        config=config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=tt_kvpe_cache,
+        chunk_size_bytes=CHUNK_SIZE_BYTES,
+    )
 
-    host_name = socket.gethostname()
-    logger.info(f"Host name: {host_name}")
-
-    # Create device groups that contain replicated data
-    # Data is replicated on each column of the mesh
-    device_group_idx_per_row = []
-
+    # Test lookup functionality
     rank = ttnn.distributed_context_get_rank()
     size = ttnn.distributed_context_get_size()
-
-    total_rows = mesh_shape[0]
-    rank_row_start = int(rank) * total_rows // int(size)
-    rank_row_end = rank_row_start + total_rows // int(size)
-
-    logger.info(f"Rank: {rank}, Size: {size}, Row start: {rank_row_start}, Row end: {rank_row_end}")
-
-    all_fabric_node_ids = []
-    for row in range(rank_row_start, rank_row_end):
-        fabric_node_ids = []
-        for col in range(mesh_shape[1]):
-            coord = ttnn.MeshCoordinate(row, col)
-            fabric_node_id = mesh_device.get_fabric_node_id(coord)
-            fabric_node_ids.append(fabric_node_id)
-
-        all_fabric_node_ids.extend(fabric_node_ids)
-        group_idx = lookup_table.add_device_group(fabric_node_ids)
-        logger.info(f"Device group {int(group_idx)}: {len(fabric_node_ids)} nodes")
-        for idx, fid in enumerate(fabric_node_ids):
-            mesh_id = int(fid.mesh_id)
-            chip_id = int(fid.chip_id)
-            logger.info(f"  Node {idx}: mesh_id={mesh_id}, chip_id={chip_id}")
-
-        device_group_idx_per_row.append(group_idx)
-
-    for fid in all_fabric_node_ids:
-        lookup_table.set_fabric_node_host(fid, host_name=host_name)
-        logger.info(
-            f"Set host name for fabric node id: mesh_id={int(fid.mesh_id)}, chip_id={int(fid.chip_id)} to {host_name}"
-        )
-
-    num_tokens_in_strip = seq_len // (mesh_shape[sp_axis] * 2)
-    num_chunks_in_strip = num_tokens_in_strip // NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
-    logger.info(f"Num tokens in strip is: {num_tokens_in_strip} num_chunks in strip is: {num_chunks_in_strip}")
-
-    # describes high and low sequence length per rank
     seq_len_per_rank = seq_len // (int(size) * 2)
-
-    device_position_indices_low_strip = []
-    device_position_indices_high_strip = []
     low_strip_start_idx = seq_len_per_rank * int(rank)
     high_strip_end_idx = seq_len_per_rank * (int(size) - int(rank)) - 1 + seq_len // 2
-    for row in range(len(device_group_idx_per_row)):
-        low_strip_end_idx = low_strip_start_idx + num_chunks_in_strip * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK - 1
-        device_position_indices_low_strip.append((low_strip_start_idx, low_strip_end_idx))
-        high_strip_start_idx = high_strip_end_idx - (num_chunks_in_strip * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK - 1)
-        device_position_indices_high_strip.append((high_strip_start_idx, high_strip_end_idx))
-
-        low_strip_start_idx = low_strip_end_idx + 1
-        high_strip_end_idx = high_strip_start_idx - 1
-        logger.info(
-            f"Token positions for device group index: Rank = {rank}, Device group index = {device_group_idx_per_row[row]} are {device_position_indices_low_strip[row]} and {device_position_indices_high_strip[row]}"
-        )
-
     layer = 0
     slot = 0
-    current_position = 0  # Must be chunk-aligned
-    chunks_per_device_group = num_chunks_in_strip * 2
-    logger.info("chunks_per_device_group = ", chunks_per_device_group)
-
-    dram_bank_0_addr = tt_kvpe_cache.buffer_address()
-    for row in range(len(device_group_idx_per_row)):
-        group_idx = device_group_idx_per_row[row]
-        curr_bank_id = 0
-        curr_bank_offset = 0
-
-        logger.info(
-            f"Rank: {rank} Populating device_group_index: {group_idx} with positions: {device_position_indices_low_strip[row]} and {device_position_indices_high_strip[row]}"
-        )
-        (current_position, max_position) = device_position_indices_low_strip[row]
-        for chunk in range(chunks_per_device_group):
-            location = ttnn.experimental.disaggregation.KvCacheLocation()
-
-            # This needs proper handling in KvCacheLocation(), just add it up atm
-            noc_addr = dram_bank_0_addr + curr_bank_id + curr_bank_offset
-            location.noc_addr = noc_addr
-            location.size_bytes = CHUNK_SIZE_BYTES
-            location.device_group_index = group_idx
-            lookup_table.set(layer, current_position, slot, location)
-            logger.info(
-                f"Rank: {rank} Set location for (layer={layer}, pos={current_position}, slot={slot}, bank_id={curr_bank_id}, curr_bank_offset = {curr_bank_offset} noc_addr = 0x{noc_addr:X})"
-            )
-
-            curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
-            # move to next chunk offset
-            if curr_bank_id == 0:
-                curr_bank_offset += CHUNK_SIZE_BYTES
-            current_position += NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
-            if chunk == num_chunks_in_strip - 1:
-                # switch to high chunk
-                assert (
-                    current_position == max_position + 1
-                ), f"Missmatch in position calculation. Expected current_position to be {max_position + 1}, but it is: {current_position}"
-                (current_position, max_position) = device_position_indices_high_strip[row]
 
     for position in range(low_strip_start_idx, high_strip_end_idx, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
-        retrieved = lookup_table.lookup(layer, position, slot)
-        logger.info(
-            f"Rank: {rank} Retrieved: position={position}, noc_addr=0x{retrieved.noc_addr:X}, "
-            f"size={retrieved.size_bytes}, group_idx={int(retrieved.device_group_index)}"
-        )
+        for layer in range(0, num_kvpe_cache_layers):
+            retrieved = lookup_table.lookup(layer, position, slot)
+            logger.info(
+                f"Rank: {rank} Retrieved: layer={layer} position={position}, noc_addr=0x{retrieved.noc_addr:X}, "
+                f"size={retrieved.size_bytes}, group_idx={int(retrieved.device_group_index)}"
+            )
 
 
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -117,64 +117,6 @@ def run_mla_inference(
     return tt_output, hidden_states, chunk_order, shard_dims
 
 
-@pytest.fixture
-def random_weights(config_only):
-    """
-    Generate random weights for testing using the config.
-
-    Args:
-        config_only: HuggingFace config (only downloads config files, not weight shards)
-
-    Returns:
-        Tuple of (config, weights_dict) in bfloat16
-    """
-    config = config_only
-
-    torch.manual_seed(42)  # this is tied to already cached reference results, so keep it consistent for now
-
-    # Use proper initialization scale from config (typically 0.02)
-    std = config.initializer_range
-
-    # Generate random weights matching MLA architecture using actual config
-    # Generate in float32 first, then convert to bfloat16 for better numerical properties
-    weights = {
-        "q_a_proj.weight": (torch.randn(config.q_lora_rank, config.hidden_size) * std).to(torch.bfloat16),
-        "q_a_layernorm.weight": torch.ones(config.q_lora_rank, dtype=torch.bfloat16),
-        "q_b_proj.weight": (
-            torch.randn(
-                config.num_attention_heads * (config.qk_nope_head_dim + config.qk_rope_head_dim),
-                config.q_lora_rank,
-            )
-            * std
-        ).to(torch.bfloat16),
-        "kv_a_proj_with_mqa.weight": (
-            torch.randn(
-                config.kv_lora_rank + config.qk_rope_head_dim,
-                config.hidden_size,
-            )
-            * std
-        ).to(torch.bfloat16),
-        "kv_a_layernorm.weight": torch.ones(config.kv_lora_rank, dtype=torch.bfloat16),
-        "kv_b_proj.weight": (
-            torch.randn(
-                config.num_attention_heads * (config.qk_nope_head_dim + config.v_head_dim),
-                config.kv_lora_rank,
-            )
-            * std
-        ).to(torch.bfloat16),
-        "o_proj.weight": (
-            torch.randn(
-                config.hidden_size,
-                config.num_attention_heads * config.v_head_dim,
-            )
-            * std
-        ).to(torch.bfloat16),
-    }
-
-    logger.info(f"Generated {len(weights)} random weight tensors using config dimensions")
-    return config, weights
-
-
 # sp x tp
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -23,58 +23,8 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from tests.ttnn.utils_for_testing import assert_with_pcc
-
-
-def init_kvpe_cache(config, mesh_device, seq_len, mesh_shape, sp_axis, num_kvpe_cache_layers):
-    """
-    Initialize KVPE cache for MLA.
-
-    Args:
-        config: Model configuration
-        mesh_device: Mesh device for TT
-        seq_len: Sequence length
-        mesh_shape: Shape of mesh device
-        sp_axis: Sequence parallel axis
-
-    Returns:
-        tt_kvpe_cache: Initialized KVPE cache on device
-    """
-    # hack in num_layers into batch size, so they are contiguous in memory
-    num_layers = num_kvpe_cache_layers
-    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
-    seq_len_local = seq_len // mesh_shape[sp_axis]
-    torch_kvpe_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
-
-    BH_NUM_DRAM_BANKS = 8
-    core_ranges = [
-        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
-    ]
-    grid = ttnn.CoreRangeSet(core_ranges)
-
-    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32  # this is a predefined constant
-
-    kv_nd_shard_spec = ttnn.NdShardSpec(
-        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim],
-        grid=grid,
-        orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
-    )
-    kv_mem_config = ttnn.MemoryConfig(
-        buffer_type=ttnn.BufferType.DRAM,
-        nd_shard_spec=kv_nd_shard_spec,
-    )
-
-    tt_kvpe_cache = ttnn.from_torch(
-        torch_kvpe_cache,
-        dtype=ttnn.bfloat8_b,
-        device=mesh_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=kv_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-    )
-
-    return tt_kvpe_cache
 
 
 def run_mla_inference(
@@ -325,8 +275,9 @@ def test_mla(
     logger.info("=" * 80)
 
     # Initialize KVPE cache
+    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank  # 576
     tt_kvpe_cache = init_kvpe_cache(
-        config=config,
+        kvpe_cache_head_dim=kvpe_cache_head_dim,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -139,7 +139,7 @@ def run_mla_inference(
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
-@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024, 6400], ids=["seq128k", "seq100k", "seq6k"])
+@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024], ids=["seq128k", "seq100k"])
 @pytest.mark.parametrize("skip_host_comparison", [False, True], ids=["check_pcc", "skip_check"])
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["sequential", "balanced"])
 @pytest.mark.timeout(0)  # Disable timeout — first run computes and caches CPU reference for large seq lengths

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -26,6 +26,147 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
+def init_kvpe_cache(config, mesh_device, seq_len, mesh_shape, sp_axis):
+    """
+    Initialize KVPE cache for MLA.
+
+    Args:
+        config: Model configuration
+        mesh_device: Mesh device for TT
+        seq_len: Sequence length
+        mesh_shape: Shape of mesh device
+        sp_axis: Sequence parallel axis
+
+    Returns:
+        tt_kvpe_cache: Initialized KVPE cache on device
+    """
+    # hack in num_layers into batch size, so they are contiguous in memory
+    num_layers = 1
+    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
+    seq_len_local = seq_len // mesh_shape[sp_axis]
+    torch_kvpe_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
+
+    BH_NUM_DRAM_BANKS = 8
+    core_ranges = [
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
+    ]
+    grid = ttnn.CoreRangeSet(core_ranges)
+
+    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32  # this is a predefined constant
+
+    kv_nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim],
+        grid=grid,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    kv_mem_config = ttnn.MemoryConfig(
+        buffer_type=ttnn.BufferType.DRAM,
+        nd_shard_spec=kv_nd_shard_spec,
+    )
+
+    tt_kvpe_cache = ttnn.from_torch(
+        torch_kvpe_cache,
+        dtype=ttnn.bfloat8_b,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=kv_mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    return tt_kvpe_cache
+
+
+def run_mla_inference(
+    config,
+    weights,
+    mesh_device,
+    seq_len,
+    mesh_shape,
+    sp_axis,
+    tp_axis,
+    is_balanced,
+    topology,
+    tt_kvpe_cache,
+):
+    """
+    Utility function to run MLA inference without host comparison.
+
+    Args:
+        config: Model configuration
+        weights: Model weights dictionary
+        mesh_device: Mesh device for TT
+        seq_len: Sequence length
+        mesh_shape: Shape of mesh device
+        sp_axis: Sequence parallel axis
+        tp_axis: Tensor parallel axis
+        is_balanced: Whether to use balanced chunk ordering
+        topology: Topology (Linear or Ring)
+        tt_kvpe_cache: Initialized KVPE cache on device
+
+    Returns:
+        Tuple of (tt_output, hidden_states, chunk_order, shard_dims)
+    """
+    # Create TT MLA
+    logger.info("Creating TT MLA...")
+
+    mla_tt = ttMLA(
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=is_balanced,
+        topology=topology,
+    )
+    rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
+    rope_tensors = rope_setup.get_rope_tensors(seq_len)
+
+    # Verify TT MLA exists
+    assert mla_tt is not None, "TT MLA should exist"
+
+    # Create test inputs
+    batch_size = 1
+    hidden_size = config.hidden_size
+
+    logger.info(f"Creating test inputs: batch_size={batch_size}, seq_len={seq_len}, hidden_size={hidden_size}")
+
+    # Create random input tensor (generate in float32, then convert to bfloat16)
+    torch.manual_seed(42)
+    hidden_states = torch.randn(batch_size, seq_len, hidden_size).to(torch.bfloat16)
+
+    # Reorder hidden_states for balanced ring attention
+    sp_factor = mesh_shape[sp_axis]
+    chunk_order = create_balanced_chunk_order(sp_factor) if is_balanced else None
+    tt_input = hidden_states.unsqueeze(0)  # [1, batch, seq, hidden]
+    if is_balanced:
+        tt_input = reorder_tensor_chunks(tt_input, chunk_order, seq_dim=2)
+
+    shard_dims = [None, None]
+    shard_dims[tp_axis] = -1
+    shard_dims[sp_axis] = -2
+    tt_hidden_states = ttnn.from_torch(
+        tt_input,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+    )
+    tt_output = mla_tt.forward(
+        hidden_states=tt_hidden_states,
+        rope_tensors=rope_tensors,
+        kvpe_cache=tt_kvpe_cache,
+    )
+
+    ttnn.synchronize_device(mesh_device)
+    ttnn.distributed_context_barrier()
+
+    return tt_output, hidden_states, chunk_order, shard_dims
+
+
 @pytest.fixture
 def random_weights(config_only):
     """
@@ -106,7 +247,7 @@ def random_weights(config_only):
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
-@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024], ids=["seq128k", "seq100k"])
+@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024, 6400], ids=["seq128k", "seq100k", "seq6k"])
 @pytest.mark.parametrize("skip_host_comparison", [False, True], ids=["check_pcc", "skip_check"])
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["sequential", "balanced"])
 @pytest.mark.timeout(0)  # Disable timeout — first run computes and caches CPU reference for large seq lengths
@@ -159,7 +300,6 @@ def test_mla(
 
     # Create reference MLA
     if use_pretrained:
-        # For pretrained, create from weights
         logger.info("Creating reference MLA with pretrained weights...")
         mla_ref = create_mla_reference(
             config=config,
@@ -168,7 +308,6 @@ def test_mla(
             module_path="model.layers.0.self_attn",
         )
     else:
-        # For random, use same weights
         logger.info("Creating reference MLA with random weights...")
         mla_ref = create_mla_reference(
             config=config,
@@ -177,76 +316,40 @@ def test_mla(
             module_path="model.layers.0.self_attn",
         )
 
-    # Create TT MLA
-    logger.info("Creating TT MLA...")
-
-    # hack in num_layers into batch size, so they are contiguous in memory
-    num_layers = 1
-    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
-    seq_len_local = seq_len // mesh_shape[sp_axis]
-    torch_kvpe_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
-
-    BH_NUM_DRAM_BANKS = 8
-    core_ranges = [
-        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
-    ]
-    grid = ttnn.CoreRangeSet(core_ranges)
-
-    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32  # this is a predefined constant
-
-    kv_nd_shard_spec = ttnn.NdShardSpec(
-        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim],
-        grid=grid,
-        orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
-    )
-    kv_mem_config = ttnn.MemoryConfig(
-        buffer_type=ttnn.BufferType.DRAM,
-        nd_shard_spec=kv_nd_shard_spec,
-    )
-
-    tt_kvpe_cache = ttnn.from_torch(
-        torch_kvpe_cache,
-        dtype=ttnn.bfloat8_b,
-        device=mesh_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=kv_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-    )
-
-    mla_tt = ttMLA(
-        config,
-        weights,
-        mesh_device,
-        layer_idx=0,
-        seq_len=seq_len,
-        sp_axis=sp_axis,
-        tp_axis=tp_axis,
-        is_balanced=is_balanced,
-        topology=topology,
-    )
-    rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
-    rope_tensors = rope_setup.get_rope_tensors(seq_len)
-
-    # Verify both exist
+    # Verify reference MLA exists
     assert mla_ref is not None, "Reference MLA should exist"
-    assert mla_tt is not None, "TT MLA should exist"
 
     # Test forward pass comparison
     logger.info("=" * 80)
     logger.info(f"Testing forward pass comparison (seq_len={seq_len})")
     logger.info("=" * 80)
 
-    # Create test inputs
+    # Initialize KVPE cache
+    tt_kvpe_cache = init_kvpe_cache(
+        config=config,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+    )
+
+    # Run MLA inference using utility function
+    tt_output, hidden_states, chunk_order, shard_dims = run_mla_inference(
+        config=config,
+        weights=weights,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=is_balanced,
+        topology=topology,
+        tt_kvpe_cache=tt_kvpe_cache,
+    )
+
     batch_size = 1
-    hidden_size = config.hidden_size
 
-    logger.info(f"Creating test inputs: batch_size={batch_size}, seq_len={seq_len}, hidden_size={hidden_size}")
-
-    # Create random input tensor (generate in float32, then convert to bfloat16)
-    torch.manual_seed(42)
-    hidden_states = torch.randn(batch_size, seq_len, hidden_size).to(torch.bfloat16)
-
+    # Host comparison: Run reference forward pass if needed
     if skip_host_comparison == False:
         # Check for cached reference results to avoid expensive host attention computation
         cache_dir = Path(os.environ.get("DEEPSEEK_V3_MLA_REF_CACHE", "/tmp/deepseek_v3_mla_ref_cache"))
@@ -295,34 +398,7 @@ def test_mla(
             logger.info(f"  Output mean:  {ref_output.mean().item():.4f}")
             logger.info(f"  Output std:   {ref_output.std().item():.4f}")
 
-    # Reorder hidden_states for balanced ring attention
-    sp_factor = mesh_shape[sp_axis]
-    chunk_order = create_balanced_chunk_order(sp_factor) if is_balanced else None
-    tt_input = hidden_states.unsqueeze(0)  # [1, batch, seq, hidden]
-    if is_balanced:
-        tt_input = reorder_tensor_chunks(tt_input, chunk_order, seq_dim=2)
-
-    shard_dims = [None, None]
-    shard_dims[tp_axis] = -1
-    shard_dims[sp_axis] = -2
-    tt_hidden_states = ttnn.from_torch(
-        tt_input,
-        device=mesh_device,
-        dtype=ttnn.bfloat16,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
-    )
-    tt_output = mla_tt.forward(
-        hidden_states=tt_hidden_states,
-        rope_tensors=rope_tensors,
-        kvpe_cache=tt_kvpe_cache,
-    )
-
-    ttnn.synchronize_device(mesh_device)
-    ttnn.distributed_context_barrier()
-
-    if skip_host_comparison == False:
+        # Compare TT output with reference output
         tt_output_cpu = ttnn.to_torch(
             tt_output,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape),

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -26,7 +26,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-def init_kvpe_cache(config, mesh_device, seq_len, mesh_shape, sp_axis):
+def init_kvpe_cache(config, mesh_device, seq_len, mesh_shape, sp_axis, num_kvpe_cache_layers):
     """
     Initialize KVPE cache for MLA.
 
@@ -41,7 +41,7 @@ def init_kvpe_cache(config, mesh_device, seq_len, mesh_shape, sp_axis):
         tt_kvpe_cache: Initialized KVPE cache on device
     """
     # hack in num_layers into batch size, so they are contiguous in memory
-    num_layers = 1
+    num_layers = num_kvpe_cache_layers
     kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
     seq_len_local = seq_len // mesh_shape[sp_axis]
     torch_kvpe_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
@@ -331,6 +331,7 @@ def test_mla(
         seq_len=seq_len,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
     )
 
     # Run MLA inference using utility function
@@ -420,7 +421,7 @@ def test_mla(
             tt_kvpe_cache,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
         ).to(torch.bfloat16)
-        tt_kvpe_cache_torch = tt_kvpe_cache_torch[:, :1, :, :]
+        tt_kvpe_cache_torch = tt_kvpe_cache_torch[:1, :1, :, :]
 
         logger.info("Starting synchronize call")
         ttnn.synchronize_device(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/test_mla_disaggregation.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla_disaggregation.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test for instantiating both reference CPU and TT device MLA modules with the same weights.
+This test verifies that both modules can be created and weights are loaded correctly.
+"""
+
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
+from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
+from models.demos.deepseek_v3_d_p.tt.mla.utils import reverse_reorder_tensor_chunks
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
+    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
+    create_kv_chunk_address_table,
+    init_kvpe_cache,
+)
+from tests.ttnn.utils_for_testing import assert_equal
+
+
+# sp x tp
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(32, 4), (8, 4)],
+    ids=["32x4", "8x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        },
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+        },
+    ],
+    ids=["line", "ring"],
+    indirect=True,
+)
+@pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
+@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024], ids=["seq128k", "seq100k"])
+@pytest.mark.timeout(0)  # Disable timeout — first run computes and caches CPU reference for large seq lengths
+def test_mla_disaggregation(
+    use_pretrained,
+    request,
+    mesh_device,
+    seq_len,
+    is_ci_env,
+    is_ci_v2_env,
+    device_params,
+):
+    """
+    Test comparing reference and TT MLA modules with same weights.
+
+    Args:
+        use_pretrained: Whether to use pretrained weights
+        request: Pytest request object for conditional fixture loading
+        mesh_device: Mesh device fixture
+        seq_len: Sequence length
+    """
+    weight_type = "Pretrained" if use_pretrained else "Random"
+    logger.info("=" * 80)
+    logger.info(f"Test: Reference vs TT Comparison ({weight_type} Weights)")
+    logger.info("=" * 80)
+
+    # Conditionally load fixtures - only load what we need!
+    if use_pretrained:
+        config, weights = request.getfixturevalue("pretrained_weights")
+    else:
+        config, weights = request.getfixturevalue("random_weights")
+
+    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
+    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+
+    sp_axis = 0
+    tp_axis = 1
+
+    mesh_shape = list(mesh_device.shape)
+
+    # temp hack
+    config.max_seq_len = seq_len
+
+    # Create reference MLA
+    if use_pretrained:
+        logger.info("Creating reference MLA with pretrained weights...")
+        mla_ref = create_mla_reference(
+            config=config,
+            state_dict={"model.layers.0.self_attn." + k: v for k, v in weights.items()},
+            layer_idx=0,
+            module_path="model.layers.0.self_attn",
+        )
+    else:
+        logger.info("Creating reference MLA with random weights...")
+        mla_ref = create_mla_reference(
+            config=config,
+            state_dict={"model.layers.0.self_attn." + k: v for k, v in weights.items()},
+            layer_idx=0,
+            module_path="model.layers.0.self_attn",
+        )
+
+    # Verify reference MLA exists
+    assert mla_ref is not None, "Reference MLA should exist"
+
+    # Test forward pass comparison
+    logger.info("=" * 80)
+    logger.info(f"Testing forward pass comparison (seq_len={seq_len})")
+    logger.info("=" * 80)
+
+    # Initialize KVPE cache
+    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank  # 576
+
+    # Initialise kvpe cache with 2 layers, but run only 1 layer.
+    # Other layer should be zeros
+    num_kvpe_cache_layers = 2
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=kvpe_cache_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_kvpe_cache_layers,
+    )
+
+    # Create and populate KV chunk address table using utility function
+    CHUNK_SIZE_BYTES = 19584  # [1, 1, 32, 576] bfp8
+    config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+    config.num_layers = num_kvpe_cache_layers
+    config.max_sequence_length = seq_len
+    config.num_slots = 1
+    config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+    config.chunk_size_bytes = CHUNK_SIZE_BYTES
+
+    lookup_table = create_kv_chunk_address_table(
+        config=config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=tt_kvpe_cache,
+        chunk_size_bytes=CHUNK_SIZE_BYTES,
+    )
+
+    # Run MLA inference using utility function
+    # Fill first layer with actual kv cache
+    # Layer 1 remains zeros
+    _, _, chunk_order, _ = run_mla_inference(
+        config=config,
+        weights=weights,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=True,
+        topology=topology,
+        tt_kvpe_cache=tt_kvpe_cache,
+    )
+
+    tt_kvpe_cache_torch = ttnn.to_torch(
+        tt_kvpe_cache,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)
+
+    # remember layer0 results
+    tt_kvpe_cache_torch_layer0 = tt_kvpe_cache_torch[:1, :1, :, :]
+
+    # assert layer1 is zeros
+    tt_kvpe_cache_torch_layer1 = tt_kvpe_cache_torch[1:2, :1, :, :]
+    torch_layer_zeros = torch.zeros(1, 1, seq_len, kvpe_cache_head_dim)
+    logger.info(f"Checking that layer 1 is all zeros")
+    assert_equal(tt_kvpe_cache_torch_layer1, torch_layer_zeros)
+    logger.info(f"Check complete")
+
+    # reorder into position continuous torch cache
+    tt_kvpe_cache_torch_layer0 = reverse_reorder_tensor_chunks(tt_kvpe_cache_torch_layer0, chunk_order, seq_dim=2)
+
+    # migrate layer0 of tt_kvpe_cache into layer1 of tt_kvpe_cache
+
+    # perform migration
+
+    # now assert equality of tt_kvpe_cache_torch_layer0 with tt_kvpe_cache_torch_layer1
+    # tt_kvpe_cache_torch = ttnn.to_torch(
+    #     tt_kvpe_cache,
+    #     mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    # ).to(torch.bfloat16)
+    # tt_kvpe_cache_torch_layer1 = tt_kvpe_cache_torch[1:2, :1, :, :]
+    # tt_kvpe_cache_torch_layer1 = reverse_reorder_tensor_chunks(tt_kvpe_cache_torch_layer1, chunk_order, seq_dim=2)
+    # assert_equal(tt_kvpe_cache_torch_layer0, tt_kvpe_cache_torch_layer1)
+    # we can also make sure layer 0 didn't get polluted
+    # assert_equal(tt_kvpe_cache_torch_layer0, tt_kvpe_cache_torch_layer0_new)
+    # ...
+
+    logger.info("Starting synchronize call")
+    ttnn.synchronize_device(mesh_device)
+    logger.info("Synchronize call ended")
+
+    logger.debug("  Distributed synchronization started")
+    ttnn.distributed_context_barrier()
+    logger.debug("✓ Distributed synchronization completed")

--- a/models/demos/deepseek_v3_d_p/tests/test_mla_disaggregation.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla_disaggregation.py
@@ -129,15 +129,15 @@ def test_mla_disaggregation(
 
     # Create and populate KV chunk address table using utility function
     CHUNK_SIZE_BYTES = 19584  # [1, 1, 32, 576] bfp8
-    config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
-    config.num_layers = num_kvpe_cache_layers
-    config.max_sequence_length = seq_len
-    config.num_slots = 1
-    config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
-    config.chunk_size_bytes = CHUNK_SIZE_BYTES
+    lookup_table_config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+    lookup_table_config.num_layers = num_kvpe_cache_layers
+    lookup_table_config.max_sequence_length = seq_len
+    lookup_table_config.num_slots = 1
+    lookup_table_config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+    lookup_table_config.chunk_size_bytes = CHUNK_SIZE_BYTES
 
     lookup_table = create_kv_chunk_address_table(
-        config=config,
+        config=lookup_table_config,
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,
         seq_len=seq_len,

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Utilities for KVPE cache initialization and management.
+"""
+
+import socket
+
+import torch
+from loguru import logger
+
+import ttnn
+
+# This is a predefined constant for the number of contiguous tokens in a DRAM bank
+NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
+BH_NUM_DRAM_BANKS = 8
+
+
+def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_axis, tt_kvpe_cache, chunk_size_bytes):
+    """
+    Create and populate a KV chunk address table for disaggregation.
+
+    Args:
+        config: KvChunkAddressTableConfig
+        mesh_device: Mesh device for TT
+        mesh_shape: Shape of mesh device
+        seq_len: Sequence length
+        sp_axis: Sequence parallel axis
+        tt_kvpe_cache: Initialized KVPE cache on device
+        chunk_size_bytes: Size of each chunk in bytes
+
+    Returns:
+        lookup_table: Populated KvChunkAddressTable
+    """
+    lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
+
+    host_name = socket.gethostname()
+    logger.info(f"Host name: {host_name}")
+
+    # Create device groups that contain replicated data
+    # Data is replicated on each column of the mesh
+    device_group_idx_per_row = []
+
+    rank = ttnn.distributed_context_get_rank()
+    size = ttnn.distributed_context_get_size()
+
+    total_rows = mesh_shape[0]
+    rank_row_start = int(rank) * total_rows // int(size)
+    rank_row_end = rank_row_start + total_rows // int(size)
+
+    logger.info(f"Rank: {rank}, Size: {size}, Row start: {rank_row_start}, Row end: {rank_row_end}")
+
+    num_layers = config.num_layers
+    print(f"Num layers is: ", num_layers)
+
+    all_fabric_node_ids = []
+    for row in range(rank_row_start, rank_row_end):
+        fabric_node_ids = []
+        for col in range(mesh_shape[1]):
+            coord = ttnn.MeshCoordinate(row, col)
+            fabric_node_id = mesh_device.get_fabric_node_id(coord)
+            fabric_node_ids.append(fabric_node_id)
+
+        all_fabric_node_ids.extend(fabric_node_ids)
+        group_idx = lookup_table.add_device_group(fabric_node_ids)
+        logger.info(f"Device group {int(group_idx)}: {len(fabric_node_ids)} nodes")
+        for idx, fid in enumerate(fabric_node_ids):
+            mesh_id = int(fid.mesh_id)
+            chip_id = int(fid.chip_id)
+            logger.info(f"  Node {idx}: mesh_id={mesh_id}, chip_id={chip_id}")
+
+        device_group_idx_per_row.append(group_idx)
+
+    for fid in all_fabric_node_ids:
+        lookup_table.set_fabric_node_host(fid, host_name=host_name)
+        logger.info(
+            f"Set host name for fabric node id: mesh_id={int(fid.mesh_id)}, chip_id={int(fid.chip_id)} to {host_name}"
+        )
+
+    num_tokens_in_strip = seq_len // (mesh_shape[sp_axis] * 2)
+    num_chunks_in_strip = num_tokens_in_strip // NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+    logger.info(f"Num tokens in strip is: {num_tokens_in_strip} num_chunks in strip is: {num_chunks_in_strip}")
+
+    # describes high and low sequence length per rank
+    seq_len_per_rank = seq_len // (int(size) * 2)
+
+    device_position_indices_low_strip = []
+    device_position_indices_high_strip = []
+    low_strip_start_idx = seq_len_per_rank * int(rank)
+    high_strip_end_idx = seq_len_per_rank * (int(size) - int(rank)) - 1 + seq_len // 2
+    for row in range(len(device_group_idx_per_row)):
+        low_strip_end_idx = low_strip_start_idx + num_chunks_in_strip * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK - 1
+        device_position_indices_low_strip.append((low_strip_start_idx, low_strip_end_idx))
+        high_strip_start_idx = high_strip_end_idx - (num_chunks_in_strip * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK - 1)
+        device_position_indices_high_strip.append((high_strip_start_idx, high_strip_end_idx))
+
+        low_strip_start_idx = low_strip_end_idx + 1
+        high_strip_end_idx = high_strip_start_idx - 1
+        logger.info(
+            f"Token positions for device group index: Rank = {rank}, Device group index = {device_group_idx_per_row[row]} are {device_position_indices_low_strip[row]} and {device_position_indices_high_strip[row]}"
+        )
+
+    slot = 0
+    current_position = 0  # Must be chunk-aligned
+    chunks_per_device_group = num_chunks_in_strip * 2
+    logger.info("chunks_per_device_group = ", chunks_per_device_group)
+
+    logger.info(f"kvpe cache shape is: {tt_kvpe_cache.shape}")
+    dram_bank_0_addr = tt_kvpe_cache.buffer_address()
+    for row in range(len(device_group_idx_per_row)):
+        group_idx = device_group_idx_per_row[row]
+        curr_bank_id = 0
+        curr_bank_offset = 0
+
+        logger.info(
+            f"Rank: {rank} Populating device_group_index: {group_idx} with positions: {device_position_indices_low_strip[row]} and {device_position_indices_high_strip[row]}"
+        )
+        (current_position, max_position) = device_position_indices_low_strip[row]
+        for layer in range(num_layers):
+            layer_current_position = current_position
+            layer_max_position = max_position
+            for chunk in range(chunks_per_device_group):
+                location = ttnn.experimental.disaggregation.KvCacheLocation()
+
+                # This needs proper handling in KvCacheLocation(), just add it up atm
+                noc_addr = dram_bank_0_addr + curr_bank_id + curr_bank_offset
+                location.noc_addr = noc_addr
+                location.size_bytes = chunk_size_bytes
+                location.device_group_index = group_idx
+                lookup_table.set(layer, layer_current_position, slot, location)
+                logger.info(
+                    f"Rank: {rank} Set location for (layer={layer}, pos={layer_current_position}, slot={slot}, bank_id={curr_bank_id}, curr_bank_offset = {curr_bank_offset} noc_addr = 0x{noc_addr:X})"
+                )
+
+                curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
+                # move to next chunk offset
+                if curr_bank_id == 0:
+                    curr_bank_offset += chunk_size_bytes
+                layer_current_position += NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+                if chunk == num_chunks_in_strip - 1:
+                    # switch to high chunk
+                    assert (
+                        layer_current_position == layer_max_position + 1
+                    ), f"Missmatch in position calculation. Expected layer current_position to be {layer_max_position + 1}, but it is: {layer_current_position}."
+                    (layer_current_position, layer_max_position) = device_position_indices_high_strip[row]
+
+    return lookup_table
+
+
+def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_axis, num_kvpe_cache_layers):
+    """
+    Initialize KVPE cache for MLA.
+
+    Args:
+        kvpe_cache_head_dim: Head dimension for KVPE cache (qk_rope_head_dim + kv_lora_rank)
+        mesh_device: Mesh device for TT
+        seq_len: Sequence length
+        mesh_shape: Shape of mesh device
+        sp_axis: Sequence parallel axis
+        num_kvpe_cache_layers: Number of layers for KVPE cache
+
+    Returns:
+        tt_kvpe_cache: Initialized KVPE cache on device
+    """
+    # hack in num_layers into batch size, so they are contiguous in memory
+    num_layers = num_kvpe_cache_layers
+    seq_len_local = seq_len // mesh_shape[sp_axis]
+    torch_kvpe_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
+
+    core_ranges = [
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
+    ]
+    grid = ttnn.CoreRangeSet(core_ranges)
+
+    kv_nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim],
+        grid=grid,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    kv_mem_config = ttnn.MemoryConfig(
+        buffer_type=ttnn.BufferType.DRAM,
+        nd_shard_spec=kv_nd_shard_spec,
+    )
+
+    tt_kvpe_cache = ttnn.from_torch(
+        torch_kvpe_cache,
+        dtype=ttnn.bfloat8_b,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=kv_mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    return tt_kvpe_cache

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -488,6 +488,7 @@ list(
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/fabric.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/disaggregation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/global_circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/global_semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/hd_socket.cpp

--- a/ttnn/cpp/ttnn-nanobind/__init__.cpp
+++ b/ttnn/cpp/ttnn-nanobind/__init__.cpp
@@ -14,6 +14,7 @@
 #include "ttnn-nanobind/device.hpp"
 #include "ttnn-nanobind/events.hpp"
 #include "ttnn-nanobind/fabric.hpp"
+#include "ttnn-nanobind/disaggregation.hpp"
 #include "ttnn-nanobind/global_circular_buffer.hpp"
 #include "ttnn-nanobind/global_semaphore.hpp"
 #include "ttnn-nanobind/hd_socket.hpp"
@@ -185,6 +186,10 @@ void py_module(nb::module_& mod) {
 
     auto m_experimental = mod.def_submodule("experimental", "experimental operations");
     experimental::py_module(m_experimental);
+
+    auto m_disaggregation =
+        m_experimental.def_submodule("disaggregation", "Disaggregation APIs for KV cache management");
+    disaggregation::bind_disaggregation_api(m_disaggregation);
 
     auto m_moreh = mod.def_submodule("moreh", "moreh operations");
     moreh::bind_moreh_operations(m_moreh);

--- a/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
+++ b/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "disaggregation.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+
+namespace ttnn::disaggregation {
+
+void bind_disaggregation_api(nb::module_& mod) {
+    using namespace tt::tt_metal::experimental::disaggregation;
+
+    // DeviceGroupIndex - StrongType wrapper around uint32_t
+    nb::class_<DeviceGroupIndex>(mod, "DeviceGroupIndex", R"(
+        Strongly-typed index into the device group table.
+        Used to reference device groups in KvCacheLocation.
+    )")
+        .def(nb::init<uint32_t>(), nb::arg("value"), "Create a DeviceGroupIndex from an integer value.")
+        .def(
+            "__int__", [](const DeviceGroupIndex& idx) { return *idx; }, "Convert DeviceGroupIndex to integer.")
+        .def(
+            "__eq__",
+            [](const DeviceGroupIndex& lhs, const DeviceGroupIndex& rhs) { return lhs == rhs; },
+            nb::arg("other"))
+        .def("__repr__", [](const DeviceGroupIndex& idx) { return fmt::format("DeviceGroupIndex({})", *idx); });
+
+    // DeviceGroup - Group of fabric nodes with replicas
+    nb::class_<DeviceGroup>(mod, "DeviceGroup", R"(
+        A unique group of fabric nodes that hold replicas of a KV cache chunk.
+        FabricNodeIds are stored sorted for deduplication.
+    )")
+        .def(nb::init<>(), "Create an empty DeviceGroup.")
+        .def_rw("fabric_node_ids", &DeviceGroup::fabric_node_ids, "List of FabricNodeIds in this group (sorted).")
+        .def("__eq__", [](const DeviceGroup& lhs, const DeviceGroup& rhs) { return lhs == rhs; }, nb::arg("other"));
+
+    // KvCacheLocation - Physical location of a KV cache chunk
+    nb::class_<KvCacheLocation>(mod, "KvCacheLocation", R"(
+        Describes the physical location of a single KV cache chunk in device memory.
+        Contains NOC address, size, and reference to the device group holding replicas.
+    )")
+        .def(nb::init<>(), "Create a KvCacheLocation with default values.")
+        .def_rw("noc_addr", &KvCacheLocation::noc_addr, "NOC address of the KV cache chunk.")
+        .def_rw("size_bytes", &KvCacheLocation::size_bytes, "Size of the KV cache chunk in bytes.")
+        .def_rw("device_group_index", &KvCacheLocation::device_group_index, "Index into the device group table.");
+
+    // KvChunkAddressTableConfig - Configuration struct
+    nb::class_<KvChunkAddressTableConfig>(mod, "KvChunkAddressTableConfig", R"(
+        Configuration for constructing a KvChunkAddressTable.
+        Defines the dimensions and chunking parameters.
+    )")
+        .def(nb::init<>(), "Create a config with default values.")
+        .def_rw("num_layers", &KvChunkAddressTableConfig::num_layers, "Number of transformer layers.")
+        .def_rw(
+            "max_sequence_length",
+            &KvChunkAddressTableConfig::max_sequence_length,
+            "Maximum sequence length in tokens.")
+        .def_rw("num_slots", &KvChunkAddressTableConfig::num_slots, "Number of KV cache slots.")
+        .def_rw(
+            "chunk_n_tokens",
+            &KvChunkAddressTableConfig::chunk_n_tokens,
+            "Tokens per chunk (KV atomic block granularity). Default: 32")
+        .def_rw(
+            "chunk_size_bytes",
+            &KvChunkAddressTableConfig::chunk_size_bytes,
+            "Physical size of one chunk in bytes. Default: 19584 (18 x 1088 bfp8 tiles)");
+
+    // KvChunkAddressTable - Main lookup table class
+    nb::class_<KvChunkAddressTable>(mod, "KvChunkAddressTable", R"(
+        Lookup table mapping (layer, position, slot) -> KvCacheLocation.
+
+        Describes how a KV cache is allocated across a multi-host, multi-chip,
+        multi-memory system. Used by the migration layer to locate KV cache chunks
+        for transfer.
+    )")
+        .def(
+            nb::init<const KvChunkAddressTableConfig&>(),
+            nb::arg("config"),
+            "Construct a KvChunkAddressTable from configuration.")
+
+        // Device group management
+        .def(
+            "add_device_group",
+            &KvChunkAddressTable::add_device_group,
+            nb::arg("fabric_node_ids"),
+            R"(
+            Register a device group (set of replica FabricNodeIds).
+            The FabricNodeIds are sorted internally for deduplication.
+            Returns the index for this group. If an identical sorted group
+            already exists, returns the existing index.
+            )")
+        .def(
+            "get_device_group",
+            &KvChunkAddressTable::get_device_group,
+            nb::arg("index"),
+            nb::rv_policy::reference_internal,
+            "Lookup a device group by index. Returns a reference to the DeviceGroup.")
+        .def("num_device_groups", &KvChunkAddressTable::num_device_groups, "Number of unique device groups registered.")
+
+        // Mutators
+        .def(
+            "set",
+            &KvChunkAddressTable::set,
+            nb::arg("layer"),
+            nb::arg("position"),
+            nb::arg("slot"),
+            nb::arg("location"),
+            R"(
+            Set the location for a specific (layer, position, slot).
+            Position is in tokens and must be chunk-aligned (multiple of chunk_n_tokens).
+            )")
+        .def(
+            "set_fabric_node_host",
+            &KvChunkAddressTable::set_fabric_node_host,
+            nb::arg("node_id"),
+            nb::arg("host_name"),
+            "Register a mapping from FabricNodeId to its host name.")
+
+        // Accessors
+        .def(
+            "lookup",
+            &KvChunkAddressTable::lookup,
+            nb::arg("layer"),
+            nb::arg("position"),
+            nb::arg("slot"),
+            nb::rv_policy::reference_internal,
+            R"(
+            Lookup a single entry. Position is in tokens (chunk-aligned).
+            Returns a reference to the KvCacheLocation.
+            )")
+        .def(
+            "lookup_range",
+            [](const KvChunkAddressTable& table, uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot) {
+                auto span = table.lookup_range(layer, start_pos, end_pos, slot);
+                // Convert span to vector for Python
+                return std::vector<KvCacheLocation>(span.begin(), span.end());
+            },
+            nb::arg("layer"),
+            nb::arg("start_pos"),
+            nb::arg("end_pos"),
+            nb::arg("slot"),
+            R"(
+            Lookup a contiguous range of position chunks for a given (layer, slot).
+            Returns a list of KvCacheLocation entries.
+            start_pos must be chunk-aligned. end_pos need not be aligned.
+            Returns entries for chunks covering positions [start_pos, end_pos).
+            )")
+        .def(
+            "get_host",
+            &KvChunkAddressTable::get_host,
+            nb::arg("node_id"),
+            nb::rv_policy::reference,
+            "Resolve a FabricNodeId to its host name. Throws if not found.")
+        .def(
+            "has_host",
+            &KvChunkAddressTable::has_host,
+            nb::arg("node_id"),
+            "Check if a FabricNodeId has a registered host mapping.")
+
+        // Properties
+        .def(
+            "config",
+            &KvChunkAddressTable::config,
+            nb::rv_policy::reference_internal,
+            "Get the configuration used to construct this table.")
+        .def(
+            "num_position_chunks",
+            &KvChunkAddressTable::num_position_chunks,
+            "Number of position chunks (computed from config).")
+        .def("total_entries", &KvChunkAddressTable::total_entries, "Total number of entries in the table.");
+}
+
+}  // namespace ttnn::disaggregation

--- a/ttnn/cpp/ttnn-nanobind/disaggregation.hpp
+++ b/ttnn/cpp/ttnn-nanobind/disaggregation.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::disaggregation {
+
+namespace nb = nanobind;
+void bind_disaggregation_api(nb::module_& mod);
+
+}  // namespace ttnn::disaggregation

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -483,7 +483,11 @@ from ttnn.operations.pool import (
 )
 
 from ttnn._ttnn.operations.experimental import Conv3dConfig
+from ttnn._ttnn.operations.experimental import disaggregation
 from ttnn._ttnn.operations.experimental import MinimalMatmulConfig
+
+# Expose disaggregation in experimental namespace
+experimental.disaggregation = disaggregation
 
 Conv1dConfig = ttnn._ttnn.operations.conv.Conv2dConfig
 


### PR DESCRIPTION
### Ticket
#41176 

### Problem description
Lookup table test for deepseek prefill - handles multi galaxies, or single galaxy, on 100k seq_length. Also added a few test seq lengths.
Expose KV cache table via pybind

### Checklist

- [ ] [T3K e2e](https://github.com/tenstorrent/tt-metal/actions/runs/24183427837)
- [x] [Deepseek prefill glx](https://github.com/tenstorrent/tt-metal/actions/runs/24183503402) 6k seq_len fails (deleted afterwards)
- [x] [BH e2e](https://github.com/tenstorrent/tt-metal/actions/runs/24183550521) 6k seq_len fails (deleted afterwards)
- [x] [Release model status console](https://github.com/tenstorrent/tt-metal/actions/runs/24183585812) 6k seq_len fails (deleted afterwards)
- [ ] [Merge gate](https://github.com/tenstorrent/tt-metal/actions/runs/24190839807)
