### PR TITLE
Branching off 32 users per row and 8 users per row code

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -531,7 +531,23 @@ def run_demo(
             )
             raise
 
-    batch_size_per_row = max_users_per_row
+    use_legacy_teacher_forced_demo_path = bool(token_accuracy)
+    if use_legacy_teacher_forced_demo_path:
+        if max_seq_len != DEFAULT_MAX_SEQ_LEN:
+            logger.info(
+                "Teacher-forced demo uses legacy max_seq_len={}, ignoring requested max_seq_len={}.",
+                DEFAULT_MAX_SEQ_LEN,
+                max_seq_len,
+            )
+        if max_users_per_row != USERS_PER_ROW:
+            logger.info(
+                "Teacher-forced demo uses legacy users_per_row={}, ignoring requested max_users_per_row={}.",
+                USERS_PER_ROW,
+                max_users_per_row,
+            )
+
+    effective_max_seq_len = DEFAULT_MAX_SEQ_LEN if use_legacy_teacher_forced_demo_path else max_seq_len
+    batch_size_per_row = USERS_PER_ROW if use_legacy_teacher_forced_demo_path else max_users_per_row
     batch_size = batch_size_per_row * mesh_device.shape[0]
 
     # Configure sampling
@@ -578,14 +594,15 @@ def run_demo(
                 enable_trace=enable_trace,
                 enable_mem_profile=enable_mem_profile,
                 signpost=signpost,
-                max_seq_len=max_seq_len,
+                max_seq_len=effective_max_seq_len,
                 prefill_max_tokens=prefill_max_tokens,
                 force_recalculate=force_recalculate,
                 profile_decode=profile_decode,
                 sample_on_device=sample_on_device,
                 enable_mtp=enable_mtp,
-                batch_size_per_row=max_users_per_row,
+                batch_size_per_row=batch_size_per_row,
                 sampling_params=sampling_params,
+                force_legacy_demo_path=use_legacy_teacher_forced_demo_path,
             )
         else:
             raise ValueError(f"Unsupported generator: {generator}")

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -8,10 +8,10 @@ import pytest
 import torch
 from loguru import logger
 
-import ttnn
 from models.demos.deepseek_v3.demo.demo import run_demo
 from models.demos.deepseek_v3.demo.token_accuracy import TokenAccuracy
-from models.demos.deepseek_v3.utils.config_helpers import DEFAULT_MAX_SEQ_LEN, USERS_PER_ROW
+from models.demos.deepseek_v3.tt.generator import MAX_SEQ_LEN as GENERATOR_MAX_SEQ_LEN
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
 
@@ -65,11 +65,6 @@ def _assert_no_garbage_tokens(
             f"Garbage tokens detected: {expected_count}/{expected_checked} checked tokens are outside the "
             f"teacher top-{token_acc.topk_candidate_k}.\n" + "\n".join(expected_debug)
         )
-
-
-def _tile_align(length: int) -> int:
-    tile_size = int(ttnn.TILE_SIZE)
-    return ((int(length) + tile_size - 1) // tile_size) * tile_size
 
 
 @pytest.mark.timeout(3600)
@@ -128,6 +123,15 @@ def test_demo_teacher_forcing_accuracy(
     tf_prompt_len = int(payload["tf_prompt_len"])
     saved_max_new_tokens = int(payload.get("max_new_tokens"))
 
+    max_supported_new_tokens = GENERATOR_MAX_SEQ_LEN - tf_prompt_len
+    if max_supported_new_tokens <= 0:
+        pytest.skip(f"Prompt length {tf_prompt_len} exceeds max_seq_len {GENERATOR_MAX_SEQ_LEN}.")
+    if max_new_tokens > max_supported_new_tokens:
+        pytest.skip(
+            f"Requested max_new_tokens={max_new_tokens} exceeds generator capacity: "
+            f"max_seq_len={GENERATOR_MAX_SEQ_LEN}, prompt_len={tf_prompt_len} -> max_new_tokens<={max_supported_new_tokens}."
+        )
+
     requested_system_name = os.getenv("MESH_DEVICE")
     if requested_system_name is None:
         pytest.fail("Environment variable $MESH_DEVICE is not set. Please set it to DUAL, QUAD, TG, or T3K.")
@@ -177,20 +181,10 @@ def test_demo_teacher_forcing_accuracy(
             f"in {reference_file}. Regenerate the reference with a larger max_new_tokens."
         )
 
-    # Teacher forcing only needs enough configured context for the prompt plus the
-    # number of forced decode steps under test.
-    configured_max_seq_len = _tile_align(tf_prompt_len + max_new_tokens)
-    if configured_max_seq_len > DEFAULT_MAX_SEQ_LEN:
-        pytest.skip(
-            f"Requested teacher-forced context requires max_seq_len={configured_max_seq_len}, "
-            f"which exceeds the default demo max_seq_len {DEFAULT_MAX_SEQ_LEN}."
-        )
-
     logger.info("=== Phase 2: Run teacher forcing ===")
     logger.info("Loaded reference from: {}", reference_file)
     logger.info("Total reference tokens: {}, prompt length: {}", total_ref_tokens, tf_prompt_len)
     logger.info("Using max_new_tokens={}", max_new_tokens)
-    logger.info("Using configured max_seq_len={}", configured_max_seq_len)
 
     # Run the demo with teacher forcing
     results = run_demo(
@@ -199,7 +193,6 @@ def test_demo_teacher_forcing_accuracy(
         cache_dir=CACHE_DIR,
         random_weights=False,
         max_new_tokens=max_new_tokens,
-        max_seq_len=configured_max_seq_len,
         repeat_batches=1,
         token_accuracy=True,
         reference_file=reference_file,

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
@@ -10,6 +10,7 @@ import ttnn
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d_base import DecoderBlock2DBase
 from models.demos.deepseek_v3.tt.mlp.non_expert import NonExpert
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -74,7 +75,7 @@ class DecoderBlock2D(DecoderBlock2DBase):
 
     @classmethod
     def forward_mlp_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
-        if x.shape[1] == 1:
+        if x.shape[1] == 1 or x.shape[1] == USERS_PER_ROW:
             return NonExpert.forward_prefill(x, cfg)
 
         batch_size = x.shape[1]

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
@@ -133,7 +133,14 @@ class DecoderBlock2DBase(DecoderBlockBase):
             ttnn.deallocate(mla_norm_in)
 
         # MLA
-        mla_norm_out = ttnn.to_memory_config(mla_norm_out, **cfg["mla_reshard"])
+        if isinstance(cfg["mla_reshard"], dict):
+            mla_reshard_memory_config = ttnn.create_sharded_memory_config(
+                mla_norm_out.shape,
+                **cfg["mla_reshard"],
+            )
+            mla_norm_out = ttnn.to_memory_config(mla_norm_out, memory_config=mla_reshard_memory_config)
+        else:
+            mla_norm_out = ttnn.to_memory_config(mla_norm_out, **cfg["mla_reshard"])
         mla_out = MLA2D.forward_decode(mla_norm_out, position_idxs, cfg["mla"], rope_tensors, page_table)
         ttnn.deallocate(mla_norm_out)
 

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -14,6 +14,7 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.config_dataclass import ReshardConfig
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
@@ -83,10 +84,17 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         else:
             mlp_input_memory_config = mlp_config["input_memory_config"]
 
+        # Keep the pre-`users_per_row` decode reshard for the original full-row path.
+        mla_reshard = (
+            mla_config["mla1d"]["wq_kv_a_in0_memory_config"]
+            if batch_size_per_row == USERS_PER_ROW
+            else ReshardConfig(memory_config=mla_config["input_memory_config"])
+        )
+
         return {
             "mla_norm_reshard": ReshardConfig(memory_config=mla_norm_config["input_memory_config"]),
             "mla_norm": mla_norm_config,
-            "mla_reshard": ReshardConfig(memory_config=mla_config["input_memory_config"]),
+            "mla_reshard": mla_reshard,
             "mla": mla_config,
             "mlp_norm_reshard": ReshardConfig(memory_config=mlp_norm_config["input_memory_config"]),
             "mlp_norm": mlp_norm_config,

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -12,7 +12,7 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d_base import DecoderBlock2DBase
 from models.demos.deepseek_v3.tt.mlp.shared_expert import SharedExpert
 from models.demos.deepseek_v3.tt.moe import MoE
-from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -126,7 +126,8 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
 
         batch_size = x_gathered.shape[1]
         seq_len = x_gathered.shape[2]
-        if batch_size > 1:
+        use_legacy_full_row_path = batch_size == USERS_PER_ROW
+        if batch_size > 1 and not use_legacy_full_row_path:
             x_gathered = ttnn.reshape(x_gathered, (x_gathered.shape[0], 1, batch_size * seq_len, x_gathered.shape[3]))
 
         # Run both MoE and SharedExpert with the same gathered input
@@ -148,7 +149,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
                 **ccl_moe.populate_reduce_scatter_runtime_args(cfg["moe"]["final_output_reduce_scatter"]),
             )
             ttnn.deallocate(combined_out)
-            if batch_size > 1:
+            if batch_size > 1 and not use_legacy_full_row_path:
                 output = ttnn.reshape(output, (output.shape[0], batch_size, seq_len, output.shape[3]))
             # Cleanup gathered tensor
             if x_gathered is not x:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -39,6 +39,8 @@ from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
+MAX_SEQ_LEN = DEFAULT_MAX_SEQ_LEN
+
 
 def _build_verify_alias_page_table_host(
     base_page_table: torch.Tensor,
@@ -170,33 +172,41 @@ class DeepseekGenerator(WarmupForwardMixin):
         sample_on_device: bool = False,
         enable_mtp: bool = False,
         sampling_params: SamplingParams | None = None,
+        force_legacy_demo_path: bool = False,
     ) -> None:
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
         self.cache_dir = cache_dir
+        self.force_legacy_demo_path = bool(force_legacy_demo_path)
 
         # Load HF config + tokenizer
         self.hf_config = (
             hf_config if hf_config is not None else AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
         )
-        model_max_seq_len = int(self.hf_config.max_position_embeddings)
-        requested_max_seq_len = DEFAULT_MAX_SEQ_LEN if max_seq_len is None else int(max_seq_len)
-        if requested_max_seq_len <= 0:
-            raise ValueError(f"max_seq_len must be > 0, got {requested_max_seq_len}")
-        if requested_max_seq_len % ttnn.TILE_SIZE != 0:
-            raise ValueError(f"max_seq_len {requested_max_seq_len} must be divisible by TILE_SIZE={ttnn.TILE_SIZE}")
-        if requested_max_seq_len > model_max_seq_len:
-            raise ValueError(
-                f"max_seq_len {requested_max_seq_len} exceeds model-supported context length {model_max_seq_len}"
-            )
-        if requested_max_seq_len != DEFAULT_MAX_SEQ_LEN:
-            logger.warning(
-                "Using overridden max_seq_len={} (default={}, model supports up to {}).",
-                requested_max_seq_len,
-                DEFAULT_MAX_SEQ_LEN,
-                model_max_seq_len,
-            )
-        self.hf_config.max_seq_len = requested_max_seq_len
+        if self.force_legacy_demo_path:
+            # Teacher-forced demo coverage intentionally stays on the pre-users-per-row demo setup.
+            if max_seq_len is not None and int(max_seq_len) != MAX_SEQ_LEN:
+                logger.warning(f"Ignoring requested max_seq_len={max_seq_len}; using MAX_SEQ_LEN={MAX_SEQ_LEN}.")
+            self.hf_config.max_seq_len = MAX_SEQ_LEN
+        else:
+            model_max_seq_len = int(self.hf_config.max_position_embeddings)
+            requested_max_seq_len = DEFAULT_MAX_SEQ_LEN if max_seq_len is None else int(max_seq_len)
+            if requested_max_seq_len <= 0:
+                raise ValueError(f"max_seq_len must be > 0, got {requested_max_seq_len}")
+            if requested_max_seq_len % ttnn.TILE_SIZE != 0:
+                raise ValueError(f"max_seq_len {requested_max_seq_len} must be divisible by TILE_SIZE={ttnn.TILE_SIZE}")
+            if requested_max_seq_len > model_max_seq_len:
+                raise ValueError(
+                    f"max_seq_len {requested_max_seq_len} exceeds model-supported context length {model_max_seq_len}"
+                )
+            if requested_max_seq_len != DEFAULT_MAX_SEQ_LEN:
+                logger.warning(
+                    "Using overridden max_seq_len={} (default={}, model supports up to {}).",
+                    requested_max_seq_len,
+                    DEFAULT_MAX_SEQ_LEN,
+                    model_max_seq_len,
+                )
+            self.hf_config.max_seq_len = requested_max_seq_len
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
             try:
@@ -228,14 +238,21 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.ccl = CCL(mesh_device)
         mesh_shape = list(mesh_device.shape)
         self.dp_factor = mesh_shape[1]
-        batch_size_per_row = int(batch_size_per_row)
-        if batch_size_per_row <= 0:
-            raise ValueError(f"batch_size_per_row must be > 0, got {batch_size_per_row}")
-        if batch_size_per_row > USERS_PER_ROW:
-            raise ValueError(f"batch_size_per_row {batch_size_per_row} exceeds the supported maximum {USERS_PER_ROW}")
-        if batch_size_per_row % self.dp_factor != 0:
-            raise ValueError(f"batch_size_per_row {batch_size_per_row} must be divisible by dp_factor={self.dp_factor}")
-        self.batch_size_per_row = batch_size_per_row
+        if self.force_legacy_demo_path:
+            self.batch_size_per_row = USERS_PER_ROW
+        else:
+            batch_size_per_row = int(batch_size_per_row)
+            if batch_size_per_row <= 0:
+                raise ValueError(f"batch_size_per_row must be > 0, got {batch_size_per_row}")
+            if batch_size_per_row > USERS_PER_ROW:
+                raise ValueError(
+                    f"batch_size_per_row {batch_size_per_row} exceeds the supported maximum {USERS_PER_ROW}"
+                )
+            if batch_size_per_row % self.dp_factor != 0:
+                raise ValueError(
+                    f"batch_size_per_row {batch_size_per_row} must be divisible by dp_factor={self.dp_factor}"
+                )
+            self.batch_size_per_row = batch_size_per_row
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
 
         # Configure sampling

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1610,6 +1610,205 @@ class MLA1D(AbstractModule):
             logger.warning("KVDBG deepseek prefill failed: {}", exc)
 
     @classmethod
+    def _forward_prefill_full_row_legacy(
+        cls,
+        x: ttnn.Tensor,
+        batch_idx: int,
+        row_idx: int | None,
+        cfg: RunPrefillConfig,
+        rope_tensors: dict,
+        page_table: ttnn.Tensor,
+    ) -> ttnn.Tensor:
+        mesh_shape = cfg["mesh_shape"]
+
+        sdpa_dp_factor = mla_tp_factor = mesh_shape[1]
+
+        num_heads = cfg["num_heads"]
+        num_heads_local = even_int_div(num_heads, mla_tp_factor)
+        q_lora_rank = cfg["q_lora_rank"]
+        kv_lora_rank = cfg["kv_lora_rank"]
+        qk_nope_head_dim = cfg["qk_nope_head_dim"]
+        qk_rope_head_dim = cfg["qk_rope_head_dim"]
+        qk_head_dim = cfg["qk_head_dim"]
+        v_head_dim = cfg["v_head_dim"]
+
+        kvpe_cache = cfg["kvpe_cache"]
+        ccl = cfg["ccl"]
+
+        seq_len = x.shape[2]
+
+        # Preserve the pre-batch8 full-row prefill path for 32 users_per_row.
+        tt_q, tt_kv_nope, tt_kv_rope = cls._fwd_prefill_wq_kv_a(
+            x,
+            cfg,
+            ccl,
+            seq_len,
+            q_lora_rank,
+            kv_lora_rank,
+            qk_rope_head_dim,
+        )
+
+        tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])
+        wq_b_program_config = build_prefill_matmul_program_config(
+            seq_len,
+            k=q_lora_rank,
+            n=num_heads_local * qk_head_dim,
+            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+        )
+        tt_q = ttnn.linear(tt_q, **cfg["wq_b"], program_config=wq_b_program_config)
+
+        tt_q = ttnn.reshape(tt_q, (1, seq_len, num_heads_local, qk_head_dim))
+        tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))
+
+        tt_q_nope = ttnn.slice(tt_q, [0, 0, 0, 0], [1, num_heads_local, seq_len, qk_nope_head_dim])
+        tt_q_rope = ttnn.slice(tt_q, [0, 0, 0, qk_nope_head_dim], [1, num_heads_local, seq_len, qk_head_dim])
+        ttnn.deallocate(tt_q)
+
+        num_heads_local_padded = pad_batch_to_dram_banks(num_heads_local)
+        wkv_b1_program_config = build_prefill_matmul_program_config(
+            seq_len,
+            k=qk_nope_head_dim,
+            n=kv_lora_rank,
+            batch=num_heads_local_padded,
+            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+        )
+        tt_q_nope = ttnn.linear(tt_q_nope, **cfg["wkv_b1"], program_config=wkv_b1_program_config)
+
+        tt_q_rope = ttnn.experimental.rotary_embedding_llama(
+            tt_q_rope,
+            rope_tensors["cos_matrix"],
+            rope_tensors["sin_matrix"],
+            rope_tensors["trans_matrix"],
+            is_decode_mode=False,
+        )
+
+        tt_q = ttnn.concat([tt_q_nope, tt_q_rope], dim=-1)
+
+        tt_kv_nope = RMSNorm.forward_prefill(tt_kv_nope, cfg["kv_norm"])
+        tt_kv_rope = ttnn.experimental.rotary_embedding_llama(
+            tt_kv_rope,
+            rope_tensors["cos_matrix"],
+            rope_tensors["sin_matrix"],
+            rope_tensors["trans_matrix"],
+            is_decode_mode=False,
+        )
+
+        tt_kvpe = ttnn.concat([tt_kv_nope, tt_kv_rope], dim=-1)
+
+        ttnn.deallocate(tt_kv_nope)
+        ttnn.deallocate(tt_kv_rope)
+
+        tt_kvpe_fp16 = tt_kvpe
+        tt_kvpe = ttnn.typecast(tt_kvpe_fp16, dtype=kvpe_cache.dtype)
+        ttnn.deallocate(tt_kvpe_fp16)
+
+        batch_size_per_dp_shard = even_int_div(USERS_PER_ROW, sdpa_dp_factor)
+        local_batch_idx = batch_idx % batch_size_per_dp_shard
+        col_idx = batch_idx // batch_size_per_dp_shard
+        if _deepseek_kvdbg_enabled():
+            cls._debug_prefill_page_table(
+                page_table=page_table,
+                local_batch_idx=local_batch_idx,
+                global_batch_idx=batch_idx,
+                row_idx=row_idx,
+                col_idx=col_idx,
+                block_size=kvpe_cache.shape[2],
+                max_blocks=kvpe_cache.shape[0],
+                mesh_device=cfg.get("mesh_device", None),
+            )
+
+        ttnn.experimental.paged_fill_cache(
+            kvpe_cache,
+            tt_kvpe,
+            page_table=page_table,
+            batch_idx=local_batch_idx,
+            mesh_coords=set(get_mesh_coords(mesh_shape, row_idx, col_idx)),
+        )
+
+        attn_out = ttnn.transformer.flash_mla_prefill(
+            tt_q,
+            tt_kvpe,
+            **cfg["flash_mla"],
+        )
+        ttnn.deallocate(tt_q)
+        ttnn.deallocate(tt_kvpe)
+
+        v_out = ttnn.experimental.all_gather_async(
+            attn_out,
+            **ccl.populate_all_gather_runtime_args(cfg["wkv_b2_ag_prefill"]),
+        )
+
+        num_heads_padded = pad_batch_to_dram_banks(num_heads)
+        wkv_b2_program_config = build_prefill_matmul_program_config(
+            seq_len,
+            k=kv_lora_rank,
+            n=v_head_dim,
+            batch=num_heads_padded,
+            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+        )
+        v_out = ttnn.linear(v_out, **cfg["wkv_b2"], program_config=wkv_b2_program_config)
+        ttnn.deallocate(attn_out)
+
+        v_out = ttnn.permute(v_out, (0, 2, 1, 3))
+
+        wo_k = num_heads * v_head_dim
+        dim = x.shape[3]
+
+        seq_len_chunk_size = 8192
+        if seq_len > seq_len_chunk_size:
+            num_heads = v_out.shape[2]
+            v_head_dim = v_out.shape[3]
+            num_chunks = (seq_len + seq_len_chunk_size - 1) // seq_len_chunk_size
+
+            padded_seq_len = num_chunks * seq_len_chunk_size
+            if seq_len != padded_seq_len:
+                v_out = ttnn.pad(
+                    v_out,
+                    padding=((0, 0), (0, padded_seq_len - seq_len), (0, 0), (0, 0)),
+                    value=0.0,
+                )
+
+            wo_chunk_program_config = build_prefill_matmul_program_config(
+                seq_len_chunk_size,
+                k=wo_k,
+                n=dim,
+                mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+            )
+
+            output_chunks = []
+            hidden_dim = num_heads * v_head_dim
+            for chunk_idx in range(num_chunks):
+                start = chunk_idx * seq_len_chunk_size
+                end = start + seq_len_chunk_size
+                v_chunk = ttnn.slice(v_out, (0, start, 0, 0), (1, end, num_heads, v_head_dim))
+                v_chunk = ttnn.reshape(v_chunk, (1, 1, seq_len_chunk_size, hidden_dim))
+                out_chunk = ttnn.linear(v_chunk, **cfg["wo"], program_config=wo_chunk_program_config)
+                output_chunks.append(out_chunk)
+                ttnn.deallocate(v_chunk)
+
+            ttnn.deallocate(v_out)
+
+            out = ttnn.concat(output_chunks, dim=2)
+            output_dim = out.shape[3]
+            for chunk in output_chunks:
+                ttnn.deallocate(chunk)
+
+            if seq_len != padded_seq_len:
+                out = ttnn.slice(out, (0, 0, 0, 0), (1, 1, seq_len, output_dim))
+        else:
+            v_out = ttnn.reshape(v_out, (1, 1, seq_len, num_heads * v_head_dim))
+            wo_program_config = build_prefill_matmul_program_config(
+                seq_len,
+                k=wo_k,
+                n=dim,
+                mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+            )
+            out = ttnn.linear(v_out, **cfg["wo"], program_config=wo_program_config)
+            ttnn.deallocate(v_out)
+
+        return out
+
+    @classmethod
     def _fwd_prefill_output_from_q_and_kvpe(
         cls,
         tt_q: ttnn.Tensor,
@@ -1847,6 +2046,9 @@ class MLA1D(AbstractModule):
 
         seq_len = x.shape[2]
         batch_size = x.shape[1]
+        if batch_size == USERS_PER_ROW:
+            return cls._forward_prefill_full_row_legacy(x, batch_idx, row_idx, cfg, rope_tensors, page_table)
+
         row_batched_prefill = batch_size > 1
         if row_batched_prefill:
             expected_batch_size = cfg["batch_size_per_row"]
@@ -2003,14 +2205,14 @@ class MLA1D(AbstractModule):
         kv_lora_rank: int,
         qk_rope_head_dim: int,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
-        # Shard in0 to L1 WIDTH sharded for qkv_a matmul
-        x_shard_shape = list(x.shape)
-        x_shard_shape[-2] = ttnn.core.roundup(x_shard_shape[-2], ttnn.TILE_SIZE)
-        in0_memory_config = ttnn.create_sharded_memory_config(
-            x_shard_shape,
-            **cfg["wq_kv_a_in0_memory_config"],
-        )
-        x = ttnn.to_memory_config(x, memory_config=in0_memory_config)
+        if bsz != USERS_PER_ROW:
+            x_shard_shape = list(x.shape)
+            x_shard_shape[-2] = ttnn.core.roundup(x_shard_shape[-2], ttnn.TILE_SIZE)
+            in0_memory_config = ttnn.create_sharded_memory_config(
+                x_shard_shape,
+                **cfg["wq_kv_a_in0_memory_config"],
+            )
+            x = ttnn.to_memory_config(x, memory_config=in0_memory_config)
 
         # Fused wq_kv_a matmul
         # 1,1,32,896, width sharded 7x4 [32,32]
@@ -2350,26 +2552,37 @@ class MLA1D(AbstractModule):
         # Reshape
         v_out = ttnn.untilize(v_out)
         v_out = ttnn.experimental.view(v_out, (1, 1, bsz // mesh_shape[1], num_heads * v_head_dim))
-        # All_gather
-        v_out = ttnn.to_memory_config(v_out, memory_config=ttnn.L1_MEMORY_CONFIG)
-        v_out = ttnn.experimental.all_gather_async(v_out, **ccl.populate_all_gather_runtime_args(cfg["wo_ag_decode"]))
-        # Decode batch sizes smaller than a tile still need a tiled tensor for `wo`.
-        v_out = ttnn.tilize_with_zero_padding(v_out)
+        if bsz == USERS_PER_ROW:
+            wo_in0_memory_config = ttnn.create_sharded_memory_config(
+                (1, 1, bsz, num_heads * v_head_dim),
+                **cfg["wo_in0_memory_config"],
+            )
+            v_out = ttnn.experimental.all_gather_async(
+                v_out, **ccl.populate_all_gather_runtime_args(cfg["wo_ag_decode"])
+            )
+            v_out = ttnn.tilize(v_out)
+            v_out = ttnn.to_memory_config(v_out, memory_config=wo_in0_memory_config)
+        else:
+            v_out = ttnn.to_memory_config(v_out, memory_config=ttnn.L1_MEMORY_CONFIG)
+            v_out = ttnn.experimental.all_gather_async(
+                v_out, **ccl.populate_all_gather_runtime_args(cfg["wo_ag_decode"])
+            )
+            # Decode batch sizes smaller than a tile still need a tiled tensor for `wo`.
+            v_out = ttnn.tilize_with_zero_padding(v_out)
         # 1,1,32,16384 WIDTH sharded 2x8 [32,1024]
 
         return v_out
 
     @classmethod
     def _fwd_decode_wo(cls, v_out: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
-        # 1,1,32,16384 L1 interleaved
-        # Shard in0 to L1 WIDTH sharded for wo matmul
-        v_out_shard_shape = list(v_out.shape)
-        v_out_shard_shape[-2] = ttnn.core.roundup(v_out_shard_shape[-2], ttnn.TILE_SIZE)
-        wo_in0_memory_config = ttnn.create_sharded_memory_config(
-            v_out_shard_shape,
-            **cfg["wo_in0_memory_config"],
-        )
-        v_out = ttnn.to_memory_config(v_out, memory_config=wo_in0_memory_config)
+        if cfg["batch_size_per_row"] != USERS_PER_ROW:
+            v_out_shard_shape = list(v_out.shape)
+            v_out_shard_shape[-2] = ttnn.core.roundup(v_out_shard_shape[-2], ttnn.TILE_SIZE)
+            wo_in0_memory_config = ttnn.create_sharded_memory_config(
+                v_out_shard_shape,
+                **cfg["wo_in0_memory_config"],
+            )
+            v_out = ttnn.to_memory_config(v_out, memory_config=wo_in0_memory_config)
         out = ttnn.linear(v_out, **cfg["wo"])  # [1, 1, bsz, dim]
         # 1,1,32,896 WIDTH sharded 2x6 [32,96]
         return out
@@ -2389,38 +2602,65 @@ class MLA1D(AbstractModule):
         dim = x.shape[3]
         batch_size = x.shape[1]
         qkv_a_n = q_lora_rank + kv_lora_rank + qk_rope_head_dim
-        # Row-batched prefill drives the fused Q/KV projection with batch on dim 1.
-        # The program config must account for that batch so fuse_batch stays disabled.
-        wq_kv_a_program_config = build_prefill_matmul_program_config(
-            seq_len,
-            k=dim,
-            n=qkv_a_n,
-            batch=batch_size,
-            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
-        )
-        tt_q_kv = ttnn.linear(x, **cfg["wq_kv_a"], program_config=wq_kv_a_program_config)
+        if batch_size == USERS_PER_ROW:
+            wq_kv_a_program_config = build_prefill_matmul_program_config(
+                seq_len,
+                k=dim,
+                n=qkv_a_n,
+                mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+            )
+            tt_q_kv = ttnn.linear(x, **cfg["wq_kv_a"], program_config=wq_kv_a_program_config)
 
-        # AR using AG + local reduce (since sub-tile RS not supported for new shapes)
-        wq_kv_a_ag_args = ccl.populate_all_gather_runtime_args(cfg["wq_kv_a_ag_prefill"])
-        wq_kv_a_reduce_args = dict(cfg["wq_kv_a_r_prefill"])
-        if batch_size > 1:
-            # Keep the user batch intact during TP reduce by borrowing the singleton dim 0 as
-            # the gather/reduce axis; dim 1 already carries the real row batch.
-            wq_kv_a_ag_args = {**wq_kv_a_ag_args, "dim": 0}
-            wq_kv_a_reduce_args = {**wq_kv_a_reduce_args, "dims": [0]}
+            tt_q_kv = ttnn.experimental.all_gather_async(
+                tt_q_kv,
+                **ccl.populate_all_gather_runtime_args(cfg["wq_kv_a_ag_prefill"]),
+            )
+            tt_q_kv = ttnn.experimental.fast_reduce_nc(tt_q_kv, **cfg["wq_kv_a_r_prefill"])
 
-        tt_q_kv = ttnn.experimental.all_gather_async(
-            tt_q_kv, **wq_kv_a_ag_args
-        )  # [1, batch, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim]
-        tt_q_kv = ttnn.experimental.fast_reduce_nc(tt_q_kv, **wq_kv_a_reduce_args)
+            tt_q = ttnn.slice(tt_q_kv, [0, 0, 0, 0], [1, 1, seq_len, q_lora_rank])
+            tt_kv_nope = ttnn.slice(
+                tt_q_kv,
+                [0, 0, 0, q_lora_rank],
+                [1, 1, seq_len, q_lora_rank + kv_lora_rank],
+            )
+            tt_kv_rope = ttnn.slice(
+                tt_q_kv,
+                [0, 0, 0, q_lora_rank + kv_lora_rank],
+                [1, 1, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim],
+            )
+        else:
+            # Row-batched prefill drives the fused Q/KV projection with batch on dim 1.
+            # The program config must account for that batch so fuse_batch stays disabled.
+            wq_kv_a_program_config = build_prefill_matmul_program_config(
+                seq_len,
+                k=dim,
+                n=qkv_a_n,
+                batch=batch_size,
+                mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+            )
+            tt_q_kv = ttnn.linear(x, **cfg["wq_kv_a"], program_config=wq_kv_a_program_config)
 
-        # Slice into three parts: tt_q, tt_kv_nope, tt_kv_rope
-        tt_q = ttnn.slice(tt_q_kv, [0, 0, 0, 0], [1, batch_size, seq_len, q_lora_rank])
-        tt_kv_nope = ttnn.slice(tt_q_kv, [0, 0, 0, q_lora_rank], [1, batch_size, seq_len, q_lora_rank + kv_lora_rank])
-        tt_kv_rope = ttnn.slice(
-            tt_q_kv,
-            [0, 0, 0, q_lora_rank + kv_lora_rank],
-            [1, batch_size, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim],
-        )
+            wq_kv_a_ag_args = ccl.populate_all_gather_runtime_args(cfg["wq_kv_a_ag_prefill"])
+            wq_kv_a_reduce_args = dict(cfg["wq_kv_a_r_prefill"])
+            if batch_size > 1:
+                # Keep the user batch intact during TP reduce by borrowing the singleton dim 0 as
+                # the gather/reduce axis; dim 1 already carries the real row batch.
+                wq_kv_a_ag_args = {**wq_kv_a_ag_args, "dim": 0}
+                wq_kv_a_reduce_args = {**wq_kv_a_reduce_args, "dims": [0]}
+
+            tt_q_kv = ttnn.experimental.all_gather_async(tt_q_kv, **wq_kv_a_ag_args)
+            tt_q_kv = ttnn.experimental.fast_reduce_nc(tt_q_kv, **wq_kv_a_reduce_args)
+
+            tt_q = ttnn.slice(tt_q_kv, [0, 0, 0, 0], [1, batch_size, seq_len, q_lora_rank])
+            tt_kv_nope = ttnn.slice(
+                tt_q_kv,
+                [0, 0, 0, q_lora_rank],
+                [1, batch_size, seq_len, q_lora_rank + kv_lora_rank],
+            )
+            tt_kv_rope = ttnn.slice(
+                tt_q_kv,
+                [0, 0, 0, q_lora_rank + kv_lora_rank],
+                [1, batch_size, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim],
+            )
         ttnn.deallocate(tt_q_kv)
         return tt_q, tt_kv_nope, tt_kv_rope


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
8 users per row code introduced new perf regressions + accuracy issues, but is needed for evals & longer seq len. 

### What's changed
While the issues are tackled this is a temp workaround to use the old 32 users per row for the vast majority of testing, but keeping 8 users per row functionality there.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-split-branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-split-branch)
