### PR TITLE
Add pipeline test

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -33,6 +33,36 @@ def create_fabric_router_config(max_payload_size: int) -> Any:
     return config
 
 
+def create_passthrough_pipeline_configuration(
+    weight_provider: WeightProvider,
+    num_procs: int,
+    *,
+    payload: PassthroughPayload = PassthroughPayload.ACTIVATION,
+) -> PipelineConfiguration:
+    """N-stage pipeline: stage 0 is :class:`EmbeddingStage`; stages 1..N-1 are :class:`PassthroughStage`.
+
+    Default ``payload`` is :attr:`~PassthroughPayload.ACTIVATION` so D2D FIFO/page sizes match
+    :class:`EmbeddingStage` downstream (embedding rows). Use :attr:`~PassthroughPayload.TOKEN` only
+    when every stage before the passthrough chain emits token-sized pages (not this factory's
+    embedding-first layout).
+
+    Stage indices 0 .. num_procs-1 must match the distributed mesh count (e.g. 4, 16, 64).
+    """
+    if num_procs < 1:
+        raise ValueError(f"num_procs must be >= 1, got {num_procs}")
+
+    def stage_0(device: ttnn.MeshDevice) -> StageKind:
+        return EmbeddingStage(
+            weight_provider.load_embedding(device),
+            loopback_payload=PassthroughPayload.ACTIVATION,
+        )
+
+    stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {0: stage_0}
+    for i in range(1, num_procs):
+        stage_factories[i] = lambda _d, p=payload: PassthroughStage(p)
+    return PipelineConfiguration(stage_factories)
+
+
 def create_single_galaxy_pipeline_configuration(
     weight_provider: WeightProvider,
     *,
@@ -59,6 +89,61 @@ def create_single_galaxy_pipeline_configuration(
             3: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
         }
     )
+
+
+def create_single_galaxy_deepseek_pipeline_configuration(
+    weight_provider: WeightProvider,
+    *,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id: int = 0,
+    moe_layer_id: int = 0,
+) -> PipelineConfiguration:
+    """4-stage single-galaxy: Embed -> Dense -> MoE -> LMHead.
+
+    This is the decoder stack that :func:`create_single_galaxy_pipeline_configuration` approximates
+    with two token :class:`PassthroughStage` stages after LMHead. Here the two passthrough slots are
+    replaced by :class:`DenseDecoderStage` and :class:`MoEDecoderStage` **before** LMHead so every
+    D2D hop stays activation-sized until the final LMHead emits token-sized pages to loopback.
+    (Placing dense/MoE after LMHead would mismatch TOKEN vs activation socket handshakes.)
+
+    """
+
+    def stage_0(device: ttnn.MeshDevice) -> StageKind:
+        return EmbeddingStage(
+            weight_provider.load_embedding(device),
+        )
+
+    def stage_1(device: ttnn.MeshDevice) -> StageKind:
+        return DenseDecoderStage(
+            weights=weight_provider.load_dense_layer(layer_id=dense_layer_id, device=device),
+            layer_idx=dense_layer_id,
+        )
+
+    def stage_2(device: ttnn.MeshDevice) -> StageKind:
+        return MoEDecoderStage(
+            weights=weight_provider.load_moe_layer(layer_id=moe_layer_id, device=device),
+            layer_idx=moe_layer_id,
+        )
+
+    def stage_3(device: ttnn.MeshDevice) -> StageKind:
+        return LMHeadStage(
+            weight_provider.load_lm_head(device),
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
+        )
+
+    return PipelineConfiguration(
+        {
+            0: stage_0,
+            1: stage_1,
+            2: stage_2,
+            3: stage_3,
+        }
+    )
+
+
+create_single_galaxy_deepseek_pipeline = create_single_galaxy_deepseek_pipeline_configuration
 
 
 def create_single_pod_pipeline_configuration(

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -59,31 +59,51 @@ class StageKind(ABC):
         """Run stage compute after ``pipeline_block.run()`` (execute pre-built programs where applicable). Default: no-op."""
 
 
-class EmbeddingStage(StageKind):
-    """Stage 0: H2D + embedding lookup, forwards activation; loopback receives token."""
-
-    def __init__(self, weights: DeepSeekV3EmbeddingLayerWeights) -> None:
-        self._weights = weights
-
-    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
-        mesh_device = ctx.mesh_device
-        return PipelineBlock(
-            mesh_device,
-            PIPELINE_CORE_COORD,
-            upstream_d2d_socket_fifo_size=TOKEN_FIFO_SIZE,
-            downstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
-            upstream_d2d_socket_page_size=TOKEN_PAGE_SIZE_BYTES,
-            downstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
-            h2d_socket_fifo_size=TOKEN_FIFO_SIZE,
-            d2h_socket_fifo_size=TOKEN_FIFO_SIZE,
-            d2h_socket_page_size=TOKEN_PAGE_SIZE_BYTES,
-            embedding_tensor=self._weights.embedding,
-        )
-
-
 class PassthroughPayload(Enum):
     ACTIVATION = "activation"
     TOKEN = "token"
+
+
+class EmbeddingStage(StageKind):
+    """Stage 0: H2D + embedding lookup, forwards activation; loopback payload is configurable."""
+
+    def __init__(
+        self,
+        weights: DeepSeekV3EmbeddingLayerWeights,
+        *,
+        loopback_payload: PassthroughPayload = PassthroughPayload.TOKEN,
+    ) -> None:
+        self._weights = weights
+        self._loopback_payload = loopback_payload
+
+    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
+        mesh_device = ctx.mesh_device
+        # Loopback entry + D2H must use the same page size (see PipelineBlock._init_first_stage).
+        # Token-sized: LMHead / sampling returns a token page to the host (default).
+        # Activation-sized: embed → passthrough chain returns an embedding row on loopback.
+        if self._loopback_payload == PassthroughPayload.ACTIVATION:
+            up_fifo = ACTIVATION_FIFO_SIZE
+            up_page = ACTIVATION_PAGE_SIZE_BYTES
+            d2h_fifo = ACTIVATION_FIFO_SIZE
+            d2h_page = ACTIVATION_PAGE_SIZE_BYTES
+        else:
+            up_fifo = TOKEN_FIFO_SIZE
+            up_page = TOKEN_PAGE_SIZE_BYTES
+            d2h_fifo = TOKEN_FIFO_SIZE
+            d2h_page = TOKEN_PAGE_SIZE_BYTES
+
+        return PipelineBlock(
+            mesh_device,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=up_fifo,
+            downstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            upstream_d2d_socket_page_size=up_page,
+            downstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            h2d_socket_fifo_size=TOKEN_FIFO_SIZE,
+            d2h_socket_fifo_size=d2h_fifo,
+            d2h_socket_page_size=d2h_page,
+            embedding_tensor=self._weights.embedding,
+        )
 
 
 class PassthroughStage(StageKind):

--- a/models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_single_galaxy_mesh_graph_descriptor.textproto
+++ b/models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_single_galaxy_mesh_graph_descriptor.textproto
@@ -1,0 +1,43 @@
+# --- Meshes ---------------------------------------------------------------
+# Single galaxy (4 pipeline stages): mesh instances 0..3 only.
+# Derived from blitz_decode_mesh_graph_descriptor_superpod.textproto
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 2 ] dim_types: [ RING, LINE ]}
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 2
+    policy: RELAXED
+  }
+}
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  # Instances: mesh ids 0..3 only (single 4x2 galaxy)
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
@@ -14,6 +14,12 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.demo.pipeline import (
+    create_passthrough_pipeline_configuration,
+    create_single_galaxy_deepseek_pipeline_configuration,
+)
+from models.demos.deepseek_v3_b1.demo.stage import TOKEN_PAGE_SIZE_BYTES
+from models.demos.deepseek_v3_b1.demo.weight_provider import SyntheticWeightProvider
 from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import MeshWrapper, SocketInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size, ttnn_dtype_from_torch_dtype
@@ -688,3 +694,141 @@ def test_pipeline_block_no_loopback(mesh_device, vocab_size, embedding_dim, toke
             )
 
     pipeline_block.terminate()
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(4, 2)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(15232),
+        }
+    ],
+    indirect=True,
+)
+def test_passthrough_pipeline_block(mesh_device):
+    if not is_slow_dispatch():
+        pytest.skip("Skipping test in fast dispatch mode")
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    pipeline_core_coord = ttnn.CoreCoord(0, 0)
+
+    num_procs = int(ttnn.distributed_context_get_size())
+
+    config = create_passthrough_pipeline_configuration(SyntheticWeightProvider(), num_procs)
+    pipeline = config.build_pipeline(mesh_device)
+    try:
+        pipeline.setup_and_run()
+
+        if pipeline.my_mesh_id == 0:
+            from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions
+
+            vocab_size = LogicalModelDimensions.VOCAB_SIZE
+            embedding_dim = LogicalModelDimensions.HIDDEN_SIZE
+
+            embedding_dtype = torch.bfloat16
+            torch_embedding = torch.zeros((1, 1, vocab_size, embedding_dim), dtype=embedding_dtype)
+            torch_embedding[
+                0,
+                0,
+                torch.arange(vocab_size, dtype=torch.int64),
+                torch.arange(vocab_size, dtype=torch.int64) % embedding_dim,
+            ] = 1
+
+            token_dtype = torch.uint32
+            token_size_bytes = 64
+            token_size_datums = token_size_bytes // dtype_size(token_dtype)
+
+            for token_id in range(vocab_size):
+                torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
+                torch_input[0, 0] = token_id
+                input_tensor = ttnn.from_torch(
+                    torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+                )
+                torch_output = torch.zeros(1, embedding_dim, dtype=embedding_dtype)
+                output_tensor = ttnn.from_torch(
+                    torch_output, dtype=ttnn_dtype_from_torch_dtype(embedding_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+                )
+                pipeline.write_token(input_tensor)
+                pipeline.read_output(output_tensor)
+
+                result_torch = ttnn.to_torch(output_tensor).reshape(-1)
+                expected = torch_embedding[0, 0, token_id, :].reshape(-1)
+                match = torch.equal(expected, result_torch)
+                assert match, (
+                    f"Token {token_id}: D2H output does not match embedding row!\n"
+                    f"Expected: {expected[:8]}...\nGot: {result_torch[:8]}..."
+                )
+            logger.info(f"{vocab_size} token lookups verified successfully over passthrough pipeline configuration")
+
+        pipeline.barrier()
+    finally:
+        pipeline.terminate()
+
+
+@pytest.mark.parametrize("use_fp32", [True])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(4, 2)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            # TORUS_X needs X-direction wrap links; mesh graph descriptors for this pipeline only
+            # provide TORUS_Y (or mesh). FabricConfig cannot add links—only restrict routing.
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+            "fabric_router_config": create_fabric_router_config(15232),
+        }
+    ],
+    indirect=True,
+)
+def test_single_galaxy_deepseek_pipeline(mesh_device, use_fp32, device_params):
+    """
+    4-stage 4x2 single-galaxy pipeline (Embed -> Dense -> MoE -> LMHead), copied from
+    ``test_pipline_block_4stage_galaxy_1_iteration`` but using
+    :func:`create_single_galaxy_deepseek_pipeline_configuration`.
+    No loopback: token is read on the last mesh (LMHead stage). One-shot LMHead (no persistent mode).
+    No numerical golden check (smoke test only).
+    """
+    if not is_slow_dispatch():
+        pytest.skip("Skipping test in fast dispatch mode")
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+    num_procs = int(ttnn.distributed_context_get_size())
+    if num_procs != 4:
+        pytest.skip("This test requires exactly 4 distributed pipeline processes (P1..P4)")
+
+    config = create_single_galaxy_deepseek_pipeline_configuration(
+        SyntheticWeightProvider(),
+        lm_head_fp32_dest_acc_en=use_fp32,
+        lm_head_persistent_mode=False,
+    )
+    pipeline = config.build_pipeline(mesh_device)
+    try:
+        pipeline.setup_and_run()
+
+        if pipeline.my_mesh_id == 0:
+            torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
+            torch_token[0, 0] = 0
+            token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+            output_tensor = ttnn.from_torch(
+                torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+            pipeline.write_token(token_tensor)
+            pipeline.read_output(output_tensor)
+            got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
+            logger.info(f"test_single_galaxy_deepseek_pipeline last-mesh output token (no golden check): {got.item()}")
+
+        pipeline.barrier()
+    finally:
+        pipeline.terminate()


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/39659)

### Problem description
Missing some tests for pipelines.

### What's changed
Add an any stage pass through test.
Add a single galaxy Deepseek stages test.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aliu/add-pipeline-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aliu/add-pipeline-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aliu/add-pipeline-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aliu/add-pipeline-tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aliu/add-pipeline-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aliu/add-pipeline-tests)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aliu/add-pipeline-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aliu/add-pipeline-tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aliu/add-pipeline-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aliu/add-pipeline-tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aliu/add-pipeline-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aliu/add-pipeline-tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
