### PR TITLE
Performance: add cached pinned-memory paths for large mesh tensor transfers

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -43,6 +43,7 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
+#include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_impl.hpp"
 
 namespace tt::tt_metal::distributed::test {
@@ -55,6 +56,22 @@ static_assert(std::is_move_assignable_v<MeshBuffer>, "MeshBuffer should be move 
 
 using MeshBufferTest2x4 = MeshDevice2x4Fixture;
 using MeshBufferTestSuite = GenericMeshDeviceFixture;
+
+class ScopedPinnedMemoryCacheLimit {
+public:
+    explicit ScopedPinnedMemoryCacheLimit(size_t limit_bytes) :
+        previous_limit_bytes_(
+            tt::tt_metal::MetalContext::instance().rtoptions().get_pinned_memory_cache_limit_bytes()) {
+        tt::tt_metal::MetalContext::instance().rtoptions().set_pinned_memory_cache_limit_bytes(limit_bytes);
+    }
+
+    ~ScopedPinnedMemoryCacheLimit() {
+        tt::tt_metal::MetalContext::instance().rtoptions().set_pinned_memory_cache_limit_bytes(previous_limit_bytes_);
+    }
+
+private:
+    size_t previous_limit_bytes_;
+};
 
 struct DeviceLocalShardedBufferTestConfig {
     Shape2D num_pages_per_core;
@@ -882,6 +899,104 @@ TEST_F(MeshBufferTestSuite, EnqueueReadWithDistributedHostBufferAndPinnedMemory)
     std::vector<uint32_t> dst_aligned(dst_ptr_aligned, dst_ptr_aligned + (bytes_per_device / sizeof(uint32_t)));
 
     EXPECT_EQ(dst_aligned, src);
+}
+
+TEST_F(MeshBufferTestSuite, PinnedMemoryCacheUpgradesCoverageForSameHostBuffer) {
+    if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+
+    if (mesh_device_->num_devices() < 2) {
+        GTEST_SKIP() << "Requires at least two devices in the mesh";
+        return;
+    }
+
+    constexpr int device_read_align = 64;
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    ASSERT_TRUE(device_read_align % hal.get_read_alignment(HalMemType::HOST) == 0)
+        << "Source vector alignment must be equal to PCIE read alignment: " << hal.get_read_alignment(HalMemType::HOST)
+        << std::endl;
+
+    const uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
+    const auto num_words = single_tile_size / sizeof(uint32_t);
+    auto src =
+        std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>>(num_words, 0);
+    std::iota(src->begin(), src->end(), 0);
+
+    HostBuffer host_buffer(tt::stl::Span<uint32_t>(src->data(), num_words), MemoryPin(src));
+
+    const auto first_coord = *MeshCoordinateRange(mesh_device_->shape()).begin();
+    const auto single_coord_range = MeshCoordinateRangeSet(MeshCoordinateRange(first_coord, first_coord));
+    auto single_coord_pin =
+        experimental::PinnedMemoryCache::instance().try_pin(*mesh_device_, single_coord_range, host_buffer, true);
+    ASSERT_TRUE(single_coord_pin);
+    EXPECT_EQ(single_coord_pin->get_device_ids().size(), 1);
+    single_coord_pin.reset();
+
+    const auto full_range = MeshCoordinateRangeSet(MeshCoordinateRange(mesh_device_->shape()));
+    auto full_mesh_pin =
+        experimental::PinnedMemoryCache::instance().try_pin(*mesh_device_, full_range, host_buffer, true);
+    ASSERT_TRUE(full_mesh_pin);
+    EXPECT_EQ(full_mesh_pin->get_device_ids().size(), mesh_device_->num_devices());
+
+    auto repeated_full_mesh_pin =
+        experimental::PinnedMemoryCache::instance().try_pin(*mesh_device_, full_range, host_buffer, true);
+    ASSERT_TRUE(repeated_full_mesh_pin);
+    EXPECT_EQ(repeated_full_mesh_pin.get(), full_mesh_pin.get());
+}
+
+TEST_F(MeshBufferTestSuite, PinnedMemoryCacheEvictsOldestEntryToStayWithinLimit) {
+    const auto pinning_params = experimental::GetMemoryPinningParameters(*mesh_device_);
+    if (!pinning_params.can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+    if (pinning_params.max_pins < 2) {
+        GTEST_SKIP() << "Requires enough pin slots to keep two cache entries resident";
+        return;
+    }
+
+    constexpr int device_read_align = 64;
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    ASSERT_TRUE(device_read_align % hal.get_read_alignment(HalMemType::HOST) == 0)
+        << "Source vector alignment must be equal to PCIE read alignment: " << hal.get_read_alignment(HalMemType::HOST)
+        << std::endl;
+
+    const uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
+    const auto num_words = single_tile_size / sizeof(uint32_t);
+    using AlignedVector = std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>;
+    auto src0 = std::make_shared<AlignedVector>(num_words, 0);
+    auto src1 = std::make_shared<AlignedVector>(num_words, 1);
+    auto src2 = std::make_shared<AlignedVector>(num_words, 2);
+
+    HostBuffer host_buffer0(tt::stl::Span<uint32_t>(src0->data(), num_words), MemoryPin(src0));
+    HostBuffer host_buffer1(tt::stl::Span<uint32_t>(src1->data(), num_words), MemoryPin(src1));
+    HostBuffer host_buffer2(tt::stl::Span<uint32_t>(src2->data(), num_words), MemoryPin(src2));
+
+    const auto first_coord = *MeshCoordinateRange(mesh_device_->shape()).begin();
+    const auto single_coord_range = MeshCoordinateRangeSet(MeshCoordinateRange(first_coord, first_coord));
+    ScopedPinnedMemoryCacheLimit cache_limit(2 * single_tile_size);
+
+    auto first_pin =
+        experimental::PinnedMemoryCache::instance().try_pin(*mesh_device_, single_coord_range, host_buffer0, true);
+    ASSERT_TRUE(first_pin);
+    std::weak_ptr<experimental::PinnedMemory> first_weak = first_pin;
+    first_pin.reset();
+
+    auto second_pin =
+        experimental::PinnedMemoryCache::instance().try_pin(*mesh_device_, single_coord_range, host_buffer1, true);
+    ASSERT_TRUE(second_pin);
+    std::weak_ptr<experimental::PinnedMemory> second_weak = second_pin;
+    second_pin.reset();
+
+    auto third_pin =
+        experimental::PinnedMemoryCache::instance().try_pin(*mesh_device_, single_coord_range, host_buffer2, true);
+    ASSERT_TRUE(third_pin);
+    third_pin.reset();
+
+    EXPECT_TRUE(first_weak.expired());
+    EXPECT_FALSE(second_weak.expired());
 }
 
 TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRangeUnaligned) {

--- a/tests/tt_metal/tt_metal/api/test_memory_pin.cpp
+++ b/tests/tt_metal/tt_metal/api/test_memory_pin.cpp
@@ -5,7 +5,10 @@
 #include <gmock/gmock.h>
 
 #include <functional>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <tt-metalium/memory_pin.hpp>
 
@@ -50,6 +53,21 @@ TEST(MemoryPinTest, FromSharedPtr) {
     }
 
     EXPECT_EQ(ptr.use_count(), 2);
+}
+
+TEST(MemoryPinTest, FinalReleaseCallbackRunsBeforeLastDecrement) {
+    std::vector<std::string> events;
+    {
+        MemoryPin pin([]() {}, [&events]() { events.push_back("decrement"); });
+        pin.add_final_release_callback([&events]() { events.push_back("final_release"); });
+
+        {
+            MemoryPin pin_copy(pin);
+        }
+        EXPECT_THAT(events, ::testing::ElementsAre("decrement"));
+    }
+
+    EXPECT_THAT(events, ::testing::ElementsAre("decrement", "final_release", "decrement"));
 }
 
 TEST(MemoryPinTest, CopyConstruction) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -6,8 +6,12 @@
 #include <gmock/gmock.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <numeric>
 #include <set>
+#include <vector>
 
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/operations/experimental/core_subset_write/copy_to_device_filtered.hpp"
@@ -24,7 +28,13 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/experimental/core_subset_write/tensor.hpp>
+#include <tt-metalium/experimental/pinned_memory.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/memory_pin.hpp>
+#include <tt_stl/aligned_allocator.hpp>
+
+#include "tt_metal/distributed/pinned_memory_cache.hpp"
 
 namespace ttnn::distributed::test {
 namespace {
@@ -579,6 +589,29 @@ using tt::tt_metal::MeshTensor;
 using tt::tt_metal::TensorTopology;
 namespace tensor_impl = tt::tt_metal::tensor_impl;
 
+constexpr int kPinnedMemoryTestAlignment = 64;
+constexpr size_t kPinnedWriteThresholdBytesForTest = 32 * 1024 * 1024;
+
+using AlignedUInt32Vector = std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, kPinnedMemoryTestAlignment>>;
+
+HostBuffer make_aligned_host_buffer(size_t num_words, uint32_t fill) {
+    auto data = std::make_shared<AlignedUInt32Vector>(num_words, fill);
+    return HostBuffer(tt::stl::Span<uint32_t>(data->data(), data->size()), tt::tt_metal::MemoryPin(data));
+}
+
+HostTensor make_full_coverage_aligned_host_tensor(
+    const ttnn::Shape& shape, const distributed::MeshShape& mesh_shape, const std::vector<uint32_t>& shard_fills) {
+    auto spec = TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    auto dhb = DistributedHostBuffer::create(mesh_shape);
+    distributed::MeshCoordinateRange range(mesh_shape);
+    std::vector<distributed::MeshCoordinate> coords(range.begin(), range.end());
+    dhb.emplace_shards(coords, [&, idx = size_t{0}](const distributed::MeshCoordinate&) mutable {
+        return make_aligned_host_buffer(static_cast<size_t>(shape.volume()), shard_fills.at(idx++));
+    });
+    auto topology = TensorTopology::create_sharded_tensor_topology(mesh_shape);
+    return HostTensor(std::move(dhb), spec, topology);
+}
+
 // Helper: create a HostTensor with a single shard at [0,0].
 HostTensor make_single_shard_host_tensor(const ttnn::Shape& shape, uint32_t fill) {
     auto spec = TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{}));
@@ -744,6 +777,149 @@ TEST_F(MeshTensorDataMovementTest, UniformCopyToDevice_CopyToHost_Roundtrip) {
     enqueue_read_tensor(cq, device_tensor, result);
 
     expect_host_tensors_eq(host_tensor, result);
+}
+
+TEST_F(MeshTensorTest, UniformCopyToDevice_ReusesPinnedMemoryCacheEntries) {
+    auto& cache = tt::tt_metal::experimental::PinnedMemoryCache::instance();
+    const auto pinning_params = tt::tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_);
+    if (!pinning_params.can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+
+    const size_t shard_count = mesh_device_->shape().mesh_size();
+    if (static_cast<size_t>(pinning_params.max_pins) < shard_count) {
+        GTEST_SKIP() << "Requires enough pin slots to keep one cache entry per tensor shard";
+        return;
+    }
+
+    // 1024 * 8193 * 4 bytes per shard exceeds the 32 MiB pinned-write threshold even on a 1x1 mesh.
+    const ttnn::Shape shape{1, 1, 1024, 8193};
+    const size_t total_size_bytes = static_cast<size_t>(shape.volume()) * sizeof(uint32_t) * shard_count;
+    ASSERT_GT(total_size_bytes, kPinnedWriteThresholdBytesForTest);
+    if (pinning_params.max_total_pin_size != 0 && pinning_params.max_total_pin_size < total_size_bytes) {
+        GTEST_SKIP() << "Pinned memory budget is too small for the test tensor";
+        return;
+    }
+
+    std::vector<uint32_t> shard_fills(shard_count);
+    std::iota(shard_fills.begin(), shard_fills.end(), 1u);
+    auto host_tensor = make_full_coverage_aligned_host_tensor(shape, mesh_device_->shape(), shard_fills);
+
+    auto& cq = mesh_device_->mesh_command_queue();
+    auto spec = TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    MeshTensor device_tensor = MeshTensor::allocate_on_device(*mesh_device_, spec, host_tensor.tensor_topology());
+
+    const size_t entries_before = cache.num_entries();
+    enqueue_write_tensor(cq, host_tensor, device_tensor);
+    cq.finish();
+    EXPECT_EQ(cache.num_entries(), entries_before + shard_count);
+
+    const auto first_coord = *distributed::MeshCoordinateRange(mesh_device_->shape()).begin();
+    auto first_shard = host_tensor.buffer().get_shard(first_coord);
+    ASSERT_TRUE(first_shard.has_value());
+    auto first_coord_range =
+        distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(first_coord, first_coord));
+    auto first_pin = cache.try_pin(*mesh_device_, first_coord_range, *first_shard, /*map_to_noc=*/true);
+    ASSERT_TRUE(first_pin);
+    std::weak_ptr<tt::tt_metal::experimental::PinnedMemory> first_weak = first_pin;
+    first_pin.reset();
+
+    enqueue_write_tensor(cq, host_tensor, device_tensor);
+    cq.finish();
+
+    EXPECT_EQ(cache.num_entries(), entries_before + shard_count);
+    EXPECT_FALSE(first_weak.expired());
+}
+
+TEST_F(MeshTensorTest, HostTensorCopyKeepsPinnedMemoryCacheEntriesUntilLastPinRelease) {
+    auto& cache = tt::tt_metal::experimental::PinnedMemoryCache::instance();
+    const auto pinning_params = tt::tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_);
+    if (!pinning_params.can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+
+    const size_t shard_count = mesh_device_->shape().mesh_size();
+    if (static_cast<size_t>(pinning_params.max_pins) < shard_count) {
+        GTEST_SKIP() << "Requires enough pin slots to keep one cache entry per tensor shard";
+        return;
+    }
+
+    const ttnn::Shape shape{1, 1, 32, 32};
+    std::vector<uint32_t> shard_fills(shard_count);
+    std::iota(shard_fills.begin(), shard_fills.end(), 1u);
+
+    const size_t entries_before = cache.num_entries();
+    std::unique_ptr<HostTensor> copied_host_tensor;
+    {
+        auto host_tensor = make_full_coverage_aligned_host_tensor(shape, mesh_device_->shape(), shard_fills);
+        for (const auto& coord : distributed::MeshCoordinateRange(mesh_device_->shape())) {
+            auto shard = host_tensor.buffer().get_shard(coord);
+            ASSERT_TRUE(shard.has_value());
+            auto coord_range = distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(coord, coord));
+            auto pinned = cache.try_pin(*mesh_device_, coord_range, *shard, /*map_to_noc=*/true);
+            ASSERT_TRUE(pinned);
+            pinned.reset();
+        }
+        ASSERT_EQ(cache.num_entries(), entries_before + shard_count);
+        copied_host_tensor = std::make_unique<HostTensor>(host_tensor);
+    }
+
+    EXPECT_EQ(cache.num_entries(), entries_before + shard_count);
+    copied_host_tensor.reset();
+    EXPECT_EQ(cache.num_entries(), entries_before);
+}
+
+TEST_F(MeshTensorTest, UniformCopyToHost_ReusesPinnedMemoryCacheEntries) {
+    auto& cache = tt::tt_metal::experimental::PinnedMemoryCache::instance();
+    const auto pinning_params = tt::tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_);
+    if (!pinning_params.can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+
+    const size_t shard_count = mesh_device_->shape().mesh_size();
+    if (static_cast<size_t>(pinning_params.max_pins) < shard_count) {
+        GTEST_SKIP() << "Requires enough pin slots to keep one cache entry per tensor shard";
+        return;
+    }
+
+    const ttnn::Shape shape{1, 1, 32, 32};
+    std::vector<uint32_t> shard_fills(shard_count);
+    std::iota(shard_fills.begin(), shard_fills.end(), 10u);
+    auto host_tensor = make_full_coverage_host_tensor(shape, mesh_device_->shape(), shard_fills);
+
+    auto& cq = mesh_device_->mesh_command_queue();
+    MeshTensor device_tensor = enqueue_write_tensor(cq, host_tensor, *mesh_device_);
+
+    auto spec = TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    auto result_dhb = DistributedHostBuffer::create(mesh_device_->shape());
+    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device_->shape())) {
+        result_dhb.emplace_shard(coord, [&]() { return tensor_impl::allocate_host_buffer(spec); });
+    }
+    HostTensor result(std::move(result_dhb), spec, TensorTopology{});
+
+    const size_t entries_before = cache.num_entries();
+    enqueue_read_tensor(cq, device_tensor, result);
+    cq.finish();
+    EXPECT_EQ(cache.num_entries(), entries_before + shard_count);
+
+    const auto first_coord = *distributed::MeshCoordinateRange(mesh_device_->shape()).begin();
+    auto first_shard = result.buffer().get_shard(first_coord);
+    ASSERT_TRUE(first_shard.has_value());
+    auto first_coord_range =
+        distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(first_coord, first_coord));
+    auto first_pin = cache.try_pin(*mesh_device_, first_coord_range, *first_shard, /*map_to_noc=*/true);
+    ASSERT_TRUE(first_pin);
+    std::weak_ptr<tt::tt_metal::experimental::PinnedMemory> first_weak = first_pin;
+    first_pin.reset();
+
+    enqueue_read_tensor(cq, device_tensor, result);
+    cq.finish();
+
+    EXPECT_EQ(cache.num_entries(), entries_before + shard_count);
+    EXPECT_FALSE(first_weak.expired());
 }
 
 // Verifies the user-facing contract: in a HEIGHT_SHARDED tensor with one shard per core, applying
@@ -1015,6 +1191,33 @@ TEST_F(MeshTensorTest2x4, CopyToDeviceFiltered_ThrowsOnInterleavedLayout) {
     copy_to_device(host_a, device_tensor);
     CoreRangeSet filter(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
     EXPECT_ANY_THROW(ttnn::experimental::core_subset_write::copy_to_device_filtered(host_b, device_tensor, filter));
+}
+
+// ---------------------------------------------------------------------------
+//  Large write roundtrip (exceeds pinned-memory threshold)
+// ---------------------------------------------------------------------------
+
+TEST_F(MeshTensorTest, LargeWriteRoundtrip_PinnedMemoryPath) {
+    // 1024 * 9216 * 4 bytes = 36 MB, above the 32 MB pinned-write threshold.
+    const ttnn::Shape shape{1, 1, 1024, 9216};
+    auto spec = TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    auto dhb = DistributedHostBuffer::create(mesh_device_->shape());
+    distributed::MeshCoordinateRange range(mesh_device_->shape());
+    std::vector<distributed::MeshCoordinate> coords(range.begin(), range.end());
+    dhb.emplace_shards(coords, [&](const distributed::MeshCoordinate&) {
+        std::vector<uint32_t> data(shape.volume());
+        std::iota(data.begin(), data.end(), 0);
+        return HostBuffer(std::move(data));
+    });
+    auto topology = TensorTopology::create_sharded_tensor_topology(mesh_device_->shape());
+    HostTensor host_tensor(std::move(dhb), spec, topology);
+
+    auto& cq = mesh_device_->mesh_command_queue();
+    MeshTensor device_tensor = enqueue_write_tensor(cq, host_tensor, *mesh_device_);
+    HostTensor result = enqueue_read_tensor(cq, device_tensor);
+
+    expect_host_tensors_eq(host_tensor, result);
 }
 
 }  // namespace

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -1220,5 +1220,52 @@ TEST_F(MeshTensorTest, LargeWriteRoundtrip_PinnedMemoryPath) {
     expect_host_tensors_eq(host_tensor, result);
 }
 
+TEST_F(MeshTensorTest, LargeWriteRoundtrip_HeightShardedDeviceRequiringShardPadding) {
+    // 1024 * 9216 * 4 bytes = 36 MB, above the 32 MB pinned-write threshold.
+    // Device uses HEIGHT_SHARDED with shard_height=257 on 4 DRAM cores;
+    // ceil(1024/257)=4, and 4*257=1028 > 1024, so the last shard carries
+    // 4 padding rows. This padding may prevent the pinned-memory fast path
+    // at the dispatch level.
+    const ttnn::Shape shape{1, 1, 1024, 9216};
+    constexpr uint32_t kShardHeight = 257;
+    constexpr uint32_t kWidth = 9216;
+
+    CoreRangeSet shard_grid(CoreRange(CoreCoord(0, 0), CoreCoord(3, 0)));
+    ShardSpec shard_spec(shard_grid, {kShardHeight, kWidth});
+    MemoryConfig sharded_mem_cfg(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::DRAM, shard_spec);
+
+    auto dhb = DistributedHostBuffer::create(mesh_device_->shape());
+    distributed::MeshCoordinateRange range(mesh_device_->shape());
+    std::vector<distributed::MeshCoordinate> coords(range.begin(), range.end());
+    dhb.emplace_shards(coords, [&](const distributed::MeshCoordinate&) {
+        std::vector<uint32_t> data(shape.volume());
+        std::iota(data.begin(), data.end(), 0);
+        return HostBuffer(std::move(data));
+    });
+    auto topology = TensorTopology::create_sharded_tensor_topology(mesh_device_->shape());
+    HostTensor host_tensor(
+        std::move(dhb), TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{})), topology);
+
+    auto& cq = mesh_device_->mesh_command_queue();
+    MeshTensor device_tensor = enqueue_write_tensor(cq, host_tensor, *mesh_device_, sharded_mem_cfg);
+    HostTensor result = enqueue_read_tensor(cq, device_tensor);
+
+    const size_t logical_volume = shape.volume();
+    const auto& exp_coords = host_tensor.buffer().shard_coords();
+    const auto& act_coords = result.buffer().shard_coords();
+    ASSERT_EQ(exp_coords, act_coords);
+    for (const auto& coord : exp_coords) {
+        auto exp_shard = host_tensor.buffer().get_shard(coord);
+        auto act_shard = result.buffer().get_shard(coord);
+        ASSERT_TRUE(exp_shard.has_value());
+        ASSERT_TRUE(act_shard.has_value());
+        auto exp_span = exp_shard->view_as<uint32_t>();
+        auto act_span = act_shard->view_as<uint32_t>();
+        ASSERT_GE(act_span.size(), logical_volume);
+        EXPECT_TRUE(std::equal(exp_span.begin(), exp_span.end(), act_span.begin()))
+            << "Data mismatch at mesh coordinate " << coord;
+    }
+}
+
 }  // namespace
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -1226,6 +1226,9 @@ TEST_F(MeshTensorTest, LargeWriteRoundtrip_HeightShardedDeviceRequiringShardPadd
     // ceil(1024/257)=4, and 4*257=1028 > 1024, so the last shard carries
     // 4 padding rows. This padding may prevent the pinned-memory fast path
     // at the dispatch level.
+    auto& cache = tt::tt_metal::experimental::PinnedMemoryCache::instance();
+    const auto pinning_params = tt::tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_);
+
     const ttnn::Shape shape{1, 1, 1024, 9216};
     constexpr uint32_t kShardHeight = 257;
     constexpr uint32_t kWidth = 9216;
@@ -1246,8 +1249,21 @@ TEST_F(MeshTensorTest, LargeWriteRoundtrip_HeightShardedDeviceRequiringShardPadd
     HostTensor host_tensor(
         std::move(dhb), TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{})), topology);
 
+    const size_t entries_before = cache.num_entries();
+    const size_t shard_count = mesh_device_->shape().mesh_size();
+
     auto& cq = mesh_device_->mesh_command_queue();
     MeshTensor device_tensor = enqueue_write_tensor(cq, host_tensor, *mesh_device_, sharded_mem_cfg);
+
+    // The write path attempts pinning because total data exceeds the 32 MB
+    // threshold.  When the system supports pinning, the cache should grow by
+    // one entry per mesh shard.
+    const bool pinning_supported = pinning_params.can_map_to_noc && pinning_params.max_pins > 0;
+    if (pinning_supported) {
+        EXPECT_EQ(cache.num_entries(), entries_before + shard_count)
+            << "Expected one new cache entry per mesh shard after the pinned write";
+    }
+
     HostTensor result = enqueue_read_tensor(cq, device_tensor);
 
     const size_t logical_volume = shape.volume();

--- a/tt_metal/api/tt-metalium/host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/host_buffer.hpp
@@ -73,6 +73,8 @@ public:
 
 private:
     friend class experimental::HostBufferPinnedMemoryHelper;
+    void register_pinned_memory_cache_release_callback();
+
     MemoryPin pin_;
     ttsl::Span<std::byte> view_;
     const std::type_info* type_info_ = nullptr;
@@ -84,6 +86,7 @@ HostBuffer::HostBuffer(const std::shared_ptr<std::vector<T>>& data) : type_info_
     const size_t size_bytes = data->size() * sizeof(T);
     view_ = ttsl::Span<std::byte>(reinterpret_cast<std::byte*>(data->data()), size_bytes);
     pin_ = MemoryPin(data);
+    register_pinned_memory_cache_release_callback();
 }
 
 template <typename T>
@@ -97,9 +100,10 @@ HostBuffer::HostBuffer(const std::vector<T>& data) :
 template <typename T>
 HostBuffer::HostBuffer(ttsl::Span<T> borrowed_data, MemoryPin pin) :
     pin_(std::move(pin)),
-    view_(
-        ttsl::Span<std::byte>(reinterpret_cast<std::byte*>(borrowed_data.data()), borrowed_data.size() * sizeof(T))),
-    type_info_(&typeid(T)) {}
+    view_(ttsl::Span<std::byte>(reinterpret_cast<std::byte*>(borrowed_data.data()), borrowed_data.size() * sizeof(T))),
+    type_info_(&typeid(T)) {
+    register_pinned_memory_cache_release_callback();
+}
 
 template <typename T>
 ttsl::Span<T> HostBuffer::view_as() & {

--- a/tt_metal/api/tt-metalium/memory_pin.hpp
+++ b/tt_metal/api/tt-metalium/memory_pin.hpp
@@ -4,9 +4,10 @@
 
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <memory>
-#include <cstddef>
+#include <vector>
 
 namespace tt::tt_metal {
 
@@ -23,17 +24,27 @@ public:
     MemoryPin(MemoryPin&& other) noexcept;
     MemoryPin& operator=(MemoryPin&& other) noexcept;
 
+    // The callback runs once when the last MemoryPin sharing this state is released, before decrementing the pin.
+    void add_final_release_callback(std::function<void()> callback);
+
     friend bool operator==(const MemoryPin& pin, std::nullptr_t) noexcept;
     friend bool operator==(std::nullptr_t, const MemoryPin& pin) noexcept;
     friend bool operator!=(const MemoryPin& pin, std::nullptr_t) noexcept;
     friend bool operator!=(std::nullptr_t, const MemoryPin& pin) noexcept;
 
 private:
+    struct FinalReleaseState {
+        std::vector<std::function<void()>> callbacks;
+        bool ran = false;
+    };
+
     void maybe_increment();
     void maybe_decrement();
+    void maybe_run_final_release_callbacks();
 
     std::function<void()> inc_;
     std::function<void()> dec_;
+    std::shared_ptr<FinalReleaseState> final_release_state_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/common/host_buffer.cpp
+++ b/tt_metal/common/host_buffer.cpp
@@ -8,6 +8,8 @@
 #include <tt_stl/span.hpp>
 #include <tt_stl/overloaded.hpp>
 
+#include "distributed/pinned_memory_cache.hpp"
+
 #include <memory>
 #include <utility>
 #include <vector>
@@ -37,6 +39,15 @@ void HostBuffer::swap(HostBuffer& other) noexcept {
     swap(view_, other.view_);
     swap(type_info_, other.type_info_);
     swap(pinned_memory_, other.pinned_memory_);
+}
+
+void HostBuffer::register_pinned_memory_cache_release_callback() {
+    if (pin_ == nullptr || view_.empty()) {
+        return;
+    }
+    const void* host_address = static_cast<const void*>(view_.data());
+    pin_.add_final_release_callback(
+        [host_address]() { experimental::PinnedMemoryCache::instance().release(host_address); });
 }
 
 tt::stl::Span<std::byte> HostBuffer::view_bytes() & noexcept { return view_; }

--- a/tt_metal/common/memory_pin.cpp
+++ b/tt_metal/common/memory_pin.cpp
@@ -4,35 +4,47 @@
 
 #include <tt-metalium/memory_pin.hpp>
 
-#include <functional>
-#include <utility>
 #include <cstddef>
+#include <functional>
+#include <memory>
+#include <utility>
 
 namespace tt::tt_metal {
 
 MemoryPin::MemoryPin(std::function<void()> increment_ref_count, std::function<void()> decrement_ref_count) :
-    inc_(std::move(increment_ref_count)), dec_(std::move(decrement_ref_count)) {
+    inc_(std::move(increment_ref_count)),
+    dec_(std::move(decrement_ref_count)),
+    final_release_state_(std::make_shared<FinalReleaseState>()) {
     maybe_increment();
 }
 
 MemoryPin::MemoryPin(std::shared_ptr<void> resource) :
-    inc_([]() {}), dec_([ref = std::move(resource)]() mutable { ref.reset(); }) {}
+    inc_([]() {}),
+    dec_([ref = std::move(resource)]() mutable { ref.reset(); }),
+    final_release_state_(std::make_shared<FinalReleaseState>()) {}
 
 MemoryPin::~MemoryPin() { maybe_decrement(); }
 
-MemoryPin::MemoryPin(const MemoryPin& other) : inc_(other.inc_), dec_(other.dec_) { maybe_increment(); }
+MemoryPin::MemoryPin(const MemoryPin& other) :
+    inc_(other.inc_), dec_(other.dec_), final_release_state_(other.final_release_state_) {
+    maybe_increment();
+}
 
 MemoryPin& MemoryPin::operator=(const MemoryPin& other) {
     if (this != &other) {
         maybe_decrement();
         inc_ = other.inc_;
         dec_ = other.dec_;
+        final_release_state_ = other.final_release_state_;
         maybe_increment();
     }
     return *this;
 }
 
-MemoryPin::MemoryPin(MemoryPin&& other) noexcept : inc_(std::move(other.inc_)), dec_(std::move(other.dec_)) {
+MemoryPin::MemoryPin(MemoryPin&& other) noexcept :
+    inc_(std::move(other.inc_)),
+    dec_(std::move(other.dec_)),
+    final_release_state_(std::move(other.final_release_state_)) {
     other.inc_ = nullptr;
     other.dec_ = nullptr;
 }
@@ -42,10 +54,18 @@ MemoryPin& MemoryPin::operator=(MemoryPin&& other) noexcept {
         maybe_decrement();
         inc_ = std::move(other.inc_);
         dec_ = std::move(other.dec_);
+        final_release_state_ = std::move(other.final_release_state_);
         other.inc_ = nullptr;
         other.dec_ = nullptr;
     }
     return *this;
+}
+
+void MemoryPin::add_final_release_callback(std::function<void()> callback) {
+    if (!final_release_state_) {
+        final_release_state_ = std::make_shared<FinalReleaseState>();
+    }
+    final_release_state_->callbacks.push_back(std::move(callback));
 }
 
 void MemoryPin::maybe_increment() {
@@ -55,8 +75,19 @@ void MemoryPin::maybe_increment() {
 }
 
 void MemoryPin::maybe_decrement() {
+    maybe_run_final_release_callbacks();
     if (dec_) {
         dec_();
+    }
+}
+
+void MemoryPin::maybe_run_final_release_callbacks() {
+    if (!final_release_state_ || final_release_state_.use_count() != 1 || final_release_state_->ran) {
+        return;
+    }
+    final_release_state_->ran = true;
+    for (const auto& callback : final_release_state_->callbacks) {
+        callback();
     }
 }
 

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -375,9 +375,11 @@ void MeshCommandQueueBase::enqueue_read(
 
         auto buf = host_buffer.get_shard(coord);
         if (buf.has_value()) {
-            shard_data_transfers.push_back(distributed::ShardDataTransfer{coord}
-                                               .host_data(buf->view_bytes().data())
-                                               .region(BufferRegion(0, buf->view_bytes().size())));
+            auto xfer = distributed::ShardDataTransfer{coord}
+                            .host_data(buf->view_bytes().data())
+                            .region(BufferRegion(0, buf->view_bytes().size()));
+            experimental::ShardDataTransferSetPinnedMemory(xfer, experimental::HostBufferGetPinnedMemory(*buf));
+            shard_data_transfers.push_back(std::move(xfer));
         }
     }
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include "impl/allocator/allocator.hpp"
+#include "pinned_memory_cache.hpp"
 #include <tt_stl/assert.hpp>
 #include "buffer.hpp"
 #include "device/device_impl.hpp"
@@ -1531,6 +1532,7 @@ MeshDevice::MeshDevice(MetalEnv& /*metal_env*/) {}
 
 MeshDevice::~MeshDevice() {
     Inspector::mesh_device_destroyed(this->pimpl_.get());
+    experimental::PinnedMemoryCache::instance().release_for_device(*this);
     pimpl_->close_impl(this);
 }
 

--- a/tt_metal/distributed/pinned_memory_cache.cpp
+++ b/tt_metal/distributed/pinned_memory_cache.cpp
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pinned_memory_cache.hpp"
+
+#include <tt-metalium/experimental/pinned_memory.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/distributed_host_buffer.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <context/metal_context.hpp>
+#include "llrt/tt_cluster.hpp"
+#include "distributed/mesh_device_view_impl.hpp"
+
+namespace tt::tt_metal::experimental {
+
+using ChipId = int;
+
+PinnedMemoryCache& PinnedMemoryCache::instance() {
+    static PinnedMemoryCache cache;
+    return cache;
+}
+
+size_t PinnedMemoryCache::num_entries() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return lru_entries_.size();
+}
+
+std::set<ChipId> PinnedMemoryCache::compute_device_ids(
+    distributed::MeshDevice& mesh_device, const distributed::MeshCoordinateRangeSet& coordinate_range_set) {
+    const auto& view = mesh_device.get_view();
+    std::set<ChipId> device_ids;
+    for (const auto& coord : coordinate_range_set.coords()) {
+        if (view.contains(coord)) {
+            // get_device is deprecated but still functional; we only use it to
+            // obtain the chip ID, which is not distribution-sensitive.
+            if (auto* device = view.impl().get_device(coord)) {
+                device_ids.insert(device->id());
+            }
+        }
+    }
+    return device_ids;
+}
+
+std::set<ChipId> PinnedMemoryCache::compute_mmio_device_ids(const std::set<ChipId>& device_ids) {
+    auto& cluster = MetalContext::instance().get_cluster();
+    std::set<ChipId> mmio_ids;
+    for (ChipId device_id : device_ids) {
+        mmio_ids.insert(cluster.get_associated_mmio_device(device_id));
+    }
+    return mmio_ids;
+}
+
+void PinnedMemoryCache::erase_entry(std::list<CacheEntry>::iterator it) {
+    const size_t entry_size_bytes = it->pinned_memory->get_buffer_size();
+    auto [range_begin, range_end] = address_map_.equal_range(it->host_address);
+    for (auto map_it = range_begin; map_it != range_end; ++map_it) {
+        if (map_it->second == it) {
+            address_map_.erase(map_it);
+            break;
+        }
+    }
+    current_size_bytes_ =
+        entry_size_bytes <= current_size_bytes_ ? current_size_bytes_ - entry_size_bytes : static_cast<size_t>(0);
+    lru_entries_.erase(it);
+}
+
+void PinnedMemoryCache::release_locked(const void* host_address) {
+    auto [range_begin, range_end] = address_map_.equal_range(host_address);
+    for (auto map_it = range_begin; map_it != range_end;) {
+        auto list_it = map_it->second;
+        auto next_map_it = std::next(map_it);
+        erase_entry(list_it);
+        map_it = next_map_it;
+    }
+}
+
+bool PinnedMemoryCache::evict_oldest_entry() {
+    for (auto it = lru_entries_.begin(); it != lru_entries_.end(); ++it) {
+        if (it->pinned_memory.use_count() > 1) {
+            continue;
+        }
+        erase_entry(it);
+        return true;
+    }
+    return false;
+}
+
+bool PinnedMemoryCache::evict_oldest_entry_for_mmio_ids(const std::set<ChipId>& target_mmio_ids) {
+    for (auto it = lru_entries_.begin(); it != lru_entries_.end(); ++it) {
+        if (it->pinned_memory.use_count() > 1) {
+            continue;
+        }
+        for (ChipId mmio_id : it->mmio_device_ids) {
+            if (target_mmio_ids.contains(mmio_id)) {
+                erase_entry(it);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool PinnedMemoryCache::evict_oldest_until_within_limit(size_t incoming_size_bytes) {
+    const size_t cache_limit_bytes = MetalContext::instance().rtoptions().get_pinned_memory_cache_limit_bytes();
+    if (incoming_size_bytes > cache_limit_bytes) {
+        return false;
+    }
+
+    while (current_size_bytes_ > cache_limit_bytes - incoming_size_bytes) {
+        if (!evict_oldest_entry()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool PinnedMemoryCache::has_conflicting_entry(const void* host_addr, const std::set<ChipId>& target_mmio_ids) const {
+    auto [range_begin, range_end] = address_map_.equal_range(host_addr);
+    for (auto map_it = range_begin; map_it != range_end; ++map_it) {
+        auto list_it = map_it->second;
+        if (list_it->pinned_memory.use_count() <= 1) {
+            continue;
+        }
+        for (ChipId mmio_id : list_it->mmio_device_ids) {
+            if (target_mmio_ids.contains(mmio_id)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+std::shared_ptr<PinnedMemory> PinnedMemoryCache::try_pin(
+    distributed::MeshDevice& mesh_device,
+    const distributed::MeshCoordinateRangeSet& coordinate_range_set,
+    HostBuffer& host_buffer,
+    bool map_to_noc) {
+    // Check whether this hardware/IOMMU configuration supports pinning at all.
+    const auto params = GetMemoryPinningParameters(mesh_device);
+    if (params.max_pins == 0) {
+        return nullptr;
+    }
+    if (map_to_noc && !params.can_map_to_noc) {
+        return nullptr;
+    }
+
+    const auto buffer_bytes = host_buffer.view_bytes();
+    if (buffer_bytes.empty()) {
+        return nullptr;
+    }
+    const void* host_addr = static_cast<const void*>(buffer_bytes.data());
+    const size_t buffer_size = buffer_bytes.size();
+    std::set<ChipId> target_device_ids = compute_device_ids(mesh_device, coordinate_range_set);
+    if (target_device_ids.empty()) {
+        return nullptr;
+    }
+
+    std::set<ChipId> target_mmio_ids = compute_mmio_device_ids(target_device_ids);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Search all entries for this host address for a usable cache hit.
+    auto [range_begin, range_end] = address_map_.equal_range(host_addr);
+    for (auto map_it = range_begin; map_it != range_end; ++map_it) {
+        auto list_it = map_it->second;
+        if (list_it->pinned_memory->get_buffer_size() < buffer_size) {
+            continue;
+        }
+        if (map_to_noc && !list_it->map_to_noc) {
+            continue;
+        }
+        bool covers_all_devices = true;
+        for (ChipId device_id : target_device_ids) {
+            if (!list_it->device_ids.contains(device_id)) {
+                covers_all_devices = false;
+                break;
+            }
+        }
+        if (covers_all_devices) {
+            lru_entries_.splice(lru_entries_.end(), lru_entries_, list_it);
+            return list_it->pinned_memory;
+        }
+    }
+
+    // No usable entry. Before creating a new pin, check whether any existing
+    // entry for this address is still referenced externally on an MMIO device
+    // we need. The kernel driver will refuse to pin the same range twice on
+    // the same MMIO device, so we must give up if there is a conflict.
+    if (has_conflicting_entry(host_addr, target_mmio_ids)) {
+        return nullptr;
+    }
+
+    // Evict existing entries for this address whose MMIO sets overlap with the
+    // target, since they would conflict with the new pin. Entries on disjoint
+    // MMIO devices are kept — they are still useful for future lookups.
+    {
+        auto [rb, re] = address_map_.equal_range(host_addr);
+        for (auto map_it = rb; map_it != re;) {
+            auto list_it = map_it->second;
+            bool mmio_overlap = false;
+            for (ChipId mmio_id : list_it->mmio_device_ids) {
+                if (target_mmio_ids.contains(mmio_id)) {
+                    mmio_overlap = true;
+                    break;
+                }
+            }
+            if (mmio_overlap) {
+                auto next_map_it = std::next(map_it);
+                erase_entry(list_it);
+                map_it = next_map_it;
+            } else {
+                ++map_it;
+            }
+        }
+    }
+
+    if (!evict_oldest_until_within_limit(buffer_size)) {
+        return nullptr;
+    }
+
+    // Try to create a new pinned region. On failure, evict the oldest entry that
+    // shares an MMIO device with the target and retry. Repeat until success or
+    // no evictable entries remain.
+    while (true) {
+        try {
+            // PinnedMemory::Create also calls HostBufferSetPinnedMemory internally
+            // as part of its public API. We immediately clear it since the cache is
+            // the long-term owner; callers set it transiently when needed.
+            auto pinned = PinnedMemory::Create(mesh_device, coordinate_range_set, host_buffer, map_to_noc);
+            HostBufferSetPinnedMemory(host_buffer, nullptr);
+
+            CacheEntry entry{pinned, host_addr, target_device_ids, target_mmio_ids, map_to_noc};
+            lru_entries_.push_back(std::move(entry));
+            address_map_.emplace(host_addr, std::prev(lru_entries_.end()));
+            current_size_bytes_ += pinned->get_buffer_size();
+            return pinned;
+        } catch (...) {
+            // Pin limit exceeded. Find the oldest LRU entry that shares an MMIO device
+            // with the target and evict it to free a kernel pin slot.
+            if (!evict_oldest_entry_for_mmio_ids(target_mmio_ids)) {
+                // No evictable entries on the relevant MMIO device; give up.
+                return nullptr;
+            }
+            // Loop and retry.
+        }
+    }
+}
+
+void PinnedMemoryCache::release(const void* host_address) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    release_locked(host_address);
+}
+
+void PinnedMemoryCache::release_for_device(distributed::MeshDevice& mesh_device) {
+    // Compute the set of MMIO device IDs for all chips in this MeshDevice.
+    auto& cluster = MetalContext::instance().get_cluster();
+    std::set<ChipId> mmio_device_ids;
+    for (ChipId chip_id : mesh_device.get_device_ids()) {
+        mmio_device_ids.insert(cluster.get_associated_mmio_device(chip_id));
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto it = lru_entries_.begin(); it != lru_entries_.end();) {
+        bool overlaps = false;
+        for (ChipId mmio_id : it->mmio_device_ids) {
+            if (mmio_device_ids.contains(mmio_id)) {
+                overlaps = true;
+                break;
+            }
+        }
+        if (overlaps) {
+            auto next = std::next(it);
+            erase_entry(it);
+            it = next;
+        } else {
+            ++it;
+        }
+    }
+}
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/distributed/pinned_memory_cache.hpp
+++ b/tt_metal/distributed/pinned_memory_cache.hpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <unordered_map>
+
+namespace tt::tt_metal {
+class HostBuffer;
+namespace distributed {
+class MeshDevice;
+class MeshCoordinateRangeSet;
+}  // namespace distributed
+namespace experimental {
+class PinnedMemory;
+}  // namespace experimental
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal::experimental {
+
+/**
+ * @brief LRU cache for PinnedMemory objects, keyed by host buffer address.
+ *
+ * The cache is the long-term owner of all PinnedMemory objects used by the
+ * tensor read/write paths. HostBuffer::pinned_memory_ is only populated
+ * transiently (during enqueue_read calls) and cleared immediately afterward.
+ *
+ * The cache evicts global LRU entries to keep total cached pinned memory under
+ * the runtime-configured limit. When pinning fails due to the kernel pin limit
+ * being exhausted, it evicts the oldest entry that shares an MMIO device with
+ * the failing pin and retries.
+ *
+ * Two cleanup hooks ensure PinnedMemory never outlives its underlying memory
+ * or its device:
+ *  - HostBuffer pins release entries associated with their host address before
+ *    the last pin releases the underlying host memory.
+ *  - MeshDevice::~MeshDevice() calls release_for_device(mmio_ids) to remove
+ *    all entries associated with the closing device.
+ *
+ * Callers must always handle a nullptr return from try_pin by falling back to
+ * the unpinned transfer path.
+ */
+class PinnedMemoryCache {
+public:
+    static PinnedMemoryCache& instance();
+
+    /**
+     * @brief Try to obtain pinned memory for a HostBuffer.
+     *
+     * If the buffer is already cached (by host address), returns the existing
+     * PinnedMemory immediately. Otherwise evicts global LRU entries to make
+     * room under the cache-size limit, then creates a new one, retrying after
+     * evicting LRU entries on the target MMIO device if creation fails.
+     * Returns nullptr on permanent failure (not an error condition).
+     *
+     * @param mesh_device          Mesh device to pin for.
+     * @param coordinate_range_set Set of device coordinates to pin for.
+     * @param host_buffer          Host buffer whose memory should be pinned.
+     * @param map_to_noc           Whether to map the buffer for direct NOC access.
+     * @return Shared pointer to PinnedMemory, or nullptr if pinning is unavailable.
+     */
+    std::shared_ptr<PinnedMemory> try_pin(
+        distributed::MeshDevice& mesh_device,
+        const distributed::MeshCoordinateRangeSet& coordinate_range_set,
+        HostBuffer& host_buffer,
+        bool map_to_noc = false);
+
+    /**
+     * @brief Release all cache entries whose host address matches `host_address`.
+     */
+    void release(const void* host_address);
+
+    /**
+     * @brief Release all cache entries associated with the given MeshDevice.
+     *
+     * Called from MeshDevice::~MeshDevice() to ensure cached PinnedMemory
+     * objects do not outlive the device they were created for. Internally
+     * maps the device's chip IDs to MMIO device IDs and evicts all matching
+     * entries.
+     */
+    void release_for_device(distributed::MeshDevice& mesh_device);
+
+    /**
+     * @brief Return the number of entries currently held in the cache.
+     */
+    size_t num_entries() const;
+
+private:
+    PinnedMemoryCache() = default;
+
+    // ChipId = int (matches tt_metal/api/tt-metalium/mesh_config.hpp)
+    struct CacheEntry {
+        std::shared_ptr<PinnedMemory> pinned_memory;
+        const void* host_address = nullptr;
+        std::set<int> device_ids;
+        std::set<int> mmio_device_ids;
+        bool map_to_noc = false;
+    };
+
+    // Compute the set of chip IDs covered by the requested mesh coordinate range.
+    std::set<int> compute_device_ids(
+        distributed::MeshDevice& mesh_device, const distributed::MeshCoordinateRangeSet& coordinate_range_set);
+
+    // Compute the set of MMIO chip IDs that back the requested device IDs.
+    std::set<int> compute_mmio_device_ids(const std::set<int>& device_ids);
+
+    // Erase the entry pointed to by `it` from both lru_entries_ and address_map_.
+    void erase_entry(std::list<CacheEntry>::iterator it);
+
+    // Erase all entries for `host_address`. Caller must hold mutex_.
+    void release_locked(const void* host_address);
+
+    // Evict oldest unreferenced entries until adding `incoming_size_bytes` keeps the cache under its limit.
+    bool evict_oldest_until_within_limit(size_t incoming_size_bytes);
+
+    // Evict the oldest unreferenced entry across all MMIO devices.
+    bool evict_oldest_entry();
+
+    // Evict the oldest unreferenced entry that overlaps the target MMIO devices.
+    bool evict_oldest_entry_for_mmio_ids(const std::set<int>& target_mmio_ids);
+
+    // Check whether any existing entry for `host_addr` has MMIO overlap with
+    // `target_mmio_ids` and is still referenced externally (use_count > 1),
+    // which would prevent the kernel driver from accepting a new pin.
+    bool has_conflicting_entry(const void* host_addr, const std::set<int>& target_mmio_ids) const;
+
+    mutable std::mutex mutex_;
+    std::list<CacheEntry> lru_entries_;  // front = oldest (LRU candidate)
+    std::unordered_multimap<const void*, std::list<CacheEntry>::iterator> address_map_;
+    size_t current_size_bytes_ = 0;
+};
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/distributed/sources.cmake
+++ b/tt_metal/distributed/sources.cmake
@@ -17,6 +17,7 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_workload.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_workload_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pinned_memory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pinned_memory_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/system_mesh.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/system_mesh_translation_map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/distributed_host_buffer.cpp

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -15,6 +15,8 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/math.hpp>
+#include <tt-metalium/experimental/pinned_memory.hpp>
+#include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include <tt_stl/concepts.hpp>
 #include <tt_stl/small_vector.hpp>
 
@@ -36,6 +38,23 @@ bool is_uniform_write(const HostTensor& host_tensor, const distributed::MeshDevi
     return std::ranges::all_of(
         all_coords, [&](const auto& coord) { return host_buffer.shard_coords().contains(coord); });
 }
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+constexpr size_t k_pin_write_threshold_bytes = 32 * 1024 * 1024;
+
+bool should_use_pinned_write_path(distributed::MeshDevice& mesh_device, size_t size_bytes) {
+    if (size_bytes <= k_pin_write_threshold_bytes) {
+        return false;
+    }
+    const auto params = experimental::GetMemoryPinningParameters(mesh_device);
+    return params.max_pins > 0 && params.can_map_to_noc;
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+
+}  // namespace
 
 // ======================================================================================
 //                                Uniform Data movement APIs
@@ -93,8 +112,34 @@ void enqueue_read_tensor(
         "Host tensor has different page config");
 
     auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
+    auto* device = mesh_buffer->device();
 
-    cq.enqueue_read(mesh_buffer, host_tensor.impl().buffer(), /*shards=*/std::nullopt, blocking);
+    DistributedHostBuffer dst_distributed_host_buffer = DistributedHostBuffer::create(device->get_view());
+    const size_t expected_per_shard_size_bytes = device_tensor.tensor_spec().compute_packed_buffer_size_bytes();
+
+    distributed::MeshCoordinateRange all_coords(device->shape());
+    std::vector<distributed::MeshCoordinate> coords(all_coords.begin(), all_coords.end());
+    for (const auto& coord : coords) {
+        dst_distributed_host_buffer.emplace_shard(coord, [&]() {
+            auto host_buffer = host_tensor.buffer().get_shard(coord);
+            TT_FATAL(host_buffer.has_value(), "Host shard for device shard {} is not populated.", coord);
+            TT_FATAL(
+                host_buffer->view_bytes().size() >= expected_per_shard_size_bytes,
+                "Host shard for device shard {} has invalid size: {} < {}",
+                coord,
+                host_buffer->view_bytes().size(),
+                expected_per_shard_size_bytes);
+
+            auto coord_range = distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(coord, coord));
+            if (auto pinned = experimental::PinnedMemoryCache::instance().try_pin(
+                    *device, coord_range, *host_buffer, /*map_to_noc=*/true)) {
+                experimental::HostBufferSetPinnedMemory(*host_buffer, std::move(pinned));
+            }
+            return *host_buffer;
+        });
+    }
+
+    cq.enqueue_read(mesh_buffer, dst_distributed_host_buffer, /*shards=*/std::nullopt, blocking);
     host_tensor.update_tensor_topology(device_tensor.tensor_topology());
 }
 
@@ -110,9 +155,51 @@ void enqueue_write_tensor(distributed::MeshCommandQueue& cq, const HostTensor& h
         "Host tensor has different page config");
 
     auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
+    const auto& distributed_host_buffer = host_tensor.buffer();
 
-    // Uniform H2D copy.
-    cq.enqueue_write(mesh_buffer, host_tensor.buffer(), /*blocking=*/false);
+    size_t total_size = 0;
+    for (const auto& coord : distributed_host_buffer.shard_coords()) {
+        auto buf = distributed_host_buffer.get_shard(coord);
+        if (buf) {
+            total_size += buf->view_bytes().size();
+        }
+    }
+
+    const bool use_pinned = CMAKE_UNIQUE_NAMESPACE::should_use_pinned_write_path(*cq.device(), total_size);
+
+    if (use_pinned) {
+        auto* mesh_device = mesh_buffer->device();
+        std::vector<distributed::ShardDataTransfer> transfers;
+        transfers.reserve(distributed_host_buffer.shard_coords().size());
+        bool any_pinned = false;
+
+        for (const auto& coord : distributed_host_buffer.shard_coords()) {
+            auto buf = distributed_host_buffer.get_shard(coord);
+            if (buf) {
+                auto coord_range = distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(coord, coord));
+                HostBuffer pinned_buf(*buf);
+                auto pinned_memory = experimental::PinnedMemoryCache::instance().try_pin(
+                    *mesh_device, coord_range, pinned_buf, /*map_to_noc=*/true);
+
+                auto xfer = distributed::ShardDataTransfer{distributed::MeshCoordinate(coord)}
+                                .host_data(buf->view_bytes().data())
+                                .region(BufferRegion(0, buf->view_bytes().size()));
+                if (pinned_memory) {
+                    experimental::ShardDataTransferSetPinnedMemory(xfer, std::move(pinned_memory));
+                    any_pinned = true;
+                }
+                transfers.push_back(std::move(xfer));
+            }
+        }
+        if (any_pinned) {
+            cq.enqueue_write_shards(mesh_buffer, transfers, /*blocking=*/true);
+        } else {
+            cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        }
+    } else {
+        cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+    }
+
     device_tensor = MeshTensor(
         mesh_buffer,
         host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()),
@@ -252,7 +339,34 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         expected_packed_buffer_size_bytes);
 
     auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
-    command_queue.enqueue_write_mesh_buffer(mesh_buffer, data_to_write.data(), /*blocking=*/false);
+    auto* mesh_device = mesh_buffer->device();
+
+    const bool use_pinned =
+        ::tt::tt_metal::CMAKE_UNIQUE_NAMESPACE::should_use_pinned_write_path(*mesh_device, data_to_write.size());
+
+    if (use_pinned) {
+        auto full_range = distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(mesh_device->shape()));
+        HostBuffer pinned_buffer(*host_buffer);
+        auto pinned_memory = experimental::PinnedMemoryCache::instance().try_pin(
+            *mesh_device, full_range, pinned_buffer, /*map_to_noc=*/true);
+
+        if (pinned_memory) {
+            std::vector<distributed::ShardDataTransfer> transfers;
+            transfers.reserve(mesh_device->shape().mesh_size());
+            for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+                auto xfer = distributed::ShardDataTransfer{coord}
+                                .host_data(const_cast<void*>(static_cast<const void*>(data_to_write.data())))
+                                .region(BufferRegion(0, data_to_write.size()));
+                experimental::ShardDataTransferSetPinnedMemory(xfer, pinned_memory);
+                transfers.push_back(std::move(xfer));
+            }
+            command_queue.enqueue_write_shards(mesh_buffer, transfers, /*blocking=*/true);
+        } else {
+            command_queue.enqueue_write_mesh_buffer(mesh_buffer, data_to_write.data(), /*blocking=*/false);
+        }
+    } else {
+        command_queue.enqueue_write_mesh_buffer(mesh_buffer, data_to_write.data(), /*blocking=*/false);
+    }
 
     const auto& mesh_device_shape = mesh_buffer->device()->shape();
     auto topology = TensorTopology::create_fully_replicated_tensor_topology(mesh_device_shape);
@@ -285,13 +399,57 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
     }
 
     auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
-    cq.enqueue_write(mesh_buffer, host_tensor.buffer(), /*blocking=*/false);
+    const auto& distributed_host_buffer = host_tensor.buffer();
+
+    size_t total_size = 0;
+    for (const auto& coord : distributed_host_buffer.shard_coords()) {
+        auto buf = distributed_host_buffer.get_shard(coord);
+        if (buf) {
+            total_size += buf->view_bytes().size();
+        }
+    }
+
+    const bool use_pinned =
+        ::tt::tt_metal::CMAKE_UNIQUE_NAMESPACE::should_use_pinned_write_path(*cq.device(), total_size);
+
+    if (use_pinned) {
+        auto* mesh_device = mesh_buffer->device();
+        std::vector<distributed::ShardDataTransfer> transfers;
+        transfers.reserve(distributed_host_buffer.shard_coords().size());
+        bool any_pinned = false;
+
+        for (const auto& coord : distributed_host_buffer.shard_coords()) {
+            auto buf = distributed_host_buffer.get_shard(coord);
+            if (buf) {
+                auto coord_range = distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(coord, coord));
+                HostBuffer pinned_buf(*buf);
+                auto pinned_memory = experimental::PinnedMemoryCache::instance().try_pin(
+                    *mesh_device, coord_range, pinned_buf, /*map_to_noc=*/true);
+
+                auto xfer = distributed::ShardDataTransfer{distributed::MeshCoordinate(coord)}
+                                .host_data(buf->view_bytes().data())
+                                .region(BufferRegion(0, buf->view_bytes().size()));
+                if (pinned_memory) {
+                    experimental::ShardDataTransferSetPinnedMemory(xfer, std::move(pinned_memory));
+                    any_pinned = true;
+                }
+                transfers.push_back(std::move(xfer));
+            }
+        }
+        if (any_pinned) {
+            cq.enqueue_write_shards(mesh_buffer, transfers, /*blocking=*/true);
+        } else {
+            cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        }
+    } else {
+        cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+    }
 
     // DistributedHostBuffer may not cover the entire MeshDevice, must preserve coords here.
     // Coordinates here represents the shards that are local to this instance, there maybe other shards that are on
     // another host.
     std::vector<distributed::MeshCoordinate> coords;
-    const auto& shard_coords = host_tensor.buffer().shard_coords();
+    const auto& shard_coords = distributed_host_buffer.shard_coords();
     coords.reserve(shard_coords.size());
     std::copy(shard_coords.begin(), shard_coords.end(), std::back_inserter(coords));
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -71,6 +72,11 @@ enum class EnvVarID {
     // ========================================
     TT_METAL_CLEAR_L1,    // Clear L1 memory on device init
     TT_METAL_CLEAR_DRAM,  // Clear DRAM on device init
+
+    // ========================================
+    // HOST MEMORY
+    // ========================================
+    TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES,  // Maximum cached pinned host memory
 
     // ========================================
     // DEBUG & TESTING
@@ -517,6 +523,39 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: 0 (don't clear)
         // Usage: export TT_METAL_CLEAR_DRAM=1
         case EnvVarID::TT_METAL_CLEAR_DRAM: this->clear_dram = is_env_enabled(value); break;
+
+        // ========================================
+        // HOST MEMORY
+        // ========================================
+
+        // TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES
+        // Maximum host memory bytes held by the pinned memory cache.
+        // Default: 4GB
+        // Usage: export TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES=4294967296
+        case EnvVarID::TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES: {
+            std::string limit_value = trim_copy(value);
+            if (limit_value.empty() || limit_value.front() == '-') {
+                TT_THROW("TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES must be a non-negative byte count: {}", value);
+            }
+
+            try {
+                size_t parse_pos = 0;
+                unsigned long long parsed_limit = std::stoull(limit_value, &parse_pos, 0);
+                if (parse_pos != limit_value.size()) {
+                    TT_THROW("TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES must be a byte count: {}", value);
+                }
+                if (parsed_limit > std::numeric_limits<size_t>::max()) {
+                    TT_THROW("TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES value out of range: {}", value);
+                }
+                this->pinned_memory_cache_limit_bytes = static_cast<size_t>(parsed_limit);
+            } catch (const std::invalid_argument&) {
+                TT_THROW("Invalid TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES: {}", value);
+            } catch (const std::out_of_range&) {
+                TT_THROW("TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES value out of range: {}", value);
+            }
+            break;
+        }
+
         // ========================================
         // DEBUG & TESTING
         // ========================================

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -12,6 +12,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <map>
@@ -215,6 +216,8 @@ class RunTimeOptions {
 
     bool clear_l1 = false;
     bool clear_dram = false;
+
+    size_t pinned_memory_cache_limit_bytes = 4ULL * 1024 * 1024 * 1024;
 
     bool skip_loading_fw = false;
 
@@ -610,6 +613,9 @@ public:
 
     bool get_clear_dram() const { return clear_dram; }
     void set_clear_dram(bool clear) { clear_dram = clear; }
+
+    size_t get_pinned_memory_cache_limit_bytes() const { return pinned_memory_cache_limit_bytes; }
+    void set_pinned_memory_cache_limit_bytes(size_t limit_bytes) { pinned_memory_cache_limit_bytes = limit_bytes; }
 
     std::string get_visible_devices() const { return visible_devices; }
     std::string get_arch_name() const { return arch_name; }


### PR DESCRIPTION
Category: Performance

### Ticket
#25673

### Problem description
Large host/device transfers for distributed tensors currently use the standard unpinned host transfer flow, which copies through the regular staging path on each operation instead of reusing host-pinned buffers for direct device DMA. That adds overhead for large writes and misses an opportunity to reuse host pinning across repeated transfers to the same mesh buffers.

### What's changed
This branch adds a pinned-memory fast path for large distributed tensor transfers and introduces a cache so pinned host mappings can be reused across operations instead of recreated each time.

The main changes are:
- Add `PinnedMemoryCache`, an LRU cache for `PinnedMemory` objects keyed by host buffer address, with cleanup hooks tied to host-buffer destruction and `MeshDevice` teardown.
- Use the cache in `ttnn` host-to-device paths for large writes:
  - replicated writes pin once across the full mesh
  - distributed writes pin per shard when possible
  - fall back to the existing unpinned path when pinning is unavailable
- Use cached pinned memory in `copy_to_host` for preallocated host tensors, while intentionally leaving `to_host()` on the regular path since it allocates fresh host buffers and would not benefit from cache reuse.
- Thread pinned-memory metadata through mesh command queue shard transfers so async read/write paths can preserve the required barrier/event lifetime handling.
- Add a regression test covering cache upgrade behavior when the same host buffer is first pinned for one shard and later reused for a wider mesh range.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/tensorpinmemory)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/tensorpinmemory)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/tensorpinmemory)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/tensorpinmemory)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/tensorpinmemory)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/tensorpinmemory)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset
  - [ ] other selection - specify runs

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/tensorpinmemory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/tensorpinmemory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/tensorpinmemory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/tensorpinmemory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/tensorpinmemory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/tensorpinmemory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/tensorpinmemory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/tensorpinmemory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/tensorpinmemory)