### PR TITLE
Fix LLK assert trip in `softmax`: use `sub_bcast_cols_init_short` in `exp_cb`

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -214,7 +214,7 @@ void exp_cb(uint32_t cb_in, uint32_t cb_out, uint32_t cb_max, const uint32_t cb_
     pack_reconfig_data_format(cb_out);
 #ifdef NUMERIC_STABLE
     reconfig_data_format_srcb(cb_max);
-    init_bcast<EltwiseBinaryType::ELWSUB, BroadcastType::COL>(cb_in, cb_max, cb_out);
+    sub_bcast_cols_init_short(cb_in, cb_max);
 #else
     copy_tile_init(cb_in);  // need to copy from CB to DST to be able to run sfpu math
 #endif


### PR DESCRIPTION
### Ticket
Closes #41708.

### Problem description
* Affected path: FP32 + `numeric_stable=True` + W large enough to trigger the large kernel (`cb_size_sum_bytes > 0.9 * L1`).
* In `exp_cb` (the function that computes `e^(x − max(x))` for the numeric-stable path), the init call was:
  ```
  #ifdef NUMERIC_STABLE
      reconfig_data_format_srcb(cb_max);
      init_bcast<EltwiseBinaryType::ELWSUB, BroadcastType::COL>(cb_in, cb_max, cb_out);
  ```
* init_bcast is a full hardware initialization — intended for the very first use of a broadcast op in a kernel. It calls, among other things:
  ```
  UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));  // reconfigures unpack HW registers
  UNPACK((llk_unpack_AB_init<BroadcastType::COL>(icb0, icb1)));   // reads back HW state + validates
  PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));             // reconfigures pack HW registers
  PACK((llk_pack_init(ocb)));
  PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
  MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
  MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
  ```
* `exp_cb` is called mid-kernel, after reduce_cb has already configured and torn down the hardware. Calling `llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)` again at this point — with `DST_ACCUM_MODE=true` (FP32) — produces hardware state that fails the validate_tensor_shape_tile_dependent_ops_ assertion inside `_llk_unpack_AB_init_<COL>`. The resulting hardware misconfiguration causes a CB deadlock.

* Two observations confirm this:
  1. `TT_METAL_LLK_ASSERTS=1` + `tt-triage` shows `0x0000FFFF` (all 16 assert slots tripped) across every Tensix core, with `0xDA02BADA`/`0x0002BADA` values encoding the assert site inside `llk_unpack_AB.h`.
  2. The rest of `softmax_large_tensor.cpp` — including `apply_recip` — already uses the `short init` variant: `mul_bcast_cols_init_short(cb_in, cb_recip);  // correct` and `softmax.cpp` (the non-large kernel) uses `sub_bcast_cols_init_short` for the same operation. The `exp_cb` function was inconsistent.

### What's changed
*  Replace the full init with the short switch-from-prior-op init:
  ```
  // Before (broken):
      reconfig_data_format_srcb(cb_max);
      init_bcast<EltwiseBinaryType::ELWSUB, BroadcastType::COL>(cb_in, cb_max, cb_out);
  ```
  ```
  // After (fixed):
      reconfig_data_format_srcb(cb_max);
      sub_bcast_cols_init_short(cb_in, cb_max);
  ```
  sub_bcast_cols_init_short configures math and unpack correctly for switching from a prior op without calling llk_unpack_hw_configure. Pack is already configured by the pack_reconfig_data_format(cb_out) call that precedes
  the #ifdef NUMERIC_STABLE block.
### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/41708/fix-softmax-llk-assert-trip)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/41708/fix-softmax-llk-assert-trip)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/41708/fix-softmax-llk-assert-trip)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/41708/fix-softmax-llk-assert-trip)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/41708/fix-softmax-llk-assert-trip)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/41708/fix-softmax-llk-assert-trip)
- [x] Existing tests provide coverage for changes