### PR TITLE
Expand is_galaxy to recognize Blackhole Galaxy cluster type

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -73,10 +73,11 @@ def galaxy_type():
 def is_galaxy():
     import ttnn
 
-    return (
-        ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
-        or ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.TG
-    )
+    return ttnn.cluster.get_cluster_type() in [
+        ttnn.cluster.ClusterType.GALAXY,
+        ttnn.cluster.ClusterType.TG,
+        ttnn.cluster.ClusterType.BLACKHOLE_GALAXY,
+    ]
 
 
 # TODO: Remove this when TG clusters are deprecated.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `is_galaxy()` helper in the root `conftest.py` only checked for `GALAXY` and `TG` cluster types. Tests relying on this function would not correctly identify a Blackhole Galaxy cluster, causing them to be skipped or misconfigured on that hardware.

### What's changed
Updated `is_galaxy()` in `conftest.py` to also match `ttnn.cluster.ClusterType.BLACKHOLE_GALAXY`. Refactored the check from chained `or` comparisons to a cleaner `in [...]` membership test.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-conftest-galaxy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-conftest-galaxy-fix) ⚠️ irrelevant failure on vit model
```
2026-04-09T07:37:30.0026194Z FAILED models/demos/vision/classification/vit/wormhole/tests/test_ttnn_optimized_sharded_vit_wh.py::test_vit_attention[224-8-google/vit-base-patch16-224] - RuntimeError: TT_FATAL @ /project/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp:185: !input_tensor.is_sharded()
2026-04-09T07:37:30.0085784Z FAILED models/demos/vision/classification/vit/wormhole/tests/test_ttnn_optimized_sharded_vit_wh.py::test_vit_layer[224-8-google/vit-base-patch16-224] - RuntimeError: TT_FATAL @ /project/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp:185: !input_tensor.is_sharded()
2026-04-09T07:37:30.0129829Z FAILED models/demos/vision/classification/vit/wormhole/tests/test_ttnn_optimized_sharded_vit_wh.py::test_vit_encoder[224-8-google/vit-base-patch16-224] - RuntimeError: TT_FATAL @ /project/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp:185: !input_tensor.is_sharded()
2026-04-09T07:37:31.0675531Z FAILED models/demos/vision/classification/vit/wormhole/tests/test_ttnn_optimized_sharded_vit_wh.py::test_vit[224-3-224-8-google/vit-base-patch16-224] - RuntimeError: TT_FATAL @ /project/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp:185: !input_tensor.is_sharded()
```