### PR TITLE
[skip ci] feat: add triage-ci.yaml caller workflow for auto-issue creation

### DIFF
--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -17,8 +17,8 @@ on:
         default: "tenstorrent/tt-metal"
       max-issues:
         description: "Maximum issues to create (0 = unlimited, useful for testing)"
-        type: string
-        default: "0"
+        type: number
+        default: 0
 
 permissions:
   contents: read

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -17,8 +17,8 @@ on:
         default: "tenstorrent/tt-metal"
       max-issues:
         description: "Maximum issues to create (0 = unlimited, useful for testing)"
-        type: number
-        default: 0
+        type: string
+        default: "0"
 
 permissions:
   contents: read

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -10,7 +10,7 @@ on:
       issue-repo:
         description: "Repository to create issues in"
         type: string
-        default: "ebanerjeeTT/issue_dump"
+        default: "tenstorrent/tt-metal"
       target-repo:
         description: "Repository to analyze workflow data from"
         type: string

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -20,17 +20,13 @@ on:
         type: number
         default: 0
       llm-backend:
-        description: "LLM backend to use for issue drafting (cursor or copilot)"
+        description: "LLM backend for issue drafting: 'cursor' (default) or 'copilot'"
         type: string
         default: "cursor"
       workflow-filter:
-        description: "Comma-separated list of workflow filenames to analyze (empty = all)"
+        description: "Comma-separated substrings to filter workflow names (e.g. 'ops-unit-tests,Blackhole'). Empty = all."
         type: string
         default: ""
-      cursor-model:
-        description: "Cursor model to use when llm-backend is 'cursor' (default: claude-4-sonnet)"
-        type: string
-        default: "claude-4-sonnet"
 
 permissions:
   contents: read

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -1,10 +1,24 @@
-name: "(triage) Cursor CLI smoke test"
+name: "(triage) Auto Issue Creation"
 
 on:
   workflow_dispatch:
+    inputs:
+      create-issues:
+        description: "Create GitHub issues for deterministic failures"
+        type: boolean
+        default: false
+      issue-repo:
+        description: "Repository to create issues in"
+        type: string
+        default: "ebanerjeeTT/issue_dump"
+      target-repo:
+        description: "Repository to analyze workflow data from"
+        type: string
+        default: "tenstorrent/tt-metal"
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   cursor-cli-smoke-test:

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -15,6 +15,10 @@ on:
         description: "Repository to analyze workflow data from"
         type: string
         default: "tenstorrent/tt-metal"
+      max-issues:
+        description: "Maximum issues to create (0 = unlimited, useful for testing)"
+        type: number
+        default: 0
 
 permissions:
   contents: read

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -27,48 +27,38 @@ on:
         description: "Comma-separated substrings to filter workflow names (e.g. 'ops-unit-tests,Blackhole'). Empty = all."
         type: string
         default: ""
+      consecutive-failures-high-volume:
+        description: "Consecutive failures required to file an issue for high-volume workflows (more than 'high-volume-runs-per-day' main runs in last 24h)."
+        type: number
+        default: 4
+      consecutive-failures-low-volume:
+        description: "Consecutive failures required to file an issue for low-volume workflows."
+        type: number
+        default: 2
+      high-volume-runs-per-day:
+        description: "Strict cutoff (>) for classifying a workflow as high-volume based on main runs in the last 24h."
+        type: number
+        default: 5
 
 permissions:
   contents: read
   actions: read
 
 jobs:
-  cursor-cli-smoke-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Ensure CURSOR_API_KEY is configured
-        env:
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-        run: |
-          if [ -z "$CURSOR_API_KEY" ]; then
-            echo "Missing secret CURSOR_API_KEY"
-            exit 1
-          fi
-
-      - name: Install Cursor CLI
-        run: |
-          set -euo pipefail
-          install_script="$(mktemp)"
-          curl --fail --show-error --silent --location \
-            --proto '=https' --tlsv1.2 \
-            https://cursor.com/install \
-            -o "$install_script"
-          bash "$install_script"
-          rm -f "$install_script"
-          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
-
-      - name: Run simple Cursor prompt
-        env:
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-        run: |
-          set -euo pipefail
-          output="$(agent -p "Reply with exactly: CURSOR_CI_OK")"
-          echo "Agent output: $output"
-          if [[ "$output" != *"CURSOR_CI_OK"* ]]; then
-            echo "Unexpected agent output; expected CURSOR_CI_OK"
-            exit 1
-          fi
+  auto-issues:
+    uses: tenstorrent/tt-auto-triage/.github/workflows/triage-ci.yaml@ebanerjee/create-issues-copilot
+    with:
+      create-issues: ${{ inputs.create-issues }}
+      issue-repo: ${{ inputs.issue-repo }}
+      target-repo: ${{ inputs.target-repo }}
+      max-issues: ${{ fromJSON(inputs.max-issues) }}
+      llm-backend: ${{ inputs.llm-backend }}
+      workflow-filter: ${{ inputs.workflow-filter }}
+      consecutive-failures-high-volume: ${{ fromJSON(inputs.consecutive-failures-high-volume) }}
+      consecutive-failures-low-volume: ${{ fromJSON(inputs.consecutive-failures-low-volume) }}
+      high-volume-runs-per-day: ${{ fromJSON(inputs.high-volume-runs-per-day) }}
+    secrets:
+      AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_WRITE_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+      CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+      COPILOT_PAT: ${{ secrets.AUTO_TRIAGE_TOKEN }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -19,6 +19,18 @@ on:
         description: "Maximum issues to create (0 = unlimited, useful for testing)"
         type: number
         default: 0
+      llm-backend:
+        description: "LLM backend to use for issue drafting (cursor or copilot)"
+        type: string
+        default: "cursor"
+      workflow-filter:
+        description: "Comma-separated list of workflow filenames to analyze (empty = all)"
+        type: string
+        default: ""
+      cursor-model:
+        description: "Cursor model to use when llm-backend is 'cursor' (default: claude-4-sonnet)"
+        type: string
+        default: "claude-4-sonnet"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds a minimal `triage-ci.yaml` workflow that calls the reusable workflow in `tt-auto-triage` to automatically create GitHub issues for deterministic CI failures.

- **Thin caller**: all logic lives in `tt-auto-triage`, this workflow just passes inputs and secrets
- **Inputs**: `create-issues` (bool), `issue-repo`, `target-repo`, `max-issues`, `llm-backend`, `workflow-filter`, `consecutive-failures-high-volume`, `consecutive-failures-low-volume`, `high-volume-runs-per-day`
- **Secrets forwarded**: `GITHUB_TOKEN` (as `AGGREGATE_READ_TOKEN`), `EVAN_RESTRICTED_TOKEN` (as `ISSUE_WRITE_TOKEN`), `EVAN_CURSOR_API_KEY` (as `CURSOR_API_KEY`), `AUTO_TRIAGE_TOKEN` (as `COPILOT_PAT`)

The three new threshold inputs added in commit `3acdd63e227` surface the
adaptive consecutive-failure logic from
[tenstorrent/tt-auto-triage#1300](https://github.com/tenstorrent/tt-auto-triage/pull/1300):
workflows that ran more than `high-volume-runs-per-day` (default 5) main runs
in the last 24h require `consecutive-failures-high-volume` (default 4)
consecutive failures before filing an issue; less-frequent workflows only
need `consecutive-failures-low-volume` (default 2). All three inputs are
optional with sensible defaults so existing callers see unchanged behavior.

### Dependency

This PR is paired with [tenstorrent/tt-auto-triage#1300](https://github.com/tenstorrent/tt-auto-triage/pull/1300) and will be merged alongside it. The `uses:` reference currently points to `triage-ci.yaml@ebanerjee/create-issues-copilot` and will be updated to `@main` prior to merge.

## Test plan

- [x] Triggered via `workflow_dispatch` from this branch (`ebanerjee/auto-issues`) with `create-issues=true`, `max-issues=2`:
  - **Run 1 — cold run:** [run 24573142479](https://github.com/tenstorrent/tt-metal/actions/runs/24573142479) → `success`. Caller forwarded inputs + secrets to `tenstorrent/tt-auto-triage/triage-ci.yaml@ebanerjee/triage-create-issues`, which created 2 issues in `ebanerjeeTT/issue_dump` ([#885](https://github.com/ebanerjeeTT/issue_dump/issues/885), [#886](https://github.com/ebanerjeeTT/issue_dump/issues/886)) with sealed metadata markers.
  - **Run 2 — idempotency check:** [run 24573599075](https://github.com/tenstorrent/tt-metal/actions/runs/24573599075) → `success`. Already-tracked jobs from Run 1 were skipped; created [#887](https://github.com/ebanerjeeTT/issue_dump/issues/887), [#888](https://github.com/ebanerjeeTT/issue_dump/issues/888) for the next-highest-priority deterministic failures. Summary reported `created: 2, skipped: 2`.
- [x] Confirmed `max-issues=2` cap is honored end-to-end.

### May 7 — adaptive threshold inputs (commit `3acdd63e227`)

Three workflow_dispatch runs verified the new threshold pass-through, all with `max-issues=1` to honor a 1-issue-per-test cap:

| Capability | Evidence |
|---|---|
| **Default thresholds** (`4/2/5`) classify Merge Gate (42 runs/day) as high-volume and vLLM nightly (1 run/day) as low-volume | [run 25514511834](https://github.com/tenstorrent/tt-metal/actions/runs/25514511834) → `success`; [issue #916](https://github.com/ebanerjeeTT/issue_dump/issues/916) body reads `### Failing job URLs (last 2 runs)` |
| **Override `high-volume-runs-per-day=0`** forces every workflow into high-volume bucket | [run 25514513368](https://github.com/tenstorrent/tt-metal/actions/runs/25514513368) → `success`; logs show `'vLLM nightly tests': 1 run(s) in last 24h (high-volume) -> requires 4` |
| **Override `high-volume-runs-per-day=999`** forces every workflow into low-volume bucket | [run 25514516052](https://github.com/tenstorrent/tt-metal/actions/runs/25514516052) → `success`; logs show `'Merge Gate': 42 run(s) in last 24h (low-volume) -> requires 2`; [issue #917](https://github.com/ebanerjeeTT/issue_dump/issues/917) body reads `### Failing job URLs (last 2 runs)` |
| **Per-workflow threshold flows into LLM prompt** | both #916 and #917 bodies correctly say `last 2 runs` (matching vLLM's `consecutive=2`), confirming the per-job `consecutive` from the result dict reaches `draft_issue_body` and substitutes `$consecutive` in the prompt |
| **`max-issues=1` honored across all 3 runs** | total of 2 issues filed across 3 dispatches |

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/auto-issues)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/auto-issues)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ebanerjee/auto-issues)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ebanerjee/auto-issues)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/auto-issues)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/auto-issues)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/auto-issues)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/auto-issues)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ebanerjee/auto-issues)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ebanerjee/auto-issues)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/auto-issues)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/auto-issues)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/auto-issues)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/auto-issues)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/auto-issues)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/auto-issues)
