### PR TITLE
Feature: Printing strings with DEVICE_PRINT

### DIFF
--- a/docs/source/tt-metalium/tools/device_print.rst
+++ b/docs/source/tt-metalium/tools/device_print.rst
@@ -47,6 +47,47 @@ An example with the different features available is shown below:
         DEVICE_PRINT_DATA1("this is the data movement kernel on noc 1\n");
     }
 
+Strings
+^^^^^^^
+
+Runtime ``const char*`` pointers are printed as hex addresses since the host cannot read device memory.
+To print the actual string content, use ``CTSTR()`` which stores the string in the ELF at compile time
+so the host can resolve it:
+
+.. code-block:: c++
+
+    const char* s = "Hello world!";
+    DEVICE_PRINT("Pointer: {}\n", s);               // prints: Pointer: 0x12345678
+    DEVICE_PRINT("String: {}\n", CTSTR("Hello!"));  // prints: String: Hello!
+
+Enums
+^^^^^
+
+Enum types are supported natively. When DWARF debug info is present in the ELF, enum values are
+printed as their symbolic names. Use ``{:#}`` to include the fully-qualified type name:
+
+.. code-block:: c++
+
+    enum class Color : uint8_t { Red = 0, Green = 1, Blue = 2 };
+    DEVICE_PRINT("Color: {}\n", Color::Green);    // prints: Color: Green
+    DEVICE_PRINT("Color: {:#}\n", Color::Blue);   // prints: Color: Color::Blue
+
+Flag enums (with ``operator|``) are detected at compile time and printed with ``|`` separators:
+
+.. code-block:: c++
+
+    enum class Flags : uint32_t { A = 1, B = 2, C = 4 };
+    constexpr Flags operator|(Flags a, Flags b) {
+        return static_cast<Flags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+    }
+    DEVICE_PRINT("Flags: {}\n", Flags::A | Flags::C);    // prints: Flags: A | C
+    DEVICE_PRINT("Flags: {:#}\n", Flags::A | Flags::C);  // prints: Flags: Flags::A | Flags::C
+
+If no DWARF debug info is available, enum values are printed as ``(TypeName)integer``.
+
+Circular Buffers
+^^^^^^^^^^^^^^^^
+
 Data from Circular Buffers can be printed using the ``TileSlice`` object. It can be constructed as described below, and fed directly to a ``DEVICE_PRINT`` call.
 
 +-----------------+---------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
@@ -215,3 +215,13 @@ TEST_F(DevicePrintFormatUpdatesFixture, PrintBuiltinTypes) {
     TestFormatUpdate(
         "tests/tt_metal/tt_metal/test_kernels/device_print/print_builtin_types.cpp", ttsl::make_span(messages));
 }
+
+TEST_F(DevicePrintFormatUpdatesFixture, PrintStringTypes) {
+    std::vector<std::string_view> messages = {
+        "Sample string: {0,s}\n"sv,
+        "Compile time string: {0,s}\n"sv,
+    };
+
+    TestFormatUpdate(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_string_types.cpp", ttsl::make_span(messages));
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -253,3 +253,14 @@ TEST_F(DevicePrintOutputFixture, PrintBuiltinTypes) {
 
     TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_builtin_types.cpp", messages);
 }
+
+TEST_F(DevicePrintOutputFixture, PrintStringTypes) {
+    std::vector<std::string> messages = {
+        // Runtime const char* prints as hex address (we just check the prefix)
+        "Sample string: 0x",
+        // Compile-time CTSTR resolves to the actual string content from the ELF
+        "Compile time string: Hello world!",
+    };
+
+    TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_string_types.cpp", messages);
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
@@ -275,7 +275,7 @@ static DramBuffer prepare_reader(
     create_circular_buffer(
         workload, config.core, DEFAULT_INPUT_CB_INDEX, config.data_format, config.get_input_buffer_size());
 
-    // Create reader kernel
+    // Create reader kernel (second compile arg: use_dfbs = 0, use circular buffers)
     auto reader_kernel = tt_metal::CreateKernel(
         program_,
         config.reader_kernel,
@@ -283,7 +283,7 @@ static DramBuffer prepare_reader(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt_metal::NOC::RISCV_1_default,
-            .compile_args = {DEFAULT_INPUT_CB_INDEX}});
+            .compile_args = {DEFAULT_INPUT_CB_INDEX, 0}});
 
     // Set runtime arguments for the reader kernel
     tt_metal::SetRuntimeArgs(
@@ -307,7 +307,7 @@ static DramBuffer prepare_writer(
     create_circular_buffer(
         workload, config.core, DEFAULT_OUTPUT_CB_INDEX, config.data_format, config.get_output_buffer_size());
 
-    // Create writer kernel
+    // Create writer kernel (second compile arg: use_dfbs = 0, use circular buffers)
     auto writer_kernel = tt_metal::CreateKernel(
         program_,
         config.writer_kernel,
@@ -315,7 +315,7 @@ static DramBuffer prepare_writer(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = {DEFAULT_OUTPUT_CB_INDEX}});
+            .compile_args = {DEFAULT_OUTPUT_CB_INDEX, 0}});
 
     // Set runtime arguments for the writer kernel
     tt_metal::SetRuntimeArgs(

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_string_types.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_string_types.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+
+/*
+ * Test printing from a kernel running on BRISC.
+ */
+
+void kernel_main() {
+    const char* s = "Hello world!";
+    DEVICE_PRINT("Sample string: {}\n", s);
+    DEVICE_PRINT("Compile time string: {}\n", CTSTR("Hello world!"));
+}

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -29,6 +29,21 @@
 // Start of the .device_print_strings_info section, which represents list of DevicePrintStringInfo structures.
 extern char __device_print_strings_info_start[];
 
+// Wrapper for compile-time strings stored in the .device_print_strings ELF section.
+// The host-side parser can resolve the pointer back to the string content via the ELF.
+struct ct_string {
+    const char* ptr;
+};
+
+// Stores a string literal in the .device_print_strings ELF section and returns a ct_string
+// that DEVICE_PRINT can serialize. The host parser resolves the address to read the string.
+#define CTSTR(literal)                                                                                              \
+    ([&]() -> ct_string {                                                                                           \
+        static const char allocated_ct_string[] __attribute__((section(DEVICE_PRINT_STRINGS_SECTION_NAME), used)) = \
+            literal;                                                                                                \
+        return ct_string{allocated_ct_string};                                                                      \
+    }())
+
 struct bf4_t {
     union {
         struct {
@@ -805,6 +820,22 @@ struct device_print_type<const char*> {
                 reinterpret_cast<uint64_t>(argument);
         } else {
             static_assert(sizeof(const char*) == 4 || sizeof(const char*) == 8, "Unsupported pointer size");
+        }
+    }
+};
+
+// Compile-time strings (CTSTR) — serialized as pointer, same type char 's' as const char*.
+// The host parser distinguishes by checking if the address falls within .device_print_strings.
+template <>
+struct device_print_type<ct_string> {
+    static constexpr device_print_type_info value = {'s', sizeof(const char*)};
+    static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, ct_string argument) {
+        if constexpr (sizeof(const char*) == 4) {
+            *reinterpret_cast<device_print_buffer_ptr<uint32_t>>(device_print_buffer + offset) =
+                reinterpret_cast<uint32_t>(argument.ptr);
+        } else if constexpr (sizeof(const char*) == 8) {
+            *reinterpret_cast<device_print_buffer_ptr<uint64_t>>(device_print_buffer + offset) =
+                reinterpret_cast<uint64_t>(argument.ptr);
         }
     }
 };

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -38,7 +38,7 @@ struct ct_string {
 // Stores a string literal in the .device_print_strings ELF section and returns a ct_string
 // that DEVICE_PRINT can serialize. The host parser resolves the address to read the string.
 #define CTSTR(literal)                                                                                              \
-    ([&]() -> ct_string {                                                                                           \
+    ([]() -> ct_string {                                                                                            \
         static const char allocated_ct_string[] __attribute__((section(DEVICE_PRINT_STRINGS_SECTION_NAME), used)) = \
             literal;                                                                                                \
         return ct_string{allocated_ct_string};                                                                      \

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -1168,6 +1168,28 @@ std::string_view DevicePrintParser::format_message(
                     arg);
                 break;
             }
+            case 's':  // string pointer — resolve from .device_print_strings if possible, else hex
+            {
+                uint32_t str_addr = std::get<uint32_t>(buffer.argument_values[placeholder.arg_id]);
+                if (str_addr >= format_strings_address &&
+                    str_addr < format_strings_address + format_strings_bytes.size()) {
+                    const char* str_ptr = reinterpret_cast<const char*>(
+                        format_strings_bytes.data() + (str_addr - format_strings_address));
+                    fmt::format_to(
+                        std::back_inserter(buffer.buffer),
+                        fmt::runtime(placeholder.fmt_format),
+                        std::string_view(str_ptr));
+                } else {
+                    fmt::format_to(std::back_inserter(buffer.buffer), "0x{:x}", str_addr);
+                }
+                break;
+            }
+            case 'p':  // generic pointer — print as hex address
+                fmt::format_to(
+                    std::back_inserter(buffer.buffer),
+                    "0x{:x}",
+                    std::get<uint32_t>(buffer.argument_values[placeholder.arg_id]));
+                break;
             default: TT_THROW("Unsupported type_id in format placeholder (format_message): {}", placeholder.type_id);
         }
     }
@@ -1245,6 +1267,9 @@ DevicePrintParser::ArgumentValue DevicePrintParser::read_argument_from_payload(
             }
             return arr;
         }
+        case 's':  // string pointer (resolved from ELF section if possible, else hex)
+        case 'p':  // generic pointer
+            return read_value_from_payload<uint32_t>(payload_bytes, offset);
         default: TT_THROW("Unsupported type_id in format placeholder (read_argument_from_payload): {}", type_id);
     }
 }

--- a/tt_metal/impl/debug/dprint_parser.hpp
+++ b/tt_metal/impl/debug/dprint_parser.hpp
@@ -146,7 +146,7 @@ private:
         std::span<char> argument_types,
         std::span<const std::byte> payload_bytes,
         std::vector<ArgumentValue>& arguments);
-    static std::string_view format_message(
+    std::string_view format_message(
         ParsedStringInfo& string_info, std::span<const std::byte> payload_bytes, FormatMessageBuffer& buffer);
 
     // Loads all enum type definitions from DWARF debug info in the ELF file.


### PR DESCRIPTION
By default, we don't want to copy variable sized data from device to host. This leaves strings in bad place. Here we add ability to print strings with `DEVICE_PRINT`:
```
    const char* s = "Hello world!";
    DEVICE_PRINT("Pointer: {}\n", s);               // prints: Pointer: 0xFFB01234
    DEVICE_PRINT("String: {}\n", CTSTR("Hello!"));  // prints: String: Hello!
```
If you want to get string output, you should use compile time string macro (`CTSTR`) that will place string into `.device_print_strings` section which we already load in print server.

Also, fixed bug in printing DEST tests.