### PR TITLE
[Feature] JIT compile server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,6 +90,7 @@ tt_metal/impl/device/ @abhullar-tt @aliuTT @tt-asaigal @tt-aho @cfjchu @tenstorr
 tt_metal/impl/dispatch/ @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/codeowner-bypass
 tt_metal/impl/event @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/codeowner-bypass
 tt_metal/impl/flatbuffer/ @cfjchu @kmabeeTT @nsmithtt @tenstorrent/codeowner-bypass
+tt_metal/impl/jit_server/ @ruizhangTT @tenstorrent/metalium-runtime @tenstorrent/codeowner-bypass
 tt_metal/impl/kernels/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @sagarwalTT @tenstorrent/codeowner-bypass
 tt_metal/impl/lightmetal/ @kmabeeTT @gsarabandoTT @tenstorrent/codeowner-bypass
 tt_metal/impl/metal2_host_api/ @akerteszTT @riverwuTT @tenstorrent/codeowner-bypass
@@ -118,6 +119,7 @@ tt_metal/tools/* @kmabeeTT @mo-tenstorrent @ihamer-tt @tenstorrent/codeowner-byp
 tt_metal/tools/lightmetal_runner @kmabeeTT @tenstorrent/codeowner-bypass
 tt_metal/tools/mem_bench @abhullar-tt @tenstorrent/codeowner-bypass # should be moved to tests micro benchmark?
 tt_metal/tools/precompile_fw @abhullar-tt @ruizhangTT @tenstorrent/codeowner-bypass
+tt_metal/tools/jit_compile_server @ruizhangTT @tenstorrent/metalium-runtime @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/ @mo-tenstorrent @abhullar-tt @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/event_metadata.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/fabric_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass

--- a/tests/tt_metal/tt_metal/jit_build/sources.cmake
+++ b/tests/tt_metal/tt_metal/jit_build/sources.cmake
@@ -1,4 +1,7 @@
 # Source files for tt_metal jit_build tests
 # Module owners should update this file when adding/removing/renaming source files
 
-set(UNIT_TESTS_JIT_BUILD_SRC test_depend.cpp)
+set(UNIT_TESTS_JIT_BUILD_SRC
+    test_depend.cpp
+    test_jit_compile_deduper.cpp
+)

--- a/tests/tt_metal/tt_metal/jit_build/test_jit_compile_deduper.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_jit_compile_deduper.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "impl/jit_server/in_flight_compile_deduper.hpp"
+#include "impl/jit_server/types.hpp"
+
+namespace tt::tt_metal::jit_server {
+
+TEST(JitCompileDeduperTest, DeduplicatesConcurrentIdenticalRequests) {
+    InFlightCompileDeduper<CompileResponse> deduper;
+
+    std::atomic<int> compile_invocations{0};
+    constexpr int kNumThreads = 8;
+    std::vector<std::future<CompileResponse>> futures;
+    futures.reserve(kNumThreads);
+
+    for (int i = 0; i < kNumThreads; ++i) {
+        futures.push_back(std::async(std::launch::async, [&]() {
+            return deduper.run("build:kernel", [&]() {
+                ++compile_invocations;
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                CompileResponse response;
+                response.success = true;
+                return response;
+            });
+        }));
+    }
+
+    for (auto& future : futures) {
+        auto response = future.get();
+        EXPECT_TRUE(response.success);
+    }
+
+    EXPECT_EQ(compile_invocations.load(), 1);
+}
+
+TEST(JitCompileDeduperTest, FailedBuildDoesNotPoisonFutureRequests) {
+    InFlightCompileDeduper<CompileResponse> deduper;
+    std::atomic<int> invocation_count{0};
+
+    EXPECT_THROW(
+        deduper.run(
+            "retry-key",
+            [&]() -> CompileResponse {
+                ++invocation_count;
+                throw std::runtime_error("simulated compile failure");
+            }),
+        std::runtime_error);
+
+    auto retry_response = deduper.run("retry-key", [&]() {
+        ++invocation_count;
+        CompileResponse response;
+        response.success = true;
+        return response;
+    });
+
+    EXPECT_TRUE(retry_response.success);
+    EXPECT_EQ(invocation_count.load(), 2);
+}
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -21,11 +21,14 @@ list(APPEND IMPL_SRC ${GENERATED_HEADERS})
 
 # Generate Inspector Cap'n Proto headers and RPC server implementation
 set(INSPECTOR_RPC_CAPNP ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/rpc.capnp)
+set(JIT_COMPILE_RPC_CAPNP ${CMAKE_CURRENT_SOURCE_DIR}/jit_server/rpc.capnp)
 set(CAPNPC_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/impl/)
 file(MAKE_DIRECTORY ${CAPNPC_OUTPUT_DIR})
 
 capnp_generate_cpp(INSPECTOR_RPC_CAPNP_SOURCES INSPECTOR_RPC_CAPNP_HEADER ${INSPECTOR_RPC_CAPNP})
 list(APPEND IMPL_SRC ${INSPECTOR_RPC_CAPNP_SOURCES})
+capnp_generate_cpp(JIT_COMPILE_RPC_CAPNP_SOURCES JIT_COMPILE_RPC_CAPNP_HEADER ${JIT_COMPILE_RPC_CAPNP})
+list(APPEND IMPL_SRC ${JIT_COMPILE_RPC_CAPNP_SOURCES})
 
 # Generate Inspector RPC callbacks server implementation
 set(INSPECTOR_RPC_GENERATED_HEADER ${CMAKE_CURRENT_BINARY_DIR}/impl/debug/inspector/rpc_server_generated.hpp)
@@ -49,6 +52,7 @@ set_source_files_properties(
     ${INSPECTOR_RPC_GENERATED_SOURCE}
     ${INSPECTOR_RPC_GENERATED_HEADER}
     ${INSPECTOR_RPC_CAPNP_SOURCES}
+    ${JIT_COMPILE_RPC_CAPNP_SOURCES}
     PROPERTIES
         SKIP_LINTING
             TRUE
@@ -61,6 +65,7 @@ if(TARGET all_generated_files)
         DEPENDS
             ${INSPECTOR_RPC_CAPNP_HEADER}
             ${INSPECTOR_RPC_GENERATED_HEADER}
+            ${JIT_COMPILE_RPC_CAPNP_HEADER}
     )
     add_dependencies(all_generated_files capnp_generated_files)
 endif()
@@ -96,6 +101,7 @@ target_link_libraries(
         capnp-rpc
         protobuf::libprotobuf
         libdwarf::dwarf-static
+        Taskflow::Taskflow
 )
 
 target_include_directories(

--- a/tt_metal/impl/jit_server/in_flight_compile_deduper.hpp
+++ b/tt_metal/impl/jit_server/in_flight_compile_deduper.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace tt::tt_metal::jit_server {
+
+template <typename TValue>
+class InFlightCompileDeduper {
+public:
+    template <typename TCallback>
+    TValue run(const std::string& dedup_key, TCallback&& callback) {
+        std::shared_future<TValue> shared_future;
+        std::shared_ptr<std::promise<TValue>> owner_promise;
+
+        {
+            std::lock_guard<std::mutex> lock(in_flight_mutex_);
+            auto it = in_flight_.find(dedup_key);
+            if (it == in_flight_.end()) {
+                owner_promise = std::make_shared<std::promise<TValue>>();
+                shared_future = owner_promise->get_future().share();
+                in_flight_[dedup_key] = shared_future;
+            } else {
+                shared_future = it->second;
+            }
+        }
+
+        if (owner_promise != nullptr) {
+            try {
+                owner_promise->set_value(std::forward<TCallback>(callback)());
+            } catch (...) {
+                owner_promise->set_exception(std::current_exception());
+            }
+
+            std::lock_guard<std::mutex> lock(in_flight_mutex_);
+            in_flight_.erase(dedup_key);
+        }
+
+        return shared_future.get();
+    }
+
+private:
+    std::mutex in_flight_mutex_;
+    std::unordered_map<std::string, std::shared_future<TValue>> in_flight_;
+};
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/jit_server/jit_compile_rpc_client.cpp
+++ b/tt_metal/impl/jit_server/jit_compile_rpc_client.cpp
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "impl/jit_server/jit_compile_rpc_client.hpp"
+
+#include <capnp/ez-rpc.h>
+#include <cctype>
+#include <cstddef>
+#include <cstdlib>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+#include "impl/jit_server/rpc.capnp.h"
+
+namespace tt::tt_metal::jit_server {
+
+namespace {
+
+constexpr const char* kJitServerEndpointEnv = "TT_METAL_JIT_SERVER_ENDPOINT";
+constexpr const char* kJitServerEndpointsEnv = "TT_METAL_JIT_SERVER_ENDPOINTS";
+constexpr const char* kJitServerEnableEnv = "TT_METAL_JIT_SERVER_ENABLE";
+
+std::string trim_ascii_whitespace(std::string_view input) {
+    size_t begin = 0;
+    while (begin < input.size() && std::isspace(static_cast<unsigned char>(input[begin]))) {
+        ++begin;
+    }
+    size_t end = input.size();
+    while (end > begin && std::isspace(static_cast<unsigned char>(input[end - 1]))) {
+        --end;
+    }
+    return std::string(input.substr(begin, end - begin));
+}
+
+std::vector<std::string> parse_endpoint_list(std::string_view endpoints) {
+    std::vector<std::string> parsed;
+    size_t start = 0;
+    while (start <= endpoints.size()) {
+        size_t comma = endpoints.find(',', start);
+        size_t end = (comma == std::string_view::npos) ? endpoints.size() : comma;
+        std::string token = trim_ascii_whitespace(endpoints.substr(start, end - start));
+        if (!token.empty()) {
+            parsed.push_back(std::move(token));
+        }
+        if (comma == std::string_view::npos) {
+            break;
+        }
+        start = comma + 1;
+    }
+    return parsed;
+}
+
+void fill_target_recipe(rpc::TargetRecipe::Builder& builder, const TargetRecipe& target) {
+    builder.setTargetName(target.target_name);
+    builder.setCflags(target.cflags);
+    builder.setDefines(target.defines);
+    builder.setIncludes(target.includes);
+    builder.setCompilerOptLevel(target.compiler_opt_level);
+    auto srcs = builder.initSrcs(target.srcs.size());
+    for (std::size_t i = 0; i < target.srcs.size(); ++i) {
+        srcs.set(i, target.srcs[i]);
+    }
+    auto objs = builder.initObjs(target.objs.size());
+    for (std::size_t i = 0; i < target.objs.size(); ++i) {
+        objs.set(i, target.objs[i]);
+    }
+    builder.setLflags(target.lflags);
+    builder.setExtraLinkObjs(target.extra_link_objs);
+    builder.setLinkerScript(target.linker_script);
+    builder.setWeakenedFirmwareName(target.weakened_firmware_name);
+    builder.setFirmwareIsKernelObject(target.firmware_is_kernel_object);
+    builder.setLinkerOptLevel(target.linker_opt_level);
+}
+
+void fill_compile_request(rpc::CompileRequest::Builder& builder, const CompileRequest& request) {
+    builder.setBuildKey(request.build_key);
+    builder.setKernelName(request.kernel_name);
+    builder.setGpp(request.gpp);
+
+    auto targets = builder.initTargets(request.targets.size());
+    for (std::size_t i = 0; i < request.targets.size(); ++i) {
+        auto t = targets[i];
+        fill_target_recipe(t, request.targets[i]);
+    }
+
+    if (!request.generated_files.empty()) {
+        auto files = builder.initGeneratedFiles(request.generated_files.size());
+        for (std::size_t i = 0; i < request.generated_files.size(); ++i) {
+            files[i].setName(request.generated_files[i].name);
+            files[i].setContent(
+                kj::arrayPtr(request.generated_files[i].content.data(), request.generated_files[i].content.size()));
+        }
+    }
+}
+
+void fill_upload_firmware_request(rpc::UploadFirmwareRequest::Builder& builder, const UploadFirmwareRequest& request) {
+    builder.setBuildKey(request.build_key);
+    auto artifacts = builder.initArtifacts(request.artifacts.size());
+    for (std::size_t i = 0; i < request.artifacts.size(); ++i) {
+        artifacts[i].setTargetName(request.artifacts[i].target_name);
+        artifacts[i].setFileName(request.artifacts[i].file_name);
+        artifacts[i].setIsKernelObject(request.artifacts[i].is_kernel_object);
+        artifacts[i].setData(kj::arrayPtr(request.artifacts[i].data.data(), request.artifacts[i].data.size()));
+    }
+}
+
+UploadFirmwareResponse read_upload_firmware_response(rpc::UploadFirmwareResponse::Reader reader) {
+    UploadFirmwareResponse response;
+    response.success = reader.getSuccess();
+    response.error_message = reader.getErrorMessage().cStr();
+    return response;
+}
+
+CompileResponse read_compile_response(rpc::CompileResponse::Reader reader) {
+    CompileResponse response;
+    response.success = reader.getSuccess();
+    response.error_message = reader.getErrorMessage().cStr();
+    for (auto blob : reader.getElfBlobs()) {
+        ElfBlob elf;
+        elf.name = blob.getName().cStr();
+        auto data = blob.getData();
+        elf.data.assign(data.begin(), data.end());
+        response.elf_blobs.push_back(std::move(elf));
+    }
+    return response;
+}
+
+}  // namespace
+
+JitCompileRpcClient::JitCompileRpcClient(std::string endpoint) : endpoint_(std::move(endpoint)) {}
+
+bool JitCompileRpcClient::enabled() {
+    const char* enabled_value = std::getenv(kJitServerEnableEnv);
+    if (enabled_value == nullptr) {
+        return false;
+    }
+    return std::string_view(enabled_value) == "1";
+}
+
+std::string JitCompileRpcClient::endpoint_from_env() {
+    const char* endpoint_value = std::getenv(kJitServerEndpointEnv);
+    if (endpoint_value == nullptr) {
+        return {};
+    }
+    return endpoint_value;
+}
+
+std::vector<std::string> JitCompileRpcClient::endpoints_from_env() {
+    const char* endpoints_value = std::getenv(kJitServerEndpointsEnv);
+    if (endpoints_value != nullptr) {
+        auto parsed = parse_endpoint_list(endpoints_value);
+        if (!parsed.empty()) {
+            return parsed;
+        }
+    }
+
+    const std::string endpoint = endpoint_from_env();
+    if (!endpoint.empty()) {
+        return {endpoint};
+    }
+    return {};
+}
+
+CompileResponse JitCompileRpcClient::compile(const CompileRequest& request) const {
+    if (endpoint_.empty()) {
+        throw std::runtime_error("Missing TT_METAL_JIT_SERVER_ENDPOINT for remote JIT compile");
+    }
+
+    try {
+        capnp::EzRpcClient client(endpoint_);
+        auto cap = client.getMain<rpc::JitCompile>();
+        auto rpc_request = cap.compileRequest();
+        auto builder = rpc_request.initRequest();
+        fill_compile_request(builder, request);
+        auto result = rpc_request.send().wait(client.getWaitScope());
+        return read_compile_response(result.getResponse());
+    } catch (const kj::Exception& e) {
+        throw std::runtime_error(
+            "Failed to connect to remote JIT compile server at " + endpoint_ + ": " + e.getDescription().cStr());
+    }
+}
+
+UploadFirmwareResponse JitCompileRpcClient::upload_firmware(const UploadFirmwareRequest& request) const {
+    if (endpoint_.empty()) {
+        throw std::runtime_error("Missing TT_METAL_JIT_SERVER_ENDPOINT for remote JIT firmware upload");
+    }
+
+    try {
+        capnp::EzRpcClient client(endpoint_);
+        auto cap = client.getMain<rpc::JitCompile>();
+        auto rpc_request = cap.uploadFirmwareRequest();
+        auto builder = rpc_request.initRequest();
+        fill_upload_firmware_request(builder, request);
+        auto result = rpc_request.send().wait(client.getWaitScope());
+        return read_upload_firmware_response(result.getResponse());
+    } catch (const kj::Exception& e) {
+        throw std::runtime_error(
+            "Failed firmware upload to remote JIT server at " + endpoint_ + ": " + e.getDescription().cStr());
+    }
+}
+
+std::vector<CompileResponse> JitCompileRpcClient::compile_batch(const std::vector<CompileRequest>& requests) const {
+    if (endpoint_.empty()) {
+        throw std::runtime_error("Missing TT_METAL_JIT_SERVER_ENDPOINT for remote JIT compile");
+    }
+    if (requests.empty()) {
+        return {};
+    }
+
+    try {
+        capnp::EzRpcClient client(endpoint_);
+        auto cap = client.getMain<rpc::JitCompile>();
+
+        using CompilePromise = capnp::RemotePromise<rpc::JitCompile::CompileResults>;
+        std::vector<CompilePromise> promises;
+        promises.reserve(requests.size());
+        for (const auto& request : requests) {
+            auto rpc_request = cap.compileRequest();
+            auto builder = rpc_request.initRequest();
+            fill_compile_request(builder, request);
+            promises.push_back(rpc_request.send());
+        }
+
+        std::vector<CompileResponse> responses;
+        responses.reserve(promises.size());
+        for (auto& promise : promises) {
+            auto result = promise.wait(client.getWaitScope());
+            responses.push_back(read_compile_response(result.getResponse()));
+        }
+        return responses;
+    } catch (const kj::Exception& e) {
+        throw std::runtime_error(
+            "Failed to connect to remote JIT compile server at " + endpoint_ + ": " + e.getDescription().cStr());
+    }
+}
+
+// -- JitCompileRpcSession --
+
+struct JitCompileRpcSession::Impl {
+    capnp::EzRpcClient client;
+    rpc::JitCompile::Client cap;
+    using CompilePromise = capnp::RemotePromise<rpc::JitCompile::CompileResults>;
+    std::vector<CompilePromise> promises;
+
+    explicit Impl(const std::string& endpoint) : client(endpoint), cap(client.getMain<rpc::JitCompile>()) {}
+};
+
+JitCompileRpcSession::JitCompileRpcSession(const std::string& endpoint) : impl_(std::make_unique<Impl>(endpoint)) {}
+
+JitCompileRpcSession::~JitCompileRpcSession() = default;
+
+CompileResponse JitCompileRpcSession::send_and_wait(const CompileRequest& request) {
+    auto rpc_request = impl_->cap.compileRequest();
+    auto builder = rpc_request.initRequest();
+    fill_compile_request(builder, request);
+    auto result = rpc_request.send().wait(impl_->client.getWaitScope());
+    return read_compile_response(result.getResponse());
+}
+
+void JitCompileRpcSession::send(const CompileRequest& request) {
+    auto rpc_request = impl_->cap.compileRequest();
+    auto builder = rpc_request.initRequest();
+    fill_compile_request(builder, request);
+    impl_->promises.push_back(rpc_request.send());
+}
+
+std::vector<CompileResponse> JitCompileRpcSession::wait_all() {
+    std::vector<CompileResponse> responses;
+    responses.reserve(impl_->promises.size());
+    for (auto& promise : impl_->promises) {
+        auto result = promise.wait(impl_->client.getWaitScope());
+        responses.push_back(read_compile_response(result.getResponse()));
+    }
+    impl_->promises.clear();
+    return responses;
+}
+
+UploadFirmwareResponse JitCompileRpcSession::upload_firmware(const UploadFirmwareRequest& request) {
+    auto rpc_request = impl_->cap.uploadFirmwareRequest();
+    auto builder = rpc_request.initRequest();
+    fill_upload_firmware_request(builder, request);
+    auto result = rpc_request.send().wait(impl_->client.getWaitScope());
+    return read_upload_firmware_response(result.getResponse());
+}
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/jit_server/jit_compile_rpc_client.cpp
+++ b/tt_metal/impl/jit_server/jit_compile_rpc_client.cpp
@@ -23,7 +23,7 @@ constexpr const char* kJitServerEndpointsEnv = "TT_METAL_JIT_SERVER_ENDPOINTS";
 constexpr const char* kJitServerEnableEnv = "TT_METAL_JIT_SERVER_ENABLE";
 
 std::string trim_ascii_whitespace(std::string_view input) {
-    size_t begin = 0;
+    size_t begin = 0u;
     while (begin < input.size() && std::isspace(static_cast<unsigned char>(input[begin]))) {
         ++begin;
     }
@@ -36,7 +36,7 @@ std::string trim_ascii_whitespace(std::string_view input) {
 
 std::vector<std::string> parse_endpoint_list(std::string_view endpoints) {
     std::vector<std::string> parsed;
-    size_t start = 0;
+    size_t start = 0u;
     while (start <= endpoints.size()) {
         size_t comma = endpoints.find(',', start);
         size_t end = (comma == std::string_view::npos) ? endpoints.size() : comma;
@@ -47,7 +47,7 @@ std::vector<std::string> parse_endpoint_list(std::string_view endpoints) {
         if (comma == std::string_view::npos) {
             break;
         }
-        start = comma + 1;
+        start = comma + 1u;
     }
     return parsed;
 }

--- a/tt_metal/impl/jit_server/jit_compile_rpc_client.hpp
+++ b/tt_metal/impl/jit_server/jit_compile_rpc_client.hpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "impl/jit_server/types.hpp"
+
+namespace tt::tt_metal::jit_server {
+
+class JitCompileRpcClient {
+public:
+    explicit JitCompileRpcClient(std::string endpoint);
+
+    static bool enabled();
+    static std::vector<std::string> endpoints_from_env();
+    static std::string endpoint_from_env();
+
+    CompileResponse compile(const CompileRequest& request) const;
+    std::vector<CompileResponse> compile_batch(const std::vector<CompileRequest>& requests) const;
+    UploadFirmwareResponse upload_firmware(const UploadFirmwareRequest& request) const;
+
+private:
+    std::string endpoint_;
+};
+
+// Holds a single persistent connection for incremental pipelined sends.
+// Usage: send() requests as they become ready, then wait_all() to collect responses.
+class JitCompileRpcSession {
+public:
+    explicit JitCompileRpcSession(const std::string& endpoint);
+    ~JitCompileRpcSession();
+
+    void send(const CompileRequest& request);
+    CompileResponse send_and_wait(const CompileRequest& request);
+    std::vector<CompileResponse> wait_all();
+
+    UploadFirmwareResponse upload_firmware(const UploadFirmwareRequest& request);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/jit_server/jit_compile_server_controller.cpp
+++ b/tt_metal/impl/jit_server/jit_compile_server_controller.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "impl/jit_server/jit_compile_server_controller.hpp"
+
+#include <capnp/rpc-twoparty.h>
+#include <kj/async-io.h>
+#include <tt-logger/tt-logger.hpp>
+
+#include <chrono>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+namespace tt::tt_metal::jit_server {
+
+JitCompileServerController::JitCompileServerController(
+    JitCompileService::CompileCallback compile_callback, JitCompileService::UploadFirmwareCallback upload_fw_callback) :
+    jit_compile_service_(std::move(compile_callback), std::move(upload_fw_callback)) {}
+
+JitCompileServerController::~JitCompileServerController() { stop(); }
+
+void JitCompileServerController::start(std::string address) {
+    if (is_running_) {
+        log_warning(tt::LogMetal, "JIT compile RPC server already running");
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(start_stop_mutex_);
+    if (is_running_) {
+        log_warning(tt::LogMetal, "JIT compile RPC server already running");
+        return;
+    }
+
+    address_ = std::move(address);
+    should_stop_ = false;
+    is_running_ = true;
+    server_start_finished_ = false;
+    server_thread_ = std::thread(&JitCompileServerController::run_server, this);
+
+    std::unique_lock start_lock(server_start_mutex_);
+    server_start_cv_.wait(start_lock, [this] { return this->server_start_finished_.load(); });
+    if (!is_running_) {
+        if (server_thread_.joinable()) {
+            server_thread_.join();
+        }
+        throw std::runtime_error(server_start_error_message_);
+    }
+}
+
+void JitCompileServerController::stop() {
+    if (!is_running_) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(start_stop_mutex_);
+    if (!is_running_) {
+        return;
+    }
+
+    should_stop_ = true;
+    if (server_thread_.joinable()) {
+        server_thread_.join();
+    }
+
+    log_trace(tt::LogMetal, "JIT compile RPC server stopped");
+    is_running_ = false;
+}
+
+void JitCompileServerController::run_server() {
+    try {
+        auto io = ::kj::setupAsyncIo();
+        auto& wait_scope = io.waitScope;
+
+        kj::Network& network = io.provider->getNetwork();
+        kj::Own<kj::NetworkAddress> address = network.parseAddress(address_).wait(wait_scope);
+        kj::Own<kj::ConnectionReceiver> listener = address->listen();
+
+        capnp::TwoPartyServer server(::kj::Own<JitCompileService>(&jit_compile_service_, ::kj::NullDisposer::instance));
+        auto listen_promise = server.listen(*listener);
+
+        {
+            std::lock_guard lock(server_start_mutex_);
+            server_start_finished_ = true;
+        }
+        server_start_cv_.notify_one();
+
+        auto last_events = std::chrono::high_resolution_clock::now();
+        while (!should_stop_) {
+            auto count = wait_scope.poll();
+            listen_promise.poll(wait_scope);
+
+            if (count > 0) {
+                last_events = std::chrono::high_resolution_clock::now();
+            } else if (std::chrono::high_resolution_clock::now() - last_events > std::chrono::milliseconds(10)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+    } catch (const kj::Exception& e) {
+        server_start_error_message_ = e.getDescription().cStr();
+    } catch (const std::exception& e) {
+        server_start_error_message_ = e.what();
+    }
+    is_running_ = false;
+
+    {
+        std::lock_guard lock(server_start_mutex_);
+        server_start_finished_ = true;
+    }
+    server_start_cv_.notify_one();
+}
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/jit_server/jit_compile_server_controller.hpp
+++ b/tt_metal/impl/jit_server/jit_compile_server_controller.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "impl/jit_server/jit_compile_service.hpp"
+
+namespace tt::tt_metal::jit_server {
+
+class JitCompileServerController {
+public:
+    explicit JitCompileServerController(
+        JitCompileService::CompileCallback compile_callback,
+        JitCompileService::UploadFirmwareCallback upload_fw_callback = {});
+    ~JitCompileServerController();
+
+    void start(std::string address);
+    void stop();
+
+private:
+    void run_server();
+
+    std::thread server_thread_;
+    JitCompileService jit_compile_service_;
+    std::mutex start_stop_mutex_;
+    std::atomic<bool> should_stop_{false};
+    std::atomic<bool> is_running_{false};
+
+    std::condition_variable server_start_cv_;
+    std::mutex server_start_mutex_;
+    std::atomic<bool> server_start_finished_{false};
+    std::string server_start_error_message_;
+
+    std::string address_;
+};
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/jit_server/jit_compile_service.cpp
+++ b/tt_metal/impl/jit_server/jit_compile_service.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "impl/jit_server/jit_compile_service.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include <kj/async.h>
+#include <tt-logger/tt-logger.hpp>
+
+namespace tt::tt_metal::jit_server {
+
+JitCompileService::JitCompileService(CompileCallback compile_callback, UploadFirmwareCallback upload_fw_callback) :
+    compile_callback_(std::move(compile_callback)), upload_fw_callback_(std::move(upload_fw_callback)) {}
+
+std::string JitCompileService::make_dedup_key(const CompileRequest& request) const {
+    return std::to_string(request.build_key) + ":" + request.kernel_name;
+}
+
+kj::Promise<void> JitCompileService::compile(CompileContext context) {
+    CompileRequest request;
+    auto reader = context.getParams().getRequest();
+    request.build_key = reader.getBuildKey();
+    request.kernel_name = reader.getKernelName().cStr();
+    request.gpp = reader.getGpp().cStr();
+    for (auto target : reader.getTargets()) {
+        TargetRecipe t;
+        t.target_name = target.getTargetName().cStr();
+        t.cflags = target.getCflags().cStr();
+        t.defines = target.getDefines().cStr();
+        t.includes = target.getIncludes().cStr();
+        t.compiler_opt_level = target.getCompilerOptLevel().cStr();
+        for (auto src : target.getSrcs()) {
+            t.srcs.push_back(src.cStr());
+        }
+        for (auto obj : target.getObjs()) {
+            t.objs.push_back(obj.cStr());
+        }
+        t.lflags = target.getLflags().cStr();
+        t.extra_link_objs = target.getExtraLinkObjs().cStr();
+        t.linker_script = target.getLinkerScript().cStr();
+        t.weakened_firmware_name = target.getWeakenedFirmwareName().cStr();
+        t.firmware_is_kernel_object = target.getFirmwareIsKernelObject();
+        t.linker_opt_level = target.getLinkerOptLevel().cStr();
+        request.targets.push_back(std::move(t));
+    }
+    for (auto file : reader.getGeneratedFiles()) {
+        GeneratedFile gf;
+        gf.name = file.getName().cStr();
+        auto content = file.getContent();
+        gf.content.assign(content.begin(), content.end());
+        request.generated_files.push_back(std::move(gf));
+    }
+
+    const std::string dedup_key = make_dedup_key(request);
+
+    auto paf = kj::newPromiseAndCrossThreadFulfiller<CompileResponse>();
+    auto fulfiller = std::make_shared<kj::Own<kj::CrossThreadPromiseFulfiller<CompileResponse>>>(kj::mv(paf.fulfiller));
+
+    thread_pool_.silent_async([this, dedup_key, request = std::move(request), fulfiller]() mutable {
+        CompileResponse response;
+        try {
+            response = compile_deduper_.run(dedup_key, [&]() {
+                if (!compile_callback_) {
+                    throw std::runtime_error("No JIT compile callback configured on server");
+                }
+                return compile_callback_(request);
+            });
+        } catch (const std::exception& e) {
+            response.success = false;
+            response.error_message = e.what();
+        }
+        (*fulfiller)->fulfill(kj::mv(response));
+    });
+
+    return paf.promise.then([context](CompileResponse response) mutable {
+        if (!response.success) {
+            log_warning(tt::LogMetal, "compile FAIL: {}", response.error_message);
+        }
+
+        auto response_builder = context.getResults().initResponse();
+        response_builder.setSuccess(response.success);
+        response_builder.setErrorMessage(response.error_message);
+        auto blobs_builder = response_builder.initElfBlobs(response.elf_blobs.size());
+        for (std::size_t i = 0; i < response.elf_blobs.size(); ++i) {
+            blobs_builder[i].setName(response.elf_blobs[i].name);
+            blobs_builder[i].setData(
+                kj::arrayPtr(response.elf_blobs[i].data.data(), response.elf_blobs[i].data.size()));
+        }
+    });
+}
+
+kj::Promise<void> JitCompileService::uploadFirmware(UploadFirmwareContext context) {
+    UploadFirmwareRequest request;
+    auto reader = context.getParams().getRequest();
+    request.build_key = reader.getBuildKey();
+    for (auto artifact : reader.getArtifacts()) {
+        FirmwareArtifact a;
+        a.target_name = artifact.getTargetName().cStr();
+        a.file_name = artifact.getFileName().cStr();
+        a.is_kernel_object = artifact.getIsKernelObject();
+        auto data = artifact.getData();
+        a.data.assign(data.begin(), data.end());
+        request.artifacts.push_back(std::move(a));
+    }
+
+    auto paf = kj::newPromiseAndCrossThreadFulfiller<UploadFirmwareResponse>();
+    auto fulfiller =
+        std::make_shared<kj::Own<kj::CrossThreadPromiseFulfiller<UploadFirmwareResponse>>>(kj::mv(paf.fulfiller));
+
+    thread_pool_.silent_async([this, request = std::move(request), fulfiller]() mutable {
+        UploadFirmwareResponse response;
+        try {
+            if (!upload_fw_callback_) {
+                throw std::runtime_error("No firmware upload callback configured on server");
+            }
+            response = upload_fw_callback_(request);
+        } catch (const std::exception& e) {
+            response.success = false;
+            response.error_message = e.what();
+        }
+        (*fulfiller)->fulfill(kj::mv(response));
+    });
+
+    return paf.promise.then([context](UploadFirmwareResponse response) mutable {
+        if (!response.success) {
+            log_warning(tt::LogMetal, "uploadFirmware FAIL: {}", response.error_message);
+        }
+        auto response_builder = context.getResults().initResponse();
+        response_builder.setSuccess(response.success);
+        response_builder.setErrorMessage(response.error_message);
+    });
+}
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/jit_server/jit_compile_service.hpp
+++ b/tt_metal/impl/jit_server/jit_compile_service.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <functional>
+#include <thread>
+
+#include <taskflow/taskflow.hpp>
+
+#include "impl/jit_server/in_flight_compile_deduper.hpp"
+#include "impl/jit_server/rpc.capnp.h"
+#include "impl/jit_server/types.hpp"
+
+namespace tt::tt_metal::jit_server {
+
+class JitCompileService final : public rpc::JitCompile::Server {
+public:
+    using CompileCallback = std::function<CompileResponse(const CompileRequest&)>;
+    using UploadFirmwareCallback = std::function<UploadFirmwareResponse(const UploadFirmwareRequest&)>;
+
+    explicit JitCompileService(CompileCallback compile_callback, UploadFirmwareCallback upload_fw_callback = {});
+
+    kj::Promise<void> compile(CompileContext context) override;
+    kj::Promise<void> uploadFirmware(UploadFirmwareContext context) override;
+
+private:
+    std::string make_dedup_key(const CompileRequest& request) const;
+
+    CompileCallback compile_callback_;
+    UploadFirmwareCallback upload_fw_callback_;
+    InFlightCompileDeduper<CompileResponse> compile_deduper_;
+    tf::Executor thread_pool_{std::thread::hardware_concurrency()};
+};
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/jit_server/jit_compile_service.hpp
+++ b/tt_metal/impl/jit_server/jit_compile_service.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
 #include <functional>
@@ -33,7 +34,7 @@ private:
     CompileCallback compile_callback_;
     UploadFirmwareCallback upload_fw_callback_;
     InFlightCompileDeduper<CompileResponse> compile_deduper_;
-    tf::Executor thread_pool_{std::thread::hardware_concurrency()};
+    tf::Executor thread_pool_{std::max(1u, std::thread::hardware_concurrency())};
 };
 
 }  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/jit_server/rpc.capnp
+++ b/tt_metal/impl/jit_server/rpc.capnp
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+@0xdbf1fcd2b54d6e11;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("tt::tt_metal::jit_server::rpc");
+
+struct GeneratedFile {
+    name @0 :Text;
+    content @1 :Data;
+}
+
+struct TargetRecipe {
+    targetName @0 :Text;
+
+    # Compile recipe.
+    cflags @1 :Text;
+    defines @2 :Text;
+    includes @3 :Text;
+    compilerOptLevel @4 :Text;
+    srcs @5 :List(Text);
+    objs @6 :List(Text);
+
+    # Link recipe.
+    lflags @7 :Text;
+    extraLinkObjs @8 :Text;
+    linkerScript @9 :Text;
+    weakenedFirmwareName @10 :Text;
+    firmwareIsKernelObject @11 :Bool;
+    linkerOptLevel @12 :Text;
+}
+
+struct CompileRequest {
+    buildKey @0 :UInt64;
+    kernelName @1 :Text;
+
+    # Toolchain (shared by all targets).
+    gpp @2 :Text;
+
+    # Per-target compile/link recipes.
+    targets @3 :List(TargetRecipe);
+
+    # Generated files to write before compiling (shared by all targets).
+    generatedFiles @4 :List(GeneratedFile);
+}
+
+struct ElfBlob {
+    name @0 :Text;
+    data @1 :Data;
+}
+
+struct CompileResponse {
+    success @0 :Bool;
+    errorMessage @1 :Text;
+    elfBlobs @2 :List(ElfBlob);
+}
+
+struct FirmwareArtifact {
+    targetName @0 :Text;
+    fileName @1 :Text;
+    isKernelObject @2 :Bool;
+    data @3 :Data;
+}
+
+struct UploadFirmwareRequest {
+    buildKey @0 :UInt64;
+    artifacts @1 :List(FirmwareArtifact);
+}
+
+struct UploadFirmwareResponse {
+    success @0 :Bool;
+    errorMessage @1 :Text;
+}
+
+interface JitCompile {
+    compile @0 (request :CompileRequest) -> (response :CompileResponse);
+    uploadFirmware @1 (request :UploadFirmwareRequest) -> (response :UploadFirmwareResponse);
+}

--- a/tt_metal/impl/jit_server/types.hpp
+++ b/tt_metal/impl/jit_server/types.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace tt::tt_metal::jit_server {
+
+struct GeneratedFile {
+    std::string name;
+    std::vector<std::uint8_t> content;
+};
+
+struct TargetRecipe {
+    std::string target_name;
+
+    // Compile recipe.
+    std::string cflags;
+    std::string defines;
+    std::string includes;
+    std::string compiler_opt_level;
+    std::vector<std::string> srcs;
+    std::vector<std::string> objs;
+
+    // Link recipe.
+    std::string lflags;
+    std::string extra_link_objs;
+    std::string linker_script;
+    std::string weakened_firmware_name;
+    bool firmware_is_kernel_object = false;
+    std::string linker_opt_level;
+};
+
+struct CompileRequest {
+    std::uint64_t build_key = 0;
+    std::string kernel_name;
+    std::string gpp;
+    std::vector<TargetRecipe> targets;
+    std::vector<GeneratedFile> generated_files;
+};
+
+struct ElfBlob {
+    std::string name;
+    std::vector<std::uint8_t> data;
+};
+
+struct FirmwareArtifact {
+    std::string target_name;
+    std::string file_name;
+    bool is_kernel_object = false;
+    std::vector<std::uint8_t> data;
+};
+
+struct UploadFirmwareRequest {
+    std::uint64_t build_key = 0;
+    std::vector<FirmwareArtifact> artifacts;
+};
+
+struct UploadFirmwareResponse {
+    bool success = false;
+    std::string error_message;
+};
+
+struct CompileResponse {
+    bool success = false;
+    std::string error_message;
+    std::vector<ElfBlob> elf_blobs;
+};
+
+}  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -56,6 +56,9 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/program/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/program/program_descriptors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/program/program_device_map.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit_server/jit_compile_rpc_client.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit_server/jit_compile_service.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit_server/jit_compile_server_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/profiler/profiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/profiler/tt_metal_profiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/profiler/profiler_analysis.cpp

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -4,8 +4,11 @@
 
 #include "jit_build_utils.hpp"
 
+#include <cctype>
+#include <cerrno>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -13,6 +16,12 @@
 #include <random>
 #include <string>
 #include <system_error>
+#include <vector>
+
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <tt-logger/tt-logger.hpp>
 
@@ -37,6 +46,81 @@ bool run_command(const std::string& cmd, const std::string& log_file, bool verbo
     }
 
     return (ret == 0);
+}
+
+std::vector<std::string> tokenize_flags(const std::string& flags) {
+    std::vector<std::string> tokens;
+    std::size_t i = 0;
+    while (i < flags.size()) {
+        while (i < flags.size() && std::isspace(static_cast<unsigned char>(flags[i]))) {
+            ++i;
+        }
+        if (i >= flags.size()) {
+            break;
+        }
+        std::size_t start = i;
+        while (i < flags.size() && !std::isspace(static_cast<unsigned char>(flags[i]))) {
+            ++i;
+        }
+        tokens.emplace_back(flags, start, i - start);
+    }
+    return tokens;
+}
+
+bool exec_command(const std::vector<std::string>& args, const std::string& working_dir, const std::string& log_file) {
+    if (args.empty()) {
+        return false;
+    }
+
+    // Build a null-terminated argv array for posix_spawn.
+    std::vector<const char*> argv;
+    argv.reserve(args.size() + 1);
+    for (const auto& a : args) {
+        argv.push_back(a.c_str());
+    }
+    argv.push_back(nullptr);
+
+    posix_spawn_file_actions_t file_actions;
+    posix_spawn_file_actions_init(&file_actions);
+
+    int log_fd = -1;
+    if (!log_file.empty()) {
+        log_fd = open(log_file.c_str(), O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0644);
+        if (log_fd < 0) {
+            posix_spawn_file_actions_destroy(&file_actions);
+            return false;
+        }
+        posix_spawn_file_actions_adddup2(&file_actions, log_fd, STDOUT_FILENO);
+        posix_spawn_file_actions_adddup2(&file_actions, log_fd, STDERR_FILENO);
+    }
+
+    if (!working_dir.empty()) {
+        posix_spawn_file_actions_addchdir_np(&file_actions, working_dir.c_str());
+    }
+
+    pid_t pid = 0;
+    int spawn_ret =
+        posix_spawnp(&pid, argv[0], &file_actions, nullptr, const_cast<char* const*>(argv.data()), ::environ);
+
+    if (log_fd >= 0) {
+        close(log_fd);
+    }
+    posix_spawn_file_actions_destroy(&file_actions);
+
+    if (spawn_ret != 0) {
+        log_error(tt::LogBuildKernels, "posix_spawnp failed for '{}': {}", argv[0], std::strerror(spawn_ret));
+        return false;
+    }
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno != EINTR) {
+            log_error(tt::LogBuildKernels, "waitpid failed for '{}': {}", argv[0], std::strerror(errno));
+            return false;
+        }
+    }
+
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
 }
 
 void create_file(const std::string& file_path_str) {

--- a/tt_metal/jit_build/jit_build_utils.hpp
+++ b/tt_metal/jit_build/jit_build_utils.hpp
@@ -7,10 +7,20 @@
 #include <cstdint>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 namespace tt::jit_build::utils {
 
 bool run_command(const std::string& cmd, const std::string& log_file, bool verbose);
+
+// Like run_command but bypasses the shell entirely by using posix_spawn with an explicit
+// argument vector.  Immune to shell metacharacter injection.
+// |working_dir| is passed as the cwd for the child process (empty = inherit parent cwd).
+bool exec_command(const std::vector<std::string>& args, const std::string& working_dir, const std::string& log_file);
+
+// Split a whitespace-delimited string into tokens (no shell quoting support).
+std::vector<std::string> tokenize_flags(const std::string& flags);
+
 void create_file(const std::string& file_path_str);
 
 // An RAII wrapper that generates a temporary filename and renames the file on destruction.

--- a/tt_metal/tools/CMakeLists.txt
+++ b/tt_metal/tools/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(watcher_dump)
 add_subdirectory(lightmetal_runner)
 add_subdirectory(mem_bench)
 add_subdirectory(precompile_fw)
+add_subdirectory(jit_compile_server)
 
 include(sources.cmake)
 

--- a/tt_metal/tools/jit_compile_server/CMakeLists.txt
+++ b/tt_metal/tools/jit_compile_server/CMakeLists.txt
@@ -1,0 +1,25 @@
+include(sources.cmake)
+
+add_executable(jit_compile_server ${JIT_COMPILE_SERVER_SOURCES})
+target_link_libraries(
+    jit_compile_server
+    PRIVATE
+        tt_metal
+        capnp
+        capnp-rpc
+        Taskflow::Taskflow
+)
+
+target_include_directories(
+    jit_compile_server
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/tt_metal
+        ${PROJECT_BINARY_DIR}/tt_metal/impl
+)
+
+set_target_properties(
+    jit_compile_server
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/tools
+)

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -1,0 +1,404 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <fmt/format.h>
+#include <tt-logger/tt-logger.hpp>
+
+#include "impl/jit_server/jit_compile_server_controller.hpp"
+#include "impl/jit_server/types.hpp"
+#include "jit_build/depend.hpp"
+#include "jit_build/jit_build_utils.hpp"
+
+// Remote JIT compile server
+//
+// TODO 1:
+// The compile/link logic below currently duplicates the core of
+// `jit_build/build.cpp` (compile_one, link_one, dependency checks). Two reasons:
+// 1. Compile server cannot have dependency on MetalContext, which would take a lock on the device.
+// 2. At this point, we are not sure what the server will need to do that jit_build does not.
+// We can unify then once the server's requirements stabilize.
+//
+// TODO 2:
+// Local builds (`JitBuildState` in build.cpp) compute `build_state_hash_` over effective
+// compile/link inputs (gpp, cflags, defines, includes, lflags, linker script, extra link
+// objs, src list, opt levels), persist it in each output dir as `.build_state`, and treat a
+// mismatch as "state changed" to force recompile/relink even when individual `.o` dependency
+// hashes might still look fresh.
+//
+// This server does not implement `.build_state` / `build_state_hash_`. It partitions the
+// on-disk cache by `build_key` and kernel path, and decides compile/link via
+// `dependencies_up_to_date` + `.dephash` (same helper family as local JIT). That matches
+// common cases when the client uses a fresh cache subtree (e.g. kernel path includes a
+// compile hash) or when sources and listed link inputs change on disk.
+//
+// Limitation: without an explicit recipe/state fingerprint in the cache dir, reusing the
+// same `build_key` + kernel path while changing only flags or other recipe fields that are
+// not reflected in dependency tracking could theoretically reuse stale `.o`/`.elf` in edge
+// cases where local build.cpp would invalidate via `build_state_hash_`.
+//
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::atomic<bool> g_keep_running{true};
+std::atomic<int> g_outstanding_compiles{0};
+
+constexpr const char* kEndpointEnv = "TT_METAL_JIT_SERVER_ENDPOINT";
+constexpr const char* kDefaultEndpoint = "0.0.0.0:9876";
+constexpr const char* kServerCacheRoot = "/tmp/tt-metal-cache/";
+
+std::string kernel_cache_dir(std::uint64_t build_key, const std::string& kernel_name) {
+    return std::string(kServerCacheRoot) + std::to_string(build_key) + "/kernels/" + kernel_name;
+}
+
+std::string target_cache_dir(std::uint64_t build_key, const std::string& kernel_name, const std::string& target_name) {
+    return kernel_cache_dir(build_key, kernel_name) + target_name + "/";
+}
+
+void handle_signal(int /*signal*/) { g_keep_running.store(false); }
+
+std::string firmware_cache_dir(std::uint64_t build_key, const std::string& target_name) {
+    return std::string(kServerCacheRoot) + std::to_string(build_key) + "/firmware/" + target_name + "/";
+}
+
+// Resolve firmware path from the server cache populated by uploadFirmware RPC.
+// PoC limitation: uploaded firmware is assumed durable in kServerCacheRoot.
+// If the server cache is cleared after upload, compile will fail until the client re-uploads.
+fs::path resolve_uploaded_firmware_path(std::uint64_t build_key, const tt::tt_metal::jit_server::TargetRecipe& target) {
+    if (target.weakened_firmware_name.empty()) {
+        throw std::runtime_error(
+            fmt::format("Internal error: expected non-empty weakened_firmware_name for target {}", target.target_name));
+    }
+    const std::string firmware_file = fs::path(target.weakened_firmware_name).filename().string();
+    const std::string fw_dir = firmware_cache_dir(build_key, target.target_name);
+    fs::path candidate = fs::path(fw_dir) / firmware_file;
+    if (fs::exists(candidate)) {
+        return candidate;
+    }
+
+    throw std::runtime_error(fmt::format(
+        "Firmware artifact not found for build_key {} target {} file {}. "
+        "Expected at {}. Ensure the client uploads firmware via uploadFirmware RPC before compiling.",
+        build_key,
+        target.target_name,
+        firmware_file,
+        candidate.string()));
+}
+
+void build_failure(
+    const std::string& target, const std::string& op, const std::string& cmd, const std::string& log_file) {
+    std::ifstream file{log_file};
+    if (file.is_open()) {
+        std::string log_contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+        throw std::runtime_error(fmt::format("{} {} failure -- cmd: {}\nLog: {}", target, op, cmd, log_contents));
+    }
+    throw std::runtime_error(
+        fmt::format("{} {} failure -- cmd: {} (log file {} not found)", target, op, cmd, log_file));
+}
+
+bool need_compile(const std::string& out_dir, const std::string& obj) {
+    return !fs::exists(out_dir + obj) || !tt::jit_build::dependencies_up_to_date(out_dir, obj);
+}
+
+bool need_link(const std::string& out_dir, const std::string& target_name) {
+    std::string elf_path = out_dir + target_name + ".elf";
+    return !fs::exists(elf_path) || !tt::jit_build::dependencies_up_to_date(out_dir, elf_path);
+}
+
+void compile_one(
+    const std::string& gpp,
+    const tt::tt_metal::jit_server::TargetRecipe& target,
+    const std::string& out_dir,
+    size_t src_index,
+    const std::string& temp_obj) {
+    std::string cmd = fmt::format("cd {} && {}", out_dir, gpp);
+    cmd += fmt::format("-{} ", target.compiler_opt_level);
+    cmd += target.cflags;
+    cmd += target.includes;
+
+    std::string obj_path = out_dir + target.objs[src_index];
+    std::string obj_temp_path = out_dir + temp_obj;
+    std::string temp_d_path = fs::path(obj_temp_path).replace_extension("d").string();
+    cmd += fmt::format("-c -o {} {} -MF {} ", obj_temp_path, target.srcs[src_index], temp_d_path);
+    cmd += target.defines;
+
+    tt::jit_build::utils::FileRenamer log_file(obj_path + ".log");
+    fs::remove(log_file.path());
+    if (!tt::jit_build::utils::run_command(cmd, log_file.path(), false)) {
+        build_failure(target.target_name, "compile", cmd, log_file.path());
+    }
+    tt::jit_build::write_dependency_hashes(out_dir, obj_temp_path, obj_temp_path + ".dephash");
+    fs::remove(temp_d_path);
+}
+
+void link_one(
+    const std::string& gpp,
+    const tt::tt_metal::jit_server::TargetRecipe& target,
+    const std::string& out_dir,
+    const std::string& link_objs_str) {
+    std::string cmd = fmt::format("cd {} && {}", out_dir, gpp);
+    cmd += fmt::format("-{} ", target.linker_opt_level);
+
+    std::vector<std::string> link_deps = {target.linker_script};
+    if (!target.weakened_firmware_name.empty()) {
+        link_deps.push_back(target.weakened_firmware_name);
+        if (!target.firmware_is_kernel_object) {
+            cmd += "-Wl,--just-symbols=";
+        }
+        cmd += target.weakened_firmware_name + " ";
+    }
+
+    cmd += target.lflags;
+    cmd += target.extra_link_objs;
+    cmd += link_objs_str;
+    std::string elf_name = out_dir + target.target_name + ".elf";
+    tt::jit_build::utils::FileRenamer elf_file(elf_name);
+    cmd += "-o " + elf_file.path();
+
+    tt::jit_build::utils::FileRenamer log_file(elf_name + ".log");
+    fs::remove(log_file.path());
+    if (!tt::jit_build::utils::run_command(cmd, log_file.path(), false)) {
+        build_failure(target.target_name, "link", cmd, log_file.path());
+    }
+
+    tt::jit_build::utils::FileRenamer dephash_file(elf_name + ".dephash");
+    std::ofstream hash_file(dephash_file.path());
+    tt::jit_build::write_dependency_hashes({{elf_name, std::move(link_deps)}}, out_dir, elf_name, hash_file);
+    hash_file.close();
+    if (hash_file.fail()) {
+        fs::remove(dephash_file.path());
+    }
+}
+
+std::vector<std::uint8_t> read_file_bytes(const std::string& path) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) {
+        throw std::runtime_error("Cannot read ELF file: " + path);
+    }
+    auto size = file.tellg();
+    file.seekg(0, std::ios::beg);
+    std::vector<std::uint8_t> data(static_cast<size_t>(size));
+    file.read(reinterpret_cast<char*>(data.data()), size);
+    return data;
+}
+
+void build_target(
+    const std::string& gpp,
+    const tt::tt_metal::jit_server::TargetRecipe& target,
+    const std::string& out_dir,
+    tt::tt_metal::jit_server::CompileResponse& response) {
+    if (target.srcs.size() != target.objs.size()) {
+        throw std::runtime_error("srcs and objs must have the same size for target " + target.target_name);
+    }
+
+    fs::create_directories(out_dir);
+
+    const size_t num_objs = target.objs.size();
+    std::vector<std::string> temp_objs;
+    temp_objs.reserve(num_objs);
+    for (const auto& obj : target.objs) {
+        temp_objs.push_back(tt::jit_build::utils::FileRenamer::generate_temp_path(obj));
+    }
+
+    std::vector<bool> compiled(num_objs, false);
+    for (size_t i = 0; i < num_objs; ++i) {
+        if (need_compile(out_dir, target.objs[i])) {
+            compiled[i] = true;
+        }
+    }
+
+    const size_t recompiled = std::count(compiled.begin(), compiled.end(), true);
+    const size_t cache_hit = num_objs - recompiled;
+    bool needs_link = need_link(out_dir, target.target_name);
+
+    log_info(
+        tt::LogMetal,
+        "  target {}: obj={} hit={} miss={} link={}",
+        target.target_name,
+        num_objs,
+        cache_hit,
+        recompiled,
+        needs_link || recompiled > 0 ? "yes" : "no");
+
+    for (size_t i = 0; i < num_objs; ++i) {
+        if (compiled[i]) {
+            compile_one(gpp, target, out_dir, i, temp_objs[i]);
+        }
+    }
+
+    if (recompiled > 0 || needs_link) {
+        std::string link_objs_str;
+        for (size_t i = 0; i < num_objs; ++i) {
+            std::string temp_path = out_dir + temp_objs[i];
+            if (!compiled[i]) {
+                std::error_code ec;
+                fs::create_hard_link(out_dir + target.objs[i], temp_path, ec);
+                if (ec) {
+                    fs::copy_file(out_dir + target.objs[i], temp_path, fs::copy_options::overwrite_existing);
+                }
+            }
+            link_objs_str += temp_path + " ";
+        }
+        link_one(gpp, target, out_dir, link_objs_str);
+    }
+
+    for (size_t i = 0; i < num_objs; ++i) {
+        fs::path src_path = out_dir + temp_objs[i];
+        fs::path dst_path = out_dir + target.objs[i];
+        if (compiled[i]) {
+            fs::rename(src_path, dst_path);
+            fs::rename(fs::path(src_path).concat(".dephash"), fs::path(dst_path).concat(".dephash"));
+        } else if (fs::exists(src_path)) {
+            fs::remove(src_path);
+        }
+    }
+
+    std::string elf_path = out_dir + target.target_name + ".elf";
+    tt::tt_metal::jit_server::ElfBlob blob;
+    blob.name = target.target_name;
+    blob.data = read_file_bytes(elf_path);
+    response.elf_blobs.push_back(std::move(blob));
+}
+
+tt::tt_metal::jit_server::CompileResponse compile_callback(const tt::tt_metal::jit_server::CompileRequest& request) {
+    tt::tt_metal::jit_server::CompileResponse response;
+    auto request_start = std::chrono::steady_clock::now();
+    int outstanding = g_outstanding_compiles.fetch_add(1) + 1;
+
+    try {
+        log_info(
+            tt::LogMetal,
+            "compile {}: targets={} genfiles={} outstanding={}",
+            request.kernel_name,
+            request.targets.size(),
+            request.generated_files.size(),
+            outstanding);
+
+        if (!request.generated_files.empty()) {
+            const std::string genfiles_dir = kernel_cache_dir(request.build_key, request.kernel_name);
+            fs::create_directories(genfiles_dir);
+            for (const auto& file : request.generated_files) {
+                std::string target_path = genfiles_dir + file.name;
+                tt::jit_build::utils::FileRenamer tmp(target_path);
+                std::ofstream out(tmp.path(), std::ios::binary);
+                if (!out.is_open()) {
+                    throw std::runtime_error("Cannot create file: " + target_path);
+                }
+                out.write(
+                    reinterpret_cast<const char*>(file.content.data()),
+                    static_cast<std::streamsize>(file.content.size()));
+                if (!out) {
+                    throw std::runtime_error("Failed to write file: " + target_path);
+                }
+            }
+        }
+
+        for (const auto& target : request.targets) {
+            tt::tt_metal::jit_server::TargetRecipe resolved_target = target;
+            if (!resolved_target.weakened_firmware_name.empty()) {
+                resolved_target.weakened_firmware_name =
+                    resolve_uploaded_firmware_path(request.build_key, resolved_target).string();
+            }
+            std::string out_dir = target_cache_dir(request.build_key, request.kernel_name, target.target_name);
+            build_target(request.gpp, resolved_target, out_dir, response);
+        }
+
+        response.success = true;
+
+        auto elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - request_start)
+                .count();
+        log_info(tt::LogMetal, "done {}: {}ms, elfs={}", request.kernel_name, elapsed_ms, response.elf_blobs.size());
+    } catch (const std::exception& e) {
+        response.success = false;
+        response.error_message = e.what();
+        log_warning(tt::LogMetal, "FAIL {}: {}", request.kernel_name, response.error_message);
+    }
+    g_outstanding_compiles.fetch_sub(1);
+    return response;
+}
+
+tt::tt_metal::jit_server::UploadFirmwareResponse upload_firmware_callback(
+    const tt::tt_metal::jit_server::UploadFirmwareRequest& request) {
+    tt::tt_metal::jit_server::UploadFirmwareResponse response;
+    try {
+        log_info(
+            tt::LogMetal, "uploadFirmware build_key={}: artifacts={}", request.build_key, request.artifacts.size());
+
+        for (const auto& artifact : request.artifacts) {
+            std::string safe_target = fs::path(artifact.target_name).filename().string();
+            std::string safe_file = fs::path(artifact.file_name).filename().string();
+            if (safe_target.empty() || safe_file.empty() || safe_target.find("..") != std::string::npos ||
+                safe_file.find("..") != std::string::npos) {
+                throw std::runtime_error(fmt::format(
+                    "Invalid firmware artifact names: target='{}' file='{}'",
+                    artifact.target_name,
+                    artifact.file_name));
+            }
+
+            std::string fw_dir = firmware_cache_dir(request.build_key, safe_target);
+            fs::create_directories(fw_dir);
+            std::string target_path = fw_dir + safe_file;
+
+            tt::jit_build::utils::FileRenamer tmp(target_path);
+            std::ofstream out(tmp.path(), std::ios::binary);
+            if (!out.is_open()) {
+                throw std::runtime_error("Cannot create firmware file: " + target_path);
+            }
+            out.write(
+                reinterpret_cast<const char*>(artifact.data.data()),
+                static_cast<std::streamsize>(artifact.data.size()));
+            if (!out) {
+                throw std::runtime_error("Failed to write firmware file: " + target_path);
+            }
+
+            log_info(
+                tt::LogMetal,
+                "  persisted firmware artifact: build_key={} target={} file={} size={}",
+                request.build_key,
+                safe_target,
+                safe_file,
+                artifact.data.size());
+        }
+
+        response.success = true;
+    } catch (const std::exception& e) {
+        response.success = false;
+        response.error_message = e.what();
+        log_warning(tt::LogMetal, "uploadFirmware FAIL: {}", response.error_message);
+    }
+    return response;
+}
+
+}  // namespace
+
+int main() {
+    const char* endpoint_env = std::getenv(kEndpointEnv);
+    const std::string endpoint = endpoint_env != nullptr ? endpoint_env : kDefaultEndpoint;
+
+    std::signal(SIGINT, handle_signal);
+    std::signal(SIGTERM, handle_signal);
+
+    tt::tt_metal::jit_server::JitCompileServerController server(compile_callback, upload_firmware_callback);
+    server.start(endpoint);
+    log_info(tt::LogMetal, "JIT compile server listening on {}", endpoint);
+
+    while (g_keep_running.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
+
+    server.stop();
+    return 0;
+}

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <csignal>
@@ -138,7 +139,7 @@ void compile_one(
     const std::string& out_dir,
     size_t src_index,
     const std::string& temp_obj) {
-    std::string cmd = fmt::format("cd {} && {}", out_dir, gpp);
+    std::string cmd = fmt::format("cd {} && {} ", out_dir, gpp);
     cmd += fmt::format("-{} ", target.compiler_opt_level);
     cmd += target.cflags;
     cmd += target.includes;
@@ -163,7 +164,7 @@ void link_one(
     const tt::tt_metal::jit_server::TargetRecipe& target,
     const std::string& out_dir,
     const std::string& link_objs_str) {
-    std::string cmd = fmt::format("cd {} && {}", out_dir, gpp);
+    std::string cmd = fmt::format("cd {} && {} ", out_dir, gpp);
     cmd += fmt::format("-{} ", target.linker_opt_level);
 
     std::vector<std::string> link_deps = {target.linker_script};
@@ -202,10 +203,14 @@ std::vector<std::uint8_t> read_file_bytes(const std::string& path) {
     if (!file.is_open()) {
         throw std::runtime_error("Cannot read ELF file: " + path);
     }
-    auto size = file.tellg();
+    std::streampos pos = file.tellg();
+    if (pos == std::streampos(-1)) {
+        throw std::runtime_error("Cannot determine size of ELF file: " + path);
+    }
+    auto byte_count = static_cast<std::streamsize>(pos);
     file.seekg(0, std::ios::beg);
-    std::vector<std::uint8_t> data(static_cast<size_t>(size));
-    file.read(reinterpret_cast<char*>(data.data()), size);
+    std::vector<std::uint8_t> data(static_cast<size_t>(byte_count));
+    file.read(reinterpret_cast<char*>(data.data()), byte_count);
     return data;
 }
 

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -307,10 +307,10 @@ tt::tt_metal::jit_server::CompileResponse compile_callback(const tt::tt_metal::j
             outstanding);
 
         if (!request.generated_files.empty()) {
-            const std::string genfiles_dir = kernel_cache_dir(request.build_key, request.kernel_name);
+            const fs::path genfiles_dir = kernel_cache_dir(request.build_key, request.kernel_name);
             fs::create_directories(genfiles_dir);
             for (const auto& file : request.generated_files) {
-                std::string target_path = genfiles_dir + file.name;
+                std::string target_path = (genfiles_dir / file.name).string();
                 tt::jit_build::utils::FileRenamer tmp(target_path);
                 std::ofstream out(tmp.path(), std::ios::binary);
                 if (!out.is_open()) {

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -5,11 +5,13 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cctype>
 #include <csignal>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -140,6 +142,17 @@ bool need_link(const std::string& out_dir, const std::string& target_name) {
     return !fs::exists(elf_path) || !tt::jit_build::dependencies_up_to_date(out_dir, elf_path);
 }
 
+std::string with_trailing_space(std::string_view segment) {
+    if (segment.empty()) {
+        return {};
+    }
+    std::string normalized(segment);
+    if (!std::isspace(static_cast<unsigned char>(normalized.back()))) {
+        normalized.push_back(' ');
+    }
+    return normalized;
+}
+
 // SECURITY: constructs a shell command from client-supplied strings (gpp, cflags, defines,
 // includes, srcs, objs). A malicious client can inject arbitrary shell commands via any of
 // these fields. This is equivalent to remote code execution by design — the server's
@@ -152,14 +165,14 @@ void compile_one(
     const std::string& temp_obj) {
     std::string cmd = fmt::format("cd {} && {} ", out_dir, gpp);
     cmd += fmt::format("-{} ", target.compiler_opt_level);
-    cmd += target.cflags;
-    cmd += target.includes;
+    cmd += with_trailing_space(target.cflags);
+    cmd += with_trailing_space(target.includes);
 
     std::string obj_path = out_dir + target.objs[src_index];
     std::string obj_temp_path = out_dir + temp_obj;
     std::string temp_d_path = fs::path(obj_temp_path).replace_extension("d").string();
     cmd += fmt::format("-c -o {} {} -MF {} ", obj_temp_path, target.srcs[src_index], temp_d_path);
-    cmd += target.defines;
+    cmd += with_trailing_space(target.defines);
 
     tt::jit_build::utils::FileRenamer log_file(obj_path + ".log");
     fs::remove(log_file.path());
@@ -190,9 +203,9 @@ void link_one(
         cmd += target.weakened_firmware_name + " ";
     }
 
-    cmd += target.lflags;
-    cmd += target.extra_link_objs;
-    cmd += link_objs_str;
+    cmd += with_trailing_space(target.lflags);
+    cmd += with_trailing_space(target.extra_link_objs);
+    cmd += with_trailing_space(link_objs_str);
     std::string elf_name = out_dir + target.target_name + ".elf";
     tt::jit_build::utils::FileRenamer elf_file(elf_name);
     cmd += "-o " + elf_file.path();
@@ -225,6 +238,10 @@ std::vector<std::uint8_t> read_file_bytes(const std::string& path) {
     file.seekg(0, std::ios::beg);
     std::vector<std::uint8_t> data(static_cast<size_t>(byte_count));
     file.read(reinterpret_cast<char*>(data.data()), byte_count);
+    if (file.gcount() != byte_count || (!file && !file.eof())) {
+        throw std::runtime_error(fmt::format(
+            "Failed to read ELF file '{}' fully (expected {} bytes, got {})", path, byte_count, file.gcount()));
+    }
     return data;
 }
 

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -57,10 +57,22 @@ std::atomic<int> g_outstanding_compiles{0};
 
 constexpr const char* kEndpointEnv = "TT_METAL_JIT_SERVER_ENDPOINT";
 constexpr const char* kDefaultEndpoint = "0.0.0.0:9876";
-constexpr const char* kServerCacheRoot = "/tmp/tt-metal-cache/";
+constexpr const char* kServerCacheRootEnv = "TT_METAL_JIT_SERVER_CACHE_ROOT";
+constexpr const char* kDefaultServerCacheRoot = "/tmp/tt-metal-cache/";
+std::string g_server_cache_root = kDefaultServerCacheRoot;
+
+std::string normalize_cache_root(std::string cache_root) {
+    if (cache_root.empty()) {
+        return std::string(kDefaultServerCacheRoot);
+    }
+    if (cache_root.back() != '/') {
+        cache_root.push_back('/');
+    }
+    return cache_root;
+}
 
 std::string kernel_cache_dir(std::uint64_t build_key, const std::string& kernel_name) {
-    return std::string(kServerCacheRoot) + std::to_string(build_key) + "/kernels/" + kernel_name;
+    return g_server_cache_root + std::to_string(build_key) + "/kernels/" + kernel_name;
 }
 
 std::string target_cache_dir(std::uint64_t build_key, const std::string& kernel_name, const std::string& target_name) {
@@ -70,11 +82,11 @@ std::string target_cache_dir(std::uint64_t build_key, const std::string& kernel_
 void handle_signal(int /*signal*/) { g_keep_running.store(false); }
 
 std::string firmware_cache_dir(std::uint64_t build_key, const std::string& target_name) {
-    return std::string(kServerCacheRoot) + std::to_string(build_key) + "/firmware/" + target_name + "/";
+    return g_server_cache_root + std::to_string(build_key) + "/firmware/" + target_name + "/";
 }
 
 // Resolve firmware path from the server cache populated by uploadFirmware RPC.
-// PoC limitation: uploaded firmware is assumed durable in kServerCacheRoot.
+// PoC limitation: uploaded firmware is assumed durable in the configured server cache root.
 // If the server cache is cleared after upload, compile will fail until the client re-uploads.
 fs::path resolve_uploaded_firmware_path(std::uint64_t build_key, const tt::tt_metal::jit_server::TargetRecipe& target) {
     if (target.weakened_firmware_name.empty()) {
@@ -387,6 +399,8 @@ tt::tt_metal::jit_server::UploadFirmwareResponse upload_firmware_callback(
 int main() {
     const char* endpoint_env = std::getenv(kEndpointEnv);
     const std::string endpoint = endpoint_env != nullptr ? endpoint_env : kDefaultEndpoint;
+    const char* cache_root_env = std::getenv(kServerCacheRootEnv);
+    g_server_cache_root = normalize_cache_root(cache_root_env != nullptr ? cache_root_env : kDefaultServerCacheRoot);
 
     std::signal(SIGINT, handle_signal);
     std::signal(SIGTERM, handle_signal);
@@ -394,6 +408,7 @@ int main() {
     tt::tt_metal::jit_server::JitCompileServerController server(compile_callback, upload_firmware_callback);
     server.start(endpoint);
     log_info(tt::LogMetal, "JIT compile server listening on {}", endpoint);
+    log_info(tt::LogMetal, "JIT compile server cache root: {}", g_server_cache_root);
 
     while (g_keep_running.load()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(250));

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -60,6 +60,9 @@ std::atomic<bool> g_keep_running{true};
 std::atomic<int> g_outstanding_compiles{0};
 
 constexpr const char* kEndpointEnv = "TT_METAL_JIT_SERVER_ENDPOINT";
+// SECURITY: binds to all interfaces by default. Any host on the network can reach this
+// server and trigger arbitrary compilation (i.e., arbitrary code execution). Restrict to
+// localhost or use a firewall in shared environments.
 constexpr const char* kDefaultEndpoint = "0.0.0.0:9876";
 constexpr const char* kServerCacheRootEnv = "TT_METAL_JIT_SERVER_CACHE_ROOT";
 constexpr const char* kDefaultServerCacheRoot = "/tmp/tt-metal-cache/";
@@ -75,6 +78,10 @@ std::string normalize_cache_root(std::string cache_root) {
     return cache_root;
 }
 
+// SECURITY: kernel_name is client-supplied and used verbatim in path construction.
+// A malicious client could use "../" segments to escape the cache subtree.
+// Currently acceptable because this is a trusted internal tool; if the server is ever
+// exposed to untrusted clients, validate that kernel_name is a safe relative path.
 std::string kernel_cache_dir(std::uint64_t build_key, const std::string& kernel_name) {
     return g_server_cache_root + std::to_string(build_key) + "/kernels/" + kernel_name;
 }
@@ -133,6 +140,10 @@ bool need_link(const std::string& out_dir, const std::string& target_name) {
     return !fs::exists(elf_path) || !tt::jit_build::dependencies_up_to_date(out_dir, elf_path);
 }
 
+// SECURITY: constructs a shell command from client-supplied strings (gpp, cflags, defines,
+// includes, srcs, objs). A malicious client can inject arbitrary shell commands via any of
+// these fields. This is equivalent to remote code execution by design — the server's
+// purpose is to run the compiler on behalf of the client.
 void compile_one(
     const std::string& gpp,
     const tt::tt_metal::jit_server::TargetRecipe& target,
@@ -159,6 +170,9 @@ void compile_one(
     fs::remove(temp_d_path);
 }
 
+// SECURITY: same shell injection exposure as compile_one — lflags, extra_link_objs,
+// linker_script, and weakened_firmware_name are all client-supplied and interpolated
+// into the shell command without escaping.
 void link_one(
     const std::string& gpp,
     const tt::tt_metal::jit_server::TargetRecipe& target,
@@ -306,6 +320,9 @@ tt::tt_metal::jit_server::CompileResponse compile_callback(const tt::tt_metal::j
             request.generated_files.size(),
             outstanding);
 
+        // SECURITY: file.name is client-supplied. While fs::path join handles separators,
+        // a name like "../../foo" could still write outside the cache. Acceptable for a
+        // trusted client; validate if the server is ever exposed to untrusted input.
         if (!request.generated_files.empty()) {
             const fs::path genfiles_dir = kernel_cache_dir(request.build_key, request.kernel_name);
             fs::create_directories(genfiles_dir);

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -22,6 +22,9 @@
 
 // Remote JIT compile server
 //
+// WARNING: Experimental feature with security implications. Do not use in production.
+// WARNING: The server can execute arbitrary code.  Make sure not to expose the RPC endpoint to untrusted clients.
+//
 // TODO 1:
 // The compile/link logic below currently duplicates the core of
 // `jit_build/build.cpp` (compile_one, link_one, dependency checks). Two reasons:

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -83,17 +83,17 @@ std::string normalize_cache_root(std::string cache_root) {
 // Currently acceptable because this is a trusted internal tool; if the server is ever
 // exposed to untrusted clients, validate that kernel_name is a safe relative path.
 std::string kernel_cache_dir(std::uint64_t build_key, const std::string& kernel_name) {
-    return g_server_cache_root + std::to_string(build_key) + "/kernels/" + kernel_name;
+    return (fs::path(g_server_cache_root) / std::to_string(build_key) / "kernels" / kernel_name).string() + "/";
 }
 
 std::string target_cache_dir(std::uint64_t build_key, const std::string& kernel_name, const std::string& target_name) {
-    return kernel_cache_dir(build_key, kernel_name) + target_name + "/";
+    return (fs::path(kernel_cache_dir(build_key, kernel_name)) / target_name).string() + "/";
 }
 
 void handle_signal(int /*signal*/) { g_keep_running.store(false); }
 
 std::string firmware_cache_dir(std::uint64_t build_key, const std::string& target_name) {
-    return g_server_cache_root + std::to_string(build_key) + "/firmware/" + target_name + "/";
+    return (fs::path(g_server_cache_root) / std::to_string(build_key) / "firmware" / target_name).string() + "/";
 }
 
 // Resolve firmware path from the server cache populated by uploadFirmware RPC.

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -189,7 +189,7 @@ void compile_one(
     size_t src_index,
     const std::string& temp_obj) {
     std::vector<std::string> args;
-    args.push_back(gpp);
+    append_tokenized(args, gpp);
     args.push_back("-" + target.compiler_opt_level);
     append_tokenized(args, target.cflags);
     append_tokenized(args, target.includes);
@@ -220,7 +220,7 @@ void link_one(
     const std::string& out_dir,
     const std::vector<std::string>& link_obj_paths) {
     std::vector<std::string> args;
-    args.push_back(gpp);
+    append_tokenized(args, gpp);
     args.push_back("-" + target.linker_opt_level);
 
     std::vector<std::string> link_deps = {target.linker_script};

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -5,13 +5,11 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <cctype>
 #include <csignal>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -25,8 +23,18 @@
 
 // Remote JIT compile server
 //
-// WARNING: Experimental feature with security implications. Do not use in production.
-// WARNING: The server can execute arbitrary code.  Make sure not to expose the RPC endpoint to untrusted clients.
+// WARNING: Experimental feature — do not expose to untrusted networks or clients.
+//
+// Security posture (consistent with Metal's MPI-based transport model):
+//  - Authentication: none.  The server trusts any client that can reach the endpoint.
+//    Default bind is localhost; set TT_METAL_JIT_SERVER_ENDPOINT to widen.
+//  - Encryption: none (Cap'n Proto over plain TCP).  Use SSH tunneling or a VPN if the
+//    link crosses an untrusted network.
+//  - Command execution: the server's purpose is to run the compiler the client specifies,
+//    so the client inherently has code-execution capability.  Shell injection is mitigated
+//    by using posix_spawn with explicit argument vectors instead of system().
+//  - Path traversal: client-supplied path components (kernel_name, target_name, obj names,
+//    generated file names) are validated to reject absolute paths and ".." components.
 //
 // TODO 1:
 // The compile/link logic below currently duplicates the core of
@@ -62,13 +70,29 @@ std::atomic<bool> g_keep_running{true};
 std::atomic<int> g_outstanding_compiles{0};
 
 constexpr const char* kEndpointEnv = "TT_METAL_JIT_SERVER_ENDPOINT";
-// SECURITY: binds to all interfaces by default. Any host on the network can reach this
-// server and trigger arbitrary compilation (i.e., arbitrary code execution). Restrict to
-// localhost or use a firewall in shared environments.
-constexpr const char* kDefaultEndpoint = "0.0.0.0:9876";
+// Binds to localhost by default — only local processes can reach the server.
+// Set TT_METAL_JIT_SERVER_ENDPOINT=0.0.0.0:9876 (or a specific interface) to accept
+// remote connections.  In that case, restrict access with a firewall or SSH tunnel.
+constexpr const char* kDefaultEndpoint = "localhost:9876";
 constexpr const char* kServerCacheRootEnv = "TT_METAL_JIT_SERVER_CACHE_ROOT";
 constexpr const char* kDefaultServerCacheRoot = "/tmp/tt-metal-cache/";
 std::string g_server_cache_root = kDefaultServerCacheRoot;
+
+// Reject paths that could escape the cache root: absolute paths, ".." components, or
+// empty strings.  Throws on violation.
+void validate_safe_relative_path(const std::string& path, const char* field_name) {
+    if (path.empty()) {
+        throw std::runtime_error(fmt::format("Empty {} is not allowed", field_name));
+    }
+    if (path[0] == '/') {
+        throw std::runtime_error(fmt::format("Absolute {} is not allowed: {}", field_name, path));
+    }
+    for (const auto& component : fs::path(path)) {
+        if (component == "..") {
+            throw std::runtime_error(fmt::format("{} must not contain '..' components: {}", field_name, path));
+        }
+    }
+}
 
 std::string normalize_cache_root(std::string cache_root) {
     if (cache_root.empty()) {
@@ -80,10 +104,8 @@ std::string normalize_cache_root(std::string cache_root) {
     return cache_root;
 }
 
-// SECURITY: kernel_name is client-supplied and used verbatim in path construction.
-// A malicious client could use "../" segments to escape the cache subtree.
-// Currently acceptable because this is a trusted internal tool; if the server is ever
-// exposed to untrusted clients, validate that kernel_name is a safe relative path.
+// All client-supplied path components (kernel_name, target_name, obj names, generated file
+// names) are validated by validate_safe_relative_path() before reaching these helpers.
 std::string kernel_cache_dir(std::uint64_t build_key, const std::string& kernel_name) {
     return (fs::path(g_server_cache_root) / std::to_string(build_key) / "kernels" / kernel_name).string() + "/";
 }
@@ -142,78 +164,87 @@ bool need_link(const std::string& out_dir, const std::string& target_name) {
     return !fs::exists(elf_path) || !tt::jit_build::dependencies_up_to_date(out_dir, elf_path);
 }
 
-std::string with_trailing_space(std::string_view segment) {
-    if (segment.empty()) {
-        return {};
+std::string format_args(const std::vector<std::string>& args) {
+    std::string result;
+    for (const auto& a : args) {
+        if (!result.empty()) {
+            result += ' ';
+        }
+        result += a;
     }
-    std::string normalized(segment);
-    if (!std::isspace(static_cast<unsigned char>(normalized.back()))) {
-        normalized.push_back(' ');
-    }
-    return normalized;
+    return result;
 }
 
-// SECURITY: constructs a shell command from client-supplied strings (gpp, cflags, defines,
-// includes, srcs, objs). A malicious client can inject arbitrary shell commands via any of
-// these fields. This is equivalent to remote code execution by design — the server's
-// purpose is to run the compiler on behalf of the client.
+void append_tokenized(std::vector<std::string>& args, const std::string& flags) {
+    auto tokens = tt::jit_build::utils::tokenize_flags(flags);
+    args.insert(args.end(), std::make_move_iterator(tokens.begin()), std::make_move_iterator(tokens.end()));
+}
+
+// Uses posix_spawn with an explicit argument vector — no shell interpretation of
+// client-supplied fields.
 void compile_one(
     const std::string& gpp,
     const tt::tt_metal::jit_server::TargetRecipe& target,
     const std::string& out_dir,
     size_t src_index,
     const std::string& temp_obj) {
-    std::string cmd = fmt::format("cd {} && {} ", out_dir, gpp);
-    cmd += fmt::format("-{} ", target.compiler_opt_level);
-    cmd += with_trailing_space(target.cflags);
-    cmd += with_trailing_space(target.includes);
+    std::vector<std::string> args;
+    args.push_back(gpp);
+    args.push_back("-" + target.compiler_opt_level);
+    append_tokenized(args, target.cflags);
+    append_tokenized(args, target.includes);
 
     std::string obj_path = out_dir + target.objs[src_index];
     std::string obj_temp_path = out_dir + temp_obj;
     std::string temp_d_path = fs::path(obj_temp_path).replace_extension("d").string();
-    cmd += fmt::format("-c -o {} {} -MF {} ", obj_temp_path, target.srcs[src_index], temp_d_path);
-    cmd += with_trailing_space(target.defines);
+    args.push_back("-c");
+    args.push_back("-o");
+    args.push_back(obj_temp_path);
+    args.push_back(target.srcs[src_index]);
+    args.push_back("-MF");
+    args.push_back(temp_d_path);
+    append_tokenized(args, target.defines);
 
     tt::jit_build::utils::FileRenamer log_file(obj_path + ".log");
     fs::remove(log_file.path());
-    if (!tt::jit_build::utils::run_command(cmd, log_file.path(), false)) {
-        build_failure(target.target_name, "compile", cmd, log_file.path());
+    if (!tt::jit_build::utils::exec_command(args, out_dir, log_file.path())) {
+        build_failure(target.target_name, "compile", format_args(args), log_file.path());
     }
     tt::jit_build::write_dependency_hashes(out_dir, obj_temp_path, obj_temp_path + ".dephash");
     fs::remove(temp_d_path);
 }
 
-// SECURITY: same shell injection exposure as compile_one — lflags, extra_link_objs,
-// linker_script, and weakened_firmware_name are all client-supplied and interpolated
-// into the shell command without escaping.
 void link_one(
     const std::string& gpp,
     const tt::tt_metal::jit_server::TargetRecipe& target,
     const std::string& out_dir,
-    const std::string& link_objs_str) {
-    std::string cmd = fmt::format("cd {} && {} ", out_dir, gpp);
-    cmd += fmt::format("-{} ", target.linker_opt_level);
+    const std::vector<std::string>& link_obj_paths) {
+    std::vector<std::string> args;
+    args.push_back(gpp);
+    args.push_back("-" + target.linker_opt_level);
 
     std::vector<std::string> link_deps = {target.linker_script};
     if (!target.weakened_firmware_name.empty()) {
         link_deps.push_back(target.weakened_firmware_name);
         if (!target.firmware_is_kernel_object) {
-            cmd += "-Wl,--just-symbols=";
+            args.push_back("-Wl,--just-symbols=" + target.weakened_firmware_name);
+        } else {
+            args.push_back(target.weakened_firmware_name);
         }
-        cmd += target.weakened_firmware_name + " ";
     }
 
-    cmd += with_trailing_space(target.lflags);
-    cmd += with_trailing_space(target.extra_link_objs);
-    cmd += with_trailing_space(link_objs_str);
+    append_tokenized(args, target.lflags);
+    append_tokenized(args, target.extra_link_objs);
+    args.insert(args.end(), link_obj_paths.begin(), link_obj_paths.end());
     std::string elf_name = out_dir + target.target_name + ".elf";
     tt::jit_build::utils::FileRenamer elf_file(elf_name);
-    cmd += "-o " + elf_file.path();
+    args.push_back("-o");
+    args.push_back(elf_file.path());
 
     tt::jit_build::utils::FileRenamer log_file(elf_name + ".log");
     fs::remove(log_file.path());
-    if (!tt::jit_build::utils::run_command(cmd, log_file.path(), false)) {
-        build_failure(target.target_name, "link", cmd, log_file.path());
+    if (!tt::jit_build::utils::exec_command(args, out_dir, log_file.path())) {
+        build_failure(target.target_name, "link", format_args(args), log_file.path());
     }
 
     tt::jit_build::utils::FileRenamer dephash_file(elf_name + ".dephash");
@@ -290,7 +321,8 @@ void build_target(
     }
 
     if (recompiled > 0 || needs_link) {
-        std::string link_objs_str;
+        std::vector<std::string> link_obj_paths;
+        link_obj_paths.reserve(num_objs);
         for (size_t i = 0; i < num_objs; ++i) {
             std::string temp_path = out_dir + temp_objs[i];
             if (!compiled[i]) {
@@ -300,9 +332,9 @@ void build_target(
                     fs::copy_file(out_dir + target.objs[i], temp_path, fs::copy_options::overwrite_existing);
                 }
             }
-            link_objs_str += temp_path + " ";
+            link_obj_paths.push_back(std::move(temp_path));
         }
-        link_one(gpp, target, out_dir, link_objs_str);
+        link_one(gpp, target, out_dir, link_obj_paths);
     }
 
     for (size_t i = 0; i < num_objs; ++i) {
@@ -329,6 +361,17 @@ tt::tt_metal::jit_server::CompileResponse compile_callback(const tt::tt_metal::j
     int outstanding = g_outstanding_compiles.fetch_add(1) + 1;
 
     try {
+        validate_safe_relative_path(request.kernel_name, "kernel_name");
+        for (const auto& target : request.targets) {
+            validate_safe_relative_path(target.target_name, "target_name");
+            for (const auto& obj : target.objs) {
+                validate_safe_relative_path(obj, "obj");
+            }
+        }
+        for (const auto& file : request.generated_files) {
+            validate_safe_relative_path(file.name, "generated_file name");
+        }
+
         log_info(
             tt::LogMetal,
             "compile {}: targets={} genfiles={} outstanding={}",
@@ -337,9 +380,6 @@ tt::tt_metal::jit_server::CompileResponse compile_callback(const tt::tt_metal::j
             request.generated_files.size(),
             outstanding);
 
-        // SECURITY: file.name is client-supplied. While fs::path join handles separators,
-        // a name like "../../foo" could still write outside the cache. Acceptable for a
-        // trusted client; validate if the server is ever exposed to untrusted input.
         if (!request.generated_files.empty()) {
             const fs::path genfiles_dir = kernel_cache_dir(request.build_key, request.kernel_name);
             fs::create_directories(genfiles_dir);

--- a/tt_metal/tools/jit_compile_server/sources.cmake
+++ b/tt_metal/tools/jit_compile_server/sources.cmake
@@ -1,0 +1,1 @@
+set(JIT_COMPILE_SERVER_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/jit_compile_server.cpp)


### PR DESCRIPTION
### Ticket
#41527

### Problem description
We need a solution to deduplicate JIT compilations.  The existing JIT compile can make use of build cache on a shared filesystem.  However, the NFS performance turned out to be poor while investigating #39858.  Even with a performant fs, there can still be some amount of duplicated compilation (see [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede)) due to lack of synchronization across processes.

### What's changed

This PR implements a JIT compile server that receives RPC calls.  It does the following:
1. Receive firmware artifacts from clients (a weakened .elf is needed for linking kernels, but the server cannot produce the .elf because it does not have access to the device).
2. Accept incoming RPCs for kernel compilations.
3. Deduplicate inflight requests (same key -> build once).
4. Compile with a flow similar to build.cpp
5. Send response with the .elf binary in the payload.

With this model, no two processes would race on building the same target and have one overwriting the other's output.

The client-side usage is not wired up in this PR; this will be in the next PR.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/compile-server)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/compile-server)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/compile-server)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/compile-server)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/compile-server)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/compile-server)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/compile-server) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/compile-server) | [#2151](https://github.com/tenstorrent/tt-metal/actions/runs/24099151392) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/compile-server) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/compile-server) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/compile-server) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/compile-server) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/compile-server) | [#4977](https://github.com/tenstorrent/tt-metal/actions/runs/24104563809) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/compile-server) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/compile-server) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/compile-server) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/compile-server) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/compile-server) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/compile-server) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/compile-server) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/compile-server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/compile-server) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/compile-server) |