### PR TITLE
#40182: SFPI s2vFloat16[ab] renamed to sFloat16[ab] [CLEANUP]

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -15,7 +15,7 @@ namespace sfpu {
 template <bool SCALE_EN, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat ckernel_sfpu_exp_accurate(sfpi::vFloat val, const uint exp_base_scale_factor) {
     if constexpr (SCALE_EN) {
-        val = val * sfpi::s2vFloat16b(exp_base_scale_factor);
+        val = val * sfpi::sFloat16b(exp_base_scale_factor);
     }
     sfpi::vFloat result = _sfpu_exp_accurate_<is_fp32_dest_acc_en>(val);
     return result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -32,7 +32,7 @@ namespace ckernel::sfpu {
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConstNeg1;
-    v_if(sfpi::abs(val) < sfpi::s2vFloat16b(0.4f)) {
+    v_if(sfpi::abs(val) < sfpi::sFloat16b(0.4f)) {
         // When x is very small, exp(x) is very close to 1. Hence, for improved precision, we use Taylor expansion of
         // expm1(x) = x + (x^2/2) + (x^3/6)
         // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -17,7 +17,7 @@ sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat out = val;
     v_if(val != 0.0f) {
         // Fast inverse square-root seed + two Newton-Raphson refinements.
-        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
+        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::sFloat16b(0x5f37)));
         sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
         sfpi::vFloat neg_half_val = val * -0.5f;
         approx = ((approx * approx) * neg_half_val + 1.5f) * approx;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -105,7 +105,7 @@ inline void calculate_tangent() {
         // j = round(v / (PI/2))
         // j = v * (2/PI) + 1.5*2**23 shifts the mantissa bits to give round-to-nearest-even.
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
-        sfpi::vFloat rounding_bias = sfpi::s2vFloat16b(0x4b40);
+        sfpi::vFloat rounding_bias = sfpi::sFloat16b(0x1.8p23f);
         sfpi::vFloat j =
             __builtin_rvtt_sfpmad(v.get(), inv_pio2.get(), rounding_bias.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
@@ -164,7 +164,7 @@ inline void calculate_sine() {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
-        sfpi::vFloat rounding_bias = sfpi::s2vFloat16b(0x4b40);  // 1.5*2^23
+        sfpi::vFloat rounding_bias = sfpi::sFloat16b(0x1.8p23f);
         sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
 
         // Compute j = round(v / PI).
@@ -240,7 +240,7 @@ inline void calculate_cosine() {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
         // Force v * (1/PI) + 0.5 to compile as a single SFPMAD sequence for consistent instruction scheduling.
-        sfpi::vFloat half = sfpi::s2vFloat16b(0x3f00);  // 0.5
+        sfpi::vFloat half = sfpi::sFloat16b(0.5f);
         sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
         sfpi::vFloat one = sfpi::vConst1;
         sfpi::vFloat neg_one = sfpi::vConstNeg1;
@@ -250,7 +250,7 @@ inline void calculate_cosine() {
         sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi.get(), half.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // sfpi::vFloat rounding_bias;
-        // rounding_bias = sfpi::s2vFloat16b(0x4b40);  // 1.5*2^23
+        // rounding_bias = sfpi::sFloat16b(0x1.8p23f);
         // j = __builtin_rvtt_sfpmad(v.get(), one, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         j = j + ROUNDING_BIAS;
@@ -261,7 +261,7 @@ inline void calculate_cosine() {
 
         j = j + NEG_ROUNDING_BIAS;
 
-        sfpi::vFloat two = sfpi::s2vFloat16b(0x4000);  // 2.0
+        sfpi::vFloat two = sfpi::sFloat16b(2.0f);
         j = __builtin_rvtt_sfpmad(j.get(), two.get(), neg_one.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // Four-stage Cody-Waite reduction; a = v + j * -PI / 2.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -14,7 +14,7 @@ namespace sfpu {
 template <bool SCALE_EN, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat ckernel_sfpu_exp_accurate(sfpi::vFloat val, const uint exp_base_scale_factor) {
     if constexpr (SCALE_EN) {
-        val = val * sfpi::s2vFloat16b(exp_base_scale_factor);
+        val = val * sfpi::sFloat16b(exp_base_scale_factor);
     }
     sfpi::vFloat result = _sfpu_exp_accurate_<is_fp32_dest_acc_en>(val);
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -32,7 +32,7 @@ namespace ckernel::sfpu {
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConstNeg1;
-    v_if(sfpi::abs(val) < sfpi::s2vFloat16b(0.4f)) {
+    v_if(sfpi::abs(val) < sfpi::sFloat16b(0.4f)) {
         // When x is very small, exp(x) is very close to 1. Hence, for improved precision, we use Taylor expansion of
         // expm1(x) = x + (x^2/2) + (x^3/6)
         // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -17,7 +17,7 @@ sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat out = val;
     v_if(val != 0.0f) {
         // Fast inverse square-root seed + two Newton-Raphson refinements.
-        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
+        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::sFloat16b(0x5f37)));
         sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
         sfpi::vFloat neg_half_val = val * -0.5f;
         approx = ((approx * approx) * neg_half_val + 1.5f) * approx;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -125,7 +125,7 @@ inline void calculate_tangent() {
         // j = round(v / (PI/2))
         // j = v * (2/PI) + 1.5*2**23 shifts the mantissa bits to give round-to-nearest-even.
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
-        sfpi::vFloat rounding_bias = sfpi::s2vFloat16b(0x4b40);
+        sfpi::vFloat rounding_bias = sfpi::sFloat16b(0x1.8p23f);
         sfpi::vFloat j =
             __builtin_rvtt_sfpmad(v.get(), inv_pio2.get(), rounding_bias.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
@@ -184,7 +184,7 @@ inline void calculate_sine() {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
-        sfpi::vFloat rounding_bias = sfpi::s2vFloat16b(0x4b40);  // 1.5*2^23
+        sfpi::vFloat rounding_bias = sfpi::sFloat16b(0x1.8p23f);
         sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
 
         // Compute j = round(v / PI).
@@ -260,7 +260,7 @@ inline void calculate_cosine() {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
         // Force v * (1/PI) + 0.5 to compile as a single SFPMAD sequence for consistent instruction scheduling.
-        sfpi::vFloat half = sfpi::s2vFloat16b(0x3f00);  // 0.5
+        sfpi::vFloat half = sfpi::sFloat16b(0.5f);  // 0.5
         sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
         sfpi::vFloat one = sfpi::vConst1;
         sfpi::vFloat neg_one = sfpi::vConstNeg1;
@@ -270,7 +270,7 @@ inline void calculate_cosine() {
         sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi.get(), half.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // sfpi::vFloat rounding_bias;
-        // rounding_bias = sfpi::s2vFloat16b(0x4b40);  // 1.5*2^23
+        // rounding_bias = sfpi::sFloat16b(0x1.8p23f);
         // j = __builtin_rvtt_sfpmad(v.get(), one, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         j = j + ROUNDING_BIAS;
@@ -281,7 +281,7 @@ inline void calculate_cosine() {
 
         j = j + NEG_ROUNDING_BIAS;
 
-        sfpi::vFloat two = sfpi::s2vFloat16b(0x4000);  // 2.0
+        sfpi::vFloat two = sfpi::sFloat16b(2.0f);
         j = __builtin_rvtt_sfpmad(j.get(), two.get(), neg_one.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // Four-stage Cody-Waite reduction; a = v + j * -PI / 2.

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -23,9 +23,9 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
     // uint format = (param0 >> 16)&0x1;
 
     // SFPU microcode
-    sfpi::vFloat min    = sfpi::s2vFloat16a(param0);
-    sfpi::vFloat max    = sfpi::s2vFloat16a(param1);
-    sfpi::vFloat offset = sfpi::s2vFloat16b(param2); // 12 bits
+    sfpi::vFloat min    = sfpi::sFloat16a(param0);
+    sfpi::vFloat max    = sfpi::sFloat16a(param1);
+    sfpi::vFloat offset = sfpi::sFloat16b(param2); // 12 bits
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -30,7 +30,7 @@ inline void _calculate_dropout_(const int iterations, std::uint32_t probability,
     {
         ////////////////////////
         // Scale samples
-        // dst_reg[0] = dst_reg[0] * s2vFloat16b(scale);
+        // dst_reg[0] = dst_reg[0] * sFloat16(scale);
         ///////////////////////
         TTI_SFPLOAD(p_sfpu::LREG0, 0, 3, 0);
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -272,7 +272,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
     v_endif;
 
     // Run series in Horner form
-    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::s2vFloat16b(0.863281);
+    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::sFloat16b(0.863281f);
     val              = val * tmp + sfpi::vConst1;
 
     v_if (exp >= 0)
@@ -353,7 +353,7 @@ inline sfpi::vFloat _calculate_exponential_piecewise_(sfpi::vFloat in, const std
     sfpi::vFloat result = 0.0f;
     if constexpr (SCALE_EN)
     {
-        in = in * sfpi::s2vFloat16b(exp_base_scale_factor);
+        in = in * sfpi::sFloat16b(exp_base_scale_factor);
     }
     if constexpr (APPROXIMATION_MODE)
     {
@@ -923,8 +923,8 @@ inline void _init_exponential_()
     else if constexpr (APPROXIMATION_MODE)
     {
         sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        sfpi::vConstFloatPrgm1 = sfpi::s2vFloat16b(p_exp::C23_73);
-        sfpi::vConstFloatPrgm2 = sfpi::s2vFloat16b(p_exp::ADJ_EXP);
+        sfpi::vConstFloatPrgm1 = sfpi::sFloat16b(p_exp::C23_73);
+        sfpi::vConstFloatPrgm2 = sfpi::sFloat16b(p_exp::ADJ_EXP);
     }
     else
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -29,8 +29,8 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
     else
     {
         // f = (0.044715*x^3 + x)
-        result = (in * in) * (in * sfpi::s2vFloat16b(0.044715f)) + in;
-        result *= sfpi::s2vFloat16b(0.79788f);
+        result = (in * in) * (in * sfpi::sFloat16(0.044715f)) + in;
+        result *= sfpi::sFloat16(0.79788f);
     }
 
     return result;
@@ -165,7 +165,7 @@ inline void _calculate_gelu_derivative_()
             sfpi::vFloat exp = _calculate_exponential_body_<false>(neg_half_sq_in);
 
             // exp = exp * 1/sqrt(2*pi)
-            sfpi::vFloat partial = exp * in * sfpi::s2vFloat16b(0.3989423F);
+            sfpi::vFloat partial = exp * in * sfpi::sFloat16b(0.3989423F);
 
             sfpi::vFloat result = _calculate_gelu_core_<true>(in);
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -21,9 +21,9 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
     // param1 = -(pos_threshold - neg_threshold)
     // param2 = -(pos_threshold)
 
-    sfpi::vFloat p0 = sfpi::s2vFloat16b(param0);
-    sfpi::vFloat p1 = sfpi::s2vFloat16b(param1);
-    sfpi::vFloat p2 = sfpi::s2vFloat16b(param2);
+    sfpi::vFloat p0 = sfpi::sFloat16b(param0);
+    sfpi::vFloat p1 = sfpi::sFloat16b(param1);
+    sfpi::vFloat p2 = sfpi::sFloat16b(param2);
 // SFPU microcode
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -59,7 +59,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
 
     if constexpr (HAS_BASE_SCALING)
     {
-        result *= sfpi::s2vFloat16a(log_base_scale_factor);
+        result *= sfpi::sFloat16a(log_base_scale_factor);
     }
 
     ////////////////////////////

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -29,7 +29,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         // Algorithm SQRT_10-bits, with modifications for reciprocal.
         sfpi::vFloat c           = x * y;
         sfpi::vFloat negative_y  = -y;
-        sfpi::vFloat infinity    = sfpi::s2vFloat16b(std::numeric_limits<float>::infinity());
+        sfpi::vFloat infinity    = sfpi::sFloat16b(std::numeric_limits<float>::infinity());
         sfpi::vInt infinity_bits = sfpi::reinterpret<sfpi::vInt>(infinity);
         sfpi::vFloat t           = sfpi::vConstFloatPrgm1 + negative_y * c;
         if constexpr (RECIPROCAL)
@@ -65,7 +65,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         sfpi::vFloat xy            = x * y;
         sfpi::vFloat negative_y    = -y;
         sfpi::vFloat c             = negative_y * xy;
-        sfpi::vFloat infinity      = sfpi::s2vFloat16b(std::numeric_limits<float>::infinity());
+        sfpi::vFloat infinity      = sfpi::sFloat16b(std::numeric_limits<float>::infinity());
         sfpi::vInt infinity_bits   = sfpi::reinterpret<sfpi::vInt>(infinity);
         y                          = y * (sfpi::vConstFloatPrgm1 + c * (sfpi::vConstFloatPrgm2 + c));
         xy                         = x * y;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -23,9 +23,9 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
     // uint format = (param0 >> 16)&0x1;
 
     // SFPU microcode
-    sfpi::vFloat min    = sfpi::s2vFloat16a(param0);
-    sfpi::vFloat max    = sfpi::s2vFloat16a(param1);
-    sfpi::vFloat offset = sfpi::s2vFloat16b(param2); // 12 bits
+    sfpi::vFloat min    = sfpi::sFloat16a(param0);
+    sfpi::vFloat max    = sfpi::sFloat16a(param1);
+    sfpi::vFloat offset = sfpi::sFloat16b(param2); // 12 bits
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -30,7 +30,7 @@ inline void _calculate_dropout_(const int iterations, std::uint32_t probability,
     {
         ////////////////////////
         // Scale samples
-        // sfpi::dst_reg[0] = sfpi::dst_reg[0] * s2vFloat16b(scale);
+        // sfpi::dst_reg[0] = sfpi::dst_reg[0] * sFloat16b(scale);
         ///////////////////////
         TTI_SFPLOAD(p_sfpu::LREG0, 0, 3, 0);
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -266,7 +266,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_(sfpi::vFloat val)
     v_endif;
 
     // Run series in Horner form
-    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::s2vFloat16b(0.863281);
+    sfpi::vFloat tmp = val * sfpi::vConst0p8373 + sfpi::sFloat16b(0.863281f);
     val              = val * tmp + sfpi::vConst1;
 
     v_if (exp >= 0)
@@ -347,7 +347,7 @@ inline sfpi::vFloat _calculate_exponential_piecewise_(sfpi::vFloat in, const std
     sfpi::vFloat result = 0.0f;
     if constexpr (SCALE_EN)
     {
-        in = in * sfpi::s2vFloat16b(exp_base_scale_factor);
+        in = in * sfpi::sFloat16b(exp_base_scale_factor);
     }
     if constexpr (APPROXIMATION_MODE)
     {
@@ -917,8 +917,8 @@ inline void _init_exponential_()
     else if constexpr (APPROXIMATION_MODE)
     {
         sfpi::vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        sfpi::vConstFloatPrgm1 = sfpi::s2vFloat16b(p_exp::C23_73);
-        sfpi::vConstFloatPrgm2 = sfpi::s2vFloat16b(p_exp::ADJ_EXP);
+        sfpi::vConstFloatPrgm1 = sfpi::sFloat16b(p_exp::C23_73);
+        sfpi::vConstFloatPrgm2 = sfpi::sFloat16b(p_exp::ADJ_EXP);
     }
     else
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -29,8 +29,8 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
     else
     {
         // f = (0.044715*x^3 + x)
-        result = (in * in) * (in * sfpi::s2vFloat16b(0.044715f)) + in;
-        result *= sfpi::s2vFloat16b(0.79788f);
+        result = (in * in) * (in * sfpi::sFloat16b(0.044715f)) + in;
+        result *= sfpi::sFloat16b(0.79788f);
     }
 
     return result;
@@ -165,7 +165,7 @@ inline void _calculate_gelu_derivative_()
             sfpi::vFloat exp = _calculate_exponential_body_<false>(neg_half_sq_in);
 
             // exp = exp * 1/sqrt(2*pi)
-            sfpi::vFloat partial = exp * in * sfpi::s2vFloat16b(0.3989423F);
+            sfpi::vFloat partial = exp * in * sfpi::sFloat16b(0.3989423F);
 
             sfpi::vFloat result = _calculate_gelu_core_<true>(in);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -21,9 +21,9 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
     // param1 = -(pos_threshold - neg_threshold)
     // param2 = -(pos_threshold)
 
-    sfpi::vFloat p0 = sfpi::s2vFloat16b(param0);
-    sfpi::vFloat p1 = sfpi::s2vFloat16b(param1);
-    sfpi::vFloat p2 = sfpi::s2vFloat16b(param2);
+    sfpi::vFloat p0 = sfpi::sFloat16b(param0);
+    sfpi::vFloat p1 = sfpi::sFloat16b(param1);
+    sfpi::vFloat p2 = sfpi::sFloat16b(param2);
 // SFPU microcode
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -59,7 +59,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
 
     if constexpr (HAS_BASE_SCALING)
     {
-        result *= sfpi::s2vFloat16a(log_base_scale_factor);
+        result *= sfpi::sFloat16a(log_base_scale_factor);
     }
 
     ////////////////////////////

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -29,7 +29,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         // Algorithm SQRT_10-bits, with modifications for reciprocal.
         sfpi::vFloat c           = x * y;
         sfpi::vFloat negative_y  = -y;
-        sfpi::vFloat infinity    = sfpi::s2vFloat16b(std::numeric_limits<float>::infinity());
+        sfpi::vFloat infinity    = sfpi::sFloat16b(std::numeric_limits<float>::infinity());
         sfpi::vInt infinity_bits = sfpi::reinterpret<sfpi::vInt>(infinity);
         sfpi::vFloat t           = sfpi::vConstFloatPrgm1 + negative_y * c;
         if constexpr (RECIPROCAL)
@@ -65,7 +65,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         sfpi::vFloat xy            = x * y;
         sfpi::vFloat negative_y    = -y;
         sfpi::vFloat c             = negative_y * xy;
-        sfpi::vFloat infinity      = sfpi::s2vFloat16b(std::numeric_limits<float>::infinity());
+        sfpi::vFloat infinity      = sfpi::sFloat16b(std::numeric_limits<float>::infinity());
         sfpi::vInt infinity_bits   = sfpi::reinterpret<sfpi::vInt>(infinity);
         y                          = y * (sfpi::vConstFloatPrgm1 + c * (sfpi::vConstFloatPrgm2 + c));
         xy                         = x * y;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40182

### Problem description
These are scalars, not vector, so use a consistent name.  Also do not use the conversion from double.

### What's changed
This is primarily a mechanical change, but I also took the opportunity to use hex-float literals rather than obscure float16b bit patterns.  One doesn't need comments explaining what the value is then.

Checked with an SFPI that issues deprecation warnings on the old names and constructor. That'll be a later change once llk is also updated. (yes I'm aware that submodule is being flattened this weekend)

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/sFloat16-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/sFloat16-40182)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/sFloat16-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/sFloat16-40182)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/sFloat16-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/sFloat16-40182)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/sFloat16-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/sFloat16-40182)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/sFloat16-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/sFloat16-40182)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/sFloat16-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/sFloat16-40182)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
