### PR TITLE
Fix stable diffusion split_qkv to use interleaved input

### DIFF
--- a/models/demos/vision/generative/stable_diffusion/wormhole/tt/ttnn_functional_cross_attention.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tt/ttnn_functional_cross_attention.py
@@ -675,10 +675,10 @@ class cross_attention:
                     num_heads=heads,
                 )
             else:
-                qkv_out = reshard_to(qkv_out, (8, 2), ttnn.TensorMemoryLayout.BLOCK_SHARDED)
+                qkv_out = ttnn.to_memory_config(qkv_out, ttnn.L1_MEMORY_CONFIG)
                 query, key, value = ttnn.transformer.split_query_key_value_and_split_heads(
                     qkv_out,
-                    memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+                    memory_config=ttnn.L1_MEMORY_CONFIG,
                     num_heads=heads,
                 )
                 query = reshard_to(query, (2, 8), ttnn.TensorMemoryLayout.HEIGHT_SHARDED)


### PR DESCRIPTION
## Summary
- `split_query_key_value_and_split_heads` produces incorrect PCC with sharded inputs, so a guard was added to reject them
- Stable diffusion cross attention was passing block-sharded `qkv_out` to this op, causing a `TT_FATAL`
- Fix: unshard `qkv_out` to interleaved L1 before calling the op, and output to interleaved L1 (then reshard q/k/v to height sharded afterward)

## Test plan
- [x] `pytest models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py::test_stable_diffusion_perf -k "device_params0"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)