### PR TITLE
Migrate conv/pool kernels to Device 2.0 experimental API

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -283,7 +283,7 @@ def test_conv2d_block_sharded_sdxl_performance():
     # Extract the device kernel duration result
     device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
 
-    expected_duration_ns = 1088021  # Measured: 1.09ms for Conv2D SDXL block sharded
+    expected_duration_ns = 1042330  # Measured: 1.04ms for Conv2D SDXL block sharded
 
     # Log the performance result
     print(

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -129,7 +129,7 @@ def run_multi_iteration_perf_test(test_func, num_runs, *args, **kwargs) -> Perfo
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1632.0) if is_wormhole_b0() else (1, 4, 3125.0),),
+    ((1, 4, 1669.0) if is_wormhole_b0() else (1, 4, 3150.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -32,8 +32,7 @@ namespace experimental {
  *  - wait(value): Block until the semaphore is set to the specified value.  Does not decrement the semaphore.
  *  - wait_min(value): Block until the semaphore is at least the specified value.  Does not decrement the semaphore.
  *  - set(value): Set the semaphore to the specified value.
- *  - set_multicast(...): Set the semaphore value on multiple cores.
- *  - set_multicast_loopback_src(...): Set the semaphore value on multiple cores including the source.
+ *  - set_multicast(...): Set the semaphore value on multiple cores (use McastMode::INCLUDE_SRC to include sender).
  */
 template <ProgrammableCoreType core_type = ProgrammableCoreType::TENSIX>
 class Semaphore {
@@ -116,7 +115,6 @@ public:
 
     /**
      * @brief Set the semaphore value on multiple cores in a specified rectangular region of the NoC.
-     * @note Sender cannot be part of the multicast destinations.
      *
      * @param noc The Noc object representing the NoC to use for the transaction.
      * @param noc_x_start The starting X coordinate of the region (inclusive).

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "conv_reader_common.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define ENABLE_DEBUG 0
 
@@ -17,6 +18,7 @@ constexpr uint32_t weight_size_w = get_compile_time_arg_val(6);
 // Only a part of the total channel depth (width) is used in one block.
 template <int window_height, int window_width>
 FORCE_INLINE void read_channels(
+    experimental::Noc noc,
     uint32_t& l1_write_addr_act,
     const uint32_t act_l1_read_addr,
     const uint32_t reader_channel_idx,
@@ -31,7 +33,7 @@ FORCE_INLINE void read_channels(
 #pragma GCC unroll weight_size_w
         for (uint32_t inner = 0; inner < window_width; inner++) {
             // Read the partial depth.
-            noc_async_read_one_packet_with_state<true>(act_l1_read_addr_row_offset, l1_write_addr_act);
+            experimental::read_with_state(noc, l1_write_addr_act, act_l1_read_addr_row_offset);
             // Increment by full depth to go to the next pixel
             l1_write_addr_act += conv_act_c_read_bytes;
             act_l1_read_addr_row_offset += stride_w_bytes;
@@ -52,12 +54,13 @@ void kernel_main() {
     constexpr uint32_t num_input_cores = get_compile_time_arg_val(9);
     constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(10);
     constexpr uint32_t act_num_blocks_w = get_compile_time_arg_val(11);
-    const uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(12));
-    const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(13));
-    constexpr uint32_t act_mcast_dest_noc_start_x = get_compile_time_arg_val(14);
-    constexpr uint32_t act_mcast_dest_noc_start_y = get_compile_time_arg_val(15);
-    constexpr uint32_t act_mcast_dest_noc_end_x = get_compile_time_arg_val(16);
-    constexpr uint32_t act_mcast_dest_noc_end_y = get_compile_time_arg_val(17);
+    experimental::Semaphore<> act_mcast_sender_sem(get_compile_time_arg_val(12));
+    experimental::Semaphore<> act_mcast_receiver_sem(get_compile_time_arg_val(13));
+    constexpr McastRect mcast_rect = {
+        get_compile_time_arg_val(14),
+        get_compile_time_arg_val(15),
+        get_compile_time_arg_val(16),
+        get_compile_time_arg_val(17)};
     constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(18);
     constexpr uint32_t num_output_cores = get_compile_time_arg_val(19);
     constexpr uint32_t num_reader_cores = get_compile_time_arg_val(20);
@@ -65,7 +68,6 @@ void kernel_main() {
     constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
     constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
     constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
-    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(24);
     constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(25);
     constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(26);
 
@@ -95,36 +97,31 @@ void kernel_main() {
         return;
     }
 
-    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(0);
+    // Experimental API objects
+    experimental::CB reader_indices_cb(cb_reader_indices);
+    experimental::CB act_rm_cb(cb_id_act_row_major_bfloat16);
+    experimental::CB act_cb(cb_id_act);
+    experimental::CB tilized_in0_cb(tilized_in0_cb_id);
+    experimental::CB sharded_act_cb(cb_id_sharded_act);
+    experimental::Noc noc;
+
+    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(noc, reader_indices_cb, 0);
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_cb.get_write_ptr());
 
-    // L1 array
-    volatile tt_l1_ptr uint32_t* act_mcast_sender_semaphore_valid_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_l1_array));
-
-    // Set up local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    act_mcast_sender_semaphore_valid_addr_ptr[0] =
-        1;  // Load const 1 to be used as semaphore valid value sent from sender to receivers
-
-    uint32_t act_mcast_sender_semaphore_valid_addr =
-        reinterpret_cast<uint32_t>(act_mcast_sender_semaphore_valid_addr_ptr);
+    // Experimental API multicast endpoint
+    experimental::MulticastEndpoint mcast_ep;
+    // Pre-built mcast destination; .addr is updated per mcast call
+    McastDst mcast_dst = {
+        .noc_x_start = mcast_rect.noc_x_start,
+        .noc_y_start = mcast_rect.noc_y_start,
+        .noc_x_end = mcast_rect.noc_x_end,
+        .noc_y_end = mcast_rect.noc_y_end,
+        .addr = 0};
 
     // Set up remote VALID value
-    volatile tt_l1_ptr uint32_t* act_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_mcast_receiver_semaphore_addr);
-    noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, VALID);
-
-    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
-    // to receive the mcast
-    volatile tt_l1_ptr uint32_t* act_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_mcast_sender_semaphore_addr);
-
-    uint64_t act_multicast_noc_addr = get_noc_multicast_addr(
-        act_mcast_dest_noc_start_x, act_mcast_dest_noc_start_y, act_mcast_dest_noc_end_x, act_mcast_dest_noc_end_y, 0);
-
-    uint64_t act_mcast_receiver_semaphore_noc_addr = act_multicast_noc_addr | act_mcast_receiver_semaphore_addr;
+    act_mcast_receiver_sem.set(VALID);
 
     // Compute is divided along the width to reduce the size of CBs.
     // Only a part of the width on each core is used in one block.
@@ -138,8 +135,8 @@ void kernel_main() {
     // Striding to next row happens using stride_h_bytes
     constexpr uint32_t stride_h_bytes = (conv_act_size_w)*conv_act_c_bytes * dilation_h;
 
-    uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), conv_act_c_read_bytes);
+    uint32_t act_l1_read_addr = sharded_act_cb.get_read_ptr();
+    experimental::set_read_state<conv_act_c_read_bytes>(noc, act_l1_read_addr);
     uint32_t reader_idx = 0;
     uint32_t l1_write_addr_act = 0;
 
@@ -149,7 +146,7 @@ void kernel_main() {
 
     // Reset reader_idx to finish act_block_h_datums
     for (uint32_t block_h_index = 0; block_h_index < act_num_blocks_h; block_h_index++) {
-        act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+        act_l1_read_addr = sharded_act_cb.get_read_ptr();
         uint32_t old_reader_idx = reader_idx;
         for (uint32_t block_w_index = 0; block_w_index < act_num_blocks_w; block_w_index++) {
             reader_idx = old_reader_idx;
@@ -165,10 +162,11 @@ void kernel_main() {
                     uint16_t end_ind = two_reader_indices >> 16;
                     for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
                         if (remaining_indexes == TILE_HEIGHT) {
-                            l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
-                            cb_reserve_back(cb_id_act_row_major_bfloat16, ntile_width);
+                            l1_write_addr_act = act_rm_cb.get_write_ptr();
+                            act_rm_cb.reserve_back(ntile_width);
                         }
                         read_channels<weight_size_h, weight_size_w>(
+                            noc,
                             l1_write_addr_act,
                             act_l1_read_addr,
                             ind,
@@ -178,16 +176,16 @@ void kernel_main() {
                             stride_w_bytes);
 
                         if (--remaining_indexes == 0) {
-                            noc_async_read_barrier();
-                            cb_push_back(cb_id_act_row_major_bfloat16, ntile_width);
-                            l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
+                            noc.async_read_barrier();
+                            act_rm_cb.push_back(ntile_width);
+                            l1_write_addr_act = act_rm_cb.get_write_ptr();
                             remaining_indexes = TILE_HEIGHT;
                         }
                     }
                 }
                 if (remaining_indexes && remaining_indexes != TILE_HEIGHT) {
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_act_row_major_bfloat16, ntile_width);
+                    noc.async_read_barrier();
+                    act_rm_cb.push_back(ntile_width);
                 }
                 reader_idx++;
 
@@ -196,8 +194,8 @@ void kernel_main() {
                 act_l1_read_addr += conv_act_c_read_bytes;
             } else {
                 for (uint32_t tile_h_index = 0; tile_h_index < ntile_height; tile_h_index++) {
-                    cb_reserve_back(cb_id_act_row_major_bfloat16, ntile_width);
-                    cb_push_back(cb_id_act_row_major_bfloat16, ntile_width);
+                    act_rm_cb.reserve_back(ntile_width);
+                    act_rm_cb.push_back(ntile_width);
                 }
             }
 
@@ -205,49 +203,58 @@ void kernel_main() {
             // Compute should function like regular mm
 #ifndef SKIP_MCAST
             for (uint32_t act_w_outer_i = 0; act_w_outer_i < num_input_cores; act_w_outer_i++) {
-                cb_reserve_back(cb_id_act, act_block_num_tiles);
+                act_cb.reserve_back(act_block_num_tiles);
                 if (act_w_outer_i == this_core_id) {
                     // MCAST SENDER: send entire tilized input to other cores in column
                     // wait until all act mcast destinations have atomically incremented the act semaphore_addr (i.e.
                     // its value should be act_mcast_num_dests), then reset the semaphore_addr value back to zero for
                     // the next block
 
-                    noc_semaphore_wait_min(act_mcast_sender_semaphore_addr_ptr, num_mcast_cores - 1);
-                    noc_semaphore_set(act_mcast_sender_semaphore_addr_ptr, 0);
+                    act_mcast_sender_sem.wait_min(num_mcast_cores - 1);
+                    act_mcast_sender_sem.set(0);
 
-                    noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    act_mcast_receiver_sem.set(INVALID);
 
                     // compute tilizes and pops cb_id_act and pushes to tilized_in0_cb_id
-                    cb_wait_front(tilized_in0_cb_id, act_block_num_tiles);
+                    tilized_in0_cb.wait_front(act_block_num_tiles);
 
                     // Now we have the block in the CB address, we can mcast to dests!
-                    uint32_t tilized_act_start_address = get_read_ptr(tilized_in0_cb_id);
+                    auto tilized_src =
+                        experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(tilized_in0_cb);
 
-                    // num_dests will source, since we are copying to a different local CB as well
-                    uint64_t act_multicast_data_addr = act_multicast_noc_addr | get_write_ptr(cb_id_act);
-
-                    noc_async_write_multicast_loopback_src(
-                        tilized_act_start_address,
-                        act_multicast_data_addr,
+                    // Multicast tilized activations to all reader cores (including self)
+                    mcast_dst.addr = act_cb.get_write_ptr();
+                    noc.async_write_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                        tilized_src,
+                        mcast_ep,
                         act_mcast_sender_size_bytes,
                         num_reader_cores,
+                        {.offset_bytes = 0},
+                        mcast_dst,
                         true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
                     // (using NOC_CMD_STATIC_VC).
 
-                    // We should also multicast VALID flag to destinations for receiver semaphore
-                    noc_semaphore_set_multicast_loopback_src(
-                        act_mcast_sender_semaphore_valid_addr,
-                        act_mcast_receiver_semaphore_noc_addr,
-                        num_reader_cores,
-                        false);
-                    noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
+                    // Multicast VALID flag to destinations for receiver semaphore.
+                    // The old code used a separate scratch L1 address as the multicast source
+                    // and wait(VALID) on the loopback as a fence. The new Semaphore::set_multicast
+                    // API uses the semaphore itself as both source and destination, so we can't
+                    // clear the local value and wait for loopback — use write barrier instead.
+                    act_mcast_receiver_sem.set(VALID);
+                    act_mcast_receiver_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                        noc,
+                        mcast_rect.noc_x_start,
+                        mcast_rect.noc_y_start,
+                        mcast_rect.noc_x_end,
+                        mcast_rect.noc_y_end,
+                        num_reader_cores);
+                    noc.async_write_barrier();
                 } else {
                     // MCAST RECEIVER: receive entire tilized input from sender core
                     // Set act semaphore value to INVALID
-                    noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    act_mcast_receiver_sem.set(INVALID);
 
                     // Compute sender's logical coordinates from iteration index
                     uint32_t sender_logical_x = act_w_outer_i % num_cores_x;
@@ -258,21 +265,19 @@ void kernel_main() {
                     uint32_t sender_y = act_mcast_y_lookup[sender_logical_y];
 
                     // Atomic increment source core counter
-                    uint64_t act_mcast_sender_semaphore_noc_addr =
-                        get_noc_addr(sender_x, sender_y, act_mcast_sender_semaphore_addr);
-                    noc_semaphore_inc(act_mcast_sender_semaphore_noc_addr, 1);
+                    act_mcast_sender_sem.up(noc, sender_x, sender_y, 1);
 
                     // wait on act semaphore value to become VALID (set by mcast sender after it multicasts data)
-                    noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
+                    act_mcast_receiver_sem.wait(VALID);
                 }
 
-                cb_push_back(cb_id_act, act_block_num_tiles);
+                act_cb.push_back(act_block_num_tiles);
 
             }  // num_input_cores
-            cb_pop_front(tilized_in0_cb_id, act_block_num_tiles);
+            tilized_in0_cb.pop_front(act_block_num_tiles);
 #endif
         }
     }
-    noc_async_read_barrier();
-    noc_async_write_barrier();
+    noc.async_read_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -18,6 +18,7 @@
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_binary.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define DEBUG_PRINT 0
 
@@ -25,58 +26,63 @@ ALWI void ACQ() { acquire_dst(); }
 ALWI void REL() { release_dst(); }
 
 inline void eltwise_mul_and_add_block_v2(
-    uint32_t in0_cb_id,
-    uint32_t in1_cb_id,
-    uint32_t eltwise_mul_partials_cb_cb_id,
-    uint32_t temp_sum_cb,
-    uint32_t out_cb_id,
+    experimental::CB in0_cb,
+    experimental::CB in1_cb,
+    experimental::CB mul_partials_cb,
+    experimental::CB temp_cb,
+    experimental::CB out_cb,
     uint32_t block_num_tiles,
     uint32_t idx,
     uint32_t total_blocks) {
-    uint32_t last_block_idx = total_blocks - 1;
+    const uint32_t in0_cb_id = in0_cb.get_cb_id();
+    const uint32_t in1_cb_id = in1_cb.get_cb_id();
+    const uint32_t mul_partials_cb_id = mul_partials_cb.get_cb_id();
+    const uint32_t temp_cb_id = temp_cb.get_cb_id();
+    const uint32_t out_cb_id = out_cb.get_cb_id();
+
     for (uint32_t i = 0; i < block_num_tiles; i++) {
-        cb_wait_front(in1_cb_id, 1);
-        cb_wait_front(in0_cb_id, 1);
-        cb_reserve_back(eltwise_mul_partials_cb_cb_id, 1);
+        in1_cb.wait_front(1);
+        in0_cb.wait_front(1);
+        mul_partials_cb.reserve_back(1);
         mul_tiles_init(in0_cb_id, in1_cb_id);
         ACQ();
         mul_tiles(in0_cb_id, in1_cb_id, 0, 0, 0);
-        pack_tile(0, eltwise_mul_partials_cb_cb_id);
+        pack_tile(0, mul_partials_cb_id);
         REL();
-        cb_push_back(eltwise_mul_partials_cb_cb_id, 1);
-        cb_pop_front(in0_cb_id, 1);
-        cb_pop_front(in1_cb_id, 1);
+        mul_partials_cb.push_back(1);
+        in0_cb.pop_front(1);
+        in1_cb.pop_front(1);
         if (idx == 0) {
-            copy_tile_to_dst_init_short(eltwise_mul_partials_cb_cb_id);
+            copy_tile_to_dst_init_short(mul_partials_cb_id);
             ACQ();
-            cb_wait_front(eltwise_mul_partials_cb_cb_id, 1);
-            cb_reserve_back(out_cb_id, 1);
-            copy_tile(eltwise_mul_partials_cb_cb_id, 0, 0);
+            mul_partials_cb.wait_front(1);
+            out_cb.reserve_back(1);
+            copy_tile(mul_partials_cb_id, 0, 0);
             pack_tile(0, out_cb_id);
             REL();
-            cb_push_back(out_cb_id, 1);
-            cb_pop_front(eltwise_mul_partials_cb_cb_id, 1);
+            out_cb.push_back(1);
+            mul_partials_cb.pop_front(1);
         } else {
-            add_tiles_init(eltwise_mul_partials_cb_cb_id, out_cb_id);
-            cb_wait_front(eltwise_mul_partials_cb_cb_id, 1);
-            cb_wait_front(out_cb_id, 1);
+            add_tiles_init(mul_partials_cb_id, out_cb_id);
+            mul_partials_cb.wait_front(1);
+            out_cb.wait_front(1);
             ACQ();
-            add_tiles(eltwise_mul_partials_cb_cb_id, out_cb_id, 0, 0, 0);
-            pack_tile(0, temp_sum_cb);
+            add_tiles(mul_partials_cb_id, out_cb_id, 0, 0, 0);
+            pack_tile(0, temp_cb_id);
             REL();
-            cb_push_back(temp_sum_cb, 1);
-            cb_pop_front(eltwise_mul_partials_cb_cb_id, 1);
-            cb_pop_front(out_cb_id, 1);
+            temp_cb.push_back(1);
+            mul_partials_cb.pop_front(1);
+            out_cb.pop_front(1);
 
-            copy_tile_to_dst_init_short(temp_sum_cb);
+            copy_tile_to_dst_init_short(temp_cb_id);
             ACQ();
-            cb_wait_front(temp_sum_cb, 1);
-            cb_reserve_back(out_cb_id, 1);
-            copy_tile(temp_sum_cb, 0, 0);
+            temp_cb.wait_front(1);
+            out_cb.reserve_back(1);
+            copy_tile(temp_cb_id, 0, 0);
             pack_tile(0, out_cb_id);
             REL();
-            cb_push_back(out_cb_id, 1);
-            cb_pop_front(temp_sum_cb, 1);
+            out_cb.push_back(1);
+            temp_cb.pop_front(1);
         }
     }
 }
@@ -120,6 +126,12 @@ void kernel_main() {
 
     constexpr uint32_t num_blocks = in0_num_blocks_h * in0_num_blocks_w;  // num_tokens window
 
+    experimental::CB cb_tilized_in0(tilized_in0_cb_id);
+    experimental::CB cb_in1(in1_cb_id);
+    experimental::CB cb_mul_partials(eltwise_mul_partials_cb);
+    experimental::CB cb_temp_sum(temp_sum_cb);
+    experimental::CB cb_out(out_cb_id);
+
     binary_op_init_common(in0_cb_id, in1_cb_id, out_cb_id);
 
     for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
@@ -131,14 +143,7 @@ void kernel_main() {
             reconfig_data_format_srca(tilized_in0_cb_id);
             pack_reconfig_data_format(eltwise_mul_partials_cb);
             eltwise_mul_and_add_block_v2(
-                tilized_in0_cb_id,
-                in1_cb_id,
-                eltwise_mul_partials_cb,
-                temp_sum_cb,
-                out_cb_id,
-                in0_block_num_tiles,
-                i,
-                num_blocks);
+                cb_tilized_in0, cb_in1, cb_mul_partials, cb_temp_sum, cb_out, in0_block_num_tiles, i, num_blocks);
 
         }  // for in0_num_blocks_h
     }  // for in0_num_blocks_w

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -14,6 +14,7 @@
 #include "api/compute/untilize.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // #include "api/debug/dprint.h"
 
@@ -52,10 +53,10 @@ void tilize_in(
 }  // tilize_in()
 
 template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id>
-inline void tilize_single_block() {
-    cb_wait_front(in_cb_id, in_block_w);
+inline void tilize_single_block(experimental::CB in_cb) {
+    in_cb.wait_front(in_block_w);
     fast_tilize_block(in_cb_id, in_block_w, out_cb_id);
-    cb_pop_front(in_cb_id, in_block_w);
+    in_cb.pop_front(in_block_w);
 }
 
 template <uint32_t in_cb_id, uint32_t window_reuse_offset>
@@ -65,10 +66,10 @@ inline uint32_t update_in_cb(uint32_t in_cb_addr) {
 }
 
 template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id, uint32_t tilized_cb_row_offset>
-inline void tilize_single_block_with_out_cb_update(uint32_t& out_cb_addr) {
+inline void tilize_single_block_with_out_cb_update(experimental::CB in_cb, uint32_t& out_cb_addr) {
     PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr));
     PACK((out_cb_addr += tilized_cb_row_offset));
-    tilize_single_block<in_cb_id, in_block_w, out_cb_id>();
+    tilize_single_block<in_cb_id, in_block_w, out_cb_id>(in_cb);
 }
 
 template <
@@ -83,12 +84,17 @@ template <
     uint32_t tilized_cb_row_offset,
     uint32_t tilized_cb_second_reader_offset,
     uint32_t image_width_in_tiles>
-inline void tilize_in_reuse_split_reader(uint32_t act_cb_start_address, uint32_t act_cb_second_reader_start_address) {
+inline void tilize_in_reuse_split_reader(
+    experimental::CB in1_cb,
+    experimental::CB in2_cb,
+    experimental::CB out_cb,
+    uint32_t act_cb_start_address,
+    uint32_t act_cb_second_reader_start_address) {
     // with activation reuse, the activation buffers are sized to fit one output image width only,
     // so we need to interleave waits and pops on the two buffers to allow parallelization;
     // we reserve back tilized CB to store whole act block h - and then we update write pointers so that
     // we fill in first row of the first half (NCRISC), first row of the second half (BRISC) and so on
-    cb_reserve_back(out_cb_id, out_cb_tiles);
+    out_cb.reserve_back(out_cb_tiles);
     fast_tilize_init_with_dt(in1_cb_id, in_block_w, out_cb_id);
 
     uint32_t in1_cb_addr = act_cb_start_address;
@@ -113,9 +119,9 @@ inline void tilize_in_reuse_split_reader(uint32_t act_cb_start_address, uint32_t
         in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
         for (uint32_t image_col = 0; image_col < image_width_in_tiles; ++image_col) {
             tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                out_cb_addr);
+                in1_cb, out_cb_addr);
             tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                out_cb_addr_second_reader);
+                in2_cb, out_cb_addr_second_reader);
         }
     }
 
@@ -125,7 +131,7 @@ inline void tilize_in_reuse_split_reader(uint32_t act_cb_start_address, uint32_t
     for (uint32_t image_col = 0; image_col < max_leftover; ++image_col) {
         if (image_col < leftover_in1) {
             tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                out_cb_addr);
+                in1_cb, out_cb_addr);
 
             if (image_col == image_width_in_tiles - 1) {
                 in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
@@ -134,7 +140,7 @@ inline void tilize_in_reuse_split_reader(uint32_t act_cb_start_address, uint32_t
 
         if (image_col < leftover_in2) {
             tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                out_cb_addr_second_reader);
+                in2_cb, out_cb_addr_second_reader);
 
             if (image_col == image_width_in_tiles - 1) {
                 in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
@@ -142,23 +148,25 @@ inline void tilize_in_reuse_split_reader(uint32_t act_cb_start_address, uint32_t
         }
     }
 
-    cb_push_back(out_cb_id, out_cb_tiles);
+    out_cb.push_back(out_cb_tiles);
     fast_tilize_uninit(in2_cb_id, out_cb_id);
 }
 
 template <uint32_t out_subblock_w, uint32_t out_block_w>
 inline void reblock_and_untilize(
+    experimental::CB interm_cb,
+    experimental::CB out_cb,
     uint32_t num_out_subblocks_in_col,
     uint32_t out_subblock_num_tiles,
-    uint32_t out_subblock_h,
-    uint32_t interm_cb_id,
-    uint32_t out_cb_id) {
+    uint32_t out_subblock_h) {
+    const uint32_t interm_cb_id = interm_cb.get_cb_id();
+    const uint32_t out_cb_id = out_cb.get_cb_id();
     uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
-    cb_wait_front(interm_cb_id, num_tiles_in_row_of_subblocks);
+    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
     uint32_t within_block_index = 0;
     for (uint32_t h = 0; h < out_subblock_h; h++) {
         uint32_t block_offset = 0;
-        cb_reserve_back(out_cb_id, out_block_w);
+        out_cb.reserve_back(out_block_w);
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < out_subblock_w; w++) {
@@ -171,10 +179,10 @@ inline void reblock_and_untilize(
             tile_regs_release();
             block_offset += out_subblock_num_tiles;
         }
-        cb_push_back(out_cb_id, out_block_w);
+        out_cb.push_back(out_block_w);
         within_block_index += out_subblock_w;
     }
-    cb_pop_front(interm_cb_id, num_tiles_in_row_of_subblocks);
+    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
 }
 
 void kernel_main() {
@@ -256,6 +264,17 @@ void kernel_main() {
     if constexpr (check_skip_compute) {
         skip_compute = (bool)get_arg_val<uint32_t>(0);
     }
+
+    experimental::CB cb_in0(in0_cb_id);
+    experimental::CB cb_in0_second_reader(in0_cb_second_reader_id);
+    experimental::CB cb_tilized_in0(tilized_in0_cb_id);
+    experimental::CB cb_mm_in0(mm_in0_cb_id);
+    experimental::CB cb_in1(in1_cb_id);
+    experimental::CB cb_matmul_partials(matmul_partials_cb);
+    experimental::CB cb_mm_out(mm_out_cb_id);
+    experimental::CB cb_out(out_cb_id);
+    experimental::CB cb_bias(bias_cb_id);
+    experimental::CB cb_untilize_mode_out(untilize_mode_out_cb_id);
 
     mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -346,7 +365,12 @@ void kernel_main() {
                                 window_reuse_offset,
                                 tilized_cb_row_offset,
                                 tilized_cb_second_reader_offset,
-                                image_width_in_tiles>(act_cb_start_address, act_cb_second_reader_start_address);
+                                image_width_in_tiles>(
+                                cb_in0,
+                                cb_in0_second_reader,
+                                cb_tilized_in0,
+                                act_cb_start_address,
+                                act_cb_second_reader_start_address);
                         }
                     }
 
@@ -361,17 +385,17 @@ void kernel_main() {
                         in0_block_w);
                 }
 
-                cb_wait_front(mm_in0_cb_id, in0_block_num_tiles);
+                cb_mm_in0.wait_front(in0_block_num_tiles);
 
                 uint32_t in0_index_subblock_offset = 0;
                 if constexpr (check_skip_compute) {
                     if (skip_compute) {
-                        cb_pop_front(mm_in0_cb_id, in0_block_num_tiles);
+                        cb_mm_in0.pop_front(in0_block_num_tiles);
                         continue;
                     }
                 }
 
-                cb_wait_front(in1_cb_id, in1_block_num_tiles);
+                cb_in1.wait_front(in1_block_num_tiles);
 
                 if (last_inner_dim_block) {
                     if constexpr (!fuse_bias) {
@@ -392,7 +416,7 @@ void kernel_main() {
                         if (enable_reload) {
                             // Reconfigure input
                             copy_tile_to_dst_init_short_with_dt(in1_cb_id, matmul_partials_cb);
-                            cb_wait_front(matmul_partials_cb, out_subblock_num_tiles);
+                            cb_matmul_partials.wait_front(out_subblock_num_tiles);
                             tile_regs_acquire();
 
                             uint32_t start_dst_index = 0;
@@ -400,7 +424,7 @@ void kernel_main() {
                             copy_block_matmul_partials(
                                 matmul_partials_cb, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
-                            cb_pop_front(matmul_partials_cb, out_subblock_num_tiles);
+                            cb_matmul_partials.pop_front(out_subblock_num_tiles);
                             // Reconfigure srcA back
                             mm_block_init_short_with_dt(
                                 mm_in0_cb_id,
@@ -450,7 +474,9 @@ void kernel_main() {
                         }
 #endif
                         tile_regs_commit();
-                        cb_reserve_back(curr_matmul_out_cb, out_subblock_num_tiles);
+                        experimental::CB curr_out_cb =
+                            curr_matmul_out_cb == matmul_partials_cb ? cb_matmul_partials : cb_mm_out;
+                        curr_out_cb.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
 
                         if constexpr (packer_l1_acc) {
@@ -469,7 +495,7 @@ void kernel_main() {
                         pack_tile_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
 
                         tile_regs_release();
-                        cb_push_back(curr_matmul_out_cb, out_subblock_num_tiles);
+                        curr_out_cb.push_back(out_subblock_num_tiles);
 
                         in1_index_subblock_offset += out_subblock_w;
                     }  // for in1_num_subblocks
@@ -486,8 +512,8 @@ void kernel_main() {
                         if (in0_block_w_i < in0_num_blocks_w - 1) {
                             // Wait for l1 accumulation to populate interm buffer,
                             // then pop to update fifo rd pointer
-                            cb_wait_front(matmul_partials_cb, out_block_num_tiles);
-                            cb_pop_front(matmul_partials_cb, out_block_num_tiles);
+                            cb_matmul_partials.wait_front(out_block_num_tiles);
+                            cb_matmul_partials.pop_front(out_block_num_tiles);
                             if constexpr (spill) {
                                 UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
                                 PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
@@ -498,8 +524,8 @@ void kernel_main() {
                     } else {
                         // Last iteration does spill and reload to output buffer
                         if (in0_block_w_i < in0_num_blocks_w - 2) {
-                            cb_wait_front(matmul_partials_cb, out_block_num_tiles);
-                            cb_pop_front(matmul_partials_cb, out_block_num_tiles);
+                            cb_matmul_partials.wait_front(out_block_num_tiles);
+                            cb_matmul_partials.pop_front(out_block_num_tiles);
                             if constexpr (spill) {
                                 UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
                                 PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
@@ -529,8 +555,8 @@ void kernel_main() {
                     }
                 }
 
-                cb_pop_front(mm_in0_cb_id, in0_block_num_tiles);
-                cb_pop_front(in1_cb_id, in1_block_num_tiles);
+                cb_mm_in0.pop_front(in0_block_num_tiles);
+                cb_in1.pop_front(in1_block_num_tiles);
             }  // for in0_num_blocks_w
             if constexpr (matmul_partials_cb == mm_out_cb_id && partials_cb_uses_output) {
                 UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
@@ -552,8 +578,8 @@ void kernel_main() {
                 reconfig_data_format(in1_cb_id, matmul_partials_cb, mm_in0_cb_id, bias_cb_id);
                 add_bcast_rows_init_short(matmul_partials_cb, bias_cb_id);
 
-                cb_wait_front(bias_cb_id, bias_ntiles_w);
-                cb_wait_front(matmul_partials_cb, out_block_num_tiles);
+                cb_bias.wait_front(bias_ntiles_w);
+                cb_matmul_partials.wait_front(out_block_num_tiles);
                 for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                     uint32_t in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {
@@ -575,15 +601,15 @@ void kernel_main() {
 #endif
                         tile_regs_commit();
                         // do not pop front bias as it may be used again for subsequent blocks
-                        cb_pop_front(matmul_partials_cb, out_subblock_num_tiles);
+                        cb_matmul_partials.pop_front(out_subblock_num_tiles);
 
-                        cb_reserve_back(untilize_mode_out_cb_id, out_subblock_num_tiles);
+                        cb_untilize_mode_out.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, untilize_mode_out_cb_id);
                         }
                         tile_regs_release();
-                        cb_push_back(untilize_mode_out_cb_id, out_subblock_num_tiles);
+                        cb_untilize_mode_out.push_back(out_subblock_num_tiles);
 
                         in1_index_subblock_offset += out_subblock_w;
                     }  // for in1_num_subblocks
@@ -610,7 +636,7 @@ void kernel_main() {
                     copy_tile_to_dst_init_short(matmul_partials_cb);
                     for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                         reblock_and_untilize<out_subblock_w, out_block_w>(
-                            in1_num_subblocks, out_subblock_num_tiles, out_subblock_h, matmul_partials_cb, out_cb_id);
+                            cb_matmul_partials, cb_out, in1_num_subblocks, out_subblock_num_tiles, out_subblock_h);
                     }
                     pack_untilize_uninit(matmul_partials_cb);
                 } else {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -5,25 +5,36 @@
 #pragma once
 
 #include <tt-metalium/constants.hpp>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+// Multicast rectangle: defines the NOC coordinate range for multicast destinations.
+struct McastRect {
+    uint32_t noc_x_start, noc_y_start, noc_x_end, noc_y_end;
+};
+
+#ifndef COMPILE_FOR_TRISC
+// Shorthand for the multicast destination args type used by Noc::async_write_multicast.
+using McastDst = experimental::noc_traits_t<experimental::MulticastEndpoint>::dst_args_mcast_type;
+#endif
 
 // Zero out all tiles for a given circular buffer.
 template <uint32_t cb_id>
-FORCE_INLINE void zero_out_tiles() {
+FORCE_INLINE void zero_out_tiles(experimental::Noc noc, experimental::CB cb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     static_assert(
         tile_size % MEM_ZEROS_SIZE == 0, "Tile size must be a multiple of MEM_ZEROS_BASE for zeroing out tiles");
     const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_num_pages;
     const uint32_t num_zeros_reads = (tile_size / MEM_ZEROS_SIZE) * num_tiles;
-    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
-    uint32_t write_addr = get_write_ptr(cb_id);
 
-    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    constexpr uint32_t packet_size = MEM_ZEROS_SIZE;
+
+    experimental::set_read_state<packet_size>(noc, MEM_ZEROS_BASE);
+
     for (uint32_t i = 0; i < num_zeros_reads; ++i) {
-        noc_async_read_one_packet_with_state<true>(zeros_noc_addr, write_addr);
-        write_addr += MEM_ZEROS_SIZE;
+        experimental::read_with_state(noc, cb, MEM_ZEROS_BASE, {.offset_bytes = i * packet_size});
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
 template <
@@ -35,6 +46,7 @@ template <
     uint32_t weight_size_w,
     uint32_t stride_w>
 FORCE_INLINE void read_sticks(
+    experimental::Noc noc,
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
     uint32_t reader_offset,
     uint32_t& l1_write_addr_act,
@@ -48,17 +60,17 @@ FORCE_INLINE void read_sticks(
 
         if constexpr (dilation_w == 1) {
             for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
-                uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
-                noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+                uint32_t src_addr = reader_offset + (ind * conv_act_c_read_bytes);
+                experimental::read_with_state(noc, l1_write_addr_act, src_addr);
                 l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
             }
         } else {
             for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
-                uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+                uint32_t src_addr = reader_offset + (ind * conv_act_c_read_bytes);
                 for (uint32_t inner = 0; inner < weight_size_w; inner++) {
-                    noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+                    experimental::read_with_state(noc, l1_write_addr_act, src_addr);
                     l1_write_addr_act += conv_act_c_read_bytes;
-                    act_l1_offset += stride_w_bytes;
+                    src_addr += stride_w_bytes;
                 }
                 l1_write_addr_act += act_block_w_extra_align_bytes;
             }
@@ -68,14 +80,15 @@ FORCE_INLINE void read_sticks(
 }
 
 template <uint32_t coalesced_read_bytes, uint32_t stride_h_bytes>
-FORCE_INLINE void read_kernel_w(uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
-    noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+FORCE_INLINE void read_kernel_w(experimental::Noc noc, uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
+    experimental::read_with_state(noc, l1_write_addr_act, act_l1_offset);
     l1_write_addr_act += coalesced_read_bytes;
     act_l1_offset += stride_h_bytes;
 }
 
 template <uint32_t cb_id_act, uint32_t act_cb_tiles, uint32_t window_reuse_offset>
 FORCE_INLINE void pass_to_the_next_image_width(
+    experimental::CB cb_act,
     uint32_t& l1_write_addr_act,
     uint32_t cb_start_addr,
     uint32_t& pixel_row,
@@ -83,7 +96,7 @@ FORCE_INLINE void pass_to_the_next_image_width(
     uint32_t& new_batch_image_rows_to_fill) {
     pixel_column = 0;
     pixel_row++;
-    cb_reserve_back(cb_id_act, act_cb_tiles);
+    cb_act.reserve_back(act_cb_tiles);
     l1_write_addr_act = cb_start_addr + pixel_row * window_reuse_offset;
     get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
 
@@ -93,17 +106,18 @@ FORCE_INLINE void pass_to_the_next_image_width(
 }
 
 template <uint32_t cb_id_act, uint32_t act_cb_w_tiles>
-FORCE_INLINE void push_full_tile_height() {
-    noc_async_read_barrier();
-    cb_push_back(cb_id_act, act_cb_w_tiles);
+FORCE_INLINE void push_full_tile_height(experimental::Noc noc, experimental::CB cb_act) {
+    noc.async_read_barrier();
+    cb_act.push_back(act_cb_w_tiles);
 }
 
 template <uint32_t cb_id_act, uint32_t act_cb_w_tiles, uint32_t image_width_tiles>
-FORCE_INLINE void push_remaining_tiles(uint32_t remaining_tiles_to_push, uint32_t cb_start_addr) {
+FORCE_INLINE void push_remaining_tiles(
+    experimental::CB cb_act, uint32_t remaining_tiles_to_push, uint32_t cb_start_addr) {
     constexpr uint32_t tiles_to_push = image_width_tiles * act_cb_w_tiles;
     for (uint32_t i = 0; i < remaining_tiles_to_push; i += image_width_tiles) {
         get_local_cb_interface(cb_id_act).fifo_wr_ptr = cb_start_addr;
-        cb_push_back(cb_id_act, tiles_to_push);
+        cb_act.push_back(tiles_to_push);
     }
 }
 
@@ -117,17 +131,22 @@ template <
     uint32_t conv_act_c_read_bytes,
     uint32_t act_block_w_extra_align_bytes>
 FORCE_INLINE void read_first_image_row_window(
-    uint32_t& l1_write_addr_act, uint32_t reader_offset, uint16_t ind, uint32_t& pixel_column) {
+    experimental::Noc noc,
+    experimental::CB cb_act,
+    uint32_t& l1_write_addr_act,
+    uint32_t reader_offset,
+    uint16_t ind,
+    uint32_t& pixel_column) {
     uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
     for (uint32_t outer = 0; outer < window_outer; outer++) {
-        read_kernel_w<coalesced_read_bytes, stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+        read_kernel_w<coalesced_read_bytes, stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
     }
     l1_write_addr_act += act_block_w_extra_align_bytes;
 
     pixel_column++;
     // if full tile, push back
     if ((pixel_column & 31) == 0) {
-        push_full_tile_height<cb_id_act, act_cb_w_tiles>();
+        push_full_tile_height<cb_id_act, act_cb_w_tiles>(noc, cb_act);
     }
 }
 
@@ -136,10 +155,11 @@ template <
     uint32_t stride_h_bytes,
     uint32_t outer_coalesced_read_bytes,
     uint32_t outer_stride_h_bytes>
-FORCE_INLINE void read_image_row_window_with_reuse(uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
+FORCE_INLINE void read_image_row_window_with_reuse(
+    experimental::Noc noc, uint32_t& l1_write_addr_act, uint32_t& act_l1_offset) {
     l1_write_addr_act += outer_coalesced_read_bytes;
     act_l1_offset += outer_stride_h_bytes;
-    read_kernel_w<coalesced_read_bytes, stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+    read_kernel_w<coalesced_read_bytes, stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
 }
 
 template <uint32_t window_inner, bool single_core_processes_multiple_batches>
@@ -184,6 +204,8 @@ template <
     uint32_t window_reuse_offset,
     bool single_core_processes_multiple_batches>
 FORCE_INLINE void read_sticks_activation_reuse(
+    experimental::Noc noc,
+    experimental::CB cb_act,
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
     uint32_t reader_offset,
     uint32_t& l1_write_addr_act,
@@ -199,7 +221,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
     uint32_t pixel_row = 0, pixel_column = 0;
     uint32_t new_batch_image_rows_to_fill = 0;
 
-    cb_reserve_back(cb_id_act, act_cb_tiles);
+    cb_act.reserve_back(act_cb_tiles);
 
     if (num_segments == 0) {
         return;
@@ -218,7 +240,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
             cb_id_act,
             act_cb_w_tiles,
             conv_act_c_read_bytes,
-            act_block_w_extra_align_bytes>(l1_write_addr_act, reader_offset, ind, pixel_column);
+            act_block_w_extra_align_bytes>(noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
     }
 
     num_segments--;
@@ -249,7 +271,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
                     cb_id_act,
                     act_cb_w_tiles,
                     conv_act_c_read_bytes,
-                    act_block_w_extra_align_bytes>(l1_write_addr_act, reader_offset, ind, pixel_column);
+                    act_block_w_extra_align_bytes>(noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
             }
 
             start_ind = start_ind + second_row_width;
@@ -268,7 +290,8 @@ FORCE_INLINE void read_sticks_activation_reuse(
                             cb_id_act,
                             act_cb_w_tiles,
                             conv_act_c_read_bytes,
-                            act_block_w_extra_align_bytes>(l1_write_addr_act, reader_offset, ind, pixel_column);
+                            act_block_w_extra_align_bytes>(
+                            noc, cb_act, l1_write_addr_act, reader_offset, ind, pixel_column);
                     }
 
                     start_ind = start_ind + third_row_width;
@@ -278,7 +301,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
     }
     // Move on to the next output image width
     pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-        l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
+        cb_act, l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
 
     // ------ HANDLE REMAINING INPUT, WHERE WE READ JUST THE LAST KERNEL WIDTH OF THE WINDOW ------
     while (num_segments--) {
@@ -290,7 +313,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
                     coalesced_read_bytes,
                     stride_h_bytes,
                     outer_coalesced_read_bytes,
-                    outer_stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+                    outer_stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
             } else {
                 // In this case, we need to check if we are in the limits of image width since we pad it to tile size
                 if (pixel_column < output_image_width && new_batch_image_rows_to_fill == 0) {
@@ -298,10 +321,10 @@ FORCE_INLINE void read_sticks_activation_reuse(
                         coalesced_read_bytes,
                         stride_h_bytes,
                         outer_coalesced_read_bytes,
-                        outer_stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+                        outer_stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
                 } else {
                     for (uint32_t outer = 0; outer < window_outer; outer++) {
-                        read_kernel_w<coalesced_read_bytes, stride_h_bytes>(l1_write_addr_act, act_l1_offset);
+                        read_kernel_w<coalesced_read_bytes, stride_h_bytes>(noc, l1_write_addr_act, act_l1_offset);
                     }
                 }
             }
@@ -310,13 +333,18 @@ FORCE_INLINE void read_sticks_activation_reuse(
 
             pixel_column++;
             if ((pixel_column & 31) == 0) {
-                push_full_tile_height<cb_id_act, act_cb_w_tiles>();
+                push_full_tile_height<cb_id_act, act_cb_w_tiles>(noc, cb_act);
 
                 // Move on to the next output image width
                 if constexpr (!readers_process_full_image_widths) {
                     if (pixel_column == image_width_padded_to_tile) {
                         pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-                            l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
+                            cb_act,
+                            l1_write_addr_act,
+                            cb_start_addr,
+                            pixel_row,
+                            pixel_column,
+                            new_batch_image_rows_to_fill);
                     }
                 }
             }
@@ -325,7 +353,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
         if constexpr (readers_process_full_image_widths) {
             // Move on to the next output image width
             pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-                l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
+                cb_act, l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
         }
 
         load_next_segment<window_inner, single_core_processes_multiple_batches>(
@@ -334,7 +362,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
 }
 
 template <uint32_t dram_addr_index, uint32_t page_size_index, uint32_t tensor_args_index, uint32_t cb_reader_index>
-void load_config_tensor_if_in_dram(uint32_t core_index) {
+void load_config_tensor_if_in_dram(experimental::Noc noc, experimental::CB reader_cb, uint32_t core_index) {
 #ifdef CONFIG_TENSOR_IN_DRAM
     // TODO: Instead of all cores reading from dram, only the first column reads, and does an MCAST to all the other
     // cores in the row.
@@ -342,53 +370,51 @@ void load_config_tensor_if_in_dram(uint32_t core_index) {
     constexpr uint32_t config_page_size = get_compile_time_arg_val(page_size_index);
     const auto config_tensor_args = TensorAccessorArgs<tensor_args_index>();
     const auto config_accessor = TensorAccessor(config_tensor_args, config_dram_addr, config_page_size);
-    uint64_t src_noc_addr = get_noc_addr(core_index, config_accessor);
 
-    noc_async_read(src_noc_addr, get_write_ptr(cb_reader_index), config_page_size);
-    noc_async_read_barrier();
-    cb_push_back(cb_reader_index, 1);
+    noc.async_read(config_accessor, reader_cb, config_page_size, {.page_id = core_index}, {});
+    noc.async_read_barrier();
+    reader_cb.push_back(1);
 #endif
 }
 
 template <int window_height, int window_width>
 FORCE_INLINE void read_dilated_channels(
+    experimental::Noc noc,
     uint32_t& l1_write_addr_act,
     const uint32_t act_l1_read_addr,
     const uint32_t reader_channel_idx,
     const uint32_t conv_act_c_bytes,
     const uint32_t stride_h_bytes,
     const uint32_t stride_w_bytes) {
-    uint32_t act_l1_read_addr_plus_offset = act_l1_read_addr + (reader_channel_idx * conv_act_c_bytes);
+    uint32_t src_addr = act_l1_read_addr + (reader_channel_idx * conv_act_c_bytes);
 #pragma GCC unroll(window_height)
     for (uint32_t outer = 0; outer < window_height; outer++) {
-        uint32_t act_l1_read_addr_row_offset = act_l1_read_addr_plus_offset;
+        uint32_t row_addr = src_addr;
 #pragma GCC unroll(window_width)
         for (uint32_t inner = 0; inner < window_width; inner++) {
-            // Read the partial depth.
-            noc_async_read_one_packet_with_state<true>(act_l1_read_addr_row_offset, l1_write_addr_act);
-            // Increment by full depth to go to the next pixel
+            experimental::read_with_state(noc, l1_write_addr_act, row_addr);
             l1_write_addr_act += conv_act_c_bytes;
-            act_l1_read_addr_row_offset += stride_w_bytes;
+            row_addr += stride_w_bytes;
         }
-        // Go to the next row
-        act_l1_read_addr_plus_offset += stride_h_bytes;
+        src_addr += stride_h_bytes;
     }
 }
 
 template <int window_height>
 FORCE_INLINE void read_channels(
+    experimental::Noc noc,
     uint32_t& l1_write_addr_act,
     const uint32_t act_l1_read_addr,
     const uint32_t reader_channel_idx,
     const uint32_t conv_act_c_read_bytes,
     const uint32_t coalesced_read_bytes,
     const uint32_t stride_h_bytes) {
-    uint32_t act_l1_read_addr_plus_offset = act_l1_read_addr + (reader_channel_idx * conv_act_c_read_bytes);
+    uint32_t src_addr = act_l1_read_addr + (reader_channel_idx * conv_act_c_read_bytes);
 #pragma GCC unroll(window_height)
     for (uint32_t inner = 0; inner < window_height; inner++) {
-        noc_async_read_one_packet_with_state<true>(act_l1_read_addr_plus_offset, l1_write_addr_act);
+        experimental::read_with_state(noc, l1_write_addr_act, src_addr);
         l1_write_addr_act += coalesced_read_bytes;
-        act_l1_read_addr_plus_offset += stride_h_bytes;
+        src_addr += stride_h_bytes;
     }
 }
 
@@ -404,6 +430,7 @@ template <
     uint32_t weight_size_h,
     uint32_t window_outer_offset>
 FORCE_INLINE void read_activation_data(
+    experimental::Noc noc,
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
     uint32_t& reader_offset,
     uint32_t& l1_write_addr_act,
@@ -418,7 +445,7 @@ FORCE_INLINE void read_activation_data(
             act_block_w_extra_align_bytes,
             stride_w_bytes,
             weight_size_w,
-            stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+            stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
     } else {
         uint16_t num_elems = packed_reader_indices_ptr[reader_idx] & 0xffff;
         while (num_elems--) {
@@ -428,6 +455,7 @@ FORCE_INLINE void read_activation_data(
             for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
                 if constexpr (dilation_w == 1) {
                     read_channels<weight_size_h>(
+                        noc,
                         l1_write_addr_act,
                         act_l1_read_addr,
                         ind,
@@ -436,6 +464,7 @@ FORCE_INLINE void read_activation_data(
                         stride_h_bytes);
                 } else {
                     read_dilated_channels<weight_size_h, weight_size_w>(
+                        noc,
                         l1_write_addr_act,
                         act_l1_read_addr,
                         ind,
@@ -450,25 +479,6 @@ FORCE_INLINE void read_activation_data(
         }
         reader_idx++;
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     reader_offset += window_outer_offset;
-}
-
-// Helper functions for split reader synchronization
-FORCE_INLINE void signal_reserve_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
-    noc_semaphore_set(semaphore_addr_ptr, VALID);
-}
-
-FORCE_INLINE void wait_reserve_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
-    noc_semaphore_wait(semaphore_addr_ptr, VALID);
-    noc_semaphore_set(semaphore_addr_ptr, INVALID);
-}
-
-FORCE_INLINE void signal_write_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
-    noc_semaphore_set(semaphore_addr_ptr, VALID);
-}
-
-FORCE_INLINE void wait_write_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
-    noc_semaphore_wait(semaphore_addr_ptr, VALID);
-    noc_semaphore_set(semaphore_addr_ptr, INVALID);
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "conv_reader_common.hpp"
 #include "noc/noc_parameters.h"
 #define ENABLE_DEBUG 0
@@ -13,29 +13,38 @@
 #include "api/debug/dprint_pages.h"
 #endif
 
-// Multicasts activation data from the local circular buffer to multiple destinations depending on the core role.
+// Multicasts activation data from src_cb to dst_cb across cores in the multicast rectangle.
+// Three cases depending on the sender's role and number of multicast destinations:
+//   is_receiver_core && act_mcast_num_cores > 0:  mcast with INCLUDE_SRC loopback
+//   is_receiver_core && act_mcast_num_cores == 0: local self-write (mcast loopback hangs with 0 destinations)
+//   !is_receiver_core:                            standard mcast EXCLUDE_SRC (even when act_mcast_num_cores == 0,
+//                                                 because the sender still needs to send to the output core)
 template <uint32_t act_mcast_num_cores>
 void multicast_data(
-    bool is_receiver_core,        // Whether this core is also a receiver of its own multicast (for loopback).
-    uint32_t src_l1_addr,         // SRC address in L1
-    uint32_t dst_l1_addr,         // DST address in L1
-    uint64_t multicast_noc_addr,  // Multicast NOC address
-    uint32_t total_bytes)         // Total bytes to send
-{
-    uint64_t multicast_write_addr = multicast_noc_addr | dst_l1_addr;
+    experimental::Noc noc,
+    experimental::MulticastEndpoint mcast_ep,
+    bool is_receiver_core,
+    experimental::CB src_cb,
+    uint32_t src_offset,
+    McastDst& dst,
+    uint32_t total_bytes) {
+    auto src = experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(src_cb);
     if (is_receiver_core) {
-        if constexpr (act_mcast_num_cores) {
-            // num_dests will source, since we are copying to a different local CB as well
-            noc_async_write_multicast_loopback_src(
-                src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
+        if constexpr (act_mcast_num_cores > 0) {
+            noc.async_write_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                src, mcast_ep, total_bytes, act_mcast_num_cores + 1, {.offset_bytes = src_offset}, dst, true);
         } else {
-            // In this case sender core is the only receiver in the grid,
-            // we can't use the multicast_loopback_src (hang)
-            noc_async_write(get_noc_addr(src_l1_addr), get_noc_addr(dst_l1_addr), total_bytes);
+            // Sender is the only receiver — can't use multicast loopback (hangs with 0 destinations)
+            noc.async_write(
+                src,
+                experimental::UnicastEndpoint{},
+                total_bytes,
+                {.offset_bytes = src_offset},
+                {.noc_x = my_x[noc.get_noc_id()], .noc_y = my_y[noc.get_noc_id()], .addr = dst.addr});
         }
     } else {
-        // If sender core is not the receiver core as well we can't use the loopback mcast. (hang)
-        noc_async_write_multicast(src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
+        noc.async_write_multicast(
+            src, mcast_ep, total_bytes, act_mcast_num_cores + 1, {.offset_bytes = src_offset}, dst, true);
     }
 }
 
@@ -54,7 +63,14 @@ template <
     uint32_t mcast_noc_burst_size,
     uint32_t block_tile_count,
     uint32_t tile_size>
-void mcast_block_chunked(bool is_receiver_core, uint32_t src_cb, uint32_t dst_cb, uint64_t multicast_noc_addr) {
+void mcast_block_chunked(
+    experimental::Noc noc,
+    experimental::MulticastEndpoint mcast_ep,
+    experimental::CB src_cb_obj,
+    bool is_receiver_core,
+    experimental::CB dst_cb_obj,
+    const McastRect& rect) {
+    // Build mcast dst once; only .addr is updated per burst
     // number of full bursts
     constexpr uint32_t mcast_full_burst_cnt = block_tile_count * tile_size / mcast_noc_burst_size;
     // size of the leftover burst, if 0 means we have no leftover burst
@@ -73,17 +89,22 @@ void mcast_block_chunked(bool is_receiver_core, uint32_t src_cb, uint32_t dst_cb
     // number of times we need to increase the wait_tile_curr for the full burst iterations
     constexpr uint32_t wait_tile_full_iter_cnt = (wait_tile_full_done / wait_tile_full_cnt) - 1;
 
-    uint32_t src_l1_addr = get_read_ptr(src_cb);
-    uint32_t dst_l1_addr = get_write_ptr(dst_cb);
+    uint32_t src_offset = 0;
+    McastDst dst = {
+        .noc_x_start = rect.noc_x_start,
+        .noc_y_start = rect.noc_y_start,
+        .noc_x_end = rect.noc_x_end,
+        .noc_y_end = rect.noc_y_end,
+        .addr = dst_cb_obj.get_write_ptr()};
 
     constexpr uint32_t wait_tile_start_cnt = std::min(block_tile_count, wait_tile_full_cnt);
     uint32_t wait_tile_curr = wait_tile_start_cnt;
     for (uint32_t i = 0; i < mcast_full_burst_cnt; i++) {
-        cb_wait_front(src_cb, wait_tile_curr);
+        src_cb_obj.wait_front(wait_tile_curr);
         multicast_data<act_mcast_num_dest_cores>(
-            is_receiver_core, src_l1_addr, dst_l1_addr, multicast_noc_addr, mcast_noc_burst_size);
-        src_l1_addr += mcast_noc_burst_size;
-        dst_l1_addr += mcast_noc_burst_size;
+            noc, mcast_ep, is_receiver_core, src_cb_obj, src_offset, dst, mcast_noc_burst_size);
+        src_offset += mcast_noc_burst_size;
+        dst.addr += mcast_noc_burst_size;
 
         if constexpr (no_need_partial_wait_tile) {
             wait_tile_curr += wait_tile_full_cnt;
@@ -97,15 +118,15 @@ void mcast_block_chunked(bool is_receiver_core, uint32_t src_cb, uint32_t dst_cb
         }
     }
     if constexpr (mcast_leftover_burst_size > 0) {
-        cb_wait_front(src_cb, block_tile_count);
+        src_cb_obj.wait_front(block_tile_count);
         multicast_data<act_mcast_num_dest_cores>(
-            is_receiver_core, src_l1_addr, dst_l1_addr, multicast_noc_addr, mcast_leftover_burst_size);
+            noc, mcast_ep, is_receiver_core, src_cb_obj, src_offset, dst, mcast_leftover_burst_size);
     }
 
     // In case we only do local l1 writes, we need to wait for the barrier to complete
     if constexpr (act_mcast_num_dest_cores == 0) {
         if (is_receiver_core) {
-            noc_async_write_barrier();
+            noc.async_write_barrier();
         }
     }
 }
@@ -127,8 +148,6 @@ void kernel_main() {
     constexpr uint32_t act_w_num_outer = get_compile_time_arg_val(13);
     constexpr uint32_t act_mcast_num_dests = get_compile_time_arg_val(14);
     constexpr uint32_t act_mcast_num_cores = get_compile_time_arg_val(15);
-    const uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
-    const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(17));
     constexpr uint32_t act_mcast_tile_size_bytes = get_compile_time_arg_val(18);
     constexpr bool transpose_mcast = get_compile_time_arg_val(19) == 1;
     constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(20) == 1;
@@ -137,35 +156,38 @@ void kernel_main() {
     constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
     constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(24);
     constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(25);
-    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(26);
     constexpr bool split_reader_enabled = get_compile_time_arg_val(27);
 
     constexpr bool split_reader_cb_shared = get_compile_time_arg_val(33) == 1;
-    volatile tt_l1_ptr uint32_t* act_split_reader_reserve_done_semaphore_addr_ptr = nullptr;
-    volatile tt_l1_ptr uint32_t* act_split_reader_write_done_semaphore_addr_ptr = nullptr;
-    if constexpr (split_reader_cb_shared) {  // When the split reader CB is shared, both readers write to the same
-                                             // circular
-                                             // buffer.
+
+    // Experimental API objects
+    experimental::Noc noc;
+    experimental::Semaphore<> act_mcast_sender_sem(get_compile_time_arg_val(16));
+    experimental::Semaphore<> act_mcast_receiver_sem(get_compile_time_arg_val(17));
+    experimental::MulticastEndpoint mcast_ep;
+    experimental::CB cb_act_obj(cb_id_act);
+    experimental::CB cb_act_rm_obj(cb_id_act_row_major_bfloat16);
+    experimental::CB cb_tilized_in0_obj(tilized_in0_cb_id);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+
+    experimental::Semaphore<> reserve_done_sem(0);
+    experimental::Semaphore<> write_done_sem(0);
+    if constexpr (split_reader_cb_shared) {
+        // When the split reader CB is shared, both readers write to the same circular buffer.
         // Synchronization is required: the main reader signals when CB space is reserved,
         // and the second reader signals when it has finished writing its portion.
-        const uint32_t act_split_reader_reserve_done_semaphore_addr = get_semaphore(get_compile_time_arg_val(34));
-        const uint32_t act_split_reader_write_done_semaphore_addr = get_semaphore(get_compile_time_arg_val(35));
-
-        act_split_reader_reserve_done_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_reserve_done_semaphore_addr);
-        act_split_reader_write_done_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_write_done_semaphore_addr);
+        reserve_done_sem = experimental::Semaphore<>(get_compile_time_arg_val(34));
+        write_done_sem = experimental::Semaphore<>(get_compile_time_arg_val(35));
     }
 
     if constexpr (needs_act_block_zero_out) {
-        zero_out_tiles<cb_id_act_row_major_bfloat16>();
+        zero_out_tiles<cb_id_act_row_major_bfloat16>(noc, cb_act_rm_obj);
     }
 
     uint32_t i = 0;
-    uint32_t act_mcast_dest_noc_start_x = get_arg_val<uint32_t>(i++);
-    uint32_t act_mcast_dest_noc_start_y = get_arg_val<uint32_t>(i++);
-    uint32_t act_mcast_dest_noc_end_x = get_arg_val<uint32_t>(i++);
-    uint32_t act_mcast_dest_noc_end_y = get_arg_val<uint32_t>(i++);
+    const McastRect act_mcast_rect = {
+        get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++)};
     uint32_t act_mcast_sender_id = get_arg_val<uint32_t>(i++);
     uint32_t act_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
     const bool is_receiver_core = get_arg_val<uint32_t>(i++) > 0;
@@ -174,31 +196,15 @@ void kernel_main() {
 
     tt_l1_ptr uint32_t* act_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(i));
 
-    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(dram_config_reader_index);
+    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(noc, cb_reader_indices_obj, dram_config_reader_index);
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr());
 
-    // L1 array
-    volatile tt_l1_ptr uint32_t* l1_array = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_l1_array));
-    // Set up local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* act_mcast_sender_semaphore_valid_addr_ptr = &l1_array[0];
-    act_mcast_sender_semaphore_valid_addr_ptr[0] =
-        1;  // Load const 1 to be used as semaphore valid value sent from sender to receivers
-    uint32_t act_mcast_sender_semaphore_valid_addr = reinterpret_cast<uint32_t>(&l1_array[0]);
-    // Set up remote VALID value
-    volatile tt_l1_ptr uint32_t* act_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_mcast_receiver_semaphore_addr);
-    noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, VALID);
+    // Set up receiver semaphore VALID value, to be mcasted to destinations after the data has been mcasted
+    act_mcast_receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-    volatile tt_l1_ptr uint32_t* act_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_mcast_sender_semaphore_addr);
-
-    uint64_t act_multicast_noc_addr = get_noc_multicast_addr(
-        act_mcast_dest_noc_start_x, act_mcast_dest_noc_start_y, act_mcast_dest_noc_end_x, act_mcast_dest_noc_end_y, 0);
-
-    uint64_t act_mcast_receiver_semaphore_noc_addr = act_multicast_noc_addr | act_mcast_receiver_semaphore_addr;
 
     // TODO: need to make the read coalescing optimization cleaner
     // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both
@@ -207,11 +213,10 @@ void kernel_main() {
         ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
 
     // Fully create act matrix and tilize it before mcast
-    // set_state uses just x/y from the get_noc_addr, addr is ignored
-    uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+    uint32_t act_l1_read_addr = cb_sharded_act_obj.get_read_ptr();
 
     if constexpr (!split_reader_cb_shared) {
-        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+        experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
     }
 
     constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
@@ -226,12 +231,12 @@ void kernel_main() {
         uint32_t reader_offset = act_l1_read_addr;
         for (uint32_t outer = 0; outer < window_outer; outer++) {
             reader_idx = start_reader_idx;
-            cb_reserve_back(cb_id_act_row_major_bfloat16, act_block_num_tiles_read);
+            cb_act_rm_obj.reserve_back(act_block_num_tiles_read);
             if (is_sender_core) {
-                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
+                uint32_t l1_write_addr_act = cb_act_rm_obj.get_write_ptr();
                 if constexpr (split_reader_cb_shared) {
-                    signal_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
-                    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                    reserve_done_sem.set(VALID);
+                    experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
                 }
                 read_activation_data<
                     sliced_inner_dim,
@@ -244,6 +249,7 @@ void kernel_main() {
                     stride_w,
                     weight_size_h,
                     window_outer_offset>(
+                    noc,
                     packed_reader_indices_ptr,
                     reader_offset,
                     l1_write_addr_act,
@@ -251,33 +257,33 @@ void kernel_main() {
                     act_l1_read_addr,
                     stride_h_bytes);
                 if constexpr (split_reader_cb_shared) {
-                    wait_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                    write_done_sem.wait(VALID);
+                    write_done_sem.set(INVALID);
                 }
             }
-            cb_push_back(cb_id_act_row_major_bfloat16, act_block_num_tiles_read);
+            cb_act_rm_obj.push_back(act_block_num_tiles_read);
 
 #ifndef SKIP_MCAST
             // Round robin self-mcast and receive tilized act matrix in cb_id_act
             // Compute should function like regular mm
             for (uint32_t act_w_outer_i = 0; act_w_outer_i < act_w_num_outer; act_w_outer_i++) {
-                cb_reserve_back(cb_id_act, act_block_num_tiles);
+                cb_act_obj.reserve_back(act_block_num_tiles);
                 if (act_w_outer_i == act_mcast_sender_id) {
                     // MCAST SENDER: send entire tilized input to other cores in column
                     // wait until all act mcast destinations have atomically incremented the act semaphore_addr
                     // (i.e. its value should be act_mcast_num_dests), then reset the semaphore_addr value back to
                     // zero for the next block
-                    noc_semaphore_wait(
-                        act_mcast_sender_semaphore_addr_ptr, act_mcast_num_dests + (is_receiver_core ? 0 : 1));
-                    noc_semaphore_set(act_mcast_sender_semaphore_addr_ptr, 0);
+                    act_mcast_sender_sem.wait(act_mcast_num_dests + (is_receiver_core ? 0 : 1));
+                    act_mcast_sender_sem.set(0);
 
-                    noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    act_mcast_receiver_sem.set(INVALID);
 
                     mcast_block_chunked<
                         act_mcast_num_cores,
                         NOC_MAX_BURST_SIZE,
                         act_block_num_tiles,
                         act_mcast_tile_size_bytes>(
-                        is_receiver_core, tilized_in0_cb_id, cb_id_act, act_multicast_noc_addr);
+                        noc, mcast_ep, cb_tilized_in0_obj, is_receiver_core, cb_act_obj, act_mcast_rect);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                     // same vc even though cmd bufs are different Also, this only works because we are setting VCs
@@ -286,45 +292,45 @@ void kernel_main() {
                     if (is_receiver_core) {
                         // We should also multicast VALID flag to destinations for receiver semaphore
                         if constexpr (act_mcast_num_cores) {
-                            noc_semaphore_set_multicast_loopback_src(
-                                act_mcast_sender_semaphore_valid_addr,
-                                act_mcast_receiver_semaphore_noc_addr,
+                            act_mcast_receiver_sem.set(VALID);
+                            act_mcast_receiver_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                                noc,
+                                act_mcast_rect.noc_x_start,
+                                act_mcast_rect.noc_y_start,
+                                act_mcast_rect.noc_x_end,
+                                act_mcast_rect.noc_y_end,
                                 act_mcast_num_cores + 1);
-                            noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
+                            noc.async_write_barrier();
                         }
                     } else {
-                        noc_semaphore_set_multicast(
-                            act_mcast_sender_semaphore_valid_addr,
-                            act_mcast_receiver_semaphore_noc_addr,
+                        act_mcast_receiver_sem.set(VALID);
+                        act_mcast_receiver_sem.set_multicast(
+                            noc,
+                            act_mcast_rect.noc_x_start,
+                            act_mcast_rect.noc_y_start,
+                            act_mcast_rect.noc_x_end,
+                            act_mcast_rect.noc_y_end,
                             act_mcast_num_cores + 1);
                     }
                 } else if (is_receiver_core) {
                     // MCAST RECEIVER: receive entire tilized input from sender core
                     // Set act semaphore value to INVALID
-                    noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    act_mcast_receiver_sem.set(INVALID);
 
                     // Atomic increment source core counter
-                    uint64_t act_mcast_sender_semaphore_noc_addr;
                     if constexpr (transpose_mcast) {
-                        act_mcast_sender_semaphore_noc_addr = get_noc_addr(
-                            act_mcast_sender_noc_x,
-                            act_mcast_sender_noc_y[act_w_outer_i],
-                            act_mcast_sender_semaphore_addr);
+                        act_mcast_sender_sem.up(noc, act_mcast_sender_noc_x, act_mcast_sender_noc_y[act_w_outer_i], 1);
                     } else {
-                        act_mcast_sender_semaphore_noc_addr = get_noc_addr(
-                            act_mcast_sender_noc_y[act_w_outer_i],
-                            act_mcast_sender_noc_x,
-                            act_mcast_sender_semaphore_addr);
+                        act_mcast_sender_sem.up(noc, act_mcast_sender_noc_y[act_w_outer_i], act_mcast_sender_noc_x, 1);
                     }
-                    noc_semaphore_inc(act_mcast_sender_semaphore_noc_addr, 1);
 
                     // wait on act semaphore value to become VALID (set by mcast sender after it multicasts data)
-                    noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
+                    act_mcast_receiver_sem.wait(VALID);
                 }
-                cb_push_back(cb_id_act, act_block_num_tiles);
+                cb_act_obj.push_back(act_block_num_tiles);
             }  // act_w_num_outer
 
-            cb_pop_front(tilized_in0_cb_id, act_block_num_tiles);
+            cb_tilized_in0_obj.pop_front(act_block_num_tiles);
 #endif
         }
         start_reader_idx = reader_idx;
@@ -337,5 +343,5 @@ void kernel_main() {
         }
     }
 
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "conv_reader_common.hpp"
 
 void kernel_main() {
@@ -28,12 +28,16 @@ void kernel_main() {
     constexpr bool split_reader_enabled = get_compile_time_arg_val(27);
     constexpr bool activation_reuse_enabled = get_compile_time_arg_val(28);
 
+    experimental::CB cb_act(cb_id_act);
+    experimental::CB cb_sharded_act(cb_id_sharded_act);
+    experimental::CB cb_reader_idx(cb_reader_indices);
+
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_idx.get_write_ptr());
 
     uint32_t runtime_arg_idx = 0;
     uint32_t core_index = get_arg_val<uint32_t>(runtime_arg_idx++);
-    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(core_index);
+    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(experimental::Noc(), cb_reader_idx, core_index);
     // Activation reuse args (offset by 4 from index 29: address + page_size + 2 TensorAccessorArgs)
     constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(33);
     constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(34);
@@ -46,8 +50,10 @@ void kernel_main() {
 
     uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(runtime_arg_idx++);
 
+    experimental::Noc noc;
+
     if constexpr (needs_act_block_zero_out) {
-        zero_out_tiles<cb_id_act>();
+        zero_out_tiles<cb_id_act>(noc, cb_act);
     }
 
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
@@ -61,7 +67,6 @@ void kernel_main() {
     // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both
     // src/dst side we check if window_inner == weight_size_w to make sure coalescing is legal along full window_inner
     // so the loop can be removed
-    constexpr bool coalesce_window_inner_reads = true;
     constexpr uint32_t num_coalesced_reads = weight_size_w;
     constexpr uint32_t coalesced_read_bytes =
         ((dilation_w == 1) ? num_coalesced_reads * conv_act_c_read_bytes : conv_act_c_read_bytes);
@@ -69,16 +74,15 @@ void kernel_main() {
     // the other path away this has shown to be a big perf win
 
     // coalesce reads along weight_size_w
-    uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+    uint32_t act_l1_read_addr = cb_sharded_act.get_read_ptr();
 
     static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
-    // set_state uses just x/y from the get_noc_addr, addr is ignored
-    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+    experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     uint32_t start_reader_idx = 0;
     uint32_t l1_write_addr_act = 0;
-    const uint32_t cb_start_addr = get_write_ptr(cb_id_act);
+    const uint32_t cb_start_addr = cb_act.get_write_ptr();
     for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
         if constexpr (activation_reuse_enabled) {
             l1_write_addr_act = cb_start_addr;
@@ -89,8 +93,8 @@ void kernel_main() {
             reader_idx = start_reader_idx;
 
             if constexpr (!activation_reuse_enabled) {
-                cb_reserve_back(cb_id_act, act_block_num_tiles);
-                l1_write_addr_act = get_write_ptr(cb_id_act);
+                cb_act.reserve_back(act_block_num_tiles);
+                l1_write_addr_act = cb_act.get_write_ptr();
 
                 read_sticks<
                     dilation_w,
@@ -99,10 +103,10 @@ void kernel_main() {
                     act_block_w_extra_align_bytes,
                     stride_w_bytes,
                     weight_size_w,
-                    stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
 
-                noc_async_read_barrier();
-                cb_push_back(cb_id_act, act_block_num_tiles);
+                noc.async_read_barrier();
+                cb_act.push_back(act_block_num_tiles);
                 reader_offset += window_outer_offset;
             } else {
                 read_sticks_activation_reuse<
@@ -121,7 +125,13 @@ void kernel_main() {
                     output_image_width,
                     window_reuse_offset,
                     single_core_processes_multiple_batches>(
-                    packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
+                    noc,
+                    cb_act,
+                    packed_reader_indices_ptr,
+                    act_l1_read_addr,
+                    l1_write_addr_act,
+                    reader_idx,
+                    cb_start_addr);
             }
         }
 
@@ -137,9 +147,9 @@ void kernel_main() {
         // to avoid blocking compute kernels
         if constexpr (need_to_push_remaining_tiles) {
             push_remaining_tiles<cb_id_act, act_block_w_tiles, image_width_tiles>(
-                remaining_tiles_to_push, cb_start_addr);
+                cb_act, remaining_tiles_to_push, cb_start_addr);
         }
     }
 
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "api/compile_time_args.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // conv1D reader kernel
 void kernel_main() {
@@ -43,9 +44,14 @@ void kernel_main() {
         reader_offset += conv_act_size_w_padded;
     }
 
+    experimental::CB act_cb(cb_id_act);
+    experimental::CB sharded_act_cb(cb_id_sharded_act);
+    experimental::CB reader_indices_cb(cb_reader_indices);
+    experimental::Noc noc;
+
     // LOOP TO FILL READER INDICES
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_cb.get_write_ptr());
 
     uint32_t reader_idx = 0;
 
@@ -54,26 +60,23 @@ void kernel_main() {
     // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both
     // src/dst side we check if window_inner == weight_size_w to make sure coalescing is legal along full window_inner
     // so the loop can be removed
-    constexpr bool coalesce_window_inner_reads = true;
     constexpr uint32_t num_coalesced_reads = weight_size_w;
     constexpr uint32_t coalesced_read_bytes = num_coalesced_reads * conv_act_c_read_bytes;
     // the conditional selecting between coalescing and no-colescing must be constexpr to that compiler can optimized
     // the other path away this has shown to be a big perf win
     reader_offset_idx = 0;
     uint32_t act_l1_offset = 0;
-    uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+    uint32_t act_l1_read_addr = sharded_act_cb.get_read_ptr();
 
-    // static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
-    //  set_state uses just x/y from the get_noc_addr, addr is ignored
-    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+    experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
     uint32_t start_reader_idx = 0;
     for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
         for (uint32_t outer = 0; outer < window_outer; outer++) {
             // Reset reader_idx to finish act_block_h_datums
             reader_idx = start_reader_idx;
 
-            cb_reserve_back(cb_id_act, act_block_num_tiles);
-            uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
+            act_cb.reserve_back(act_block_num_tiles);
+            uint32_t l1_write_addr_act = act_cb.get_write_ptr();
             uint32_t reader_offset = act_l1_read_addr + (reader_offsets[reader_offset_idx] * conv_act_c_read_bytes);
             // #pragma GCC unroll 4 // unroll didn't help, but act_block_h_datums (loop bound) being const does help
             uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
@@ -89,12 +92,12 @@ void kernel_main() {
 
                 for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
                     act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
-                    noc_async_read(get_noc_addr(act_l1_offset), l1_write_addr_act, coalesced_read_bytes);
+                    experimental::read_with_state(noc, l1_write_addr_act, act_l1_offset);
                     l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
                 }
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_act, act_block_num_tiles);
+            noc.async_read_barrier();
+            act_cb.push_back(act_block_num_tiles);
 
             reader_offset_idx += window_inner;
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "conv_reader_common.hpp"
 #include "debug/debug.h"
 
@@ -55,22 +55,25 @@ void kernel_main() {
         return;
     }
 
+    // Experimental API objects
+    experimental::Noc noc;
+
     if constexpr (split_reader_enabled) {
         if constexpr (needs_act_block_zero_out) {
-            zero_out_tiles<cb_id_act_second_reader>();
+            zero_out_tiles<cb_id_act_second_reader>(noc, experimental::CB(cb_id_act_second_reader));
         }
     }
 
     // mcast args
     const uint32_t weights_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
     const uint32_t weights_mcast_sender_noc_y = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-    const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-
-    volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
-    const uint64_t weights_mcast_sender_semaphore_noc_addr =
-        get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
+    experimental::Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
+    experimental::Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
+    experimental::CB cb_weight_obj(cb_id_weight);
+    experimental::CB cb_bias_obj(bias_cb_id);
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
 
     const uint32_t remaining_tiles_to_push =
         split_reader_enabled && activation_reuse_enabled ? get_arg_val<uint32_t>(i++) : 0;
@@ -78,21 +81,21 @@ void kernel_main() {
     // Split reader configuration
     if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-        cb_wait_front(cb_reader_indices, 1);
+        cb_reader_indices_obj.wait_front(1);
 #endif
     }
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
                              : nullptr;
     uint32_t reader_idx = 0;
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     constexpr uint32_t coalesced_read_bytes =
         ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
-    const uint32_t act_l1_read_addr = split_reader_enabled ? get_read_ptr(cb_id_sharded_act) : 0;
+    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
     uint32_t start_reader_idx =
         split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1 : 0;
-    const uint32_t cb_start_addr = split_reader_enabled ? get_write_ptr(cb_id_act_second_reader) : 0;
+    const uint32_t cb_start_addr = split_reader_enabled ? cb_act_second_obj.get_write_ptr() : 0;
 
     // read in bias if enabled (done only once for all batches)
     bool load_bias = true;
@@ -114,12 +117,12 @@ void kernel_main() {
         for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
             if constexpr (split_reader_enabled) {
                 // Do the second half of the reads for act
-                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
                 reader_idx = start_reader_idx;
 
                 if constexpr (!activation_reuse_enabled) {
-                    cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
-                    l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    cb_act_second_obj.reserve_back(act_block_num_tiles);
+                    l1_write_addr_act = cb_act_second_obj.get_write_ptr();
                     read_sticks<
                         dilation_w,
                         coalesced_read_bytes,
@@ -127,9 +130,9 @@ void kernel_main() {
                         act_block_w_extra_align_bytes,
                         stride_w_bytes,
                         weight_size_w,
-                        stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+                        stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    noc.async_read_barrier();
+                    cb_act_second_obj.push_back(act_block_num_tiles);
 
                     reader_offset += window_outer_offset;
                 } else {
@@ -149,50 +152,56 @@ void kernel_main() {
                         output_image_width,
                         window_reuse_offset,
                         single_core_processes_multiple_batches>(
-                        packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
+                        noc,
+                        cb_act_second_obj,
+                        packed_reader_indices_ptr,
+                        act_l1_read_addr,
+                        l1_write_addr_act,
+                        reader_idx,
+                        cb_start_addr);
 
                     if constexpr (need_to_push_remaining_tiles) {
                         if (block_weight_h == num_blocks_weight_h - 1) {
                             // Last core sometimes has less work to do, but we still need to push the same number of
                             // tiles to avoid blocking compute kernels
                             push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
-                                remaining_tiles_to_push, cb_start_addr);
+                                cb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
                         }
                     }
                 }
             }
 
             // Receive weights
-            cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+            cb_weight_obj.reserve_back(weight_block_num_tiles);
             if (bh == 0) {
                 // Set weights semaphore value to INVALID
-                noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
+                weights_mcast_receiver_sem.set(INVALID);
 
                 // Atomic increment source core counter
-                noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
+                weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
 
                 // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts
                 // data)
-                noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
+                weights_mcast_receiver_sem.wait(VALID);
             }
 
-            cb_push_back(cb_id_weight, weight_block_num_tiles);
+            cb_weight_obj.push_back(weight_block_num_tiles);
         }
 
         if constexpr (fuse_bias) {
             if (load_bias) {
-                cb_reserve_back(bias_cb_id, bias_ntiles);
+                cb_bias_obj.reserve_back(bias_ntiles);
 
                 // Set weights semaphore value to INVALID
-                noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
+                weights_mcast_receiver_sem.set(INVALID);
 
                 // Atomic increment source core counter
-                noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
+                weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
 
                 // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
-                noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
+                weights_mcast_receiver_sem.wait(VALID);
 
-                cb_push_back(bias_cb_id, bias_ntiles);
+                cb_bias_obj.push_back(bias_ntiles);
                 load_bias = false;
             }
         }
@@ -203,5 +212,5 @@ void kernel_main() {
         }
     }  // out_num_blocks_h
 
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "conv_reader_common.hpp"
 
 void kernel_main() {
@@ -64,21 +64,35 @@ void kernel_main() {
     const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
     const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i++);
 
+    // Experimental API objects
+    experimental::Noc noc;
+
     if constexpr (split_reader_enabled) {
         if constexpr (needs_act_block_zero_out) {
-            zero_out_tiles<cb_id_act_second_reader>();
+            zero_out_tiles<cb_id_act_second_reader>(noc, experimental::CB(cb_id_act_second_reader));
         }
     }
 
     // mcast args
-    const uint32_t weights_mcast_dest_noc_start_x = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_dest_noc_start_y = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_dest_noc_end_x = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_dest_noc_end_y = get_arg_val<uint32_t>(i++);
+    const McastRect mcast_rect = {
+        get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++)};
     const uint32_t weights_mcast_num_dests = get_arg_val<uint32_t>(i++);
     const uint32_t weights_mcast_num_cores = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-    const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
+    experimental::Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
+    experimental::Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
+    experimental::MulticastEndpoint mcast_ep;
+    experimental::CB cb_weight_obj(cb_id_weight);
+    experimental::CB cb_bias_obj(bias_cb_id);
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    // Pre-built mcast destination; .addr is updated per mcast call
+    McastDst mcast_dst = {
+        .noc_x_start = mcast_rect.noc_x_start,
+        .noc_y_start = mcast_rect.noc_y_start,
+        .noc_x_end = mcast_rect.noc_x_end,
+        .noc_y_end = mcast_rect.noc_y_end,
+        .addr = 0};
 
     const uint32_t remaining_tiles_to_push =
         split_reader_enabled && activation_reuse_enabled ? get_arg_val<uint32_t>(i++) : 0;
@@ -86,40 +100,29 @@ void kernel_main() {
     // Split reader configuration
     if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-        cb_wait_front(cb_reader_indices, 1);
+        cb_reader_indices_obj.wait_front(1);
 #endif
     }
 
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
                              : nullptr;
     uint32_t reader_idx = 0;
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     constexpr uint32_t coalesced_read_bytes =
         ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
-    uint32_t act_l1_read_addr = split_reader_enabled ? get_read_ptr(cb_id_sharded_act) : 0;
+    uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
     // coalesce reads along weight_size_w
     uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
-    uint32_t cb_start_addr = split_reader_enabled ? get_write_ptr(cb_id_act_second_reader) : 0;
+    uint32_t cb_start_addr = split_reader_enabled ? cb_act_second_obj.get_write_ptr() : 0;
     uint32_t reader_offset = act_l1_read_addr;
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
-    *(weights_mcast_receiver_semaphore_addr_ptr) = VALID;
+    weights_mcast_receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-    volatile tt_l1_ptr uint32_t* weights_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_sender_semaphore_addr);
-
-    const uint64_t weights_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        weights_mcast_dest_noc_start_x,
-        weights_mcast_dest_noc_start_y,
-        weights_mcast_dest_noc_end_x,
-        weights_mcast_dest_noc_end_y,
-        weights_mcast_receiver_semaphore_addr);
 #endif
 
     // read in bias if enabled (done only once for all batches)
@@ -157,12 +160,12 @@ void kernel_main() {
         for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
             if constexpr (split_reader_enabled) {
                 // Do the second half of the reads for act
-                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
                 reader_idx = start_reader_idx;
 
                 if constexpr (!activation_reuse_enabled) {
-                    cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
-                    l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    cb_act_second_obj.reserve_back(act_block_num_tiles);
+                    l1_write_addr_act = cb_act_second_obj.get_write_ptr();
                     read_sticks<
                         dilation_w,
                         coalesced_read_bytes,
@@ -170,9 +173,9 @@ void kernel_main() {
                         act_block_w_extra_align_bytes,
                         stride_w_bytes,
                         weight_size_w,
-                        stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+                        stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    noc.async_read_barrier();
+                    cb_act_second_obj.push_back(act_block_num_tiles);
 
                     reader_offset += window_outer_offset;
                 } else {
@@ -192,27 +195,31 @@ void kernel_main() {
                         output_image_width,
                         window_reuse_offset,
                         single_core_processes_multiple_batches>(
-                        packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
+                        noc,
+                        cb_act_second_obj,
+                        packed_reader_indices_ptr,
+                        act_l1_read_addr,
+                        l1_write_addr_act,
+                        reader_idx,
+                        cb_start_addr);
 
                     if constexpr (need_to_push_remaining_tiles) {
                         if (block_weight_h == num_blocks_weight_h - 1) {
                             // Last core sometimes has less work to do, but we still need to push the same number of
                             // tiles to avoid blocking compute kernels
                             push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
-                                remaining_tiles_to_push, cb_start_addr);
+                                cb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
                         }
                     }
                 }
             }
 
             // Do weights read + mcast
-            cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+            cb_weight_obj.reserve_back(weight_block_num_tiles);
             if (bh == 0) {
-                uint32_t weight_write_l1_addr = get_write_ptr(cb_id_weight);
                 uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id + weight_h_offset;
 
-                // mcast args
-                uint32_t weights_start_address = weight_write_l1_addr;
+                uint32_t weight_write_offset = 0;
                 uint32_t weights_block_size_bytes = 0;
 
                 // loop over weight block tiles along h
@@ -221,36 +228,37 @@ void kernel_main() {
                     // loop over weight block tiles along w
                     for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
                         // DPRINT << "weight_tile_id=" << weight_tile_id << ENDL();
-                        // DEVICE_PRINT("weight_tile_id={}\n", weight_tile_id);
-                        noc_async_read_tile(weight_tile_id, s_weight, weight_write_l1_addr);
-                        weight_write_l1_addr += weight_tile_nbytes;
+                        noc.async_read(
+                            s_weight,
+                            cb_weight_obj,
+                            weight_tile_nbytes,
+                            {.page_id = weight_tile_id},
+                            {.offset_bytes = weight_write_offset});
+                        weight_write_offset += weight_tile_nbytes;
                         weights_block_size_bytes += weight_tile_nbytes;
                         weight_tile_id += 1;
                     }  // for weight_block_w
                     weight_row_start_tile_id += weight_stride_h;
                 }  // for weight_block_h
-                noc_async_read_barrier();
+                noc.async_read_barrier();
 
 #ifndef SKIP_MCAST
                 // wait until all weights mcast destinations have atomically incremented the weights
                 // semaphore_addr (i.e. its value should be weights_mcast_num_dests), then reset the
                 // semaphore_addr value back to zero for the next block
-                noc_semaphore_wait(weights_mcast_sender_semaphore_addr_ptr, weights_mcast_num_dests);
-                noc_semaphore_set(weights_mcast_sender_semaphore_addr_ptr, 0);
+                weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                weights_mcast_sender_sem.set(0);
 
                 // Now we have the block in the CB address, we can mcast to dests!
-                uint64_t weights_multicast_data_addr = get_noc_multicast_addr(
-                    weights_mcast_dest_noc_start_x,
-                    weights_mcast_dest_noc_start_y,
-                    weights_mcast_dest_noc_end_x,
-                    weights_mcast_dest_noc_end_y,
-                    weights_start_address);
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                noc_async_write_multicast(
-                    weights_start_address,
-                    weights_multicast_data_addr,
+                mcast_dst.addr = cb_weight_obj.get_write_ptr();
+                noc.async_write_multicast(
+                    experimental::use<experimental::CB::AddrSelector::WRITE_PTR>(cb_weight_obj),
+                    mcast_ep,
                     weights_block_size_bytes,
                     weights_mcast_num_cores,
+                    {},
+                    mcast_dst,
                     true);
 
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and
@@ -258,9 +266,12 @@ void kernel_main() {
                 // statically (using NOC_CMD_STATIC_VC).
                 // We should also multicast the flag to destinations
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                noc_semaphore_set_multicast(
-                    weights_mcast_receiver_semaphore_addr,
-                    weights_mcast_receiver_semaphore_noc_addr,
+                weights_mcast_receiver_sem.set_multicast(
+                    noc,
+                    mcast_rect.noc_x_start,
+                    mcast_rect.noc_y_start,
+                    mcast_rect.noc_x_end,
+                    mcast_rect.noc_y_end,
                     weights_mcast_num_cores,
                     false);
 #endif
@@ -268,57 +279,64 @@ void kernel_main() {
                 weight_current_block_start_tile_id += weight_next_block_stride_h;
             }
 
-            cb_push_back(cb_id_weight, weight_block_num_tiles);
+            cb_weight_obj.push_back(weight_block_num_tiles);
         }  // for num_blocks_weight_h
         weight_h_offset += weight_inner_block_stride_h;
 
         if constexpr (fuse_bias) {
             if (load_bias) {
-                cb_reserve_back(bias_cb_id, bias_ntiles);
-                uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
+                cb_bias_obj.reserve_back(bias_ntiles);
 
-                // mcast args
-                uint32_t bias_start_address = bias_l1_addr;
+                uint32_t bias_write_offset = 0;
                 uint32_t bias_block_size_bytes = 0;
                 for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
-                    noc_async_read_tile(bias_tile, s_bias, bias_l1_addr);
-                    bias_l1_addr += bias_pagesize;
+                    noc.async_read(
+                        s_bias,
+                        cb_bias_obj,
+                        bias_pagesize,
+                        {.page_id = bias_tile},
+                        {.offset_bytes = bias_write_offset});
+                    bias_write_offset += bias_pagesize;
                     bias_block_size_bytes += bias_pagesize;
                 }
-                noc_async_read_barrier();
+                noc.async_read_barrier();
 
 // MCAST BIAS (shares some mcast args with weights)
 #ifndef SKIP_MCAST
                 // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
                 // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to zero
                 // for the next block
-                noc_semaphore_wait(weights_mcast_sender_semaphore_addr_ptr, weights_mcast_num_dests);
-                noc_semaphore_set(weights_mcast_sender_semaphore_addr_ptr, 0);
+                weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                weights_mcast_sender_sem.set(0);
 
                 // Now we have the block in the CB address, we can mcast to dests!
-                uint64_t bias_multicast_data_addr = get_noc_multicast_addr(
-                    weights_mcast_dest_noc_start_x,
-                    weights_mcast_dest_noc_start_y,
-                    weights_mcast_dest_noc_end_x,
-                    weights_mcast_dest_noc_end_y,
-                    bias_start_address);
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                noc_async_write_multicast(
-                    bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true);
+                mcast_dst.addr = cb_bias_obj.get_write_ptr();
+                noc.async_write_multicast(
+                    experimental::use<experimental::CB::AddrSelector::WRITE_PTR>(cb_bias_obj),
+                    mcast_ep,
+                    bias_block_size_bytes,
+                    weights_mcast_num_cores,
+                    {},
+                    mcast_dst,
+                    true);
 
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
                 // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
                 // NOC_CMD_STATIC_VC).
                 // We should also multicast the flag to destinations
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                noc_semaphore_set_multicast(
-                    weights_mcast_receiver_semaphore_addr,
-                    weights_mcast_receiver_semaphore_noc_addr,
+                weights_mcast_receiver_sem.set_multicast(
+                    noc,
+                    mcast_rect.noc_x_start,
+                    mcast_rect.noc_y_start,
+                    mcast_rect.noc_x_end,
+                    mcast_rect.noc_y_end,
                     weights_mcast_num_cores,
                     false);
 #endif
 
-                cb_push_back(bias_cb_id, bias_ntiles);
+                cb_bias_obj.push_back(bias_ntiles);
                 load_bias = false;
             }
         }
@@ -327,5 +345,5 @@ void kernel_main() {
             start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
         }
     }  // out_num_blocks_h
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "api/debug/dprint.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
@@ -42,6 +43,11 @@ void kernel_main() {
     const uint32_t bias_pagesize =
         fuse_bias ? get_tile_size(bias_cb_id) : 0;  // dummy but valid value in case bias is not enabled
     const auto s_bias = TensorAccessor(s_bias_args, bias_addr_dram_base, bias_pagesize);
+
+    experimental::CB weight_cb(cb_id_weight);
+    experimental::CB bias_cb(bias_cb_id);
+    experimental::Noc noc;
+
     bool to_load_bias = true;
 
     for (uint32_t act_block_h_index = 0; act_block_h_index < act_num_blocks_h; act_block_h_index++) {
@@ -60,15 +66,13 @@ void kernel_main() {
             // Stride = in_channels*out_channels*sizeof(elem)/num_cores.
             for (uint32_t remote_weight_block_index = 0; remote_weight_block_index < remote_weight_height_blocks;
                  remote_weight_block_index++) {
-                cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+                weight_cb.reserve_back(weight_block_num_tiles);
                 if (is_active) {
-                    uint32_t weight_write_l1_addr = get_write_ptr(cb_id_weight);
-                    uint32_t weights_start_address = weight_write_l1_addr;
-                    uint32_t weights_block_size_bytes = 0;
                     uint32_t weight_current_block_start_tile_id = weight_block_start_tile_id;
 
                     // for window size, picking up the channels for that window.
                     // Stride is in_channels*out_channels*sizeof(elem).
+                    uint32_t weight_write_offset = 0;
                     for (uint32_t block_weight_h = 0; block_weight_h < window_size_hw; block_weight_h++) {
                         uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id;
 
@@ -80,32 +84,41 @@ void kernel_main() {
                             // loop over output channels, width of the output/weights.
                             for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
                                  ++weight_tile_w_i) {
-                                noc_async_read_tile(weight_tile_id, s_weight, weight_write_l1_addr);
-                                weight_write_l1_addr += weight_tile_nbytes;
-                                weights_block_size_bytes += weight_tile_nbytes;
+                                noc.async_read(
+                                    s_weight,
+                                    weight_cb,
+                                    weight_tile_nbytes,
+                                    {.page_id = weight_tile_id},
+                                    {.offset_bytes = weight_write_offset});
+                                weight_write_offset += weight_tile_nbytes;
                                 weight_tile_id += 1;
                             }  // for weight_block_w
                             weight_row_start_tile_id += weight_matrix_width_ntiles;
                         }  // for weight_block_h
                         weight_current_block_start_tile_id += weight_next_channel_stride_h;
                     }
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                 }
-                cb_push_back(cb_id_weight, weight_block_num_tiles);
+                weight_cb.push_back(weight_block_num_tiles);
                 weight_block_start_tile_id += weight_next_block_other_core_stride_h;
             }
             weight_start_tile_id += weight_next_block_this_core_stride_h;
             if (to_load_bias) {
                 if constexpr (fuse_bias) {
-                    cb_reserve_back(bias_cb_id, weight_block_width_ntiles);
-                    uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
+                    bias_cb.reserve_back(weight_block_width_ntiles);
+                    uint32_t bias_write_offset = 0;
                     for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
-                        noc_async_read_tile(bias_start_tile_id, s_bias, bias_l1_addr);
-                        bias_l1_addr += bias_pagesize;
+                        noc.async_read(
+                            s_bias,
+                            bias_cb,
+                            bias_pagesize,
+                            {.page_id = bias_start_tile_id},
+                            {.offset_bytes = bias_write_offset});
+                        bias_write_offset += bias_pagesize;
                         bias_start_tile_id += 1;
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(bias_cb_id, weight_block_width_ntiles);
+                    noc.async_read_barrier();
+                    bias_cb.push_back(weight_block_width_ntiles);
                 }
                 to_load_bias = false;
             }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "conv_reader_common.hpp"
 
 #define ENABLE_DEBUG 0
@@ -51,51 +51,48 @@ void kernel_main() {
     // Synchronization is required: the main reader signals when CB space is reserved,
     // and the second reader signals when it has finished writing its portion.
     constexpr bool split_reader_cb_shared = get_compile_time_arg_val(31) == 1;
-    const uint32_t act_split_reader_reserve_done_semaphore_addr =
-        (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(32)) : 0;
-    const uint32_t act_split_reader_write_done_semaphore_addr =
-        (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(33)) : 0;
+    experimental::Semaphore<> reserve_done_sem((split_reader_cb_shared) ? get_compile_time_arg_val(32) : 0);
+    experimental::Semaphore<> write_done_sem((split_reader_cb_shared) ? get_compile_time_arg_val(33) : 0);
     constexpr uint32_t act_write_offset = get_compile_time_arg_val(34);
     constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(35);
 
-    volatile tt_l1_ptr uint32_t* act_split_reader_reserve_done_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_reserve_done_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* act_split_reader_write_done_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_write_done_semaphore_addr);
-
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
     const uint32_t split_reader_cb_write_addr =
-        (split_reader_cb_shared) ? get_write_ptr(cb_id_act_second_reader) + act_write_offset : 0;
+        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset : 0;
     // In case of double buffering the split reader can write to two different addresses
     const uint32_t split_reader_cb_write_addr_last =
-        (split_reader_cb_shared) ? get_write_ptr(cb_id_act_second_reader) + act_write_offset_last : 0;
+        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset_last : 0;
     const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
 
     // mcast args
     uint32_t i = 0;
     const uint32_t weights_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
     const uint32_t weights_mcast_sender_noc_y = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-    const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-    const bool is_sender_core = get_arg_val<uint32_t>(i++) > 0;
 
-    volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
-    const uint64_t weights_mcast_sender_semaphore_noc_addr =
-        get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
+    // Experimental API objects
+    experimental::Noc noc;
+    experimental::Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
+    experimental::Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
+    experimental::CB cb_weight_obj(cb_id_weight);
+    experimental::CB cb_bias_obj(bias_cb_id);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+
+    const bool is_sender_core = get_arg_val<uint32_t>(i++) > 0;
 
     // Split reader configuration
     if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-        cb_wait_front(cb_reader_indices, 1);
+        cb_reader_indices_obj.wait_front(1);
 #endif
         if constexpr (needs_act_block_zero_out) {
-            zero_out_tiles<cb_id_act_second_reader>();
+            zero_out_tiles<cb_id_act_second_reader>(noc, cb_act_second_obj);
         }
     }
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         (split_reader_enabled && is_sender_core)
-            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
             : nullptr;
 
     // Initial setup for second reader (starting from second reader's data)
@@ -110,7 +107,7 @@ void kernel_main() {
     constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
     constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
 
-    const uint32_t act_l1_read_addr = split_reader_enabled ? get_read_ptr(cb_id_sharded_act) : 0;
+    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
     // read in bias if enabled (done only once for all batches)
     bool load_bias = true;
 
@@ -129,17 +126,18 @@ void kernel_main() {
                 if constexpr (split_reader_enabled) {
                     reader_idx = start_reader_idx;
                     if constexpr (!split_reader_cb_shared) {
-                        cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                        cb_act_second_obj.reserve_back(act_block_num_tiles_split_last);
                     }
 
                     if (is_sender_core) {
                         if constexpr (split_reader_cb_shared) {
-                            wait_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
+                            reserve_done_sem.wait(VALID);
+                            reserve_done_sem.set(INVALID);
                             prev_addr = l1_write_addr_act;
                         } else {
-                            l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                            l1_write_addr_act = cb_act_second_obj.get_write_ptr();
                         }
-                        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                        experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
                         read_activation_data<
                             sliced_inner_dim,
                             dilation_w,
@@ -151,6 +149,7 @@ void kernel_main() {
                             stride_w,
                             weight_size_h,
                             window_outer_offset>(
+                            noc,
                             packed_reader_indices_ptr,
                             reader_offset,
                             l1_write_addr_act,
@@ -161,11 +160,11 @@ void kernel_main() {
                             // in case of shared cb we update the write address (it will remain the same if double
                             // buffering is not enabled)
                             l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
-                            signal_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                            write_done_sem.set(VALID);
                         }
                     }
                     if constexpr (!split_reader_cb_shared) {
-                        cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                        cb_act_second_obj.push_back(act_block_num_tiles_split_last);
                     }
                 }
                 for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
@@ -174,17 +173,17 @@ void kernel_main() {
                     // read weight blocks inner dim
                     // read weight slice - 1 block of weights in width dim and full weight matrix height
                     // read slice only once for all activation blocks
-                    cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+                    cb_weight_obj.reserve_back(weight_block_num_tiles);
                     // Set weights semaphore value to INVALID
-                    noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    weights_mcast_receiver_sem.set(INVALID);
 
                     // Atomic increment source core counter
-                    noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
+                    weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
 
                     // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
-                    noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
+                    weights_mcast_receiver_sem.wait(VALID);
 
-                    cb_push_back(cb_id_weight, weight_block_num_tiles);
+                    cb_weight_obj.push_back(weight_block_num_tiles);
                 }  // for weight_block_height_num_outer
             }
             if constexpr (split_reader_enabled) {
@@ -197,18 +196,18 @@ void kernel_main() {
             }
             if constexpr (fuse_bias) {
                 if (load_bias) {
-                    cb_reserve_back(bias_cb_id, bias_ntiles);
+                    cb_bias_obj.reserve_back(bias_ntiles);
 
                     // Set weights semaphore value to INVALID
-                    noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    weights_mcast_receiver_sem.set(INVALID);
 
                     // Atomic increment source core counter
-                    noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
+                    weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
 
                     // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
-                    noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
+                    weights_mcast_receiver_sem.wait(VALID);
 
-                    cb_push_back(bias_cb_id, bias_ntiles);
+                    cb_bias_obj.push_back(bias_ntiles);
                     load_bias = false;
                 }
             }
@@ -216,5 +215,5 @@ void kernel_main() {
         }  // out_num_blocks_h
     }  // out_num_blocks_w
 
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "conv_reader_common.hpp"
 
 #define ENABLE_DEBUG 0
@@ -58,23 +58,17 @@ void kernel_main() {
     // When the split reader CB is shared, both readers write to the same circular buffer.
     // Synchronization is required: the main reader signals when CB space is reserved,
     // and the second reader signals when it has finished writing its portion.
-    const uint32_t act_split_reader_reserve_done_semaphore_addr =
-        (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(32)) : 0;
-    const uint32_t act_split_reader_write_done_semaphore_addr =
-        (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(33)) : 0;
+    experimental::Semaphore<> reserve_done_sem((split_reader_cb_shared) ? get_compile_time_arg_val(32) : 0);
+    experimental::Semaphore<> write_done_sem((split_reader_cb_shared) ? get_compile_time_arg_val(33) : 0);
     constexpr uint32_t act_write_offset = get_compile_time_arg_val(34);
     constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(35);
 
-    volatile tt_l1_ptr uint32_t* act_split_reader_reserve_done_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_reserve_done_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* act_split_reader_write_done_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_write_done_semaphore_addr);
-
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
     const uint32_t split_reader_cb_write_addr =
-        (split_reader_cb_shared) ? get_write_ptr(cb_id_act_second_reader) + act_write_offset : 0;
+        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset : 0;
     // In case of double buffering the split reader can write to two different addresses
     const uint32_t split_reader_cb_write_addr_last =
-        (split_reader_cb_shared) ? get_write_ptr(cb_id_act_second_reader) + act_write_offset_last : 0;
+        (split_reader_cb_shared) ? cb_act_second_obj.get_write_ptr() + act_write_offset_last : 0;
     const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
 
     constexpr uint32_t ct_arg_idx = 36;
@@ -89,14 +83,28 @@ void kernel_main() {
     const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i++);
 
     // mcast args
-    const uint32_t weights_mcast_dest_noc_start_x = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_dest_noc_start_y = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_dest_noc_end_x = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_dest_noc_end_y = get_arg_val<uint32_t>(i++);
+    const McastRect mcast_rect = {
+        get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++), get_arg_val<uint32_t>(i++)};
     const uint32_t weights_mcast_num_dests = get_arg_val<uint32_t>(i++);
     const uint32_t weights_mcast_num_cores = get_arg_val<uint32_t>(i++);
-    const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-    const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
+
+    // Experimental API objects
+    experimental::Noc noc;
+    experimental::Semaphore<> weights_mcast_sender_sem(get_arg_val<uint32_t>(i++));
+    experimental::Semaphore<> weights_mcast_receiver_sem(get_arg_val<uint32_t>(i++));
+    experimental::MulticastEndpoint mcast_ep;
+    experimental::CB cb_weight_obj(cb_id_weight);
+    experimental::CB cb_bias_obj(bias_cb_id);
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    // Pre-built mcast destination; .addr is updated per mcast call
+    McastDst mcast_dst = {
+        .noc_x_start = mcast_rect.noc_x_start,
+        .noc_y_start = mcast_rect.noc_y_start,
+        .noc_x_end = mcast_rect.noc_x_end,
+        .noc_y_end = mcast_rect.noc_y_end,
+        .addr = 0};
+
     const bool is_sender_core = get_arg_val<uint32_t>(i++) > 0;
     const bool skip_work = get_arg_val<uint32_t>(i++) > 0;
 
@@ -107,16 +115,16 @@ void kernel_main() {
     // Split reader configuration
     if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-        cb_wait_front(cb_reader_indices, 1);
+        cb_reader_indices_obj.wait_front(1);
 #endif
         if constexpr (needs_act_block_zero_out) {
-            zero_out_tiles<cb_id_act_second_reader>();
+            zero_out_tiles<cb_id_act_second_reader>(noc, cb_act_second_obj);
         }
     }
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         (split_reader_enabled && is_sender_core)
-            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
             : nullptr;
     // Initial setup for second reader (starting from second reader's data)
     // Only read reader indices on cores that have sharded input (is_sender_core).
@@ -130,24 +138,13 @@ void kernel_main() {
     constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
     constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
 
-    const uint32_t act_l1_read_addr = split_reader_enabled ? get_read_ptr(cb_id_sharded_act) : 0;
+    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
-    *(weights_mcast_receiver_semaphore_addr_ptr) = VALID;
+    weights_mcast_receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-    volatile tt_l1_ptr uint32_t* weights_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_sender_semaphore_addr);
-
-    const uint64_t weights_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        weights_mcast_dest_noc_start_x,
-        weights_mcast_dest_noc_start_y,
-        weights_mcast_dest_noc_end_x,
-        weights_mcast_dest_noc_end_y,
-        weights_mcast_receiver_semaphore_addr);
 #endif
 
     // read in bias if enabled (done only once for all batches)
@@ -181,16 +178,17 @@ void kernel_main() {
                 if constexpr (split_reader_enabled) {
                     reader_idx = start_reader_idx;
                     if constexpr (!split_reader_cb_shared) {
-                        cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                        cb_act_second_obj.reserve_back(act_block_num_tiles_split_last);
                     }
                     if (is_sender_core) {
                         if constexpr (split_reader_cb_shared) {
-                            wait_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
+                            reserve_done_sem.wait(VALID);
+                            reserve_done_sem.set(INVALID);
                             prev_addr = l1_write_addr_act;
                         } else {
-                            l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                            l1_write_addr_act = cb_act_second_obj.get_write_ptr();
                         }
-                        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                        experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
                         read_activation_data<
                             sliced_inner_dim,
                             dilation_w,
@@ -202,6 +200,7 @@ void kernel_main() {
                             stride_w,
                             weight_size_h,
                             window_outer_offset>(
+                            noc,
                             packed_reader_indices_ptr,
                             reader_offset,
                             l1_write_addr_act,
@@ -212,11 +211,11 @@ void kernel_main() {
                             // in case of shared cb we update the write address (it will remain the same if double
                             // buffering is not enabled)
                             l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
-                            signal_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                            write_done_sem.set(VALID);
                         }
                     }
                     if constexpr (!split_reader_cb_shared) {
-                        cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                        cb_act_second_obj.push_back(act_block_num_tiles_split_last);
                     }
                     if (skip_work) {
                         continue;
@@ -226,45 +225,45 @@ void kernel_main() {
                 const uint32_t height_block_offset = height_block_index * height_stride_factor;
                 for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
                      weight_tile_h_outer_i++) {
-                    cb_reserve_back(cb_id_weight, weight_block_num_tiles);
-                    uint32_t weight_write_l1_addr = get_write_ptr(cb_id_weight);
+                    cb_weight_obj.reserve_back(weight_block_num_tiles);
 
                     const uint32_t outer_block_offset = weight_tile_h_outer_i * tiles_per_full_block;
                     uint32_t tile_id = weight_start_tile_id + height_block_offset + outer_block_offset;
-                    // mcast args
-                    uint32_t weights_start_address = weight_write_l1_addr;
+                    uint32_t weight_write_offset = 0;
                     for (uint32_t block_weight_h = 0; block_weight_h < weight_block_height_ntiles; block_weight_h++) {
                         uint32_t weight_tile_id = tile_id;
 
                         for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
                              ++weight_tile_w_i) {
-                            noc_async_read_tile(weight_tile_id++, s_weight, weight_write_l1_addr);
-                            weight_write_l1_addr += weight_tile_nbytes;
+                            noc.async_read(
+                                s_weight,
+                                cb_weight_obj,
+                                weight_tile_nbytes,
+                                {.page_id = weight_tile_id++},
+                                {.offset_bytes = weight_write_offset});
+                            weight_write_offset += weight_tile_nbytes;
                         }
                         tile_id += weight_stride_h;
                     }
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
 
 #ifndef SKIP_MCAST
                     // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
                     // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to
                     // zero for the next block
-                    noc_semaphore_wait(weights_mcast_sender_semaphore_addr_ptr, weights_mcast_num_dests);
-                    noc_semaphore_set(weights_mcast_sender_semaphore_addr_ptr, 0);
+                    weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                    weights_mcast_sender_sem.set(0);
 
                     // Now we have the block in the CB address, we can mcast to dests!
-                    uint64_t weights_multicast_data_addr = get_noc_multicast_addr(
-                        weights_mcast_dest_noc_start_x,
-                        weights_mcast_dest_noc_start_y,
-                        weights_mcast_dest_noc_end_x,
-                        weights_mcast_dest_noc_end_y,
-                        weights_start_address);
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_async_write_multicast(
-                        weights_start_address,
-                        weights_multicast_data_addr,
+                    mcast_dst.addr = cb_weight_obj.get_write_ptr();
+                    noc.async_write_multicast(
+                        experimental::use<experimental::CB::AddrSelector::WRITE_PTR>(cb_weight_obj),
+                        mcast_ep,
                         weights_block_size_bytes,
                         weights_mcast_num_cores,
+                        {},
+                        mcast_dst,
                         true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
@@ -272,12 +271,15 @@ void kernel_main() {
                     // (using NOC_CMD_STATIC_VC).
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_semaphore_set_multicast(
-                        weights_mcast_receiver_semaphore_addr,
-                        weights_mcast_receiver_semaphore_noc_addr,
+                    weights_mcast_receiver_sem.set_multicast(
+                        noc,
+                        mcast_rect.noc_x_start,
+                        mcast_rect.noc_y_start,
+                        mcast_rect.noc_x_end,
+                        mcast_rect.noc_y_end,
                         weights_mcast_num_cores);
 #endif
-                    cb_push_back(cb_id_weight, weight_block_num_tiles);
+                    cb_weight_obj.push_back(weight_block_num_tiles);
                 }  // for weight_block_height_num_outer
             }
             if constexpr (split_reader_enabled) {
@@ -293,41 +295,41 @@ void kernel_main() {
             }
             if constexpr (fuse_bias) {
                 if (load_bias) {
-                    cb_reserve_back(bias_cb_id, bias_ntiles);
-                    uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
+                    cb_bias_obj.reserve_back(bias_ntiles);
 
-                    // mcast args
-                    uint32_t bias_start_address = bias_l1_addr;
+                    uint32_t bias_write_offset = 0;
                     uint32_t bias_block_size_bytes = 0;
                     for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles;
                          ++bias_tile) {
-                        noc_async_read_tile(bias_tile, s_bias, bias_l1_addr);
-                        bias_l1_addr += bias_pagesize;
+                        noc.async_read(
+                            s_bias,
+                            cb_bias_obj,
+                            bias_pagesize,
+                            {.page_id = bias_tile},
+                            {.offset_bytes = bias_write_offset});
+                        bias_write_offset += bias_pagesize;
                         bias_block_size_bytes += bias_pagesize;
                     }
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
 
 // MCAST BIAS (shares some mcast args with weights)
 #ifndef SKIP_MCAST
                     // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
                     // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to
                     // zero for the next block
-                    noc_semaphore_wait(weights_mcast_sender_semaphore_addr_ptr, weights_mcast_num_dests);
-                    noc_semaphore_set(weights_mcast_sender_semaphore_addr_ptr, 0);
+                    weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                    weights_mcast_sender_sem.set(0);
 
                     // Now we have the block in the CB address, we can mcast to dests!
-                    uint64_t bias_multicast_data_addr = get_noc_multicast_addr(
-                        weights_mcast_dest_noc_start_x,
-                        weights_mcast_dest_noc_start_y,
-                        weights_mcast_dest_noc_end_x,
-                        weights_mcast_dest_noc_end_y,
-                        bias_start_address);
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_async_write_multicast(
-                        bias_start_address,
-                        bias_multicast_data_addr,
+                    mcast_dst.addr = cb_bias_obj.get_write_ptr();
+                    noc.async_write_multicast(
+                        experimental::use<experimental::CB::AddrSelector::WRITE_PTR>(cb_bias_obj),
+                        mcast_ep,
                         bias_block_size_bytes,
                         weights_mcast_num_cores,
+                        {},
+                        mcast_dst,
                         true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
@@ -335,13 +337,16 @@ void kernel_main() {
                     // (using NOC_CMD_STATIC_VC).
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_semaphore_set_multicast(
-                        weights_mcast_receiver_semaphore_addr,
-                        weights_mcast_receiver_semaphore_noc_addr,
+                    weights_mcast_receiver_sem.set_multicast(
+                        noc,
+                        mcast_rect.noc_x_start,
+                        mcast_rect.noc_y_start,
+                        mcast_rect.noc_x_end,
+                        mcast_rect.noc_y_end,
                         weights_mcast_num_cores);
 #endif
 
-                    cb_push_back(bias_cb_id, bias_ntiles);
+                    cb_bias_obj.push_back(bias_ntiles);
                     load_bias = false;
                 }
             }
@@ -352,5 +357,5 @@ void kernel_main() {
         weight_start_tile_id += weight_next_block_stride_w;
     }  // out_num_blocks_w
 
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Convenience header that includes all experimental device 2.0 APIs
+// and provides short type aliases for kernel code in conv/pool operations.
+// Safe to include from both dataflow and compute (TRISC) kernels.
+
+#pragma once
+
+#include "experimental/circular_buffer.h"
+
+#ifndef COMPILE_FOR_TRISC
+#include "experimental/noc.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/tensor.h"
+#endif
+
+namespace experimental {
+
+// Short alias for CircularBuffer (available on both dataflow and compute)
+using CB = CircularBuffer;
+
+#ifndef COMPILE_FOR_TRISC
+// Short aliases for NOC types (dataflow kernels only)
+// Note: CoreLocalMem<uint32_t> is used internally by the read_with_state raw-address overload below.
+// Prefer passing experimental::CB with offset_bytes args over constructing CoreLocalMem directly.
+
+// Single-packet convenience wrappers for set_async_read_state / async_read_with_state.
+// All conv/pool activation reads are single-packet (size <= NOC_MAX_BURST_SIZE),
+// but the upstream API defaults to multi-packet mode. These wrappers put max_page_size
+// first so callers don't need to spell out VcSelection::DEFAULT every time.
+
+// Helper to create UnicastEndpoint src_args for local L1 self-reads.
+// Must use my_x/my_y for the correct NOC — NOC 0 and NOC 1 have different coordinate spaces.
+FORCE_INLINE auto local_addr(uint32_t addr, uint8_t noc_id = noc_index) {
+    return noc_traits_t<UnicastEndpoint>::src_args_type{.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = addr};
+}
+
+// Single-packet read with state: call set_read_state once, then read_with_state in a loop.
+// transfer_size is baked into both calls so they always agree on single-packet mode.
+template <uint32_t transfer_size>
+FORCE_INLINE void set_read_state(Noc noc, uint32_t src_addr) {
+    static_assert(transfer_size <= NOC_MAX_BURST_SIZE, "Use noc.async_read for multi-packet transfers");
+    UnicastEndpoint ep;
+    noc.set_async_read_state<Noc::VcSelection::DEFAULT, transfer_size>(
+        ep, transfer_size, local_addr(src_addr, noc.get_noc_id()));
+}
+
+// Simple form: local L1 src addr -> local L1 dst addr
+FORCE_INLINE void read_with_state(Noc noc, uint32_t dst_addr, uint32_t src_addr) {
+    UnicastEndpoint ep;
+    noc.async_read_with_state<Noc::VcSelection::DEFAULT, 1>(
+        ep, CoreLocalMem<uint32_t>(dst_addr), 0, local_addr(src_addr, noc.get_noc_id()), {});
+}
+
+// CB/typed destination form with dst_args (e.g. offset_bytes)
+template <typename Dst>
+FORCE_INLINE void read_with_state(
+    Noc noc, const Dst& dst, uint32_t src_addr, const typename noc_traits_t<Dst>::dst_args_type& dst_args) {
+    UnicastEndpoint ep;
+    noc.async_read_with_state<Noc::VcSelection::DEFAULT, 1>(
+        ep, dst, 0, local_addr(src_addr, noc.get_noc_id()), dst_args);
+}
+
+// CB/typed destination form, no offset
+template <typename Dst>
+FORCE_INLINE void read_with_state(Noc noc, const Dst& dst, uint32_t src_addr) {
+    UnicastEndpoint ep;
+    noc.async_read_with_state<Noc::VcSelection::DEFAULT, 1>(ep, dst, 0, local_addr(src_addr, noc.get_noc_id()), {});
+}
+
+#endif
+
+}  // namespace experimental

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define ALWI inline __attribute__((always_inline))
 
@@ -40,59 +41,59 @@ ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val, bool unco
 }
 
 template <uint32_t cb_id, uint32_t clear_value_cb_id>
-ALWI void clear_out_tiles() {
+ALWI void clear_out_tiles(experimental::Noc noc, experimental::CB cb, experimental::CB clear_cb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     const uint32_t num_pages = get_local_cb_interface(cb_id).fifo_num_pages;
     const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_page_size / tile_size;
-    const uint64_t clear_value_addr = get_noc_addr(get_read_ptr(clear_value_cb_id));
-    uint64_t write_addr = get_noc_addr(get_write_ptr(cb_id));
+
+    experimental::UnicastEndpoint self_ep;
+    const auto src = experimental::local_addr(clear_cb.get_read_ptr());
 
     for (uint32_t i = 0; i < num_tiles * num_pages; ++i) {
-        noc_async_read(clear_value_addr, write_addr, tile_size);
-        write_addr += tile_size;
+        noc.async_read(self_ep, cb, tile_size, src, {.offset_bytes = i * tile_size});
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
-template <uint32_t clear_value_cb_id, uint32_t num_tiles>
-ALWI void clear_out_tiles(uint64_t write_addr, uint64_t clear_value_addr) {
+template <uint32_t clear_value_cb_id>
+ALWI void clear_out_tiles(
+    experimental::Noc noc, experimental::CB dst_cb, experimental::CB clear_value_cb, uint32_t num_tiles) {
     constexpr uint32_t tile_size = get_tile_size(clear_value_cb_id);
 
+    experimental::UnicastEndpoint self_ep;
+    const auto src = experimental::local_addr(clear_value_cb.get_read_ptr());
+
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        noc_async_read(clear_value_addr, write_addr, tile_size);
-        write_addr += tile_size;
+        noc.async_read(self_ep, dst_cb, tile_size, src, {.offset_bytes = i * tile_size});
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
 // Zero out all tiles for a given circular buffer.
 template <uint32_t cb_id>
-ALWI void zero_out_tiles() {
+ALWI void zero_out_tiles(experimental::Noc noc, experimental::CB cb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_num_pages;
     const uint32_t num_zeros_reads = (tile_size / MEM_ZEROS_SIZE) * num_tiles;
-    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
-    uint32_t write_addr = get_write_ptr(cb_id);
 
-    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    constexpr uint32_t packet_size = MEM_ZEROS_SIZE;
+
+    experimental::set_read_state<packet_size>(noc, MEM_ZEROS_BASE);
+
     for (uint32_t i = 0; i < num_zeros_reads; ++i) {
-        noc_async_read_one_packet_with_state<true>(zeros_noc_addr, write_addr);
-        write_addr += MEM_ZEROS_SIZE;
+        experimental::read_with_state(noc, cb, MEM_ZEROS_BASE, {.offset_bytes = i * packet_size});
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
 template <uint32_t config_dram_addr, uint32_t config_page_size, uint32_t tensor_args_index, uint32_t cb_reader_index>
-ALWI void load_config_tensor_if_in_dram(uint32_t core_index) {
-    // TODO: Instead of all cores reading from dram, only the first column reads, and does an MCAST to all the other
-    // cores in the row.
+ALWI void load_config_tensor_if_in_dram(experimental::Noc noc, experimental::CB reader_cb, uint32_t core_index) {
     constexpr auto config_tensor_args = TensorAccessorArgs<tensor_args_index>();
     const auto config_accessor = TensorAccessor(config_tensor_args, config_dram_addr, config_page_size);
-    uint64_t src_noc_addr = get_noc_addr(core_index, config_accessor);
 
-    noc_async_read(src_noc_addr, get_write_ptr(cb_reader_index), config_page_size);
-    noc_async_read_barrier();
-    cb_push_back(cb_reader_index, 1);
+    noc.async_read(config_accessor, reader_cb, config_page_size, {.page_id = core_index}, {});
+    noc.async_read_barrier();
+    reader_cb.push_back(1);
 }
 
 template <
@@ -102,6 +103,7 @@ template <
     bool split_reader,
     uint32_t multi_buffering_factor>
 ALWI void fill_scalar(
+    experimental::CB scalar_cb,
     uint32_t& scalar_start,
     uint32_t& scalar_end,
     uint32_t& scalar_value,
@@ -109,7 +111,7 @@ ALWI void fill_scalar(
     uint32_t& counter,
     volatile uint16_t* config_ptr) {
     constexpr uint32_t num_readers = split_reader ? 2 : 1;
-    cb_reserve_back(in_scalar_cb_id, 1);
+    scalar_cb.reserve_back(1);
 
     while (counter >= scalar_end && scalar_end < reader_nindices) {
         scalar_index++;
@@ -124,26 +126,31 @@ ALWI void fill_scalar(
         // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
         // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
         // between the first and second face.
-        fill_with_val(get_write_ptr(in_scalar_cb_id), FACE_WIDTH, scalar_value, false);
+        fill_with_val(scalar_cb.get_write_ptr(), FACE_WIDTH, scalar_value, false);
     }
     counter += num_readers;
 
-    cb_push_back(in_scalar_cb_id, 1);
+    scalar_cb.push_back(1);
 }
 
 template <uint32_t cb_id>
-ALWI void zero_out_page(uint32_t write_addr) {
+ALWI void zero_out_page(experimental::Noc noc, experimental::CB cb) {
     const uint32_t page_size = get_local_cb_interface(cb_id).fifo_page_size;
     const uint32_t num_zeros_reads = page_size / MEM_ZEROS_SIZE;
     const uint32_t remainder_bytes = page_size % MEM_ZEROS_SIZE;
-    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    constexpr uint32_t packet_size = MEM_ZEROS_SIZE;
 
-    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    experimental::set_read_state<packet_size>(noc, MEM_ZEROS_BASE);
     for (uint32_t i = 0; i < num_zeros_reads; ++i) {
-        noc_async_read_one_packet_with_state<true>(zeros_noc_addr, write_addr);
-        write_addr += MEM_ZEROS_SIZE;
+        experimental::read_with_state(noc, cb, MEM_ZEROS_BASE, {.offset_bytes = i * packet_size});
     }
     if (remainder_bytes > 0) {
-        noc_async_read(zeros_noc_addr, write_addr, remainder_bytes);
+        experimental::UnicastEndpoint self_ep;
+        noc.async_read(
+            self_ep,
+            cb,
+            remainder_bytes,
+            experimental::local_addr(MEM_ZEROS_BASE),
+            {.offset_bytes = num_zeros_reads * packet_size});
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp
@@ -13,6 +13,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/add_int_sfpu.h"
 #include "api/compute/copy_dest_values.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define DEBUG_PRINT 0
 
@@ -73,6 +74,21 @@ void kernel_main() {
     constexpr uint32_t kernel_w = get_compile_time_arg_val(35);
     constexpr uint32_t indexes_32_bit = get_compile_time_arg_val(36);
 
+    // experimental::CB wrappers for CB operations
+    experimental::CB in_scalar_cb(in_scalar_cb_id_0);
+    experimental::CB in_idx_cb(in_idx_cb_id);
+    experimental::CB pack_tmp_cb(pack_tmp_cb_id);
+    experimental::CB pack_idx_tmp_cb(pack_idx_tmp_cb_id);
+    experimental::CB right_inc_cb(right_inc_cb_id);
+    experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
+    experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
+    experimental::CB out_idx_cb(out_idx_cb_id);
+    experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
+    experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
+    experimental::CB compute_tmp_idx_cb(compute_tmp_idx_cb_id);
+    experimental::CB clear_value_cb(clear_value_cb_id);
+    experimental::CB in_cb_0(in_cb_id_0);
+
     constexpr DataFormat copy_format = indexes_32_bit ? DataFormat::UInt32 : DataFormat::UInt16;
 
     constexpr uint32_t mpwi_cb_tile_idx = 0;
@@ -104,7 +120,7 @@ void kernel_main() {
                                                                            : kernel_w / max_sticks_for_reduction + 1;
     constexpr uint32_t interm_reduction_chunks = is_large_kernel ? w_chunks * kernel_h : 1;
 
-    cb_wait_front(in_scalar_cb_id_0, 1);
+    in_scalar_cb.wait_front(1);
 
     uint32_t current_idx_col;
     uint32_t current_idx_row;
@@ -114,13 +130,13 @@ void kernel_main() {
     current_idx_row = start_row;
 
     constexpr uint32_t sticks_per_chunk = kernel_w <= max_sticks_for_reduction ? kernel_w : max_sticks_for_reduction;
-    cb_wait_front(right_inc_cb_id, 1);
-    cb_wait_front(down_left_wrap_inc_cb_id, 1);
-    cb_wait_front(up_left_wrap_inc_cb_id, 1);
+    right_inc_cb.wait_front(1);
+    down_left_wrap_inc_cb.wait_front(1);
+    up_left_wrap_inc_cb.wait_front(1);
     if constexpr (is_large_kernel) {
-        cb_wait_front(intra_kernel_right_inc_cb_id, 1);
-        cb_wait_front(intra_kernel_down_left_wrap_inc_cb_id, 1);
-        cb_wait_front(clear_value_cb_id, 1);
+        intra_kernel_right_inc_cb.wait_front(1);
+        intra_kernel_down_left_wrap_inc_cb.wait_front(1);
+        clear_value_cb.wait_front(1);
     }
 
     unary_op_init_common(in_cb_id_0, in_cb_id_0);
@@ -133,7 +149,6 @@ void kernel_main() {
 
     bool first_iteration = true;
     for (uint32_t n = 0; n < num_out_sticks_this_core; ++n) {
-        const uint32_t curr_in_cb_id = in_cb_id_0;
         for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
             const bool last_c_block = c_i == in_nblocks_c - 1;
 
@@ -143,14 +158,14 @@ void kernel_main() {
             reconfig_data_format_srca(compute_tmp_idx_cb_id);
             copy_tile_to_dst_init_short(compute_tmp_idx_cb_id);
             if (first_iteration) {  // move the initial indexes from the reader to DST
-                cb_wait_front(in_idx_cb_id, 1);
+                in_idx_cb.wait_front(1);
                 copy_tile(in_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
-                cb_pop_front(in_idx_cb_id, 1);
+                in_idx_cb.pop_front(1);
                 first_iteration = false;
             } else {  // move incremented indexes from compute back to DST
-                cb_wait_front(compute_tmp_idx_cb_id, 1);
+                compute_tmp_idx_cb.wait_front(1);
                 copy_tile(compute_tmp_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
-                cb_pop_front(compute_tmp_idx_cb_id, 1);
+                compute_tmp_idx_cb.pop_front(1);
             }
             if constexpr (is_large_kernel) {
                 // clear the accumulation tiles since they will contain garbage data which is partially loaded
@@ -167,10 +182,10 @@ void kernel_main() {
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
                 bool last_chunk = chunk == interm_reduction_chunks - 1;
 
-                cb_wait_front(curr_in_cb_id, 1);
-                reconfig_data_format_srca(curr_in_cb_id);
-                copy_tile_to_dst_init_short(curr_in_cb_id);
-                copy_tile(curr_in_cb_id, mpwi_cb_tile_idx, data_dst_idx);
+                in_cb_0.wait_front(1);
+                reconfig_data_format_srca(in_cb_id_0);
+                copy_tile_to_dst_init_short(in_cb_id_0);
+                copy_tile(in_cb_id_0, mpwi_cb_tile_idx, data_dst_idx);
 
                 // increments happen between every chunk within a C block, and between C blocks
                 bool increment_needed = false;
@@ -230,7 +245,7 @@ void kernel_main() {
                     }
                 }
 
-                cb_pop_front(curr_in_cb_id, 1);
+                in_cb_0.pop_front(1);
             }
 
             // After all chunks: if not last C block, restore base indices for next C block
@@ -243,27 +258,27 @@ void kernel_main() {
             tile_regs_commit();
             tile_regs_wait();
 
-            cb_reserve_back(pack_tmp_cb_id, 1);
+            pack_tmp_cb.reserve_back(1);
             pack_reconfig_data_format(pack_tmp_cb_id);
             pack_tile<true>(data_dst_idx, pack_tmp_cb_id, mpwi_cb_tile_idx);  // for reader (output data)
-            cb_push_back(pack_tmp_cb_id, 1);
+            pack_tmp_cb.push_back(1);
 
-            cb_reserve_back(pack_idx_tmp_cb_id, 1);
+            pack_idx_tmp_cb.reserve_back(1);
             pack_reconfig_data_format(pack_idx_tmp_cb_id);
             pack_tile<true>(index_dst_idx, pack_idx_tmp_cb_id, mpwi_cb_tile_idx);  // for reader (output indexes)
-            cb_push_back(pack_idx_tmp_cb_id, 1);
+            pack_idx_tmp_cb.push_back(1);
 
             // Only push to compute_tmp_idx_cb_id if there's a next iteration that will consume it
             // This prevents leaving stale data in the CB between program runs when using caching
             bool is_last_iteration = (n == num_out_sticks_this_core - 1) && last_c_block;
             if (!is_last_iteration) {
-                cb_reserve_back(compute_tmp_idx_cb_id, 1);
+                compute_tmp_idx_cb.reserve_back(1);
                 pack_reconfig_data_format(compute_tmp_idx_cb_id);
                 pack_tile<true>(
                     index_scratch_out_dst_idx,
                     compute_tmp_idx_cb_id,
                     mpwi_cb_tile_idx);  // for compute (incremented indexes)
-                cb_push_back(compute_tmp_idx_cb_id, 1);
+                compute_tmp_idx_cb.push_back(1);
             }
 
             tile_regs_release();
@@ -271,13 +286,13 @@ void kernel_main() {
     }
 
     // This prevents leaving stale data in the CB between program runs when using caching
-    cb_pop_front(in_scalar_cb_id_0, 1);
-    cb_pop_front(right_inc_cb_id, 1);
-    cb_pop_front(down_left_wrap_inc_cb_id, 1);
-    cb_pop_front(up_left_wrap_inc_cb_id, 1);
+    in_scalar_cb.pop_front(1);
+    right_inc_cb.pop_front(1);
+    down_left_wrap_inc_cb.pop_front(1);
+    up_left_wrap_inc_cb.pop_front(1);
     if constexpr (is_large_kernel) {
-        cb_pop_front(intra_kernel_right_inc_cb_id, 1);
-        cb_pop_front(intra_kernel_down_left_wrap_inc_cb_id, 1);
-        cb_pop_front(clear_value_cb_id, 1);
+        intra_kernel_right_inc_cb.pop_front(1);
+        intra_kernel_down_left_wrap_inc_cb.pop_front(1);
+        clear_value_cb.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -11,6 +11,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/add_int_sfpu.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define DEBUG_PRINT 0
 
@@ -83,6 +84,14 @@ void kernel_main() {
                                      window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
 
     constexpr uint32_t tilize_untilize_cb = is_output_tiled ? pre_tilize_cb_id : out_cb_id;
+
+    experimental::CB in_scalar_cb_0(in_scalar_cb_id_0);
+    experimental::CB in_scalar_cb_1(in_scalar_cb_id_1);
+    experimental::CB in_cb_0(in_cb_id_0);
+    experimental::CB in_cb_1(in_cb_id_1);
+    experimental::CB out_cb(out_cb_id);
+    experimental::CB pre_tilize_cb(pre_tilize_cb_id);
+
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, tilize_untilize_cb, num_faces_in_input_tile, face_r_dim);
     pack_untilize_dest_init<max_tiles_per_iter>(tilize_untilize_cb, num_out_sticks, num_faces_in_output_tile);
@@ -93,7 +102,7 @@ void kernel_main() {
 
     // wait for initialization to complete
     if constexpr (one_scalar_per_core) {
-        cb_wait_front(in_scalar_cb_id_0, 1);
+        in_scalar_cb_0.wait_front(1);
     }
 
     // if max out sticks is non-zero then this will be used as the number of out sticks for every core
@@ -107,13 +116,16 @@ void kernel_main() {
     uint32_t tilize_stick_total = 0;
     for (uint32_t n = 0; n < num_out_sticks_this_core; ++n) {
         const bool reader0 = !(use_split_reader && (n & 0x1));
-        const uint32_t curr_scalar_cb_id = (!reader0 && !one_scalar_per_core) ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+        const bool use_reader1_scalar = !reader0 && !one_scalar_per_core;
+        const uint32_t curr_scalar_cb_id = use_reader1_scalar ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
         const uint32_t curr_in_cb_id = !reader0 ? in_cb_id_1 : in_cb_id_0;
+        experimental::CB curr_scalar_cb = use_reader1_scalar ? in_scalar_cb_1 : in_scalar_cb_0;
+        experimental::CB curr_in_cb = reader0 ? in_cb_0 : in_cb_1;
         if constexpr (!one_scalar_per_core) {
-            cb_wait_front(curr_scalar_cb_id, 1);
+            curr_scalar_cb.wait_front(1);
         }
         if (is_output_tiled && !tilize_stick_counter) {
-            cb_reserve_back(out_cb_id, in_ntiles_c);
+            out_cb.reserve_back(in_ntiles_c);
         }
         for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
             const bool last_c_block = c_i == in_nblocks_c - 1;
@@ -126,7 +138,7 @@ void kernel_main() {
                     ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
                     : number_of_tiles * num_faces_in_output_tile;
             if constexpr (!is_output_tiled) {
-                cb_reserve_back(out_cb_id, output_faces);
+                out_cb.reserve_back(output_faces);
             }
             if constexpr (tilize_reconfig) {
                 if (first_c_block || last_c_block) {
@@ -136,7 +148,7 @@ void kernel_main() {
             }
             tile_regs_acquire();
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
-                cb_wait_front(curr_in_cb_id, 1);
+                curr_in_cb.wait_front(1);
                 unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                     curr_in_cb_id,
                     curr_scalar_cb_id,
@@ -147,7 +159,7 @@ void kernel_main() {
                 for (uint32_t math_tile_idx = 0; math_tile_idx < tiles_to_reduce; ++math_tile_idx) {
                     reduce_tile_math(math_tile_idx, num_faces_in_input_tile);
                 }
-                cb_pop_front(curr_in_cb_id, 1);
+                curr_in_cb.pop_front(1);
             }
             tile_regs_commit();
             tile_regs_wait();
@@ -156,29 +168,29 @@ void kernel_main() {
                 if (last_c_block) {
                     pack_untilize_dest<partial_iter_output_tiles>(
                         pre_tilize_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
-                    cb_push_back(pre_tilize_cb_id, partial_iter_output_tiles);
+                    pre_tilize_cb.push_back(partial_iter_output_tiles);
                     tilize_stick_counter++;
                     tilize_stick_total++;
                 } else {
                     pack_untilize_dest<max_tiles_per_iter>(
                         pre_tilize_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
-                    cb_push_back(pre_tilize_cb_id, max_tiles_per_iter);
+                    pre_tilize_cb.push_back(max_tiles_per_iter);
                 }
                 tile_regs_release();
 
                 bool last_tile = num_out_sticks_this_core - tilize_stick_total < last_tile_height;
                 if (tilize_stick_counter == TILE_HEIGHT || (last_tile && tilize_stick_counter == last_tile_height)) {
                     if (last_tile && last_tile_height != TILE_HEIGHT) {
-                        cb_wait_front(pre_tilize_cb_id, last_tile_height * in_ntiles_c);
+                        pre_tilize_cb.wait_front(last_tile_height * in_ntiles_c);
                         // if the last tile is not whole we won't have pushed enough sticks, so we need to
                         // push some filler sticks to reach TILE_HEIGHT to make sure the CB pointers are correct
                         // before calling tilize
                         uint32_t filler_stick_tiles =
                             (TILE_HEIGHT - last_tile_height) *
                             ((in_nblocks_c - 1) * max_tiles_per_iter + partial_iter_output_tiles);
-                        cb_push_back(pre_tilize_cb_id, filler_stick_tiles);
+                        pre_tilize_cb.push_back(filler_stick_tiles);
                     }
-                    cb_wait_front(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
+                    pre_tilize_cb.wait_front(TILE_HEIGHT * in_ntiles_c);
                     PACK((pack_untilize_uninit(pre_tilize_cb_id)));
 
                     unpack_tilizeA_B_uninit(curr_in_cb_id);
@@ -188,9 +200,9 @@ void kernel_main() {
                     fast_tilize_block(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
                     fast_tilize_uninit(pre_tilize_cb_id, out_cb_id);
 
-                    cb_push_back(out_cb_id, in_ntiles_c);
-                    cb_pop_front(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
-                    cb_reserve_back(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
+                    out_cb.push_back(in_ntiles_c);
+                    pre_tilize_cb.pop_front(TILE_HEIGHT * in_ntiles_c);
+                    pre_tilize_cb.reserve_back(TILE_HEIGHT * in_ntiles_c);
 
                     tilize_stick_counter = 0;
 
@@ -219,12 +231,12 @@ void kernel_main() {
                 } else {
                     pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
                 }
-                cb_push_back(out_cb_id, output_faces);
+                out_cb.push_back(output_faces);
                 tile_regs_release();
             }
         }
         if constexpr (!one_scalar_per_core) {
-            cb_pop_front(curr_scalar_cb_id, 1);
+            curr_scalar_cb.pop_front(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -4,7 +4,7 @@
 #include <sys/types.h>
 
 #include <cstdint>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include <ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp>
 
 #define ENABLE_DEBUG_PRINT 0
@@ -38,8 +38,8 @@ template <
     uint32_t sticks_per_chunk,
     uint32_t in_idx_cb_id>
 void fill_indexes(uint32_t init_index) {
-    volatile tt_l1_ptr IndexType* idx_ptr =
-        reinterpret_cast<volatile tt_l1_ptr IndexType*>(get_write_ptr(in_idx_cb_id));
+    experimental::CB idx_cb(in_idx_cb_id);
+    volatile tt_l1_ptr IndexType* idx_ptr = reinterpret_cast<volatile tt_l1_ptr IndexType*>(idx_cb.get_write_ptr());
     uint32_t kernel_idx = 0;
 
     for (uint32_t h = 0; h < kernel_h; ++h) {
@@ -125,7 +125,8 @@ ALWI void initialize_return_indices_data() {
     constexpr uint32_t row_stride = dilation_h * in_w - eff_kernel_w - (dilation_w - 1);
 
     // initialize the index CB
-    cb_reserve_back(in_idx_cb_id, 1);
+    experimental::CB idx_cb(in_idx_cb_id);
+    idx_cb.reserve_back(1);
     fill_indexes<
         typename IndexType<indexes_32_bit>::type,
         kernel_h,
@@ -136,14 +137,14 @@ ALWI void initialize_return_indices_data() {
         is_large_kernel,
         sticks_per_chunk,
         in_idx_cb_id>(init_index);
-    cb_push_back(in_idx_cb_id, 1);
+    idx_cb.push_back(1);
 
     // initialize the increment CBs
     // TODO we used to fill the 16 bit values two at a time, but this technically resulted in overflow with odd
     // c dimensions so for now we do it one at a time for both 16 and 32 bit indexes
     if constexpr (indexes_32_bit) {
-        auto fill_inc_32 = [&](uint32_t cb_id, uint32_t inc) __attribute__((always_inline)) {
-            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+        auto fill_inc_32 = [&](experimental::CB& inc_cb, uint32_t inc) __attribute__((always_inline)) {
+            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
             for (uint32_t k = 0; k < window_size_hw; ++k) {
                 for (uint32_t c = 0; c < fill_c; ++c) {
                     ptr[k * TILE_WIDTH + c] = inc;
@@ -151,32 +152,37 @@ ALWI void initialize_return_indices_data() {
             }
         };
 
-        cb_reserve_back(right_inc_cb_id, 1);
-        fill_inc_32(right_inc_cb_id, right_inc);
-        cb_push_back(right_inc_cb_id, 1);
+        experimental::CB right_inc_cb(right_inc_cb_id);
+        right_inc_cb.reserve_back(1);
+        fill_inc_32(right_inc_cb, right_inc);
+        right_inc_cb.push_back(1);
 
-        cb_reserve_back(down_left_wrap_inc_cb_id, 1);
-        fill_inc_32(down_left_wrap_inc_cb_id, down_left_wrap_inc);
-        cb_push_back(down_left_wrap_inc_cb_id, 1);
+        experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
+        down_left_wrap_inc_cb.reserve_back(1);
+        fill_inc_32(down_left_wrap_inc_cb, down_left_wrap_inc);
+        down_left_wrap_inc_cb.push_back(1);
 
-        cb_reserve_back(up_left_wrap_inc_cb_id, 1);
-        fill_inc_32(up_left_wrap_inc_cb_id, up_left_wrap_inc);
-        cb_push_back(up_left_wrap_inc_cb_id, 1);
+        experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
+        up_left_wrap_inc_cb.reserve_back(1);
+        fill_inc_32(up_left_wrap_inc_cb, up_left_wrap_inc);
+        up_left_wrap_inc_cb.push_back(1);
 
         if constexpr (is_large_kernel) {
-            cb_reserve_back(intra_kernel_right_inc_cb_id, 1);
-            fill_inc_32(intra_kernel_right_inc_cb_id, intra_kernel_right_inc);
-            cb_push_back(intra_kernel_right_inc_cb_id, 1);
+            experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
+            intra_kernel_right_inc_cb.reserve_back(1);
+            fill_inc_32(intra_kernel_right_inc_cb, intra_kernel_right_inc);
+            intra_kernel_right_inc_cb.push_back(1);
 
-            cb_reserve_back(intra_kernel_down_left_wrap_inc_cb_id, 1);
-            fill_inc_32(intra_kernel_down_left_wrap_inc_cb_id, intra_kernel_down_left_wrap_inc);
-            cb_push_back(intra_kernel_down_left_wrap_inc_cb_id, 1);
+            experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
+            intra_kernel_down_left_wrap_inc_cb.reserve_back(1);
+            fill_inc_32(intra_kernel_down_left_wrap_inc_cb, intra_kernel_down_left_wrap_inc);
+            intra_kernel_down_left_wrap_inc_cb.push_back(1);
         }
     } else {
-        auto fill_inc = [&](uint32_t cb_id, uint32_t inc) __attribute__((always_inline)) {
+        auto fill_inc = [&](experimental::CB& inc_cb, uint32_t inc) __attribute__((always_inline)) {
             uint16_t inc_16 = (uint16_t)inc;
             uint32_t inc_32_bit = (uint32_t)inc_16 | ((uint32_t)inc_16 << 16);
-            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inc_cb.get_write_ptr());
             for (uint32_t k = 0; k < window_size_hw; ++k) {
                 for (uint32_t c = 0; c < fill_c_32_bit; ++c) {
                     ptr[k * HALF_TILE_WIDTH + c] = inc_32_bit;
@@ -184,26 +190,31 @@ ALWI void initialize_return_indices_data() {
             }
         };
 
-        cb_reserve_back(right_inc_cb_id, 1);
-        fill_inc(right_inc_cb_id, right_inc);
-        cb_push_back(right_inc_cb_id, 1);
+        experimental::CB right_inc_cb(right_inc_cb_id);
+        right_inc_cb.reserve_back(1);
+        fill_inc(right_inc_cb, right_inc);
+        right_inc_cb.push_back(1);
 
-        cb_reserve_back(down_left_wrap_inc_cb_id, 1);
-        fill_inc(down_left_wrap_inc_cb_id, down_left_wrap_inc);
-        cb_push_back(down_left_wrap_inc_cb_id, 1);
+        experimental::CB down_left_wrap_inc_cb(down_left_wrap_inc_cb_id);
+        down_left_wrap_inc_cb.reserve_back(1);
+        fill_inc(down_left_wrap_inc_cb, down_left_wrap_inc);
+        down_left_wrap_inc_cb.push_back(1);
 
-        cb_reserve_back(up_left_wrap_inc_cb_id, 1);
-        fill_inc(up_left_wrap_inc_cb_id, up_left_wrap_inc);
-        cb_push_back(up_left_wrap_inc_cb_id, 1);
+        experimental::CB up_left_wrap_inc_cb(up_left_wrap_inc_cb_id);
+        up_left_wrap_inc_cb.reserve_back(1);
+        fill_inc(up_left_wrap_inc_cb, up_left_wrap_inc);
+        up_left_wrap_inc_cb.push_back(1);
 
         if constexpr (is_large_kernel) {
-            cb_reserve_back(intra_kernel_right_inc_cb_id, 1);
-            fill_inc(intra_kernel_right_inc_cb_id, intra_kernel_right_inc);
-            cb_push_back(intra_kernel_right_inc_cb_id, 1);
+            experimental::CB intra_kernel_right_inc_cb(intra_kernel_right_inc_cb_id);
+            intra_kernel_right_inc_cb.reserve_back(1);
+            fill_inc(intra_kernel_right_inc_cb, intra_kernel_right_inc);
+            intra_kernel_right_inc_cb.push_back(1);
 
-            cb_reserve_back(intra_kernel_down_left_wrap_inc_cb_id, 1);
-            fill_inc(intra_kernel_down_left_wrap_inc_cb_id, intra_kernel_down_left_wrap_inc);
-            cb_push_back(intra_kernel_down_left_wrap_inc_cb_id, 1);
+            experimental::CB intra_kernel_down_left_wrap_inc_cb(intra_kernel_down_left_wrap_inc_cb_id);
+            intra_kernel_down_left_wrap_inc_cb.reserve_back(1);
+            fill_inc(intra_kernel_down_left_wrap_inc_cb, intra_kernel_down_left_wrap_inc);
+            intra_kernel_down_left_wrap_inc_cb.push_back(1);
         }
     }
 }
@@ -244,6 +255,15 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
     constexpr uint32_t in_ntiles_c = (in_c + TILE_WIDTH - 1) / TILE_WIDTH;
     static_assert(MAX_TILES_PER_REDUCTION == 1, "MAX_TILES_PER_REDUCTION must be 1 for MPWI");
     constexpr uint32_t max_write_inc = TILE_WIDTH * BYTES_PER_ELEM;
+
+    experimental::CB in_cb(in_cb_id);
+    experimental::CB out_cb(out_cb_id);
+    experimental::CB out_idx_cb(out_idx_cb_id);
+    experimental::CB pack_tmp_cb(pack_tmp_cb_id);
+    experimental::CB pack_idx_tmp_cb(pack_idx_tmp_cb_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint self_ep;
+
     for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
         uint32_t read_bytes = in_nbytes_c;
         if constexpr (wide_reduction) {
@@ -251,16 +271,15 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                 (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
         }
 
-        uint32_t in_l1_write_addr = 0;
+        uint32_t write_offset = 0;
         if constexpr (reader_id == 0) {
-            in_l1_write_addr = get_write_ptr(in_cb_id);
-            cb_reserve_back(in_cb_id, 1);
+            in_cb.reserve_back(1);
         }
         // page zeroing is only necessary for tiled block output format so that scale is not affected by
         // junk/padding data
         if constexpr (zero_pages && reader_id == 0) {
             if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
-                zero_out_page<in_cb_id>(get_write_ptr(in_cb_id));
+                zero_out_page<in_cb_id>(noc, in_cb);
             }
         }
         for (uint32_t h = 0; h < kernel_h; ++h) {
@@ -270,19 +289,24 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                     const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
                     const uint32_t read_offset =
                         in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
-                    noc_async_read_one_packet(get_noc_addr(read_offset), in_l1_write_addr, read_bytes * w_multiple);
-                    in_l1_write_addr += max_write_inc * w_multiple;
+                    noc.async_read(
+                        self_ep,
+                        in_cb,
+                        read_bytes * w_multiple,
+                        experimental::local_addr(read_offset),
+                        {.offset_bytes = write_offset});
+                    write_offset += max_write_inc * w_multiple;
                 }
                 bool kernel_complete = h == kernel_h - 1 && w == kernel_w - 1;
                 bool push_chunk =
                     kernel_complete || (is_large_kernel && ((w + 1) % sticks_per_chunk == 0 || w == (kernel_w - 1)));
                 if (push_chunk) {
                     if constexpr (reader_id == 0) {  // push a chunk
-                        noc_async_read_barrier();
-                        cb_push_back(in_cb_id, 1);
+                        noc.async_read_barrier();
+                        in_cb.push_back(1);
                         if (!kernel_complete) {
-                            cb_reserve_back(in_cb_id, 1);
-                            in_l1_write_addr = get_write_ptr(in_cb_id);
+                            in_cb.reserve_back(1);
+                            write_offset = 0;
                         }
                     } else {
                         if (kernel_complete) {  // write output once all chunks are done
@@ -292,27 +316,31 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                             uint32_t output_faces =
                                 c_i == in_nblocks_c - 1 ? num_faces_in_last_output_tile : num_faces_in_output_tile;
 
-                            cb_reserve_back(out_cb_id, output_faces);
-                            cb_reserve_back(out_idx_cb_id, output_faces);
+                            out_cb.reserve_back(output_faces);
+                            out_idx_cb.reserve_back(output_faces);
 
-                            cb_wait_front(pack_tmp_cb_id, 1);
-                            noc_async_read_one_packet(
-                                get_noc_addr(get_read_ptr(pack_tmp_cb_id)),
-                                get_write_ptr(out_cb_id),
-                                output_faces * FACE_WIDTH * BYTES_PER_ELEM);
+                            pack_tmp_cb.wait_front(1);
+                            noc.async_read(
+                                self_ep,
+                                out_cb,
+                                output_faces * FACE_WIDTH * BYTES_PER_ELEM,
+                                experimental::local_addr(pack_tmp_cb.get_read_ptr()),
+                                {});
 
-                            cb_wait_front(pack_idx_tmp_cb_id, 1);
+                            pack_idx_tmp_cb.wait_front(1);
                             constexpr uint32_t BYTES_PER_ELEM_IDX = indexes_32_bit ? 4 : 2;
-                            noc_async_read_one_packet(
-                                get_noc_addr(get_read_ptr(pack_idx_tmp_cb_id)),
-                                get_write_ptr(out_idx_cb_id),
-                                output_faces * FACE_WIDTH * BYTES_PER_ELEM_IDX);
-                            noc_async_read_barrier();
-                            cb_pop_front(pack_tmp_cb_id, 1);
-                            cb_pop_front(pack_idx_tmp_cb_id, 1);
+                            noc.async_read(
+                                self_ep,
+                                out_idx_cb,
+                                output_faces * FACE_WIDTH * BYTES_PER_ELEM_IDX,
+                                experimental::local_addr(pack_idx_tmp_cb.get_read_ptr()),
+                                {});
+                            noc.async_read_barrier();
+                            pack_tmp_cb.pop_front(1);
+                            pack_idx_tmp_cb.pop_front(1);
 
-                            cb_push_back(out_cb_id, output_faces);
-                            cb_push_back(out_idx_cb_id, output_faces);
+                            out_cb.push_back(output_faces);
+                            out_idx_cb.push_back(output_faces);
                         }
                     }
                 }
@@ -357,11 +385,9 @@ void kernel_main() {
     constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(17);
     constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(18);
     constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(19);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(20);
     constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(21);
     constexpr bool is_avg_pool = (bool)get_compile_time_arg_val(22);
     constexpr bool one_scalar_per_core = get_compile_time_arg_val(23);
-    constexpr uint32_t config_cb_id = get_compile_time_arg_val(24);
     constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(25);
     constexpr uint32_t shard_width_bytes = get_compile_time_arg_val(26);
     constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(27);
@@ -395,12 +421,8 @@ void kernel_main() {
     constexpr uint32_t indexes_32_bit = get_compile_time_arg_val(54);
     constexpr uint32_t reader_tensor_args_index = 55;
 
-    constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;
-
     constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
-    constexpr uint32_t in_scalar_cb_id = in_scalar_cb_id_0;
-
     constexpr uint32_t window_size_hw = kernel_h * kernel_w;
     constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
     constexpr uint32_t sticks_per_chunk = kernel_w <= max_sticks_for_reduction ? kernel_w : max_sticks_for_reduction;
@@ -409,9 +431,10 @@ void kernel_main() {
 
     // fill the clear cb
     if constexpr (reader_id == 0) {
-        fill_with_val(get_write_ptr(clear_value_cb_id), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
-        cb_push_back(clear_value_cb_id, 1);
-        clear_out_tiles<in_cb_id, clear_value_cb_id>();
+        experimental::CB clear_value_cb(clear_value_cb_id);
+        fill_with_val(clear_value_cb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
+        clear_value_cb.push_back(1);
+        clear_out_tiles<in_cb_id, clear_value_cb_id>(experimental::Noc(), experimental::CB(in_cb_id), clear_value_cb);
     }
 
     if constexpr (reader_id == 0) {
@@ -445,25 +468,28 @@ void kernel_main() {
         // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
         // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
         // between the first and second face.
-        fill_with_val(get_write_ptr(in_scalar_cb_id_0), FACE_WIDTH, bf16_scalar >> 16);
-        cb_push_back(in_scalar_cb_id_0, 1);
+        experimental::CB in_scalar_cb(in_scalar_cb_id_0);
+        fill_with_val(in_scalar_cb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
+        in_scalar_cb.push_back(1);
     }
     const uint32_t core_nhw_index = get_arg_val<uint32_t>(1);
 
-    const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
+    experimental::CB in_shard_cb(in_shard_cb_id);
+    const uint32_t in_l1_read_base_addr = in_shard_cb.get_read_ptr();
+    experimental::CB in_reader_indices_cb(in_reader_indices_cb_id);
     if constexpr (config_in_dram) {
         if (reader_id == 0) {
             load_config_tensor_if_in_dram<
                 reader_dram_addr,
                 reader_page_size,
                 reader_tensor_args_index,
-                in_reader_indices_cb_id>(core_nhw_index);
+                in_reader_indices_cb_id>(experimental::Noc(), in_reader_indices_cb, core_nhw_index);
 
         } else {
-            cb_wait_front(in_reader_indices_cb_id, 1);
+            in_reader_indices_cb.wait_front(1);
         }
     }
-    uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
+    uint32_t reader_indices_l1_addr = in_reader_indices_cb.get_read_ptr();
     volatile tt_l1_ptr uint32_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -45,6 +45,12 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
     constexpr uint32_t in_ntiles_c = (in_c + TILE_WIDTH - 1) / TILE_WIDTH;
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
                                      (kernel_h * kernel_w) <= 16 && !last_tile_is_partial;
+
+    experimental::CB in_cb(in_cb_id);
+    experimental::CB clear_cb(clear_value_cb_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint self_ep;
+
     uint32_t max_write_inc = wide_reduction ? MAX_BYTES_PER_REDUCTION : in_nbytes_leftover;
     for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
         uint32_t read_bytes = in_nbytes_c;
@@ -53,14 +59,14 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                 (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
         }
 
-        uint32_t in_l1_write_addr = get_write_ptr(in_cb_id);
-        cb_reserve_back(in_cb_id, 1);
+        in_cb.reserve_back(1);
+        uint32_t write_offset = 0;
         uint32_t processed_sticks = 0;
         // page zeroing is only necessary for tiled block output format so that scale is not affected by
         // junk/padding data
         if constexpr (zero_pages) {
             if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
-                zero_out_page<in_cb_id>(get_write_ptr(in_cb_id));
+                zero_out_page<in_cb_id>(noc, in_cb);
             }
         }
         for (uint32_t h = 0; h < kernel_h; ++h) {
@@ -68,22 +74,27 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                 const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
                 const uint32_t read_offset =
                     in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
-                noc_async_read_one_packet(get_noc_addr(read_offset), in_l1_write_addr, read_bytes * w_multiple);
+                noc.async_read(
+                    self_ep,
+                    in_cb,
+                    read_bytes * w_multiple,
+                    experimental::local_addr(read_offset),
+                    {.offset_bytes = write_offset});
                 // if compute is using tilize_reconfig we will only untilize the needed number of tiles rather
                 // than the entire MAX_TILES_PER_REDUCTION, thus we use a different offset for the write address
                 if constexpr (tilize_reconfig) {
-                    in_l1_write_addr += read_bytes * w_multiple;
+                    write_offset += read_bytes * w_multiple;
                 } else {
-                    in_l1_write_addr += max_write_inc * w_multiple;
+                    write_offset += max_write_inc * w_multiple;
                 }
                 processed_sticks += w_multiple;
                 if constexpr (is_large_kernel) {
                     if ((processed_sticks % max_sticks_for_reduction) == 0 ||
                         processed_sticks == total_elems_to_reduce) {
-                        noc_async_read_barrier();
-                        cb_push_back(in_cb_id, 1);
-                        cb_reserve_back(in_cb_id, 1);
-                        in_l1_write_addr = get_write_ptr(in_cb_id);
+                        noc.async_read_barrier();
+                        in_cb.push_back(1);
+                        in_cb.reserve_back(1);
+                        write_offset = 0;
                         // If next is last chunk, fill whole buffer with the init_value. note for max pool we do
                         // not need to fill the CB for the partial chunk since as long as we have N>1 chunks we
                         // are guaranteed that the junk data remaining from chunk N-1 will fill the entire CB and
@@ -94,8 +105,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                             // clear the in CB
                             if ((total_elems_to_reduce - processed_sticks) < max_sticks_for_reduction &&
                                 processed_sticks != total_elems_to_reduce) {
-                                clear_out_tiles<clear_value_cb_id, in_cb_ntiles>(
-                                    get_noc_addr(in_l1_write_addr), get_noc_addr(get_read_ptr(clear_value_cb_id)));
+                                clear_out_tiles<clear_value_cb_id>(noc, in_cb, clear_cb, in_cb_ntiles);
                             }
                         }
                     }
@@ -124,8 +134,8 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
             }
         }
         if constexpr (!is_large_kernel) {
-            noc_async_read_barrier();
-            cb_push_back(in_cb_id, 1);
+            noc.async_read_barrier();
+            in_cb.push_back(1);
         }
     }
 }
@@ -183,7 +193,6 @@ void kernel_main() {
     constexpr uint32_t reader_tensor_args_index = 55;
 
     constexpr bool use_split_reader = split_reader;
-    constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;
 
     constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
@@ -205,18 +214,25 @@ void kernel_main() {
          interm_reduction_chunks <= multi_buffering_factor);
     constexpr uint32_t in_cb_ntiles = in_cb_sz / (TILE_WIDTH * TILE_HEIGHT);  // only use the non-multi buffering size
 
+    experimental::CB clear_value_cb(clear_value_cb_id);
+    experimental::CB in_scalar_cb(in_scalar_cb_id);
+    experimental::CB in_shard_cb(in_shard_cb_id);
+    experimental::CB reader_indices_cb(in_reader_indices_cb_id);
+    experimental::CB config_cb(config_cb_id);
+
     // fill the clear cb
     if constexpr (is_avg_pool || need_to_initialize_in_cb) {
         if constexpr (reader_id == 0) {
-            fill_with_val(get_write_ptr(clear_value_cb_id), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
-            cb_push_back(clear_value_cb_id, 1);
+            fill_with_val(clear_value_cb.get_write_ptr(), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
+            clear_value_cb.push_back(1);
         }
         if constexpr (reader_id == 1) {
-            cb_wait_front(clear_value_cb_id, 1);
+            clear_value_cb.wait_front(1);
         }
         // for average pool clear out tiles runs in loop, no need to initialize here
         if constexpr (!is_avg_pool || !is_large_kernel) {
-            clear_out_tiles<in_cb_id, clear_value_cb_id>();
+            clear_out_tiles<in_cb_id, clear_value_cb_id>(
+                experimental::Noc(), experimental::CB(in_cb_id), clear_value_cb);
         }
     }
 
@@ -225,25 +241,25 @@ void kernel_main() {
         // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
         // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
         // between the first and second face.
-        fill_with_val(get_write_ptr(in_scalar_cb_id_0), FACE_WIDTH, bf16_scalar >> 16);
-        cb_push_back(in_scalar_cb_id_0, 1);
+        fill_with_val(in_scalar_cb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
+        in_scalar_cb.push_back(1);
     }
     const uint32_t core_nhw_index = get_arg_val<uint32_t>(1);
 
-    const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
+    const uint32_t in_l1_read_base_addr = in_shard_cb.get_read_ptr();
     if constexpr (config_in_dram) {
         if (reader_id == 0) {
             load_config_tensor_if_in_dram<
                 reader_dram_addr,
                 reader_page_size,
                 reader_tensor_args_index,
-                in_reader_indices_cb_id>(core_nhw_index);
+                in_reader_indices_cb_id>(experimental::Noc(), reader_indices_cb, core_nhw_index);
 
         } else {
-            cb_wait_front(in_reader_indices_cb_id, 1);
+            reader_indices_cb.wait_front(1);
         }
     }
-    uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
+    uint32_t reader_indices_l1_addr = reader_indices_cb.get_read_ptr();
     volatile tt_l1_ptr uint32_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
 
@@ -257,7 +273,7 @@ void kernel_main() {
     uint32_t scalar_end;
     uint32_t counter = reader_id;
     if constexpr (!one_scalar_per_core) {
-        uint32_t config_l1_addr = get_read_ptr(config_cb_id);
+        uint32_t config_l1_addr = config_cb.get_read_ptr();
         if constexpr (config_in_dram) {
             if (reader_id == 0) {
                 constexpr uint32_t config_tensor_args_index =
@@ -266,9 +282,9 @@ void kernel_main() {
                     config_dram_addr,
                     config_page_size,
                     config_tensor_args_index,
-                    config_cb_id>(core_nhw_index);
+                    config_cb_id>(experimental::Noc(), config_cb, core_nhw_index);
             } else {
-                cb_wait_front(config_cb_id, 1);
+                config_cb.wait_front(1);
             }
         }
         config_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(config_l1_addr);
@@ -298,7 +314,8 @@ void kernel_main() {
                     in_scalar_cb_id,
                     reader_nindices,
                     use_split_reader,
-                    multi_buffering_factor>(scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
+                    multi_buffering_factor>(
+                    in_scalar_cb, scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
             }
             read_kernel_with_top_left_index<
                 in_nblocks_c,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <stdint.h>
 #include "api/compile_time_args.h"
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "ttnn/operations/pool/device/kernels/pool_kernels_common.hpp"
 #include "../grid_sample_reader_common.hpp"
 
@@ -40,20 +40,14 @@ void kernel_main() {
     const auto grid_tensor_accessor = TensorAccessor(grid_args, grid_addr, grid_stick_nbytes);
     const auto input_tensor_accessor = TensorAccessor(src_args, input_addr, input_stick_nbytes);
 
+    experimental::CB grid_cb(grid_cb_index);
+    experimental::Noc noc;
+
     const uint32_t end_id = start_page_id + num_pages;
 
-    /*
-    In the case of grid sampling, we need to account for the fact that the grid coordinates may fall outside the bounds
-    of the input image. Since the padding mode is zero, we would simply set the weights for the appropriate sticks to
-    zero in the for loop, and simply do not read from DRAM. In that case the stick we send to reduction would be the
-    last pixel that we read for the appropriate location (SW, SE, NW, NE), but since weights are 0 this is not a
-    problem.
-
-    However, if there was no previous read for the appropriate stick, the memory in that location is invalid, and could
-    include NaN and Inf values. For that reason we zero out the input_cb at the start.
-    */
-
-    zero_out_tiles<input_cb_index>();
+    experimental::CB input_cb(input_cb_index);
+    experimental::CB scalar_cb(scalar_cb_index);
+    zero_out_tiles<input_cb_index>(noc, input_cb);
 
     // Calculate starting batch from starting spatial position (avoid division in loop)
     uint32_t curr_batch = start_page_id / output_hw_size;
@@ -63,14 +57,11 @@ void kernel_main() {
     // Outer loop: iterate over spatial positions (output sticks)
     for (uint32_t spatial_pos = start_page_id; spatial_pos < end_id; ++spatial_pos) {
         // Read the grid stick for this spatial position (contains grid_batches sets of coordinates)
-        uint32_t l1_write_grid_addr = get_write_ptr(grid_cb_index);
-        uint64_t grid_noc_addr = grid_tensor_accessor.get_noc_addr(spatial_pos);
-
-        noc_async_read(grid_noc_addr, l1_write_grid_addr, grid_stick_nbytes);
-        noc_async_read_barrier();
+        noc.async_read(grid_tensor_accessor, grid_cb, grid_stick_nbytes, {.page_id = spatial_pos}, {});
+        noc.async_read_barrier();
 
         // Cast to appropriate pointer type for grid data access
-        volatile tt_l1_ptr uint16_t* grid_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_grid_addr);
+        volatile tt_l1_ptr uint16_t* grid_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(grid_cb.get_write_ptr());
 
         // Inner loop: process grid_batches coordinate sets within this spatial position
         for (uint32_t grid_idx = 0; grid_idx < grid_batches; ++grid_idx) {
@@ -82,7 +73,7 @@ void kernel_main() {
                 input_width,
                 input_stick_nbytes,
                 input_cb_index,
-                scalar_cb_index>(grid_ptr, grid_idx, input_tensor_accessor, batch_offset);
+                scalar_cb_index>(noc, input_cb, scalar_cb, grid_ptr, grid_idx, input_tensor_accessor, batch_offset);
         }
 
         // Update batch tracking (avoid division in loop)

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -4,7 +4,7 @@
 
 #include <cmath>
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "ttnn/operations/pool/device/kernels/pool_kernels_common.hpp"
 #include "../grid_sample_reader_common.hpp"
 
@@ -20,15 +20,15 @@
 // so we must push placeholder pages to keep reader and compute in sync.
 // The scalar page is zeroed so the interpolation weight is 0, making the
 // padded output harmless (written to the shard but masked by valid_sticks).
-template <uint32_t input_cb_index, uint32_t scalar_cb_index>
-ALWI void push_noop_sticks() {
-    cb_reserve_back(input_cb_index, 1);
-    cb_push_back(input_cb_index, 1);
+template <uint32_t scalar_cb_index>
+ALWI void push_noop_sticks(experimental::Noc noc, experimental::CB input_cb, experimental::CB scalar_cb) {
+    input_cb.reserve_back(1);
+    input_cb.push_back(1);
 
-    cb_reserve_back(scalar_cb_index, 1);
-    zero_out_page<scalar_cb_index>(get_write_ptr(scalar_cb_index));
-    noc_async_read_barrier();
-    cb_push_back(scalar_cb_index, 1);
+    scalar_cb.reserve_back(1);
+    zero_out_page<scalar_cb_index>(noc, scalar_cb);
+    noc.async_read_barrier();
+    scalar_cb.push_back(1);
 }
 
 ALWI void advance_grid_index_bounded(
@@ -88,10 +88,14 @@ void kernel_main() {
     const uint32_t starting_batch = global_grid_stick_start / grid_hw;
 
     // Zero out input CB to handle invalid coordinates properly
-    zero_out_tiles<input_cb_index>();
+    experimental::Noc noc;
+    experimental::CB input_cb(input_cb_index);
+    experimental::CB scalar_cb(scalar_cb_index);
+    zero_out_tiles<input_cb_index>(noc, input_cb);
 
     // Get local grid data base address (already in L1)
-    const uint32_t l1_grid_base_addr = get_read_ptr(grid_cb_index);
+    experimental::CB grid_cb(grid_cb_index);
+    const uint32_t l1_grid_base_addr = grid_cb.get_read_ptr();
 
     // Clamp this core's stick count to exclude height-sharding padding.
     // Padding sticks contain garbage that would produce invalid NOC addresses.
@@ -140,11 +144,12 @@ void kernel_main() {
                 input_width,
                 input_stick_nbytes,
                 input_cb_index,
-                scalar_cb_index>(grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
+                scalar_cb_index>(
+                noc, input_cb, scalar_cb, grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
         } else {
             // Padding stick from height-sharding — push zero-weight data to CBs
             // so the compute kernel receives the expected number of items.
-            push_noop_sticks<input_cb_index, scalar_cb_index>();
+            push_noop_sticks<scalar_cb_index>(noc, input_cb, scalar_cb);
         }
 
         // Always advance once after processing

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -18,6 +19,9 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(dst_args, dst_addr, output_stick_size);
 
+    experimental::CB out_cb(cb_id_out0);
+    experimental::Noc noc;
+
     uint32_t end_stick_id = start_stick_id + num_sticks_to_write;
 
     // For grid sample: output is row major, each stick is written directly
@@ -25,23 +29,15 @@ void kernel_main() {
     for (uint32_t stick_id = start_stick_id; stick_id < end_stick_id; stick_id++) {
         {
             // Wait for ntiles_c pages in output CB (one full stick)
-            cb_wait_front(cb_id_out0, ntiles_c);
+            out_cb.wait_front(ntiles_c);
 
-            // Get base read address for this stick's data
-            uint64_t base_l1_read_addr = get_read_ptr(cb_id_out0);
+            // Write the complete stick
+            noc.async_write(out_cb, s0, output_stick_size, {}, {.page_id = stick_id});
 
-            // For row major grid sample output, we write one complete stick
-
-            uint64_t dst_noc_addr = s0.get_noc_addr(stick_id);
-
-            // Write the complete stick (ntiles_c * TILE_WIDTH elements)
-            // The data is already laid out correctly in the CB pages
-            noc_async_write(base_l1_read_addr, dst_noc_addr, output_stick_size);
-
-            noc_async_write_barrier();
+            noc.async_write_barrier();
 
             // Pop the ntiles_c pages we just consumed
-            cb_pop_front(cb_id_out0, ntiles_c);
+            out_cb.pop_front(ntiles_c);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
@@ -4,10 +4,11 @@
 
 #include <cmath>
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include "api/debug/dprint.h"
 #include <ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp>
 #include "../grid_sample_reader_common.hpp"
+// experimental headers already included via grid_sample_reader_common.hpp
 
 // Process single grid point for nearest neighbor - adapted from common utilities
 template <
@@ -22,11 +23,13 @@ template <
     typename TensorAccessor,
     typename GridPtrType>
 ALWI void process_grid_point_nearest(
+    experimental::Noc noc,
     GridPtrType grid_ptr,
     uint32_t grid_idx,
     const TensorAccessor& input_tensor_accessor,
     uint32_t batch_offset,
-    uint32_t l1_write_output_addr,
+    experimental::CB output_cb,
+    uint32_t output_write_offset,
     uint32_t fill_stick_addr) {
     // Compute scaling factors to match prepare_grid.cpp
     constexpr float input_height_f = float(input_height);
@@ -91,10 +94,20 @@ ALWI void process_grid_point_nearest(
     if (h_valid && w_valid) {
         // Read the nearest neighbor pixel
         const uint32_t input_stick_index = batch_offset + (nearest_h * input_width) + nearest_w;
-        const uint64_t input_noc_addr = input_tensor_accessor.get_noc_addr(input_stick_index);
-        noc_async_read(input_noc_addr, l1_write_output_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            output_cb,
+            input_stick_nbytes,
+            {.page_id = input_stick_index},
+            {.offset_bytes = output_write_offset});
     } else {
-        noc_async_read(get_noc_addr(fill_stick_addr), l1_write_output_addr, input_stick_nbytes);
+        experimental::UnicastEndpoint self_ep;
+        noc.async_read(
+            self_ep,
+            output_cb,
+            input_stick_nbytes,
+            experimental::local_addr(fill_stick_addr, noc.get_noc_id()),
+            {.offset_bytes = output_write_offset});
     }
 }
 
@@ -173,15 +186,19 @@ void kernel_main() {
     const uint32_t starting_batch = global_grid_stick_start / grid_hw;
 
     // Get local grid data base address (already in L1)
-    const uint32_t l1_grid_base_addr = get_write_ptr(grid_cb_index);
-    const uint32_t l1_write_output_base_addr = get_write_ptr(output_cb_index);
+    experimental::CB grid_cb(grid_cb_index);
+    experimental::CB output_cb(output_cb_index);
+    experimental::CB fill_cb(fill_cb_index);
+    experimental::Noc noc;
+
+    const uint32_t l1_grid_base_addr = grid_cb.get_write_ptr();
 
     // Process each grid stick assigned to this core
     uint32_t grid_stick_idx = 0;
     uint32_t l1_grid_addr = l1_grid_base_addr;
 
-    uint32_t fill_stick_addr = get_write_ptr(fill_cb_index);
-    zero_out_page<fill_cb_index>(fill_stick_addr);
+    uint32_t fill_stick_addr = fill_cb.get_write_ptr();
+    zero_out_page<fill_cb_index>(noc, fill_cb);
 
     // For split reader: track grid point index starting from reader_id
     uint32_t in_grid_row_idx = 0;
@@ -209,14 +226,12 @@ void kernel_main() {
         uint32_t batch_offset = curr_batch * input_height * input_width;
 
         if constexpr (!is_sharded) {
-            uint64_t grid_noc_addr = grid_tensor_accessor.get_noc_addr(grid_stick_idx + start_page_id);
-
-            noc_async_read(grid_noc_addr, l1_grid_base_addr, grid_stick_nbytes);
-            noc_async_read_barrier();
+            noc.async_read(
+                grid_tensor_accessor, grid_cb, grid_stick_nbytes, {.page_id = grid_stick_idx + start_page_id}, {});
+            noc.async_read_barrier();
         }
-        uint32_t l1_write_output_addr =
-            l1_write_output_base_addr +
-            (grid_stick_idx * grid_batching_factor * input_stick_nbytes + in_grid_row_idx * input_stick_nbytes);
+        uint32_t output_write_offset =
+            grid_stick_idx * grid_batching_factor * input_stick_nbytes + in_grid_row_idx * input_stick_nbytes;
 
         if (curr_batch < batch_size) {
             // Process nearest neighbor sampling and write directly to output
@@ -229,15 +244,23 @@ void kernel_main() {
                 input_width,
                 input_stick_nbytes,
                 output_cb_index>(
+                noc,
                 grid_stick_ptr,
                 in_grid_row_idx,
                 input_tensor_accessor,
                 batch_offset,
-                l1_write_output_addr,
+                output_cb,
+                output_write_offset,
                 fill_stick_addr);
         } else {
             // Padding stick beyond valid batches - write zeros
-            noc_async_read(get_noc_addr(fill_stick_addr), l1_write_output_addr, input_stick_nbytes);
+            experimental::UnicastEndpoint self_ep;
+            noc.async_read(
+                self_ep,
+                output_cb,
+                input_stick_nbytes,
+                experimental::local_addr(fill_stick_addr, noc.get_noc_id()),
+                {.offset_bytes = output_write_offset});
         }
 
         // Always advance once after processing
@@ -266,5 +289,5 @@ void kernel_main() {
                 grid_nsticks_per_core);
         }
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp
@@ -6,7 +6,8 @@
 
 #include <cmath>
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define ALWI inline __attribute__((always_inline))
 
@@ -136,9 +137,10 @@ struct GridCoordinateReader {
 };
 
 // Input data reading template - handles both tensor accessor and direct NOC reads
-template <typename TensorAccessor>
+template <typename TensorAccessorT>
 ALWI void read_four_corner_inputs(
-    const TensorAccessor& input_tensor_accessor,
+    experimental::Noc noc,
+    const TensorAccessorT& input_tensor_accessor,
     uint32_t batch_offset,
     uint32_t input_width,
     uint32_t input_stick_nbytes,
@@ -147,47 +149,64 @@ ALWI void read_four_corner_inputs(
     int32_t w0,
     int32_t w1,
     uint32_t input_height,
-    uint32_t l1_write_input_addr) {
+    experimental::CB input_cb) {
     // Boundary checks (recompute for performance)
     const bool h0_valid = is_coordinate_valid(h0, input_height);
     const bool h1_valid = is_coordinate_valid(h1, input_height);
     const bool w0_valid = is_coordinate_valid(w0, input_width);
     const bool w1_valid = is_coordinate_valid(w1, input_width);
 
-    uint32_t write_addr = l1_write_input_addr;
+    uint32_t write_offset = 0;
 
     // Read 4 corner input sticks via NOC from remote input tensor
     if (h0_valid && w0_valid) {
         const uint32_t north_west_stick_index = batch_offset + (h0 * input_width) + w0;
-        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(north_west_stick_index);
-        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = north_west_stick_index},
+            {.offset_bytes = write_offset});
     }
-    write_addr += input_stick_nbytes;
+    write_offset += input_stick_nbytes;
 
     if (h0_valid && w1_valid) {
         const uint32_t north_east_stick_index = batch_offset + (h0 * input_width) + w1;
-        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(north_east_stick_index);
-        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = north_east_stick_index},
+            {.offset_bytes = write_offset});
     }
-    write_addr += input_stick_nbytes;
+    write_offset += input_stick_nbytes;
 
     if (h1_valid && w0_valid) {
         const uint32_t south_west_stick_index = batch_offset + (h1 * input_width) + w0;
-        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(south_west_stick_index);
-        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = south_west_stick_index},
+            {.offset_bytes = write_offset});
     }
-    write_addr += input_stick_nbytes;
+    write_offset += input_stick_nbytes;
 
     if (h1_valid && w1_valid) {
         const uint32_t south_east_stick_index = batch_offset + (h1 * input_width) + w1;
-        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(south_east_stick_index);
-        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = south_east_stick_index},
+            {.offset_bytes = write_offset});
     }
 }
 
-template <typename TensorAccessor>
+template <typename TensorAccessorT>
 ALWI void read_four_corner_inputs_with_fill(
-    const TensorAccessor& input_tensor_accessor,
+    experimental::Noc noc,
+    const TensorAccessorT& input_tensor_accessor,
     uint32_t batch_offset,
     uint32_t input_width,
     uint32_t input_stick_nbytes,
@@ -196,48 +215,66 @@ ALWI void read_four_corner_inputs_with_fill(
     int32_t w0,
     int32_t w1,
     uint32_t input_height,
-    uint32_t l1_write_input_addr,
+    experimental::CB input_cb,
     uint32_t fill_stick_addr) {
     const bool h0_valid = is_coordinate_valid(h0, input_height);
     const bool h1_valid = is_coordinate_valid(h1, input_height);
     const bool w0_valid = is_coordinate_valid(w0, input_width);
     const bool w1_valid = is_coordinate_valid(w1, input_width);
 
-    uint32_t write_addr = l1_write_input_addr;
+    experimental::UnicastEndpoint self_ep;
+    const auto fill_src = experimental::local_addr(fill_stick_addr, noc.get_noc_id());
+    uint32_t write_offset = 0;
 
     if (h0_valid && w0_valid) {
         const uint32_t north_west_stick_index = batch_offset + (h0 * input_width) + w0;
-        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(north_west_stick_index);
-        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = north_west_stick_index},
+            {.offset_bytes = write_offset});
     } else {
-        noc_async_read(get_noc_addr(fill_stick_addr), write_addr, input_stick_nbytes);
+        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
     }
-    write_addr += input_stick_nbytes;
+    write_offset += input_stick_nbytes;
 
     if (h0_valid && w1_valid) {
         const uint32_t north_east_stick_index = batch_offset + (h0 * input_width) + w1;
-        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(north_east_stick_index);
-        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = north_east_stick_index},
+            {.offset_bytes = write_offset});
     } else {
-        noc_async_read(get_noc_addr(fill_stick_addr), write_addr, input_stick_nbytes);
+        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
     }
-    write_addr += input_stick_nbytes;
+    write_offset += input_stick_nbytes;
 
     if (h1_valid && w0_valid) {
         const uint32_t south_west_stick_index = batch_offset + (h1 * input_width) + w0;
-        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(south_west_stick_index);
-        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = south_west_stick_index},
+            {.offset_bytes = write_offset});
     } else {
-        noc_async_read(get_noc_addr(fill_stick_addr), write_addr, input_stick_nbytes);
+        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
     }
-    write_addr += input_stick_nbytes;
+    write_offset += input_stick_nbytes;
 
     if (h1_valid && w1_valid) {
         const uint32_t south_east_stick_index = batch_offset + (h1 * input_width) + w1;
-        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(south_east_stick_index);
-        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = south_east_stick_index},
+            {.offset_bytes = write_offset});
     } else {
-        noc_async_read(get_noc_addr(fill_stick_addr), write_addr, input_stick_nbytes);
+        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
     }
 }
 
@@ -253,7 +290,13 @@ template <
     typename TensorAccessor,
     typename GridPtrType>
 ALWI void process_grid_point(
-    GridPtrType grid_ptr, uint32_t grid_idx, const TensorAccessor& input_tensor_accessor, uint32_t batch_offset) {
+    experimental::Noc noc,
+    experimental::CB input_cb,
+    experimental::CB scalar_cb,
+    GridPtrType grid_ptr,
+    uint32_t grid_idx,
+    const TensorAccessor& input_tensor_accessor,
+    uint32_t batch_offset) {
     // Compute scaling factors as constexpr
     constexpr float input_height_f = float(input_height);
     constexpr float input_width_f = float(input_width);
@@ -307,12 +350,11 @@ ALWI void process_grid_point(
         }
     }
 
-    // Reserve CB space for 4 corner input sticks for this grid point
-    cb_reserve_back(input_cb_index, 1);
-    const uint32_t l1_write_input_addr = get_write_ptr(input_cb_index);
+    input_cb.reserve_back(1);
 
     // Read 4 corner input sticks
     read_four_corner_inputs(
+        noc,
         input_tensor_accessor,
         batch_offset,
         input_width,
@@ -322,14 +364,14 @@ ALWI void process_grid_point(
         w0,
         w1,
         input_height,
-        l1_write_input_addr);
+        input_cb);
 
     // Store bilinear interpolation weights for this grid point
-    cb_reserve_back(scalar_cb_index, 1);
-    const uint32_t l1_write_scalar_addr = get_write_ptr(scalar_cb_index);
+    scalar_cb.reserve_back(1);
+    const uint32_t l1_write_scalar_addr = scalar_cb.get_write_ptr();
     fill_four_val(l1_write_scalar_addr, weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf);
-    cb_push_back(scalar_cb_index, 1);
+    scalar_cb.push_back(1);
 
-    noc_async_read_barrier();
-    cb_push_back(input_cb_index, 1);
+    noc.async_read_barrier();
+    input_cb.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_bilinear_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_bilinear_interleaved.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 
 #include "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp"
 #include "ttnn/cpp/ttnn/operations/pool/device/kernels/fixed_point_arithmetic.hpp"
@@ -23,13 +23,13 @@ void kernel_main() {
     uint32_t center_y_bits = get_arg_val<uint32_t>(6);
     uint32_t fill_value_bits = get_arg_val<uint32_t>(7);
 
-    constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t scalar_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t scalar_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(2);
     constexpr uint32_t input_batch = get_compile_time_arg_val(3);
     constexpr uint32_t input_height = get_compile_time_arg_val(4);
     constexpr uint32_t input_width = get_compile_time_arg_val(5);
-    constexpr uint32_t fill_cb_index = get_compile_time_arg_val(6);
+    constexpr uint32_t fill_cb_id = get_compile_time_arg_val(6);
     constexpr uint32_t input_channels = get_compile_time_arg_val(7);
     constexpr bool fill_is_zero = get_compile_time_arg_val(8) != 0;
     constexpr uint32_t element_size = get_compile_time_arg_val(9);
@@ -46,9 +46,14 @@ void kernel_main() {
 
     const uint32_t end_stick_id = start_stick_id + num_sticks;
 
-    uint32_t fill_stick_addr = get_write_ptr(fill_cb_index);
+    experimental::CB input_cb(input_cb_id);
+    experimental::CB scalar_cb(scalar_cb_id);
+    experimental::CB fill_cb(fill_cb_id);
+    experimental::Noc noc;
+
+    uint32_t fill_stick_addr = fill_cb.get_write_ptr();
     if constexpr (fill_is_zero) {
-        zero_out_page<fill_cb_index>(fill_stick_addr);
+        zero_out_page<fill_cb_id>(noc, fill_cb);
     } else {
         volatile tt_l1_ptr uint32_t* fill_ptr32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fill_stick_addr);
         if constexpr (element_size == 2) {
@@ -68,7 +73,7 @@ void kernel_main() {
             }
         }
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
     uint32_t curr_batch = start_stick_id / hw_size;
     uint32_t spatial_pos_in_batch = start_stick_id % hw_size;
@@ -113,10 +118,10 @@ void kernel_main() {
         const uint16_t weight_sw_bf = fixed_to_bf16(weight_sw_q16);
         const uint16_t weight_se_bf = fixed_to_bf16(weight_se_q16);
 
-        cb_reserve_back(input_cb_index, 1);
-        const uint32_t l1_write_input_addr = get_write_ptr(input_cb_index);
+        input_cb.reserve_back(1);
 
         read_four_corner_inputs_with_fill(
+            noc,
             input_tensor_accessor,
             batch_offset,
             input_width,
@@ -126,16 +131,16 @@ void kernel_main() {
             w0,
             w1,
             input_height,
-            l1_write_input_addr,
+            input_cb,
             fill_stick_addr);
 
-        cb_reserve_back(scalar_cb_index, 1);
-        const uint32_t l1_write_scalar_addr = get_write_ptr(scalar_cb_index);
+        scalar_cb.reserve_back(1);
+        const uint32_t l1_write_scalar_addr = scalar_cb.get_write_ptr();
         fill_four_val(l1_write_scalar_addr, weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf);
-        cb_push_back(scalar_cb_index, 1);
+        scalar_cb.push_back(1);
 
-        noc_async_read_barrier();
-        cb_push_back(input_cb_index, 1);
+        noc.async_read_barrier();
+        input_cb.push_back(1);
 
         ++spatial_pos_in_batch;
         if (spatial_pos_in_batch == hw_size) {

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_nearest_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_nearest_interleaved.cpp
@@ -18,14 +18,14 @@ void kernel_main() {
     int32_t center_y = static_cast<int32_t>(get_arg_val<uint32_t>(6));
     uint32_t fill_value_bf16 = get_arg_val<uint32_t>(7);
 
-    constexpr uint32_t output_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(1);
     constexpr uint32_t input_batch = get_compile_time_arg_val(2);
     constexpr uint32_t input_height = get_compile_time_arg_val(3);
     constexpr uint32_t input_width = get_compile_time_arg_val(4);
     constexpr uint32_t input_channels = get_compile_time_arg_val(5);
     constexpr uint32_t num_cb_pages = get_compile_time_arg_val(6);
-    constexpr uint32_t fill_cb_index = get_compile_time_arg_val(7);
+    constexpr uint32_t fill_cb_id = get_compile_time_arg_val(7);
     constexpr uint32_t input_stick_nbytes_unaligned = get_compile_time_arg_val(8);
     constexpr bool fill_is_zero = get_compile_time_arg_val(9) != 0;
     constexpr uint32_t burst_size = get_compile_time_arg_val(10);
@@ -33,9 +33,14 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<11>();
     const auto input_tensor_accessor = TensorAccessor(src_args, input_addr, input_stick_nbytes_unaligned);
 
-    uint32_t fill_stick_addr = get_write_ptr(fill_cb_index);
+    experimental::CB output_cb(output_cb_id);
+    experimental::CB fill_cb(fill_cb_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint self_ep;
+
+    uint32_t fill_stick_addr = fill_cb.get_write_ptr();
     if constexpr (fill_is_zero) {
-        zero_out_page<fill_cb_index>(fill_stick_addr);
+        zero_out_page<fill_cb_id>(noc, fill_cb);
     } else {
         volatile tt_l1_ptr uint32_t* fill_ptr32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fill_stick_addr);
         const uint32_t fill_value_packed = (fill_value_bf16 << 16) | fill_value_bf16;
@@ -52,8 +57,8 @@ void kernel_main() {
     for (uint32_t local_stick_idx = 0; local_stick_idx < num_sticks;) {
         uint32_t sticks_this_burst =
             (num_sticks - local_stick_idx) < burst_size ? (num_sticks - local_stick_idx) : burst_size;
-        cb_reserve_back(output_cb_index, sticks_this_burst);
-        uint32_t l1_write_addr = get_write_ptr(output_cb_index);
+        output_cb.reserve_back(sticks_this_burst);
+        uint32_t write_offset = 0;
 
         for (uint32_t i = 0; i < sticks_this_burst; i++, local_stick_idx++) {
             const uint32_t global_stick_idx = start_stick_id + local_stick_idx;
@@ -82,15 +87,24 @@ void kernel_main() {
             if (x_valid && y_valid) {
                 const uint32_t input_stick_index =
                     batch_idx * (input_height * input_width) + nearest_y * input_width + nearest_x;
-                const uint64_t input_noc_addr = input_tensor_accessor.get_noc_addr(input_stick_index);
-                noc_async_read(input_noc_addr, l1_write_addr, input_stick_nbytes_unaligned);
+                noc.async_read(
+                    input_tensor_accessor,
+                    output_cb,
+                    input_stick_nbytes_unaligned,
+                    {.page_id = input_stick_index},
+                    {.offset_bytes = write_offset});
             } else {
-                noc_async_read(get_noc_addr(fill_stick_addr), l1_write_addr, input_stick_nbytes_unaligned);
+                noc.async_read(
+                    self_ep,
+                    output_cb,
+                    input_stick_nbytes_unaligned,
+                    experimental::local_addr(fill_stick_addr, noc.get_noc_id()),
+                    {.offset_bytes = write_offset});
             }
-            l1_write_addr += input_stick_nbytes;
+            write_offset += input_stick_nbytes;
         }
 
-        noc_async_read_barrier();
-        cb_push_back(output_cb_index, sticks_this_burst);
+        noc.async_read_barrier();
+        output_cb.push_back(sticks_this_burst);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/writer_rotate_nearest_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/writer_rotate_nearest_interleaved.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     // Runtime arguments
@@ -12,26 +13,33 @@ void kernel_main() {
     uint32_t start_stick_id = get_arg_val<uint32_t>(2);
 
     // Compile-time arguments
-    constexpr uint32_t output_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t output_stick_nbytes = get_compile_time_arg_val(1);
     constexpr uint32_t num_cb_pages = get_compile_time_arg_val(2);
     constexpr uint32_t burst_size = get_compile_time_arg_val(3);
     constexpr auto dst_args = TensorAccessorArgs<4>();
     const auto output_tensor_accessor = TensorAccessor(dst_args, output_addr, output_stick_nbytes);
 
+    experimental::CB output_cb(output_cb_id);
+    experimental::Noc noc;
+
     for (uint32_t local_stick_idx = 0; local_stick_idx < num_sticks;) {
         uint32_t sticks_this_burst =
             (num_sticks - local_stick_idx) < burst_size ? (num_sticks - local_stick_idx) : burst_size;
-        cb_wait_front(output_cb_index, sticks_this_burst);
-        uint32_t l1_read_addr = get_read_ptr(output_cb_index);
+        output_cb.wait_front(sticks_this_burst);
+        uint32_t read_offset = 0;
 
         for (uint32_t i = 0; i < sticks_this_burst; i++, local_stick_idx++) {
             const uint32_t global_stick_idx = start_stick_id + local_stick_idx;
-            const uint64_t output_noc_addr = output_tensor_accessor.get_noc_addr(global_stick_idx);
-            noc_async_write(l1_read_addr, output_noc_addr, output_stick_nbytes);
-            l1_read_addr += output_stick_nbytes;
+            noc.async_write(
+                output_cb,
+                output_tensor_accessor,
+                output_stick_nbytes,
+                {.offset_bytes = read_offset},
+                {.page_id = global_stick_idx});
+            read_offset += output_stick_nbytes;
         }
-        noc_async_write_barrier();
-        cb_pop_front(output_cb_index, sticks_this_burst);
+        noc.async_write_barrier();
+        output_cb.pop_front(sticks_this_burst);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
@@ -132,26 +132,11 @@ ttsl::hash::hash_t RotateDeviceOperation::compute_program_hash(
         tensor_args.input.dtype());
 }
 
-std::tuple<RotateDeviceOperation::operation_attributes_t, RotateDeviceOperation::tensor_args_t>
-rotate_build_operation_args(
-    const Tensor& input,
-    float angle,
-    const std::optional<std::tuple<float, float>>& center,
-    float fill,
-    bool expand,
-    const std::string& interpolation_mode,
-    const std::optional<MemoryConfig>& memory_config) {
-    return {
-        RotateDeviceOperation::operation_attributes_t{
-            angle, center, fill, expand, interpolation_mode, memory_config.value_or(input.memory_config())},
-        RotateDeviceOperation::tensor_args_t{input}};
-}
-
 }  // namespace ttnn::operations::rotate
 
 namespace ttnn::prim {
 
-Tensor rotate(
+ttnn::Tensor rotate(
     const Tensor& input,
     float angle,
     const std::optional<std::tuple<float, float>>& center,
@@ -159,9 +144,11 @@ Tensor rotate(
     bool expand,
     const std::string& interpolation_mode,
     const std::optional<MemoryConfig>& memory_config) {
-    auto [attrs, tensor_args] = operations::rotate::rotate_build_operation_args(
-        input, angle, center, fill, expand, interpolation_mode, memory_config);
-    return ttnn::device_operation::launch<operations::rotate::RotateDeviceOperation>(attrs, tensor_args);
+    using Op = ttnn::operations::rotate::RotateDeviceOperation;
+    return ttnn::device_operation::launch<Op>(
+        Op::operation_attributes_t{
+            angle, center, fill, expand, interpolation_mode, memory_config.value_or(input.memory_config())},
+        Op::tensor_args_t{input});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.hpp
@@ -5,8 +5,6 @@
 #pragma once
 
 #include <string>
-#include <tuple>
-
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::operations::rotate {
@@ -92,21 +90,10 @@ struct RotateDeviceOperation {
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
-std::tuple<RotateDeviceOperation::operation_attributes_t, RotateDeviceOperation::tensor_args_t>
-rotate_build_operation_args(
-    const Tensor& input,
-    float angle,
-    const std::optional<std::tuple<float, float>>& center,
-    float fill,
-    bool expand,
-    const std::string& interpolation_mode,
-    const std::optional<MemoryConfig>& memory_config);
-
 }  // namespace ttnn::operations::rotate
 
 namespace ttnn::prim {
-
-Tensor rotate(
+ttnn::Tensor rotate(
     const Tensor& input,
     float angle,
     const std::optional<std::tuple<float, float>>& center,
@@ -114,5 +101,4 @@ Tensor rotate(
     bool expand,
     const std::string& interpolation_mode,
     const std::optional<MemoryConfig>& memory_config);
-
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/pack_untilize.h"
 #include "internal/circular_buffer_interface.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // Push 1 stick or partial stick to a cb (a (partial) stick consists of num_pages pages, in our case, size of a page is
 // the width of a tile (setup in program factory))
@@ -24,9 +25,10 @@ inline void llk_push_pages_bilinear(const std::int32_t operand, const std::int32
 }
 
 template <uint32_t tiles_per_reduction, uint32_t unpA_face_r_dim>
-inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_id, const uint32_t out_cb_id) {
+inline void reduce_h_fused(experimental::CB in_cb, experimental::CB scalar_cb, experimental::CB out_cb) {
+    const uint32_t out_cb_id = out_cb.get_cb_id();
     tile_regs_acquire();
-    cb_wait_front(in_cb_id, 4);
+    in_cb.wait_front(4);
 
     // Template parameters for unpack_tilizeA_B_block:
     constexpr bool use_neginf_srcA = false;  // Don't use negative infinity for source A
@@ -39,11 +41,11 @@ inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_
     constexpr uint32_t num_faces = 2;  // Unpack 2 faces (top faces contain 4 rows needed for bilinear interpolation)
 
     unpack_tilizeA_B_block<use_neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
-        in_cb_id, in_scalar_cb_id, tiles_per_reduction, scalar_tile_idx, num_faces, unpA_face_r_dim);
+        in_cb.get_cb_id(), scalar_cb.get_cb_id(), tiles_per_reduction, scalar_tile_idx, num_faces, unpA_face_r_dim);
     for (uint32_t c_i = 0; c_i < tiles_per_reduction; ++c_i) {
         reduce_tile_math(c_i, num_faces);  // Reduce the 2 faces (containing 4 rows for bilinear interpolation)
     }
-    cb_pop_front(in_cb_id, 4);
+    in_cb.pop_front(4);
 
     tile_regs_wait();
     tile_regs_commit();
@@ -85,19 +87,24 @@ void kernel_main() {
     constexpr uint32_t num_faces = 2;        // Use 2 faces (top faces contain 4 rows for bilinear interpolation)
     constexpr uint32_t face_r_dim = 4;       // 4 rows per face (sufficient for bilinear interpolation)
 
+    experimental::CB tilize_reduce_cb0(tilize_reduce_cb_0);
+    experimental::CB tilize_reduce_cb1(tilize_reduce_cb_1);
+    experimental::CB scalar_cb_1(in_scalar_cb_id1);
+    experimental::CB scalar_cb_2(in_scalar_cb_id2);
+    experimental::CB out_cb(out_cb_id);
+
     tilizeA_B_reduce_init<use_neginf_srcA, zero_srcA_reduce>(
         tilize_reduce_cb_0, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, num_faces, face_r_dim);
     pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, 1, num_faces); /* pack 1 row (1x32) from 2 faces */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
-        const uint32_t cb_id = (i % 2 == 0) ? tilize_reduce_cb_0 : tilize_reduce_cb_1;
-        const uint32_t scalar_cb_id = (i % 2 == 0) ? in_scalar_cb_id1 : in_scalar_cb_id2;
+        experimental::CB cur_in_cb = (i % 2 == 0) ? tilize_reduce_cb0 : tilize_reduce_cb1;
+        experimental::CB cur_scalar_cb = (i % 2 == 0) ? scalar_cb_1 : scalar_cb_2;
 
         for (uint32_t j = 0; j < blocks - 1; j++) {
-            // Wait for the core to push data in cb
-            reduce_h_fused<max_tiles_per_iter, window_size_hw>(cb_id, scalar_cb_id, out_cb_id);
-            cb_pop_front(scalar_cb_id, 1);
+            reduce_h_fused<max_tiles_per_iter, window_size_hw>(cur_in_cb, cur_scalar_cb, out_cb);
+            cur_scalar_cb.pop_front(1);
         }
-        reduce_h_fused<partial_iter_output_tiles, window_size_hw>(cb_id, scalar_cb_id, out_cb_id);
-        cb_pop_front(scalar_cb_id, 1);
+        reduce_h_fused<partial_iter_output_tiles, window_size_hw>(cur_in_cb, cur_scalar_cb, out_cb);
+        cur_scalar_cb.pop_front(1);
     }
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include <ttnn/operations/pool/device/kernels/fixed_point_arithmetic.hpp>
 #include "bilinear_weights_lut.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 //
 // Halo padding configuration
@@ -295,7 +295,13 @@ void kernel_main() {
     constexpr uint32_t blocks = get_compile_time_arg_val(14);
     constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(15);
 
-    uint32_t l1_read_addr = get_read_ptr(halo_cb_id);
+    experimental::CB halo_cb(halo_cb_id);
+    experimental::CB tilize_reduce_cb(tilize_reduce_cb_id);
+    experimental::CB scalar_cb(in_scalar_cb_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint self_ep;
+
+    uint32_t l1_read_addr = halo_cb.get_read_ptr();
 
     // Split work between reader and writer threads
     // Reader gets ceiling(N/2), writer gets floor(N/2)
@@ -352,34 +358,54 @@ void kernel_main() {
         uint32_t block_offset = 0;
 #pragma unroll
         for (uint32_t i = 0; i < blocks; i++) {
-            cb_reserve_back(tilize_reduce_cb_id, 4);
+            tilize_reduce_cb.reserve_back(4);
 
             uint32_t current_block_size_bytes = (i == blocks - 1) ? last_block_size_bytes : input_block_size_bytes;
 
-            uint32_t l1_write_addr = get_write_ptr(tilize_reduce_cb_id);
+            uint32_t write_offset = 0;
 
             // Read 4 neighbor stick segments
-            noc_async_read(get_noc_addr(y1x1_addr + block_offset), l1_write_addr, current_block_size_bytes);
-            l1_write_addr += input_block_size_bytes;
+            noc.async_read(
+                self_ep,
+                tilize_reduce_cb,
+                current_block_size_bytes,
+                experimental::local_addr(y1x1_addr + block_offset),
+                {.offset_bytes = write_offset});
+            write_offset += input_block_size_bytes;
 
-            noc_async_read(get_noc_addr(y1x2_addr + block_offset), l1_write_addr, current_block_size_bytes);
-            l1_write_addr += input_block_size_bytes;
+            noc.async_read(
+                self_ep,
+                tilize_reduce_cb,
+                current_block_size_bytes,
+                experimental::local_addr(y1x2_addr + block_offset),
+                {.offset_bytes = write_offset});
+            write_offset += input_block_size_bytes;
 
-            noc_async_read(get_noc_addr(y2x1_addr + block_offset), l1_write_addr, current_block_size_bytes);
-            l1_write_addr += input_block_size_bytes;
+            noc.async_read(
+                self_ep,
+                tilize_reduce_cb,
+                current_block_size_bytes,
+                experimental::local_addr(y2x1_addr + block_offset),
+                {.offset_bytes = write_offset});
+            write_offset += input_block_size_bytes;
 
-            noc_async_read(get_noc_addr(y2x2_addr + block_offset), l1_write_addr, current_block_size_bytes);
+            noc.async_read(
+                self_ep,
+                tilize_reduce_cb,
+                current_block_size_bytes,
+                experimental::local_addr(y2x2_addr + block_offset),
+                {.offset_bytes = write_offset});
 
             // Write weights for compute kernel
             fill_four_val(
-                get_write_ptr(in_scalar_cb_id),
+                scalar_cb.get_write_ptr(),
                 weight_top_left_bf16,
                 weight_top_right_bf16,
                 weight_bottom_left_bf16,
                 weight_bottom_right_bf16);
-            cb_push_back(in_scalar_cb_id, 1);
+            scalar_cb.push_back(1);
 
-            cb_push_back(tilize_reduce_cb_id, 4);
+            tilize_reduce_cb.push_back(4);
             block_offset += current_block_size_bytes;
         }
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_nearest_float.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_nearest_float.cpp
@@ -4,8 +4,9 @@
 
 #include <stdint.h>
 
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
 #include <ttnn/operations/pool/device/kernels/fixed_point_arithmetic.hpp>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     // Runtime arguments
@@ -28,6 +29,9 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<9>();
     const auto input_tensor_accessor = TensorAccessor(src_args, input_buffer_addr, aligned_stick_nbytes);
 
+    experimental::CB out_cb(cb_id_out);
+    experimental::Noc noc;
+
     // Process sticks assigned to this core
     uint32_t page_id = start_stick_id;
     for (uint32_t i = 0; i < num_sticks; i++) {
@@ -41,8 +45,6 @@ void kernel_main() {
         const uint32_t x_out = remainder % output_width;
 
         // Map output coordinates to input coordinates using fixed-point arithmetic
-        // src_y = floor(y_out * reciprocal_scale_h) = floor(y_out / scale_h)
-        // src_x = floor(x_out * reciprocal_scale_w) = floor(x_out / scale_w)
         const uint32_t src_y =
             static_cast<uint32_t>(fixed_point_arithmetic::fixed_mul(y_out, reciprocal_scale_h_fixed));
         const uint32_t src_x =
@@ -58,20 +60,16 @@ void kernel_main() {
                                       clamped_src_x * num_pages_per_width + in_stick_offset;
 
         // Reserve space in output CB
-        cb_reserve_back(cb_id_out, 1);
-
-        // Get L1 write address
-        uint32_t l1_write_addr = get_write_ptr(cb_id_out);
+        out_cb.reserve_back(1);
 
         // Read source stick from DRAM
-        uint64_t src_noc_addr = input_tensor_accessor.get_noc_addr(src_stick_id);
-        noc_async_read(src_noc_addr, l1_write_addr, aligned_stick_nbytes);
+        noc.async_read(input_tensor_accessor, out_cb, aligned_stick_nbytes, {.page_id = src_stick_id}, {});
 
         // Wait for read to complete
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // Push to CB
-        cb_push_back(cb_id_out, 1);
+        out_cb.push_back(1);
 
         page_id++;
     }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_upsample_unary_stick_layout_interleaved_start_id.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -16,18 +17,19 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<2>();
     const auto s0 = TensorAccessor(src_args, src_addr, page_size);
 
+    experimental::CB in_cb(cb_id_in0);
+    experimental::Noc noc;
+
     const uint32_t end_id = start_page_id + num_pages;
 
     // reader copied the data from DRAM to CB buffer.
     for (uint32_t i = start_page_id; i < end_id; ++i) {
-        cb_reserve_back(cb_id_in0, 1);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        uint64_t src_noc_addr = s0.get_noc_addr(i);
+        in_cb.reserve_back(1);
 
-        noc_async_read(src_noc_addr, l1_write_addr, page_size);
+        noc.async_read(s0, in_cb, page_size, {.page_id = i}, {});
 
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
-        cb_push_back(cb_id_in0, 1);
+        in_cb.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_interleaved.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -29,6 +30,9 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<8>();
     const auto s0 = TensorAccessor(dst_args, dst_addr, output_page_size);
 
+    experimental::CB out_cb(cb_id_out0);
+    experimental::Noc noc;
+
     constexpr uint32_t in_width = width / scale_w;
     constexpr uint32_t in_height = height / scale_h;
     uint32_t end_block_id = start_block_id + num_blocks_to_read;
@@ -38,9 +42,7 @@ void kernel_main() {
     uint32_t current_stick = block_height * start_block_id;
 
     for (uint32_t b = start_block_id; b < end_block_id; b++) {
-        cb_wait_front(cb_id_out0, num_tiles_per_block_row);
-
-        uint64_t base_l1_read_addr = get_read_ptr(cb_id_out0);
+        out_cb.wait_front(num_tiles_per_block_row);
 
         for (uint32_t in_block_row = 0; in_block_row < block_height; ++in_block_row) {
             uint32_t curr_index = current_stick % (in_width * in_height);
@@ -48,7 +50,7 @@ void kernel_main() {
             uint32_t x = curr_index / in_width;
             uint32_t y = curr_index % in_width;
 
-            uint64_t read_addr = base_l1_read_addr + in_block_row * output_page_size;
+            uint32_t read_offset = in_block_row * output_page_size;
 
             // calculate the start index where writer will start writing the data.
             // total --> scale_h * scale_w times data will be written to the DRAM.
@@ -57,15 +59,15 @@ void kernel_main() {
 
             for (uint32_t j = 0; j < scale_h; j++) {
                 for (uint32_t k = 0; k < scale_w; k++) {
-                    uint64_t offset = j * width + k;
+                    uint32_t offset = j * width + k;
 
-                    uint64_t dst_noc_addr_1 = s0.get_noc_addr(start_index + offset);
-                    noc_async_write(read_addr, dst_noc_addr_1, output_page_size);
+                    noc.async_write(
+                        out_cb, s0, output_page_size, {.offset_bytes = read_offset}, {.page_id = start_index + offset});
                 }
             }
             current_stick++;
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, num_tiles_per_block_row);
+        noc.async_write_barrier();
+        out_cb.pop_front(num_tiles_per_block_row);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);
@@ -23,13 +24,19 @@ void kernel_main() {
         ((in_nsticks_per_core * scale_h + 1) / 2) *
         scale_w;  // divided by 2 because each core has 2 readers which get near equal number of output sticks
 
-    uint32_t l1_read_addr = get_read_ptr(in_cb_id);
-    uint32_t l1_write_addr = get_write_ptr(out_cb_id);
+    experimental::CB in_cb(in_cb_id);
+    experimental::CB out_cb(out_cb_id);
+    experimental::CB config_cb(config_cb_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint remote_ep;
+
+    uint32_t l1_read_addr = in_cb.get_read_ptr();
+    uint32_t write_offset = 0;
     if (!is_reader) {
-        l1_write_addr += out_nsticks_per_core * stick_nbytes;
+        write_offset = out_nsticks_per_core * stick_nbytes;
     }
 
-    uint32_t config_l1_addr = get_read_ptr(config_cb_id);
+    uint32_t config_l1_addr = config_cb.get_read_ptr();
     // Interpreted as a vector of 32bit elements to lessen the number of l1 reads
     volatile tt_l1_ptr uint32_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
 
@@ -50,14 +57,19 @@ void kernel_main() {
         const uint16_t offset_end = offset_info >> 16;
 
         for (uint32_t offset = offset_start; offset <= offset_end; offset++) {
-            uint64_t src_remote_addr = get_noc_addr(corex, corey, l1_read_addr + offset * stick_nbytes);
+            uint32_t src_addr = l1_read_addr + offset * stick_nbytes;
             // replicate stick scale_w times.
             for (uint32_t sw = 0; sw < scale_w; sw++) {
-                noc_async_read(src_remote_addr, l1_write_addr, stick_nbytes);
-                l1_write_addr += stick_nbytes;
+                noc.async_read(
+                    remote_ep,
+                    out_cb,
+                    stick_nbytes,
+                    {.noc_x = corex, .noc_y = corey, .addr = src_addr},
+                    {.offset_bytes = write_offset});
+                write_offset += stick_nbytes;
             }
         }
     }
 
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_nearest_float.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_nearest_float.cpp
@@ -4,7 +4,8 @@
 
 #include <stdint.h>
 
-#include "api/dataflow/dataflow_api.h"
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     // Runtime arguments
@@ -20,24 +21,23 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<2>();
     const auto output_tensor_accessor = TensorAccessor(dst_args, output_buffer_addr, aligned_stick_nbytes);
 
+    experimental::CB out_cb(cb_id_out);
+    experimental::Noc noc;
+
     // Process sticks assigned to this core
     uint32_t stick_id = start_stick_id;
     for (uint32_t i = 0; i < num_sticks; i++) {
         // Wait for data in CB
-        cb_wait_front(cb_id_out, 1);
-
-        // Get L1 read address
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        out_cb.wait_front(1);
 
         // Write to output DRAM
-        uint64_t dst_noc_addr = output_tensor_accessor.get_noc_addr(stick_id);
-        noc_async_write(l1_read_addr, dst_noc_addr, aligned_stick_nbytes);
+        noc.async_write(out_cb, output_tensor_accessor, aligned_stick_nbytes, {}, {.page_id = stick_id});
 
         // Wait for write to complete
-        noc_async_write_barrier();
+        noc.async_write_barrier();
 
         // Pop from CB
-        cb_pop_front(cb_id_out, 1);
+        out_cb.pop_front(1);
 
         stick_id++;
     }


### PR DESCRIPTION
## Summary

- Migrate all conv2d, pool, grid_sample, rotate, and upsample dataflow/compute kernels from legacy API (`noc_async_read/write`, `cb_reserve_back/push_back`, raw semaphore pointers) to the experimental Device 2.0 API (`experimental::Noc`, `experimental::CB`, `experimental::Semaphore`)
- Add shared convenience header (`experimental_device_api.hpp`) with single-packet read wrappers, `local_addr()` helper, and short type aliases for `CB`/`Noc`
- Fix double `get_semaphore()` bug in split-reader and width-sharded semaphore init that caused silent weight data corruption
- Fix `compute_pool_2d` semantic divergence where `curr_scalar_cb_id` and `curr_scalar_cb` used different selection logic
- Fix grid_sample/rotate fill reads using hardcoded `my_x[0]`/`my_y[0]` instead of NOC-aware coordinates
- Update perf targets for UNet (+0.8% BH, +2.3% WH) and SDXL conv2d block sharded (-4.2% latency on WH)

## Test plan
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests-pr.yaml/badge.svg?branch=pjosipovic%2Fconv_dm2)](https://github.com/tenstorrent/tt-metal/actions/runs/24133050112)
- [ ] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=pjosipovic%2Fconv_dm2)](https://github.com/tenstorrent/tt-metal/actions/runs/24133008360)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic%2Fconv_dm2)](https://github.com/tenstorrent/tt-metal/actions/runs/24133077940)
- [ ] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic%2Fconv_dm2)](https://github.com/tenstorrent/tt-metal/actions/runs/24133080164)

🤖 Generated with [Claude Code](https://claude.com/claude-code)