### PR TITLE
fix: make MeshCoordinateRange and MeshContainer iterators satisfy std::forward_iterator

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -5,6 +5,7 @@
 #include <boost/move/utility_core.hpp>
 #include <gtest/gtest.h>
 #include <cstdint>
+#include <iterator>
 #include <optional>
 #include <unordered_set>
 #include <utility>
@@ -14,6 +15,16 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/shape_base.hpp>
 #include <tt_stl/span.hpp>
+
+// Verify that MeshCoordinateRange::Iterator satisfies the C++20 std::forward_iterator concept.
+// This catches missing type aliases (iterator_category, value_type, difference_type, etc.)
+// and ensures the iterator can be used with std::vector range construction and STL algorithms.
+static_assert(std::forward_iterator<tt::tt_metal::distributed::MeshCoordinateRange::Iterator>);
+
+// Note: MeshContainer::Iterator and ConstIterator are stashing proxy iterators (ValueProxy is
+// stored inside the iterator). std::indirectly_readable requires iter_reference_t<const I> ==
+// iter_reference_t<I>, which cannot be satisfied without changing proxy semantics. No standard
+// concept check is asserted for these iterators.
 
 namespace tt::tt_metal::distributed {
 namespace {

--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -1222,4 +1222,3 @@ TEST(MeshCoordinateRangeTest, VectorConstructionFromIterators) {
 
 }  // namespace
 }  // namespace tt::tt_metal::distributed
-

--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -1198,5 +1198,17 @@ TEST(MeshCoordinateRangeTest, Wraparound4D_BasicIterationAndShape) {
 
 // Add more detailed assertions as needed
 
+TEST(MeshCoordinateRangeTest, VectorConstructionFromIterators) {
+    // Verify that MeshCoordinateRange::Iterator satisfies the requirements for
+    // std::vector range construction (requires standard iterator type aliases).
+    MeshShape shape({2, 4});
+    auto coord_range = MeshCoordinateRange(shape);
+    std::vector<MeshCoordinate> coords(coord_range.begin(), coord_range.end());
+    EXPECT_EQ(coords.size(), 8u);
+    EXPECT_EQ(coords.front(), MeshCoordinate({0, 0}));
+    EXPECT_EQ(coords.back(), MeshCoordinate({1, 3}));
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::distributed
+

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -642,4 +642,3 @@ struct hash<tt::tt_metal::distributed::MeshCoordinateRangeSet> {
 };
 
 }  // namespace std
-

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -177,6 +177,8 @@ public:
         using pointer = const MeshCoordinate*;
         using reference = const MeshCoordinate&;
 
+        // Default-constructs a singular (invalid) iterator. Required by std::forward_iterator.
+        Iterator() : current_coord_(MeshCoordinate::zero_coordinate(0)) {}
         Iterator& operator++();
         Iterator operator++(int);
         const MeshCoordinate& operator*() const;
@@ -336,6 +338,7 @@ public:
         using reference = ValueProxy&;
 
         Iterator& operator++();
+        Iterator operator++(int);
         ValueProxy& operator*() { return value_proxy_; }
         const ValueProxy& operator*() const { return value_proxy_; }
         ValueProxy* operator->() { return &value_proxy_; }
@@ -365,6 +368,7 @@ public:
         using reference = const ValueProxy&;
 
         ConstIterator& operator++();
+        ConstIterator operator++(int);
         const ValueProxy& operator*() const { return value_proxy_; }
         const ValueProxy* operator->() const { return &value_proxy_; }
         bool operator==(const ConstIterator& other) const;
@@ -502,6 +506,13 @@ typename MeshContainer<T>::Iterator& MeshContainer<T>::Iterator::operator++() {
 }
 
 template <typename T>
+typename MeshContainer<T>::Iterator MeshContainer<T>::Iterator::operator++(int) {
+    auto tmp = *this;
+    ++*this;
+    return tmp;
+}
+
+template <typename T>
 MeshContainer<T>::ConstIterator::ConstIterator(
     const MeshContainer* container, const MeshCoordinateRange::Iterator& coord_iter, size_t linear_index) :
     container_(container),
@@ -519,6 +530,13 @@ typename MeshContainer<T>::ConstIterator& MeshContainer<T>::ConstIterator::opera
         coord_iter_ != container_->coord_range_.end() ? *coord_iter_ : MeshCoordinate::zero_coordinate(container_->shape().dims()),
         linear_index_ < container_->values_.size() ? &container_->values_[linear_index_] : nullptr);
     return *this;
+}
+
+template <typename T>
+typename MeshContainer<T>::ConstIterator MeshContainer<T>::ConstIterator::operator++(int) {
+    auto tmp = *this;
+    ++*this;
+    return tmp;
 }
 
 template <typename T>

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -171,6 +171,12 @@ public:
     // Iterator over the range, provides access to coordinates in row-major order.
     class Iterator {
     public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = MeshCoordinate;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const MeshCoordinate*;
+        using reference = const MeshCoordinate&;
+
         Iterator& operator++();
         Iterator operator++(int);
         const MeshCoordinate& operator*() const;
@@ -618,3 +624,4 @@ struct hash<tt::tt_metal::distributed::MeshCoordinateRangeSet> {
 };
 
 }  // namespace std
+


### PR DESCRIPTION
## Ticket

Closes https://github.com/tenstorrent/tt-metal/issues/41621

## Problem description

`MeshCoordinateRange::Iterator` was missing the five standard iterator type aliases (`iterator_category`, `value_type`, `difference_type`, `pointer`, `reference`) and a default constructor. This caused the following pattern to fail to compile:

```cpp
auto coord_range = MeshCoordinateRange(device.shape());
std::vector<MeshCoordinate> coords(coord_range.begin(), coord_range.end());
```

`std::vector`'s range constructor deduces the iterator type via `std::iterator_traits`, which requires these aliases to be present. Without them, the template substitution fails.

## What's changed

**`mesh_coord.hpp` — `MeshCoordinateRange::Iterator` only (no semantic changes):**
- Added five standard type aliases so `std::iterator_traits` works
- Added `Iterator()` default constructor (required by `std::forward_iterator`; constructs a singular/invalid iterator)
- Added postfix `operator++(int)` to `MeshContainer::Iterator` and `MeshContainer::ConstIterator`, which were simply missing (no behaviour change)

**`test_mesh_coord.cpp`:**
- Added `static_assert(std::forward_iterator<MeshCoordinateRange::Iterator>)` so regressions are caught at compile time
- Added `VectorConstructionFromIterators` unit test
- Added explanatory comment for why `MeshContainer::Iterator`/`ConstIterator` do not get a concept check (stashing proxy iterator — `std::indirectly_readable` cannot be satisfied without semantic changes)

## Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu-b/mesh-coord-itr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu-b/mesh-coord-itr)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu-b/mesh-coord-itr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu-b/mesh-coord-itr)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu-b/mesh-coord-itr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu-b/mesh-coord-itr)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
