### PR TITLE
Cleanup: Consolidate DispatchMemMap to a single canonical instance

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -987,8 +987,8 @@ inline tt_metal::DataMovementProcessor dispatch_dm() {
     return tt::tt_metal::detail::dispatch_dm_processor();
 }
 
-inline const tt_metal::DispatchMemMap& sd_dispatch_mem_map(const tt_metal::IDevice* device) {
-    return tt_metal::MetalContext::instance().dispatch_mem_map(sd_cq_kernel_core_type(device));
+inline const tt_metal::DispatchMemMap& sd_dispatch_mem_map(const tt_metal::IDevice* /*device*/) {
+    return tt_metal::MetalContext::instance().dispatch_mem_map();
 }
 
 inline tt_metal::KernelHandle create_sd_cq_kernel(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -987,7 +987,7 @@ inline tt_metal::DataMovementProcessor dispatch_dm() {
     return tt::tt_metal::detail::dispatch_dm_processor();
 }
 
-inline const tt_metal::DispatchMemMap& sd_dispatch_mem_map(const tt_metal::IDevice* /*device*/) {
+inline const tt_metal::DispatchMemMap& sd_dispatch_mem_map() {
     return tt_metal::MetalContext::instance().dispatch_mem_map();
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1123,7 +1123,7 @@ public:
             append_dispatch_payload(raw, term_cmd);
         }
 
-        const auto& memmap = Common::sd_dispatch_mem_map(this->device_);
+        const auto& memmap = Common::sd_dispatch_mem_map();
         const tt::CoreType cq_core_type = Common::sd_cq_kernel_core_type(this->device_);
         // CQ0: this is a slow-dispatch (SD) test with no real command queue.
         const uint32_t l1_buf_base = memmap.dispatch_buffer_base(/*cq_id=*/0);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -595,7 +595,7 @@ std::array<tt_metal::Program, 2> create_standard_programs(
 std::pair<std::vector<tt_metal::Program>, std::unordered_map<std::string, uint32_t>> create_load_prefetcher_programs(
     const TestInfo& info, const std::shared_ptr<MeshDevice>& mesh_device, DispatchCoreType dispatch_core_type) {
     uint32_t prefetcher_cache_size = tt::tt_metal::MetalContext::instance()
-                                         .dispatch_mem_map(dispatch_core_type_to_core_type(dispatch_core_type))
+                                         .dispatch_mem_map()
                                          .ringbuffer_size();
     uint32_t target_total_size = (3 * prefetcher_cache_size) / 2;
     uint32_t num_kernels = get_num_kernels(info);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -594,9 +594,7 @@ std::array<tt_metal::Program, 2> create_standard_programs(
 // Helper function to create prefetcher cache load programs
 std::pair<std::vector<tt_metal::Program>, std::unordered_map<std::string, uint32_t>> create_load_prefetcher_programs(
     const TestInfo& info, const std::shared_ptr<MeshDevice>& mesh_device, DispatchCoreType dispatch_core_type) {
-    uint32_t prefetcher_cache_size = tt::tt_metal::MetalContext::instance()
-                                         .dispatch_mem_map()
-                                         .ringbuffer_size();
+    uint32_t prefetcher_cache_size = tt::tt_metal::MetalContext::instance().dispatch_mem_map().ringbuffer_size();
     uint32_t target_total_size = (3 * prefetcher_cache_size) / 2;
     uint32_t num_kernels = get_num_kernels(info);
     uint32_t estimated_program_size =

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -593,7 +593,7 @@ std::array<tt_metal::Program, 2> create_standard_programs(
 }
 // Helper function to create prefetcher cache load programs
 std::pair<std::vector<tt_metal::Program>, std::unordered_map<std::string, uint32_t>> create_load_prefetcher_programs(
-    const TestInfo& info, const std::shared_ptr<MeshDevice>& mesh_device, DispatchCoreType dispatch_core_type) {
+    const TestInfo& info, const std::shared_ptr<MeshDevice>& mesh_device) {
     uint32_t prefetcher_cache_size = tt::tt_metal::MetalContext::instance().dispatch_mem_map().ringbuffer_size();
     uint32_t target_total_size = (3 * prefetcher_cache_size) / 2;
     uint32_t num_kernels = get_num_kernels(info);
@@ -728,7 +728,7 @@ static int pgm_dispatch(T& state, TestInfo info) {
         ProgramExecutor executor([]() {}, []() {}, 0);  // Initialize with placeholder
         std::vector<MeshWorkload> mesh_workloads;
         if (info.load_prefetcher) {
-            auto [programs, extra_counters] = create_load_prefetcher_programs(info, mesh_device, dispatch_core_type);
+            auto [programs, extra_counters] = create_load_prefetcher_programs(info, mesh_device);
             executor = create_load_prefetcher_executor(info, mesh_workloads, programs, mesh_cq);
             // Store extra counters for later use
             if constexpr (std::is_same_v<T, benchmark::State>) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2637,7 +2637,7 @@ public:
         this->send_to_all_ = this->cfg_.send_to_all;
         this->host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
         // Cap inline command size to avoid cmddat_q L1 overflow on the prefetch-d core.
-        this->max_fetch_bytes_ = Common::sd_dispatch_mem_map(this->device_).scratch_db_size();
+        this->max_fetch_bytes_ = Common::sd_dispatch_mem_map().scratch_db_size();
 
         this->dram_base_ = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
         this->num_banks_ = this->device_->allocator_impl()->get_num_banks(BufferType::DRAM);
@@ -2677,7 +2677,7 @@ public:
         uint32_t num_iterations,
         bool /*wait_for_completion*/ = true,
         bool /*wait_for_host_writes*/ = false) override {
-        const auto& memmap = Common::sd_dispatch_mem_map(this->device_);
+        const auto& memmap = Common::sd_dispatch_mem_map();
         const tt::CoreType cq_core_type = Common::sd_cq_kernel_core_type(this->device_);
         const CoreCoord prefetch_logical = Common::sd_prefetch_core(this->device_);
         const CoreCoord dispatch_logical = Common::dispatch_core(this->device_);
@@ -2993,7 +2993,7 @@ public:
             quasar_completion_buf_.resize(this->sd_completion_queue_size());
             return quasar_completion_buf_.data();
         }
-        const auto& memmap = Common::sd_dispatch_mem_map(device_);
+        const auto& memmap = Common::sd_dispatch_mem_map();
         const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         const ChipId mmio_id =
             tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_->id());
@@ -3010,7 +3010,7 @@ public:
         if (Common::is_quasar_cq_dram_backed()) {
             // Read the dispatch kernel's DRAM completion writes into the host staging buffer so device_data.validate()
             // sees the correct data.
-            const auto& memmap = Common::sd_dispatch_mem_map(device_);
+            const auto& memmap = Common::sd_dispatch_mem_map();
             const CoreCoord phys_disp = Common::sd_virtual_core(this->device_, Common::dispatch_core(this->device_));
             const tt_cxy_pair dispatch_cxy(this->device_->id(), phys_disp);
             // CQ0: this is a slow-dispatch (SD) test with no real command queue.

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -509,7 +509,6 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_unicast_wptr(),
             expected_num_workers_completed,
             this->virtual_program_dispatch_core(),
-            this->dispatch_core_type_,
             sub_device_id,
             dispatch_metadata,
             mesh_workload.impl().get_program_binary_status(mesh_device_id),
@@ -1186,12 +1185,7 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
         program_dispatch::write_program_command_sequence(
-            program_cmd_seq,
-            device->sysmem_manager(),
-            id_,
-            this->dispatch_core_type_,
-            stall_first,
-            stall_before_program);
+            program_cmd_seq, device->sysmem_manager(), id_, stall_first, stall_before_program);
         chip_ids_in_workload.insert(device->id());
     });
 }
@@ -1548,7 +1542,6 @@ void FDMeshCommandQueue::record_end() {
                 worker_launch_msg_state.get_unicast_wptr(),
                 trace_worker_descriptors[sub_device_id].num_completion_worker_cores,
                 this->virtual_program_dispatch_core(),
-                MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type(),
                 sub_device_id,
                 ProgramBinaryStatus::Committed,
                 std::pair<bool, int>(mesh_node.unicast_go_signals, num_virtual_eth_cores),
@@ -1561,7 +1554,6 @@ void FDMeshCommandQueue::record_end() {
                 cached_program_command_sequence,
                 sysmem_manager_for_trace,
                 this->id_,
-                MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type(),
                 node.dispatch_metadata.stall_first,
                 node.dispatch_metadata.stall_before_program,
                 node.dispatch_metadata.send_binary);

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -182,7 +182,7 @@ FDMeshCommandQueue::FDMeshCommandQueue(
     prefetcher_dram_aligned_block_size_(
         MetalContext::instance(mesh_device->impl().get_context_id()).hal().get_alignment(HalMemType::DRAM)),
     prefetcher_cache_sizeB_(MetalContext::instance(mesh_device->impl().get_context_id())
-                                .dispatch_mem_map(this->dispatch_core_type_)
+                                .dispatch_mem_map()
                                 .ringbuffer_size()),
     prefetcher_dram_aligned_num_blocks_(prefetcher_cache_sizeB_ / prefetcher_dram_aligned_block_size_),
     prefetcher_cache_manager_size_(

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -181,9 +181,8 @@ FDMeshCommandQueue::FDMeshCommandQueue(
     reader_thread_pool_(reader_thread_pool),
     prefetcher_dram_aligned_block_size_(
         MetalContext::instance(mesh_device->impl().get_context_id()).hal().get_alignment(HalMemType::DRAM)),
-    prefetcher_cache_sizeB_(MetalContext::instance(mesh_device->impl().get_context_id())
-                                .dispatch_mem_map()
-                                .ringbuffer_size()),
+    prefetcher_cache_sizeB_(
+        MetalContext::instance(mesh_device->impl().get_context_id()).dispatch_mem_map().ringbuffer_size()),
     prefetcher_dram_aligned_num_blocks_(prefetcher_cache_sizeB_ / prefetcher_dram_aligned_block_size_),
     prefetcher_cache_manager_size_(
         1 << (std::bit_width(std::min(1024u, std::max(2u, prefetcher_dram_aligned_num_blocks_ >> 4))) - 1)),

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -212,8 +212,7 @@ void MeshWorkloadImpl::generate_dispatch_commands(MeshCommandQueue& mesh_cq) {
     // These commands will be updated based on MeshDevice state when the
     // workload is enqueued.
     auto* mesh_device = mesh_cq.device();
-    auto dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    uint32_t prefetcher_cache_sizeB = MetalContext::instance().dispatch_mem_map(dispatch_core_type).ringbuffer_size();
+    uint32_t prefetcher_cache_sizeB = MetalContext::instance().dispatch_mem_map().ringbuffer_size();
 
     bool use_prefetcher_cache =
         this->max_program_kernels_sizeB_ and this->max_program_kernels_sizeB_ <= prefetcher_cache_sizeB;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -13,7 +13,6 @@
 #include <vector>
 #include <unordered_set>
 
-#include <enchantum/enchantum.hpp>
 #include <tracy/Tracy.hpp>
 
 #include "metal_context.hpp"
@@ -234,16 +233,21 @@ void MetalContext::initialize(
     dispatch_query_manager_ =
         std::make_unique<DispatchQueryManager>(*this->env_, *dispatch_core_manager_, dispatch_core_config_, num_hw_cqs);
     const bool is_galaxy_cluster = get_cluster().is_galaxy_cluster();
-    std::vector<CoreType> core_types{CoreType::WORKER, CoreType::ETH};
-    if (hal().has_programmable_core_type(HalProgrammableCoreType::DISPATCH)) {
-        core_types.push_back(CoreType::DISPATCH);
+    // Build the single canonical DispatchMemMap for the core type we actually dispatch on. On Quasar the dispatch
+    // engine runs on DISPATCH cores (resolved per-device from the soc descriptor), which differs from the WORKER/ETH
+    // config core type; elsewhere the resolved type matches the config core type.
+    CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config_);
+    const auto& cluster = get_cluster();
+    if (env_ != nullptr && cluster.arch() == tt::ARCH::QUASAR && !cluster.all_chip_ids().empty()) {
+        const ChipId device_id = *cluster.all_chip_ids().begin();
+        dispatch_core_type =
+            resolve_dispatch_core_type(MetalEnvAccessor(*env_).impl(), device_id, dispatch_core_config_);
     }
-    for (CoreType core_type : core_types) {
-        const CommandQueueDispatchLayout& cq_dispatch_layout = dispatch_query_manager_->cq_dispatch_layout(core_type);
-        dispatch_mem_map_[enchantum::to_underlying(core_type)] = std::make_unique<DispatchMemMap>(
-            core_type, num_hw_cqs, hal(), is_galaxy_cluster, cq_dispatch_layout, rtoptions());
-    }
-// Initialize debug servers. Attaching individual devices done below
+    const CommandQueueDispatchLayout& cq_dispatch_layout =
+        dispatch_query_manager_->cq_dispatch_layout(dispatch_core_type);
+    dispatch_mem_map_ = std::make_unique<DispatchMemMap>(
+        dispatch_core_type, num_hw_cqs, hal(), is_galaxy_cluster, cq_dispatch_layout, rtoptions());
+    // Initialize debug servers. Attaching individual devices done below
     rtoptions().resolve_fabric_node_ids_to_chip_ids(this->get_control_plane());
     rtoptions().resolve_mesh_coords_to_chip_ids(this->get_system_mesh());
     if (rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
@@ -506,9 +510,7 @@ void MetalContext::register_handlers_locked() {
 }
 
 void MetalContext::teardown_dispatch_state() {
-    for (auto& mem_map : dispatch_mem_map_) {
-        mem_map.reset();
-    }
+    dispatch_mem_map_.reset();
     device_manager_->reset_dispatch_topology();
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();
@@ -582,19 +584,8 @@ DispatchQueryManager& MetalContext::get_dispatch_query_manager() {
 }
 
 const DispatchMemMap& MetalContext::dispatch_mem_map() const {
-    const auto& cluster = get_cluster();
-    if (env_ != nullptr && cluster.arch() == tt::ARCH::QUASAR && !cluster.all_chip_ids().empty()) {
-        const ChipId device_id = *cluster.all_chip_ids().begin();
-        return dispatch_mem_map(
-            resolve_dispatch_core_type(MetalEnvAccessor(*env_).impl(), device_id, dispatch_core_config_));
-    }
-    return dispatch_mem_map(get_core_type_from_config(dispatch_core_config_));
-}
-
-const DispatchMemMap& MetalContext::dispatch_mem_map(const CoreType& core_type) const {
-    const auto& mem_map = dispatch_mem_map_[enchantum::to_underlying(core_type)];
-    TT_FATAL(mem_map, "Tried to get dispatch_mem_map for {} before initializing it.", core_type);
-    return *mem_map;
+    TT_FATAL(dispatch_mem_map_, "Tried to get dispatch_mem_map before initializing it.");
+    return *dispatch_mem_map_;
 }
 
 // ─── Fabric / control plane / system mesh — delegated to MetalEnv ─────────────

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -99,7 +99,6 @@ public:
     DispatchQueryManager& get_dispatch_query_manager();
 
     const DispatchMemMap& dispatch_mem_map() const;  // DispatchMemMap for the core type we're dispatching on.
-    const DispatchMemMap& dispatch_mem_map(const CoreType& core_type) const;  // DispatchMemMap for specific core type.
 
     inspector::Data* get_inspector_data() const {
         return inspector_data_.get();
@@ -253,7 +252,7 @@ private:
     std::unique_ptr<RiscFirmwareInitializer> risc_firmware_initializer_;
     std::unordered_set<InitializerKey> risc_fw_init_done_;
 
-    std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
+    std::unique_ptr<DispatchMemMap> dispatch_mem_map_;
 
     // We are using a thread_local to allow each thread to have its own command queue id stack.
     // This not only allows consumers to set active command queue for a thread

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -145,10 +145,8 @@ uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
     CoreType dispatch_core_type = dispatch_core_manager.get_dispatch_core_type();
 
     // Get the L1 address where dispatch progress counter is stored
-    uint32_t dev_dispatch_progress_ptr =
-        MetalContext::instance()
-            .dispatch_mem_map()
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS, cq_id);
+    uint32_t dev_dispatch_progress_ptr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
+        CommandQueueDeviceAddrType::DISPATCH_PROGRESS, cq_id);
 
     // read_core expects TRANSLATED (virtual) coordinates
     // dispatcher_core_manager stores logical coordinates, so convert LOGICAL -> TRANSLATED (virtual)

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -142,11 +142,12 @@ uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
             ? dispatch_core_manager.dispatcher_d_core(chip_id, channel, cq_id)
             : dispatch_core_manager.dispatcher_core(chip_id, channel, cq_id);
 
-    // Get the L1 address where dispatch progress counter is stored
     CoreType dispatch_core_type = dispatch_core_manager.get_dispatch_core_type();
+
+    // Get the L1 address where dispatch progress counter is stored
     uint32_t dev_dispatch_progress_ptr =
         MetalContext::instance()
-            .dispatch_mem_map(dispatch_core_type)
+            .dispatch_mem_map()
             .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS, cq_id);
 
     // read_core expects TRANSLATED (virtual) coordinates

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -101,7 +101,7 @@ DispatchKernel::DispatchKernel(
 void DispatchKernel::GenerateStaticConfigs() {
     uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = get_dispatch_mem_map();
 
     // May be zero if not using dispatch on fabric
     static_config_.fabric_header_rb_base =
@@ -615,7 +615,7 @@ void DispatchKernel::ConfigureCore() {
 
     // For all dispatchers, need to clear the dispatch message
     std::vector<uint32_t> zero = {0x0};
-    const auto& my_dispatch_constants = *this->dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = get_dispatch_mem_map();
     uint32_t dispatch_s_sync_sem_base_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM, cq_id_);
     for (uint32_t i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -123,7 +123,7 @@ DispatchSKernel::DispatchSKernel(
 }
 
 void DispatchSKernel::GenerateStaticConfigs() {
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = get_dispatch_mem_map();
 
     uint32_t dispatch_s_buffer_base = 0xff;
     if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
@@ -395,7 +395,7 @@ void DispatchSKernel::ConfigureCore() {
 
         // Just need to clear the dispatch message
         std::vector<uint32_t> zero = {0x0};
-        const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+        const auto& my_dispatch_constants = get_dispatch_mem_map();
         uint32_t dispatch_s_sync_sem_base_addr = my_dispatch_constants.get_device_command_queue_addr(
             CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM, cq_id_);
         for (uint32_t i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -19,7 +19,7 @@
 #include "kernel_types.hpp"
 #include "prefetch.hpp"
 #include "impl/context/context_descriptor.hpp"
-// #include "impl/context/metal_context.hpp"
+#include "impl/context/metal_context.hpp"
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "kernels/kernel.hpp"
 #include <umd/device/types/core_coordinates.hpp>
@@ -92,6 +92,10 @@ const DispatchQueryManager& FDKernel::get_dispatch_query_manager_ref() const {
 uint32_t FDKernel::get_max_num_eth_cores() const {
     TT_ASSERT(static_cast<bool>(get_max_num_eth_cores_), "Max num eth cores accessor not set");
     return get_max_num_eth_cores_();
+}
+
+const DispatchMemMap& FDKernel::get_dispatch_mem_map() const {
+    return descriptor_.metal_context().dispatch_mem_map();
 }
 
 FDKernel* FDKernel::Generate(

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -94,9 +94,7 @@ uint32_t FDKernel::get_max_num_eth_cores() const {
     return get_max_num_eth_cores_();
 }
 
-const DispatchMemMap& FDKernel::get_dispatch_mem_map() const {
-    return descriptor_.metal_context().dispatch_mem_map();
-}
+const DispatchMemMap& FDKernel::get_dispatch_mem_map() const { return descriptor_.metal_context().dispatch_mem_map(); }
 
 FDKernel* FDKernel::Generate(
     int node_id,

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -116,18 +116,7 @@ public:
         get_control_plane_(get_control_plane),
         get_dispatch_query_manager_(get_dispatch_query_manager),
         get_max_num_eth_cores_(get_max_num_eth_cores),
-        get_reads_dispatch_cores_(get_reads_dispatch_cores) {
-        const bool is_galaxy_cluster = descriptor_.cluster().is_galaxy_cluster();
-        std::vector<CoreType> core_types{CoreType::WORKER, CoreType::ETH};
-        if (descriptor.hal().has_programmable_core_type(HalProgrammableCoreType::DISPATCH)) {
-            core_types.push_back(CoreType::DISPATCH);
-        }
-        for (CoreType core_type : core_types) {
-            const auto& layout = get_dispatch_query_manager_ref().cq_dispatch_layout(core_type);
-            dispatch_mem_map_[enchantum::to_underlying(core_type)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
-                core_type, descriptor.num_cqs(), descriptor.hal(), is_galaxy_cluster, layout, descriptor.rtoptions());
-        }
-    }
+        get_reads_dispatch_cores_(get_reads_dispatch_cores) {}
     virtual ~FDKernel() = default;
 
     // Populate the static configs for this kernel (ones that do not depend on configs from other kernels), including
@@ -197,6 +186,8 @@ public:
     uint32_t get_max_num_eth_cores() const;
 
 protected:
+    const DispatchMemMap& get_dispatch_mem_map() const;
+
     // Attributes for an EDM client to connect to the router
     struct FDKernelEdmConnectionAttributes {
         size_t worker_flow_control_sem{0};
@@ -250,7 +241,6 @@ protected:
     GetDispatchQueryManagerFn get_dispatch_query_manager_;
     GetMaxNumEthCoresFn get_max_num_eth_cores_;
     GetReadsDispatchCoresFn get_reads_dispatch_cores_;
-    std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -95,7 +95,7 @@ PrefetchKernel::PrefetchKernel(
 void PrefetchKernel::GenerateStaticConfigs() {
     uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = get_dispatch_mem_map();
     // May be zero if not using dispatch on fabric
     static_config_.fabric_header_rb_base =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_HEADER_RB, cq_id_);
@@ -544,7 +544,7 @@ void PrefetchKernel::CreateKernel() {
         {"IS_H_VARIANT", std::to_string(static_config_.is_h_variant.value())},
     };
 
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = get_dispatch_mem_map();
     defines["PREFETCH_Q_ENTRY_BITS"] = std::to_string(my_dispatch_constants.prefetch_q_entry_size_bytes() * 8);
 
     if (!is_hd()) {
@@ -587,7 +587,7 @@ void PrefetchKernel::ConfigureCore() {
     if (static_config_.is_h_variant.value()) {
         // Initialize the FetchQ
         uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_->id());
-        const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+        const auto& my_dispatch_constants = get_dispatch_mem_map();
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
         const uint32_t prefetch_q_bytes = my_dispatch_constants.prefetch_q_size();

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -240,7 +240,7 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
     const CoreType core_type = ctx.get_dispatch_core_manager().get_dispatch_core_type();
     const uint32_t cq_start = ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-    const auto& mem_map = ctx.dispatch_mem_map(core_type);
+    const auto& mem_map = ctx.dispatch_mem_map();
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
         // L1 addresses differ per cq_id when this CQ's dispatch kernels share their dispatch core's L1 with another
         // CQ's
@@ -694,9 +694,8 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
     }
 
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
-    const CoreType core_type = ctx.get_dispatch_core_manager().get_dispatch_core_type();
     const uint32_t prefetch_q_rd_ptr =
-        ctx.dispatch_mem_map(core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD, cq_id);
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD, cq_id);
 
     // Helper to wait for fetch queue space, if needed
     uint32_t fence;
@@ -736,7 +735,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
     wait_for_fetch_q_space();
     // Wrap FetchQ if possible
-    const auto& mem_map = ctx.dispatch_mem_map(core_type);
+    const auto& mem_map = ctx.dispatch_mem_map();
     uint32_t prefetch_q_base = mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED, cq_id);
     uint32_t prefetch_q_limit =
         prefetch_q_base + (mem_map.prefetch_q_entries() * mem_map.prefetch_q_entry_size_bytes());

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -32,6 +32,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "dispatch_mem_map.hpp"
+#include "impl/context/metal_context.hpp"
 #include <llrt/tt_cluster.hpp>
 #include "dispatch_core_manager.hpp"
 
@@ -430,16 +431,6 @@ DispatchTopology::DispatchTopology(
     get_max_num_eth_cores_(get_max_num_eth_cores),
     get_reads_dispatch_cores_(get_reads_dispatch_cores) {
     command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
-    const bool is_galaxy_cluster = descriptor_.cluster().is_galaxy_cluster();
-    std::vector<CoreType> core_types{CoreType::WORKER, CoreType::ETH};
-    if (descriptor_.hal().has_programmable_core_type(HalProgrammableCoreType::DISPATCH)) {
-        core_types.push_back(CoreType::DISPATCH);
-    }
-    for (CoreType core_type : core_types) {
-        const auto& layout = this->get_dispatch_query_manager_().cq_dispatch_layout(core_type);
-        dispatch_mem_map_[enchantum::to_underlying(core_type)] = std::make_unique<DispatchMemMap>(
-            core_type, descriptor_.num_cqs(), descriptor_.hal(), is_galaxy_cluster, layout, descriptor_.rtoptions());
-    }
 }
 
 DispatchTopology::~DispatchTopology() { reset(); }
@@ -791,7 +782,7 @@ void DispatchTopology::configure_dispatch_cores(Device* device) {
     // Set up completion_queue_writer core. This doesn't actually have a kernel so keep it out of the struct and config
     // it here. TODO: should this be in the struct?
     CoreType dispatch_core_type = this->dispatch_core_manager_.get_dispatch_core_type();
-    const auto& mem_map = *this->dispatch_mem_map_[enchantum::to_underlying(dispatch_core_type)];
+    const auto& mem_map = descriptor_.metal_context().dispatch_mem_map();
     uint32_t cq_start = mem_map.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     uint32_t cq_size = device->sysmem_manager().get_cq_size();
     std::vector<uint32_t> zero = {0x0};

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -35,7 +35,6 @@ namespace tt::tt_metal {
 
 class IDevice;
 class DeviceManager;
-class DispatchMemMap;
 class dispatch_core_manager;
 enum DispatchWorkerType : uint32_t;
 
@@ -93,7 +92,6 @@ private:
     GetDispatchQueryManagerFn get_dispatch_query_manager_;
     GetMaxNumEthCoresFn get_max_num_eth_cores_;
     GetReadsDispatchCoresFn get_reads_dispatch_cores_;
-    std::unique_ptr<DispatchMemMap> dispatch_mem_map_[enchantum::to_underlying(CoreType::COUNT)];
     std::vector<FDKernel*> node_id_to_kernel_;
     std::unique_ptr<detail::ProgramCompileGroup> command_queue_compile_group_;
     std::unordered_map<ChipId, std::unordered_set<CoreCoord>> dispatch_cores_;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1437,8 +1437,7 @@ public:
         DeviceCommandCalculator& calculator,
         bool using_prefetcher_cache) {
         const auto& hal = MetalContext::instance().hal();
-        const uint32_t max_length_per_sub_cmd =
-            MetalContext::instance().dispatch_mem_map().scratch_db_size() / 2;
+        const uint32_t max_length_per_sub_cmd = MetalContext::instance().dispatch_mem_map().scratch_db_size() / 2;
         const uint32_t max_paged_length_per_sub_cmd =
             max_length_per_sub_cmd / HostMemDeviceCommand::PROGRAM_PAGE_SIZE * HostMemDeviceCommand::PROGRAM_PAGE_SIZE;
 
@@ -2184,12 +2183,8 @@ public:
                 // Dispatch X/Y resolved when the program is enqueued
                 0,
                 0,
-                MetalContext::instance()
-                    .dispatch_mem_map()
-                    .get_dispatch_message_update_offset(sub_device_index)),
-            MetalContext::instance()
-                .dispatch_mem_map()
-                .get_dispatch_stream_index(sub_device_index),
+                MetalContext::instance().dispatch_mem_map().get_dispatch_message_update_offset(sub_device_index)),
+            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(sub_device_index),
             has_multicast_launch_cmds ? sub_device_index : CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET,
             num_noc_unicast_txns,
             noc_data_start_idx,
@@ -2203,9 +2198,7 @@ public:
             sub_device_index,
             num_noc_unicast_txns,
             noc_data_start_idx,
-            MetalContext::instance()
-                .dispatch_mem_map()
-                .get_dispatch_stream_index(sub_device_index));
+            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(sub_device_index));
 
         program_command_sequence.mcast_go_signal_cmd_ptr =
             &(reinterpret_cast<CQDispatchCmd*>(
@@ -2235,8 +2228,7 @@ void assemble_device_commands(
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     constants.dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     constants.noc_index = k_dispatch_downstream_noc;
-    constants.max_prefetch_command_size =
-        MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    constants.max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     constants.packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(mesh_device);
     BatchedTransfers batched_transfers =
         assemble_runtime_args_commands(program_command_sequence, program, mesh_device, constants);
@@ -2664,9 +2656,7 @@ void update_program_dispatch_commands(
         dev_msgs::RUN_MSG_GO,
         dispatch_core.x,
         dispatch_core.y,
-        MetalContext::instance()
-                .dispatch_mem_map()
-                .get_dispatch_message_update_offset(*sub_device_id) +
+        MetalContext::instance().dispatch_mem_map().get_dispatch_message_update_offset(*sub_device_id) +
             MetalContext::instance().dispatch_mem_map().get_completion_counter_offset(cq_id));
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = expected_num_workers_completed;
     // Update the number of unicast txns based on user provided parameter
@@ -2873,9 +2863,7 @@ void update_traced_program_dispatch_commands(
         dev_msgs::RUN_MSG_GO,
         dispatch_core.x,
         dispatch_core.y,
-        MetalContext::instance()
-                .dispatch_mem_map()
-                .get_dispatch_message_update_offset(*sub_device_id) +
+        MetalContext::instance().dispatch_mem_map().get_dispatch_message_update_offset(*sub_device_id) +
             MetalContext::instance().dispatch_mem_map().get_completion_counter_offset(cq_id));
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = expected_num_workers_completed;
     // Update the number of unicast txns based on user provided parameter
@@ -2912,8 +2900,7 @@ void write_program_command_sequence(
     // Check if it's possible to write all commands in a single fetch queue entry
     uint32_t one_shot_fetch_size =
         program_command_sequence.get_one_shot_fetch_size(stall_first, stall_before_program, send_binary);
-    bool one_shot = one_shot_fetch_size <=
-                    MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    bool one_shot = one_shot_fetch_size <= MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
 
     LOG_TRACE_LAZY(tt::LogDispatch, "One-shot mode: {}, Fetch size: {} bytes", one_shot, one_shot_fetch_size);
     if (one_shot) {
@@ -3346,8 +3333,7 @@ void set_core_go_message_mapping_on_device(
     std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds;
     std::vector<std::pair<uint32_t, uint32_t>> payload;
     uint32_t noc_index = k_dispatch_downstream_noc;
-    uint32_t max_prefetch_command_size =
-        MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
 
     for (const auto& [core_range_set, go_msg_offset] : core_go_message_mapping) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -104,7 +104,6 @@ inline bool is_watcher_assert_enabled() {
 }
 
 struct CommandConstants {
-    CoreType dispatch_core_type;
     NOC noc_index;
     uint32_t max_prefetch_command_size;
     uint32_t packed_write_max_unicast_sub_cmds;
@@ -2147,7 +2146,6 @@ public:
     void assemble_commands(
         ProgramCommandSequence& program_command_sequence,
         HostMemDeviceCommand& device_command_sequence,
-        [[maybe_unused]] const CommandConstants& constants,
         distributed::MeshDevice* mesh_device,
         SubDeviceId sub_device_id,
         const ProgramTransferInfo& program_transfer_info,
@@ -2225,8 +2223,6 @@ void assemble_device_commands(
         use_prefetcher_cache ? "enabled" : "disabled");
 
     CommandConstants constants{};
-    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    constants.dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     constants.noc_index = k_dispatch_downstream_noc;
     constants.max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     constants.packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(mesh_device);
@@ -2323,7 +2319,6 @@ void assemble_device_commands(
     go_signal_generator.assemble_commands(
         program_command_sequence,
         program_command_sequence.go_msg_command_sequence,
-        constants,
         mesh_device,
         sub_device_id,
         program_transfer_info,
@@ -2470,7 +2465,6 @@ void update_program_dispatch_commands(
     uint32_t unicast_cores_launch_message_wptr,
     uint32_t expected_num_workers_completed,
     CoreCoord dispatch_core,
-    [[maybe_unused]] CoreType dispatch_core_type,
     SubDeviceId sub_device_id,
     const ProgramDispatchMetadata& dispatch_md,
     ProgramBinaryStatus program_binary_status,
@@ -2679,7 +2673,6 @@ void update_traced_program_dispatch_commands(
     uint32_t unicast_cores_launch_message_wptr,
     uint32_t expected_num_workers_completed,
     CoreCoord dispatch_core,
-    [[maybe_unused]] CoreType dispatch_core_type,
     SubDeviceId sub_device_id,
     ProgramBinaryStatus program_binary_status,
     std::pair<bool, int> unicast_go_signal_update,
@@ -2883,7 +2876,6 @@ void write_program_command_sequence(
     const ProgramCommandSequence& program_command_sequence,
     SystemMemoryManager& manager,
     uint32_t command_queue_id,
-    [[maybe_unused]] CoreType dispatch_core_type,
     bool stall_first,
     bool stall_before_program,
     bool send_binary) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1438,7 +1438,7 @@ public:
         bool using_prefetcher_cache) {
         const auto& hal = MetalContext::instance().hal();
         const uint32_t max_length_per_sub_cmd =
-            MetalContext::instance().dispatch_mem_map(constants.dispatch_core_type).scratch_db_size() / 2;
+            MetalContext::instance().dispatch_mem_map().scratch_db_size() / 2;
         const uint32_t max_paged_length_per_sub_cmd =
             max_length_per_sub_cmd / HostMemDeviceCommand::PROGRAM_PAGE_SIZE * HostMemDeviceCommand::PROGRAM_PAGE_SIZE;
 
@@ -2148,7 +2148,7 @@ public:
     void assemble_commands(
         ProgramCommandSequence& program_command_sequence,
         HostMemDeviceCommand& device_command_sequence,
-        const CommandConstants& constants,
+        [[maybe_unused]] const CommandConstants& constants,
         distributed::MeshDevice* mesh_device,
         SubDeviceId sub_device_id,
         const ProgramTransferInfo& program_transfer_info,
@@ -2185,10 +2185,10 @@ public:
                 0,
                 0,
                 MetalContext::instance()
-                    .dispatch_mem_map(constants.dispatch_core_type)
+                    .dispatch_mem_map()
                     .get_dispatch_message_update_offset(sub_device_index)),
             MetalContext::instance()
-                .dispatch_mem_map(constants.dispatch_core_type)
+                .dispatch_mem_map()
                 .get_dispatch_stream_index(sub_device_index),
             has_multicast_launch_cmds ? sub_device_index : CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET,
             num_noc_unicast_txns,
@@ -2204,7 +2204,7 @@ public:
             num_noc_unicast_txns,
             noc_data_start_idx,
             MetalContext::instance()
-                .dispatch_mem_map(constants.dispatch_core_type)
+                .dispatch_mem_map()
                 .get_dispatch_stream_index(sub_device_index));
 
         program_command_sequence.mcast_go_signal_cmd_ptr =
@@ -2236,7 +2236,7 @@ void assemble_device_commands(
     constants.dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     constants.noc_index = k_dispatch_downstream_noc;
     constants.max_prefetch_command_size =
-        MetalContext::instance().dispatch_mem_map(constants.dispatch_core_type).max_prefetch_command_size();
+        MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     constants.packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(mesh_device);
     BatchedTransfers batched_transfers =
         assemble_runtime_args_commands(program_command_sequence, program, mesh_device, constants);
@@ -2478,7 +2478,7 @@ void update_program_dispatch_commands(
     uint32_t unicast_cores_launch_message_wptr,
     uint32_t expected_num_workers_completed,
     CoreCoord dispatch_core,
-    CoreType dispatch_core_type,
+    [[maybe_unused]] CoreType dispatch_core_type,
     SubDeviceId sub_device_id,
     const ProgramDispatchMetadata& dispatch_md,
     ProgramBinaryStatus program_binary_status,
@@ -2665,9 +2665,9 @@ void update_program_dispatch_commands(
         dispatch_core.x,
         dispatch_core.y,
         MetalContext::instance()
-                .dispatch_mem_map(dispatch_core_type)
+                .dispatch_mem_map()
                 .get_dispatch_message_update_offset(*sub_device_id) +
-            MetalContext::instance().dispatch_mem_map(dispatch_core_type).get_completion_counter_offset(cq_id));
+            MetalContext::instance().dispatch_mem_map().get_completion_counter_offset(cq_id));
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = expected_num_workers_completed;
     // Update the number of unicast txns based on user provided parameter
     // This is required when a MeshWorkload uses ethernet cores on a set of devices
@@ -2689,7 +2689,7 @@ void update_traced_program_dispatch_commands(
     uint32_t unicast_cores_launch_message_wptr,
     uint32_t expected_num_workers_completed,
     CoreCoord dispatch_core,
-    CoreType dispatch_core_type,
+    [[maybe_unused]] CoreType dispatch_core_type,
     SubDeviceId sub_device_id,
     ProgramBinaryStatus program_binary_status,
     std::pair<bool, int> unicast_go_signal_update,
@@ -2874,9 +2874,9 @@ void update_traced_program_dispatch_commands(
         dispatch_core.x,
         dispatch_core.y,
         MetalContext::instance()
-                .dispatch_mem_map(dispatch_core_type)
+                .dispatch_mem_map()
                 .get_dispatch_message_update_offset(*sub_device_id) +
-            MetalContext::instance().dispatch_mem_map(dispatch_core_type).get_completion_counter_offset(cq_id));
+            MetalContext::instance().dispatch_mem_map().get_completion_counter_offset(cq_id));
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = expected_num_workers_completed;
     // Update the number of unicast txns based on user provided parameter
     // This is required when a MeshWorkload uses ethernet cores on a set of devices
@@ -2895,7 +2895,7 @@ void write_program_command_sequence(
     const ProgramCommandSequence& program_command_sequence,
     SystemMemoryManager& manager,
     uint32_t command_queue_id,
-    CoreType dispatch_core_type,
+    [[maybe_unused]] CoreType dispatch_core_type,
     bool stall_first,
     bool stall_before_program,
     bool send_binary) {
@@ -2913,7 +2913,7 @@ void write_program_command_sequence(
     uint32_t one_shot_fetch_size =
         program_command_sequence.get_one_shot_fetch_size(stall_first, stall_before_program, send_binary);
     bool one_shot = one_shot_fetch_size <=
-                    MetalContext::instance().dispatch_mem_map(dispatch_core_type).max_prefetch_command_size();
+                    MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
 
     LOG_TRACE_LAZY(tt::LogDispatch, "One-shot mode: {}, Fetch size: {} bytes", one_shot, one_shot_fetch_size);
     if (one_shot) {
@@ -3345,11 +3345,9 @@ void set_core_go_message_mapping_on_device(
     std::vector<std::pair<const void*, uint32_t>> data;
     std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds;
     std::vector<std::pair<uint32_t, uint32_t>> payload;
-    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    auto dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     uint32_t noc_index = k_dispatch_downstream_noc;
     uint32_t max_prefetch_command_size =
-        MetalContext::instance().dispatch_mem_map(dispatch_core_type).max_prefetch_command_size();
+        MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
 
     for (const auto& [core_range_set, go_msg_offset] : core_go_message_mapping) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2510,7 +2510,7 @@ void update_program_dispatch_commands(
     // insert_stall_cmds baked in a placeholder wait.addr; patch in the real completion address for cq_id here. Unused
     // when this arch waits via a NOC stream register instead of an L1 address.
     if (!MetalContext::instance().hal().has_stream_registers()) {
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map(dispatch_core_type);
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
         const uint32_t wait_addr = mem_map.get_dispatch_message_addr_start() +
                                    mem_map.get_completion_counter_offset(cq_id) *
                                        MetalContext::instance().hal().get_alignment(HalMemType::L1) +
@@ -2727,7 +2727,7 @@ void update_traced_program_dispatch_commands(
     // insert_stall_cmds baked in a placeholder wait.addr; patch in the real completion address for cq_id here. Unused
     // when this arch waits via a NOC stream register instead of an L1 address.
     if (!hal.has_stream_registers()) {
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map(dispatch_core_type);
+        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
         const uint32_t wait_addr = mem_map.get_dispatch_message_addr_start() +
                                    mem_map.get_completion_counter_offset(cq_id) * hal.get_alignment(HalMemType::L1) +
                                    mem_map.get_sync_offset(*sub_device_id);

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -137,7 +137,6 @@ void update_program_dispatch_commands(
     uint32_t unicast_cores_launch_message_wptr,
     uint32_t expected_num_workers_completed,
     CoreCoord dispatch_core,
-    CoreType dispatch_core_type,
     SubDeviceId sub_device_id,
     const ProgramDispatchMetadata& dispatch_md,
     ProgramBinaryStatus program_binary_status,
@@ -151,7 +150,6 @@ void update_traced_program_dispatch_commands(
     uint32_t unicast_cores_launch_message_wptr,
     uint32_t expected_num_workers_completed,
     CoreCoord dispatch_core,
-    CoreType dispatch_core_type,
     SubDeviceId sub_device_id,
     ProgramBinaryStatus program_binary_status,
     std::pair<bool, int> unicast_go_signal_update,
@@ -167,7 +165,6 @@ void write_program_command_sequence(
     const ProgramCommandSequence& program_command_sequence,
     SystemMemoryManager& manager,
     uint32_t command_queue_id,
-    CoreType dispatch_core_type,
     bool stall_first,
     bool stall_before_program,
     bool send_binary = true);


### PR DESCRIPTION
Cleanup

### Ticket
N/A

### Problem description
Multiple classes (`FDKernel`, `DispatchTopology`, `DispatchKernelInitializer`) each held their own `std::array<std::unique_ptr<DispatchMemMap>, CoreType::COUNT>` members, resulting in duplicated memory allocation and construction across the dispatch subsystem. Additionally, `MetalContext` itself stored one `DispatchMemMap` per `CoreType` even though only the map corresponding to the active dispatch core configuration is ever needed at runtime.

### What's changed
- Collapsed `MetalContext::dispatch_mem_map_` from an array of unique pointers (one per `CoreType`) to a single `std::unique_ptr<DispatchMemMap>`, constructed once using the active dispatch core type at initialization time.
- Removed the `dispatch_mem_map(const CoreType& core_type)` overload from `MetalContext`; all callers now use the no-arg `dispatch_mem_map()` accessor.
- Removed duplicate `dispatch_mem_map_` members and their construction logic from `FDKernel`, `DispatchTopology`, and `DispatchKernelInitializer`.
- Added a `get_dispatch_mem_map()` protected helper in `FDKernel` that delegates to `descriptor_.metal_context().dispatch_mem_map()`, used by `prefetch.cpp`, `dispatch.cpp`, and `dispatch_s.cpp`.
- Updated `topology.cpp` to access the canonical map via `descriptor_.metal_context().dispatch_mem_map()`.
- Cleaned up now-unused includes and suppressed `[[maybe_unused]]` parameters where signatures could not be changed.

No functional changes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/unifydispatchmemmap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/unifydispatchmemmap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/unifydispatchmemmap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/unifydispatchmemmap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/unifydispatchmemmap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/unifydispatchmemmap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/unifydispatchmemmap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/unifydispatchmemmap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/unifydispatchmemmap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/unifydispatchmemmap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/unifydispatchmemmap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/unifydispatchmemmap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/unifydispatchmemmap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/unifydispatchmemmap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/unifydispatchmemmap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/unifydispatchmemmap)