### PR TITLE
Support for Blackhole Loudbox based on 8x P150 trays

### DIFF
--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -7,6 +7,8 @@
 #include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 
+#include <tt-logger/tt-logger.hpp>
+
 #include <unistd.h>
 #include <climits>
 #include <fstream>
@@ -45,11 +47,25 @@ TrayID get_tray_id_for_chip(
         {"X12DPG-QT6", {0xb1, 0xca, 0x31, 0x4b}},
     };
 
+    auto bus_id = tt::tt_fabric::get_bus_id(cluster, chip_id);
+    log_info(
+        tt::LogAlways,
+        "get_tray_id_for_chip: chip_id={}, mobo_name='{}', bus_id=0x{:x}, using_mock={}",
+        chip_id,
+        mobo_name,
+        bus_id,
+        using_mock_cluster_desc);
     if (using_mock_cluster_desc || !mobo_to_bus_ids.contains(mobo_name)) {
+        log_warning(
+            tt::LogAlways,
+            "Unknown motherboard '{}' for chip_id={} (bus_id=0x{:x}) — defaulting tray_id to 0. "
+            "Add this motherboard and its bus IDs to mobo_to_bus_ids in physical_system_discovery.cpp.",
+            mobo_name,
+            chip_id,
+            bus_id);
         return TrayID{0};
     }
     const auto& ordered_bus_ids = mobo_to_bus_ids.at(mobo_name);
-    auto bus_id = tt::tt_fabric::get_bus_id(cluster, chip_id);
     auto bus_id_it = std::find(ordered_bus_ids.begin(), ordered_bus_ids.end(), bus_id);
     TT_FATAL(bus_id_it != ordered_bus_ids.end(), "Bus ID {} not found.", bus_id);
     auto tray_id = std::distance(ordered_bus_ids.begin(), bus_id_it) + 1;
@@ -63,8 +79,21 @@ std::pair<TrayID, ASICLocation> get_asic_position(
     std::unordered_map<uint32_t, std::unordered_set<uint32_t>>& pcie_devices_per_tray,
     std::unordered_map<uint32_t, ASICLocation>& pcie_id_to_asic_location) {
     auto* cluster_desc = cluster.get_cluster_description();
-    if (cluster_desc->get_board_type(chip_id) == BoardType::UBB_WORMHOLE ||
-        cluster_desc->get_board_type(chip_id) == BoardType::UBB_BLACKHOLE) {
+    auto board_type = cluster_desc->get_board_type(chip_id);
+    auto arch = cluster_desc->get_arch(chip_id);
+    auto board_id = cluster_desc->get_board_id_for_chip(chip_id);
+    uint64_t upi = (board_id >> 36) & 0xFFFFF;
+    log_info(
+        tt::LogAlways,
+        "get_asic_position: chip_id={}, arch={}, board_type={} ({}), board_id=0x{:x}, upi=0x{:x}",
+        chip_id,
+        arch,
+        static_cast<uint32_t>(board_type),
+        tt::board_type_to_string(board_type),
+        board_id,
+        upi);
+    if (board_type == BoardType::UBB_WORMHOLE ||
+        board_type == BoardType::UBB_BLACKHOLE) {
         constexpr std::string_view ubb_mobo_name = "S7T-MB";
 
         TT_FATAL(
@@ -73,11 +102,16 @@ std::pair<TrayID, ASICLocation> get_asic_position(
         auto pcie_id = cluster_desc->get_chips_with_mmio().at(chip_id);
         pcie_devices_per_tray[ubb_id.tray_id].insert(pcie_id);
         pcie_id_to_asic_location[pcie_id] = ASICLocation{ubb_id.asic_id};
+        log_info(
+            tt::LogAlways,
+            "get_asic_position result: chip_id={}, tray_id={}, asic_location={} (UBB path)",
+            chip_id,
+            ubb_id.tray_id,
+            ubb_id.asic_id);
         return {TrayID{ubb_id.tray_id}, ASICLocation{ubb_id.asic_id}};
     }
     auto tray_id = get_tray_id_for_chip(cluster, chip_id, get_mobo_name(), using_mock_cluster_desc);
     ASICLocation asic_location;
-    tt::ARCH arch = cluster_desc->get_arch(chip_id);
     if (arch == tt::ARCH::WORMHOLE_B0) {
         // Derive ASIC Location based on the tunnel depth for Wormhole systems
         // TODO: Remove this once UMD populates the ASIC Location for WH systems.
@@ -97,6 +131,13 @@ std::pair<TrayID, ASICLocation> get_asic_position(
     } else {
         TT_THROW("Unrecognized Architecture. Cannot determine asic location.");
     }
+    log_info(
+        tt::LogAlways,
+        "get_asic_position result: chip_id={}, tray_id={}, asic_location={} (non-UBB path, arch={})",
+        chip_id,
+        *tray_id,
+        *asic_location,
+        arch);
     return {tray_id, asic_location};
 }
 

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -12,7 +12,6 @@
 #include <unistd.h>
 #include <climits>
 #include <fstream>
-#include <iostream>
 #include <algorithm>
 #include <set>
 #include <unordered_map>
@@ -49,20 +48,19 @@ TrayID get_tray_id_for_chip(
         {"H13DSG-O-CPU", {0x01, 0x21, 0x41, 0x61, 0x81, 0xa1, 0xc1, 0xe1}},
     };
 
-    auto bus_id = tt::tt_fabric::get_bus_id(cluster, chip_id);
-    std::cout << "[get_tray_id_for_chip] chip_id=" << chip_id
-              << " mobo_name='" << mobo_name << "'"
-              << " bus_id=0x" << std::hex << bus_id << std::dec
-              << " using_mock=" << using_mock_cluster_desc
-              << " mobo_known=" << mobo_to_bus_ids.contains(mobo_name)
-              << std::endl;
     if (using_mock_cluster_desc || !mobo_to_bus_ids.contains(mobo_name)) {
-        std::cout << "[get_tray_id_for_chip] DEFAULTING tray_id=0 for chip_id=" << chip_id
-                  << " (mobo='" << mobo_name << "', mock=" << using_mock_cluster_desc << ")"
-                  << std::endl;
+        auto bus_id = tt::tt_fabric::get_bus_id(cluster, chip_id);
+        log_warning(
+            tt::LogAlways,
+            "Unknown motherboard '{}' for chip_id={} (bus_id=0x{:x}) — defaulting tray_id to 0. "
+            "Add this motherboard and its bus IDs to mobo_to_bus_ids in physical_system_discovery.cpp.",
+            mobo_name,
+            chip_id,
+            bus_id);
         return TrayID{0};
     }
     const auto& ordered_bus_ids = mobo_to_bus_ids.at(mobo_name);
+    auto bus_id = tt::tt_fabric::get_bus_id(cluster, chip_id);
     auto bus_id_it = std::find(ordered_bus_ids.begin(), ordered_bus_ids.end(), bus_id);
     TT_FATAL(bus_id_it != ordered_bus_ids.end(), "Bus ID {} not found.", bus_id);
     auto tray_id = std::distance(ordered_bus_ids.begin(), bus_id_it) + 1;
@@ -76,20 +74,8 @@ std::pair<TrayID, ASICLocation> get_asic_position(
     std::unordered_map<uint32_t, std::unordered_set<uint32_t>>& pcie_devices_per_tray,
     std::unordered_map<uint32_t, ASICLocation>& pcie_id_to_asic_location) {
     auto* cluster_desc = cluster.get_cluster_description();
-    auto board_type = cluster_desc->get_board_type(chip_id);
-    auto arch = cluster_desc->get_arch(chip_id);
-    auto board_id = cluster_desc->get_board_id_for_chip(chip_id);
-    uint64_t upi = (board_id >> 36) & 0xFFFFF;
-    std::cout << "[get_asic_position] chip_id=" << chip_id
-              << " arch=" << tt::arch_to_str(arch)
-              << " board_type=" << static_cast<uint32_t>(board_type)
-              << " (" << tt::board_type_to_string(board_type) << ")"
-              << " board_id=0x" << std::hex << board_id
-              << " upi=0x" << upi << std::dec
-              << " using_mock=" << using_mock_cluster_desc
-              << std::endl;
-    if (board_type == BoardType::UBB_WORMHOLE ||
-        board_type == BoardType::UBB_BLACKHOLE) {
+    if (cluster_desc->get_board_type(chip_id) == BoardType::UBB_WORMHOLE ||
+        cluster_desc->get_board_type(chip_id) == BoardType::UBB_BLACKHOLE) {
         constexpr std::string_view ubb_mobo_name = "S7T-MB";
 
         TT_FATAL(
@@ -98,14 +84,11 @@ std::pair<TrayID, ASICLocation> get_asic_position(
         auto pcie_id = cluster_desc->get_chips_with_mmio().at(chip_id);
         pcie_devices_per_tray[ubb_id.tray_id].insert(pcie_id);
         pcie_id_to_asic_location[pcie_id] = ASICLocation{ubb_id.asic_id};
-        std::cout << "[get_asic_position] result: chip_id=" << chip_id
-                  << " tray_id=" << ubb_id.tray_id
-                  << " asic_location=" << ubb_id.asic_id
-                  << " (UBB path)" << std::endl;
         return {TrayID{ubb_id.tray_id}, ASICLocation{ubb_id.asic_id}};
     }
     auto tray_id = get_tray_id_for_chip(cluster, chip_id, get_mobo_name(), using_mock_cluster_desc);
     ASICLocation asic_location;
+    tt::ARCH arch = cluster_desc->get_arch(chip_id);
     if (arch == tt::ARCH::WORMHOLE_B0) {
         // Derive ASIC Location based on the tunnel depth for Wormhole systems
         // TODO: Remove this once UMD populates the ASIC Location for WH systems.
@@ -125,11 +108,6 @@ std::pair<TrayID, ASICLocation> get_asic_position(
     } else {
         TT_THROW("Unrecognized Architecture. Cannot determine asic location.");
     }
-    std::cout << "[get_asic_position] result: chip_id=" << chip_id
-              << " tray_id=" << *tray_id
-              << " asic_location=" << *asic_location
-              << " (non-UBB path, arch=" << tt::arch_to_str(arch) << ")"
-              << std::endl;
     return {tray_id, asic_location};
 }
 

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -48,7 +48,10 @@ TrayID get_tray_id_for_chip(
         {"H13DSG-O-CPU", {0x01, 0x21, 0x41, 0x61, 0x81, 0xa1, 0xc1, 0xe1}},
     };
 
-    if (using_mock_cluster_desc || !mobo_to_bus_ids.contains(mobo_name)) {
+    if (using_mock_cluster_desc) {
+        return TrayID{0};
+    }
+    if (!mobo_to_bus_ids.contains(mobo_name)) {
         auto bus_id = tt::tt_fabric::get_bus_id(cluster, chip_id);
         log_warning(
             tt::LogAlways,

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -45,6 +45,7 @@ TrayID get_tray_id_for_chip(
     static const std::unordered_map<std::string, std::vector<uint16_t>> mobo_to_bus_ids = {
         {"SIENAD8-2L2T", {0xc1, 0x01, 0x41, 0x42}},
         {"X12DPG-QT6", {0xb1, 0xca, 0x31, 0x4b}},
+        {"H13DSG-O-CPU", {0x01, 0x21, 0x41, 0x61, 0x81, 0xa1, 0xc1, 0xe1}},
     };
 
     auto bus_id = tt::tt_fabric::get_bus_id(cluster, chip_id);

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <climits>
 #include <fstream>
+#include <iostream>
 #include <algorithm>
 #include <set>
 #include <unordered_map>
@@ -49,21 +50,16 @@ TrayID get_tray_id_for_chip(
     };
 
     auto bus_id = tt::tt_fabric::get_bus_id(cluster, chip_id);
-    log_info(
-        tt::LogAlways,
-        "get_tray_id_for_chip: chip_id={}, mobo_name='{}', bus_id=0x{:x}, using_mock={}",
-        chip_id,
-        mobo_name,
-        bus_id,
-        using_mock_cluster_desc);
+    std::cout << "[get_tray_id_for_chip] chip_id=" << chip_id
+              << " mobo_name='" << mobo_name << "'"
+              << " bus_id=0x" << std::hex << bus_id << std::dec
+              << " using_mock=" << using_mock_cluster_desc
+              << " mobo_known=" << mobo_to_bus_ids.contains(mobo_name)
+              << std::endl;
     if (using_mock_cluster_desc || !mobo_to_bus_ids.contains(mobo_name)) {
-        log_warning(
-            tt::LogAlways,
-            "Unknown motherboard '{}' for chip_id={} (bus_id=0x{:x}) — defaulting tray_id to 0. "
-            "Add this motherboard and its bus IDs to mobo_to_bus_ids in physical_system_discovery.cpp.",
-            mobo_name,
-            chip_id,
-            bus_id);
+        std::cout << "[get_tray_id_for_chip] DEFAULTING tray_id=0 for chip_id=" << chip_id
+                  << " (mobo='" << mobo_name << "', mock=" << using_mock_cluster_desc << ")"
+                  << std::endl;
         return TrayID{0};
     }
     const auto& ordered_bus_ids = mobo_to_bus_ids.at(mobo_name);
@@ -84,15 +80,14 @@ std::pair<TrayID, ASICLocation> get_asic_position(
     auto arch = cluster_desc->get_arch(chip_id);
     auto board_id = cluster_desc->get_board_id_for_chip(chip_id);
     uint64_t upi = (board_id >> 36) & 0xFFFFF;
-    log_info(
-        tt::LogAlways,
-        "get_asic_position: chip_id={}, arch={}, board_type={} ({}), board_id=0x{:x}, upi=0x{:x}",
-        chip_id,
-        arch,
-        static_cast<uint32_t>(board_type),
-        tt::board_type_to_string(board_type),
-        board_id,
-        upi);
+    std::cout << "[get_asic_position] chip_id=" << chip_id
+              << " arch=" << tt::arch_to_str(arch)
+              << " board_type=" << static_cast<uint32_t>(board_type)
+              << " (" << tt::board_type_to_string(board_type) << ")"
+              << " board_id=0x" << std::hex << board_id
+              << " upi=0x" << upi << std::dec
+              << " using_mock=" << using_mock_cluster_desc
+              << std::endl;
     if (board_type == BoardType::UBB_WORMHOLE ||
         board_type == BoardType::UBB_BLACKHOLE) {
         constexpr std::string_view ubb_mobo_name = "S7T-MB";
@@ -103,12 +98,10 @@ std::pair<TrayID, ASICLocation> get_asic_position(
         auto pcie_id = cluster_desc->get_chips_with_mmio().at(chip_id);
         pcie_devices_per_tray[ubb_id.tray_id].insert(pcie_id);
         pcie_id_to_asic_location[pcie_id] = ASICLocation{ubb_id.asic_id};
-        log_info(
-            tt::LogAlways,
-            "get_asic_position result: chip_id={}, tray_id={}, asic_location={} (UBB path)",
-            chip_id,
-            ubb_id.tray_id,
-            ubb_id.asic_id);
+        std::cout << "[get_asic_position] result: chip_id=" << chip_id
+                  << " tray_id=" << ubb_id.tray_id
+                  << " asic_location=" << ubb_id.asic_id
+                  << " (UBB path)" << std::endl;
         return {TrayID{ubb_id.tray_id}, ASICLocation{ubb_id.asic_id}};
     }
     auto tray_id = get_tray_id_for_chip(cluster, chip_id, get_mobo_name(), using_mock_cluster_desc);
@@ -132,13 +125,11 @@ std::pair<TrayID, ASICLocation> get_asic_position(
     } else {
         TT_THROW("Unrecognized Architecture. Cannot determine asic location.");
     }
-    log_info(
-        tt::LogAlways,
-        "get_asic_position result: chip_id={}, tray_id={}, asic_location={} (non-UBB path, arch={})",
-        chip_id,
-        *tray_id,
-        *asic_location,
-        arch);
+    std::cout << "[get_asic_position] result: chip_id=" << chip_id
+              << " tray_id=" << *tray_id
+              << " asic_location=" << *asic_location
+              << " (non-UBB path, arch=" << tt::arch_to_str(arch) << ")"
+              << std::endl;
     return {tray_id, asic_location};
 }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Exabox Blackhole Loudboxes (e.g. bh-lb-a10u24) were not working in telemetry because physical system discovery was not familiar with their motherboard ID and therefore could not enumerate trays, resulting in ASIC descriptors for each chip that were invalid (tray_id=0) and non-unique.

### What's changed
Added the motherboard type `H13DSG-O-CPU` to `get_tray_id_for_chip()` in `physical_system_discovery.cpp` and *bada bing bada boom* it works.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bart/psd-bh-lb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bart/psd-bh-lb)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bart/psd-bh-lb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bart/psd-bh-lb)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bart/psd-bh-lb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bart/psd-bh-lb)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bart/psd-bh-lb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bart/psd-bh-lb)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bart/psd-bh-lb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bart/psd-bh-lb)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bart/psd-bh-lb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bart/psd-bh-lb)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
