### PR TITLE
Use new batched MM in MLA

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -463,13 +463,8 @@ class ttMLA:
         # Update KV cache with compressed latent representation
         ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe, 0)
 
-        # expand v with wkv_b2
-        # TODO: workaround for #37416, remove when resolved
-        tt_v_latent_post_repeat = ttnn.repeat(tt_kv_nope, [1, num_heads_local, 1, 1])
-        ttnn.deallocate(tt_kv_nope)
-
         tt_v_embedding = ttnn.linear(
-            tt_v_latent_post_repeat,
+            tt_kv_nope,
             self.wkv_b2_weight,
             compute_kernel_config=self.default_compute_kernel_config,
             **self._get_mm_kwargs("wkv_b2", seq_len_local),


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41560

### Problem description
Current implementation on the MLA doesn't use new batched MM operation (https://github.com/tenstorrent/tt-metal/pull/40172 and https://github.com/tenstorrent/tt-metal/pull/40921). The idea is to replace the use of `ttnn.repeat()` function that replicates in0 of the MM B times (where B is the number of batches of in1) with the newly added batched MM that keeps in0 in L1 instead of replicating and reloading it.

### What's changed
The `ttnn.repeat()` was removed. I am also attaching the snippet of perf report (MLA) before and after the optimization.

Before:
```
163    2.2 %         UpdateKVCacheOperation                          12 us     50,772 us    100                                                  BFP8, BFP8 => BFP8
174    3.6 %         UntilizeDeviceOperation                         25 us     84,938 us    100                                                        BF16 => BF16
180    2.3 %         RepeatDeviceOperation                          648 us     52,870 us    130                                                        BF16 => BF16
186    3.1 %         TilizeDeviceOperation                          549 us     71,498 us    128                                                        BF16 => BF16
200    3.9 %   DRAM  MatmulDeviceOperation 3200 x 512 x 128         455 us     91,765 us    100  264 GB/s  91.6 %   29.5 TFLOPs   14.3 %  HiFi2 BF16 x BFP8 => BFP8
208    7.8 %         RingJointSDPADeviceOperation                 4,994 us    179,032 us    124                                                  BF16, BFP8 => BF16
```

After:
```
166    0.7 %         UpdateKVCacheOperation                          13 us     40,608 us    100                                                  BFP8, BFP8 => BFP8
173   68.4 %   SLOW  MatmulDeviceOperation 3200 x 512 x 128         291 us  3,959,937 us    100   63 GB/s  22.0 %    1.4 TFLOPs    0.7 %  HiFi2 BF16 x BFP8 => BFP8
178    2.9 %         RingJointSDPADeviceOperation                 4,989 us    164,675 us    124                                                  BF16, BFP8 => BF16
```

The optimization also removed utilize, repeat and tilize operations.

Without optimization: 25 us + 648 us + 549 us + 455 us = 1.677 us
With optimization: 291 us
Diff: **1.386 us**

### Checklist

- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nbabin/batched_matmul_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nbabin/batched_matmul_mla)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nbabin/batched_matmul_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nbabin/batched_matmul_mla)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nbabin/batched_matmul_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nbabin/batched_matmul_mla):`tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py` is also failing on the `main` branch
- [ ] [![(Release) Model Status for Console Deployment](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nbabin/batched_matmul_mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nbabin/batched_matmul_mla)
