### PR TITLE
Update exabox fabric test script

### DIFF
--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -5,16 +5,17 @@ show_help() {
     cat << EOF
 Usage: $0 --hosts <comma-separated-host-list> --image <docker-image> [OPTIONS]
 
-Run fabric tests on 4x32 or 8x16 cluster configuration.
+Run fabric tests on 4x8, 4x32, or 8x16 cluster configuration.
 
 Required Options:
-    --hosts <host-list>                 Comma-separated list of hosts
+    --hosts <host-list>                 Comma-separated list of hosts (single host for 4x8)
     --image <docker-image>              Docker image to use
 
 Optional:
-    --config <4x32|8x16>                Mesh configuration (default: 4x32)
+    --config <4x8|4x32|8x16>           Mesh configuration (default: 4x32)
     --output <directory>                Output directory for log files (default: fabric_test_logs)
     --mesh-graph-desc-path <path>       Path to mesh graph descriptor file (overrides --config)
+                                        4x8 default:  tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
                                         4x32 default: tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
                                         8x16 default: tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
     --test-binary <path>                Path to test binary
@@ -33,6 +34,7 @@ EOF
 HOSTS=""
 DOCKER_IMAGE=""
 OUTPUT_DIR="fabric_test_logs"
+MESH_GRAPH_DESC_PATH_4x8="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_4x32="tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_8x16="tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
 CONFIG="4x32"
@@ -65,8 +67,8 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             CONFIG="$2"
-            if [[ "$CONFIG" != "4x32" && "$CONFIG" != "8x16" ]]; then
-                echo "Error: --config must be either '4x32' or '8x16'"
+            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" ]]; then
+                echo "Error: --config must be one of '4x8', '4x32', or '8x16'"
                 echo ""
                 show_help
                 exit 1
@@ -136,7 +138,9 @@ fi
 
 # Set mesh graph descriptor path based on config if not explicitly provided
 if [[ "$MESH_GRAPH_DESC_PATH_EXPLICIT" == false ]]; then
-    if [[ "$CONFIG" == "4x32" ]]; then
+    if [[ "$CONFIG" == "4x8" ]]; then
+        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x8"
+    elif [[ "$CONFIG" == "4x32" ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x32"
     elif [[ "$CONFIG" == "8x16" ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_8x16"
@@ -161,30 +165,51 @@ echo "Log file: $LOG_FILE"
 echo "=========================================="
 echo ""
 
-./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
-    --empty-entrypoint \
-    --bind-to none \
-    --host "$HOSTS" \
-    -np 1 \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-    -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
-    --test_config "$TEST_CONFIG" : \
-    -np 1 \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-    -x TT_MESH_HOST_RANK=1 "$TEST_BINARY" \
-    --test_config "$TEST_CONFIG" : \
-    -np 1 \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-    -x TT_MESH_HOST_RANK=2 "$TEST_BINARY" \
-    --test_config "$TEST_CONFIG" : \
-    -np 1 \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-    -x TT_MESH_HOST_RANK=3 "$TEST_BINARY" \
-    --test_config "$TEST_CONFIG" |& tee "$LOG_FILE"
+EXTRA_BINARY_ARGS=""
+if [[ "$TEST_BINARY" == *test_tt_fabric ]]; then
+    EXTRA_BINARY_ARGS="--show-progress --show-workers"
+fi
+
+if [[ "$CONFIG" == "4x8" ]]; then
+    SINGLE_HOST="${HOSTS%%,*}"
+    echo "Running single-host 4x8 on: $SINGLE_HOST"
+    echo ""
+
+    ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
+        --empty-entrypoint \
+        --bind-to none \
+        --host "$SINGLE_HOST" \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
+else
+    ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
+        --empty-entrypoint \
+        --bind-to none \
+        --host "$HOSTS" \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=1 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=2 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=3 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
+fi
 
 echo ""
 echo "=========================================="


### PR DESCRIPTION
### Problem description
Need to add more info to the run_fabric_tests.sh script for output logging and supporting single device tests

### What's changed
Updated run_fabric_tests.sh to support single bh galaxy (4x8) config and added --show-progress/--show-workers tags when running test_tt_fabric

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nnyamagoudar/update-exabox-fabric-test-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nnyamagoudar/update-exabox-fabric-test-script)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/update-exabox-fabric-test-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/update-exabox-fabric-test-script)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/update-exabox-fabric-test-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/update-exabox-fabric-test-script)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/update-exabox-fabric-test-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/update-exabox-fabric-test-script)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/update-exabox-fabric-test-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/update-exabox-fabric-test-script)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/update-exabox-fabric-test-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/update-exabox-fabric-test-script)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
