### PR TITLE
[Sampling] Fix get_read_ptr and use float32 arithmetic in sampling writer kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -21,194 +21,12 @@ appropriate index.
 constexpr uint32_t FACE_WIDTH = 16;
 constexpr uint32_t FACE_HEIGHT = 16;
 
-uint16_t bfloat16_add(uint16_t bf16_a, uint16_t bf16_b) {
-    // Extract the sign, exponent, and mantissa from both values
-    uint16_t sign_a = bf16_a & 0x8000;
-    uint16_t sign_b = bf16_b & 0x8000;
-    int16_t exp_a = (bf16_a & 0x7F80) >> 7;
-    int16_t exp_b = (bf16_b & 0x7F80) >> 7;
-    uint16_t mant_a = (bf16_a & 0x007F) | 0x0080;  // Add implicit leading 1
-    uint16_t mant_b = (bf16_b & 0x007F) | 0x0080;  // Add implicit leading 1
-
-    // Handle subnormal numbers (exponent is zero)
-    if (exp_a == 0) {
-        mant_a &= 0x007F;  // Remove implicit leading 1
-    }
-    if (exp_b == 0) {
-        mant_b &= 0x007F;
-    }
-
-    // Align the mantissas by shifting the smaller one
-    if (exp_a > exp_b) {
-        mant_b >>= (exp_a - exp_b);
-    } else if (exp_b > exp_a) {
-        mant_a >>= (exp_b - exp_a);
-        exp_a = exp_b;
-    }
-
-    // Add or subtract mantissas based on signs
-    uint16_t mant_res;
-    uint16_t sign_res;
-    if (sign_a == sign_b) {
-        mant_res = mant_a + mant_b;
-        sign_res = sign_a;  // Result keeps the same sign
-    } else {
-        if (mant_a >= mant_b) {
-            mant_res = mant_a - mant_b;
-            sign_res = sign_a;  // Result keeps the sign of the larger magnitude
-        } else {
-            mant_res = mant_b - mant_a;
-            sign_res = sign_b;
-        }
-    }
-
-    // Handle zero result
-    if (mant_res == 0) {
-        return 0;
-    }
-
-    // Normalize the result
-    if (mant_res & 0x0100) {  // Mantissa overflow
-        mant_res >>= 1;
-        exp_a += 1;
-    }
-    while (mant_res && !(mant_res & 0x0080)) {  // Normalize mantissa (shift left)
-        mant_res <<= 1;
-        exp_a -= 1;
-    }
-
-    // Handle exponent overflow and underflow
-    if (exp_a >= 0xFF) {  // Overflow to infinity
-        return sign_res | 0x7F80;
-    }
-    if (exp_a <= 0) {              // Underflow to zero or subnormal
-        mant_res >>= (1 - exp_a);  // Shift mantissa to make exponent zero
-        exp_a = 0;
-    }
-
-    // Combine the result
-    uint16_t result = sign_res | (exp_a << 7) | (mant_res & 0x007F);
-    return result;
-}
-
-uint16_t bfloat16_div(uint16_t bf16_a, uint16_t bf16_b) {
-    // Extract sign, exponent, mantissa
-    uint16_t sign_a = bf16_a & 0x8000;
-    uint16_t sign_b = bf16_b & 0x8000;
-    int16_t exp_a = (bf16_a & 0x7F80) >> 7;
-    int16_t exp_b = (bf16_b & 0x7F80) >> 7;
-    uint16_t mant_a = bf16_a & 0x007F;
-    uint16_t mant_b = bf16_b & 0x007F;
-
-    // Handle special cases (NaN, inf, zero)
-    int a_is_nan = (exp_a == 0xFF) && (mant_a != 0);
-    int b_is_nan = (exp_b == 0xFF) && (mant_b != 0);
-    int a_is_inf = (exp_a == 0xFF) && (mant_a == 0);
-    int b_is_inf = (exp_b == 0xFF) && (mant_b == 0);
-    int a_is_zero = (exp_a == 0) && (mant_a == 0);
-    int b_is_zero = (exp_b == 0) && (mant_b == 0);
-
-    // NaN propagation
-    if (a_is_nan) {
-        return bf16_a;
-    }
-    if (b_is_nan) {
-        return bf16_b | 0x0040;  // Make sure it's a quiet NaN
-    }
-
-    // Inf/0 rules
-    if (a_is_inf && b_is_inf) {
-        return 0x7FC0;  // NaN
-    }
-    if (a_is_inf) {
-        return (sign_a ^ sign_b) | 0x7F80;  // Inf with correct sign
-    }
-    if (b_is_inf) {
-        return (sign_a ^ sign_b);  // Zero with correct sign
-    }
-    if (a_is_zero && b_is_zero) {
-        return 0x7FC0;  // NaN
-    }
-    if (a_is_zero) {
-        return (sign_a ^ sign_b);  // Zero
-    }
-    if (b_is_zero) {
-        return (sign_a ^ sign_b) | 0x7F80;  // Inf
-    }
-
-    // Handle subnormal numbers (normalize them first)
-    if (exp_a == 0) {
-        // Subnormal number - normalize it
-        exp_a = 1;  // Start with minimum normal exponent
-        while (mant_a && !(mant_a & 0x80)) {
-            mant_a <<= 1;
-            exp_a -= 1;
-        }
-        // If mant_a became 0, it was actually zero (handled above)
-        // Otherwise, mant_a now has implicit leading 1 in bit 7
-        if (mant_a) {
-            mant_a &= 0x7F;  // Remove the implicit leading 1
-        }
-    } else {
-        // Normal number - add implicit leading 1
-        mant_a = mant_a | 0x80;
-    }
-
-    if (exp_b == 0) {
-        // Subnormal number - normalize it
-        exp_b = 1;  // Start with minimum normal exponent
-        while (mant_b && !(mant_b & 0x80)) {
-            mant_b <<= 1;
-            exp_b -= 1;
-        }
-        // If mant_b became 0, it was actually zero (handled above)
-        if (mant_b) {
-            mant_b &= 0x7F;  // Remove the implicit leading 1
-        }
-    } else {
-        // Normal number - add implicit leading 1
-        mant_b = mant_b | 0x80;
-    }
-
-    // Result sign
-    uint16_t sign_res = sign_a ^ sign_b;
-
-    // Result exponent (subtract exponents, add bias)
-    int16_t exp_res = exp_a - exp_b + 127;
-
-    // Division of mantissas
-    // Use 16 bits for numerator to preserve precision
-    uint32_t mant_res = ((uint32_t)mant_a << 7) / mant_b;
-
-    // Normalize result mantissa
-    // The result should have leading 1 in bit 7 position
-    while (mant_res && !(mant_res & 0x80)) {
-        mant_res <<= 1;
-        exp_res -= 1;
-    }
-
-    // Handle exponent overflow
-    if (exp_res >= 0xFF) {
-        return sign_res | 0x7F80;  // Infinity
-    }
-
-    // Handle exponent underflow to subnormal or zero
-    if (exp_res <= 0) {
-        if (exp_res < -7) {
-            // Too small, return zero
-            return sign_res;
-        }
-        // Create subnormal result
-        // Shift mantissa right by (1 - exp_res) positions
-        mant_res >>= (1 - exp_res);
-        exp_res = 0;
-    } else {
-        // Normal result - remove implicit leading 1
-        mant_res &= 0x7F;
-    }
-
-    // Combine the result
-    uint16_t result = sign_res | (exp_res << 7) | (mant_res & 0x7F);
+// Widen bf16 to float32 — exact since bf16 is a subset of float32.
+// Uses soft-float on the data-movement RISC-V core.
+FORCE_INLINE float bf16_to_f32(uint16_t bf16) {
+    uint32_t bits = (uint32_t)bf16 << 16;
+    float result;
+    __builtin_memcpy(&result, &bits, sizeof(float));
     return result;
 }
 
@@ -292,21 +110,21 @@ void kernel_main() {
     generate_mask<cb_id_mask, one>(one, ids_per_batch / 32, k - 1);
     // get random number
     cb_wait_front(rand_tile_index, 1);
-    uint32_t cb_rand_addr = get_write_ptr(rand_tile_index);
+    uint32_t cb_rand_addr = get_read_ptr(rand_tile_index);
     volatile tt_l1_ptr uint16_t* rand_values = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb_rand_addr);
     uint16_t rand = rand_values[0];
     // wait for compute kernel
     cb_wait_front(output_final_indices_rm_cb_index, 32);
     cb_wait_front(output_local_values_cb_index, 1);
     cb_wait_front(output_local_indices_cb_index, 1);
-    // Use cb as L1 scratch memory
-    uint32_t cb_local_values_addr = get_write_ptr(output_local_values_cb_index);
+    // Read producer-written compute outputs from these CBs in L1.
+    uint32_t cb_local_values_addr = get_read_ptr(output_local_values_cb_index);
     volatile tt_l1_ptr uint16_t* local_values = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb_local_values_addr);
 
-    uint32_t cb_local_indices_addr = get_write_ptr(output_local_indices_cb_index);
+    uint32_t cb_local_indices_addr = get_read_ptr(output_local_indices_cb_index);
     volatile tt_l1_ptr uint16_t* local_indices = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb_local_indices_addr);
 
-    uint32_t cb_final_indices_addr = get_write_ptr(output_final_indices_rm_cb_index);
+    uint32_t cb_final_indices_addr = get_read_ptr(output_final_indices_rm_cb_index);
     volatile tt_l1_ptr uint32_t* final_indices =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_final_indices_addr + core_id * final_indices_stick_size);
 
@@ -329,16 +147,17 @@ void kernel_main() {
         end_id_local_phase_1 = end_id_local_phase_0;
     }
 
-    uint16_t bf16_p = static_cast<uint16_t>(p & 0xFFFF);
-    uint32_t cum_prob = 0;
+    // Top-p filtering in float32 for precision
+    float p_f = bf16_to_f32(static_cast<uint16_t>(p & 0xFFFF));
+    float cum_prob_f = 0.0f;
     uint32_t kept_tokens = 0;
     bool cutoff_found_in_phase_0 = false;
     bool cutoff_found_in_phase_1 = false;
     uint32_t top_p_cutoff = end_id_local_phase_1;  // Default to all tokens
     for (uint32_t i = start_id_local_phase_0; i < end_id_local_phase_0; ++i) {
-        cum_prob = bfloat16_add(cum_prob, local_values[i]);
-        if (bfloat16_greater(cum_prob, bf16_p)) {
-            top_p_cutoff = i + 1;  // Include this token in the top-p set
+        cum_prob_f += bf16_to_f32(local_values[i]);
+        if (cum_prob_f > p_f) {
+            top_p_cutoff = i + 1;
             cutoff_found_in_phase_0 = true;
             kept_tokens = top_p_cutoff - start_id_local_phase_0;
             break;
@@ -348,8 +167,8 @@ void kernel_main() {
         kept_tokens = FACE_WIDTH;
         for (uint32_t i = start_id_local_phase_1; i < end_id_local_phase_1; ++i) {
             // cum sum of local values
-            cum_prob = bfloat16_add(cum_prob, local_values[i]);
-            if (bfloat16_greater(cum_prob, bf16_p)) {
+            cum_prob_f += bf16_to_f32(local_values[i]);
+            if (cum_prob_f > p_f) {
                 top_p_cutoff = i + 1;
                 kept_tokens += top_p_cutoff - start_id_local_phase_1;
                 cutoff_found_in_phase_1 = true;
@@ -370,15 +189,15 @@ void kernel_main() {
         end_id_local_phase_1 = start_id_local_phase_1 + (kept_tokens - FACE_WIDTH);
     }
 
-    uint32_t cum_sum = 0;
+    // Stochastic sampling in float32
+    float rand_f = bf16_to_f32(rand);
+    float cum_sum_f = 0.0f;
     index_out[core_id] = final_indices[local_indices[start_id_local_phase_0]];
     bool index_found = false;
 
-    // Sample from the top-k values
     for (uint32_t i = start_id_local_phase_0; i < end_id_local_phase_0; ++i) {
-        // cum sum of local values
-        cum_sum = bfloat16_add(cum_sum, bfloat16_div(local_values[i], cum_prob));
-        if (bfloat16_greater(cum_sum, rand)) {
+        cum_sum_f += bf16_to_f32(local_values[i]) / cum_prob_f;
+        if (cum_sum_f > rand_f) {
             index_out[core_id] = final_indices[local_indices[i]];
             index_found = true;
             break;
@@ -386,15 +205,20 @@ void kernel_main() {
     }
     if (!index_found) {
         for (uint32_t i = start_id_local_phase_1; i < end_id_local_phase_1; ++i) {
-            // cum sum of local values
-            cum_sum = bfloat16_add(cum_sum, bfloat16_div(local_values[i], cum_prob));
-            if (bfloat16_greater(cum_sum, rand)) {
+            cum_sum_f += bf16_to_f32(local_values[i]) / cum_prob_f;
+            if (cum_sum_f > rand_f) {
                 index_out[core_id] = final_indices[local_indices[i]];
                 index_found = true;
                 break;
             }
         }
     }
+
+    // Release consumed CBs
+    cb_pop_front(rand_tile_index, 1);
+    cb_pop_front(output_local_values_cb_index, 1);
+    cb_pop_front(output_local_indices_cb_index, 1);
+    cb_pop_front(output_final_indices_rm_cb_index, 32);
 
     const auto s_out = TensorAccessor(dst_args, dst_addr, out_stick_size);
     uint64_t dst_noc_addr = get_noc_addr(0, s_out);


### PR DESCRIPTION
…rnel

The sampling data-movement kernel had two bugs:

1. Used get_write_ptr() instead of get_read_ptr() to read compute kernel outputs from circular buffers. get_write_ptr returns the write-side address (stale/uninitialized data), while get_read_ptr returns the read-side with actual computed values. This caused completely wrong token selection.

2. Used bf16 soft-float arithmetic (bfloat16_add/bfloat16_div/ bfloat16_greater) for cumulative probability in top-p filtering and stochastic sampling. The cumulative rounding errors caused ~5-10% wrong token selection rate. Replaced with native float32 via bf16_to_f32 widening, which is exact since bf16 is a subset of f32.

Both fixes are required for correct on-device sampling. Without get_read_ptr: complete garbage output. Without float32: noisy/garbled output that degrades eval scores.

Verified: AIME25 eval 0% -> 90% (with additional vLLM-side fixes).

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/fix-sampling-kernel-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/fix-sampling-kernel-precision)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/fix-sampling-kernel-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/fix-sampling-kernel-precision)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/fix-sampling-kernel-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/fix-sampling-kernel-precision)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/fix-sampling-kernel-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/fix-sampling-kernel-precision)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/fix-sampling-kernel-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/fix-sampling-kernel-precision)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/fix-sampling-kernel-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/fix-sampling-kernel-precision)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
