### PR TITLE
Fix GPT-OSS structured output regression (bf8 slice + CCL corruption)

### DIFF
--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -181,6 +181,11 @@ def decode_forward(
             ends=[1, 1, batch_size, hidden_size],
             steps=[1, 1, 1, 1],
         )
+        # Workaround: ttnn.slice on bf8 TILE produces a buffer with non-standard
+        # page layout under L1 fragmentation that CCL all_reduce misreads.
+        # DRAM round-trip normalizes the buffer. See #41640 for repro and root cause analysis.
+        tt_out = ttnn.to_memory_config(tt_out, ttnn.DRAM_MEMORY_CONFIG)
+        tt_out = ttnn.to_memory_config(tt_out, ttnn.L1_MEMORY_CONFIG)
 
     # Tensor parallel all-reduce (AllBroadcast, ~80μs vs RS+AG ~138μs).
     if mesh_config.tp > 1:


### PR DESCRIPTION
## Summary

Add DRAM round-trip after `ttnn.slice` on `bfloat8_b` tensor in attention decode, before `ttnn.all_reduce`. This fixes the 0% correct_rate on the vLLM structured output benchmark for GPT-OSS-120B.

## Root cause

`ttnn.slice` on `bfloat8_b` TILE tensors produces a buffer with non-standard page layout under L1 fragmentation. `ttnn.all_reduce` (CCL reduce_scatter) misreads these pages during cross-device transfer, causing silent data corruption — 62% of elements differ by >1.0 in isolated repro.

The bug requires both **bfloat8_b** dtype AND **fragmented L1** to trigger. See #41640 for standalone reproduction and full experiment table.

## Changes

- `models/demos/gpt_oss/tt/attention/decode.py`: Add `to_memory_config(DRAM) -> to_memory_config(L1)` after slice, before all_reduce (+5 lines)

## Test plan

- [x] Verified on g10glx02: `correct_rate(%) 100.0` (32/32 prompts) on vLLM structured output benchmark with DP4 high-throughput config
- [x] Standalone repro confirms fix (DRAM round-trip eliminates corruption)
- [ ] CI: vLLM nightly `[WH-GLX] GPT-OSS-120B (high-throughput)` structured output step
