### PR TITLE
ds prefill: mla pod enabled

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -126,9 +126,9 @@ jobs:
           - name: bh_lb_DeepSeek_PREFILL
             cmd: |
               pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc" --timeout 1800
-              pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2' -vvv --tb=short
+              pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and pcc_check' -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py -k '4x2' -vvv --tb=short
-              pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc" -vvv --tb=short
+              pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short
             timeout: 45
             test-type: loudbox
             owner_id: U08E1JCMAJF # Marko Bezulj
@@ -136,7 +136,7 @@ jobs:
           - name: bh_qb_DeepSeek_PREFILL
             cmd: |
               pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc" --timeout 1800
-              pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2' -vvv --tb=short
+              pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2 and pcc_check' -vvv --tb=short
             timeout: 40
             test-type: qb
             owner_id: U08E1JCMAJF # Marko Bezulj

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,8 +6,10 @@
 import pytest
 import torch
 from loguru import logger
+from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_wormhole_b0
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
     reorder_tensor_chunks,
@@ -398,6 +400,11 @@ def run_ring_joint_sdpa(
             logger.debug("Synchronize call...")
             ttnn.synchronize_device(submesh)
             logger.debug("Done synchronizing...")
+
+            logger.debug("  Distributed synchronization started")
+            ttnn.distributed_context_barrier()
+            logger.debug("✓ Distributed synchronization completed")
+
             tt_out = ttnn.to_torch(
                 tt_out_list[i],
                 mesh_composer=ttnn.ConcatMesh2dToTensor(
@@ -448,6 +455,10 @@ def run_ring_joint_sdpa(
         ttnn.synchronize_device(submesh)
         logger.info("Synchronize call ended")
 
+        logger.debug("  Distributed synchronization started")
+        ttnn.distributed_context_barrier()
+        logger.debug("✓ Distributed synchronization completed")
+
 
 #  Note: seq_len and nhq_v will be scaled down to the hw test runs on, inputs are for 32x4 devices configuration
 @pytest.mark.parametrize("q_dtype, kv_dtype", [(ttnn.bfloat16, ttnn.bfloat8_b)], ids=["q_bf16_kv_bf8"])
@@ -457,6 +468,7 @@ def run_ring_joint_sdpa(
         (128 * 1024, 256, 128),
         (100 * 1024, 320, 64),
     ],
+    ids=["seq128k", "seq100k"],
 )
 @pytest.mark.parametrize(
     "b, nhq_v, nhk, head_dim_q_k, head_dim_v",
@@ -465,13 +477,8 @@ def run_ring_joint_sdpa(
     ],
 )
 @pytest.mark.parametrize("n_iters", [1, 3], ids=["single_run", "determinism_check"])
-@pytest.mark.parametrize(
-    "trace_enabled, skip_check",
-    [
-        (False, False),
-    ],
-    ids=["no_trace"],
-)
+@pytest.mark.parametrize("trace_enabled", [False], ids=["no_trace"])
+@pytest.mark.parametrize("skip_check", [True, False], ids=["skip_pcc", "pcc_check"])
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
     "device_params, all_gather_topology",
@@ -488,8 +495,8 @@ def run_ring_joint_sdpa(
 )
 @pytest.mark.parametrize(
     "mesh_device",
-    [(4, 2), (2, 2)],
-    ids=["4x2", "2x2"],
+    [(32, 4), (4, 2), (2, 2)],
+    ids=["32x4", "4x2", "2x2"],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -502,6 +509,7 @@ def run_ring_joint_sdpa(
     ],
 )
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["no_balancing", "balanced"])
+@pytest.mark.timeout(0)
 def test_mla_sdpa(
     mesh_device,
     b,
@@ -571,4 +579,366 @@ def test_mla_sdpa(
         is_causal=True,
         is_balanced=is_balanced,
         cache_path=cache_path,
+    )
+
+
+def run_ring_joint_sdpa_perf(
+    submesh,
+    b,
+    nhq,
+    nhk,
+    nhv,
+    base_seq_len,
+    padded_seq_len,
+    joint_seq_len,
+    head_dim_q,
+    head_dim_k,
+    head_dim_v,
+    q_chunk_size,
+    k_chunk_size,
+    q_dtype,
+    kv_dtype,
+    num_perf_runs,
+    num_links,
+    rp_axis,
+    up_axis,
+    all_gather_topology,
+    is_causal=False,
+    is_balanced=False,
+    math_fidelity=ttnn.MathFidelity.HiFi2,
+):
+    """Run ring joint SDPA with 1 compile run + num_perf_runs measured runs with signposts."""
+    logger.info("Perf test: setting up sub-devices")
+    full_compute_grid = submesh.compute_with_storage_grid_size()
+    sdpa_compute_grid = (full_compute_grid.x - 1, full_compute_grid.y)
+    ccl_core_grid_offset = (full_compute_grid.x - 1, 0)
+
+    # Sub-device setup
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+
+    sub_device_manager = submesh.create_sub_device_manager([worker_sub_device], 0)
+    submesh.load_sub_device_manager(sub_device_manager)
+    submesh.set_sub_device_stall_group(sub_device_stall_group)
+
+    # 1 compile run + num_perf_runs measured runs, each needs its own semaphores/buffers
+    n_total_iters = 1 + num_perf_runs
+    logger.info(f"Perf test: creating {n_total_iters} sets of global semaphores")
+    ccl_semaphore_handles = [create_global_semaphores(submesh, ccl_sub_device_crs, 0) for _ in range(n_total_iters)]
+
+    # Persistent output buffers
+    ag_output_shape_k = (b, nhk, padded_seq_len, head_dim_k)
+    ag_output_shape_v = (b, nhv, padded_seq_len, head_dim_v)
+
+    kv_shard_dims = [None, None]
+    kv_shard_dims[rp_axis] = None
+    kv_shard_dims[up_axis] = 1
+
+    persistent_k_output_shard_dims = [None, None]
+    if nhk != 1:
+        persistent_k_output_shard_dims[up_axis] = 1
+
+    logger.info(f"Perf test: creating {n_total_iters} persistent output buffer pairs")
+    persistent_output_buffers = [
+        [
+            ttnn.as_tensor(
+                torch.zeros(ag_output_shape_k),
+                device=submesh,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=kv_dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    submesh, mesh_shape=tuple(submesh.shape), dims=persistent_k_output_shard_dims
+                ),
+            ),
+            ttnn.as_tensor(
+                torch.zeros(ag_output_shape_v),
+                device=submesh,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=kv_dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=kv_shard_dims),
+            ),
+        ]
+        for _ in range(n_total_iters)
+    ]
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=sdpa_compute_grid,
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=math_fidelity,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    # Create input tensors
+    logger.info(
+        f"Perf test: creating torch input tensors (Q: [{b},{nhq},{base_seq_len},{head_dim_q}], "
+        f"K: [{b},{nhk},{base_seq_len},{head_dim_k}], V: [{b},{nhv},{base_seq_len},{head_dim_v}])"
+    )
+    Q = fa_rand(b, nhq, base_seq_len, head_dim_q)
+    K = fa_rand(b, nhk, base_seq_len, head_dim_k)
+    V = fa_rand(b, nhv, base_seq_len, head_dim_v)
+
+    logger.info(f"Perf test: padding tensors (seq {base_seq_len} -> {padded_seq_len})")
+    padded_Q = torch.cat([Q, torch.zeros(b, nhq, padded_seq_len - base_seq_len, head_dim_q)], dim=2)
+    padded_K = torch.cat([K, torch.zeros(b, nhk, padded_seq_len - base_seq_len, head_dim_k)], dim=2)
+    padded_V = torch.cat([V, torch.zeros(b, nhv, padded_seq_len - base_seq_len, head_dim_v)], dim=2)
+
+    if is_balanced:
+        rp_factor = submesh.shape[rp_axis]
+        chunk_order = create_balanced_chunk_order(rp_factor)
+        logger.info(f"Perf test: applying balanced reordering (rp_factor={rp_factor})")
+        padded_Q = reorder_tensor_chunks(padded_Q, chunk_order, seq_dim=2)
+        padded_K = reorder_tensor_chunks(padded_K, chunk_order, seq_dim=2)
+        padded_V = reorder_tensor_chunks(padded_V, chunk_order, seq_dim=2)
+
+    # Joint tensors
+    joint_Q = fa_rand(b, nhq, joint_seq_len, head_dim_q)
+    joint_K = fa_rand(b, nhk, joint_seq_len, head_dim_k)
+    joint_V = fa_rand(b, nhv, joint_seq_len, head_dim_v)
+
+    # Shard dims
+    sdpa_input_shard_dims = [None, None]
+    sdpa_input_shard_dims[rp_axis] = 2
+    sdpa_input_shard_dims[up_axis] = 1
+
+    sdpa_joint_shard_dims = [None, None]
+    sdpa_joint_shard_dims[up_axis] = 1
+
+    sdpa_k_input_shard_dims = [None, None]
+    sdpa_k_input_shard_dims[rp_axis] = 2
+    if nhk == 1:
+        sdpa_k_input_shard_dims[up_axis] = None
+    else:
+        sdpa_k_input_shard_dims[up_axis] = 1
+
+    logger.info("Perf test: converting Q to device tensor")
+    tt_Q = ttnn.as_tensor(
+        padded_Q,
+        dtype=q_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims),
+    )
+    logger.info("Perf test: converting K to device tensor")
+    tt_K = ttnn.as_tensor(
+        padded_K,
+        dtype=kv_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_k_input_shard_dims),
+    )
+    logger.info("Perf test: converting V to device tensor")
+    tt_V = ttnn.as_tensor(
+        padded_V,
+        dtype=kv_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims),
+    )
+
+    logger.info("Perf test: converting joint tensors to device")
+    tt_joint_Q = ttnn.from_torch(
+        joint_Q,
+        dtype=q_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_joint_shard_dims),
+    )
+    joint_k_mesh_mapper = (
+        ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_k_input_shard_dims)
+        if nhk > 1
+        else ttnn.ReplicateTensorToMesh(submesh)
+    )
+    tt_joint_K = ttnn.from_torch(
+        joint_K,
+        dtype=kv_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=joint_k_mesh_mapper,
+    )
+    tt_joint_V = ttnn.from_torch(
+        joint_V,
+        dtype=kv_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_joint_shard_dims),
+    )
+    logger.info("Perf test: all tensors ready on device")
+
+    def run_once(iter_idx):
+        ttnn.transformer.ring_joint_scaled_dot_product_attention(
+            tt_Q,
+            tt_K,
+            tt_V,
+            tt_joint_Q,
+            tt_joint_K,
+            tt_joint_V,
+            persistent_output_buffer_k=persistent_output_buffers[iter_idx][0],
+            persistent_output_buffer_v=persistent_output_buffers[iter_idx][1],
+            joint_strategy="rear",
+            logical_n=base_seq_len,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            dim=2,
+            multi_device_global_semaphore=ccl_semaphore_handles[iter_idx],
+            num_links=num_links,
+            cluster_axis=rp_axis,
+            mesh_device=submesh,
+            topology=all_gather_topology,
+            subdevice_id=worker_sub_device_id,
+            ccl_core_grid_offset=ccl_core_grid_offset,
+            use_column_major_ccl=True,
+            is_causal=is_causal,
+            is_balanced=is_balanced,
+        )
+
+    # Step 1: Compile run (caches kernels)
+    logger.info("Perf test: compile run (1/1)")
+    run_once(0)
+    ttnn.synchronize_device(submesh)
+    logger.info("Perf test: compile run done")
+
+    # Step 2: Execute op num_perf_runs times with signposts for tracy measurement
+    logger.info(f"Perf test: starting {num_perf_runs} measured runs")
+    signpost("start")
+    for i in range(num_perf_runs):
+        logger.info(f"Perf test: run {i + 1}/{num_perf_runs}")
+        run_once(1 + i)
+        ttnn.synchronize_device(submesh)
+    signpost("stop")
+    logger.info(f"Perf test: all {num_perf_runs} runs complete")
+
+    ttnn.synchronize_device(submesh)
+    ttnn.distributed_context_barrier()
+    logger.info("Perf test: done")
+
+
+# Perf test: 1 compile run + num_perf_runs measured runs with tracy signposts
+# Inputs are for 32x4 production config, scaled down for smaller meshes
+@pytest.mark.parametrize("q_dtype, kv_dtype", [(ttnn.bfloat16, ttnn.bfloat8_b)], ids=["q_bf16_kv_bf8"])
+@pytest.mark.parametrize(
+    "seq_len, q_chunk_size, k_chunk_size",
+    [
+        (128 * 1024, 256, 128),
+        (100 * 1024, 160, 160),
+    ],
+    ids=["seq128k", "seq100k"],
+)
+@pytest.mark.parametrize(
+    "b, nhq_v, nhk, head_dim_q_k, head_dim_v",
+    [
+        (1, 128, 1, 576, 128),
+    ],
+)
+@pytest.mark.parametrize("num_perf_runs", [5], ids=["5runs"])
+@pytest.mark.parametrize("num_links", [1, 2], ids=["1link", "2link"])
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            ttnn.Topology.Linear,
+        ),
+        (
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
+            ttnn.Topology.Ring,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["line", "ring"],
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(32, 4), (8, 4), (2, 4)],
+    ids=["32x4", "8x4", "2x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "rp_axis, up_axis",
+    [[0, 1]],
+    ids=["rpxup"],
+)
+@pytest.mark.parametrize("is_balanced", [False, True], ids=["no_balancing", "balanced"])
+@pytest.mark.timeout(0)
+def test_mla_sdpa_perf(
+    mesh_device,
+    b,
+    nhq_v,
+    nhk,
+    head_dim_q_k,
+    head_dim_v,
+    seq_len,
+    q_chunk_size,
+    k_chunk_size,
+    q_dtype,
+    kv_dtype,
+    num_perf_runs,
+    num_links,
+    rp_axis,
+    up_axis,
+    all_gather_topology,
+    is_balanced,
+    reset_seeds,
+):
+    if num_links == 2 and is_wormhole_b0():
+        pytest.skip("2 links not supported on Wormhole")
+
+    production_shape = [32, 4]
+
+    mesh_device_shape = list(mesh_device.shape)
+    rp_factor = mesh_device_shape[rp_axis]
+    up_factor = mesh_device_shape[up_axis]
+
+    submesh = create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_factor)
+
+    seq_len = (seq_len // production_shape[0]) * rp_factor
+    nhq_v = (nhq_v // production_shape[1]) * up_factor
+    padded_seq_len = get_padded_vision_seq_len(seq_len, mesh_device_shape[rp_axis])
+
+    logger.info(
+        f"Perf test config: mesh={mesh_device_shape}, rp={rp_factor}, up={up_factor}, "
+        f"seq_len={seq_len}, padded_seq_len={padded_seq_len}, nhq_v={nhq_v}, "
+        f"num_links={num_links}, topology={all_gather_topology}"
+    )
+
+    joint_seq_len = 0
+
+    run_ring_joint_sdpa_perf(
+        submesh,
+        b,
+        nhq_v,
+        nhk,
+        nhq_v,
+        seq_len,
+        padded_seq_len,
+        joint_seq_len,
+        head_dim_q_k,
+        head_dim_q_k,
+        head_dim_v,
+        q_chunk_size,
+        k_chunk_size,
+        q_dtype,
+        kv_dtype,
+        num_perf_runs,
+        num_links,
+        rp_axis,
+        up_axis,
+        all_gather_topology,
+        is_causal=True,
+        is_balanced=is_balanced,
     )

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
-
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -95,8 +94,8 @@ def run_ring_joint_sdpa(
 ):
     full_compute_grid = submesh.compute_with_storage_grid_size()
 
-    sdpa_compute_grid = (full_compute_grid.x, full_compute_grid.y - 1)
-    ccl_core_grid_offset = (0, full_compute_grid.y - 1)
+    sdpa_compute_grid = (full_compute_grid.x - 1, full_compute_grid.y)
+    ccl_core_grid_offset = (full_compute_grid.x - 1, 0)
     logger.debug(f"full_compute_grid: {full_compute_grid}")
     logger.debug(f"sdpa_compute_grid: {sdpa_compute_grid}")
     # Basic CCL setup
@@ -364,6 +363,7 @@ def run_ring_joint_sdpa(
                 topology=all_gather_topology,
                 subdevice_id=worker_sub_device_id,
                 ccl_core_grid_offset=ccl_core_grid_offset,
+                use_column_major_ccl=True,
                 is_causal=is_causal,
                 is_balanced=is_balanced,
             )
@@ -466,7 +466,7 @@ def run_ring_joint_sdpa(
     "seq_len, q_chunk_size, k_chunk_size",
     [
         (128 * 1024, 256, 128),
-        (100 * 1024, 320, 64),
+        (100 * 1024, 160, 160),
     ],
     ids=["seq128k", "seq100k"],
 )

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -87,8 +87,8 @@ def random_weights(config_only):
 # sp x tp
 @pytest.mark.parametrize(
     "mesh_device",
-    [(32, 4), (4, 32), (8, 4), (2, 4)],
-    ids=["32x4", "4x32", "8x4", "2x4"],
+    [(32, 4), (8, 4), (2, 4)],
+    ids=["32x4", "8x4", "2x4"],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -323,17 +323,7 @@ def test_mla(
         rope_tensors=rope_tensors,
         kvpe_cache=tt_kvpe_cache,
     )
-    ttnn.synchronize_device(mesh_device)
 
-    logger.info("Second MLA run")
-    ttnn.distributed_context_barrier()
-
-    # Second forward to test program cache hit
-    tt_output = mla_tt.forward(
-        hidden_states=tt_hidden_states,
-        rope_tensors=rope_tensors,
-        kvpe_cache=tt_kvpe_cache,
-    )
     ttnn.synchronize_device(mesh_device)
     ttnn.distributed_context_barrier()
 

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -39,7 +39,7 @@ def random_weights(config_only):
     """
     config = config_only
 
-    torch.manual_seed(42)  # this is likely tied to already cached reference results, so keep it consistent for now
+    torch.manual_seed(42)  # this is tied to already cached reference results, so keep it consistent for now
 
     # Use proper initialization scale from config (typically 0.02)
     std = config.initializer_range
@@ -87,8 +87,8 @@ def random_weights(config_only):
 # sp x tp
 @pytest.mark.parametrize(
     "mesh_device",
-    [(8, 4), (2, 4)],
-    ids=["8x4", "2x4"],
+    [(32, 4), (4, 32), (8, 4), (2, 4)],
+    ids=["32x4", "4x32", "8x4", "2x4"],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -96,8 +96,12 @@ def random_weights(config_only):
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        }
+        },
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+        },
     ],
+    ids=["line", "ring"],
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
@@ -116,6 +120,7 @@ def test_mla(
     is_balanced,
     is_ci_env,
     is_ci_v2_env,
+    device_params,
 ):
     """
     Test comparing reference and TT MLA modules with same weights.
@@ -137,11 +142,20 @@ def test_mla(
     else:
         config, weights = request.getfixturevalue("random_weights")
 
+    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
+    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+
     production_mesh = [32, 4]
     sp_axis = 0
     tp_axis = 1
 
     mesh_shape = list(mesh_device.shape)
+
+    # NOTE: We want to keep TP=4
+    if mesh_shape[tp_axis] != 4:
+        sp_axis = 1
+        tp_axis = 0
+
     if scale_down_sl:
         seq_len = (seq_len // production_mesh[sp_axis]) * mesh_shape[sp_axis]
 
@@ -214,6 +228,7 @@ def test_mla(
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_balanced=is_balanced,
+        topology=topology,
     )
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
     rope_tensors = rope_setup.get_rope_tensors(seq_len)
@@ -292,23 +307,40 @@ def test_mla(
     if is_balanced:
         tt_input = reorder_tensor_chunks(tt_input, chunk_order, seq_dim=2)
 
+    shard_dims = [None, None]
+    shard_dims[tp_axis] = -1
+    shard_dims[sp_axis] = -2
     tt_hidden_states = ttnn.from_torch(
         tt_input,
         device=mesh_device,
         dtype=ttnn.bfloat16,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=(-2, -1)),
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
     )
     tt_output = mla_tt.forward(
         hidden_states=tt_hidden_states,
         rope_tensors=rope_tensors,
         kvpe_cache=tt_kvpe_cache,
     )
+    ttnn.synchronize_device(mesh_device)
+
+    logger.info("Second MLA run")
+    ttnn.distributed_context_barrier()
+
+    # Second forward to test program cache hit
+    tt_output = mla_tt.forward(
+        hidden_states=tt_hidden_states,
+        rope_tensors=rope_tensors,
+        kvpe_cache=tt_kvpe_cache,
+    )
+    ttnn.synchronize_device(mesh_device)
+    ttnn.distributed_context_barrier()
 
     if skip_host_comparison == False:
         tt_output_cpu = ttnn.to_torch(
-            tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 3), mesh_shape=mesh_device.shape)
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape),
         ).to(torch.bfloat16)
 
         if is_balanced:
@@ -329,6 +361,14 @@ def test_mla(
         ).to(torch.bfloat16)
         tt_kvpe_cache_torch = tt_kvpe_cache_torch[:, :1, :, :]
 
+        logger.info("Starting synchronize call")
+        ttnn.synchronize_device(mesh_device)
+        logger.info("Synchronize call ended")
+
+        logger.debug("  Distributed synchronization started")
+        ttnn.distributed_context_barrier()
+        logger.debug("✓ Distributed synchronization completed")
+
         if is_balanced:
             tt_kvpe_cache_torch = reverse_reorder_tensor_chunks(tt_kvpe_cache_torch, chunk_order, seq_dim=2)
 
@@ -343,6 +383,12 @@ def test_mla(
         )
         logger.info(f"KVPE cache PE part PCC is {pe_pcc_message}")
     else:
+        logger.info("Starting synchronize call")
         ttnn.synchronize_device(mesh_device)
+        logger.info("Synchronize call ended")
+
+        logger.debug("  Distributed synchronization started")
+        ttnn.distributed_context_barrier()
+        logger.debug("✓ Distributed synchronization completed")
 
     logger.success(f"✓ Reference and TT comparison with {weight_type} weights successful")

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -151,11 +151,6 @@ def test_mla(
 
     mesh_shape = list(mesh_device.shape)
 
-    # NOTE: We want to keep TP=4
-    if mesh_shape[tp_axis] != 4:
-        sp_axis = 1
-        tp_axis = 0
-
     if scale_down_sl:
         seq_len = (seq_len // production_mesh[sp_axis]) * mesh_shape[sp_axis]
 

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -24,6 +24,7 @@ class ttMLA:
         sp_axis: int = 0,
         tp_axis: int = 1,
         is_balanced: bool = False,
+        topology=ttnn.FabricConfig.FABRIC_1D,
     ):
         self.config = config
         self.mesh_device = mesh_device
@@ -87,13 +88,14 @@ class ttMLA:
 
         # Create CCL object for semaphore management
         self.tt_ccl = get_tt_ccl(mesh_device)
-        self.tp_factor = mesh_device.shape[tp_axis]
+        self.tp_factor = mesh_device.shape[self.tp_axis]
 
         self.ccl_num_links = 2 if is_blackhole() else 1
+        self.ccl_topology = topology
 
         # ring attention setup
         persistent_v_shard_dims = [None, None]
-        persistent_v_shard_dims[tp_axis] = 1  # TP heads
+        persistent_v_shard_dims[self.tp_axis] = 1  # TP heads
         persistent_k_shard_dims = [None, None]
 
         ag_output_shape_k = (1, 1, seq_len, self.kv_lora_rank + self.qk_rope_head_dim)
@@ -124,7 +126,7 @@ class ttMLA:
         # Pre-allocate dummy joint tensors for ring_joint_scaled_dot_product_attention (seq_len=0)
         num_heads_local = self.num_heads // self.tp_factor
         joint_shard_dims = [None, None]
-        joint_shard_dims[tp_axis] = 1  # shard on head dimension
+        joint_shard_dims[self.tp_axis] = 1  # shard on head dimension
 
         self.joint_q = ttnn.from_torch(
             torch.zeros(1, num_heads_local, 0, self.qk_head_dim),
@@ -343,7 +345,7 @@ class ttMLA:
             barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
             num_links=self.ccl_num_links,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=ttnn.Topology.Linear,
+            topology=self.ccl_topology,
             cluster_axis=self.tp_axis,
         )
         tt_q = ttnn.experimental.all_gather_async(
@@ -353,7 +355,7 @@ class ttMLA:
             barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
             num_links=self.ccl_num_links,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=ttnn.Topology.Linear,
+            topology=self.ccl_topology,
             cluster_axis=self.tp_axis,
         )
 
@@ -425,7 +427,7 @@ class ttMLA:
             barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
             num_links=self.ccl_num_links,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=ttnn.Topology.Linear,
+            topology=self.ccl_topology,
             cluster_axis=self.tp_axis,
         )
         tt_kv = ttnn.experimental.fast_reduce_nc(
@@ -475,6 +477,18 @@ class ttMLA:
             **self._get_mm_kwargs("wkv_b2", seq_len_local),
         )
 
+        # from tracy import Profiler
+
+        # profiler = Profiler()
+
+        # profiler.enable()
+        # ttnn.synchronize_device(self.mesh_device)
+        # ttnn.distributed_context_barrier()
+
+        # start = time.time()
+
+        # ttnn.distributed_context_barrier()
+
         attn_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
             tt_q,
             tt_kvpe,
@@ -493,13 +507,19 @@ class ttMLA:
             num_links=self.ccl_num_links,
             cluster_axis=self.sp_axis,
             mesh_device=self.mesh_device,
-            topology=ttnn.Topology.Linear,
+            topology=self.ccl_topology,
             subdevice_id=self.tt_ccl.worker_sub_device_id,
             ccl_core_grid_offset=self.tt_ccl.ring_attention_ccl_core_grid_offset,
             is_causal=True,
             scale=self.scale,
             is_balanced=self.is_balanced,
         )
+        # ttnn.synchronize_device(self.mesh_device)
+        # profiler.disable()
+
+        # ttnn.distributed_context_barrier()
+        # end = time.time()
+        # logger.debug(f"SDPA time: {end - start}s")
 
         v_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         v_out = ttnn.linear(
@@ -515,7 +535,7 @@ class ttMLA:
             barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
             num_links=self.ccl_num_links,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=ttnn.Topology.Linear,
+            topology=self.ccl_topology,
             cluster_axis=self.tp_axis,
         )
         return out

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -477,18 +477,6 @@ class ttMLA:
             **self._get_mm_kwargs("wkv_b2", seq_len_local),
         )
 
-        # from tracy import Profiler
-
-        # profiler = Profiler()
-
-        # profiler.enable()
-        # ttnn.synchronize_device(self.mesh_device)
-        # ttnn.distributed_context_barrier()
-
-        # start = time.time()
-
-        # ttnn.distributed_context_barrier()
-
         attn_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
             tt_q,
             tt_kvpe,
@@ -515,12 +503,6 @@ class ttMLA:
             scale=self.scale,
             is_balanced=self.is_balanced,
         )
-        # ttnn.synchronize_device(self.mesh_device)
-        # profiler.disable()
-
-        # ttnn.distributed_context_barrier()
-        # end = time.time()
-        # logger.debug(f"SDPA time: {end - start}s")
 
         v_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         v_out = ttnn.linear(

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -82,8 +82,8 @@ class ttMLA:
         )
 
         self.ring_sdpa_compute_grid = (
-            mesh_device.compute_with_storage_grid_size().x,
-            mesh_device.compute_with_storage_grid_size().y - 1,
+            mesh_device.compute_with_storage_grid_size().x - 1,
+            mesh_device.compute_with_storage_grid_size().y,
         )
 
         # Create CCL object for semaphore management
@@ -510,6 +510,7 @@ class ttMLA:
             topology=self.ccl_topology,
             subdevice_id=self.tt_ccl.worker_sub_device_id,
             ccl_core_grid_offset=self.tt_ccl.ring_attention_ccl_core_grid_offset,
+            use_column_major_ccl=True,
             is_causal=True,
             scale=self.scale,
             is_balanced=self.is_balanced,

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -24,7 +24,7 @@ class ttMLA:
         sp_axis: int = 0,
         tp_axis: int = 1,
         is_balanced: bool = False,
-        topology=ttnn.FabricConfig.FABRIC_1D,
+        topology=ttnn.Topology.Linear,
     ):
         self.config = config
         self.mesh_device = mesh_device
@@ -89,6 +89,7 @@ class ttMLA:
         # Create CCL object for semaphore management
         self.tt_ccl = get_tt_ccl(mesh_device)
         self.tp_factor = mesh_device.shape[self.tp_axis]
+        self.sp_factor = mesh_device.shape[self.sp_axis]
 
         self.ccl_num_links = 2 if is_blackhole() else 1
         self.ccl_topology = topology
@@ -321,11 +322,7 @@ class ttMLA:
     # Expects ativation in form of:
     # [1, batch_size == 1, seq_len // sp_factor, hidden_size // tp_factor]
     def forward(self, hidden_states: ttnn.Tensor, rope_tensors: dict, kvpe_cache: ttnn.Tensor) -> ttnn.Tensor:
-        mesh_size = self.mesh_device.shape
-        sp_factor = mesh_size[0]
-        tp_factor = mesh_size[1]
-
-        num_heads_local = self.num_heads // tp_factor
+        num_heads_local = self.num_heads // self.tp_factor
         seq_len_local = hidden_states.shape[2]
 
         # q_projection
@@ -487,7 +484,7 @@ class ttMLA:
             persistent_output_buffer_k=self.persistent_k_output_buffer,
             persistent_output_buffer_v=self.persistent_v_output_buffer,
             joint_strategy="rear",
-            logical_n=seq_len_local * sp_factor,
+            logical_n=seq_len_local * self.sp_factor,
             program_config=self._get_sdpa_program_config(seq_len_local),
             compute_kernel_config=self.default_compute_kernel_config,
             dim=2,

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
@@ -237,8 +237,8 @@ MLA_SDPA_CONFIG = {
     },
     # 100k total seq_len → 3200 per device
     3200: {
-        "q_chunk_size": 320,
-        "k_chunk_size": 64,
+        "q_chunk_size": 160,
+        "k_chunk_size": 160,
     },
 }
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -7,7 +7,7 @@ import ttnn
 
 # NOTE: This file is forked from models/common/modules/tt_ccl.py
 #       This is done to include logic for divifing the grid of cores for ring attention
-#       One row is taken for the CCL communication of the op
+#       One col is taken for the CCL communication of the op
 
 # =============================================================================
 # CCL tuning defaults - shared across all TTTv2 modules

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -74,7 +74,7 @@ class TT_CCL:
             }
         )
 
-        self.ring_attention_ccl_core_grid_offset = (0, full_compute_grid.y - 1)
+        self.ring_attention_ccl_core_grid_offset = (full_compute_grid.x - 1, 0)
         ccl_sub_device_crs = ttnn.CoreRangeSet(
             {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
         )

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -23,7 +23,7 @@
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py -k "mesh-8x4"
     export DEEPSEEK_V3_MLA_REF_CACHE=/mnt/MLPerf/deepseek-prefill-cache/test_mla_output
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "8x4 and random and max_sl and check_pcc and balanced" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "8x4 and random and max_sl and check_pcc and balanced and ring" -vvv --tb=short
   model: deepseek_prefill
   skus:
     bh_galaxy:
@@ -38,8 +38,8 @@
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py -vvv --tb=short -k "2048 and (linear-4x1 or mesh-4x2 or mesh-2x4)"
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4)"
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py -vvv --tb=short -k "mesh-4x2"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run' -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run and pcc_check' -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short
   model: deepseek_prefill
   skus:
     wh_llmbox_perf:
@@ -50,9 +50,9 @@
 - name: bh_lb_DeepSeek_PREFILL
   cmd: |
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2' -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and pcc_check' -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py -k '4x2' -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short
   model: deepseek_prefill
   skus:
     bh_loudbox:
@@ -63,7 +63,7 @@
 - name: bh_qb_DeepSeek_PREFILL
   cmd: |
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2' -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2 and pcc_check' -vvv --tb=short
   model: deepseek_prefill
   skus:
     bh_llmbox:

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -17,7 +17,7 @@
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py -k "mesh-8x4"
     export DEEPSEEK_V3_MLA_REF_CACHE=/mnt/MLPerf/deepseek-prefill-cache/test_mla_output
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "8x4 and random and max_sl and check_pcc and balanced" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "8x4 and random and max_sl and check_pcc and balanced and ring" -vvv --tb=short
   test_type: module
   skus:
     bh_galaxy:

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -129,8 +129,8 @@
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py -vvv --tb=short -k "2048 and (linear-4x1 or mesh-4x2 or mesh-2x4)"
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4)"
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py -vvv --tb=short -k "mesh-4x2" --timeout 900
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run' -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run and pcc_check' -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short
   skus:
     wh_llmbox:
       timeout: 45


### PR DESCRIPTION
### Ticket
#41177

### What's changed
PR covers the following changes:

- Adapted MLA test and to be able to run on a galaxy pod 
- Modified MLA module to have column ccls in ring attention with 160 chunks for 100k input
- Added an ring attention perf test that executes the op 5 times after compile run to examine host skew

### Checklist

- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ipotkonjak/pod_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ipotkonjak/pod_mla)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ipotkonjak/pod_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ipotkonjak/pod_mla)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ipotkonjak/pod_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ipotkonjak/pod_mla)
- [ ] [![(Release) Model Status for Console Deployment](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=ipotkonjak/pod_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:ipotkonjak/pod_mla)


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/pod_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/pod_mla)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/pod_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/pod_mla)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/pod_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/pod_mla)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
