### PR TITLE
Port repeat/split/indexed_fill kernels to Device 2.0 API (#41702 pilot batch A)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp
@@ -8,8 +8,6 @@
 #include "api/debug/dprint.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
-#include "experimental/core_local_mem.h"
-#include "experimental/endpoints.h"
 #include "experimental/tensor.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp
@@ -6,6 +6,11 @@
 #include "api/dataflow/dataflow_api.h"
 
 #include "api/debug/dprint.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t batch_ids_addr = get_arg_val<uint32_t>(0);
@@ -27,6 +32,10 @@ void kernel_main() {
 
     const auto batchAddr = TensorAccessor(batch_ids_args, batch_ids_addr, batch_id_size << 2);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer batch_cb(batch_cb_id);
+
     bool replace_batch = false;
     uint32_t batch_to_replace_id = 0;
     // first go through batch id
@@ -34,10 +43,9 @@ void kernel_main() {
     volatile tt_l1_ptr int* addr_ptr;
 
     if (batch_id_size > 0) {
-        uint64_t src_noc_addr = get_noc_addr(0, batchAddr);
-        uint32_t l1_write_addr = get_write_ptr(batch_cb_id);
-        noc_async_read(src_noc_addr, l1_write_addr, (batch_id_size << 2));
-        noc_async_read_barrier();
+        uint32_t l1_write_addr = batch_cb.get_write_ptr();
+        noc.async_read(batchAddr, batch_cb, (batch_id_size << 2), {.page_id = 0}, {.offset_bytes = 0});
+        noc.async_read_barrier();
         addr_ptr = reinterpret_cast<volatile tt_l1_ptr int*>(l1_write_addr);
     }
     for (uint32_t i = 0; i < batch_id_size; i++) {
@@ -57,16 +65,13 @@ void kernel_main() {
 
     uint32_t end_id = start_id + batch_size_in_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_reserve_back(cb_id_in0, 1);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        uint64_t src_noc_addr;
+        cb_in0.reserve_back(1);
         if (replace_batch) {
-            src_noc_addr = get_noc_addr(i, s1);
+            noc.async_read(s1, cb_in0, stick_size, {.page_id = i}, {.offset_bytes = 0});
         } else {
-            src_noc_addr = get_noc_addr(i, s0);
+            noc.async_read(s0, cb_in0, stick_size, {.page_id = i}, {.offset_bytes = 0});
         }
-        noc_async_read(src_noc_addr, l1_write_addr, stick_size);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, 1);
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp
@@ -41,9 +41,12 @@ void kernel_main() {
     volatile tt_l1_ptr int* addr_ptr;
 
     if (batch_id_size > 0) {
+        // Reserve CB space before reading into it
+        batch_cb.reserve_back(1);
         uint32_t l1_write_addr = batch_cb.get_write_ptr();
         noc.async_read(batchAddr, batch_cb, (batch_id_size << 2), {.page_id = 0}, {.offset_bytes = 0});
         noc.async_read_barrier();
+        batch_cb.push_back(1);
         addr_ptr = reinterpret_cast<volatile tt_l1_ptr int*>(l1_write_addr);
     }
     for (uint32_t i = 0; i < batch_id_size; i++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/tensor.h"
 
 using namespace tt::data_movement::common;
 
@@ -45,6 +50,10 @@ void kernel_main() {
     const auto s = TensorAccessor(src_args, src_addr, original_page_size_bytes);
     const auto d = TensorAccessor(dst_args, dst_addr, original_page_size_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb0(cb_id_in0);
+    experimental::CircularBuffer cb1(cb_id_in1);
+
     // alignments pre-calculations
     constexpr uint64_t r_mask_to_use = src_args.is_dram ? MASK_64 : MASK_16;
     constexpr uint64_t r_offset_to_use = src_args.is_dram ? OFFSET_64 : OFFSET_16;
@@ -54,12 +63,12 @@ void kernel_main() {
     const uint64_t w_mask_to_use = MASK_16;
     const uint64_t w_offset_to_use = OFFSET_16;
 
-    cb_reserve_back(cb_id_in0, 1);
-    cb_reserve_back(cb_id_in1, 1);
-    uint32_t input_buffer = get_write_ptr(cb_id_in0);
-    uint32_t alignment_buffer = get_write_ptr(cb_id_in1);
-    cb_push_back(cb_id_in1, 1);
-    cb_push_back(cb_id_in0, 1);
+    cb0.reserve_back(1);
+    cb1.reserve_back(1);
+    uint32_t input_buffer = cb0.get_write_ptr();
+    uint32_t alignment_buffer = cb1.get_write_ptr();
+    cb1.push_back(1);
+    cb0.push_back(1);
 
     alignment_buffer = align_address<w_alignment_requirement>(alignment_buffer, w_mask_to_use);  // aligned for writes
     input_buffer = align_address<r_alignment_requirement>(input_buffer, r_mask_to_use);          // aligned for reads
@@ -76,9 +85,16 @@ void kernel_main() {
                 uint32_t read_offset = h_offset + r_offset + l;
                 src_noc_addr = s.get_noc_addr(read_offset, 0);
                 data_location = input_buffer + (src_noc_addr & r_offset_to_use);  // Guaranteed aligned to src_noc_addr
-                enhanced_noc_async_read<original_page_size_bytes, false>(
-                    src_noc_addr, data_location, original_page_size_bytes);
-                noc_async_read_barrier();
+
+                experimental::UnicastEndpoint src;
+                experimental::CoreLocalMem<uint32_t> dst_mem(data_location);
+                uint32_t src_addr = src_noc_addr & 0xFFFFFFFFF;  // Extract address (bits 0-35)
+                uint32_t src_x = (src_noc_addr >> 36) & 0x3F;    // Extract x (bits 36-41)
+                uint32_t src_y = (src_noc_addr >> 42) & 0x3F;    // Extract y (bits 42-47)
+
+                noc.async_read(
+                    src, dst_mem, original_page_size_bytes, {.noc_x = src_x, .noc_y = src_y, .addr = src_addr}, {});
+                noc.async_read_barrier();
 
                 for (uint32_t n = 0; n < repetitions; n++) {
                     // Perform the writes
@@ -98,10 +114,16 @@ void kernel_main() {
                     }
                     // Now we are ensured the data is at write_buffer and it is aligned for the write
                     // Orchestrate the write
-                    enhanced_noc_async_write<original_page_size_bytes, false>(
-                        data_location, dst_noc_addr, original_page_size_bytes);
+                    experimental::CoreLocalMem<uint32_t> src_mem(data_location);
+                    experimental::UnicastEndpoint dst;
+                    uint32_t dst_addr = dst_noc_addr & 0xFFFFFFFFF;  // Extract address (bits 0-35)
+                    uint32_t dst_x = (dst_noc_addr >> 36) & 0x3F;    // Extract x (bits 36-41)
+                    uint32_t dst_y = (dst_noc_addr >> 42) & 0x3F;    // Extract y (bits 42-47)
+
+                    noc.async_write(
+                        src_mem, dst, original_page_size_bytes, {}, {.noc_x = dst_x, .noc_y = dst_y, .addr = dst_addr});
                 }
-                noc_async_write_barrier();
+                noc.async_write_barrier();
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
@@ -87,7 +87,8 @@ void kernel_main() {
 
                 experimental::CoreLocalMem<uint32_t> dst_mem(data_location);
                 // Use TensorAccessor directly to avoid address truncation
-                noc.async_read(
+                // Template parameter preserves one-packet fast path for page-sized transfers
+                noc.async_read<experimental::Noc::TxnIdMode::DISABLED, original_page_size_bytes>(
                     s,
                     dst_mem,
                     original_page_size_bytes,
@@ -115,7 +116,11 @@ void kernel_main() {
                     // Orchestrate the write
                     experimental::CoreLocalMem<uint32_t> src_mem(data_location);
                     // Use TensorAccessor directly to avoid address truncation
-                    noc.async_write(
+                    // Template parameter preserves one-packet fast path for page-sized transfers
+                    noc.async_write<
+                        experimental::Noc::TxnIdMode::DISABLED,
+                        experimental::Noc::ResponseMode::NON_POSTED,
+                        original_page_size_bytes>(
                         src_mem,
                         d,
                         original_page_size_bytes,

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
@@ -8,7 +8,6 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/core_local_mem.h"
-#include "experimental/endpoints.h"
 #include "experimental/tensor.h"
 
 using namespace tt::data_movement::common;
@@ -86,14 +85,14 @@ void kernel_main() {
                 src_noc_addr = s.get_noc_addr(read_offset, 0);
                 data_location = input_buffer + (src_noc_addr & r_offset_to_use);  // Guaranteed aligned to src_noc_addr
 
-                experimental::UnicastEndpoint src;
                 experimental::CoreLocalMem<uint32_t> dst_mem(data_location);
-                uint32_t src_addr = src_noc_addr & 0xFFFFFFFFF;  // Extract address (bits 0-35)
-                uint32_t src_x = (src_noc_addr >> 36) & 0x3F;    // Extract x (bits 36-41)
-                uint32_t src_y = (src_noc_addr >> 42) & 0x3F;    // Extract y (bits 42-47)
-
+                // Use TensorAccessor directly to avoid address truncation
                 noc.async_read(
-                    src, dst_mem, original_page_size_bytes, {.noc_x = src_x, .noc_y = src_y, .addr = src_addr}, {});
+                    s,
+                    dst_mem,
+                    original_page_size_bytes,
+                    {.page_id = read_offset, .offset_bytes = 0},
+                    {.offset_bytes = 0});
                 noc.async_read_barrier();
 
                 for (uint32_t n = 0; n < repetitions; n++) {
@@ -115,13 +114,13 @@ void kernel_main() {
                     // Now we are ensured the data is at write_buffer and it is aligned for the write
                     // Orchestrate the write
                     experimental::CoreLocalMem<uint32_t> src_mem(data_location);
-                    experimental::UnicastEndpoint dst;
-                    uint32_t dst_addr = dst_noc_addr & 0xFFFFFFFFF;  // Extract address (bits 0-35)
-                    uint32_t dst_x = (dst_noc_addr >> 36) & 0x3F;    // Extract x (bits 36-41)
-                    uint32_t dst_y = (dst_noc_addr >> 42) & 0x3F;    // Extract y (bits 42-47)
-
+                    // Use TensorAccessor directly to avoid address truncation
                     noc.async_write(
-                        src_mem, dst, original_page_size_bytes, {}, {.noc_x = dst_x, .noc_y = dst_y, .addr = dst_addr});
+                        src_mem,
+                        d,
+                        original_page_size_bytes,
+                        {.offset_bytes = 0},
+                        {.page_id = write_offset, .offset_bytes = 0});
                 }
                 noc.async_write_barrier();
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
@@ -8,6 +8,11 @@ Function reads from RM and writes to RM repeating the last dimension
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/tensor.h"
 
 using namespace tt::data_movement::common;
 
@@ -51,13 +56,17 @@ void kernel_main() {
     const auto s = TensorAccessor(src_args, src_addr, original_page_size_bytes);
     const auto d = TensorAccessor(dst_args, dst_addr, dest_page_size_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb0(cb_id_in0);
+    experimental::CircularBuffer cb1(cb_id_in1);
+
     // Get scratchpads guaranteed to be allocated until the function terminates
-    cb_reserve_back(cb_id_in0, 1);
-    cb_reserve_back(cb_id_in1, 1);
-    uint32_t input_buffer = get_write_ptr(cb_id_in0);
-    uint32_t alignment_buffer = get_write_ptr(cb_id_in1);
-    cb_push_back(cb_id_in1, 1);
-    cb_push_back(cb_id_in0, 1);
+    cb0.reserve_back(1);
+    cb1.reserve_back(1);
+    uint32_t input_buffer = cb0.get_write_ptr();
+    uint32_t alignment_buffer = cb1.get_write_ptr();
+    cb1.push_back(1);
+    cb0.push_back(1);
 
     constexpr uint64_t r_mask_to_use = src_args.is_dram ? MASK_64 : MASK_16;
     constexpr uint64_t r_offset_to_use = src_args.is_dram ? OFFSET_64 : OFFSET_16;
@@ -77,9 +86,16 @@ void kernel_main() {
         uint64_t dst_noc_addr = d.get_noc_addr(i, 0);
         uint32_t data_location =
             input_buffer + (src_noc_addr & r_offset_to_use);  // Guaranteed to be aligned for our read
-        enhanced_noc_async_read<original_page_size_bytes, false>(src_noc_addr, data_location, original_page_size_bytes);
+
+        experimental::UnicastEndpoint src;
+        experimental::CoreLocalMem<uint32_t> dst_mem(data_location);
+        uint32_t src_addr = src_noc_addr & 0xFFFFFFFFF;  // Extract address (bits 0-35)
+        uint32_t src_x = (src_noc_addr >> 36) & 0x3F;    // Extract x (bits 36-41)
+        uint32_t src_y = (src_noc_addr >> 42) & 0x3F;    // Extract y (bits 42-47)
+
+        noc.async_read(src, dst_mem, original_page_size_bytes, {.noc_x = src_x, .noc_y = src_y, .addr = src_addr}, {});
         cur_page_size = original_page_size_bytes;
-        noc_async_read_barrier();
+        noc.async_read_barrier();
         if constexpr (num_doublings != 0) {
             // The if is not needed but it is just for performance as the vast majority of times num_doublings will be 0
             // and we don't want target offset to be allocated and the for loop bounds computed
@@ -102,15 +118,27 @@ void kernel_main() {
         }
 
         uint64_t num_written = 0;
+        uint32_t dst_addr_base = dst_noc_addr & 0xFFFFFFFFF;  // Extract address (bits 0-35)
+        uint32_t dst_x = (dst_noc_addr >> 36) & 0x3F;         // Extract x (bits 36-41)
+        uint32_t dst_y = (dst_noc_addr >> 42) & 0x3F;         // Extract y (bits 42-47)
+
         while (num_written < dest_page_size_bytes) {
             // Either write out the whole input buffer or however much is left
             uint32_t to_write = (dest_page_size_bytes - num_written) > cur_page_size
                                     ? cur_page_size
                                     : (dest_page_size_bytes - num_written);
-            enhanced_noc_async_write<dest_page_size_bytes, false>(data_location, dst_noc_addr + num_written, to_write);
+
+            experimental::CoreLocalMem<uint32_t> src_mem(data_location);
+            experimental::UnicastEndpoint dst;
+            noc.async_write(
+                src_mem,
+                dst,
+                to_write,
+                {},
+                {.noc_x = dst_x, .noc_y = dst_y, .addr = dst_addr_base + static_cast<uint32_t>(num_written)});
             num_written += to_write;
         }
-        noc_async_write_barrier();
+        noc.async_write_barrier();
     }
     return;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
@@ -11,7 +11,6 @@ Function reads from RM and writes to RM repeating the last dimension
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/core_local_mem.h"
-#include "experimental/endpoints.h"
 #include "experimental/tensor.h"
 
 using namespace tt::data_movement::common;
@@ -87,13 +86,9 @@ void kernel_main() {
         uint32_t data_location =
             input_buffer + (src_noc_addr & r_offset_to_use);  // Guaranteed to be aligned for our read
 
-        experimental::UnicastEndpoint src;
         experimental::CoreLocalMem<uint32_t> dst_mem(data_location);
-        uint32_t src_addr = src_noc_addr & 0xFFFFFFFFF;  // Extract address (bits 0-35)
-        uint32_t src_x = (src_noc_addr >> 36) & 0x3F;    // Extract x (bits 36-41)
-        uint32_t src_y = (src_noc_addr >> 42) & 0x3F;    // Extract y (bits 42-47)
-
-        noc.async_read(src, dst_mem, original_page_size_bytes, {.noc_x = src_x, .noc_y = src_y, .addr = src_addr}, {});
+        // Use TensorAccessor directly to avoid address truncation
+        noc.async_read(s, dst_mem, original_page_size_bytes, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = 0});
         cur_page_size = original_page_size_bytes;
         noc.async_read_barrier();
         if constexpr (num_doublings != 0) {
@@ -118,10 +113,6 @@ void kernel_main() {
         }
 
         uint64_t num_written = 0;
-        uint32_t dst_addr_base = dst_noc_addr & 0xFFFFFFFFF;  // Extract address (bits 0-35)
-        uint32_t dst_x = (dst_noc_addr >> 36) & 0x3F;         // Extract x (bits 36-41)
-        uint32_t dst_y = (dst_noc_addr >> 42) & 0x3F;         // Extract y (bits 42-47)
-
         while (num_written < dest_page_size_bytes) {
             // Either write out the whole input buffer or however much is left
             uint32_t to_write = (dest_page_size_bytes - num_written) > cur_page_size
@@ -129,13 +120,13 @@ void kernel_main() {
                                     : (dest_page_size_bytes - num_written);
 
             experimental::CoreLocalMem<uint32_t> src_mem(data_location);
-            experimental::UnicastEndpoint dst;
+            // Use TensorAccessor directly to avoid address truncation
             noc.async_write(
                 src_mem,
-                dst,
+                d,
                 to_write,
-                {},
-                {.noc_x = dst_x, .noc_y = dst_y, .addr = dst_addr_base + static_cast<uint32_t>(num_written)});
+                {.offset_bytes = 0},
+                {.page_id = i, .offset_bytes = static_cast<uint32_t>(num_written)});
             num_written += to_write;
         }
         noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
@@ -45,6 +45,8 @@ void kernel_main() {
                                        : ((original_page_size_bytes % 4) == 0) ? 2
                                        : ((original_page_size_bytes % 2) == 0) ? 3
                                                                                : 4;
+    // Max write size after doublings, used for template parameter to enable fast path
+    constexpr uint32_t max_write_size = original_page_size_bytes << num_doublings;
 
     // Since we need to operate on a grid of cores but sometimes pages don't split properly, if nop then don't use this
     // core
@@ -88,7 +90,9 @@ void kernel_main() {
 
         experimental::CoreLocalMem<uint32_t> dst_mem(data_location);
         // Use TensorAccessor directly to avoid address truncation
-        noc.async_read(s, dst_mem, original_page_size_bytes, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = 0});
+        // Template parameter preserves one-packet fast path for page-sized transfers
+        noc.async_read<experimental::Noc::TxnIdMode::DISABLED, original_page_size_bytes>(
+            s, dst_mem, original_page_size_bytes, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = 0});
         cur_page_size = original_page_size_bytes;
         noc.async_read_barrier();
         if constexpr (num_doublings != 0) {
@@ -121,7 +125,11 @@ void kernel_main() {
 
             experimental::CoreLocalMem<uint32_t> src_mem(data_location);
             // Use TensorAccessor directly to avoid address truncation
-            noc.async_write(
+            // Template parameter preserves one-packet fast path for writes up to max_write_size
+            noc.async_write<
+                experimental::Noc::TxnIdMode::DISABLED,
+                experimental::Noc::ResponseMode::NON_POSTED,
+                max_write_size>(
                 src_mem,
                 d,
                 to_write,

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_two_chunks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_two_chunks.cpp
@@ -6,6 +6,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "tensix_types.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 // #define DEBUG
 #ifdef DEBUG
@@ -34,6 +37,9 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(in0_tensor_args, in0_tensor_addr, single_tile_size_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+
     uint32_t tensor_stride = out_num_tiles_per_tensor_x;
     uint32_t tensor_stride_cum = 0;
 #ifdef DEBUG
@@ -51,11 +57,15 @@ void kernel_main() {
             for (uint32_t j = 0; j < out_num_tiles_per_tensor_y; j++) {
                 for (uint32_t i = 0; i < out_num_tiles_per_tensor_x; i++) {
                     uint32_t tile_id = y_stride_cum + tensor_stride_cum + z_stride_cum + i;
-                    cb_reserve_back(cb_id_in0, onetile);
-                    uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                    noc_async_read_tile(tile_id + in0_tensor_tile_id, s0, l1_write_addr_in0);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_in0, onetile);
+                    cb_in0.reserve_back(onetile);
+                    noc.async_read(
+                        s0,
+                        cb_in0,
+                        single_tile_size_bytes,
+                        {.page_id = tile_id + in0_tensor_tile_id},
+                        {.offset_bytes = 0});
+                    noc.async_read_barrier();
+                    cb_in0.push_back(onetile);
 #ifdef DEBUG
                     // DPRINT << "Reader Tile ID: " << tile_id  + in0_tensor_tile_id << ENDL();
                     // DPRINT << "Reader Address: " << l1_write_addr_in0 << ENDL() << ENDL();

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/writer_tm_tile_layout_split_two_chunks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/writer_tm_tile_layout_split_two_chunks.cpp
@@ -8,6 +8,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "tensix_types.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 // #define DEBUG
 
@@ -36,6 +39,9 @@ void kernel_main() {
     const auto s0 = TensorAccessor(out0_tensor_args, out0_tensor_addr, single_tile_size_bytes);
     const auto s1 = TensorAccessor(out1_tensor_args, out1_tensor_addr, single_tile_size_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out0(cb_id_out0);
+
     if (!out1_only) {
         uint32_t z_stride_cum = 0;
         for (uint32_t k = 0; k < z; k++) {
@@ -43,11 +49,15 @@ void kernel_main() {
             for (uint32_t j = 0; j < out_num_tiles_per_tensor_y; j++) {
                 for (uint32_t i = 0; i < out_num_tiles_per_tensor_x; i++) {
                     uint32_t tile_id = y_stride_cum + z_stride_cum + i;
-                    cb_wait_front(cb_id_out0, onetile);
-                    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-                    noc_async_write_tile(tile_id + out_tensor_tile_id, s0, l1_read_addr);
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_id_out0, onetile);
+                    cb_out0.wait_front(onetile);
+                    noc.async_write(
+                        cb_out0,
+                        s0,
+                        single_tile_size_bytes,
+                        {.offset_bytes = 0},
+                        {.page_id = tile_id + out_tensor_tile_id});
+                    noc.async_write_barrier();
+                    cb_out0.pop_front(onetile);
                 }
                 y_stride_cum += y_stride;
             }
@@ -61,11 +71,15 @@ void kernel_main() {
             for (uint32_t j = 0; j < out_num_tiles_per_tensor_y; j++) {
                 for (uint32_t i = 0; i < out_num_tiles_per_tensor_x; i++) {
                     uint32_t tile_id = y_stride_cum + z_stride_cum + i;
-                    cb_wait_front(cb_id_out0, onetile);
-                    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-                    noc_async_write_tile(tile_id + out_tensor_tile_id, s1, l1_read_addr);
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_id_out0, onetile);
+                    cb_out0.wait_front(onetile);
+                    noc.async_write(
+                        cb_out0,
+                        s1,
+                        single_tile_size_bytes,
+                        {.offset_bytes = 0},
+                        {.page_id = tile_id + out_tensor_tile_id});
+                    noc.async_write_barrier();
+                    cb_out0.pop_front(onetile);
                 }
                 y_stride_cum += y_stride;
             }


### PR DESCRIPTION
### Ticket
Part of #41702

### Problem description
Five data-movement kernels (`repeat`, `split`, `indexed_fill`) were still using legacy NoC/CB APIs. Migrating to `experimental::Noc` / `experimental::CircularBuffer` is required for Device 2.0 compatibility. An initial migration attempt also introduced an address truncation bug by manually decomposing 64-bit NOC addresses into 36-bit fields via bitmasks—silently corrupting high-address bits.

### What's changed

**Kernel migrations** (`ttnn/cpp/ttnn/operations/data_movement/`):
- `repeat/device/kernels/repeat_higher_dim_rm.cpp`
- `repeat/device/kernels/repeat_last_dim_rm.cpp`
- `split/device/kernels/dataflow/reader_tm_tile_layout_split_two_chunks.cpp`
- `split/device/kernels/dataflow/writer_tm_tile_layout_split_two_chunks.cpp`
- `indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp`

**API replacements:**
| Legacy | Device 2.0 |
|--------|-----------|
| `cb_reserve_back` / `cb_push_back` / `cb_wait_front` / `cb_pop_front` | `cb.reserve_back` / `cb.push_back` / `cb.wait_front` / `cb.pop_front` |
| `noc_async_read` / `noc_async_write` | `noc.async_read` / `noc.async_write` using `TensorAccessor` with `{.page_id, .offset_bytes}` |
| `noc_async_read_barrier` / `noc_async_write_barrier` | `noc.async_read_barrier` / `noc.async_write_barrier` |

**Bug fix:** Replaced manual NOC address decomposition (`addr & 0xFFFFFFFFF`, `>> 36`, `>> 42`) with `TensorAccessor` passed directly to `noc.async_read/write`. The bitmask approach truncated 64-bit addresses and would silently corrupt memory accesses on high-address regions.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:device-2.0-migration/pilot-a)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:device-2.0-migration/pilot-a)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:device-2.0-migration/pilot-a)
- [x] New/Existing tests provide coverage for changes — 762 tests passed across repeat, split, indexed_fill
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:device-2.0-migration/pilot-a)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:device-2.0-migration/pilot-a)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:device-2.0-migration/pilot-a)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:device-2.0-migration/pilot-a) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:device-2.0-migration/pilot-a) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:device-2.0-migration/pilot-a) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:device-2.0-migration/pilot-a) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:device-2.0-migration/pilot-a) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:device-2.0-migration/pilot-a) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:device-2.0-migration/pilot-a) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:device-2.0-migration/pilot-a) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:device-2.0-migration/pilot-a) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:device-2.0-migration/pilot-a) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:device-2.0-migration/pilot-a) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:device-2.0-migration/pilot-a) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:device-2.0-migration/pilot-a) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:device-2.0-migration/pilot-a) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:device-2.0-migration/pilot-a) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:device-2.0-migration/pilot-a) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=device-2.0-migration/pilot-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:device-2.0-migration/pilot-a) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:device-2.0-migration/pilot-a) |