### PR TITLE
Revert TT_FATAL for sharded input in split_query_key_value_and_split_heads

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
@@ -400,39 +400,6 @@ def test_vit_split_query_key_value_and_split_heads(
     assert ttnn.pearson_correlation_coefficient(torch_value_tensor, value_tensor) > 0.999
 
 
-def test_split_query_key_value_and_split_heads_rejects_sharded_input(device):
-    """Regression test for issue #41526: sharded input must be rejected (was silently producing garbage)."""
-    torch.manual_seed(0)
-
-    batch_size, sequence_size, num_heads, head_size = 8, 197, 12, 64
-    hidden_dim = num_heads * 3 * head_size
-    input_shape = (batch_size, sequence_size, hidden_dim)
-    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
-
-    tile_size = ttnn.TILE_SIZE
-    padded_seq = ((sequence_size + tile_size - 1) // tile_size) * tile_size
-    num_h_cores, num_w_cores = batch_size, num_heads // 2
-
-    block_sharded_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(
-            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_w_cores - 1, num_h_cores - 1))]),
-            [padded_seq, hidden_dim // num_w_cores],
-            ttnn.ShardOrientation.ROW_MAJOR,
-        ),
-    )
-
-    dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
-    tt_input = ttnn.from_torch(
-        torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram
-    )
-    tt_sharded = ttnn.to_memory_config(tt_input, block_sharded_config)
-
-    with pytest.raises(RuntimeError, match="Sharded input is not supported"):
-        ttnn.transformer.split_query_key_value_and_split_heads(tt_sharded, num_heads=num_heads, transpose_key=False)
-
-
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("sequence_size", [224, 384])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b])

--- a/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
@@ -179,10 +179,25 @@ std::tuple<Tensor, Tensor, Tensor> split_query_key_value_and_split_heads(
         head_size,
         padded_head_size);
 
-    TT_FATAL(
-        !input_tensor.is_sharded(),
-        "Sharded input is not supported for split_query_key_value_and_split_heads. "
-        "The input must be interleaved (DRAM or L1). The caller should unshard the input before calling this op.");
+    if (input_tensor.is_sharded()) {
+        TT_FATAL(
+            !input_tensor_kv.has_value(),
+            "Invalid operation: KV tensor should not be provided when the input tensor is sharded. Please ensure that "
+            "the KV tensor is only used in non-sharded configurations.");
+
+        const auto input_tensor_4d = ttnn::experimental::view(
+            input_tensor, ttnn::Shape{padded_input_shape[0], 1, padded_input_shape[1], padded_input_shape[2]});
+        return ttnn::operations::transformer::detail::reshape_outputs_of_split_query_key_value_and_split_heads(
+            ttnn::experimental::create_qkv_heads(
+                input_tensor_4d,
+                num_heads,
+                num_kv_heads.value_or(num_heads),
+                transpose_key,
+                memory_config.value_or(input_tensor.memory_config())),
+            sequence_size,
+            sequence_size_padded,
+            transpose_key);
+    }
     const auto input_tensor_4d = ttnn::experimental::view(
         input_tensor, ttnn::Shape{padded_input_shape[0], 1, padded_input_shape[1], padded_input_shape[2]});
     std::optional<Tensor> input_tensor_kv_4d = std::nullopt;


### PR DESCRIPTION
## Summary

Reverts #41550 which added a blanket `TT_FATAL` rejecting all sharded inputs to `split_query_key_value_and_split_heads`.
