### PR TITLE
Skip strided reduce scatter related tests with invalid fabric router config

### DIFF
--- a/models/tt_dit/tests/models/wan2_2/test_strided_reduce_scatter_wan_tg.py
+++ b/models/tt_dit/tests/models/wan2_2/test_strided_reduce_scatter_wan_tg.py
@@ -31,13 +31,14 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
     "device_params, topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
-        (
+        pytest.param(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
                 "fabric_router_config": _make_fabric_router_config(8192),
                 "trace_region_size": 1531456,
             },
             ttnn.Topology.Ring,
+            marks=pytest.mark.skipif(is_wormhole_b0(), reason="fabric_router_config=8192 not supported on wormhole_b0"),
         ),
     ],
     indirect=["device_params"],
@@ -92,13 +93,14 @@ def test_strided_reduce_scatter_async_tg(mesh_device, num_links, cluster_axis, t
     "device_params, topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
-        (
+        pytest.param(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
                 "fabric_router_config": _make_fabric_router_config(8192),
                 "trace_region_size": 1531456,
             },
             ttnn.Topology.Ring,
+            marks=pytest.mark.skipif(is_wormhole_b0(), reason="fabric_router_config=8192 not supported on wormhole_b0"),
         ),
     ],
     indirect=["device_params"],

--- a/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_matmul_strided_reduce_scatter_async.py
@@ -207,13 +207,14 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
     "device_params, topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
-        (
+        pytest.param(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
                 "fabric_router_config": _make_fabric_router_config(8192),
                 "trace_region_size": 1531456,
             },
             ttnn.Topology.Ring,
+            marks=pytest.mark.skipif(is_wormhole_b0(), reason="fabric_router_config=8192 not supported on wormhole_b0"),
         ),
     ],
     indirect=["device_params"],
@@ -303,13 +304,14 @@ def test_minimal_matmul_strided_reduce_scatter_async(
     "device_params, topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
-        (
+        pytest.param(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
                 "fabric_router_config": _make_fabric_router_config(8192),
                 "trace_region_size": 1531456,
             },
             ttnn.Topology.Ring,
+            marks=pytest.mark.skipif(is_wormhole_b0(), reason="fabric_router_config=8192 not supported on wormhole_b0"),
         ),
     ],
     indirect=["device_params"],

--- a/tests/nightly/tg/ccl/test_strided_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_strided_reduce_scatter_async.py
@@ -10,6 +10,7 @@ from tests.nightly.t3000.ccl.test_strided_reduce_scatter_async import (
     ReduceScatterTestConfig,
     run_reduce_scatter_impl,
 )
+from models.common.utility_functions import is_wormhole_b0
 
 
 def _make_fabric_router_config(max_packet_payload_size_bytes):
@@ -232,13 +233,14 @@ def _make_fabric_router_config(max_packet_payload_size_bytes):
     "device_params, topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
-        (
+        pytest.param(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
                 "fabric_router_config": _make_fabric_router_config(8192),
                 "trace_region_size": 1531456,
             },
             ttnn.Topology.Ring,
+            marks=pytest.mark.skipif(is_wormhole_b0(), reason="fabric_router_config=8192 not supported on wormhole_b0"),
         ),
     ],
     indirect=["device_params"],


### PR DESCRIPTION
The tests involved sending packet too large for wormhole machines leaving them in a bad state. Skip the tests on such machines.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bklockiewicz/fix-str-8k)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bklockiewicz/fix-str-8k)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bklockiewicz/fix-str-8k)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bklockiewicz/fix-str-8k)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bklockiewicz/fix-str-8k)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bklockiewicz/fix-str-8k)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bklockiewicz/fix-str-8k)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bklockiewicz/fix-str-8k)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bklockiewicz/fix-str-8k)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bklockiewicz/fix-str-8k)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bklockiewicz/fix-str-8k)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bklockiewicz/fix-str-8k)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
