### PR TITLE
#0: Switch MLA to do TP4 outer-dim of o_proj + additional column AllGather after row AllReduce

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -43,6 +43,7 @@
 #include "../../../unified_kernels/sdpa_reduce_worker.hpp"
 #include "../../../unified_kernels/sdpa_reduce_forwarder.hpp"
 #include "../../../unified_kernels/all_reduce.hpp"
+#include "../../../unified_kernels/all_gather.hpp"
 
 // Compile-time role flags for dead code elimination via if constexpr
 // Defined at namespace scope (local classes cannot have static data members)
@@ -154,6 +155,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather_reduce_half_num_cores"),
         get_named_compile_time_arg_val("gather_reduce_dst_cb"),
         get_named_compile_time_arg_val("gather_reduce_half_size_bytes"),
+        0,  // sender_idx (unused; UsePerCoreSenderIdx=false uses grid)
         get_named_compile_time_arg_val("gather_reduce_noc_idx"),
     };
 
@@ -446,35 +448,27 @@ void kernel_main() {
             },
     };
 
-    // Matmul5 CTArgs
-    using Matmul5CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
-    deepseek_b1_ops::Matmul::ReaderArgs matmul5_args{};
+    // Matmul5 (KNSlicedMatmul) reader args - NCRISC is no-op
+    using Matmul5CTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::ReaderArgs matmul5_args{};
 
-    // Gather3 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
-    // via gather3_sender_idx, avoiding gaps from the non-rectangular o_proj grid).
-    // Sender picks noc0/noc1 receiver semaphore at compile-time based on gather3_noc_idx.
-    deepseek_b1_ops::Gather::DMArgs gather3_args{
-        .sender =
-            {
-                get_named_compile_time_arg_val("gather3_dest_noc_x"),
-                get_named_compile_time_arg_val("gather3_dest_noc_y"),
-                get_named_compile_time_arg_val("gather3_data_size_bytes"),
-                get_semaphore(
-                    get_named_compile_time_arg_val("gather3_noc_idx") == 0
-                        ? get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")
-                        : get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-                get_named_compile_time_arg_val("gather3_src_cb"),
-                get_named_compile_time_arg_val("gather3_src_num_pages"),
-                get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
-                get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
-                get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
-                get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
-                get_named_compile_time_arg_val("gather3_row_major"),
-                get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 3),  // gather3_receiver_data_addr
-                get_named_compile_time_arg_val("gather3_sender_idx"),
-                get_named_compile_time_arg_val("gather3_noc_idx"),
-            },
-        .receiver = {},
+    // GatherReduce3 sender args
+    deepseek_b1_ops::GatherReduce::SenderArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_dest_noc_x"),
+        get_named_compile_time_arg_val("gather3_dest_noc_y"),
+        get_named_compile_time_arg_val("gather3_data_size_bytes"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_addr")),
+        get_named_compile_time_arg_val("gather3_src_cb"),
+        get_named_compile_time_arg_val("gather3_src_num_pages"),
+        get_named_compile_time_arg_val("gather3_grid_start_x"),
+        get_named_compile_time_arg_val("gather3_grid_start_y"),
+        get_named_compile_time_arg_val("gather3_grid_end_x"),
+        get_named_compile_time_arg_val("gather3_grid_end_y"),
+        get_named_compile_time_arg_val("gather3_half_num_cores"),
+        get_named_compile_time_arg_val("gather3_dst_cb_id"),
+        get_named_compile_time_arg_val("gather3_half_size_bytes"),
+        get_named_compile_time_arg_val("gather3_sender_idx"),
+        get_named_compile_time_arg_val("gather3_noc_idx"),
     };
 
     // ========================================================================o
@@ -583,11 +577,14 @@ void kernel_main() {
 
     deepseek_b1_ops::AllReduce::SenderArgs ccl_sender_args{};
     deepseek_b1_ops::AllReduce::ReceiverArgs ccl_receiver_args{};
+    uint32_t ncrisc_allreduce_fabric_count = 0;
 
     if constexpr (Core::is_allreduce_sender_core) {
         ccl_sender_args.intermediate_buffer_address = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.dest_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.dest_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        // Read allreduce fabric arg count (placed before fabric args in RT arg stream)
+        ncrisc_allreduce_fabric_count = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.per_core_rta_start_idx = per_core_rta_arg_idx;
     }
 
@@ -599,6 +596,56 @@ void kernel_main() {
         ccl_receiver_args.sender_local_data_l1_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_receiver_args.local_ready_sem_bank_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
     }
+
+    // AllGather CT types (NCRISC: gather controller on receiver + bwd transport on sender)
+    using AllGatherGatherCT = deepseek_b1_ops::AllGather::GatherCTArgs<
+        get_named_compile_time_arg_val("allgather_gather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_gather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_ring_size"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot")>;
+
+    using AllGatherTransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+        get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+        get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+        get_named_compile_time_arg_val("allgather_num_links"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+        get_named_compile_time_arg_val("allgather_r2_active")>;
+
+    // AllGather transport args (sender core NCRISC = backward sender)
+    deepseek_b1_ops::AllGather::TransportArgs allgather_transport_args{};
+    if constexpr (Core::is_allreduce_sender_core) {
+        // Skip past allreduce fabric per-core RT args using pre-read count
+        per_core_rta_arg_idx += ncrisc_allreduce_fabric_count;
+
+        allgather_transport_args.scratch_base_addr = get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_transport_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_transport_args.dest_output_base_addr =
+            get_named_compile_time_arg_val("allgather_dest_output_base_addr");
+        allgather_transport_args.r1_dest_slot_index = get_named_compile_time_arg_val("allgather_r1_dest_slot_index");
+        allgather_transport_args.dest_noc_x = get_named_compile_time_arg_val("allgather_dest_noc_x");
+        allgather_transport_args.dest_noc_y = get_named_compile_time_arg_val("allgather_dest_noc_y");
+        allgather_transport_args.dest_recv_sem_addr = get_named_compile_time_arg_val("allgather_dest_recv_sem_addr");
+        allgather_transport_args.r2_dest_slot_index = get_named_compile_time_arg_val("allgather_r2_dest_slot_index");
+        allgather_transport_args.per_core_rta_start_idx = per_core_rta_arg_idx;
+    }
+
+    // AllGather gather args (receiver core NCRISC = gather controller)
+    deepseek_b1_ops::AllGather::GatherArgs allgather_gather_args{};
+    if constexpr (Core::is_allreduce_receiver_core) {
+        // local_input_addr set at runtime after cb_wait_front in execution section
+        allgather_gather_args.output_buffer_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 5);
+        allgather_gather_args.self_slot_index = get_named_compile_time_arg_val("allgather_self_slot_index");
+        allgather_gather_args.transport_scratch_base_addr =
+            get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_gather_args.transport_noc_x = get_named_compile_time_arg_val("allgather_transport_noc_x");
+        allgather_gather_args.transport_noc_y = get_named_compile_time_arg_val("allgather_transport_noc_y");
+        allgather_gather_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_gather_args.recv_sem_addr = get_named_compile_time_arg_val("allgather_recv_sem_addr");
+        allgather_gather_args.r2_src_slot_index = get_named_compile_time_arg_val("allgather_r2_src_slot_index");
+    }
+
 // ============================================================================
 // BRISC (Writer + Mcast Sender) - WriterConfigDescriptor compiles as BRISC
 // Named compile-time args: bcast writer + rmsnorm writer, mcast sender, matmul writer, gather receiver
@@ -756,11 +803,12 @@ void kernel_main() {
 
     using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
 
-    // Matmul4/2 CTArgs (BRISC is no-op for matmul)
+    // Matmul4 CTArgs (BRISC is no-op for matmul)
     using Matmul4CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
-    using Matmul5CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
     deepseek_b1_ops::Matmul::WriterArgs matmul4_args{};
-    deepseek_b1_ops::Matmul::WriterArgs matmul5_args{};
+    // Matmul5 (KNSlicedMatmul) writer args - BRISC is no-op
+    using Matmul5CTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::WriterArgs matmul5_args{};
 
     // Gather2 receiver args
     deepseek_b1_ops::Gather::DMArgs gather2_args{
@@ -797,18 +845,14 @@ void kernel_main() {
         .receiver = {},
     };
 
-    // Gather3 receiver args (on sender core 11,9 instead of gather core 12,9)
-    deepseek_b1_ops::Gather::DMArgs gather3_args{
-        .sender = {},
-        .receiver =
-            {
-                get_named_compile_time_arg_val("gather3_noc0_num_senders"),
-                get_named_compile_time_arg_val("gather3_noc1_num_senders"),
-                get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
-                get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-                get_named_compile_time_arg_val("gather3_dst_cb"),
-                get_named_compile_time_arg_val("gather3_dst_num_pages"),
-            },
+    // GatherReduce3 receiver args (on sender core 11,9)
+    deepseek_b1_ops::GatherReduce::ReceiverArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather3_noc1_num_senders"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather3_dst_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_tiles"),
     };
 
     // ========================================================================o
@@ -914,11 +958,41 @@ void kernel_main() {
         get_named_compile_time_arg_val("allreduce_skip_local_push")>;
 
     deepseek_b1_ops::AllReduce::SenderArgs ccl_sender_args{};
+    uint32_t brisc_allreduce_fabric_count = 0;
     if constexpr (Core::is_allreduce_sender_core) {
         ccl_sender_args.intermediate_buffer_address = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.dest_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.dest_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        // Read allreduce fabric arg count (placed before fabric args in RT arg stream)
+        brisc_allreduce_fabric_count = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.per_core_rta_start_idx = per_core_rta_arg_idx;
+    }
+
+    // AllGather CT types (BRISC = forward transport sender on sender core)
+    using AllGatherTransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+        get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+        get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+        get_named_compile_time_arg_val("allgather_num_links"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+        get_named_compile_time_arg_val("allgather_r2_active")>;
+
+    deepseek_b1_ops::AllGather::TransportArgs allgather_transport_args{};
+    if constexpr (Core::is_allreduce_sender_core) {
+        // Skip past allreduce fabric per-core RT args using pre-read count
+        per_core_rta_arg_idx += brisc_allreduce_fabric_count;
+
+        allgather_transport_args.scratch_base_addr = get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_transport_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_transport_args.dest_output_base_addr =
+            get_named_compile_time_arg_val("allgather_dest_output_base_addr");
+        allgather_transport_args.r1_dest_slot_index = get_named_compile_time_arg_val("allgather_r1_dest_slot_index");
+        allgather_transport_args.dest_noc_x = get_named_compile_time_arg_val("allgather_dest_noc_x");
+        allgather_transport_args.dest_noc_y = get_named_compile_time_arg_val("allgather_dest_noc_y");
+        allgather_transport_args.dest_recv_sem_addr = get_named_compile_time_arg_val("allgather_dest_recv_sem_addr");
+        allgather_transport_args.r2_dest_slot_index = get_named_compile_time_arg_val("allgather_r2_dest_slot_index");
+        allgather_transport_args.per_core_rta_start_idx = per_core_rta_arg_idx;
     }
 
 // ============================================================================
@@ -1156,19 +1230,27 @@ void kernel_main() {
     // Mcast3 CTArgs (no-op)
     deepseek_b1_ops::Mcast::ComputeArgs mcast3_args{};
 
-    // Matmul5 CTArgs
+    // Matmul5 (KNSlicedMatmul) CTArgs + compute args
+    constexpr uint32_t matmul5_k_offset = get_named_compile_time_arg_val("matmul5_k_offset");
+
     using Matmul5CTArgs =
-        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
-    deepseek_b1_ops::Matmul::ComputeArgs matmul5_args{
+        deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
+    deepseek_b1_ops::KNSlicedMatmul::ComputeArgs matmul5_args{
         get_named_compile_time_arg_val("matmul5_in0"),
         get_named_compile_time_arg_val("matmul5_in1"),
         get_named_compile_time_arg_val("matmul5_out"),
-        get_named_compile_time_arg_val("matmul5_k_num_tiles"),
+        matmul5_k_offset,
+        get_named_compile_time_arg_val("matmul5_k_per_core"),
+        get_named_compile_time_arg_val("matmul5_act_total_tiles"),
         get_common_arg_val<uint32_t>(14),  // matmul5_weights_addr
     };
 
-    // Gather3 compute args (no-op)
-    deepseek_b1_ops::Gather::ComputeArgs gather3_args{};
+    // GatherReduce3 compute args
+    deepseek_b1_ops::GatherReduce::ComputeArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_scratch_cb"),
+        get_named_compile_time_arg_val("gather3_out_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_tiles"),
+    };
 
     // CCL Broadcast CTArgs (no-op for TRISC)
     using BcastCTArgs = deepseek_b1_ops::Broadcast::ComputeCTArgs;
@@ -1563,33 +1645,34 @@ void kernel_main() {
         }
 
         // ========================================================================
-        // Matmul5: [1, 8192] x [8192, 64] -> [1, 64] per core (112 active cores)
+        // Matmul5 (KNSlicedMatmul): [1, 8192] x [4096, 32] -> [1, 32] per core (112 active cores)
         // Input: mcast3_dst_cb (CB 4), Weights: matmul5_in1 (CB 5), Output: matmul5_out (CB 6)
-        // Only runs on 112 active cores (is_matmul5_core=true), 18 inactive cores skip
+        // K-split: 2 halves of 56 cores, each core does [1, 4096] @ [4096, 32] -> [1, 32]
         // ========================================================================
         {
             DeviceZoneScopedN("MATMUL5");
-            // pop_in0 = true (mcast3 output consumed), pop_in1 = false (weights persistent)
-            deepseek_b1_ops::Matmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
+            deepseek_b1_ops::KNSlicedMatmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
             matmul5(matmul5_args);
         }
 
         // ========================================================================
-        // Gather3: 112 active matmul5 cores -> sender core (11, 9)
-        // Collects [1, 64] * 112 = [1, 7168]
+        // GatherReduce3: 112 matmul5 cores (2x56 halves) -> sender core (11, 9)
+        // Reduces [1, 32] * 56 from each half -> [1, 1792] per device
         // ========================================================================
         {
             DeviceZoneScopedN("GATHER3");
-            deepseek_b1_ops::Gather::Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, true, true> gather3;
+            deepseek_b1_ops::GatherReduce::
+                Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, Core::is_allreduce_sender_core, true, true>
+                    gather3;
             gather3(gather3_args);
         }
 
         // ========================================================================
-        // CCL All-Reduce: Exchange [1, 7168] between devices
+        // CCL All-Reduce: Exchange [1, per_device_out_w] between column devices
         // - Sender core (11, 9): NCRISC writer (link 1) + BRISC writer (link 0)
-        //   gather3 writes directly to sender's local_data_cb; writer NOC-copies
+        //   GatherReduce3 output -> sender's local_data_cb; writer NOC-copies
         //   to receiver and sends via fabric.
-        // - Receiver core (12, 9): NCRISC reader + TRISC compute
+        // - Receiver core (12, 9): NCRISC reader + TRISC compute (with residual offset)
         // ========================================================================
         if constexpr (Core::is_allreduce_sender_core) {
             DeviceZoneScopedN("CCL_SENDER_WRITER");
@@ -1603,16 +1686,53 @@ void kernel_main() {
             uint64_t ccl_sync_sem_noc_addr = get_noc_addr(input_noc_coord_x, input_noc_coord_y, ccl_sync_sem_addr);
             noc_semaphore_inc(ccl_sync_sem_noc_addr, 1);
             noc_async_atomic_barrier();
+
+            // All-Gather: transport sender (BRISC=fwd, NCRISC=bwd)
+            {
+                DeviceZoneScopedN("ALLGATHER_TRANSPORT");
+                deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
+                allgather_sender(allgather_transport_args);
+            }
 #endif
         }
 
         if constexpr (Core::is_allreduce_receiver_core) {
             DeviceZoneScopedN("CCL_RECEIVER");
 #if defined(COMPILE_FOR_NCRISC)
-            // TODO: We're popping the RMSNorm input and then re-pushing it here as the residual
-            // Should avoid this and not pop in RMSNorm
+            // TP4 outer-dim: NOC-copy the correct [1, per_device_out_w] slice of the
+            // input tensor into the residual CB (2 tiles of 32x32) before AllReduce.
+            {
+                constexpr uint32_t residual_offset = get_named_compile_time_arg_val("residual_byte_offset");
+                constexpr uint32_t residual_size = get_named_compile_time_arg_val("residual_copy_size");
+                constexpr uint32_t residual_cb = get_named_compile_time_arg_val("residual_cb_id");
+                constexpr uint32_t residual_num_tiles = get_named_compile_time_arg_val("residual_num_tiles");
+                constexpr uint32_t inp_noc_x = get_named_compile_time_arg_val("input_noc_coord_x");
+                constexpr uint32_t inp_noc_y = get_named_compile_time_arg_val("input_noc_coord_y");
+                uint32_t input_l1_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 4);
+                cb_reserve_back(residual_cb, residual_num_tiles);
+                uint32_t residual_dst = get_write_ptr(residual_cb);
+                uint64_t src_noc_addr = get_noc_addr(inp_noc_x, inp_noc_y, input_l1_addr + residual_offset);
+                noc_async_read(src_noc_addr, residual_dst, residual_size);
+                noc_async_read_barrier();
+                cb_push_back(residual_cb, residual_num_tiles);
+            }
+
             deepseek_b1_ops::AllReduce::Reader<AllReduceReaderCTArgs> ccl_reader;
             ccl_reader(ccl_receiver_args);
+
+            // All-Gather: gather controller — reads [1, per_device_out_w] from
+            // ccl_output_cb and distributes across row ring into output tensor.
+            {
+                DeviceZoneScopedN("ALLGATHER_GATHER");
+                constexpr uint32_t out_cb = get_named_compile_time_arg_val("output_cb_id");
+                constexpr uint32_t out_num_tiles = get_named_compile_time_arg_val("output_num_tiles");
+                cb_wait_front(out_cb, out_num_tiles);
+                allgather_gather_args.local_input_addr = get_read_ptr(out_cb);
+
+                deepseek_b1_ops::AllGather::GatherController<AllGatherGatherCT> allgather_controller;
+                allgather_controller(allgather_gather_args);
+                cb_pop_front(out_cb, out_num_tiles);
+            }
 #elif defined(COMPILE_FOR_TRISC)
             deepseek_b1_ops::AllReduce::Compute<AllReduceComputeCTArgs> ccl_compute;
             ccl_compute(ccl_compute_args);

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -16,6 +16,7 @@ from models.demos.deepseek_v3_b1.circular_buffer_utils import (
     record_cb_metadata,
 )
 from models.demos.deepseek_v3_b1.fused_ops.post_sdpa.op import _extend_runtime_args, _get_element_size_bytes, _round_up
+from models.demos.deepseek_v3_b1.micro_ops.ccl_all_gather.op import AllGatherConfig
 from models.demos.deepseek_v3_b1.micro_ops.ccl_all_reduce.op import DeepseekMinimalAllReduce
 from models.demos.deepseek_v3_b1.micro_ops.ccl_broadcast.op import DeepseekMinimalBroadcast
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import (
@@ -187,7 +188,8 @@ class AttentionBlock:
         pipeline_num_semaphores = 15
         allreduce_num_semaphores = DeepseekMinimalAllReduce.get_num_semaphores(num_links=num_links_allreduce)
         bcast_num_semaphores = DeepseekMinimalBroadcast.get_num_semaphores(num_links=num_links_bcast)
-        return pipeline_num_semaphores + allreduce_num_semaphores + bcast_num_semaphores
+        allgather_num_semaphores = 2  # handoff_sem + recv_sem
+        return pipeline_num_semaphores + allreduce_num_semaphores + bcast_num_semaphores + allgather_num_semaphores
 
     @staticmethod
     def create_semaphores(mesh_device, num_links_bcast=1, num_links_allreduce=1):
@@ -324,11 +326,10 @@ class AttentionBlock:
         # Post-SDPA parameters
         post_sdpa_weights1_fused_tensors_per_device = ttnn.get_device_tensors(post_sdpa_weights1_tensor.fused_tensor)
         post_sdpa_weights2_fused_tensors_per_device = ttnn.get_device_tensors(post_sdpa_weights2_tensor.fused_tensor)
+        attention_block_output_tensors_per_device = ttnn.get_device_tensors(attention_block_output_tensor)
 
         # Uncomment to debug local FlashMLA output
         # output_tensors_per_device = ttnn.get_device_tensors(output_tensor)
-        attention_block_output_tensors_per_device = ttnn.get_device_tensors(attention_block_output_tensor)
-
         assert attention_block_semaphores is not None and len(
             attention_block_semaphores
         ) == AttentionBlock.get_num_semaphores(num_links_bcast=num_links_bcast, num_links_allreduce=num_links_allreduce)
@@ -531,6 +532,7 @@ class AttentionBlock:
 
         TILE_1x32 = ttnn.Tile((1, 32))
         tile_1x32_size = TILE_1x32.get_tile_size(data_format)
+        tile_32x32_size = FULL_32x32_TILE.get_tile_size(data_format)
         # Mcast setup: sender core (rmsnorm) -> full mcast grid
         # Only matmul cores (is_matmul_core=true) will actually participate in receive
 
@@ -568,16 +570,22 @@ class AttentionBlock:
         # TODO: Subtract the pipeline core
         is_full_mcast_grid_core = ttnn.CoreRangeSet([main_grid]).subtract(rmsnorm_core_grid)
 
-        # Active Matmul5 cores: o_proj cores (12×8 + 8×2 = 112 cores)
+        # Active Matmul5 cores: o_proj cores (12x8 + 8x2 = 112 cores)
         o_proj_spec = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
         matmul5_active_core_grid = o_proj_spec.o_proj.core_range_set
         num_matmul5_cores = matmul5_active_core_grid.num_cores()  # 112
+        matmul5_half_num_cores = num_matmul5_cores // 2  # 56
 
         # Per-core gather3 sender index: contiguous 0..111 in row-major order.
-        # Needed because o_proj grid is non-rectangular (12×8 + 8×2).
+        # Needed because o_proj grid is non-rectangular (12x8 + 8x2).
         # Row-major (y then x) matches WIDTH_SHARDED shard placement order.
         matmul5_cores = ttnn.corerange_to_cores(matmul5_active_core_grid, row_wise=True)
         gather3_sender_idx_per_core = [(core, idx) for idx, core in enumerate(matmul5_cores)]
+
+        # TP4 outer-dim: each device produces [1, per_device_out_w]
+        num_sp = mesh_shape[0]
+        per_device_out_w = input_shape[1] // num_sp
+        per_device_out_tiles = per_device_out_w // tile_width
 
         # Full grid (union of all cores for semaphore allocation)
         # TODO: Subtract the pipeline core
@@ -700,10 +708,16 @@ class AttentionBlock:
         matmul4_out_w_per_core = 4  # 128 / 32 = 4 tiles per core
 
         # ========================================================================
-        # Matmul5 parameters: [1, 8192] x [8192, 64] -> [1, 64]
+        # Matmul5 (KNSlicedMatmul) parameters: [1, 8192] x [4096, 32] -> [1, 32]
+        # TP4 outer-dim: weights packed as (4096, 3584) with K-halves interleaved
+        # 112 cores split into 2 halves of 56; each core: [1, 4096] @ [4096, 32] -> [1, 32]
         # ========================================================================
-        matmul5_k_num_tiles = 256  # 8192 / 32 = 256 tiles
-        matmul5_out_w_per_core = 2  # 64 / 32 = 2 tiles per core
+        matmul5_act_total_tiles = 256  # 8192 / 32 = 256 tiles (full activation)
+        matmul5_k_per_core = matmul5_act_total_tiles // 2  # 128 tiles per half
+        matmul5_out_w_per_core = 1  # 32 / 32 = 1 tile per core
+        matmul5_k_offset_per_core = [
+            (core, 0 if idx < matmul5_half_num_cores else matmul5_k_per_core) for idx, core in enumerate(matmul5_cores)
+        ]
 
         # ========================================================================
         # Gather2 parameters: 64 cores -> [1, 8192]
@@ -721,12 +735,16 @@ class AttentionBlock:
         mcast3_dst_num_pages = gather2_dst_num_pages  # 256 pages per receiver
 
         # ========================================================================
-        # Gather3 parameters: 112 cores -> [1, 7168]
+        # GatherReduce3 parameters: 112 cores (2x56 halves) -> [1, per_device_out_w]
+        # Each sender produces 1 tile of 1x32; halves are reduced on receiver
+        # using 32x32 tile reinterpretation (ceil(56/32) = 2 tiles per half).
         # ========================================================================
-        gather3_data_size_bytes = matmul5_out_w_per_core * tile_1x32_size
-        gather3_src_num_pages = matmul5_out_w_per_core  # 2 pages per sender
-        gather3_dst_num_pages = num_tiles  # Same as input tensor
-        # gather3 noc0/noc1 sender counts are populated per-device from per-core noc_idx assignments.
+        gather3_data_size_bytes = matmul5_out_w_per_core * tile_1x32_size  # 1 tile per sender
+        gather3_src_num_pages = matmul5_out_w_per_core  # 1 page per sender
+        gather3_dst_num_tiles = (per_device_out_tiles + 31) // 32  # 2 tiles of 32x32 per half
+        gather3_half_size_bytes = gather3_dst_num_tiles * tile_32x32_size  # padded to 32x32 boundary
+        gather3_noc0_num_senders = num_matmul5_cores
+        gather3_noc1_num_senders = 0
 
         # ========================================================================
         # Semaphore IDs
@@ -810,6 +828,12 @@ class AttentionBlock:
         ccl_sync_semaphore = attention_block_semaphores[semaphore_index]
         semaphore_index += 1
         ccl_sync_semaphore_addr = ttnn.get_global_semaphore_address(ccl_sync_semaphore)
+        allgather_handoff_semaphore = attention_block_semaphores[semaphore_index]
+        semaphore_index += 1
+        allgather_recv_semaphore = attention_block_semaphores[semaphore_index]
+        semaphore_index += 1
+        allgather_handoff_sem_addr = ttnn.get_global_semaphore_address(allgather_handoff_semaphore)
+        allgather_recv_sem_addr = ttnn.get_global_semaphore_address(allgather_recv_semaphore)
         assert semaphore_index == len(attention_block_semaphores), "Unexpected attention_block semaphore consumption"
 
         # Calculate mcast data size in bytes (RMSNorm output = num_tiles * tile_size)
@@ -966,18 +990,19 @@ class AttentionBlock:
         assert (
             post_sdpa_weights2_tensor.get_tile() == matmul_weights_tensor.get_tile()
         ), f"Post SDPA weights2 tensor tile ({post_sdpa_weights2_tensor.get_tile()}) must be equal to matmul weights tensor tile ({matmul_weights_tensor.get_tile()})"
-        matmul5_out_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Matmul5 output (112 active cores)
-        gather3_dst_cb = cb_id_context.get_cb_id(
-            data_format, TD_INTERP
-        )  # Gather3 output = CCL local data (sender core 11,9)
+        matmul5_out_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # KNSlicedMatmul output (112 active cores)
+        gather3_scratch_cb = cb_id_context.get_cb_id(
+            data_format, TD_32x32
+        )  # GatherReduce scratch CB (2 * gather3_dst_num_tiles of 32x32 on receiver)
+        gather3_out_cb = cb_id_context.get_cb_id(
+            data_format, TD_32x32
+        )  # GatherReduce output = CCL local data (sender core 11,9)
         ccl_recv_local_data_cb = cb_id_context.get_cb_id(
-            data_format, TD_INTERP
+            data_format, TD_32x32
         )  # CCL receiver local data (NOC copy on receiver core 12,9)
-        ccl_remote_data_cb = cb_id_context.get_cb_id(data_format, TD_INTERP)  # CCL received remote data (receiver core)
-        ccl_residual_cb = input_cb
-        ccl_output_cb = cb_id_context.get_cb_id(data_format, TD_INTERP)  # CCL output (receiver core)
-
-        attention_block_output_cb = ccl_output_cb  # Attention block output (receiver core)
+        ccl_remote_data_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # CCL received remote data (receiver core)
+        ccl_residual_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # CCL residual (offset slice of input)
+        ccl_output_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # CCL output (receiver core)
 
         # Configure AllReduceConfig in no-ownership mode:
         # All CCL CBs are carved from overlapped memory (sdpa_kv_cache_buffer),
@@ -989,7 +1014,7 @@ class AttentionBlock:
             semaphores=ccl_fabric_semaphores + [ccl_local_ready_semaphore],
             cluster_axis=reduce_cluster_axis,
             num_links=num_links_allreduce,
-            local_data_cb_id=gather3_dst_cb,
+            local_data_cb_id=gather3_out_cb,
             recv_local_data_cb_id=ccl_recv_local_data_cb,
             remote_data_cb_id=ccl_remote_data_cb,
             output_cb_id=ccl_output_cb,
@@ -997,7 +1022,21 @@ class AttentionBlock:
             skip_local_push=True,
             skip_ccl=skip_ccl,
             sender_core=ccl_sender_core,
+            num_tiles_override=gather3_dst_num_tiles,
+            page_size_override=tile_32x32_size,
         )
+
+        # ========================================================================
+        # AllGather config: gather 4 x [1, per_device_out_w] slices into [1, full_out_w]
+        # Runs along axis=0 (rows) after the all-reduce completes on axis=1 (columns).
+        # Reuses the same two cores: gather core (12,9) and transport core (11,9).
+        # ========================================================================
+        allgather_slice_size_bytes = per_device_out_tiles * tile_1x32_size  # 1792 * 2 = 3584
+        allgather_num_links = 1  # single fabric link per direction
+        allgather_cluster_axis = 0  # gather along rows
+
+        # Scratch: reuse gather3_scratch_cb L1 address on sender/transport core
+        # Need 2 * slice_size_bytes = 7168 bytes; gather3_scratch has 2*ccl_cb_total_size available
 
         # RMSNorm2 parameters (for 1536 element input using 16x32 tiles)
         rmsnorm2_numel = 1536
@@ -1727,25 +1766,28 @@ class AttentionBlock:
             ("mcast3_data_receiver_semaphore", mcast3_data_receiver_semaphore_id),
             ("mcast3_dst_cb", matmul5_in0_cb),
             ("mcast3_dst_num_pages", mcast3_dst_num_pages),
-            # Matmul5
+            # Matmul5 (KNSlicedMatmul)
             ("matmul5_in0", matmul5_in0_cb),
             ("matmul5_in1", matmul5_in1_cb),
             ("matmul5_out", matmul5_out_cb),
-            ("matmul5_k_num_tiles", matmul5_k_num_tiles),
             ("matmul5_out_w_per_core", matmul5_out_w_per_core),
-            # Gather3 sender (picks noc0/noc1 semaphore id at compile-time per gather3_noc_idx)
+            ("matmul5_k_per_core", matmul5_k_per_core),
+            ("matmul5_act_total_tiles", matmul5_act_total_tiles),
+            # GatherReduce3 sender (destination is now sender core 11,9)
             ("gather3_dest_noc_x", ccl_sender_noc_core.x),
             ("gather3_dest_noc_y", ccl_sender_noc_core.y),
             ("gather3_data_size_bytes", gather3_data_size_bytes),
-            ("gather3_noc0_receiver_semaphore_id", gather3_noc0_receiver_semaphore_id),
-            ("gather3_noc1_receiver_semaphore_id", gather3_noc1_receiver_semaphore_id),
+            ("gather3_receiver_semaphore_addr", gather3_noc0_receiver_semaphore_id),
             ("gather3_src_cb", matmul5_out_cb),
             ("gather3_src_num_pages", gather3_src_num_pages),
-            ("gather3_sender_grid_start_x", 0),
-            ("gather3_sender_grid_start_y", 0),
-            ("gather3_sender_grid_end_x", 0),
-            ("gather3_sender_grid_end_y", 0),
-            ("gather3_row_major", 1),
+            # Grid args unused when UsePerCoreSenderIdx=true, but required for struct init
+            ("gather3_grid_start_x", 0),
+            ("gather3_grid_start_y", 0),
+            ("gather3_grid_end_x", 0),
+            ("gather3_grid_end_y", 0),
+            ("gather3_half_num_cores", matmul5_half_num_cores),
+            ("gather3_dst_cb_id", gather3_scratch_cb),
+            ("gather3_half_size_bytes", gather3_half_size_bytes),
         ]
 
         # Append AllReduceConfig NCRISC CT args (writer on sender core + reader on receiver core)
@@ -1799,11 +1841,13 @@ class AttentionBlock:
             ("mcast3_src_cb", gather2_dst_cb),
             ("mcast3_src_num_pages", mcast3_src_num_pages),
             ("mcast3_dst_cb", matmul5_in0_cb),
-            # Gather3 receiver (now on sender core 11,9; noc0/noc1 sender counts added per-device)
+            # GatherReduce3 receiver (now on sender core 11,9)
+            ("gather3_noc0_num_senders", gather3_noc0_num_senders),
+            ("gather3_noc1_num_senders", gather3_noc1_num_senders),
             ("gather3_noc0_receiver_semaphore_id", gather3_noc0_receiver_semaphore_id),
             ("gather3_noc1_receiver_semaphore_id", gather3_noc1_receiver_semaphore_id),
-            ("gather3_dst_cb", gather3_dst_cb),
-            ("gather3_dst_num_pages", gather3_dst_num_pages),
+            ("gather3_dst_cb", gather3_scratch_cb),
+            ("gather3_dst_num_tiles", gather3_dst_num_tiles),
             ("sdpa_fwd_num_cores", num_sdpa_forwarder_cores),
             ("num_ccl_sender_cores", 1),
             # Input NOC coord
@@ -1858,12 +1902,17 @@ class AttentionBlock:
             ("matmul4_out", matmul4_out_cb),
             ("matmul4_k_num_tiles", matmul4_k_num_tiles),
             ("matmul4_out_w_per_core", matmul4_out_w_per_core),
-            # Matmul5
+            # Matmul5 (KNSlicedMatmul)
             ("matmul5_in0", matmul5_in0_cb),
             ("matmul5_in1", matmul5_in1_cb),
             ("matmul5_out", matmul5_out_cb),
-            ("matmul5_k_num_tiles", matmul5_k_num_tiles),
             ("matmul5_out_w_per_core", matmul5_out_w_per_core),
+            ("matmul5_k_per_core", matmul5_k_per_core),
+            ("matmul5_act_total_tiles", matmul5_act_total_tiles),
+            # GatherReduce3 compute
+            ("gather3_scratch_cb", gather3_scratch_cb),
+            ("gather3_out_cb", gather3_out_cb),
+            ("gather3_dst_num_tiles", gather3_dst_num_tiles),
             # CCL sync semaphore
             ("ccl_sync_semaphore_addr", ccl_sync_semaphore_addr),
         ]
@@ -2285,7 +2334,7 @@ class AttentionBlock:
         create_q_heads_out_total_size = create_q_heads_out_page_size * q_tiles
         create_q_heads_out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             create_q_heads_out_cb,
-            ref_attention_block_output_tensor,  # Overlap with attn output since it's only on the mcast core
+            ref_attention_block_output_tensor,  # Overlap with output tensor (free before final o_proj writes)
             address_offset=attn_block_output_running_offset,
             total_size=create_q_heads_out_total_size,
             core_ranges=full_device_grid,
@@ -2704,73 +2753,118 @@ class AttentionBlock:
         matmul5_out_cb_descriptor.format_descriptors = [matmul5_out_cb_format]
         sdpa_kv_cache_running_offset_post_sdpa += matmul5_out_cb_descriptor.total_size
 
-        # CB: Gather3 output = CCL local data (overlapped with sdpa_kv_cache on mcast core)
-        # Owned externally — gather3 writes here, CCL writer reads from it.
-        gather3_dst_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=gather3_dst_cb,
-            data_format=data_format,
-            page_size=tile_size,
-            tile=tile_descriptor,
-        )
-        gather3_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            gather3_dst_cb,
+        ccl_cb_total_size = gather3_dst_num_tiles * tile_32x32_size
+
+        # CB: GatherReduce3 scratch (2x for both halves; TRISC reduces into gather3_out_cb)
+        gather3_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            gather3_scratch_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset_mcast_core,
-            total_size=num_tiles * tile_size,
+            total_size=2 * ccl_cb_total_size,
             core_ranges=full_device_grid,
         )
-        gather3_dst_cb_descriptor.format_descriptors = [gather3_dst_cb_format]
-        sdpa_kv_cache_running_offset_mcast_core += gather3_dst_cb_descriptor.total_size
-        gather3_receiver_data_addr = ttnn.get_cb_address(gather3_dst_cb_descriptor)
+        gather3_scratch_cb_descriptor.format_descriptors = [
+            ttnn.CBFormatDescriptor(
+                buffer_index=gather3_scratch_cb, data_format=data_format, page_size=tile_32x32_size, tile=TD_32x32
+            )
+        ]
+        sdpa_kv_cache_running_offset_mcast_core += gather3_scratch_cb_descriptor.total_size
+
+        # AllGather config (no-ownership mode) — scratch lives in gather3_scratch_cb,
+        # output in attention_block_output_tensor.  Addresses are uniform across devices
+        # (same L1 layout / same mesh tensor allocation).
+        allgather_config = AllGatherConfig(
+            mesh_device=mesh_device,
+            cluster_axis=allgather_cluster_axis,
+            num_links=allgather_num_links,
+            slice_size_bytes=allgather_slice_size_bytes,
+            scratch_base_addr=ttnn.get_cb_address(gather3_scratch_cb_descriptor),
+            output_addr=ref_attention_block_output_tensor.buffer_address(),
+            handoff_sem_addr=allgather_handoff_sem_addr,
+            recv_sem_addr=allgather_recv_sem_addr,
+            gather_noc_core=gather_dest_noc_core,
+            transport_noc_core=ccl_sender_noc_core,
+            output_cb_id=ccl_output_cb,
+            output_num_tiles=gather3_dst_num_tiles,
+        )
+
+        # CB: GatherReduce3 output = CCL local data
+        gather3_out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            gather3_out_cb,
+            ref_sdpa_kv_cache_buffer,
+            address_offset=sdpa_kv_cache_running_offset_mcast_core,
+            total_size=ccl_cb_total_size,
+            core_ranges=full_device_grid,
+        )
+        gather3_out_cb_descriptor.format_descriptors = [
+            ttnn.CBFormatDescriptor(
+                buffer_index=gather3_out_cb, data_format=data_format, page_size=tile_32x32_size, tile=TD_32x32
+            )
+        ]
+        sdpa_kv_cache_running_offset_mcast_core += gather3_out_cb_descriptor.total_size
+        gather3_receiver_data_addr = ttnn.get_cb_address(gather3_out_cb_descriptor)
         allreduce_config.set_local_data_addr(gather3_receiver_data_addr)
 
-        # CB: CCL recv local data (overlapped with sdpa_kv_cache on mcast core)
-        # Sender NOC-copies gather3 output here; receiver NCRISC reads it for compute.
+        # CB: CCL recv local data
         ccl_recv_local_data_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             ccl_recv_local_data_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset_mcast_core,
-            total_size=num_tiles * tile_size,
+            total_size=ccl_cb_total_size,
             core_ranges=full_device_grid,
         )
         ccl_recv_local_data_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
-                buffer_index=ccl_recv_local_data_cb,
-                data_format=data_format,
-                page_size=tile_size,
-                tile=tile_descriptor,
+                buffer_index=ccl_recv_local_data_cb, data_format=data_format, page_size=tile_32x32_size, tile=TD_32x32
             )
         ]
         sdpa_kv_cache_running_offset_mcast_core += ccl_recv_local_data_cb_descriptor.total_size
 
-        # CB: CCL remote data (overlapped with sdpa_kv_cache on mcast core)
-        # Fabric writes remote data here; TRISC reads it for reduction.
+        # CB: CCL remote data
         ccl_remote_data_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             ccl_remote_data_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset_mcast_core,
-            total_size=num_tiles * tile_size,
+            total_size=ccl_cb_total_size,
             core_ranges=full_device_grid,
         )
         ccl_remote_data_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
-                buffer_index=ccl_remote_data_cb,
-                data_format=data_format,
-                page_size=tile_size,
-                tile=tile_descriptor,
+                buffer_index=ccl_remote_data_cb, data_format=data_format, page_size=tile_32x32_size, tile=TD_32x32
             )
         ]
         sdpa_kv_cache_running_offset_mcast_core += ccl_remote_data_cb_descriptor.total_size
-        ccl_send_addr = ttnn.get_cb_address(ccl_remote_data_cb_descriptor)
-        allreduce_config.set_remote_data_addr(ccl_send_addr)
+        allreduce_config.set_remote_data_addr(ttnn.get_cb_address(ccl_remote_data_cb_descriptor))
 
-        # CB: CCL output (backed by attention_block_output_tensor)
-        attention_block_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            attention_block_output_cb, ref_attention_block_output_tensor
+        # CB: CCL residual (per-device [1, per_device_out_w] slice of the full residual)
+        ccl_residual_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            ccl_residual_cb,
+            ref_sdpa_kv_cache_buffer,
+            address_offset=sdpa_kv_cache_running_offset_mcast_core,
+            total_size=ccl_cb_total_size,
+            core_ranges=full_device_grid,
         )
-        attention_block_output_cb_descriptor.core_ranges = full_device_grid
-        attention_block_output_cb_descriptor.format_descriptors[0].tile = tile_descriptor
-        attention_block_output_cb_descriptor.format_descriptors[0].page_size = cb_page_size
+        ccl_residual_cb_descriptor.format_descriptors = [
+            ttnn.CBFormatDescriptor(
+                buffer_index=ccl_residual_cb, data_format=data_format, page_size=tile_32x32_size, tile=TD_32x32
+            )
+        ]
+        sdpa_kv_cache_running_offset_mcast_core += ccl_residual_cb_descriptor.total_size
+
+        # CB: CCL output (AllReduce writes here; NCRISC copies to output tensor)
+        ccl_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            ccl_output_cb,
+            ref_sdpa_kv_cache_buffer,
+            address_offset=sdpa_kv_cache_running_offset_mcast_core,
+            total_size=ccl_cb_total_size,
+            core_ranges=full_device_grid,
+        )
+        ccl_output_cb_descriptor.format_descriptors = [
+            ttnn.CBFormatDescriptor(
+                buffer_index=ccl_output_cb, data_format=data_format, page_size=tile_32x32_size, tile=TD_32x32
+            )
+        ]
+        sdpa_kv_cache_running_offset_mcast_core += ccl_output_cb_descriptor.total_size
 
         post_sdpa_cb_list = [
             matmul4_in0_cb_descriptor,
@@ -2778,14 +2872,13 @@ class AttentionBlock:
             gather2_dst_cb_descriptor,
             matmul5_in0_cb_descriptor,
             matmul5_out_cb_descriptor,
-            gather3_dst_cb_descriptor,
+            gather3_scratch_cb_descriptor,
+            gather3_out_cb_descriptor,
             ccl_recv_local_data_cb_descriptor,
             ccl_remote_data_cb_descriptor,
-            attention_block_output_cb_descriptor,
+            ccl_residual_cb_descriptor,
+            ccl_output_cb_descriptor,
         ]
-
-        # In no-ownership mode, get_cb_descriptors() returns [] — all CCL CBs are above.
-        post_sdpa_cb_list.extend(allreduce_config.get_cb_descriptors(sender_mesh_coord))
 
         # CB 16: SDPA neighbor L (aliased to intermediate recv buffer)
         # The recv buffer holds both L and MS data, but this CB should only
@@ -3265,6 +3358,11 @@ class AttentionBlock:
                 core_values=gather3_sender_idx_per_core,
                 other_value=0,
             ),
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="matmul5_k_offset",
+                core_values=matmul5_k_offset_per_core,
+                other_value=0,
+            ),
         ]
 
         per_core_ncrisc_args = mla_ncrisc_per_core_args
@@ -3432,25 +3530,43 @@ class AttentionBlock:
                     ("kv_cache_num_sp_devices", mesh_rows),
                 ]
 
-                # Assemble full compile-time arg lists from base + per-device parts
+                # TP4 outer-dim residual copy params (receiver core NOC-reads input slice)
+                residual_byte_offset = row * per_device_out_tiles * tile_1x32_size
+                residual_copy_size = per_device_out_tiles * tile_1x32_size
+                residual_copy_named_compile_time_args = [
+                    ("residual_byte_offset", residual_byte_offset),
+                    ("residual_copy_size", residual_copy_size),
+                    ("residual_cb_id", ccl_residual_cb),
+                    ("residual_num_tiles", gather3_dst_num_tiles),
+                ]
+
+                # Assemble full compile-time arg lists from base + per-device parts.
+                # AllGather CT args (schema + named) come from allgather_config.
                 ncrisc_named_compile_time_args = (
                     bcast_ncrisc_named_compile_time_args
                     + ncrisc_named_compile_time_args_base
                     + qrope_ncrisc_addr_args
                     + krope_ncrisc_addr_args
                     + kv_cache_sp_named_compile_time_args
+                    + residual_copy_named_compile_time_args
+                    + allgather_config.get_fused_ncrisc_named_ct_args(mesh_coord)
                 )
                 ncrisc_common_runtime_args = ncrisc_bcast_common_args + [
                     kv_cache_tensor_device.buffer_address(),
                     position_ids_tensor_addr,
                     gather2_receiver_data_addr,
                     gather3_receiver_data_addr,
+                    ttnn.get_cb_address(
+                        in_cb_descriptor
+                    ),  # input CB L1 addr for residual copy (backed by sdpa_kv_cache)
+                    ref_attention_block_output_tensor.buffer_address(),  # output tensor L1 addr (all-gather destination)
                 ]
 
                 brisc_named_compile_time_args = (
                     bcast_brisc_named_compile_time_args
                     + brisc_named_compile_time_args_base
                     + kv_cache_sp_named_compile_time_args
+                    + allgather_config.get_fused_brisc_named_ct_args(mesh_coord)
                 )
                 brisc_common_runtime_args = [
                     kv_cache_tensor_device.buffer_address(),
@@ -3461,13 +3577,15 @@ class AttentionBlock:
                     bcast_trisc_named_compile_time_args
                     + trisc_named_compile_time_args_base
                     + kv_cache_sp_named_compile_time_args
+                    + allgather_config.get_fused_trisc_named_ct_args(mesh_coord)
                 )
 
                 # ========================================================================
-                # CCL context (per-device) — AllReduceConfig handles all RT arg generation
+                # CCL context (per-device) — config classes handle all RT arg generation
                 # ========================================================================
                 ccl_ctx = {
                     "allreduce_config": allreduce_config,
+                    "allgather_config": allgather_config,
                     "mesh_coord": mesh_coord,
                     "sender_ncrisc_common_rt_args": list(allreduce_config.get_sender_ncrisc_common_rt_args(mesh_coord)),
                     "sender_brisc_common_rt_args": list(allreduce_config.get_sender_brisc_common_rt_args(mesh_coord)),
@@ -4047,26 +4165,41 @@ class AttentionBlock:
                 ccl_sender_core = ctx["ccl_sender_core"]
                 gather_core = ctx["gather_core"]
                 allreduce_config = ccl["allreduce_config"]
+                allgather_config = ccl["allgather_config"]
                 coord = ccl["mesh_coord"]
 
                 sender_group = kernel_result.get_group_by_arg("is_allreduce_sender_core", 1)
                 receiver_group = kernel_result.get_group_by_arg("is_allreduce_receiver_core", 1)
 
-                # Sender NCRISC: common RT args + per-core fabric args
+                # Sender NCRISC: common RT args + [count] + allreduce fabric args + allgather fabric args
                 ccl_sender_ncrisc_rt = program.kernels[sender_group.ncrisc_kernel_index].runtime_args[
                     ccl_sender_core.x
                 ][ccl_sender_core.y]
                 ccl_sender_ncrisc_rt.extend(ccl["sender_ncrisc_common_rt_args"])
-                ccl_sender_ncrisc_rt.extend(
+                allreduce_ncrisc_pc_args = list(
                     allreduce_config.get_ncrisc_per_core_rt_args(coord, program, ccl_sender_core)
                 )
+                # Embed allreduce fabric arg count BEFORE fabric args (kernel reads count, then sets per_core_rta_start_idx)
+                ccl_sender_ncrisc_rt.append(len(allreduce_ncrisc_pc_args))
+                ccl_sender_ncrisc_rt.extend(allreduce_ncrisc_pc_args)
+                ccl_sender_ncrisc_rt.extend(
+                    allgather_config.get_transport_ncrisc_per_core_rt_args(coord, program, ccl_sender_core)
+                )
 
-                # Sender BRISC: common RT args + per-core fabric args
+                # Sender BRISC: common RT args + [count] + allreduce fabric args + allgather fabric args
                 ccl_sender_brisc_rt = program.kernels[sender_group.brisc_kernel_index].runtime_args[ccl_sender_core.x][
                     ccl_sender_core.y
                 ]
                 ccl_sender_brisc_rt.extend(ccl["sender_brisc_common_rt_args"])
-                ccl_sender_brisc_rt.extend(allreduce_config.get_brisc_per_core_rt_args(coord, program, ccl_sender_core))
+                allreduce_brisc_pc_args = list(
+                    allreduce_config.get_brisc_per_core_rt_args(coord, program, ccl_sender_core)
+                )
+                # Embed allreduce fabric arg count BEFORE fabric args (kernel reads count, then sets per_core_rta_start_idx)
+                ccl_sender_brisc_rt.append(len(allreduce_brisc_pc_args))
+                ccl_sender_brisc_rt.extend(allreduce_brisc_pc_args)
+                ccl_sender_brisc_rt.extend(
+                    allgather_config.get_transport_brisc_per_core_rt_args(coord, program, ccl_sender_core)
+                )
 
                 # Receiver NCRISC: common RT args only (reader uses semaphores, no fabric)
                 ccl_receiver_ncrisc_rt = program.kernels[receiver_group.ncrisc_kernel_index].runtime_args[
@@ -4075,5 +4208,5 @@ class AttentionBlock:
                 ccl_receiver_ncrisc_rt.extend(ccl["receiver_ncrisc_common_rt_args"])
 
             mesh_program_descriptor[ttnn.MeshCoordinateRange(mesh_coord, mesh_coord)] = program
-        result = ttnn.generic_op(io_tensors, mesh_program_descriptor)
-        return result
+        ttnn.generic_op(io_tensors, mesh_program_descriptor)
+        return attention_block_output_tensor

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -43,6 +43,7 @@
 #include "../../../unified_kernels/sdpa_reduce_worker.hpp"
 #include "../../../unified_kernels/sdpa_reduce_forwarder.hpp"
 #include "../../../unified_kernels/all_reduce.hpp"
+#include "../../../unified_kernels/all_gather.hpp"
 
 #include "../../../unified_kernels/moe_gather.hpp"
 #include "../../../unified_kernels/deepseek_moe_gate.hpp"
@@ -191,6 +192,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather_reduce_half_num_cores"),
         get_named_compile_time_arg_val("gather_reduce_dst_cb"),
         get_named_compile_time_arg_val("gather_reduce_half_size_bytes"),
+        0,  // sender_idx (unused; UsePerCoreSenderIdx=false uses grid)
         get_named_compile_time_arg_val("gather_reduce_noc_idx"),
     };
 
@@ -479,35 +481,27 @@ void kernel_main() {
             get_named_compile_time_arg_val("mcast3_dst_num_pages"),
         }};
 
-    // Matmul5 CTArgs
-    using Matmul5CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
-    deepseek_b1_ops::Matmul::ReaderArgs matmul5_args{};
+    // Matmul5 (KNSlicedMatmul) reader args - NCRISC is no-op
+    using Matmul5CTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::ReaderArgs matmul5_args{};
 
-    // Gather3 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
-    // via gather3_sender_idx, avoiding gaps from the non-rectangular o_proj grid).
-    // Sender picks noc0/noc1 receiver semaphore at compile-time based on gather3_noc_idx.
-    deepseek_b1_ops::Gather::DMArgs gather3_args{
-        .sender =
-            {
-                get_named_compile_time_arg_val("gather3_dest_noc_x"),
-                get_named_compile_time_arg_val("gather3_dest_noc_y"),
-                get_named_compile_time_arg_val("gather3_data_size_bytes"),
-                get_semaphore(
-                    get_named_compile_time_arg_val("gather3_noc_idx") == 0
-                        ? get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")
-                        : get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-                get_named_compile_time_arg_val("gather3_src_cb"),
-                get_named_compile_time_arg_val("gather3_src_num_pages"),
-                get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
-                get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
-                get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
-                get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
-                get_named_compile_time_arg_val("gather3_row_major"),
-                get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 3),  // gather3_receiver_data_addr
-                get_named_compile_time_arg_val("gather3_sender_idx"),
-                get_named_compile_time_arg_val("gather3_noc_idx"),
-            },
-        .receiver = {},
+    // GatherReduce3 sender args
+    deepseek_b1_ops::GatherReduce::SenderArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_dest_noc_x"),
+        get_named_compile_time_arg_val("gather3_dest_noc_y"),
+        get_named_compile_time_arg_val("gather3_data_size_bytes"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_addr")),
+        get_named_compile_time_arg_val("gather3_src_cb"),
+        get_named_compile_time_arg_val("gather3_src_num_pages"),
+        get_named_compile_time_arg_val("gather3_grid_start_x"),
+        get_named_compile_time_arg_val("gather3_grid_start_y"),
+        get_named_compile_time_arg_val("gather3_grid_end_x"),
+        get_named_compile_time_arg_val("gather3_grid_end_y"),
+        get_named_compile_time_arg_val("gather3_half_num_cores"),
+        get_named_compile_time_arg_val("gather3_dst_cb_id"),
+        get_named_compile_time_arg_val("gather3_half_size_bytes"),
+        get_named_compile_time_arg_val("gather3_sender_idx"),
+        get_named_compile_time_arg_val("gather3_noc_idx"),
     };
 
     // ========================================================================o
@@ -616,11 +610,14 @@ void kernel_main() {
 
     deepseek_b1_ops::AllReduce::SenderArgs ccl_sender_args{};
     deepseek_b1_ops::AllReduce::ReceiverArgs ccl_receiver_args{};
+    uint32_t ncrisc_allreduce_fabric_count = 0;
 
     if constexpr (Core::is_allreduce_sender_core) {
         ccl_sender_args.intermediate_buffer_address = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.dest_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.dest_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        // Read allreduce fabric arg count (placed before fabric args in RT arg stream)
+        ncrisc_allreduce_fabric_count = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.per_core_rta_start_idx = per_core_rta_arg_idx;
     }
 
@@ -632,6 +629,56 @@ void kernel_main() {
         ccl_receiver_args.sender_local_data_l1_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_receiver_args.local_ready_sem_bank_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
     }
+
+    // AllGather CT types (NCRISC: gather controller on receiver + bwd transport on sender)
+    using AllGatherGatherCT = deepseek_b1_ops::AllGather::GatherCTArgs<
+        get_named_compile_time_arg_val("allgather_gather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_gather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_ring_size"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot")>;
+
+    using AllGatherTransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+        get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+        get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+        get_named_compile_time_arg_val("allgather_num_links"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+        get_named_compile_time_arg_val("allgather_r2_active")>;
+
+    // AllGather transport args (sender core NCRISC = backward sender)
+    deepseek_b1_ops::AllGather::TransportArgs allgather_transport_args{};
+    if constexpr (Core::is_allreduce_sender_core) {
+        // Skip past allreduce fabric per-core RT args using pre-read count
+        per_core_rta_arg_idx += ncrisc_allreduce_fabric_count;
+
+        allgather_transport_args.scratch_base_addr = get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_transport_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_transport_args.dest_output_base_addr =
+            get_named_compile_time_arg_val("allgather_dest_output_base_addr");
+        allgather_transport_args.r1_dest_slot_index = get_named_compile_time_arg_val("allgather_r1_dest_slot_index");
+        allgather_transport_args.dest_noc_x = get_named_compile_time_arg_val("allgather_dest_noc_x");
+        allgather_transport_args.dest_noc_y = get_named_compile_time_arg_val("allgather_dest_noc_y");
+        allgather_transport_args.dest_recv_sem_addr = get_named_compile_time_arg_val("allgather_dest_recv_sem_addr");
+        allgather_transport_args.r2_dest_slot_index = get_named_compile_time_arg_val("allgather_r2_dest_slot_index");
+        allgather_transport_args.per_core_rta_start_idx = per_core_rta_arg_idx;
+    }
+
+    // AllGather gather args (receiver core NCRISC = gather controller)
+    deepseek_b1_ops::AllGather::GatherArgs allgather_gather_args{};
+    if constexpr (Core::is_allreduce_receiver_core) {
+        // local_input_addr set at runtime after cb_wait_front in execution section
+        allgather_gather_args.output_buffer_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 5);
+        allgather_gather_args.self_slot_index = get_named_compile_time_arg_val("allgather_self_slot_index");
+        allgather_gather_args.transport_scratch_base_addr =
+            get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_gather_args.transport_noc_x = get_named_compile_time_arg_val("allgather_transport_noc_x");
+        allgather_gather_args.transport_noc_y = get_named_compile_time_arg_val("allgather_transport_noc_y");
+        allgather_gather_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_gather_args.recv_sem_addr = get_named_compile_time_arg_val("allgather_recv_sem_addr");
+        allgather_gather_args.r2_src_slot_index = get_named_compile_time_arg_val("allgather_r2_src_slot_index");
+    }
+
 // ============================================================================
 // BRISC (Writer + Mcast Sender) - WriterConfigDescriptor compiles as BRISC
 // Named compile-time args: bcast writer + rmsnorm writer, mcast sender, matmul writer, gather receiver
@@ -789,9 +836,9 @@ void kernel_main() {
 
     // Matmul4/2 CTArgs (BRISC is no-op for matmul)
     using Matmul4CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
-    using Matmul5CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    using Matmul5CTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
     deepseek_b1_ops::Matmul::WriterArgs matmul4_args{};
-    deepseek_b1_ops::Matmul::WriterArgs matmul5_args{};
+    deepseek_b1_ops::KNSlicedMatmul::WriterArgs matmul5_args{};
 
     // Gather2 receiver args
     deepseek_b1_ops::Gather::DMArgs gather2_args{
@@ -827,18 +874,14 @@ void kernel_main() {
             },
         .receiver = {}};
 
-    // Gather3 receiver args
-    deepseek_b1_ops::Gather::DMArgs gather3_args{
-        .sender = {},
-        .receiver =
-            {
-                get_named_compile_time_arg_val("gather3_noc0_num_senders"),
-                get_named_compile_time_arg_val("gather3_noc1_num_senders"),
-                get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
-                get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-                get_named_compile_time_arg_val("gather3_dst_cb"),
-                get_named_compile_time_arg_val("gather3_dst_num_pages"),
-            },
+    // GatherReduce3 receiver args
+    deepseek_b1_ops::GatherReduce::ReceiverArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather3_noc1_num_senders"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather3_dst_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_tiles"),
     };
 
     // ========================================================================o
@@ -944,11 +987,40 @@ void kernel_main() {
         get_named_compile_time_arg_val("allreduce_skip_local_push")>;
 
     deepseek_b1_ops::AllReduce::SenderArgs ccl_sender_args{};
+    uint32_t brisc_allreduce_fabric_count = 0;
     if constexpr (Core::is_allreduce_sender_core) {
         ccl_sender_args.intermediate_buffer_address = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.dest_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.dest_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        // Read allreduce fabric arg count (placed before fabric args in RT arg stream)
+        brisc_allreduce_fabric_count = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         ccl_sender_args.per_core_rta_start_idx = per_core_rta_arg_idx;
+    }
+
+    // AllGather CT types (BRISC = forward transport sender on sender core)
+    using AllGatherTransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+        get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+        get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+        get_named_compile_time_arg_val("allgather_num_links"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+        get_named_compile_time_arg_val("allgather_r2_active")>;
+
+    deepseek_b1_ops::AllGather::TransportArgs allgather_transport_args{};
+    if constexpr (Core::is_allreduce_sender_core) {
+        // Skip past allreduce fabric per-core RT args using pre-read count
+        per_core_rta_arg_idx += brisc_allreduce_fabric_count;
+        allgather_transport_args.scratch_base_addr = get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_transport_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_transport_args.dest_output_base_addr =
+            get_named_compile_time_arg_val("allgather_dest_output_base_addr");
+        allgather_transport_args.r1_dest_slot_index = get_named_compile_time_arg_val("allgather_r1_dest_slot_index");
+        allgather_transport_args.dest_noc_x = get_named_compile_time_arg_val("allgather_dest_noc_x");
+        allgather_transport_args.dest_noc_y = get_named_compile_time_arg_val("allgather_dest_noc_y");
+        allgather_transport_args.dest_recv_sem_addr = get_named_compile_time_arg_val("allgather_dest_recv_sem_addr");
+        allgather_transport_args.r2_dest_slot_index = get_named_compile_time_arg_val("allgather_r2_dest_slot_index");
+        allgather_transport_args.per_core_rta_start_idx = per_core_rta_arg_idx;
     }
 
 // ============================================================================
@@ -1186,19 +1258,27 @@ void kernel_main() {
     // Mcast3 CTArgs (no-op)
     deepseek_b1_ops::Mcast::ComputeArgs mcast3_args{};
 
-    // Matmul5 CTArgs
+    // Matmul5 (KNSlicedMatmul) CTArgs + compute args
+    constexpr uint32_t matmul5_k_offset = get_named_compile_time_arg_val("matmul5_k_offset");
+
     using Matmul5CTArgs =
-        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
-    deepseek_b1_ops::Matmul::ComputeArgs matmul5_args{
+        deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
+    deepseek_b1_ops::KNSlicedMatmul::ComputeArgs matmul5_args{
         get_named_compile_time_arg_val("matmul5_in0"),
         get_named_compile_time_arg_val("matmul5_in1"),
         get_named_compile_time_arg_val("matmul5_out"),
-        get_named_compile_time_arg_val("matmul5_k_num_tiles"),
+        matmul5_k_offset,
+        get_named_compile_time_arg_val("matmul5_k_per_core"),
+        get_named_compile_time_arg_val("matmul5_act_total_tiles"),
         get_common_arg_val<uint32_t>(14),  // matmul5_weights_addr
     };
 
-    // Gather3 compute args (no-op)
-    deepseek_b1_ops::Gather::ComputeArgs gather3_args{};
+    // GatherReduce3 compute args
+    deepseek_b1_ops::GatherReduce::ComputeArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_scratch_cb"),
+        get_named_compile_time_arg_val("gather3_out_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_tiles"),
+    };
 
     // CCL Broadcast CTArgs (no-op for TRISC)
     using BcastCTArgs = deepseek_b1_ops::Broadcast::ComputeCTArgs;
@@ -2406,24 +2486,24 @@ void kernel_main() {
         }
 
         // ========================================================================
-        // Matmul5: [1, 8192] x [8192, 64] -> [1, 64] per core (112 active cores)
-        // Input: mcast3_dst_cb (CB 4), Weights: matmul5_in1 (CB 5), Output: matmul5_out (CB 6)
-        // Only runs on 112 active cores (is_matmul5_core=true), 18 inactive cores skip
+        // Matmul5 (KNSlicedMatmul): TP4 outer-dim o_proj
+        // 112 cores split into 2 halves of 56; each core: [1, 4096] @ [4096, 32] -> [1, 32]
         // ========================================================================
         {
             DeviceZoneScopedN("MATMUL5");
-            // pop_in0 = true (mcast3 output consumed), pop_in1 = false (weights persistent)
-            deepseek_b1_ops::Matmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
+            deepseek_b1_ops::KNSlicedMatmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
             matmul5(matmul5_args);
         }
 
         // ========================================================================
-        // Gather3: 112 active matmul5 cores -> sender core (11, 9)
-        // Collects [1, 64] * 112 = [1, 7168]
+        // GatherReduce3: 112 cores (2x56 halves) -> sender core (11, 9)
+        // Each sender produces 1 tile of 1x32; halves are reduced on receiver
         // ========================================================================
         {
             DeviceZoneScopedN("GATHER3");
-            deepseek_b1_ops::Gather::Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, true, true> gather3;
+            deepseek_b1_ops::GatherReduce::
+                Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, Core::is_allreduce_sender_core, true, true>
+                    gather3;
             gather3(gather3_args);
         }
 
@@ -2446,16 +2526,53 @@ void kernel_main() {
             uint64_t ccl_sync_sem_noc_addr = get_noc_addr(input_noc_coord_x, input_noc_coord_y, ccl_sync_sem_addr);
             noc_semaphore_inc(ccl_sync_sem_noc_addr, 1);
             noc_async_atomic_barrier();
+
+            // All-Gather: transport sender (BRISC=fwd, NCRISC=bwd)
+            {
+                DeviceZoneScopedN("ALLGATHER_TRANSPORT");
+                deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
+                allgather_sender(allgather_transport_args);
+            }
 #endif
         }
 
         if constexpr (Core::is_allreduce_receiver_core) {
             DeviceZoneScopedN("CCL_RECEIVER");
 #if defined(COMPILE_FOR_NCRISC)
-            // TODO: We're popping the RMSNorm input and then re-pushing it here as the residual
-            // Should avoid this and not pop in RMSNorm
+            // TP4 outer-dim: NOC-copy the correct [1, per_device_out_w] slice of the
+            // input tensor into the residual CB (2 tiles of 32x32) before AllReduce.
+            {
+                constexpr uint32_t residual_offset = get_named_compile_time_arg_val("residual_byte_offset");
+                constexpr uint32_t residual_size = get_named_compile_time_arg_val("residual_copy_size");
+                constexpr uint32_t residual_cb = get_named_compile_time_arg_val("residual_cb_id");
+                constexpr uint32_t residual_num_tiles = get_named_compile_time_arg_val("residual_num_tiles");
+                constexpr uint32_t inp_noc_x = get_named_compile_time_arg_val("input_noc_coord_x");
+                constexpr uint32_t inp_noc_y = get_named_compile_time_arg_val("input_noc_coord_y");
+                uint32_t input_l1_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 4);
+                cb_reserve_back(residual_cb, residual_num_tiles);
+                uint32_t residual_dst = get_write_ptr(residual_cb);
+                uint64_t src_noc_addr = get_noc_addr(inp_noc_x, inp_noc_y, input_l1_addr + residual_offset);
+                noc_async_read(src_noc_addr, residual_dst, residual_size);
+                noc_async_read_barrier();
+                cb_push_back(residual_cb, residual_num_tiles);
+            }
+
             deepseek_b1_ops::AllReduce::Reader<AllReduceReaderCTArgs> ccl_reader;
             ccl_reader(ccl_receiver_args);
+
+            // All-Gather: gather controller — reads [1, per_device_out_w] from
+            // ccl_output_cb and distributes across row ring into output tensor.
+            {
+                DeviceZoneScopedN("ALLGATHER_GATHER");
+                constexpr uint32_t out_cb = get_named_compile_time_arg_val("output_cb_id");
+                constexpr uint32_t out_num_tiles = get_named_compile_time_arg_val("output_num_tiles");
+                cb_wait_front(out_cb, out_num_tiles);
+                allgather_gather_args.local_input_addr = get_read_ptr(out_cb);
+
+                deepseek_b1_ops::AllGather::GatherController<AllGatherGatherCT> allgather_controller;
+                allgather_controller(allgather_gather_args);
+                cb_pop_front(out_cb, out_num_tiles);
+            }
 #elif defined(COMPILE_FOR_TRISC)
             deepseek_b1_ops::AllReduce::Compute<AllReduceComputeCTArgs> ccl_compute;
             ccl_compute(ccl_compute_args);

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -517,26 +517,39 @@ class DecoderBlock:
                 ccl_sender_core = ctx["ccl_sender_core"]
                 gather_core = ctx["gather_core"]
                 allreduce_config = ccl["allreduce_config"]
+                allgather_config = ccl["allgather_config"]
                 coord = ccl["mesh_coord"]
 
                 sender_group = kernel_result.get_group_by_arg("is_allreduce_sender_core", 1)
                 receiver_group = kernel_result.get_group_by_arg("is_allreduce_receiver_core", 1)
 
-                # Sender NCRISC: common RT args + per-core fabric args
+                # Sender NCRISC: common RT args + [count] + allreduce fabric args + allgather fabric args
                 ccl_sender_ncrisc_rt = program.kernels[sender_group.ncrisc_kernel_index].runtime_args[
                     ccl_sender_core.x
                 ][ccl_sender_core.y]
                 ccl_sender_ncrisc_rt.extend(ccl["sender_ncrisc_common_rt_args"])
-                ccl_sender_ncrisc_rt.extend(
+                allreduce_ncrisc_pc_args = list(
                     allreduce_config.get_ncrisc_per_core_rt_args(coord, program, ccl_sender_core)
                 )
+                ccl_sender_ncrisc_rt.append(len(allreduce_ncrisc_pc_args))
+                ccl_sender_ncrisc_rt.extend(allreduce_ncrisc_pc_args)
+                ccl_sender_ncrisc_rt.extend(
+                    allgather_config.get_transport_ncrisc_per_core_rt_args(coord, program, ccl_sender_core)
+                )
 
-                # Sender BRISC: common RT args + per-core fabric args
+                # Sender BRISC: common RT args + [count] + allreduce fabric args + allgather fabric args
                 ccl_sender_brisc_rt = program.kernels[sender_group.brisc_kernel_index].runtime_args[ccl_sender_core.x][
                     ccl_sender_core.y
                 ]
                 ccl_sender_brisc_rt.extend(ccl["sender_brisc_common_rt_args"])
-                ccl_sender_brisc_rt.extend(allreduce_config.get_brisc_per_core_rt_args(coord, program, ccl_sender_core))
+                allreduce_brisc_pc_args = list(
+                    allreduce_config.get_brisc_per_core_rt_args(coord, program, ccl_sender_core)
+                )
+                ccl_sender_brisc_rt.append(len(allreduce_brisc_pc_args))
+                ccl_sender_brisc_rt.extend(allreduce_brisc_pc_args)
+                ccl_sender_brisc_rt.extend(
+                    allgather_config.get_transport_brisc_per_core_rt_args(coord, program, ccl_sender_core)
+                )
 
                 # Receiver NCRISC: common RT args only (reader uses semaphores, no fabric)
                 ccl_receiver_ncrisc_rt = program.kernels[receiver_group.ncrisc_kernel_index].runtime_args[

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -597,6 +597,15 @@ void kernel_main() {
         args.sender_noc_y = get_common_arg_val<uint32_t>(3);
         args.sender_local_data_l1_addr = get_common_arg_val<uint32_t>(4);
         args.local_ready_sem_bank_addr = get_common_arg_val<uint32_t>(5);
+
+        // Residual CB is tensor-backed (data already in L1); signal TRISC so
+        // Compute's cb_wait_front(cb_residual) unblocks. Reader no longer does
+        // this — responsibility moved to the caller.
+        if constexpr (AllReduceReaderCTArgs::has_residual) {
+            cb_reserve_back(AllReduceReaderCTArgs::residual_cb_id, AllReduceReaderCTArgs::total_num_tiles);
+            cb_push_back(AllReduceReaderCTArgs::residual_cb_id, AllReduceReaderCTArgs::total_num_tiles);
+        }
+
         deepseek_b1_ops::AllReduce::Reader<AllReduceReaderCTArgs> reader;
         reader(args);
     }

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/op.py
@@ -133,7 +133,7 @@ def _gather_common_rt_schema(
     transport_scratch_base_addr=0,
     transport_noc_x=0,
     transport_noc_y=0,
-    handoff_sem_bank_addr=0,
+    handoff_sem_addr=0,
     recv_sem_addr=0,
     r2_src_slot_index=0,
 ):
@@ -145,7 +145,7 @@ def _gather_common_rt_schema(
         int(transport_scratch_base_addr),
         int(transport_noc_x),
         int(transport_noc_y),
-        int(handoff_sem_bank_addr),
+        int(handoff_sem_addr),
         int(recv_sem_addr),
         int(r2_src_slot_index),
     ]
@@ -161,7 +161,11 @@ def _transport_common_rt_schema(
     dest_recv_sem_addr=0,
     r2_dest_slot_index=0,
 ):
-    """Transport core common RT args (shared by BRISC fwd and NCRISC bwd)."""
+    """Transport core common RT args.
+
+    handoff_sem_bank_addr is the shared handoff semaphore address.
+    Both BRISC and NCRISC use the same semaphore.
+    """
     return [
         int(scratch_base_addr),
         int(handoff_sem_bank_addr),
@@ -180,28 +184,50 @@ def _transport_common_rt_schema(
 
 
 class AllGatherConfig:
-    """Standalone all-gather config for a 4-device torused ring.
+    """All-gather host-side config for a 4-device torused ring.
 
-    Cores are derived from tensor shard grids:
-      gather_core  — from input_tensor_mesh shard grid start
-      transport_core — from scratch_tensor_mesh shard grid start
+    Two init modes:
+
+    1. **Tensor-owned mode** (standalone): pass tensor meshes + semaphores.
+       Addresses, cores, slice size, and semaphore addresses are all derived
+       from the tensors.
+
+    2. **No-ownership mode** (fused kernels): pass explicit
+       ``slice_size_bytes``, ``output_addr``, ``scratch_base_addr``,
+       ``handoff_sem_addr``, ``recv_sem_addr``, ``gather_noc_core``,
+       ``transport_noc_core``. Used when the gather/transport cores and
+       memory regions live inside a larger fused kernel's CBs and are not
+       backed by dedicated ttnn tensors. Optionally pass ``output_cb_id`` +
+       ``output_num_tiles`` to emit those as named CT args for the fused
+       kernel.
 
     Public API mirrors the all-reduce config pattern:
       Named CT:   get_ncrisc_named_ct_args, get_brisc_named_ct_args, get_trisc_named_ct_args
-      Common RT:  get_gather_ncrisc_common_rt_args, get_transport_common_rt_args
+                  (+ get_fused_* variants that also emit address/slot/noc as named CT)
+      Common RT:  get_gather_ncrisc_common_rt_args, get_transport_common_rt_args (tensor-owned only)
       Per-core RT: get_transport_brisc_per_core_rt_args, get_transport_ncrisc_per_core_rt_args
     """
 
     def __init__(
         self,
         mesh_device,
-        input_tensor_mesh,
-        output_tensor_mesh,
-        scratch_tensor_mesh,
-        semaphores,
+        input_tensor_mesh=None,
+        output_tensor_mesh=None,
+        scratch_tensor_mesh=None,
+        semaphores=None,
         cluster_axis=0,
         num_links=1,
         max_chunk_size_bytes=None,
+        # No-ownership mode
+        slice_size_bytes=None,
+        output_addr=None,
+        scratch_base_addr=None,
+        handoff_sem_addr=None,
+        recv_sem_addr=None,
+        gather_noc_core=None,
+        transport_noc_core=None,
+        output_cb_id=None,
+        output_num_tiles=None,
     ):
         self.mesh_device = mesh_device
         self.cluster_axis = int(cluster_axis)
@@ -213,53 +239,29 @@ class AllGatherConfig:
         ring_size = mesh_shape[self.cluster_axis]
         if ring_size != RING_SIZE:
             raise ValueError(f"All-gather requires ring size {RING_SIZE}, got {ring_size}")
-        if len(semaphores) < 2:
-            raise ValueError(f"Need 2 semaphores (handoff + recv), got {len(semaphores)}")
         if self.num_links < 1 or self.num_links > MAX_NUM_LINKS:
             raise ValueError(f"num_links must be in [1, {MAX_NUM_LINKS}], got {self.num_links}")
 
-        input_per_device = ttnn.get_device_tensors(input_tensor_mesh)
-        output_per_device = ttnn.get_device_tensors(output_tensor_mesh)
-        scratch_per_device = ttnn.get_device_tensors(scratch_tensor_mesh)
-        self.input_per_device = input_per_device
-        self.output_per_device = output_per_device
-        self.scratch_per_device = scratch_per_device
+        self._owns_tensors = input_tensor_mesh is not None
+        if self._owns_tensors:
+            self._init_tensor_owned(
+                input_tensor_mesh, output_tensor_mesh, scratch_tensor_mesh, semaphores, max_chunk_size_bytes
+            )
+        else:
+            self._init_no_ownership(
+                slice_size_bytes=slice_size_bytes,
+                output_addr=output_addr,
+                scratch_base_addr=scratch_base_addr,
+                handoff_sem_addr=handoff_sem_addr,
+                recv_sem_addr=recv_sem_addr,
+                gather_noc_core=gather_noc_core,
+                transport_noc_core=transport_noc_core,
+                max_chunk_size_bytes=max_chunk_size_bytes,
+            )
 
-        # Derive cores from tensor shard grids
-        gather_grid_start = input_per_device[0].memory_config().shard_spec.grid.bounding_box().start
-        self.gather_core = ttnn.CoreCoord(int(gather_grid_start.x), int(gather_grid_start.y))
-
-        transport_grid_start = scratch_per_device[0].memory_config().shard_spec.grid.bounding_box().start
-        self.transport_core = ttnn.CoreCoord(int(transport_grid_start.x), int(transport_grid_start.y))
-
-        # Slice size from input tensor shard
-        input_shard = input_per_device[0].memory_config().shard_spec
-        element_size = 2  # bf16
-        shard_elements = input_shard.shape[0] * input_shard.shape[1]
-        self.slice_size_bytes = shard_elements * element_size
-
-        self.chunk = resolve_byte_chunk_config(self.slice_size_bytes, max_chunk_size_bytes)
-
-        # L1 addresses (uniform across devices for same tensor allocation)
-        self.input_addr = input_per_device[0].buffer_address()
-        self.output_addr = output_per_device[0].buffer_address()
-        self.scratch_base_addr = scratch_per_device[0].buffer_address()
-
-        # Global semaphore addresses
-        self.handoff_sem_addr = ttnn.get_global_semaphore_address(semaphores[0])
-        self.recv_sem_addr = ttnn.get_global_semaphore_address(semaphores[1])
-
-        # Physical NOC coords (uniform across devices)
-        ref_device = input_per_device[0].device()
-        gather_phys = ref_device.worker_core_from_logical_core(self.gather_core)
-        transport_phys = ref_device.worker_core_from_logical_core(self.transport_core)
-        self.gather_noc_x = gather_phys.x
-        self.gather_noc_y = gather_phys.y
-        self.transport_noc_x = transport_phys.x
-        self.transport_noc_y = transport_phys.y
-
-        self.gather_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(self.gather_core, self.gather_core)])
-        self.transport_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(self.transport_core, self.transport_core)])
+        # Optional fused-kernel output CB fields (None in tensor-owned mode)
+        self.output_cb_id = int(output_cb_id) if output_cb_id is not None else None
+        self.output_num_tiles = int(output_num_tiles) if output_num_tiles is not None else None
 
         # Per-device schedule
         mesh_rows, mesh_cols = mesh_shape
@@ -307,6 +309,104 @@ class AllGatherConfig:
                     "r2_dest_slot_index": r2_src_slot,
                 }
 
+    def _init_tensor_owned(
+        self, input_tensor_mesh, output_tensor_mesh, scratch_tensor_mesh, semaphores, max_chunk_size_bytes
+    ):
+        if semaphores is None or len(semaphores) < 2:
+            raise ValueError(f"Need 2 semaphores (handoff + recv), got {len(semaphores) if semaphores else 0}")
+
+        input_per_device = ttnn.get_device_tensors(input_tensor_mesh)
+        output_per_device = ttnn.get_device_tensors(output_tensor_mesh)
+        scratch_per_device = ttnn.get_device_tensors(scratch_tensor_mesh)
+        self.input_per_device = input_per_device
+        self.output_per_device = output_per_device
+        self.scratch_per_device = scratch_per_device
+
+        # Derive cores from tensor shard grids
+        gather_grid_start = input_per_device[0].memory_config().shard_spec.grid.bounding_box().start
+        self.gather_core = ttnn.CoreCoord(int(gather_grid_start.x), int(gather_grid_start.y))
+
+        transport_grid_start = scratch_per_device[0].memory_config().shard_spec.grid.bounding_box().start
+        self.transport_core = ttnn.CoreCoord(int(transport_grid_start.x), int(transport_grid_start.y))
+
+        # Slice size from input tensor shard
+        input_shard = input_per_device[0].memory_config().shard_spec
+        element_size = 2  # bf16
+        shard_elements = input_shard.shape[0] * input_shard.shape[1]
+        self.slice_size_bytes = shard_elements * element_size
+
+        self.chunk = resolve_byte_chunk_config(self.slice_size_bytes, max_chunk_size_bytes)
+
+        # L1 addresses (uniform across devices for same tensor allocation)
+        self.input_addr = input_per_device[0].buffer_address()
+        self.output_addr = output_per_device[0].buffer_address()
+        self.scratch_base_addr = scratch_per_device[0].buffer_address()
+
+        # Global semaphore addresses
+        self.handoff_sem_addr = ttnn.get_global_semaphore_address(semaphores[0])
+        self.recv_sem_addr = ttnn.get_global_semaphore_address(semaphores[1])
+
+        # Physical NOC coords (uniform across devices)
+        ref_device = input_per_device[0].device()
+        gather_phys = ref_device.worker_core_from_logical_core(self.gather_core)
+        transport_phys = ref_device.worker_core_from_logical_core(self.transport_core)
+        self.gather_noc_x = gather_phys.x
+        self.gather_noc_y = gather_phys.y
+        self.transport_noc_x = transport_phys.x
+        self.transport_noc_y = transport_phys.y
+
+        self.gather_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(self.gather_core, self.gather_core)])
+        self.transport_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(self.transport_core, self.transport_core)])
+
+    def _init_no_ownership(
+        self,
+        slice_size_bytes,
+        output_addr,
+        scratch_base_addr,
+        handoff_sem_addr,
+        recv_sem_addr,
+        gather_noc_core,
+        transport_noc_core,
+        max_chunk_size_bytes,
+    ):
+        required = {
+            "slice_size_bytes": slice_size_bytes,
+            "output_addr": output_addr,
+            "scratch_base_addr": scratch_base_addr,
+            "handoff_sem_addr": handoff_sem_addr,
+            "recv_sem_addr": recv_sem_addr,
+            "gather_noc_core": gather_noc_core,
+            "transport_noc_core": transport_noc_core,
+        }
+        missing = [k for k, v in required.items() if v is None]
+        if missing:
+            raise ValueError(f"No-ownership mode requires: {missing}")
+
+        self.input_per_device = None
+        self.output_per_device = None
+        self.scratch_per_device = None
+        self.input_addr = None  # Not used — fused kernel sources input from a CB.
+        self.output_addr = int(output_addr)
+        self.scratch_base_addr = int(scratch_base_addr)
+        self.handoff_sem_addr = int(handoff_sem_addr)
+        self.recv_sem_addr = int(recv_sem_addr)
+        self.slice_size_bytes = int(slice_size_bytes)
+        self.chunk = resolve_byte_chunk_config(self.slice_size_bytes, max_chunk_size_bytes)
+
+        # NOC coords passed directly (caller already resolved them to the
+        # fused kernel's owning cores).
+        self.gather_noc_x = int(gather_noc_core.x)
+        self.gather_noc_y = int(gather_noc_core.y)
+        self.transport_noc_x = int(transport_noc_core.x)
+        self.transport_noc_y = int(transport_noc_core.y)
+
+        # Logical cores / core sets unused in no-ownership mode (fused kernel
+        # owns its own core grid).
+        self.gather_core = None
+        self.transport_core = None
+        self.gather_core_set = None
+        self.transport_core_set = None
+
     # ======================================================================
     # Named compile-time args
     # ======================================================================
@@ -339,6 +439,57 @@ class AllGatherConfig:
         )
 
     def get_trisc_named_ct_args(self, coord):
+        return []
+
+    # ======================================================================
+    # Fused-kernel named CT args
+    #
+    # Fused kernels can't use positional common RT args for the all-gather
+    # block (they interleave with other fused-op RT args), so these methods
+    # emit the address/slot/noc values as NAMED CT args instead.  The fused
+    # kernel reads them via get_named_compile_time_arg_val.
+    # ======================================================================
+
+    def _transport_addr_named_ct(self, coord):
+        info = self._per_device[coord]
+        return [
+            ("allgather_handoff_sem_addr", self.handoff_sem_addr),
+            ("allgather_scratch_base_addr", self.scratch_base_addr),
+            ("allgather_dest_output_base_addr", self.output_addr),
+            ("allgather_r1_dest_slot_index", info["r1_dest_slot_index"]),
+            ("allgather_dest_noc_x", self.gather_noc_x),
+            ("allgather_dest_noc_y", self.gather_noc_y),
+            ("allgather_dest_recv_sem_addr", self.recv_sem_addr),
+            ("allgather_r2_dest_slot_index", info["r2_dest_slot_index"]),
+        ]
+
+    def _gather_addr_named_ct(self, coord):
+        info = self._per_device[coord]
+        out = [
+            ("allgather_self_slot_index", info["self_rank"]),
+            ("allgather_r2_src_slot_index", info["r2_src_slot_index"]),
+            ("allgather_transport_noc_x", self.transport_noc_x),
+            ("allgather_transport_noc_y", self.transport_noc_y),
+            ("allgather_handoff_sem_addr", self.handoff_sem_addr),
+            ("allgather_recv_sem_addr", self.recv_sem_addr),
+        ]
+        if self.output_cb_id is not None:
+            out.append(("output_cb_id", self.output_cb_id))
+        if self.output_num_tiles is not None:
+            out.append(("output_num_tiles", self.output_num_tiles))
+        return out
+
+    def get_fused_ncrisc_named_ct_args(self, coord):
+        return (
+            self.get_ncrisc_named_ct_args(coord)
+            + self._transport_addr_named_ct(coord)
+            + self._gather_addr_named_ct(coord)
+        )
+
+    def get_fused_brisc_named_ct_args(self, coord):
+        return self.get_brisc_named_ct_args(coord) + self._transport_addr_named_ct(coord)
+
+    def get_fused_trisc_named_ct_args(self, coord):
         return []
 
     # ======================================================================
@@ -391,18 +542,13 @@ class AllGatherConfig:
             transport_scratch_base_addr=self.scratch_base_addr,
             transport_noc_x=self.transport_noc_x,
             transport_noc_y=self.transport_noc_y,
-            handoff_sem_bank_addr=self.handoff_sem_addr,
+            handoff_sem_addr=self.handoff_sem_addr,
             recv_sem_addr=self.recv_sem_addr,
             r2_src_slot_index=info["r2_src_slot_index"],
         )
 
     def get_transport_common_rt_args(self, coord):
-        """Common RT args shared by both transport BRISC (fwd) and NCRISC (bwd).
-
-        Destination NOC coords and L1 addresses are direction-independent
-        because all devices share the same physical layout.  The actual
-        fabric routing is determined by per-core RT args (fabric connection).
-        """
+        """Common RT args shared by transport BRISC (fwd sender) and NCRISC (bwd sender)."""
         info = self._per_device[coord]
         return _transport_common_rt_schema(
             scratch_base_addr=self.scratch_base_addr,
@@ -551,10 +697,10 @@ class DeepseekMinimalAllGather:
                 program.kernels[gather_group.brisc_kernel_index].common_runtime_args = []
                 program.kernels[gather_group.trisc_kernel_index].common_runtime_args = []
 
-                # Transport core common RT args
-                transport_rt = config.get_transport_common_rt_args(coord)
-                program.kernels[transport_group.ncrisc_kernel_index].common_runtime_args = transport_rt
-                program.kernels[transport_group.brisc_kernel_index].common_runtime_args = transport_rt
+                # Transport core common RT args (shared layout across BRISC + NCRISC)
+                transport_common_rt = config.get_transport_common_rt_args(coord)
+                program.kernels[transport_group.brisc_kernel_index].common_runtime_args = transport_common_rt
+                program.kernels[transport_group.ncrisc_kernel_index].common_runtime_args = transport_common_rt
                 program.kernels[transport_group.trisc_kernel_index].common_runtime_args = []
 
                 # Append fabric per-core RT args (one connection per link per direction)

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/kernels/all_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/kernels/all_reduce_kernel.cpp
@@ -56,6 +56,14 @@ void kernel_main() {
         args.sender_local_data_l1_addr = get_common_arg_val<uint32_t>(4);
         args.local_ready_sem_bank_addr = get_common_arg_val<uint32_t>(5);
 
+        // Residual CB is tensor-backed (data already in L1); signal TRISC so
+        // Compute's cb_wait_front(cb_residual) unblocks. Reader no longer does
+        // this — responsibility moved to the caller.
+        if constexpr (ReaderCT::has_residual) {
+            cb_reserve_back(ReaderCT::residual_cb_id, ReaderCT::total_num_tiles);
+            cb_push_back(ReaderCT::residual_cb_id, ReaderCT::total_num_tiles);
+        }
+
         deepseek_b1_ops::AllReduce::Reader<ReaderCT> reader;
         reader(args);
     }

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
@@ -242,6 +242,8 @@ class AllReduceConfig:
         residual_cb_id=None,
         skip_local_push=False,
         sender_core=None,
+        num_tiles_override=None,
+        page_size_override=None,
     ):
         self.mesh_device = mesh_device
         self.cluster_axis = int(cluster_axis)
@@ -292,15 +294,28 @@ class AllReduceConfig:
         metadata_sample = (
             self.input_tensors_per_device[0] if self._owns_local_data_cb else self.output_tensors_per_device[0]
         )
-        shard_width = metadata_sample.memory_config().shard_spec.shape[1]
-        tiny_tile_w = metadata_sample.tile.tile_shape[1]
-        num_pages = shard_width // tiny_tile_w
-        if num_pages % 32 != 0:
-            raise ValueError(f"Tile count must be divisible by 32 for 32x32 reinterpretation, got {num_pages}")
 
-        self.total_num_tiles = num_pages // 32
-        self.element_size = 2
-        self.tile_size_bytes = CCL_TILE_H * CCL_TILE_W * self.element_size
+        if (num_tiles_override is None) != (page_size_override is None):
+            raise ValueError(
+                "num_tiles_override and page_size_override must both be provided or both be None; "
+                f"got num_tiles_override={num_tiles_override}, page_size_override={page_size_override}"
+            )
+
+        if num_tiles_override is not None and page_size_override is not None:
+            self.total_num_tiles = int(num_tiles_override)
+            self.tile_size_bytes = int(page_size_override)
+            self.element_size = 2
+        else:
+            shard_width = metadata_sample.memory_config().shard_spec.shape[1]
+            tiny_tile_w = metadata_sample.tile.tile_shape[1]
+            num_pages = shard_width // tiny_tile_w
+            if num_pages % 32 != 0:
+                raise ValueError(f"Tile count must be divisible by 32 for 32x32 reinterpretation, got {num_pages}")
+
+            self.total_num_tiles = num_pages // 32
+            self.element_size = 2
+            self.tile_size_bytes = CCL_TILE_H * CCL_TILE_W * self.element_size
+
         self.chunk = resolve_chunk_config(self.total_num_tiles, self.tile_size_bytes, chunk_num_tiles)
 
         self.data_format = metadata_sample.dtype
@@ -798,6 +813,8 @@ class DeepseekMinimalAllReduce:
         skip_local_push=False,
         skip_ccl=False,
         sender_core=None,
+        num_tiles_override=None,
+        page_size_override=None,
     ):
         if skip_ccl:
             return BypassAllReduceConfig(
@@ -833,6 +850,8 @@ class DeepseekMinimalAllReduce:
             residual_cb_id=residual_cb_id,
             skip_local_push=skip_local_push,
             sender_core=sender_core,
+            num_tiles_override=num_tiles_override,
+            page_size_override=page_size_override,
         )
 
     @staticmethod

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -29,8 +29,7 @@ from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
 )
 from models.demos.deepseek_v3_b1.weights.transforms.attention import (
     fuse_kv_b12,
-    fuse_o_proj_gate_mm_norms,
-    fuse_q_ab_kv_a,
+    fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a,
 )
 
 
@@ -374,20 +373,34 @@ def test_attention_block(
 
     # kv_b2_proj: [K1, intermediate * num_tp] — full TP width, split along output dim per column
     torch_kv_b2_proj_weights = generate_mm_weights((K1, post_sdpa_intermediate * num_tp), dtype=torch.bfloat16)
-    # o_proj: [K2 * num_tp, output_size] — full TP height, split along input dim per column
+    # o_proj: [K2*num_tp, output_size] — inner-dim split across columns,
+    # outer-dim split across mesh rows.  Same full weight goes to both
+    # packing (which slices per device) and golden.
     torch_o_proj_weights = generate_mm_weights((K2 * num_tp, output_size), dtype=torch.bfloat16)
 
-    # Fused matmul1 (q_a_proj packed), matmul2 (q_b_proj shuffled), and DKV matmul (kv_a_proj)
-    # weights as overlapped tensors sharing a single L1 buffer via fuse_q_ab_kv_a.
-    qab_kva = fuse_q_ab_kv_a(
+    # KV Cache Branch RMSNorm gamma
+    torch_dkv_rmsnorm_gamma = torch.randn((1, KNOPE_DIM), dtype=torch.bfloat16)
+
+    # Fused o_proj (TP4 shuffled), gate_mm, norms, and q_a/q_b/kv_a into one L1 buffer.
+    fused = fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
+        torch_o_proj_weights,
+        torch_gate_mm_weights,
+        torch_gamma,
+        torch_rmsnorm2_gamma,
+        torch_dkv_rmsnorm_gamma,
+        torch_ffn_norm,
         torch_matmul_weights,
         torch_matmul2_weights_full_unshuffled,
         torch_dkv_matmul_weights,
         submesh,
     )
-    matmul_weights_overlapped = qab_kva["q_a_proj"]
-    matmul2_weights_overlapped = qab_kva["q_b_proj"]
-    dkv_matmul_weights_overlapped = qab_kva["kv_a_proj"]
+    o_proj_overlapped = fused["o_proj"]
+    gamma_overlapped = fused["attn_norm"]
+    rmsnorm2_gamma_overlapped = fused["q_norm"]
+    dkv_rmsnorm_gamma_overlapped = fused["kv_norm"]
+    matmul_weights_overlapped = fused["q_a_proj"]
+    matmul2_weights_overlapped = fused["q_b_proj"]
+    dkv_matmul_weights_overlapped = fused["kv_a_proj"]
 
     # Matmul3 / kv_b1_proj weights — fused with kv_b2_proj
     torch_matmul3_weights_flat = torch_matmul3_weights.reshape(num_tp * NUM_QNOPE_HEADS * QNOPE_HEAD_DIM, QNOPE_OUT_DIM)
@@ -494,24 +507,6 @@ def test_attention_block(
         tile=trans_tile,
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
-
-    # KV Cache Branch RMSNorm gamma
-    torch_dkv_rmsnorm_gamma = torch.randn((1, KNOPE_DIM), dtype=torch.bfloat16)
-
-    # Fused o_proj, gate_mm, and RMSNorm gammas — we only need the 3 gamma overlapped views.
-    o_norms = fuse_o_proj_gate_mm_norms(
-        torch_o_proj_weights,
-        torch_gate_mm_weights,
-        torch_gamma,
-        torch_rmsnorm2_gamma,
-        torch_dkv_rmsnorm_gamma,
-        torch_ffn_norm,
-        submesh,
-    )
-    o_proj_overlapped = o_norms["o_proj"]
-    gamma_overlapped = o_norms["attn_norm"]
-    rmsnorm2_gamma_overlapped = o_norms["q_norm"]
-    dkv_rmsnorm_gamma_overlapped = o_norms["kv_norm"]
 
     # KRoPE cos/sin: DRAM INTERLEAVED (each krope core reads its width slice)
     krope_num_cores = kv_cache_branch_rope_crs.num_cores()
@@ -724,7 +719,11 @@ def test_attention_block(
     # ========================================================================
     # Create CCL tensors
     # ========================================================================
-    # Final output: receiver core (12,9) — all-reduce output + residual add
+    # o_proj (112 cores) produces [M, 7168] split across 4 TP rows (1792 each).
+    # GatherReduce3 collects the 112-core result onto the receiver core (11,9).
+    # AllReduce sums across the 2 column devices so each has the same [M, 1792].
+    # AllGather concatenates the 4 row slices into the full [M, 7168] on every device.
+    # Output is written to a separate tensor (not in-place into the input).
     output_shard_spec = ttnn.ShardSpec(gather_core_grid, (M, output_size), ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
     mesh_output_torch = torch.cat([torch.zeros((M, output_size), dtype=torch.bfloat16)] * num_devices, dim=0)
@@ -1103,20 +1102,27 @@ def test_attention_block(
             assert passing, f"Device {device_idx} (TP={tp_group}, SP={sp_group}) PreSDPA Output PCC check failed: {pcc}"
 
     # ========================================================================
-    # Validate attention block output (full pipeline: SDPA -> kv_b2 -> o_proj -> all-reduce + residual)
+    # Validate attention block output: after AllGather every device has full [1, 7168]
     # ========================================================================
-    ref_device_idx = 0
-    ref_device_output = output_torch[ref_device_idx : ref_device_idx + 1, :]
+    slot_size = torch_output_expected.shape[-1] // mesh_rows  # 7168 / 4 = 1792
+    all_passing = True
     for device_idx in range(mesh_rows * mesh_cols):
         received = output_torch[device_idx : device_idx + 1, :]
-        if device_idx != ref_device_idx:
-            dev_eq = torch.equal(received, ref_device_output)
-            assert dev_eq, f"Device {device_idx} output mismatch"
 
         passing, pcc = comp_pcc(torch_output_expected, received, 0.997)
         max_diff = torch.max(torch.abs(torch_output_expected - received)).item()
         logger.info(f"Device {device_idx} Attention Block Output PCC: {pcc} Max Diff: {max_diff}")
-        assert passing, f"Device {device_idx} Attention Block Output PCC check failed: {pcc}"
+        if not passing:
+            all_passing = False
+            # Per-slot breakdown to identify which rank's data is corrupted
+            for slot in range(mesh_rows):
+                s, e = slot * slot_size, (slot + 1) * slot_size
+                slot_recv = received[:, s:e]
+                slot_gold = torch_output_expected[:, s:e]
+                _, slot_pcc = comp_pcc(slot_gold, slot_recv, 0.0)
+                slot_max = torch.max(torch.abs(slot_gold - slot_recv)).item()
+                logger.info(f"  Device {device_idx} slot {slot} [{s}:{e}] PCC: {slot_pcc} Max Diff: {slot_max}")
+    assert all_passing, "Attention Block Output PCC check failed (see per-slot breakdown above)"
 
     logger.info("✓ Attention Block mesh test passed!")
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
@@ -10,7 +10,11 @@
 //   transport core: BRISC = fwd sender, NCRISC = bwd sender, TRISC = idle
 //
 // Semaphores (2 total):
-//   handoff_sem on transport core — monotonic (0 → 1 → 2 → 0)
+//   handoff_sem on transport core — shared bitfield (BRISC+NCRISC):
+//     bit 1: gather → scratch[0] ready  (noc_semaphore_inc 1)
+//     bit 2: gather → scratch[1] ready  (noc_semaphore_inc 1 << 1)
+//     bit 3: non-R2 RISC ack            (noc_semaphore_inc 1 << 2)
+//     R2-active resets to 0 after the non-R2 peer acks (bit 3).
 //   recv_sem on gather core — packed cumulative per-slot counter
 //
 // Data flow (mcast-owned receives, sender-only forwarding):
@@ -57,6 +61,14 @@ FORCE_INLINE void wait_for_slot(volatile tt_l1_ptr uint32_t* sem_ptr, uint32_t s
     } while (((*sem_ptr >> shift) & field_mask) < NumChunksPerSlice);
 }
 
+// Poll until all bits in BitMask are set in the semaphore word.
+template <uint32_t BitMask>
+FORCE_INLINE void wait_for_bits(volatile tt_l1_ptr uint32_t* sem_ptr) {
+    do {
+        invalidate_l1_cache();
+    } while ((*sem_ptr & BitMask) != BitMask);
+}
+
 #endif  // COMPILE_FOR_NCRISC || COMPILE_FOR_BRISC
 
 // ============================================================================
@@ -100,7 +112,7 @@ struct GatherCTArgs {
 
 struct TransportArgs {
     uint32_t scratch_base_addr;
-    uint32_t handoff_sem_bank_addr;
+    uint32_t handoff_sem_bank_addr;  // Shared handoff semaphore; both BRISC and NCRISC use the same one
     uint32_t dest_output_base_addr;
     uint32_t r1_dest_slot_index;
     uint32_t dest_noc_x;
@@ -161,6 +173,9 @@ private:
 
         volatile tt_l1_ptr uint32_t* handoff_sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.handoff_sem_bank_addr);
+        // Local NOC address for ack increments (must use NOC atomic to avoid
+        // racing with the gather core's NOC atomic incs on the same word).
+        const uint64_t local_handoff_noc = get_noc_addr(args.handoff_sem_bank_addr);
 
         // Send a full slice (possibly multi-chunk) rotating across links.
         auto send_slice = [&](uint32_t src_addr, uint32_t dest_slot_index) __attribute__((always_inline)) {
@@ -192,15 +207,23 @@ private:
             noc_async_writes_flushed();
         };
 
-        // Round 1: send local slice to neighbor
-        noc_semaphore_wait_min(handoff_sem_ptr, 1);
+        // Round 1: wait for bit 1 (scratch[0] ready), send local slice
+        wait_for_bits<1>(handoff_sem_ptr);
         send_slice(args.scratch_base_addr, args.r1_dest_slot_index);
 
         if constexpr (CTArgs::r2_active) {
-            // Round 2: forward the received slice to pair partner
-            noc_semaphore_wait_min(handoff_sem_ptr, 2);
+            // Round 2: wait for bit 2 (scratch[1] ready), forward received slice
+            wait_for_bits<1 << 1>(handoff_sem_ptr);
             send_slice(args.scratch_base_addr + CTArgs::slice_size_bytes, args.r2_dest_slot_index);
+
+            // Wait for non-R2 peer's bit 3 ack. Once observed, all NOC incs to
+            // this word (bits 1/2 from gather, bit 3 from peer) have landed,
+            // so the direct L1 reset is safe.
+            wait_for_bits<1 << 2>(handoff_sem_ptr);
             noc_semaphore_set(handoff_sem_ptr, 0);
+        } else {
+            // Ack: set bit 3 via NOC atomic inc
+            noc_semaphore_inc(local_handoff_noc, 1 << 2);
         }
 
         for (uint32_t link = 0; link < CTArgs::num_links; link++) {
@@ -240,7 +263,8 @@ private:
         // Cross-core write to transport scratch[0] FIRST to unblock R1 ASAP.
         noc_async_write(args.local_input_addr, scratch_base_noc, CTArgs::slice_size_bytes);
         noc_async_writes_flushed();
-        noc_semaphore_inc(handoff_sem_noc, 1);  // handoff_sem: 0 → 1
+        // Signal bit 1: scratch[0] ready (unblocks R1 on both BRISC and NCRISC)
+        noc_semaphore_inc(handoff_sem_noc, 1);
 
         // Local copy to own output slot (can overlap with R1 fabric sends).
         noc_async_write(
@@ -254,7 +278,8 @@ private:
         const uint64_t scratch_r2_noc = scratch_base_noc + CTArgs::slice_size_bytes;
         noc_async_write(args.output_buffer_addr + r2_src_slot_offset, scratch_r2_noc, CTArgs::slice_size_bytes);
         noc_async_writes_flushed();
-        noc_semaphore_inc(handoff_sem_noc, 1);  // handoff_sem: 1 → 2
+        // Signal bit 2: scratch[1] ready (unblocks R2 on the active RISC)
+        noc_semaphore_inc(handoff_sem_noc, 1 << 1);
 
         // Wait for all remaining slots (topology-agnostic).
         for (uint32_t slot = 0; slot < CTArgs::ring_size; slot++) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_reduce.hpp
@@ -245,11 +245,8 @@ public:
 private:
     void impl([[maybe_unused]] const ReceiverArgs& args) {
 #if defined(COMPILE_FOR_NCRISC)
-        if constexpr (CTArgs::has_residual) {
-            cb_reserve_back(CTArgs::residual_cb_id, CTArgs::total_num_tiles);
-            cb_push_back(CTArgs::residual_cb_id, CTArgs::total_num_tiles);
-        }
-
+        // Note: residual CB lifecycle is handled by the caller (kernel NOC-copies
+        // the residual slice and does cb_reserve_back/cb_push_back before Reader runs).
         cb_reserve_back(CTArgs::recv_local_data_cb_id, CTArgs::total_num_tiles);
         cb_reserve_back(CTArgs::remote_data_cb_id, CTArgs::total_num_tiles);
         constexpr uint32_t local_payload_bytes = CTArgs::total_num_tiles * CTArgs::page_size_bytes;
@@ -360,12 +357,12 @@ private:
 
     void impl() {
 #if defined(COMPILE_FOR_TRISC)
+        // TODO: Fix this to account for actual dst size
+        static_assert(CTArgs::num_tiles <= 8, "num_tiles must be less than or equal to 8");
+
         reconfig_data_format<false, true>(CTArgs::cb_local, CTArgs::cb_remote);
         pack_reconfig_data_format<true>(CTArgs::cb_out);
         pack_block_contiguous_init(CTArgs::cb_out);
-
-        // TODO: Fix this to account for actual dst size
-        static_assert(CTArgs::num_tiles <= 8, "num_tiles must be less than or equal to 8");
 
         if constexpr (CTArgs::has_residual) {
             copy_tile_to_dst_init_short(CTArgs::cb_residual);

--- a/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
@@ -73,6 +73,8 @@ struct GatherReduce {
         uint32_t gather_reduce_half_num_cores;
         uint32_t dst_cb_id;
         uint32_t half_size_bytes;
+        uint32_t sender_idx =
+            0;  // explicit per-core index; 0 means compute from grid (only valid for rectangular grids)
         uint32_t noc;
     };
 
@@ -86,24 +88,29 @@ struct GatherReduce {
     using RTArgs = unified_kernels::SelectByRISCV<SenderArgs, ReceiverArgs, ComputeArgs>;
 
 #if defined(COMPILE_FOR_TRISC)
+    // in_cb and out_cb use 32x32 tiles.  Each half is padded to a whole
+    // number of 32x32 tiles so the half boundary is tile-aligned.
+    // num_tiles is the 32x32 tile count per half (e.g. 2 for 56 rows).
     static inline void add_half_tiles(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
         reconfig_data_format<false, true>(in_cb, in_cb);
         pack_reconfig_data_format<true>(out_cb);
         pack_block_contiguous_init(out_cb);
         add_tiles_init(in_cb, in_cb);
         cb_wait_front(in_cb, 2 * num_tiles);
-        cb_reserve_back(out_cb, num_tiles);
+        {
+            DeviceZoneScopedN("add-tiles");
+            cb_reserve_back(out_cb, num_tiles);
 
-        // Process tiles - element-wise add
-        tile_regs_acquire();
-        for (uint32_t i = 0; i < num_tiles; i++) {
-            add_tiles(in_cb, in_cb, i, num_tiles + i, i);
+            tile_regs_acquire();
+            for (uint32_t i = 0; i < num_tiles; i++) {
+                add_tiles(in_cb, in_cb, i, num_tiles + i, i);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_block_contiguous(0, out_cb, num_tiles);
+            cb_push_back(out_cb, num_tiles);
+            tile_regs_release();
         }
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_block_contiguous(0, out_cb, num_tiles);
-        cb_push_back(out_cb, num_tiles);
-        tile_regs_release();
 
         cb_pop_front(in_cb, 2 * num_tiles);
     }
@@ -117,7 +124,7 @@ struct GatherReduce {
     // IsReduceCore: compile-time flag for reduce cores
     // pop_src: whether to pop the source CB after sending
     // ========================================================================
-    template <bool IsSenderCore, bool IsReceiverCore, bool IsReduceCore, bool pop_src>
+    template <bool IsSenderCore, bool IsReceiverCore, bool IsReduceCore, bool pop_src, bool UsePerCoreSenderIdx = false>
     class Op {
     public:
         void operator()(const RTArgs& args) { impl(args); }
@@ -130,12 +137,19 @@ struct GatherReduce {
             // ================================================================
             if constexpr (IsSenderCore) {
                 ASSERT(noc_mode == DM_DYNAMIC_NOC || args.noc == noc_index);
-                const auto half_info = unified_kernels::get_split_half_core_info<true>(
-                    args.gather_reduce_grid_start_x,
-                    args.gather_reduce_grid_start_y,
-                    args.gather_reduce_grid_end_x,
-                    args.gather_reduce_grid_end_y,
-                    args.gather_reduce_half_num_cores);
+                unified_kernels::SplitHalfCoreInfo half_info;
+                if constexpr (UsePerCoreSenderIdx) {
+                    const bool is_half0 = args.sender_idx < args.gather_reduce_half_num_cores;
+                    half_info = {
+                        is_half0, is_half0 ? args.sender_idx : (args.sender_idx - args.gather_reduce_half_num_cores)};
+                } else {
+                    half_info = unified_kernels::get_split_half_core_info<true>(
+                        args.gather_reduce_grid_start_x,
+                        args.gather_reduce_grid_start_y,
+                        args.gather_reduce_grid_end_x,
+                        args.gather_reduce_grid_end_y,
+                        args.gather_reduce_half_num_cores);
+                }
                 uint32_t dst_base_addr = get_write_ptr(args.dst_cb_id);
                 uint32_t dst_offset =
                     (half_info.is_half0 ? 0 : args.half_size_bytes) + half_info.half_local_idx * args.data_size_bytes;

--- a/models/demos/deepseek_v3_b1/unified_kernels/moe_gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/moe_gather.hpp
@@ -129,10 +129,10 @@ struct MoeGather {
                 noc_async_write_one_packet<true, true>(input_data_addr, dst_data_noc_addr, args.data_size_bytes);
                 // BH does not support posted atomics due to a bug
                 noc_semaphore_inc(dst_semaphore_noc_addr, 1);
-                noc_async_posted_writes_flushed();
 
                 // Pop the source CB after sending
                 if constexpr (pop_src) {
+                    noc_async_posted_writes_flushed();
                     cb_pop_front(args.src_cb, args.src_num_pages);
                 }
                 noc_async_atomic_barrier();

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -46,6 +46,7 @@ from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
 
 Q_AB_KV_A_SPEC = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 O_PROJ_GATE_MM_NORMS_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
+MERGED_TP4_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.tp4_merged_fusion_group_spec()
 KV_B12_SPEC = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 GATE_UP_SPEC = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor
@@ -690,30 +691,7 @@ def prepare_attention_weights(
     kv_norm_key = _key(layer_idx, "self_attn.kv_a_layernorm.weight")
     ffn_norm_key = _key(layer_idx, "post_attention_layernorm.weight")
 
-    def _preprocess_q_ab_kv_a(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        q_a = t[q_a_key].T.contiguous()
-        q_b = deinterleave_q_b_proj(t[q_b_key])
-        kv_a = t[kv_a_key].T.contiguous()
-        if mla_tp == 1 and q_b.shape[1] == _MLA_TP1_Q_B_WIDTH * 2:
-            q_b = q_b[:, :_MLA_TP1_Q_B_WIDTH].contiguous()
-        return preprocess_q_ab_kv_a(q_a, q_b, kv_a, mesh_shape)
-
-    q_ab_fp = cache_config.context.fingerprint(
-        source=SourceTensorSelection(names=(q_a_key, q_b_key, kv_a_key)),
-        target=Q_AB_KV_A_SPEC,
-    )
-    q_ab_views = cache_config.cache.get_or_create(
-        q_ab_fp,
-        device,
-        preprocess=_preprocess_q_ab_kv_a,
-        raw_tensors=lambda: {k: state_dict[k] for k in (q_a_key, q_b_key, kv_a_key)},
-    )
-    if not isinstance(q_ab_views, dict):
-        raise TypeError("expected dict[str, OverlappedTensor] for q_ab_kv_a cache entry")
-    q_a_proj = q_ab_views["q_a_proj"]
-    q_b_proj = q_ab_views["q_b_proj"]
-    kv_a_proj = q_ab_views["kv_a_proj"]
-
+    # -- kv_b12: always a separate fusion group --
     def _preprocess_kv_b12(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         kv_b1, kv_b2 = split_kv_b_proj(t[kv_b_key])
         if mla_tp == 1:
@@ -738,6 +716,142 @@ def prepare_attention_weights(
     kv_b1_proj = kv_views["kv_b1_proj"]
     kv_b2_proj = kv_views["kv_b2_proj"]
 
+    # -- mla_tp == 2: merged buffer (o_proj + gate_mm + norms + q_ab + kv_a) --
+    if mla_tp == 2:
+        q_ab_keys = (q_a_key, q_b_key, kv_a_key)
+
+        def _preprocess_merged(t: dict[str, torch.Tensor], *, include_gate: bool) -> dict[str, torch.Tensor]:
+            o_proj = t[o_proj_key].T.contiguous()
+            o_proj = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.pack_o_proj_weights_tp4_shuffled(o_proj)
+            if include_gate:
+                gate_mm = t[gate_key].T.contiguous()
+            else:
+                gate_mm = torch.zeros(D.HIDDEN_SIZE, D.GATE_NUM_INDICES, dtype=torch.bfloat16, device=o_proj.device)
+            q_a = t[q_a_key].T.contiguous()
+            q_b = deinterleave_q_b_proj(t[q_b_key])
+            kv_a = t[kv_a_key].T.contiguous()
+            q_ab_kv_a = preprocess_q_ab_kv_a(q_a, q_b, kv_a, mesh_shape)
+            return {
+                "o_proj": o_proj,
+                "gate_mm": gate_mm,
+                "attn_norm": t[attn_norm_key].unsqueeze(0),
+                "q_norm": t[q_norm_key].unsqueeze(0),
+                "kv_norm": t[kv_norm_key].unsqueeze(0),
+                "ffn_norm": t[ffn_norm_key].unsqueeze(0),
+                **q_ab_kv_a,
+            }
+
+        if is_moe:
+            gate_key = _key(layer_idx, "mlp.gate.weight")
+            merged_src = (o_proj_key, gate_key, attn_norm_key, q_norm_key, kv_norm_key, ffn_norm_key) + q_ab_keys
+            merged_fp = cache_config.context.fingerprint(
+                source=SourceTensorSelection(names=merged_src),
+                target=MERGED_TP4_SPEC,
+            )
+            merged_views = cache_config.cache.get_or_create(
+                merged_fp,
+                device,
+                preprocess=lambda t: _preprocess_merged(t, include_gate=True),
+                raw_tensors=lambda: {k: state_dict[k] for k in merged_src},
+            )
+            if not isinstance(merged_views, dict):
+                raise TypeError("expected dict[str, OverlappedTensor] for merged cache entry")
+
+            _bias_key = _key(layer_idx, "mlp.gate.e_score_correction_bias")
+            target = _gate_bias_target(layer_idx)
+            fingerprint = cache_config.context.fingerprint(
+                source=SourceTensorSelection(names=(_bias_key,)),
+                target=target,
+            )
+            gate_bias_tt = cache_config.cache.get_or_create(
+                fingerprint,
+                device,
+                preprocess=lambda t: {target.name: t[_bias_key].reshape(16, 16).T.contiguous().to(torch.bfloat16)},
+                raw_tensors=lambda: {_bias_key: state_dict[_bias_key]},
+            )
+            if not isinstance(gate_bias_tt, ttnn.Tensor):
+                raise TypeError("expected ttnn.Tensor for gate_bias cache entry")
+
+            logger.debug(
+                "Attention fusion groups (MoE, merged) for layer {} in {:.3f}s",
+                layer_idx,
+                time.perf_counter() - t0,
+            )
+            return AttentionWeights(
+                q_a_proj=merged_views["q_a_proj"],
+                q_b_proj=merged_views["q_b_proj"],
+                kv_a_proj=merged_views["kv_a_proj"],
+                o_proj=merged_views["o_proj"],
+                gate_mm=merged_views["gate_mm"],
+                attn_norm=merged_views["attn_norm"],
+                q_norm=merged_views["q_norm"],
+                kv_norm=merged_views["kv_norm"],
+                ffn_norm=merged_views["ffn_norm"],
+                kv_b1_proj=kv_b1_proj,
+                kv_b2_proj=kv_b2_proj,
+                gate_bias=gate_bias_tt,
+            )
+
+        # Dense merged path
+        merged_src_dense = (o_proj_key, attn_norm_key, q_norm_key, kv_norm_key, ffn_norm_key) + q_ab_keys
+        merged_fp_dense = cache_config.context.fingerprint(
+            source=SourceTensorSelection(names=merged_src_dense),
+            target=MERGED_TP4_SPEC,
+        )
+        merged_views = cache_config.cache.get_or_create(
+            merged_fp_dense,
+            device,
+            preprocess=lambda t: _preprocess_merged(t, include_gate=False),
+            raw_tensors=lambda: {k: state_dict[k] for k in merged_src_dense},
+        )
+        if not isinstance(merged_views, dict):
+            raise TypeError("expected dict[str, OverlappedTensor] for merged cache entry")
+
+        logger.debug(
+            "Attention fusion groups (dense, merged) for layer {} in {:.3f}s",
+            layer_idx,
+            time.perf_counter() - t0,
+        )
+        return AttentionWeights(
+            q_a_proj=merged_views["q_a_proj"],
+            q_b_proj=merged_views["q_b_proj"],
+            kv_a_proj=merged_views["kv_a_proj"],
+            o_proj=merged_views["o_proj"],
+            gate_mm=None,
+            attn_norm=merged_views["attn_norm"],
+            q_norm=merged_views["q_norm"],
+            kv_norm=merged_views["kv_norm"],
+            ffn_norm=merged_views["ffn_norm"],
+            kv_b1_proj=kv_b1_proj,
+            kv_b2_proj=kv_b2_proj,
+            gate_bias=None,
+        )
+
+    # -- mla_tp == 1: separate q_ab_kv_a and o_proj fusion groups --
+    def _preprocess_q_ab_kv_a(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        q_a = t[q_a_key].T.contiguous()
+        q_b = deinterleave_q_b_proj(t[q_b_key])
+        kv_a = t[kv_a_key].T.contiguous()
+        if q_b.shape[1] == _MLA_TP1_Q_B_WIDTH * 2:
+            q_b = q_b[:, :_MLA_TP1_Q_B_WIDTH].contiguous()
+        return preprocess_q_ab_kv_a(q_a, q_b, kv_a, mesh_shape)
+
+    q_ab_fp = cache_config.context.fingerprint(
+        source=SourceTensorSelection(names=(q_a_key, q_b_key, kv_a_key)),
+        target=Q_AB_KV_A_SPEC,
+    )
+    q_ab_views = cache_config.cache.get_or_create(
+        q_ab_fp,
+        device,
+        preprocess=_preprocess_q_ab_kv_a,
+        raw_tensors=lambda: {k: state_dict[k] for k in (q_a_key, q_b_key, kv_a_key)},
+    )
+    if not isinstance(q_ab_views, dict):
+        raise TypeError("expected dict[str, OverlappedTensor] for q_ab_kv_a cache entry")
+    q_a_proj = q_ab_views["q_a_proj"]
+    q_b_proj = q_ab_views["q_b_proj"]
+    kv_a_proj = q_ab_views["kv_a_proj"]
+
     if is_moe:
         gate_key = _key(layer_idx, "mlp.gate.weight")
 
@@ -748,9 +862,8 @@ def prepare_attention_weights(
             q_norm = t[q_norm_key].unsqueeze(0)
             kv_norm = t[kv_norm_key].unsqueeze(0)
             ffn_norm = t[ffn_norm_key].unsqueeze(0)
-            if mla_tp == 1:
-                if o_proj.shape[0] == _MLA_TP1_O_PROJ_HEIGHT * 2:
-                    o_proj = o_proj[:_MLA_TP1_O_PROJ_HEIGHT, :].contiguous()
+            if o_proj.shape[0] == _MLA_TP1_O_PROJ_HEIGHT * 2:
+                o_proj = o_proj[:_MLA_TP1_O_PROJ_HEIGHT, :].contiguous()
             return {
                 "o_proj": o_proj,
                 "gate_mm": gate_mm,
@@ -773,12 +886,6 @@ def prepare_attention_weights(
         )
         if not isinstance(o_views, dict):
             raise TypeError("expected dict[str, OverlappedTensor] for o_proj_gate_mm_norms cache entry")
-        o_proj_ot = o_views["o_proj"]
-        gate_mm_ot = o_views["gate_mm"]
-        attn_norm_ot = o_views["attn_norm"]
-        q_norm_ot = o_views["q_norm"]
-        kv_norm_ot = o_views["kv_norm"]
-        ffn_norm_ot = o_views["ffn_norm"]
 
         _bias_key = _key(layer_idx, "mlp.gate.e_score_correction_bias")
         target = _gate_bias_target(layer_idx)
@@ -804,12 +911,12 @@ def prepare_attention_weights(
             q_a_proj=q_a_proj,
             q_b_proj=q_b_proj,
             kv_a_proj=kv_a_proj,
-            o_proj=o_proj_ot,
-            gate_mm=gate_mm_ot,
-            attn_norm=attn_norm_ot,
-            q_norm=q_norm_ot,
-            kv_norm=kv_norm_ot,
-            ffn_norm=ffn_norm_ot,
+            o_proj=o_views["o_proj"],
+            gate_mm=o_views["gate_mm"],
+            attn_norm=o_views["attn_norm"],
+            q_norm=o_views["q_norm"],
+            kv_norm=o_views["kv_norm"],
+            ffn_norm=o_views["ffn_norm"],
             kv_b1_proj=kv_b1_proj,
             kv_b2_proj=kv_b2_proj,
             gate_bias=gate_bias_tt,
@@ -821,7 +928,7 @@ def prepare_attention_weights(
         q_norm = t[q_norm_key].unsqueeze(0)
         kv_norm = t[kv_norm_key].unsqueeze(0)
         ffn_norm = t[ffn_norm_key].unsqueeze(0)
-        if mla_tp == 1 and o_proj.shape[0] == _MLA_TP1_O_PROJ_HEIGHT * 2:
+        if o_proj.shape[0] == _MLA_TP1_O_PROJ_HEIGHT * 2:
             o_proj = o_proj[:_MLA_TP1_O_PROJ_HEIGHT, :].contiguous()
         gate_mm = torch.zeros(D.HIDDEN_SIZE, D.GATE_NUM_INDICES, dtype=torch.bfloat16, device=o_proj.device)
         return {
@@ -846,11 +953,6 @@ def prepare_attention_weights(
     )
     if not isinstance(o_views, dict):
         raise TypeError("expected dict[str, OverlappedTensor] for o_proj_gate_mm_norms cache entry")
-    o_proj_ot = o_views["o_proj"]
-    attn_norm_ot = o_views["attn_norm"]
-    q_norm_ot = o_views["q_norm"]
-    kv_norm_ot = o_views["kv_norm"]
-    ffn_norm_ot = o_views["ffn_norm"]
 
     logger.debug(
         "Attention fusion groups (dense) for layer {} in {:.3f}s",
@@ -861,12 +963,12 @@ def prepare_attention_weights(
         q_a_proj=q_a_proj,
         q_b_proj=q_b_proj,
         kv_a_proj=kv_a_proj,
-        o_proj=o_proj_ot,
+        o_proj=o_views["o_proj"],
         gate_mm=None,
-        attn_norm=attn_norm_ot,
-        q_norm=q_norm_ot,
-        kv_norm=kv_norm_ot,
-        ffn_norm=ffn_norm_ot,
+        attn_norm=o_views["attn_norm"],
+        q_norm=o_views["q_norm"],
+        kv_norm=o_views["kv_norm"],
+        ffn_norm=o_views["ffn_norm"],
         kv_b1_proj=kv_b1_proj,
         kv_b2_proj=kv_b2_proj,
         gate_bias=None,

--- a/models/demos/deepseek_v3_b1/weights/specs/overlap_configs.py
+++ b/models/demos/deepseek_v3_b1/weights/specs/overlap_configs.py
@@ -354,6 +354,39 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             transform_version=self.transform_version,
         )
 
+    def tp4_merged_fusion_group_spec(
+        self,
+        o_proj_dtype: ttnn.DataType = ttnn.DataType.BFLOAT8_B,
+        mla_proj_dtype: ttnn.DataType = ttnn.DataType.BFLOAT8_B,
+    ) -> FusionGroupSpec:
+        """Build merged spec: TP4 o_proj + gate_mm + norms + q_ab + kv_a in one buffer."""
+        q_cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+        o_proj_tp4 = replace(
+            self.o_proj,
+            raw_tensor_shape=(8192, 14336),
+            dtype=o_proj_dtype,
+            tp_dim=(1, 0),
+        )
+        q_a = replace(q_cfg.q_a_shard_spec, dtype=mla_proj_dtype)
+        q_b = replace(q_cfg.q_b_shard_spec, dtype=mla_proj_dtype)
+        kv_a = replace(q_cfg.kv_a_shard_spec, dtype=mla_proj_dtype)
+        return _build_fusion_group_spec(
+            "o_proj_tp4_gate_mm_norms_q_ab_kv_a",
+            [
+                [("o_proj", o_proj_tp4)],
+                [("gate_mm", self.gate_mm)],
+                [("attn_norm", self.attn_norm), ("q_norm", self.q_norm), ("ffn_norm", self.ffn_norm)],
+                [("kv_norm", self.kv_norm)],
+                [("q_a_proj", q_a), ("q_b_proj", q_b)],
+                [("kv_a_proj", kv_a)],
+            ],
+            sharding_strategy=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            # Explicit: mixed tp_dims (o_proj=(1,0), q_b=(None,1)) would
+            # conflict in _infer_mesh_mapper.  Per-tensor tp is handled by
+            # overlap_tensors independently; this config is for fingerprinting.
+            mesh_mapper_config=Shard2dMeshMapper(dims=(1, 0)),
+        )
+
 
 O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
 


### PR DESCRIPTION
### Ticket
None

### Problem description
For hot/cold experts, we need to make space in SRAM by changing o_proj matmul to also do TP4 along the outer dim, which reclaims ~408KB of SRAM. With this change, an additional AllGather within the column is needed after TP AllReduce (which now only does 1/4 of the original 7168) to produce the full result on all chips. In addition, there are two small complications which this PR addresses:
- Per device, o_proj matmul needs to be sliced along the inner dim as well to maintain distribution over 112 cores (after TP4, the width can only be split onto 56 cores before being < 32). The Matmul -> Gather flow is replaced with the KNSlicedMatmul -> GatherReduce, similar to the first q_a_proj matmul.
- With TP4 of 7168, per device shape is 1792 which doesn't map to nice tile shapes for eltwise add (previously, 7168 is interpreted as 7 tiles of 32x32). We have to pad to 2048 to do 2 full tiles of work in GatherReduce, TP AllReduce (including the addition with residual). Prior to TP AllReduce, the residual is first copied out (dev0 copies first 1792 slice, dev1 copies second 1792 slice, etc...) into a 32x32 CB with two files.

### What's changed
- Switch o_proj matmul to TP4 outer-dim o_proj
  * Each device produces [1, 1792]; weights are sliced along inner dim and gather reduced
  * TP AllReduces along the rows and adds the correct 1792 slice of the residual
    ** For gather reduce and TP AllReduce (and residual), pad 1792 to 2 full tiles of 32x32
    ** Additional NOC copy on NCRISC to move the correct residual slice of 1792 into a new CB for TP AllReduce
  * New AllGather within the column to produce full [1, 7168] output per device
  * Switch weights to use the new overlap for o_proj with attention
    weights
- Add explicit sender_idx to GatherReduce for non-rectangular sender grids
- Fix potential hang in AllGather with sharing handoff semaphore between RISCs
  * Different RISCs inc over different bits in the semaphore (basically using the shared semaphore as two)
- Minor API changes to AllReduce micro-op
  * Move residual CB reserve/push out of the reader into callers (needed to input coming from NOC copy)
  * Add num_tiles_override/page_size_override to support padded tiles
- Move flush to pop_src block in moe_gather to align with other gather micro-ops

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bliu/deepseek)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/deepseek): https://github.com/tenstorrent/tt-metal/actions/runs/24545235291
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/deepseek)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bliu/deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/deepseek)