### PR TITLE
ttsim ttnn tests: set OPENBLAS_NUM_THREADS=1 and OMP_NUM_THREADS=1

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -227,6 +227,8 @@ jobs:
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
         PYTHONHASHSEED: 0
+        OPENBLAS_NUM_THREADS: 1
+        OMP_NUM_THREADS: 1
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Sets `OPENBLAS_NUM_THREADS=1` and `OMP_NUM_THREADS=1` in the container env for the `ttnn-pytests` job in ttsim CI.

Prevents OpenBLAS/OpenMP from spawning extra threads inside the ttsim ubuntu-latest runner, reducing noise and CPU contention.