### PR TITLE
vLLM warmup rework and trace memory corruption fixes

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -119,15 +119,35 @@ class SamplingGenerator:
                 continue
         self._trace_states.clear()
 
-    def reset_prompt_tokens(self, prompt_tokens):
+    def reset_prompt_tokens(
+        self,
+        prompt_tokens,
+        *,
+        prompt_tokens_tt: ttnn.Tensor | None = None,
+        prompt_src_tt: ttnn.Tensor | None = None,
+    ):
         if not self._penalties_active:
             return
-        self.tt_penalties.reset_prompt_tokens(prompt_tokens)
+        self.tt_penalties.reset_prompt_tokens(
+            prompt_tokens,
+            prompt_tokens_tt=prompt_tokens_tt,
+            src_tt=prompt_src_tt,
+        )
 
-    def reset_output_state(self, tokens=None):
+    def reset_output_state(
+        self,
+        tokens=None,
+        *,
+        output_tokens_tt: ttnn.Tensor | None = None,
+        output_src_tt: ttnn.Tensor | None = None,
+    ):
         if not self._penalties_active:
             return
-        self.tt_penalties.reset_output_tokens(tokens)
+        self.tt_penalties.reset_output_tokens(
+            tokens,
+            output_tokens_tt=output_tokens_tt,
+            src_tt=output_src_tt,
+        )
 
     # ---------------------------------------------------------------------
     # Prefill / decode state helpers
@@ -160,6 +180,10 @@ class SamplingGenerator:
         reset_batch: bool = False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
+        prompt_tokens_tt: ttnn.Tensor | None = None,
+        prompt_src_tt: ttnn.Tensor | None = None,
+        output_tokens_tt: ttnn.Tensor | None = None,
+        output_src_tt: ttnn.Tensor | None = None,
     ):
         """Format, merge (if row-sharded), and apply sampling params for one model instance.
 
@@ -195,9 +219,22 @@ class SamplingGenerator:
             formatted_params = SamplingParams(**concat_fields)
             self.reset_sampling_params(formatted_params)
 
+        logger.info(f"reset_batch: {reset_batch}")
         if reset_batch:
-            self.reset_prompt_tokens(prompt_tokens)
-            self.reset_output_state(output_tokens)
+            logger.info(f"reset_prompt_tokens")
+            self.reset_prompt_tokens(
+                prompt_tokens,
+                prompt_tokens_tt=prompt_tokens_tt,
+                prompt_src_tt=prompt_src_tt,
+            )
+            logger.info(f"reset_prompt_tokens completed")
+            logger.info(f"reset_output_state")
+            self.reset_output_state(
+                output_tokens,
+                output_tokens_tt=output_tokens_tt,
+                output_src_tt=output_src_tt,
+            )
+            logger.info(f"reset_output_state completed")
 
     # ---------------------------------------------------------------------
     # Sampling helpers
@@ -213,8 +250,11 @@ class SamplingGenerator:
             num_logprobs=num_logprobs,
             empty_slots=empty_slots,
         )
+        logger.info(f"reset_sampling_params completed")
         if self.tt_sampling.force_argmax_sampling != old_force_argmax_sampling:
+            logger.info(f"reset_trace")
             self.reset_trace()
+            logger.info(f"reset_trace completed")
 
         old_penalties_active = self._penalties_active
         self._penalties_active = not (
@@ -227,10 +267,13 @@ class SamplingGenerator:
             or self._penalties_active
             or self._penalties_active != old_penalties_active
         ):
+            logger.info(f"reset_penalties")
             self.tt_penalties.reset_params(
                 sampling_params.presence_penalty, sampling_params.frequency_penalty, sampling_params.repetition_penalty
             )
+            logger.info(f"reset_penalties completed")
         self._log_probs_active = self.tt_sampling.log_probs_calculator.enable_log_probs
+        logger.info(f"log_probs_active set to {self._log_probs_active}")
 
     def _validate_trace_inputs(self, slot, logits: ttnn.Tensor, tt_out_tok: Optional[ttnn.Tensor]):
         if slot["input"] is None or slot["output"] is None:
@@ -271,6 +314,7 @@ class SamplingGenerator:
         logits: ttnn.Tensor,
         *,
         tt_out_tok: Optional[ttnn.Tensor] = None,
+        warmup_mode: bool = True,
     ) -> ttnn.Tensor:
         """
         Capture a trace of the sampling pipeline for the given configuration.
@@ -281,14 +325,19 @@ class SamplingGenerator:
 
         key, slot = self._trace_slot(penalties_on, log_probs_on, force_argmax)
 
-        logger.debug(
-            f"Pre-compiling sampling path before trace capture (penalties={penalties_on},log_probs_on={log_probs_on},force_argmax={force_argmax})"
-        )
-        self._run_sampling(
-            logits,
-            penalties_on=penalties_on,
-            tt_out_tok=tt_out_tok,
-        )
+        if warmup_mode:
+            logger.debug(
+                f"Pre-compiling sampling path before trace capture (penalties={penalties_on},log_probs_on={log_probs_on},force_argmax={force_argmax})"
+            )
+            self._run_sampling(
+                logits,
+                penalties_on=penalties_on,
+                tt_out_tok=tt_out_tok,
+            )
+        else:
+            logger.debug(
+                f"Sampling pre-compilation skipped before trace capture (penalties={penalties_on},log_probs_on={log_probs_on},force_argmax={force_argmax})"
+            )
 
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=self.cq_id)
         sampled = self._run_sampling(
@@ -330,6 +379,7 @@ class SamplingGenerator:
         *,
         enable_trace: bool = True,
         tt_out_tok: Optional[ttnn.Tensor] = None,
+        warmup_mode: bool = True,
     ) -> ttnn.Tensor:
         """
         Convenience wrapper that either runs the sampling module directly or
@@ -340,6 +390,10 @@ class SamplingGenerator:
         log_probs_on = getattr(self, "_log_probs_active", False)
         force_argmax = self.tt_sampling.force_argmax_sampling
         use_internal_trace = enable_trace and self.enable_internal_trace
+
+        logger.info(
+            f"Sampling generator internal trace: {use_internal_trace}, enable_trace: {enable_trace}, self.enable_internal_trace: {self.enable_internal_trace}, warmup_mode: {warmup_mode}"
+        )
 
         if not use_internal_trace:
             tt_out = self._run_sampling(
@@ -353,6 +407,7 @@ class SamplingGenerator:
                 return self.capture_trace(
                     logits,
                     tt_out_tok=tt_out_tok,
+                    warmup_mode=warmup_mode,
                 )
 
             self._validate_trace_inputs(slot, logits, tt_out_tok)

--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -294,6 +294,7 @@ class LogProbsCalculator:
                 and the rest of the batch retains its previous values.
         """
         if empty_slots is not None:
+            logger.info(f"setting log_probs_mode: partial update")
             # Partial update: only modify the specified batch positions
             if isinstance(enable_log_probs, list):
                 for i, slot in enumerate(empty_slots):
@@ -310,6 +311,7 @@ class LogProbsCalculator:
                     for slot in empty_slots:
                         self.num_logprobs[slot] = num_logprobs
         else:
+            logger.info(f"setting log_probs_mode: full batch update")
             # Full batch update
             if isinstance(enable_log_probs, list):
                 self.logprobs_enabled = list(enable_log_probs)
@@ -325,11 +327,14 @@ class LogProbsCalculator:
                 self.num_logprobs = [0] * self.batch_size
 
         # Recompute derived flags from the full arrays
+        logger.info(f"recomputing derived flags from the full arrays")
         self.enable_log_probs = any(self.logprobs_enabled)
         # Top-K computation is needed whenever logprobs are enabled (even with
         # num_logprobs=0) because the sampled token's logprob is extracted from
         # the top-K results in the new path.
+        logger.info(f"topk_logprobs_needed: {self.topk_logprobs_needed}")
         self.topk_logprobs_needed = self.enable_log_probs
+        logger.info(f"now topk_logprobs_needed: {self.topk_logprobs_needed}")
 
     def _compute_global_stats(
         self,

--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any, List, Optional
 
 import torch
+from loguru import logger
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
@@ -137,6 +138,7 @@ class TTPenalties(LightweightModule):
         self._shard_dims_gathered = shard_dims_gathered
 
         self.prompt_mask = self._alloc_int_buffer(shard_dims=shard_dims)
+        self.prompt_counts = self._alloc_int_buffer(shard_dims=shard_dims)
         self.output_mask = self._alloc_int_buffer(shard_dims=shard_dims)
         self.output_counts_gathered = self._alloc_int_buffer(shard_dims=shard_dims_gathered)
         self.output_counts = self._alloc_int_buffer(shard_dims=shard_dims)
@@ -144,6 +146,8 @@ class TTPenalties(LightweightModule):
             host=torch.ones(self._total_batch, 1), shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT
         )
         self.zeros = self._alloc_int_buffer(shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT)
+        self.scatter_add_output = self._alloc_int_buffer(shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT)
+        self.tilize_output = self._alloc_int_buffer(shard_dims=shard_dims_gathered)
         self.presence_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
         self.frequency_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
         self.repetition_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
@@ -240,7 +244,13 @@ class TTPenalties(LightweightModule):
             return tokens_2d[: self._total_batch]
         return tokens_2d
 
-    def reset_prompt_tokens(self, prompt_tokens: torch.Tensor):
+    def reset_prompt_tokens(
+        self,
+        prompt_tokens: torch.Tensor,
+        *,
+        prompt_tokens_tt: Optional[ttnn.Tensor] = None,
+        src_tt: Optional[ttnn.Tensor] = None,
+    ):
         # Mask out padding positions (-1) instead of inventing a fake token id by expanding vocab_size.
         prompt_tokens_2d = prompt_tokens.reshape(-1, prompt_tokens.shape[-1])
         prompt_tokens_2d = self._pad_batch_to_max(prompt_tokens_2d, pad_value=-1)
@@ -248,19 +258,59 @@ class TTPenalties(LightweightModule):
         src_host = (prompt_tokens_2d != -1).to(torch.int32)
         idx_host = torch.where(prompt_tokens_2d == -1, torch.zeros_like(prompt_tokens_2d), prompt_tokens_2d)
 
-        prompt_tokens_tt = self._alloc_int_buffer(
-            host=idx_host,
-            shard_dims=self._shard_dims_gathered,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
+        using_preallocated_buffers = prompt_tokens_tt is not None and src_tt is not None
+        if using_preallocated_buffers:
+            logger.info(f"using preallocated buffers")
+            mapper = (
+                ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._shard_dims_gathered, mesh_shape=self.cluster_shape)
+                if self._sampling_dp > 1
+                else None
+            )
+            idx_host_tt = ttnn.from_torch(
+                idx_host,
+                device=None,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=mapper,
+            )
+            src_host_tt = ttnn.from_torch(
+                src_host,
+                device=None,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=mapper,
+            )
+            ttnn.copy_host_to_device_tensor(idx_host_tt, prompt_tokens_tt)
+            ttnn.copy_host_to_device_tensor(src_host_tt, src_tt)
+        else:
+            logger.info(f"allocating prompt_tokens_tt")
+            prompt_tokens_tt = self._alloc_int_buffer(
+                host=idx_host,
+                shard_dims=self._shard_dims_gathered,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+            logger.info(f"allocating src_tt")
+            src_tt = self._alloc_int_buffer(
+                host=src_host,
+                shard_dims=self._shard_dims_gathered,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+        logger.info(f"token_bin_counts_and_mask")
+        self.token_bin_counts_and_mask(
+            new_tokens=prompt_tokens_tt,
+            src=src_tt,
+            counts_sliced=self.prompt_counts,
+            mask=self.prompt_mask,
+            deallocate_new_tokens=not using_preallocated_buffers,
         )
-        src_tt = self._alloc_int_buffer(
-            host=src_host,
-            shard_dims=self._shard_dims_gathered,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        self.token_bin_counts_and_mask(new_tokens=prompt_tokens_tt, src=src_tt, mask=self.prompt_mask)
 
-    def reset_output_tokens(self, tokens=None):
+    def reset_output_tokens(
+        self,
+        tokens=None,
+        *,
+        output_tokens_tt: Optional[ttnn.Tensor] = None,
+        src_tt: Optional[ttnn.Tensor] = None,
+    ):
         # ALWAYS reset output buffers to zero first (this is the core accuracy fix from issue #35731)
         # This ensures penalty statistics are cleared between prefill and decode phases
         self.output_mask = ttnn.mul(self.output_mask, 0, output_tensor=self.output_mask, **self._op_kwargs)
@@ -277,34 +327,62 @@ class TTPenalties(LightweightModule):
             src_host = (tokens_2d != -1).to(torch.int32)
             idx_host = torch.where(tokens_2d == -1, torch.zeros_like(tokens_2d), tokens_2d)
 
-            mapper = (
-                ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._shard_dims_gathered, mesh_shape=self.cluster_shape)
-                if self._sampling_dp > 1
-                else None
-            )
-            tokens_tt = ttnn.from_torch(
-                idx_host,
-                device=self.mesh_device,
-                dtype=ttnn.uint32,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                mesh_mapper=mapper,
-            )
-            src_tt = ttnn.from_torch(
-                src_host,
-                device=self.mesh_device,
-                dtype=ttnn.int32,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                mesh_mapper=mapper,
-            )
+            using_preallocated_buffers = output_tokens_tt is not None and src_tt is not None
+            if using_preallocated_buffers:
+                logger.info(f"using preallocated output buffers")
+                mapper = (
+                    ttnn.ShardTensor2dMesh(
+                        self.mesh_device, dims=self._shard_dims_gathered, mesh_shape=self.cluster_shape
+                    )
+                    if self._sampling_dp > 1
+                    else None
+                )
+                idx_host_tt = ttnn.from_torch(
+                    idx_host,
+                    device=None,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=mapper,
+                )
+                src_host_tt = ttnn.from_torch(
+                    src_host,
+                    device=None,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=mapper,
+                )
+                ttnn.copy_host_to_device_tensor(idx_host_tt, output_tokens_tt)
+                ttnn.copy_host_to_device_tensor(src_host_tt, src_tt)
+            else:
+                mapper = (
+                    ttnn.ShardTensor2dMesh(
+                        self.mesh_device, dims=self._shard_dims_gathered, mesh_shape=self.cluster_shape
+                    )
+                    if self._sampling_dp > 1
+                    else None
+                )
+                output_tokens_tt = ttnn.from_torch(
+                    idx_host,
+                    device=self.mesh_device,
+                    dtype=ttnn.uint32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=mapper,
+                )
+                src_tt = ttnn.from_torch(
+                    src_host,
+                    device=self.mesh_device,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=mapper,
+                )
             self.token_bin_counts_and_mask(
-                new_tokens=tokens_tt,
+                new_tokens=output_tokens_tt,
                 counts=self.output_counts_gathered,
                 src=src_tt,
                 counts_sliced=self.output_counts,
                 mask=self.output_mask,
+                deallocate_new_tokens=not using_preallocated_buffers,
             )
-            tokens_tt.deallocate()
-            src_tt.deallocate()
 
     def update_output_tokens(self, new_tokens):
         # Reshape decode token to [batch, 1] for scatter_add.
@@ -330,18 +408,44 @@ class TTPenalties(LightweightModule):
             mask=self.output_mask,
         )
 
-    def token_bin_counts_and_mask(self, new_tokens, src, counts=None, mask=None, counts_sliced=None):
-        counts_new = ttnn.scatter_add(self.zeros, 1, new_tokens, src, **self._op_kwargs)
-
-        new_tokens.deallocate()
-        # need to use use_low_perf because llama galaxy runs out of L1 otherwise
-        counts_new = ttnn.tilize(
-            counts_new, **self._op_kwargs, use_low_perf=True if self.sub_core_grids is not None else False
+    def token_bin_counts_and_mask(
+        self,
+        new_tokens,
+        src,
+        counts=None,
+        mask=None,
+        counts_sliced=None,
+        *,
+        deallocate_new_tokens: bool = True,
+    ):
+        logger.info(f"scatter_add")
+        counts_new = ttnn.scatter_add(
+            self.zeros,
+            1,
+            new_tokens,
+            src,
+            output_tensor=self.scatter_add_output,
+            **self._op_kwargs,
         )
+        logger.info(f"scatter_add completed")
+        if deallocate_new_tokens:
+            new_tokens.deallocate()
+        # need to use use_low_perf because llama galaxy runs out of L1 otherwise
+        logger.info(f"tilizing counts_new")
+        counts_new = ttnn.tilize(
+            counts_new,
+            output_tensor=self.tilize_output,
+            **self._op_kwargs,
+            use_low_perf=True if self.sub_core_grids is not None else False,
+        )
+        logger.info(f"tilizing counts_new completed")
         if counts:
+            logger.info(f"adding counts")
             counts = ttnn.add(counts, counts_new, output_tensor=counts, **self._op_kwargs)
         else:
+            logger.info(f"no counts, setting counts to counts_new")
             counts = counts_new
+        logger.info(f"slicing counts")
         counts_sliced = ttnn.slice(
             counts,
             self.slice_start,
@@ -351,8 +455,9 @@ class TTPenalties(LightweightModule):
             num_devices=self.num_devices,
             **self._op_kwargs,
         )
-
+        logger.info(f"slicing counts completed")
         mask = ttnn.gt(counts_sliced, 0, output_tensor=mask, **self._op_kwargs)
+        logger.info(f"gt completed")
         return counts, mask
 
     def apply(self, tt_logits: ttnn.Tensor) -> ttnn.Tensor:

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -346,6 +346,7 @@ class TTSampling(LightweightModule):
             else:
                 mapper = None
 
+            logger.info(f"creating k_tensor from torch tensor")
             self.k_tensor_new = ttnn.from_torch(
                 torch.tensor(k),
                 device=None,
@@ -353,6 +354,7 @@ class TTSampling(LightweightModule):
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=mapper,
             )
+            logger.info(f"creating p_tensor from torch tensor")
             self.p_tensor_new = ttnn.from_torch(
                 torch.tensor(p),
                 device=None,
@@ -360,6 +362,7 @@ class TTSampling(LightweightModule):
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=mapper,
             )
+            logger.info(f"creating temp_tensor from torch tensor")
             self.temp_tensor_new = ttnn.from_torch(
                 torch.tensor(temp),
                 device=None,
@@ -368,13 +371,17 @@ class TTSampling(LightweightModule):
                 mesh_mapper=mapper,
             )
 
+            logger.info(f"copying to device")
             ttnn.copy_host_to_device_tensor(self.k_tensor_new, self.k_tensor)
             ttnn.copy_host_to_device_tensor(self.p_tensor_new, self.p_tensor)
             ttnn.copy_host_to_device_tensor(self.temp_tensor_new, self.temp_tensor)
+            logger.info(f"copying to device completed")
 
+        logger.info(f"setting log_probs_calculator mode")
         self.log_probs_calculator.set_log_probs_mode(
             enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
         )
+        logger.info(f"log_probs_calculator mode set")
 
     def forward(
         self,

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -101,16 +101,51 @@ class WarmupForwardMixin:
         logger.info(f"Start pos shape: {start_pos.shape}")
         logger.info(f"Page table shape: {page_table.shape}")
 
-        for param in sampling_params:
-            logger.info(f"Warming up decode for sampling params: {param}")
-            self.decode_forward(
-                tokens=tokens,
-                start_pos=start_pos,
-                page_table=page_table,
-                kv_cache=kv_cache,
-                enable_trace=enable_trace,
-                read_from_device=True,
-                sampling_params=param,
-            )
+        trace_values = [False, True] if enable_trace else [False]
+        for trace_value in trace_values:
+            for param in sampling_params:
+                # summarize sampling params for simple logging
+                if param is None:
+                    param_summary = "None"
+                else:
+                    temp0 = (
+                        param.temperature[0]
+                        if isinstance(param.temperature, list) and len(param.temperature) > 0
+                        else param.temperature
+                    )
+                    topk0 = param.top_k[0] if isinstance(param.top_k, list) and len(param.top_k) > 0 else param.top_k
+                    topp0 = param.top_p[0] if isinstance(param.top_p, list) and len(param.top_p) > 0 else param.top_p
+                    penalties_on = any(
+                        x is not None
+                        and (
+                            (isinstance(x, list) and len(x) > 0 and x[0] not in (0.0, 1.0))
+                            or (not isinstance(x, list) and x not in (0.0, 1.0, None))
+                        )
+                        for x in (param.presence_penalty, param.frequency_penalty, param.repetition_penalty)
+                    )
+                    log_probs_on = (
+                        any(param.enable_log_probs)
+                        if isinstance(param.enable_log_probs, list)
+                        else bool(param.enable_log_probs)
+                    )
+                    param_summary = (
+                        f"temperature={temp0}, top_k={topk0}, top_p={topp0}, "
+                        f"penalties_on={penalties_on}, log_probs_on={log_probs_on}"
+                    )
+
+                warmup_mode = not trace_value
+                logger.info(
+                    f"Warming up decode for sampling params: {param_summary} with enable_trace={trace_value} and warmup_mode={warmup_mode}"
+                )
+                self.decode_forward(
+                    tokens=tokens,
+                    start_pos=start_pos,
+                    page_table=page_table,
+                    kv_cache=kv_cache,
+                    enable_trace=trace_value,
+                    read_from_device=True,
+                    sampling_params=param,
+                    warmup_mode=warmup_mode,
+                )
 
         logger.info("Decode warmup completed")

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -224,6 +224,8 @@ class DeepseekGenerator(WarmupForwardMixin):
         # Tokenizer is optional; caller can pass a tokenizer or handle failure.
         self.tokenizer = tokenizer
 
+        self.hf_config.num_hidden_layers = 5
+        logger.info(f"num_hidden_layers: {self.hf_config.num_hidden_layers}")
         # Runtime helpers
         self.ccl = CCL(mesh_device)
         mesh_shape = list(mesh_device.shape)
@@ -302,68 +304,80 @@ class DeepseekGenerator(WarmupForwardMixin):
 
     def _validate_and_initialize_sampling(
         self,
-        sampling_params: SamplingParams | None,
+        new_sampling_params: SamplingParams | None,
         sample_on_device: bool,
         enable_trace: bool = False,
         enable_mtp: bool = False,
+        warmup_mode: bool = False,
     ) -> None:
         if enable_mtp and sample_on_device:
             raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
 
-        current_sampling_params = getattr(self, "sampling_params", None)
-        params_same = (
-            sampling_params is not None
-            and current_sampling_params is not None
-            and self._are_sampling_params_same(sampling_params, current_sampling_params)
-        )
-        if not params_same:
-            self.sampling_generator = None
-            self.sampling_params = None
-
-        if not sample_on_device:
-            self.sampling_generator = None
-
-        if getattr(self, "sampling_generator", None) is not None:
-            return
-
         self.sample_on_device = sample_on_device
+        previous_sampling_params = getattr(self, "sampling_params", None)
+
         # sampling params of all users are assumed to be the same default values if not provided.
-        self.sampling_params = (
-            self._to_local_sampling_params(sampling_params)
-            if sampling_params is not None
+        normalized_sampling_params = (
+            self._to_local_sampling_params(new_sampling_params)
+            if new_sampling_params is not None
             else SamplingParams(
                 temperature=[DEFAULT_SAMPLING_TEMPERATURE] * self.batch_size,
                 top_p=[DEFAULT_SAMPLING_TOP_P] * self.batch_size,
                 top_k=[DEFAULT_SAMPLING_TOP_K] * self.batch_size,
             )
         )
-        if self._get_sampling_value(self.sampling_params.top_k, 0) == 0 and sample_on_device:
-            raise SystemExit(
-                "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
-            )
-        if sample_on_device:
-            enable_internal_trace_sampling = enable_trace and self.sample_on_device
-            self.sampling_args = make_deepseek_sampling_args(
-                self.mesh_device,
-                self.hf_config.vocab_size,
-                max_batch_size=self.batch_size_per_row,
-            )
-            self.sampling_generator = SamplingGenerator(
-                args=self.sampling_args,
-                mesh_device=self.mesh_device,
-                tt_ccl=self.ccl,
-                enable_internal_trace=enable_internal_trace_sampling,
+
+        if self.sample_on_device:
+            params_same = previous_sampling_params is not None and self._are_sampling_params_same(
+                normalized_sampling_params, previous_sampling_params
             )
 
-            self._reset_sampling_state(self.sampling_params, self.batch_size, self.batch_size_per_row)
+            if self._get_sampling_value(normalized_sampling_params.top_k, 0) == 0:
+                raise SystemExit(
+                    "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
+                )
+
+            if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
+                logger.info(f"Sampling generator exists")
+                # sampling generator exists; reset if params are different
+                if not params_same:
+                    logger.info(f"Sampling params are different; resetting sampling state")
+                    self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
+                else:
+                    logger.info(f"Sampling params are the same; no need to reset sampling state")
+            else:
+                # create new sampling generator
+                logger.info(f"Creating new sampling generator")
+                enable_internal_trace_sampling = enable_trace
+                self.sampling_args = make_deepseek_sampling_args(self.mesh_device, self.hf_config.vocab_size)
+                self.sampling_generator = SamplingGenerator(
+                    args=self.sampling_args,
+                    mesh_device=self.mesh_device,
+                    tt_ccl=self.ccl,
+                    enable_internal_trace=enable_internal_trace_sampling,
+                )
+                logger.info(f"Resetting sampling state")
+                self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
+                logger.info(f"Sampling state reset")
+
+            # disable internal trace of sampling generator for warmup mode
+            if warmup_mode:
+                self.sampling_generator.enable_internal_trace = False
+
+            logger.info(f"Sampling generator internal trace: {self.sampling_generator.enable_internal_trace}")
+
+        self.sampling_params = normalized_sampling_params
 
         logger.info(f"Sampling mode: {'device' if sample_on_device else 'host'}")
-        logger.info(
-            f"Sampling parameters for first user (other users may have different values): "
-            + f"temperature={self._get_sampling_value(self.sampling_params.temperature, 0)}, "
-            + f"top_p={self._get_sampling_value(self.sampling_params.top_p, 0)}, "
-            + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
-        )
+        if self.sampling_params:
+            logger.info(
+                f"Sampling parameters for first user (other users may have different values): "
+                + f"temperature={self._get_sampling_value(self.sampling_params.temperature, 0)}, "
+                + f"top_p={self._get_sampling_value(self.sampling_params.top_p, 0)}, "
+                + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
+            )
+        else:
+            logger.info("sampling parameters = None")
 
     def _to_local_sampling_params(self, params_obj) -> SamplingParams:
         """Project duck-typed sampling params to local SamplingParams fields."""
@@ -405,6 +419,88 @@ class DeepseekGenerator(WarmupForwardMixin):
         if isinstance(value, (list, tuple)):
             return f"{type(value).__name__}(len={len(value)})"
         return type(value).__name__
+
+    def _free_prefill_token_buffers(self) -> None:
+        buffers = getattr(self, "_prefill_tokens_tt_by_seq_len", None)
+        if not buffers:
+            return
+        for seq_len, tensor in buffers.items():
+            try:
+                ttnn.deallocate(tensor)
+            except Exception as e:
+                logger.warning(f"Failed to deallocate prefill token buffer for seq_len={seq_len}: {e}")
+        self._prefill_tokens_tt_by_seq_len = {}
+
+    def _get_prefill_tokens_buffer(self, seq_len: int) -> ttnn.Tensor:
+        buffers = getattr(self, "_prefill_tokens_tt_by_seq_len", None)
+        if buffers is None:
+            buffers = {}
+            self._prefill_tokens_tt_by_seq_len = buffers
+        cached = buffers.get(seq_len)
+        if cached is not None:
+            return cached
+        zero_host = torch.zeros((1, 1, seq_len), dtype=torch.int32)
+        tt_buffer = ttnn.from_torch(
+            zero_host,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        buffers[seq_len] = tt_buffer
+        return tt_buffer
+
+    def _free_sampling_reset_prompt_buffers(self) -> None:
+        buffers = getattr(self, "_sampling_reset_prompt_buffers", None)
+        if not buffers:
+            return
+        for key in ("prompt_tokens_tt", "prompt_src_tt", "output_tokens_tt", "output_src_tt"):
+            tensor = buffers.get(key)
+            if tensor is None:
+                continue
+            try:
+                ttnn.deallocate(tensor)
+            except Exception as e:
+                logger.warning(f"Failed to deallocate sampling reset buffer {key}: {e}")
+        self._sampling_reset_prompt_buffers = None
+
+    def _get_sampling_reset_prompt_buffers(self, token_width: int) -> dict:
+        penalties = self.sampling_generator.tt_penalties
+        expected_shape = (penalties._total_batch, token_width)
+
+        buffers = getattr(self, "_sampling_reset_prompt_buffers", None)
+        if buffers is not None:
+            if buffers.get("owner") is penalties and buffers.get("shape") == expected_shape:
+                return buffers
+            self._free_sampling_reset_prompt_buffers()
+
+        zero_host = torch.zeros(expected_shape, dtype=torch.int32)
+        self._sampling_reset_prompt_buffers = {
+            "owner": penalties,
+            "shape": expected_shape,
+            "prompt_tokens_tt": penalties._alloc_int_buffer(
+                host=zero_host,
+                shard_dims=penalties._shard_dims_gathered,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            ),
+            "prompt_src_tt": penalties._alloc_int_buffer(
+                host=zero_host,
+                shard_dims=penalties._shard_dims_gathered,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            ),
+            "output_tokens_tt": penalties._alloc_int_buffer(
+                host=zero_host,
+                shard_dims=penalties._shard_dims_gathered,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            ),
+            "output_src_tt": penalties._alloc_int_buffer(
+                host=zero_host,
+                shard_dims=penalties._shard_dims_gathered,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            ),
+        }
+        return self._sampling_reset_prompt_buffers
 
     def _dump_meminfo(self, header: str) -> None:
         if self.enable_mem_profile:
@@ -550,6 +646,15 @@ class DeepseekGenerator(WarmupForwardMixin):
 
     def cleanup_all(self) -> None:
         """Comprehensive cleanup of all resources managed by the generator."""
+        try:
+            self._free_sampling_reset_prompt_buffers()
+        except Exception as e:
+            logger.warning(f"Failed to cleanup sampling reset prompt buffers: {e}")
+        try:
+            self._free_prefill_token_buffers()
+        except Exception as e:
+            logger.warning(f"Failed to cleanup prefill token buffers: {e}")
+
         # Clear TTNN weight cache
         try:
             self.clear_ttnn_weight_cache()
@@ -746,22 +851,43 @@ class DeepseekGenerator(WarmupForwardMixin):
 
     def _reset_sampling_state(self, sampling_params: SamplingParams, batch_size: int, batch_size_per_row: int) -> None:
         # TODO(vllm): Thread prompt/output token state into sampling resets for penalty correctness.
+        logger.info(f"format_sampling_params")
         sampling_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
         sampling_dp = self.sampling_generator.tt_sampling._sampling_dp
+        logger.info(f"chunk_sampling_params")
         sampling_param_chunks = chunk_sampling_params(sampling_params, sampling_dp)
         seed = getattr(sampling_params, "seed", None)
         if seed is not None:
             user_ids = list(range(batch_size))
+            logger.info(f"reset_seed")
             self.sampling_generator.seed_manager.reset_seed(seed, user_ids)
+
+        logger.info(f"creating prompt_tokens")
+        prompt_tokens = torch.zeros((batch_size_per_row, 1), dtype=torch.int64)
+        logger.info(f"prompt_tokens shape: {prompt_tokens.shape}")
+        logger.info(f"creating output_tokens")
+        output_tokens = torch.zeros((batch_size_per_row, 1), dtype=torch.int64)
+        logger.info(f"output_tokens shape: {output_tokens.shape}")
+        prompt_reset_buffers = self._get_sampling_reset_prompt_buffers(prompt_tokens.shape[-1])
+        logger.info(f"apply_decode_state")
         self.sampling_generator.apply_decode_state(
             sampling_param_chunks,
             reset_batch=True,
-            prompt_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
-            output_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
+            prompt_tokens=prompt_tokens,
+            output_tokens=output_tokens,
+            prompt_tokens_tt=prompt_reset_buffers["prompt_tokens_tt"],
+            prompt_src_tt=prompt_reset_buffers["prompt_src_tt"],
+            output_tokens_tt=prompt_reset_buffers["output_tokens_tt"],
+            output_src_tt=prompt_reset_buffers["output_src_tt"],
         )
+        logger.info(f"sampling state reseted")
 
     def _sample_tokens_device(
-        self, logits: ttnn.Tensor, enable_trace: bool = False, user_slots: list[int] | None = None
+        self,
+        logits: ttnn.Tensor,
+        enable_trace: bool = False,
+        user_slots: list[int] | None = None,
+        warmup_mode: bool = True,
     ) -> ttnn.Tensor:
         sampling_batch_size = self.sampling_generator.tt_sampling.max_batch_size
         sampling_logits = logits
@@ -789,7 +915,11 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.sampling_generator.seed_manager.get_new_values(user_slots)
         self.sampling_generator.enable_internal_trace = enable_trace
         try:
-            tt_out = self.sampling_generator.sample(sampling_logits, enable_trace=enable_trace)
+            tt_out = self.sampling_generator.sample(
+                sampling_logits,
+                enable_trace=enable_trace,
+                warmup_mode=warmup_mode,
+            )
         finally:
             if sampling_logits is not logits:
                 ttnn.deallocate(sampling_logits)
@@ -804,10 +934,12 @@ class DeepseekGenerator(WarmupForwardMixin):
         return tt_out
 
     def _tokens_from_device(self, tt_out_tok, mesh_device, batch_size_per_row: int) -> torch.Tensor:
+        logger.info(f"before to_torch tt_out_tok shape: {tt_out_tok.shape}")
         composed = ttnn.to_torch(
             tt_out_tok,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, -1), mesh_shape=tuple(mesh_device.shape)),
         )
+        logger.info(f"after to_torch composed shape: {composed.shape}")
         if composed.ndim == 4:
             if tt_out_tok.shape[-2] == batch_size_per_row:
                 tokens = composed[:, :, :, 0]
@@ -2232,15 +2364,18 @@ class DeepseekGenerator(WarmupForwardMixin):
         tokens = tokens.view(1, 1, -1)
         seq_len = tokens.shape[-1]
 
-        # Prepare TT inputs for prefill - reshape to [1, 1, actual_seq_len]
-        tt_tokens = ttnn.from_torch(
+        # Reuse per-seq_len device buffers and only refresh host values per call.
+        logger.info(f"before copy_host_to_device tokens shape: {tokens.shape} user_id: {user_id}")
+        tt_tokens = self._get_prefill_tokens_buffer(seq_len)
+        host_tokens_tt = ttnn.from_torch(
             tokens,
-            device=self.mesh_device,
+            device=None,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
             dtype=ttnn.uint32,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
+        ttnn.copy_host_to_device_tensor(host_tokens_tt, tt_tokens)
+        logger.info(f"after copy_host_to_device tt_tokens shape: {tt_tokens.shape} user_id: {user_id}")
 
         rot_mats = self.rope_setup.get_rot_mats_table(seq_len)
         rope_tensors = {
@@ -2266,6 +2401,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                 return_hidden=True,
             )
         else:
+            logger.info(f"before forward_prefill user_id: {user_id}")
             logits_tt = RowBatchedModel.forward_prefill(
                 x=tt_tokens,
                 user_id=user_id,
@@ -2279,15 +2415,17 @@ class DeepseekGenerator(WarmupForwardMixin):
             raise ValueError("sample_on_device=True and return_last_hidden=True is not supported.")
 
         if sample_on_device:
+            logger.info(f"sample_on_device: Returning logits_tt from {logits_tt.shape}")
             logits = logits_tt
         else:
+            logger.info(f"sample_on_device: Converting logits_tt to torch from {logits_tt.shape}")
             logits = ttnn.to_torch(
                 logits_tt,
                 mesh_composer=ttnn.ConcatMesh2dToTensor(
                     self.mesh_device, dims=(-2, -1), mesh_shape=self.mesh_device.shape
                 ),
             )
-
+            logger.info(f"sample_on_device: Converted logits to torch from {logits.shape}")
         if self.enable_mtp:
             # Prime MTP cache for this user using prompt tokens.
             mtp_page_table = self._get_mtp_page_table()
@@ -2386,7 +2524,6 @@ class DeepseekGenerator(WarmupForwardMixin):
 
             ttnn.deallocate(hidden_tt)
 
-        ttnn.deallocate(tt_tokens)
         self._deallocate_rope_tensors(rope_tensors)
         if not sample_on_device:
             ttnn.deallocate(logits_tt)
@@ -2664,18 +2801,20 @@ class DeepseekGenerator(WarmupForwardMixin):
         init_tokens: torch.Tensor,
         positions: torch.Tensor,
         page_tables: torch.Tensor | None = None,
+        warmup_mode: bool = True,
     ) -> None:
         """Allocate persistent inputs, capture trace for one decode iteration, and store trace state."""
         assert self._trace_id is None, "Trace already captured"
 
         # 1) Warm-up compile run (no trace) to keep compilation out of capture
-        logger.info("Running warm-up decode step (no trace)...")
-        if self.signpost:
-            signpost(header="decode_warmup")
-        _ = self._decode_step(init_tokens, positions, page_tables=page_tables, sample_on_device=False)
-        ttnn.synchronize_device(self.mesh_device)
-        if self.signpost:
-            signpost(header="decode_warmup")
+        if warmup_mode:
+            logger.info("Running warm-up decode step (no trace)...")
+            if self.signpost:
+                signpost(header="decode_warmup")
+            _ = self._decode_step(init_tokens, positions, page_tables=page_tables, sample_on_device=False)
+            ttnn.synchronize_device(self.mesh_device)
+            if self.signpost:
+                signpost(header="decode_warmup")
 
         # 2) Allocate persistent device inputs
         self._trace_tokens = self._tt_from_tokens_step(init_tokens)
@@ -2729,6 +2868,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         page_table: torch.Tensor | None = None,
         kv_cache: None = None,
         sample_on_device: bool = False,
+        warmup_mode: bool = True,
     ) -> ttnn.Tensor | torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
@@ -2739,7 +2879,12 @@ class DeepseekGenerator(WarmupForwardMixin):
         else:
             # Capture trace and return trace output
             if self._trace_id is None:
-                self._capture_decode_trace(tokens, start_pos, page_table)
+                self._capture_decode_trace(
+                    tokens,
+                    start_pos,
+                    page_table,
+                    warmup_mode=warmup_mode,
+                )
                 # First call: return the captured run's output
                 assert self._trace_output is not None
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -174,6 +174,20 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
         self.cache_dir = cache_dir
+        disable_program_cache = False
+        if disable_program_cache:
+            logger.info("Disabling program cache on mesh_device")
+            self.mesh_device.disable_and_clear_program_cache()
+        else:
+            logger.info("program cache enabled on mesh_device")
+
+        logger.info(f"TT_METAL_TRACE_ALLOC_TRACKING: {os.environ.get('TT_METAL_TRACE_ALLOC_TRACKING', 'undefined')}")
+        logger.info(
+            f"TT_METAL_TRACE_ALLOC_TRACEBACKS: {os.environ.get('TT_METAL_TRACE_ALLOC_TRACEBACKS', 'undefined')}"
+        )
+        logger.info(
+            f"TT_METAL_TRACE_ALLOC_SKIP_PROGRAM_CACHE: {os.environ.get('TT_METAL_TRACE_ALLOC_SKIP_PROGRAM_CACHE', 'undefined')}"
+        )
 
         # Load HF config + tokenizer
         self.hf_config = (
@@ -301,6 +315,9 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         self._prepare_weight_configs(cache_dir)
         self._assert_mtp_available()
+
+        logger.info(f"before get_prefill_tokens_buffer max_seq_len: {self.hf_config.max_seq_len}")
+        tt_tokens = self._get_prefill_tokens_buffer(self.hf_config.max_seq_len)
 
     def _validate_and_initialize_sampling(
         self,
@@ -431,15 +448,20 @@ class DeepseekGenerator(WarmupForwardMixin):
                 logger.warning(f"Failed to deallocate prefill token buffer for seq_len={seq_len}: {e}")
         self._prefill_tokens_tt_by_seq_len = {}
 
-    def _get_prefill_tokens_buffer(self, seq_len: int) -> ttnn.Tensor:
+    def _get_prefill_tokens_buffer(self, seq_len: int, use_max_seq_len: bool = True) -> ttnn.Tensor:
+        if use_max_seq_len:
+            logger.info(f"Using max_seq_len: {self.hf_config.max_seq_len}")
+            seq_len = self.hf_config.max_seq_len
         buffers = getattr(self, "_prefill_tokens_tt_by_seq_len", None)
         if buffers is None:
             buffers = {}
             self._prefill_tokens_tt_by_seq_len = buffers
         cached = buffers.get(seq_len)
         if cached is not None:
+            logger.info(f"Using cached prefill tokens buffer for seq_len={seq_len}")
             return cached
         zero_host = torch.zeros((1, 1, seq_len), dtype=torch.int32)
+        logger.info(f"Creating new prefill tokens buffer for seq_len={seq_len}")
         tt_buffer = ttnn.from_torch(
             zero_host,
             device=self.mesh_device,
@@ -449,6 +471,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
         buffers[seq_len] = tt_buffer
+        logger.info(f"New prefill tokens buffer created for seq_len={seq_len}")
         return tt_buffer
 
     def _free_sampling_reset_prompt_buffers(self) -> None:
@@ -2367,6 +2390,10 @@ class DeepseekGenerator(WarmupForwardMixin):
         # Reuse per-seq_len device buffers and only refresh host values per call.
         logger.info(f"before copy_host_to_device tokens shape: {tokens.shape} user_id: {user_id}")
         tt_tokens = self._get_prefill_tokens_buffer(seq_len)
+        tt_tokens_trimmed = tt_tokens
+        if tt_tokens.shape[-1] != seq_len:
+            tt_tokens_trimmed = ttnn.slice(tt_tokens, [0, 0, 0], [1, 1, seq_len])
+
         host_tokens_tt = ttnn.from_torch(
             tokens,
             device=None,
@@ -2374,7 +2401,8 @@ class DeepseekGenerator(WarmupForwardMixin):
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
-        ttnn.copy_host_to_device_tensor(host_tokens_tt, tt_tokens)
+        logger.info(f"before copy_host_to_device host_tokens_tt shape: {host_tokens_tt.shape} user_id: {user_id}")
+        ttnn.copy_host_to_device_tensor(host_tokens_tt, tt_tokens_trimmed)
         logger.info(f"after copy_host_to_device tt_tokens shape: {tt_tokens.shape} user_id: {user_id}")
 
         rot_mats = self.rope_setup.get_rot_mats_table(seq_len)
@@ -2393,7 +2421,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         last_hidden = None
         if self.enable_mtp:
             logits_tt, hidden_tt = RowBatchedModel.forward_prefill(
-                x=tt_tokens,
+                x=tt_tokens_trimmed,
                 user_id=user_id,
                 cfg=self.model_run_config_prefill,
                 rope_tensors=rope_tensors,
@@ -2403,7 +2431,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         else:
             logger.info(f"before forward_prefill user_id: {user_id}")
             logits_tt = RowBatchedModel.forward_prefill(
-                x=tt_tokens,
+                x=tt_tokens_trimmed,
                 user_id=user_id,
                 cfg=self.model_run_config_prefill,
                 rope_tensors=rope_tensors,
@@ -2524,6 +2552,8 @@ class DeepseekGenerator(WarmupForwardMixin):
 
             ttnn.deallocate(hidden_tt)
 
+        if tt_tokens_trimmed is not tt_tokens:
+            ttnn.deallocate(tt_tokens_trimmed)
         self._deallocate_rope_tensors(rope_tensors)
         if not sample_on_device:
             ttnn.deallocate(logits_tt)

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -79,6 +79,8 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         return self.cache_dir
 
     def prefill_forward(self, *args, **kwargs):
+        positional_arg_names = [f"arg{i}" for i in range(len(args))]
+        logger.info(f"prefill_forward positional arg names: {positional_arg_names}, keyword arg names: {kwargs.keys()}")
         start_pos = kwargs.get("start_pos", None)
         assert (start_pos is None) or all(
             x == 0 for x in start_pos
@@ -112,11 +114,18 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         )
         num_of_users = tokens.shape[0]
         if sample_on_device:
-            self._validate_and_initialize_sampling(sampling_params, sample_on_device)
+            logger.info("Validating and initializing sampling")
+            self._validate_and_initialize_sampling(
+                sampling_params,
+                sample_on_device,
+                enable_trace=False,
+                warmup_mode=False,
+            )
 
         user_outputs = []
         for i in range(num_of_users):
             user_id = empty_slots[i] if empty_slots is not None else i
+            logger.info(f"Processing user {user_id}")
             prompt_len = int(lengths[i])
             if prompt_len == 0:
                 if sample_on_device:
@@ -173,6 +182,8 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         return prefill_output
 
     def decode_forward(self, *args, **kwargs):
+        positional_arg_names = [f"arg{i}" for i in range(len(args))]
+        logger.info(f"decode_forward positional arg names: {positional_arg_names}, keyword arg names: {kwargs.keys()}")
         assert self.model_run_config_decode is not None, "Model run config decode is not initialized"
 
         page_tables = kwargs.get("page_table", None)
@@ -180,24 +191,40 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         enable_trace = kwargs.get("enable_trace", False)
         read_from_device = kwargs.get("read_from_device", True)
         sampling_params = kwargs.get("sampling_params", None)
+        warmup_mode = kwargs.get("warmup_mode", False)
         sample_on_device = bool(sampling_params is not None)
+        logger.info(
+            f"decode_forward sample_on_device: {sample_on_device}, warmup_mode: {warmup_mode} enable_trace: {enable_trace}"
+        )
+
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):
             self.set_kv_cache(kv_cache)
 
         tokens_step = kwargs["tokens"].squeeze(1)
         if sample_on_device:
-            self._validate_and_initialize_sampling(sampling_params, sample_on_device, enable_trace=enable_trace)
+            logger.info("decode_forward: Validating and initializing sampling")
+            self._validate_and_initialize_sampling(
+                sampling_params,
+                sample_on_device,
+                enable_trace=enable_trace,
+                warmup_mode=warmup_mode,
+            )
         decode_step_output = super().decode_forward(
             tokens=tokens_step,
             start_pos=kwargs["start_pos"],
             enable_trace=enable_trace,
             page_table=page_tables,
             sample_on_device=sample_on_device,
+            warmup_mode=warmup_mode,
         )
 
         if sample_on_device:
-            decode_output = self._sample_tokens_device(decode_step_output, enable_trace=enable_trace)
+            decode_output = self._sample_tokens_device(
+                decode_step_output,
+                enable_trace=enable_trace,
+                warmup_mode=warmup_mode,
+            )
             if read_from_device:
                 decode_output = self._tokens_from_device(
                     decode_output, self.mesh_device, batch_size_per_row=self.batch_size_per_row

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
@@ -26,6 +26,7 @@ void ScatterDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor{tensor_args.input_tensor};
     const auto& index_tensor{tensor_args.index_tensor};
     const auto& src_tensor{tensor_args.src_tensor};
+    const auto& preallocated_output_tensor{tensor_args.preallocated_output};
     const auto& input_dtype{input_tensor.dtype()};
     const auto& index_dtype{index_tensor.dtype()};
     const auto& src_dtype{src_tensor.dtype()};
@@ -53,10 +54,31 @@ void ScatterDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be allocated on a device.");
     TT_FATAL(index_tensor.storage_type() == StorageType::DEVICE, "Index tensor must be allocated on a device.");
     TT_FATAL(src_tensor.storage_type() == StorageType::DEVICE, "Src tensor must be allocated on a device.");
+
+    if (preallocated_output_tensor.has_value()) {
+        TT_FATAL(
+            preallocated_output_tensor.value().storage_type() == StorageType::DEVICE,
+            "Preallocated output tensor must be allocated on a device.");
+        TT_FATAL(
+            preallocated_output_tensor.value().logical_shape() == input_tensor.logical_shape(),
+            "Preallocated output tensor must match input logical shape.");
+        TT_FATAL(
+            preallocated_output_tensor.value().dtype() == input_tensor.dtype(),
+            "Preallocated output tensor dtype must match input dtype.");
+        TT_FATAL(
+            preallocated_output_tensor.value().layout() == Layout::ROW_MAJOR,
+            "Preallocated output tensor must be ROW_MAJOR layout.");
+        TT_FATAL(
+            preallocated_output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Preallocated output tensor must use INTERLEAVED memory layout.");
+    }
 }
 
 ScatterDeviceOperation::spec_return_value_t ScatterDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output->tensor_spec();
+    }
     using namespace tt::tt_metal;
     return TensorSpec{
         tensor_args.input_tensor.logical_shape(),
@@ -65,6 +87,9 @@ ScatterDeviceOperation::spec_return_value_t ScatterDeviceOperation::compute_outp
 
 ScatterDeviceOperation::tensor_return_value_t ScatterDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output.value();
+    }
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 
@@ -85,11 +110,12 @@ ttnn::Tensor scatter(
     const Tensor& source_tensor,
     const MemoryConfig& output_memory_config,
     const operations::data_movement::scatter::ScatterReductionType& reduction,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const std::optional<Tensor>& preallocated_output_tensor) {
     using OperationType = ttnn::prim::ScatterDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{dim, output_memory_config, reduction, sub_core_grid},
-        OperationType::tensor_args_t{input_tensor, index_tensor, source_tensor});
+        OperationType::tensor_args_t{input_tensor, index_tensor, source_tensor, preallocated_output_tensor});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
@@ -49,5 +49,6 @@ ttnn::Tensor scatter(
     const Tensor& source_tensor,
     const MemoryConfig& output_memory_config,
     const ttnn::operations::data_movement::scatter::ScatterReductionType& opt_reduction,
-    const std::optional<CoreRangeSet>& sub_core_grid);
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const std::optional<Tensor>& preallocated_output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation_types.hpp
@@ -25,6 +25,7 @@ struct ScatterInputs {
     const Tensor& input_tensor;
     const Tensor& index_tensor;
     const Tensor& src_tensor;
+    std::optional<Tensor> preallocated_output;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
@@ -276,7 +276,8 @@ Tensor scatter(
     const Tensor& source_tensor,
     const std::optional<MemoryConfig>& output_memory_config,
     const std::optional<std::string>& opt_reduction_string,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const std::optional<Tensor>& output_tensor) {
     const ttnn::Shape& original_input_tensor_lshape = input_tensor.logical_shape();
     const auto input_tensor_rank = input_tensor.padded_shape().rank();
 
@@ -309,6 +310,12 @@ Tensor scatter(
     Tensor transformed_source_tensor = pre_scatter_transform_tensor(
         source_tensor, dim, input_tensor_is_dim_last_idx, input_tensor_is_rank_le_4d, index_tensor.logical_shape());
 
+    std::optional<Tensor> transformed_output_tensor = std::nullopt;
+    if (output_tensor.has_value()) {
+        transformed_output_tensor = pre_scatter_transform_tensor(
+            output_tensor.value(), dim, input_tensor_is_dim_last_idx, input_tensor_is_rank_le_4d);
+    }
+
     const MemoryConfig final_memory_config{
         output_memory_config.has_value() ? output_memory_config.value() : input_tensor.memory_config()};
 
@@ -321,7 +328,8 @@ Tensor scatter(
         transformed_source_tensor,
         final_memory_config,
         reduction,
-        sub_core_grid);
+        sub_core_grid,
+        transformed_output_tensor);
     output = post_scatter_transform_tensor(
         output,
         after_transpose_shape,
@@ -338,9 +346,17 @@ Tensor scatter_add(
     const Tensor& index_tensor,
     const Tensor& source_tensor,
     const std::optional<MemoryConfig>& output_memory_config,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const std::optional<Tensor>& output_tensor) {
     return scatter(
-        input_tensor, dim, index_tensor, source_tensor, output_memory_config, std::make_optional("add"), sub_core_grid);
+        input_tensor,
+        dim,
+        index_tensor,
+        source_tensor,
+        output_memory_config,
+        std::make_optional("add"),
+        sub_core_grid,
+        output_tensor);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.hpp
@@ -20,7 +20,8 @@ Tensor scatter(
     const Tensor& source_tensor,
     const std::optional<MemoryConfig>& output_memory_config = std::nullopt,
     const std::optional<std::string>& opt_reduction_string = std::nullopt,
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    const std::optional<Tensor>& output_tensor = std::nullopt);
 
 Tensor scatter_add(
     const Tensor& input_tensor,
@@ -28,6 +29,7 @@ Tensor scatter_add(
     const Tensor& index_tensor,
     const Tensor& source_tensor,
     const std::optional<MemoryConfig>& output_memory_config = std::nullopt,
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    const std::optional<Tensor>& output_tensor = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter_nanobind.cpp
@@ -54,7 +54,8 @@ void bind_scatter(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("reduce") = nb::none(),
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("output_tensor") = nb::none());
 }
 
 void bind_scatter_add(nb::module_& mod) {
@@ -71,6 +72,7 @@ void bind_scatter_add(nb::module_& mod) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the output tensor. Defaults to `None`.
             sub_core_grids (ttnn.CoreRangeSet, optional): specifies which cores scatter should run on. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor with scattered values.
@@ -89,7 +91,8 @@ void bind_scatter_add(nb::module_& mod) {
         nb::arg("src").noconvert(),
         nb::kw_only(),
         nb::arg("memory_config") = nb::none(),
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("output_tensor") = nb::none());
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -69,6 +69,7 @@ void TilizeDeviceOperation::validate_on_program_cache_miss(
     const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
     const TilizeDeviceOperation::tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor;
+    const auto& output_tensor = tensor_args.optional_output_tensor;
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to tilize need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to tilize need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
@@ -110,11 +111,26 @@ void TilizeDeviceOperation::validate_on_program_cache_miss(
             alignment_requirement);  // The shard width must be an aligned size, or we will face alignment issues
                                      // when the reader tries to write to the CB.
     }
+
+    if (output_tensor.has_value()) {
+        TT_FATAL(output_tensor->storage_type() == StorageType::DEVICE, "Preallocated output tensor must be on device");
+        TT_FATAL(output_tensor->layout() == Layout::TILE, "Preallocated output tensor must be in TILE layout");
+        TT_FATAL(
+            output_tensor->logical_shape() == input_tensor_a.logical_shape(),
+            "Preallocated output tensor logical shape must match input");
+        TT_FATAL(
+            output_tensor->dtype() == operation_attributes.output_dtype,
+            "Preallocated output tensor dtype must match requested output dtype");
+    }
 }
 
 TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output_specs(
     const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
     const TilizeDeviceOperation::tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor->tensor_spec();
+    }
+
     const auto& input_tensor = tensor_args.input_tensor;
     if (can_use_sharded_optimized_factories(operation_attributes, tensor_args)) {
         log_warning(
@@ -207,6 +223,9 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
 TilizeDeviceOperation::tensor_return_value_t TilizeDeviceOperation::create_output_tensors(
     const TilizeDeviceOperation::operation_attributes_t& args,
     const TilizeDeviceOperation::tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor.value();
+    }
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 
@@ -218,7 +237,8 @@ ttnn::Tensor tilize(
     bool enough_space_width,
     bool enough_space_height,
     bool use_low_perf,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<Tensor>& output_tensor) {
     return ttnn::device_operation::launch<TilizeDeviceOperation>(
         TilizeParams{
             .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
@@ -229,6 +249,6 @@ ttnn::Tensor tilize(
             .use_low_perf = use_low_perf,
             .sub_core_grids = sub_core_grids,
         },
-        TilizeInputs{input_tensor, std::nullopt});
+        TilizeInputs{input_tensor, output_tensor});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
@@ -46,5 +46,6 @@ ttnn::Tensor tilize(
     bool enough_space_width,
     bool enough_space_height,
     bool use_low_perf,
-    const std::optional<CoreRangeSet>& sub_core_grids);
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<Tensor>& output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation_types.hpp
@@ -21,7 +21,7 @@ struct TilizeParams {
 
 struct TilizeInputs {
     Tensor input_tensor;
-    std::optional<Tensor> optional_input_tensor;
+    std::optional<Tensor> optional_output_tensor;
 };
 
 struct MultiCoreSharedVariables {

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -44,7 +44,12 @@ ttnn::Tensor tilize(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     bool use_low_perf,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<Tensor>& output_tensor) {
+    TT_FATAL(
+        !output_tensor.has_value() || input_tensor.logical_shape().rank() <= 4,
+        "tilize with preallocated output_tensor currently supports rank <= 4 only");
+
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
     uint32_t output_single_tile_size =
@@ -71,7 +76,8 @@ ttnn::Tensor tilize(
             enough_space_width,
             enough_space_height,
             use_low_perf,
-            sub_core_grids);
+            sub_core_grids,
+            output_tensor);
     };
 
     return ttnn::operations::data_movement::build_ndiml_tilize(base_tilize, sub_core_grids)(input_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
@@ -13,6 +13,7 @@ ttnn::Tensor tilize(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     bool use_low_perf = false,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<Tensor>& output_tensor = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize_nanobind.cpp
@@ -31,6 +31,7 @@ void bind_tilize(nb::module_& mod) {
             use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
             use_low_perf (bool, optional): Use a low performance version that uses less memory. USE ONLY IF ABSOLUTELY NEEDED IN MODELS. Defaults to `False`.
             sub_core_grids (CoreRangeSet, optional): Used to restrict tilize to a set of cores, Defaults to using the entire device
+            output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -46,6 +47,7 @@ void bind_tilize(nb::module_& mod) {
         nb::arg("dtype") = nb::none(),
         nb::arg("use_multicore") = true,
         nb::arg("use_low_perf") = false,
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("output_tensor") = nb::none());
 }
 }  // namespace ttnn::operations::data_movement::detail


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/deepseek_warmup_vllm2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/deepseek_warmup_vllm2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/deepseek_warmup_vllm2)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/deepseek_warmup_vllm2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/deepseek_warmup_vllm2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/deepseek_warmup_vllm2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
