### PR TITLE
Fix prefix_scan OOB SRAM reads for non-32-aligned tile widths (#41179)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/ssm/test_ssm_prefix_scan.py
+++ b/tests/ttnn/nightly/unit_tests/operations/ssm/test_ssm_prefix_scan.py
@@ -58,16 +58,17 @@ def run_ssm_prefix_scan(L: int, E: int, N: int, num_cores: int, dtype, device):
     assert actual.dtype == dtype
 
     actual = tt2torch_tensor(actual)
-    passing_pcc, output_pcc = comp_pcc(actual, expected, 0.999)
-    logger.debug(f"Out passing={passing_pcc}")
+    output_passing_pcc, output_pcc = comp_pcc(actual, expected, 0.999)
+    logger.debug(f"Out passing={output_passing_pcc}")
     logger.debug(f"Output pcc={output_pcc}")
 
     h_prev = tt2torch_tensor(h_prev)
-    passing_pcc, output_pcc = comp_pcc(h_prev, expected[0, 0, -1, :], 0.999)
-    logger.debug(f"Hidden state passing={passing_pcc}")
-    logger.debug(f"Hidden state pcc={output_pcc}")
+    hidden_passing_pcc, hidden_pcc = comp_pcc(h_prev, expected[0, 0, -1, :], 0.999)
+    logger.debug(f"Hidden state passing={hidden_passing_pcc}")
+    logger.debug(f"Hidden state pcc={hidden_pcc}")
 
-    assert passing_pcc
+    assert output_passing_pcc, f"Output PCC {output_pcc} below threshold"
+    assert hidden_passing_pcc, f"Hidden state PCC {hidden_pcc} below threshold"
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp
@@ -34,7 +34,6 @@ void kernel_main() {
     const uint32_t num_chunks_per_row =
         (total_tiles_per_row + NUM_TILES_IN_TILIZED_CHUNK - 1) / NUM_TILES_IN_TILIZED_CHUNK;
 
-    const uint32_t total_tiles = total_tiles_per_row * total_tiles_per_col;
     const uint32_t chunk_bytes = NUM_TILES_IN_TILIZED_CHUNK * input_tile_size;
 
     // Copy h_prev data from shard to staging CB via NOC read.
@@ -54,15 +53,19 @@ void kernel_main() {
     // Copy tiles from shard to staging CB chunk by chunk via NOC read.
     // A single staging CB is shared between a and bx: the reader pushes a's chunk, compute
     // consumes it (untilize), then the reader pushes bx's chunk and compute consumes that.
-    // Always copy 32 tiles of contiguous shard data to match original shard-backed behavior.
-    // Only the very last chunk that extends past the shard end needs zero-padding.
+    // Each staging chunk always contains 32 tiles. For row tails shorter than 32 tiles,
+    // read only the remaining tiles from the current row and zero-pad the rest so the
+    // consumer never observes data from the next row.
     for (uint32_t row = 0; row < total_tiles_per_col; row++) {
         for (uint32_t chunk = 0; chunk < num_chunks_per_row; chunk++) {
-            const uint32_t tile_offset = row * total_tiles_per_row + chunk * NUM_TILES_IN_TILIZED_CHUNK;
+            const uint32_t tile_offset_in_row = chunk * NUM_TILES_IN_TILIZED_CHUNK;
+            const uint32_t tile_offset = row * total_tiles_per_row + tile_offset_in_row;
             const uint32_t byte_offset = tile_offset * input_tile_size;
-            const uint32_t tiles_available = total_tiles - tile_offset;
-            const uint32_t tiles_to_read =
-                tiles_available >= NUM_TILES_IN_TILIZED_CHUNK ? NUM_TILES_IN_TILIZED_CHUNK : tiles_available;
+            const uint32_t tiles_remaining_in_row =
+                tile_offset_in_row < total_tiles_per_row ? (total_tiles_per_row - tile_offset_in_row) : 0;
+            const uint32_t tiles_to_read = tiles_remaining_in_row >= NUM_TILES_IN_TILIZED_CHUNK
+                                               ? NUM_TILES_IN_TILIZED_CHUNK
+                                               : tiles_remaining_in_row;
             const uint32_t bytes_to_copy = tiles_to_read * input_tile_size;
 
             // Copy a chunk to shared staging CB

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp
@@ -12,7 +12,8 @@ constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 
 void kernel_main() {
     constexpr uint32_t cb_in_id = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_bx_in_id = get_compile_time_arg_val(1);  // same as cb_in_id (shared staging CB)
+    constexpr uint32_t cb_bx_in_id = get_compile_time_arg_val(1);
+    static_assert(cb_bx_in_id == cb_in_id, "cb_bx_in_id must match cb_in_id because bx reuses the shared staging CB");
     constexpr uint32_t cb_h_in_id = get_compile_time_arg_val(2);
     constexpr uint32_t input_tile_size = get_compile_time_arg_val(3);
     constexpr uint32_t h_page_size = get_compile_time_arg_val(4);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp
@@ -3,18 +3,103 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc.h"
 
 constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 
 void kernel_main() {
-    uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
-    uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
+    constexpr uint32_t cb_in_id = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_bx_in_id = get_compile_time_arg_val(1);  // same as cb_in_id (shared staging CB)
+    constexpr uint32_t cb_h_in_id = get_compile_time_arg_val(2);
+    constexpr uint32_t input_tile_size = get_compile_time_arg_val(3);
+    constexpr uint32_t h_page_size = get_compile_time_arg_val(4);
 
-    constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_h_in = get_compile_time_arg_val(2);
+    const uint32_t total_tiles_per_row = get_arg_val<uint32_t>(0);
+    const uint32_t total_tiles_per_col = get_arg_val<uint32_t>(1);
+    const uint32_t a_shard_l1_addr = get_arg_val<uint32_t>(2);
+    const uint32_t bx_shard_l1_addr = get_arg_val<uint32_t>(3);
+    const uint32_t h_shard_l1_addr = get_arg_val<uint32_t>(4);
 
-    cb_push_back(cb_a_in, num_tiles_per_core);
-    cb_push_back(cb_bx_in, num_tiles_per_core);
-    cb_push_back(cb_h_in, total_tiles_per_row);
+    experimental::CircularBuffer cb_in(cb_in_id);
+    experimental::CircularBuffer cb_h_in(cb_h_in_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint shard_src;
+
+    const uint32_t local_noc_x = my_x[noc.get_noc_id()];
+    const uint32_t local_noc_y = my_y[noc.get_noc_id()];
+
+    const uint32_t num_chunks_per_row =
+        (total_tiles_per_row + NUM_TILES_IN_TILIZED_CHUNK - 1) / NUM_TILES_IN_TILIZED_CHUNK;
+
+    const uint32_t total_tiles = total_tiles_per_row * total_tiles_per_col;
+    const uint32_t chunk_bytes = NUM_TILES_IN_TILIZED_CHUNK * input_tile_size;
+
+    // Copy h_prev data from shard to staging CB via NOC read.
+    // cb_h_in is non-shard-backed to keep it at a low L1 address, avoiding unpacker OOB
+    // when the h_prev shard is near the L1 boundary.
+    const uint32_t h_total_bytes = total_tiles_per_row * h_page_size;
+    cb_h_in.reserve_back(total_tiles_per_row);
+    noc.async_read(
+        shard_src,
+        cb_h_in,
+        h_total_bytes,
+        {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = h_shard_l1_addr},
+        {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_h_in.push_back(total_tiles_per_row);
+
+    // Copy tiles from shard to staging CB chunk by chunk via NOC read.
+    // A single staging CB is shared between a and bx: the reader pushes a's chunk, compute
+    // consumes it (untilize), then the reader pushes bx's chunk and compute consumes that.
+    // Always copy 32 tiles of contiguous shard data to match original shard-backed behavior.
+    // Only the very last chunk that extends past the shard end needs zero-padding.
+    for (uint32_t row = 0; row < total_tiles_per_col; row++) {
+        for (uint32_t chunk = 0; chunk < num_chunks_per_row; chunk++) {
+            const uint32_t tile_offset = row * total_tiles_per_row + chunk * NUM_TILES_IN_TILIZED_CHUNK;
+            const uint32_t byte_offset = tile_offset * input_tile_size;
+            const uint32_t tiles_available = total_tiles - tile_offset;
+            const uint32_t tiles_to_read =
+                tiles_available >= NUM_TILES_IN_TILIZED_CHUNK ? NUM_TILES_IN_TILIZED_CHUNK : tiles_available;
+            const uint32_t bytes_to_copy = tiles_to_read * input_tile_size;
+
+            // Copy a chunk to shared staging CB
+            cb_in.reserve_back(NUM_TILES_IN_TILIZED_CHUNK);
+            noc.async_read(
+                shard_src,
+                cb_in,
+                bytes_to_copy,
+                {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = a_shard_l1_addr + byte_offset},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
+            if (bytes_to_copy < chunk_bytes) {
+                experimental::CoreLocalMem<volatile uint32_t> pad(cb_in.get_write_ptr() + bytes_to_copy);
+                const uint32_t padding_words = (chunk_bytes - bytes_to_copy) / sizeof(uint32_t);
+                for (uint32_t w = 0; w < padding_words; w++) {
+                    pad[w] = 0;
+                }
+            }
+            cb_in.push_back(NUM_TILES_IN_TILIZED_CHUNK);
+
+            // Copy bx chunk to the same shared staging CB (compute pops a first, freeing space)
+            cb_in.reserve_back(NUM_TILES_IN_TILIZED_CHUNK);
+            noc.async_read(
+                shard_src,
+                cb_in,
+                bytes_to_copy,
+                {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = bx_shard_l1_addr + byte_offset},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
+            if (bytes_to_copy < chunk_bytes) {
+                experimental::CoreLocalMem<volatile uint32_t> pad(cb_in.get_write_ptr() + bytes_to_copy);
+                const uint32_t padding_words = (chunk_bytes - bytes_to_copy) / sizeof(uint32_t);
+                for (uint32_t w = 0; w < padding_words; w++) {
+                    pad[w] = 0;
+                }
+            }
+            cb_in.push_back(NUM_TILES_IN_TILIZED_CHUNK);
+        }
+    }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -11,53 +11,38 @@
 
 constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 
-constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
-constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
-constexpr uint32_t cb_h_in = get_compile_time_arg_val(2);
-
-constexpr uint32_t cb_a_tilize_in = get_compile_time_arg_val(3);
-constexpr uint32_t cb_bx_tilize_in = get_compile_time_arg_val(4);
-
-constexpr uint32_t cb_h_prev = get_compile_time_arg_val(5);
-constexpr uint32_t cb_ah = get_compile_time_arg_val(6);
-constexpr uint32_t cb_h = get_compile_time_arg_val(7);
-
-constexpr uint32_t cb_tilize_out = get_compile_time_arg_val(8);
-constexpr uint32_t cb_out = get_compile_time_arg_val(9);
-
-constexpr uint32_t cb_h_acc = get_compile_time_arg_val(10);
-
-// This function relies on untilizing NUM_TILES_IN_TILIZED_CHUNK tiles so we pad up to that amount
-FORCE_INLINE void pack_block_rows_into_tiles(uint32_t cb_in, uint32_t cb_out, uint32_t num_tiles) {
+// Staging CB always has NUM_TILES_IN_TILIZED_CHUNK tiles; pop the full chunk to keep it clean.
+FORCE_INLINE void pack_block_rows_into_tiles(uint32_t cb_in, uint32_t cb_out) {
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
     untilize_init(cb_in);
 
-    cb_wait_front(cb_in, num_tiles);
+    cb_wait_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
     cb_reserve_back(cb_out, NUM_TILES_IN_TILIZED_CHUNK);
 
     untilize_block(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
 
     cb_push_back(cb_out, NUM_TILES_IN_TILIZED_CHUNK);
-    cb_pop_front(cb_in, num_tiles);
+    cb_pop_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
 
     untilize_uninit(cb_in);
 }
 
-// This function relies on tilizing NUM_TILES_IN_TILIZED_CHUNK tiles so we pad up to that amount
-FORCE_INLINE void pack_block_tiles_into_rows(uint32_t cb_in, uint32_t cb_out, uint32_t num_tiles) {
+// Tilize num_valid_tiles from cb_in to cb_out.
+// Always pops NUM_TILES_IN_TILIZED_CHUNK from cb_in since compute_ht produces a full 32-tile chunk.
+FORCE_INLINE void pack_block_tiles_into_rows(uint32_t cb_in, uint32_t cb_out, uint32_t num_valid_tiles) {
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
-    tilize_init(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
+    tilize_init(cb_in, num_valid_tiles, cb_out);
 
     cb_wait_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
-    cb_reserve_back(cb_out, num_tiles);
+    cb_reserve_back(cb_out, num_valid_tiles);
 
-    tilize_block(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
+    tilize_block(cb_in, num_valid_tiles, cb_out);
 
-    cb_push_back(cb_out, num_tiles);
+    cb_push_back(cb_out, num_valid_tiles);
     cb_pop_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
 
     tilize_uninit(cb_in, cb_out);
@@ -127,7 +112,15 @@ FORCE_INLINE void copy(uint32_t cb_in, uint32_t cb_out, uint32_t num_input_units
     cb_push_back(cb_out, 1);
 }
 
-FORCE_INLINE void compute_ht(uint32_t cb_a, uint32_t cb_bx, uint32_t cb_out, uint32_t num_tiles) {
+FORCE_INLINE void compute_ht(
+    uint32_t cb_a,
+    uint32_t cb_bx,
+    uint32_t cb_out,
+    uint32_t cb_h_prev,
+    uint32_t cb_ah,
+    uint32_t cb_h,
+    uint32_t cb_h_acc,
+    uint32_t num_tiles) {
     for (uint32_t idx = 0; idx < num_tiles; idx++) {
         mul(cb_a, cb_h_prev, cb_ah);
         sum(cb_ah, cb_bx, cb_h);
@@ -143,6 +136,18 @@ FORCE_INLINE void compute_ht(uint32_t cb_a, uint32_t cb_bx, uint32_t cb_out, uin
 }
 
 void kernel_main() {
+    constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_h_in = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_a_tilize_in = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_bx_tilize_in = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_h_prev = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_ah = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_h = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_tilize_out = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_h_acc = get_compile_time_arg_val(10);
+
     const uint32_t total_tiles = get_arg_val<uint32_t>(0);
     const uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
     const uint32_t total_tiles_per_col = get_arg_val<uint32_t>(2);
@@ -173,10 +178,18 @@ void kernel_main() {
             const uint32_t remaining_tiles_in_chunk =
                 tilized_chunk_idx == num_chunks_per_row - 1 ? num_tiles_last_chunk : NUM_TILES_IN_TILIZED_CHUNK;
 
-            pack_block_rows_into_tiles(cb_a_in, cb_a_tilize_in, remaining_tiles_in_chunk);
-            pack_block_rows_into_tiles(cb_bx_in, cb_bx_tilize_in, remaining_tiles_in_chunk);
+            pack_block_rows_into_tiles(cb_a_in, cb_a_tilize_in);
+            pack_block_rows_into_tiles(cb_bx_in, cb_bx_tilize_in);
 
-            compute_ht(cb_a_tilize_in, cb_bx_tilize_in, cb_tilize_out, NUM_TILES_IN_TILIZED_CHUNK);
+            compute_ht(
+                cb_a_tilize_in,
+                cb_bx_tilize_in,
+                cb_tilize_out,
+                cb_h_prev,
+                cb_ah,
+                cb_h,
+                cb_h_acc,
+                NUM_TILES_IN_TILIZED_CHUNK);
 
             pack_block_tiles_into_rows(cb_tilize_out, cb_out, remaining_tiles_in_chunk);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -29,18 +29,19 @@ FORCE_INLINE void pack_block_rows_into_tiles(uint32_t cb_in, uint32_t cb_out) {
     untilize_uninit(cb_in);
 }
 
-// Tilize num_valid_tiles from cb_in to cb_out.
-// Always pops NUM_TILES_IN_TILIZED_CHUNK from cb_in since compute_ht produces a full 32-tile chunk.
+// Tilize the full 32-tile block from cb_in to cb_out, but only push num_valid_tiles.
+// The tilize must always process the full NUM_TILES_IN_TILIZED_CHUNK block to correctly
+// reconstruct the tile layout from row-major format (inverse of untilize_block(32)).
 FORCE_INLINE void pack_block_tiles_into_rows(uint32_t cb_in, uint32_t cb_out, uint32_t num_valid_tiles) {
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
-    tilize_init(cb_in, num_valid_tiles, cb_out);
+    tilize_init(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
 
     cb_wait_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
     cb_reserve_back(cb_out, num_valid_tiles);
 
-    tilize_block(cb_in, num_valid_tiles, cb_out);
+    tilize_block(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
 
     cb_push_back(cb_out, num_valid_tiles);
     cb_pop_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/writer_ssm_prefix_scan.cpp
@@ -12,18 +12,18 @@ constexpr uint32_t NUM_BYTES_IN_TILIZED_CHUNK = NUM_TILES_IN_TILIZED_CHUNK * TIL
 void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
     const uint32_t hidden_state_len = get_arg_val<uint32_t>(1);
+    const uint32_t h_shard_l1_addr = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     constexpr uint32_t cb_h_acc = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_h_out = get_compile_time_arg_val(2);
 
     const uint32_t hidden_state_len_bytes = hidden_state_len * NUM_BYTES_IN_BFLOAT16;
 
     cb_wait_front(cb_out, num_tiles_per_core);
 
-    // This assumes we are updating h input tensor in-place
+    // Write accumulated hidden state back to the h_prev shard (in-place update)
     uint32_t src_addr = get_read_ptr(cb_h_acc);
-    uint64_t dst_addr = get_noc_addr(get_write_ptr(cb_h_out));
+    uint64_t dst_addr = get_noc_addr(h_shard_l1_addr);
     noc_async_write(src_addr, dst_addr, hidden_state_len_bytes);
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
@@ -185,6 +185,11 @@ void PrefixScanProgramFactory::override_runtime_arguments(
     tt::tt_metal::Buffer* h_buffer = h_prev.buffer();
     tt::tt_metal::Buffer* output_buffer = output.buffer();
 
+    TT_ASSERT(a_buffer != nullptr, "Input a buffer should be allocated on device");
+    TT_ASSERT(bx_buffer != nullptr, "Input bx buffer should be allocated on device");
+    TT_ASSERT(h_buffer != nullptr, "Input h_prev buffer should be allocated on device");
+    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device");
+
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
@@ -20,13 +20,8 @@ PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const auto& a = tensor_args.a;
-    const auto& bx = tensor_args.bx;
-    const auto& h_prev = tensor_args.h_prev;
     auto& output = tensor_return_value;
 
-    auto* a_buffer = a.buffer();
-    auto* bx_buffer = bx.buffer();
-    auto* h_buffer = h_prev.buffer();
     auto* output_buffer = output.buffer();
     TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device");
 
@@ -62,19 +57,20 @@ PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
     constexpr uint32_t num_tiles_in_chunk = 32;
     const uint32_t num_chunks_per_row = tt::div_up(total_tiles_per_row, num_tiles_in_chunk);
 
+    // Create all non-shard-backed CBs BEFORE shard-backed CBs to keep them at low L1 addresses.
+    // The CB allocator tracks the sequential allocation pointer; shard-backed CBs at high buffer
+    // addresses would push the pointer up, placing subsequent non-shard-backed CBs near the L1 limit.
+
+    // Non-shard-backed staging CB shared between a and bx inputs.
+    // The untilize operation always reads 32 tiles. When total_tiles_per_row is not a multiple of 32,
+    // the last chunk has fewer tiles in the shard, causing OOB reads on a shard-backed CB.
+    // Using a staging CB with exactly 32 tiles ensures the untilize reads stay within allocated memory.
+    // The reader kernel copies data from the shard to this staging CB chunk by chunk via NOC read,
+    // alternating between a and bx data. The compute kernel consumes each in sequence.
     const uint32_t cb_a_in_id = tt::CBIndex::c_0;
-    const auto cb_a_in = create_circular_buffer(cb_a_in_id, total_tiles, input_tile_size, input_format, a_buffer);
+    create_circular_buffer(cb_a_in_id, num_tiles_in_chunk, input_tile_size, input_format);
 
-    const uint32_t cb_bx_in_id = tt::CBIndex::c_1;
-    const auto cb_bx_in = create_circular_buffer(cb_bx_in_id, total_tiles, input_tile_size, input_format, bx_buffer);
-
-    // Hidden state is in row-major so must be bfloat16
-    const uint32_t cb_h_in_id = tt::CBIndex::c_2;
-    const auto cb_h_in =
-        create_circular_buffer(cb_h_in_id, total_tiles_per_row, intermediary_row_size, intermediary_format, h_buffer);
-
-    const uint32_t cb_out_id = tt::CBIndex::c_16;
-    const auto cb_out = create_circular_buffer(cb_out_id, total_tiles, input_tile_size, input_format, output_buffer);
+    const uint32_t cb_bx_in_id = cb_a_in_id;  // shared staging CB
 
     const uint32_t num_tiles_in_row_to_tile_cb = 32;  // Tilizing 32 tiles will pack tensor rows into separate tiles
     const uint32_t cb_a_tilize_in_id = tt::CBIndex::c_24;
@@ -99,11 +95,20 @@ PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
     const uint32_t cb_h_acc_id = tt::CBIndex::c_31;
     create_circular_buffer(cb_h_acc_id, num_chunks_per_row, intermediary_tile_size, intermediary_format);
 
-    std::vector<uint32_t> reader_compile_time_args = {cb_a_in_id, cb_bx_in_id, cb_h_in_id};
-    std::vector<uint32_t> writer_compile_time_args = {cb_out_id, cb_h_acc_id, cb_h_in_id};
-    tt::tt_metal::TensorAccessorArgs(a_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(bx_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(h_buffer).append_to(reader_compile_time_args);
+    // Non-shard-backed staging CB for h_in. The h_prev shard uses intermediary_row_size pages
+    // (64 bytes) but Float16_b format. The unpacker reads full-format tiles (~2KB) which overshoot
+    // the 64-byte page boundary. If the shard is near the L1 limit this causes OOB.
+    // Using a non-shard-backed CB at a low L1 address avoids this.
+    const uint32_t cb_h_in_id = tt::CBIndex::c_2;
+    create_circular_buffer(cb_h_in_id, total_tiles_per_row, intermediary_row_size, intermediary_format);
+
+    // Shard-backed output CB last - buffer address may be high in L1
+    const uint32_t cb_out_id = tt::CBIndex::c_16;
+    const auto cb_out = create_circular_buffer(cb_out_id, total_tiles, input_tile_size, input_format, output_buffer);
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        cb_a_in_id, cb_bx_in_id, cb_h_in_id, input_tile_size, intermediary_row_size};
+    std::vector<uint32_t> writer_compile_time_args = {cb_out_id, cb_h_acc_id};
     tt::tt_metal::TensorAccessorArgs(output_buffer).append_to(writer_compile_time_args);
     std::vector<uint32_t> compute_compile_time_args = {
         cb_a_in_id,
@@ -150,9 +155,6 @@ PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
     shared_variables.writer_kernel_id = writer_kernel_id;
     shared_variables.compute_kernel_id = compute_kernel_id;
     shared_variables.cores = cores;
-    shared_variables.cb_a_in = cb_a_in;
-    shared_variables.cb_bx_in = cb_bx_in;
-    shared_variables.cb_h_in = cb_h_in;
     shared_variables.cb_out = cb_out;
     shared_variables.total_tiles = total_tiles;
     shared_variables.total_tiles_per_row = total_tiles_per_row;
@@ -186,25 +188,28 @@ void PrefixScanProgramFactory::override_runtime_arguments(
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
 
-    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_a_in, *a_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_bx_in, *bx_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_h_in, *h_buffer);
+    // Only update shard-backed output CB; a_in/bx_in and h_in are non-shard-backed staging CBs
     UpdateDynamicCircularBufferAddress(program, shared_vars.cb_out, *output_buffer);
 
     std::vector<std::vector<uint32_t>> reader_runtime_args = {
-        shared_vars.cores.size(), {0, 0}};  // (num_tiles_per_core, total_tiles_per_row)
+        shared_vars.cores.size(),
+        {0, 0, 0, 0, 0}};  // (total_tiles_per_row, total_tiles_per_col, a_shard_addr, bx_shard_addr, h_shard_addr)
     std::vector<std::vector<uint32_t>> writer_runtime_args = {
-        shared_vars.cores.size(), {0, 0}};  // (num_tiles_per_core, hidden_state_len)
+        shared_vars.cores.size(), {0, 0, 0}};  // (num_tiles_per_core, hidden_state_len, h_shard_addr)
     std::vector<std::vector<uint32_t>> compute_runtime_args = {
         shared_vars.cores.size(),
         {0, 0, 0, 0}};  // (total_tiles, total_tiles_per_row, total_tiles_per_col, num_chunks_per_row)
 
     for (uint32_t i = 0; i < shared_vars.cores.size(); i++) {
-        reader_runtime_args[i][0] = shared_vars.total_tiles;
-        reader_runtime_args[i][1] = shared_vars.total_tiles_per_row;
+        reader_runtime_args[i][0] = shared_vars.total_tiles_per_row;
+        reader_runtime_args[i][1] = shared_vars.total_tiles_per_col;
+        reader_runtime_args[i][2] = static_cast<uint32_t>(a_buffer->address());
+        reader_runtime_args[i][3] = static_cast<uint32_t>(bx_buffer->address());
+        reader_runtime_args[i][4] = static_cast<uint32_t>(h_buffer->address());
 
         writer_runtime_args[i][0] = shared_vars.total_tiles;
         writer_runtime_args[i][1] = shared_vars.sharded_hidden_state_length;
+        writer_runtime_args[i][2] = static_cast<uint32_t>(h_buffer->address());
 
         compute_runtime_args[i][0] = shared_vars.total_tiles;
         compute_runtime_args[i][1] = shared_vars.total_tiles_per_row;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
@@ -185,10 +185,10 @@ void PrefixScanProgramFactory::override_runtime_arguments(
     tt::tt_metal::Buffer* h_buffer = h_prev.buffer();
     tt::tt_metal::Buffer* output_buffer = output.buffer();
 
-    TT_ASSERT(a_buffer != nullptr, "Input a buffer should be allocated on device");
-    TT_ASSERT(bx_buffer != nullptr, "Input bx buffer should be allocated on device");
-    TT_ASSERT(h_buffer != nullptr, "Input h_prev buffer should be allocated on device");
-    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device");
+    TT_FATAL(a_buffer != nullptr, "Input a buffer should be allocated on device");
+    TT_FATAL(bx_buffer != nullptr, "Input bx buffer should be allocated on device");
+    TT_FATAL(h_buffer != nullptr, "Input h_prev buffer should be allocated on device");
+    TT_FATAL(output_buffer != nullptr, "Output buffer should be allocated on device");
 
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.hpp
@@ -14,9 +14,6 @@ struct PrefixScanSharedVariables {
     tt::tt_metal::KernelHandle writer_kernel_id = 0;
     tt::tt_metal::KernelHandle compute_kernel_id = 0;
     std::vector<tt::tt_metal::CoreCoord> cores;
-    tt::tt_metal::CBHandle cb_a_in{};
-    tt::tt_metal::CBHandle cb_bx_in{};
-    tt::tt_metal::CBHandle cb_h_in{};
     tt::tt_metal::CBHandle cb_out{};
     uint32_t total_tiles = 0;
     uint32_t total_tiles_per_row = 0;


### PR DESCRIPTION
Replace shard-backed input CBs with non-shard-backed staging CBs to fix three OOB sources detected by WH ttsim

### Ticket
#41179

### Problem description
1. Untilize always reads 32 tiles - overshoots shard-backed CBs when total_tiles_per_row is not a multiple of 32
2. cb_h_in uses 64-byte pages with Float16_b format - unpacker reads full-format tiles (~2KB), overshooting when h_prev shard is near the L1 boundary (0x16E000)
3. CB allocator places non-shard-backed CBs after high-address shard-backed CBs, pushing them near L1 limit

### What's changed
All input CBs (a, bx, h_prev) are now non-shard-backed staging CBs at low L1 addresses. Reader copies data from shards via NOC read. a and bx share a single staging CB. Writer writes h_acc directly to h_prev shard address. Non-shard-backed CBs created before shard-backed ones.


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mateusznowakTT/41179_prefix_scan_oob_ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mateusznowakTT/41179_prefix_scan_oob_ttsim)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mateusznowakTT/41179_prefix_scan_oob_ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mateusznowakTT/41179_prefix_scan_oob_ttsim)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mateusznowakTT/41179_prefix_scan_oob_ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mateusznowakTT/41179_prefix_scan_oob_ttsim)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mateusznowakTT/41179_prefix_scan_oob_ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mateusznowakTT/41179_prefix_scan_oob_ttsim)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mateusznowakTT/41179_prefix_scan_oob_ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mateusznowakTT/41179_prefix_scan_oob_ttsim)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mateusznowakTT/41179_prefix_scan_oob_ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mateusznowakTT/41179_prefix_scan_oob_ttsim)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
