### PR TITLE
[quasar] fix: Guard CircularBuffer branches in DM kernels for Quasar compilation

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -48,7 +48,9 @@ void kernel_main() {
             tlocal_src_addr += dfb.get_stride_size();
         }
         dfb.finish();
-    } else {
+    }
+#ifndef ARCH_QUASAR
+    else {
         experimental::CircularBuffer cb(cb_id);
         uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
 
@@ -60,4 +62,5 @@ void kernel_main() {
             src_addr += ublock_size_bytes;
         }
     }
+#endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -57,7 +57,9 @@ void kernel_main() {
             noc.async_write_barrier<experimental::Noc::BarrierMode::TXN_ID>(local_dfb_interface.txn_ids[i]);
         }
 #endif
-    } else {
+    }
+#ifndef ARCH_QUASAR
+    else {
         experimental::CircularBuffer cb(cb_id);
         uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
 
@@ -69,4 +71,5 @@ void kernel_main() {
             dst_addr += ublock_size_bytes;
         }
     }
+#endif
 }


### PR DESCRIPTION
### Problem description
Fix Quasar DM kernel compilation by wrapping `experimental::CircularBuffer` else-branches in `direct_reader_unary.cpp` and `direct_writer_unary.cpp` with `#ifndef ARCH_QUASAR`. The compiler still parses both sides of if constexpr for syntax validity, and CircularBuffer is not available on Quasar, causing build failures.                                                                                                                                                                                                                                        
### What's changed
`direct_reader_unary.cpp` and `direct_writer_unary.cpp` use `experimental::CircularBuffer` in the else branch of if-constexpr, which the compiler still parses on Quasar where CircularBuffer is not available. Wrap those else branches with `#ifndef ARCH_QUASAR` so they are excluded from Quasar builds entirely.   