### PR TITLE
Migrate eltwise kernels to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -36,14 +36,19 @@ void kernel_main() {
     constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
 #endif
 
+    experimental::CircularBuffer exp_cb_bcast(cb_bcast);
+    experimental::CircularBuffer exp_cb_llk_post(cb_llk_post);
+    experimental::CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    experimental::CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+
     binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
 #ifdef PACK_RELU
     PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
 #endif
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_wait_front(cb_bcast, num_tiles_per_cycle);
-        cb_reserve_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_bcast.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
         unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
 
         tile_regs_acquire();
@@ -52,9 +57,9 @@ void kernel_main() {
 
         tile_regs_wait();
         pack_tile(0, cb_llk_post);
-        cb_push_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
         tile_regs_release();
-        cb_pop_front(cb_bcast, num_tiles_per_cycle);
+        exp_cb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
 #ifdef ARCH_BLACKHOLE
@@ -62,10 +67,10 @@ void kernel_main() {
 #endif
 
         PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
-        cb_wait_front(cb_post_lhs, num_tiles_per_cycle);
+        exp_cb_post_lhs.wait_front(num_tiles_per_cycle);
 
         PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
-        cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
+        exp_cb_post_rhs.wait_front(num_tiles_per_cycle);
 
         binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
         exp_cb_out.reserve_back(num_tiles_per_cycle);
@@ -80,7 +85,7 @@ void kernel_main() {
         tile_regs_release();
 
         exp_cb_out.push_back(num_tiles_per_cycle);
-        cb_pop_front(cb_post_lhs, num_tiles_per_cycle);
-        cb_pop_front(cb_post_rhs, num_tiles_per_cycle);
+        exp_cb_post_lhs.pop_front(num_tiles_per_cycle);
+        exp_cb_post_rhs.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -10,12 +10,14 @@
 
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
     constexpr auto cb_out = tt::CBIndex::c_2;
+    experimental::CircularBuffer exp_cb_out(cb_out);
 
 #if SRC_BCAST
     constexpr auto cb_bcast = tt::CBIndex::c_0;
@@ -66,7 +68,7 @@ void kernel_main() {
         cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
 
         binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
-        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
@@ -77,7 +79,7 @@ void kernel_main() {
         pack_tile(0, cb_out);
         tile_regs_release();
 
-        cb_push_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.push_back(num_tiles_per_cycle);
         cb_pop_front(cb_post_lhs, num_tiles_per_cycle);
         cb_pop_front(cb_post_rhs, num_tiles_per_cycle);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -10,6 +10,7 @@
 
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "experimental/circular_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs,
@@ -21,6 +22,7 @@ ALWI void process_tile(
     uint32_t tile_start,
     uint32_t num_tiles_per_cycle) {
     using namespace ckernel;
+    experimental::CircularBuffer exp_cb_out(cb_out);
 
 #if BCAST_INPUT  // ROW_A_COL_B
 #define CB_PRE_BCAST cb_pre_rhs
@@ -68,7 +70,7 @@ ALWI void process_tile(
         cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
 
         binary_tiles_init<true, BINARY_OP_TYPE>(cb_left, cb_right);
-        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
 
         tile_regs_acquire();
         BINARY_OP(cb_left, cb_right, 0, 0, 0);
@@ -79,7 +81,7 @@ ALWI void process_tile(
         pack_tile(0, cb_out);
         tile_regs_release();
 
-        cb_push_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.push_back(num_tiles_per_cycle);
         cb_pop_front(CB_POST_OTHER, num_tiles_per_cycle);
     }
     cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -42,13 +42,18 @@ ALWI void process_tile(
     auto cb_right = cb_post_rhs;
 #endif
 
+    experimental::CircularBuffer exp_cb_raw_other(cb_raw_other);
+    experimental::CircularBuffer exp_cb_llk_post(cb_llk_post);
+    experimental::CircularBuffer exp_cb_post_bcast(CB_POST_BCAST);
+    experimental::CircularBuffer exp_cb_post_other(CB_POST_OTHER);
+
     binary_op_init_common(cb_left, cb_right, cb_out);
     PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, num_tiles_per_cycle);
-    cb_wait_front(CB_POST_BCAST, num_tiles_per_cycle);
+    exp_cb_post_bcast.wait_front(num_tiles_per_cycle);
 
     for (uint32_t j = tile_start; j < freq; ++j) {
-        cb_wait_front(cb_raw_other, num_tiles_per_cycle);
-        cb_reserve_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_raw_other.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
         unary_bcast_init<BroadcastType::ROW>(cb_raw_other, cb_llk_post);
 
         tile_regs_acquire();
@@ -57,9 +62,9 @@ ALWI void process_tile(
 
         tile_regs_wait();
         pack_tile(0, cb_llk_post);
-        cb_push_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
         tile_regs_release();
-        cb_pop_front(cb_raw_other, num_tiles_per_cycle);
+        exp_cb_raw_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_raw_other);
         pack_reconfig_data_format(cb_llk_post, cb_out);
 #ifdef ARCH_BLACKHOLE
@@ -67,7 +72,7 @@ ALWI void process_tile(
 #endif
 
         PREPROCESS(OTHER_OP, cb_llk_post, CB_POST_OTHER, cb_out, num_tiles_per_cycle);
-        cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
+        exp_cb_post_other.wait_front(num_tiles_per_cycle);
 
         binary_tiles_init<true, BINARY_OP_TYPE>(cb_left, cb_right);
         exp_cb_out.reserve_back(num_tiles_per_cycle);
@@ -82,9 +87,9 @@ ALWI void process_tile(
         tile_regs_release();
 
         exp_cb_out.push_back(num_tiles_per_cycle);
-        cb_pop_front(CB_POST_OTHER, num_tiles_per_cycle);
+        exp_cb_post_other.pop_front(num_tiles_per_cycle);
     }
-    cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
+    exp_cb_post_bcast.pop_front(num_tiles_per_cycle);
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -54,6 +54,11 @@ void kernel_main() {
     constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
 #endif
 
+    experimental::CircularBuffer exp_cb_bcast(cb_bcast);
+    experimental::CircularBuffer exp_cb_llk_post(cb_llk_post);
+    experimental::CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    experimental::CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+
     unary_op_init_common(cb_post_lhs, cb_out);
 #ifdef PACK_RELU
     PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
@@ -64,8 +69,8 @@ void kernel_main() {
 #endif
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_wait_front(cb_bcast, num_tiles_per_cycle);
-        cb_reserve_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_bcast.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
         unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
 
         tile_regs_acquire();
@@ -74,9 +79,9 @@ void kernel_main() {
 
         tile_regs_wait();
         pack_tile(0, cb_llk_post);
-        cb_push_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
         tile_regs_release();
-        cb_pop_front(cb_bcast, num_tiles_per_cycle);
+        exp_cb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
 #ifdef ARCH_BLACKHOLE
@@ -84,10 +89,10 @@ void kernel_main() {
 #endif
 
         PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
-        cb_wait_front(cb_post_lhs, num_tiles_per_cycle);
+        exp_cb_post_lhs.wait_front(num_tiles_per_cycle);
 
         PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
-        cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
+        exp_cb_post_rhs.wait_front(num_tiles_per_cycle);
 
         exp_cb_out.reserve_back(num_tiles_per_cycle);
 #if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
@@ -118,7 +123,7 @@ void kernel_main() {
         tile_regs_release();
 
         exp_cb_out.push_back(num_tiles_per_cycle);
-        cb_pop_front(cb_post_lhs, num_tiles_per_cycle);
-        cb_pop_front(cb_post_rhs, num_tiles_per_cycle);
+        exp_cb_post_lhs.pop_front(num_tiles_per_cycle);
+        exp_cb_post_rhs.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -27,6 +27,7 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -34,6 +35,7 @@ void kernel_main() {
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
 
     constexpr auto cb_out = tt::CBIndex::c_2;
+    experimental::CircularBuffer exp_cb_out(cb_out);
 
 #if SRC_BCAST
     constexpr auto cb_bcast = tt::CBIndex::c_0;
@@ -87,7 +89,7 @@ void kernel_main() {
         PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
         cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
 
-        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
 #if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
         BINARY_SFPU_INIT
 #endif
@@ -115,7 +117,7 @@ void kernel_main() {
         }
         tile_regs_release();
 
-        cb_push_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.push_back(num_tiles_per_cycle);
         cb_pop_front(cb_post_lhs, num_tiles_per_cycle);
         cb_pop_front(cb_post_rhs, num_tiles_per_cycle);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -59,13 +59,18 @@ ALWI void process_tile(
     auto cb_right = cb_post_rhs;
 #endif
 
+    experimental::CircularBuffer exp_cb_raw_other(cb_raw_other);
+    experimental::CircularBuffer exp_cb_llk_post(cb_llk_post);
+    experimental::CircularBuffer exp_cb_post_bcast(CB_POST_BCAST);
+    experimental::CircularBuffer exp_cb_post_other(CB_POST_OTHER);
+
     unary_op_init_common(cb_left, cb_out);
     PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, num_tiles_per_cycle);
-    cb_wait_front(CB_POST_BCAST, num_tiles_per_cycle);
+    exp_cb_post_bcast.wait_front(num_tiles_per_cycle);
 
     for (uint32_t j = tile_start; j < freq; ++j) {
-        cb_wait_front(cb_raw_other, num_tiles_per_cycle);
-        cb_reserve_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_raw_other.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
         unary_bcast_init<BroadcastType::ROW>(cb_raw_other, cb_llk_post);
 
         tile_regs_acquire();
@@ -74,9 +79,9 @@ ALWI void process_tile(
 
         tile_regs_wait();
         pack_tile(0, cb_llk_post);
-        cb_push_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
         tile_regs_release();
-        cb_pop_front(cb_raw_other, num_tiles_per_cycle);
+        exp_cb_raw_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_raw_other);
         pack_reconfig_data_format(cb_llk_post, cb_out);
 #ifdef ARCH_BLACKHOLE
@@ -84,7 +89,7 @@ ALWI void process_tile(
 #endif
 
         PREPROCESS(OTHER_OP, cb_llk_post, CB_POST_OTHER, cb_out, num_tiles_per_cycle);
-        cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
+        exp_cb_post_other.wait_front(num_tiles_per_cycle);
 
         exp_cb_out.reserve_back(num_tiles_per_cycle);
 #if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
@@ -113,9 +118,9 @@ ALWI void process_tile(
         }
         tile_regs_release();
         exp_cb_out.push_back(num_tiles_per_cycle);
-        cb_pop_front(CB_POST_OTHER, num_tiles_per_cycle);
+        exp_cb_post_other.pop_front(num_tiles_per_cycle);
     }
-    cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
+    exp_cb_post_bcast.pop_front(num_tiles_per_cycle);
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -27,6 +27,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 #include "api/compute/bcast.h"
+#include "experimental/circular_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs,
@@ -38,6 +39,7 @@ ALWI void process_tile(
     uint32_t tile_start,
     uint32_t num_tiles_per_cycle) {
     using namespace ckernel;
+    experimental::CircularBuffer exp_cb_out(cb_out);
 
 #if BCAST_INPUT  // ROW_A_COL_B
 #define CB_PRE_BCAST cb_pre_rhs
@@ -84,7 +86,7 @@ ALWI void process_tile(
         PREPROCESS(OTHER_OP, cb_llk_post, CB_POST_OTHER, cb_out, num_tiles_per_cycle);
         cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
 
-        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
 #if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
         BINARY_SFPU_INIT
 #endif
@@ -110,7 +112,7 @@ ALWI void process_tile(
             pack_tile(i * 2, cb_out);
         }
         tile_regs_release();
-        cb_push_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.push_back(num_tiles_per_cycle);
         cb_pop_front(CB_POST_OTHER, num_tiles_per_cycle);
     }
     cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -21,6 +22,7 @@ void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
     constexpr auto cb_in1 = tt::CBIndex::c_1;
     constexpr auto cb_out = tt::CBIndex::c_2;
+    experimental::CircularBuffer exp_cb_out(cb_out);
 
 #if SRC_BCAST
     constexpr auto cb_bcast = cb_in0;
@@ -61,7 +63,7 @@ void kernel_main() {
         PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 #endif
 
-        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
         cb_wait_front(cb_llk_post, num_tiles_per_cycle);
 
         tile_regs_acquire();
@@ -109,7 +111,7 @@ void kernel_main() {
         }
         tile_regs_release();
 
-        cb_push_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.push_back(num_tiles_per_cycle);
         cb_pop_front(cb_left, num_tiles_per_cycle);
         cb_pop_front(cb_right, num_tiles_per_cycle);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
@@ -37,14 +37,21 @@ void kernel_main() {
     constexpr auto cb_right = tt::CBIndex::c_6;
 #endif
 
+    experimental::CircularBuffer exp_cb_in0(cb_in0);
+    experimental::CircularBuffer exp_cb_in1(cb_in1);
+    experimental::CircularBuffer exp_cb_bcast(cb_bcast);
+    experimental::CircularBuffer exp_cb_llk_post(cb_llk_post);
+    experimental::CircularBuffer exp_cb_left(cb_left);
+    experimental::CircularBuffer exp_cb_right(cb_right);
+
     unary_op_init_common(cb_in0, cb_out);
     BINARY_SFPU_INIT
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_wait_front(cb_in0, num_tiles_per_cycle);
-        cb_wait_front(cb_in1, num_tiles_per_cycle);
+        exp_cb_in0.wait_front(num_tiles_per_cycle);
+        exp_cb_in1.wait_front(num_tiles_per_cycle);
 
-        cb_reserve_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
         unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
 
         tile_regs_acquire();
@@ -53,10 +60,10 @@ void kernel_main() {
 
         tile_regs_wait();
         pack_tile(0, cb_llk_post);
-        cb_push_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
         tile_regs_release();
 
-        cb_pop_front(cb_bcast, num_tiles_per_cycle);
+        exp_cb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
 #ifdef ARCH_BLACKHOLE
@@ -64,7 +71,7 @@ void kernel_main() {
 #endif
 
         exp_cb_out.reserve_back(num_tiles_per_cycle);
-        cb_wait_front(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.wait_front(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
@@ -112,7 +119,7 @@ void kernel_main() {
         tile_regs_release();
 
         exp_cb_out.push_back(num_tiles_per_cycle);
-        cb_pop_front(cb_left, num_tiles_per_cycle);
-        cb_pop_front(cb_right, num_tiles_per_cycle);
+        exp_cb_left.pop_front(num_tiles_per_cycle);
+        exp_cb_right.pop_front(num_tiles_per_cycle);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
@@ -41,14 +41,18 @@ ALWI void process_tile(
     constexpr auto cb_right = tt::CBIndex::c_6;
 #endif
 
+    experimental::CircularBuffer exp_cb_bcast(CB_BCAST);
+    experimental::CircularBuffer exp_cb_other(CB_OTHER);
+    experimental::CircularBuffer exp_cb_llk_post(cb_llk_post);
+
     unary_op_init_common(cb_left, cb_out);
     BINARY_SFPU_INIT
 
-    cb_wait_front(CB_BCAST, num_tiles_per_cycle);
+    exp_cb_bcast.wait_front(num_tiles_per_cycle);
 
     for (uint32_t j = tile_start; j < freq; ++j) {
-        cb_wait_front(CB_OTHER, num_tiles_per_cycle);
-        cb_reserve_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_other.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
         unary_bcast_init<BroadcastType::ROW>(CB_OTHER, cb_llk_post);
 
         tile_regs_acquire();
@@ -57,10 +61,10 @@ ALWI void process_tile(
 
         tile_regs_wait();
         pack_tile(0, cb_llk_post);
-        cb_push_back(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
         tile_regs_release();
 
-        cb_pop_front(CB_OTHER, num_tiles_per_cycle);
+        exp_cb_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(CB_OTHER);
         pack_reconfig_data_format(cb_llk_post, cb_out);
 #ifdef ARCH_BLACKHOLE
@@ -68,7 +72,7 @@ ALWI void process_tile(
 #endif
 
         exp_cb_out.reserve_back(num_tiles_per_cycle);
-        cb_wait_front(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.wait_front(num_tiles_per_cycle);
 
         tile_regs_acquire();
 
@@ -116,9 +120,9 @@ ALWI void process_tile(
         tile_regs_release();
 
         exp_cb_out.push_back(num_tiles_per_cycle);
-        cb_pop_front(cb_llk_post, num_tiles_per_cycle);
+        exp_cb_llk_post.pop_front(num_tiles_per_cycle);
     }
-    cb_pop_front(CB_BCAST, num_tiles_per_cycle);
+    exp_cb_bcast.pop_front(num_tiles_per_cycle);
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 #include "api/compute/bcast.h"
+#include "experimental/circular_buffer.h"
 
 ALWI void process_tile(
     tt::CBIndex cb_in0,
@@ -22,6 +23,7 @@ ALWI void process_tile(
     uint32_t tile_start,
     uint32_t num_tiles_per_cycle) {
     using namespace ckernel;
+    experimental::CircularBuffer exp_cb_out(cb_out);
 
 #if BCAST_INPUT  // ROW_A_COL_B
                  // BCAST_INPUT == 1 : input B ( true or false tensor) is broadcasted
@@ -65,7 +67,7 @@ ALWI void process_tile(
         PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 #endif
 
-        cb_reserve_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
         cb_wait_front(cb_llk_post, num_tiles_per_cycle);
 
         tile_regs_acquire();
@@ -113,7 +115,7 @@ ALWI void process_tile(
         }
         tile_regs_release();
 
-        cb_push_back(cb_out, num_tiles_per_cycle);
+        exp_cb_out.push_back(num_tiles_per_cycle);
         cb_pop_front(cb_llk_post, num_tiles_per_cycle);
     }
     cb_pop_front(CB_BCAST, num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -5,6 +5,9 @@
 
 #include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {
@@ -64,6 +67,10 @@ void kernel_main() {
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
     constexpr auto src_args = TensorAccessorArgs<0>();
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_src(cb_id_src);
+    experimental::CircularBuffer cb_src_b(cb_id_src_b);
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
@@ -147,11 +154,11 @@ void kernel_main() {
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
                             const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
 
-                            cb_reserve_back(cb_id_src, 1);
-                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
 
-                            cb_reserve_back(cb_id_src_b, 1);
-                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
 
 #if SRC_BCAST
                             const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
@@ -165,7 +172,7 @@ void kernel_main() {
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
 
                                 noc_async_read(addr_a, scratch_l1_addr, element_size);
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
@@ -178,7 +185,7 @@ void kernel_main() {
                                 noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 #else
                             const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
 
@@ -189,7 +196,7 @@ void kernel_main() {
                                 noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
@@ -200,15 +207,15 @@ void kernel_main() {
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
 
                                 noc_async_read(addr_b, scratch_l1_addr, element_size);
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 #endif
 
-                            cb_push_back(cb_id_src, 1);
-                            cb_push_back(cb_id_src_b, 1);
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
                         }
 
                         row_blocks_pushed++;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
@@ -5,6 +5,9 @@
 
 #include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t index = 0;
@@ -41,6 +44,10 @@ void kernel_main() {
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
     constexpr auto src_args = TensorAccessorArgs<0>();
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_src(cb_id_src);
+    experimental::CircularBuffer cb_src_b(cb_id_src_b);
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
@@ -118,11 +125,11 @@ void kernel_main() {
                             const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
                             const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
 
-                            cb_reserve_back(cb_id_src, 1);
-                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
 
-                            cb_reserve_back(cb_id_src_b, 1);
-                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
 
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
@@ -131,7 +138,7 @@ void kernel_main() {
                                 noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
@@ -140,10 +147,10 @@ void kernel_main() {
                                 noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
-                            cb_push_back(cb_id_src, 1);
-                            cb_push_back(cb_id_src_b, 1);
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
                         }
 
                         row_blocks_pushed++;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t index = 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
@@ -5,6 +5,9 @@
 
 #include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
@@ -42,6 +45,10 @@ void kernel_main() {
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
     constexpr auto src_args = TensorAccessorArgs<0>();
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_src(cb_id_src);
+    experimental::CircularBuffer cb_src_b(cb_id_src_b);
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
@@ -125,11 +132,11 @@ void kernel_main() {
                             const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
                             const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
 
-                            cb_reserve_back(cb_id_src, 1);
-                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
 
-                            cb_reserve_back(cb_id_src_b, 1);
-                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
 
 #if SRC_BCAST
                             const uint64_t addr_a = get_noc_addr(row_block_a, src) + current_chunk_offset;
@@ -142,7 +149,7 @@ void kernel_main() {
                                 noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #else
                             uint32_t curr_l1_a = l1_write_addr_src;
@@ -156,12 +163,12 @@ void kernel_main() {
                             const uint64_t addr_b = get_noc_addr(row_block_b, src_b) + current_chunk_offset;
                             noc_async_read(addr_b, l1_write_addr_src_b, current_read_len_b);
 
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
 #endif
 
-                            cb_push_back(cb_id_src, 1);
-                            cb_push_back(cb_id_src_b, 1);
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
                         }
 
                         row_blocks_pushed++;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -5,6 +5,9 @@
 
 #include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {
@@ -64,6 +67,10 @@ void kernel_main() {
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
     constexpr auto src_args = TensorAccessorArgs<0>();
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_src(cb_id_src);
+    experimental::CircularBuffer cb_src_b(cb_id_src_b);
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
@@ -147,11 +154,11 @@ void kernel_main() {
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
                             const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
 
-                            cb_reserve_back(cb_id_src, 1);
-                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
 
-                            cb_reserve_back(cb_id_src_b, 1);
-                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
 
 #if SRC_BCAST_ROW_B
                             const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
@@ -165,7 +172,7 @@ void kernel_main() {
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
 
                                 noc_async_read(addr_a, scratch_l1_addr, element_size);
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
@@ -173,7 +180,7 @@ void kernel_main() {
 
                             const uint64_t addr_b = get_noc_addr(row_block_b, src_b) + current_chunk_offset;
                             noc_async_read(addr_b, l1_write_addr_src_b, current_read_len_b);
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
 #else
                             const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
@@ -187,7 +194,7 @@ void kernel_main() {
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
 
                                 noc_async_read(addr_b, scratch_l1_addr, element_size);
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
@@ -195,12 +202,12 @@ void kernel_main() {
 
                             const uint64_t addr_a = get_noc_addr(row_block_a, src) + current_chunk_offset;
                             noc_async_read(addr_a, l1_write_addr_src, current_read_len_a);
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #endif
 
-                            cb_push_back(cb_id_src, 1);
-                            cb_push_back(cb_id_src_b, 1);
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
                         }
 
                         row_blocks_pushed++;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -5,6 +5,9 @@
 
 #include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {
@@ -64,6 +67,10 @@ void kernel_main() {
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
     constexpr auto src_args = TensorAccessorArgs<0>();
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_src(cb_id_src);
+    experimental::CircularBuffer cb_src_b(cb_id_src_b);
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
@@ -147,11 +154,11 @@ void kernel_main() {
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
                             const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
 
-                            cb_reserve_back(cb_id_src, 1);
-                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
 
-                            cb_reserve_back(cb_id_src_b, 1);
-                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
 
 #if SRC_BCAST
                             const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
@@ -160,7 +167,7 @@ void kernel_main() {
                             const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
 
                             noc_async_read(addr_a, scratch_l1_addr, element_size);
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
                             copy_one_element<element_size>(l1_write_addr_src, scratch_l1_addr);
                             FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src, current_chunk_elements);
@@ -172,7 +179,7 @@ void kernel_main() {
                                 noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #else
@@ -184,22 +191,22 @@ void kernel_main() {
                                 noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
                             const uint64_t addr_b = get_noc_addr(row_block_b, src_b);
                             const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
 
                             noc_async_read(addr_b, scratch_l1_addr, element_size);
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
                             copy_one_element<element_size>(l1_write_addr_src_b, scratch_l1_addr);
                             FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src_b, current_chunk_elements);
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
 #endif
 
-                            cb_push_back(cb_id_src, 1);
-                            cb_push_back(cb_id_src_b, 1);
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
                         }
 
                         row_blocks_pushed++;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -5,6 +5,9 @@
 
 #include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
@@ -38,6 +41,10 @@ void kernel_main() {
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
     constexpr auto src_args = TensorAccessorArgs<0>();
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_src(cb_id_src);
+    experimental::CircularBuffer cb_src_b(cb_id_src_b);
+
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
     constexpr uint32_t element_size = src_tile_bytes / tile_hw;
@@ -52,7 +59,7 @@ void kernel_main() {
     const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
     const auto src = TensorAccessor(src_args, src_addr, page_size_a);
 
-    cb_reserve_back(cb_id_src_b, 1);
+    cb_src_b.reserve_back(1);
 #ifdef FILL_WITH_VALUE_FLOAT_B
     const auto float_ptr_b = reinterpret_cast<const float*>(&packed_scalar);
     FILL_WITH_VALUE_FLOAT_B(cb_id_src_b, *float_ptr_b);
@@ -60,7 +67,7 @@ void kernel_main() {
 #ifdef FILL_WITH_VALUE_B
     FILL_WITH_VALUE_B(cb_id_src_b, packed_scalar);
 #endif
-    cb_push_back(cb_id_src_b, 1);
+    cb_src_b.push_back(1);
 
     const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
     const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
@@ -109,8 +116,8 @@ void kernel_main() {
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
                             const uint32_t current_read_len = align(current_chunk_bytes, alignment_a);
 
-                            cb_reserve_back(cb_id_src, 1);
-                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
 
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
@@ -119,9 +126,9 @@ void kernel_main() {
                                 noc_async_read(addr_a, curr_l1_a, current_read_len);
                                 curr_l1_a += current_chunk_bytes;
                             }
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
-                            cb_push_back(cb_id_src, 1);
+                            cb_src.push_back(1);
                         }
 
                         row_blocks_pushed++;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t index = 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -5,6 +5,9 @@
 
 #include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t index = 0;
@@ -27,6 +30,9 @@ void kernel_main() {
 
     constexpr auto cb_id_out = tt::CBIndex::c_2;
     constexpr auto dst_args = TensorAccessorArgs<0>();
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out(cb_id_out);
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_out);
     constexpr uint32_t tile_hw = get_tile_hw(cb_id_out);
@@ -68,9 +74,9 @@ void kernel_main() {
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
                             const uint32_t current_write_len = align(current_chunk_bytes, alignment);
 
-                            cb_wait_front(cb_id_out, 1);
+                            cb_out.wait_front(1);
 
-                            uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+                            uint32_t l1_read_addr = cb_out.get_read_ptr();
                             for (uint32_t row = 0; row < limit; ++row) {
                                 const uint32_t row_abs_idx = row_block_base_row + row;
                                 const uint64_t dst_noc_addr = get_noc_addr(row_abs_idx, dst) + current_chunk_offset;
@@ -78,8 +84,8 @@ void kernel_main() {
                                 l1_read_addr += current_chunk_bytes;
                             }
 
-                            noc_async_write_barrier();
-                            cb_pop_front(cb_id_out, 1);
+                            noc.async_write_barrier();
+                            cb_out.pop_front(1);
                         }
 
                         row_blocks_written++;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_kernel.cpp
@@ -16,6 +16,7 @@
 #include "api/compute/eltwise_unary/where.h"
 #include "api/compute/eltwise_unary/comp.h"
 #include "api/compute/compute_kernel_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
@@ -24,14 +25,17 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
 
+    experimental::CircularBuffer cb_in(cb_input);
+    experimental::CircularBuffer cb_out(cb_output);
+
     constexpr float M_PI = 3.14159265358979323846f;
 
     init_sfpu(cb_input, cb_output);
 
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
-        cb_reserve_back(cb_output, per_core_block_dim);
+        cb_out.reserve_back(per_core_block_dim);
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
-            cb_wait_front(cb_input, 1);
+            cb_in.wait_front(1);
             tile_regs_acquire();
 
             // copy input to dst 0 and 1
@@ -130,8 +134,8 @@ void kernel_main() {
 
             tile_regs_release();
 
-            cb_pop_front(cb_input, 1);
+            cb_in.pop_front(1);
         }
-        cb_push_back(cb_output, per_core_block_dim);
+        cb_out.push_back(per_core_block_dim);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/kernels/compute/eltwise_bw_tanh_deriv.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/kernels/compute/eltwise_bw_tanh_deriv.cpp
@@ -14,6 +14,7 @@
 #include "api/compute/eltwise_unary/tanh_derivative.h"
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/compute_kernel_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
@@ -23,14 +24,18 @@ void kernel_main() {
     constexpr auto cb_input = tt::CBIndex::c_1;
     constexpr auto cb_grad_in = tt::CBIndex::c_2;
 
+    experimental::CircularBuffer exp_cb_grad_out(cb_grad_out);
+    experimental::CircularBuffer exp_cb_input(cb_input);
+    experimental::CircularBuffer exp_cb_grad_in(cb_grad_in);
+
     unary_op_init_common(cb_grad_out, cb_grad_in);
     tanh_derivative_tile_init<false>();
     mul_binary_tile_init();
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
-        cb_reserve_back(cb_grad_in, per_core_block_size);
-        cb_wait_front(cb_grad_out, per_core_block_size);
-        cb_wait_front(cb_input, per_core_block_size);
+        exp_cb_grad_in.reserve_back(per_core_block_size);
+        exp_cb_grad_out.wait_front(per_core_block_size);
+        exp_cb_input.wait_front(per_core_block_size);
 
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
             tile_regs_acquire();
@@ -48,8 +53,8 @@ void kernel_main() {
             tile_regs_release();
         }
 
-        cb_pop_front(cb_grad_out, per_core_block_size);
-        cb_pop_front(cb_input, per_core_block_size);
-        cb_push_back(cb_grad_in, per_core_block_size);
+        exp_cb_grad_out.pop_front(per_core_block_size);
+        exp_cb_input.pop_front(per_core_block_size);
+        exp_cb_grad_in.push_back(per_core_block_size);
     }
 }


### PR DESCRIPTION
## Summary
Migrate 15 eltwise kernel files from legacy free-function APIs to the new Device 2.0 object-oriented API (`experimental::CircularBuffer`, `experimental::Noc`).

These files were recently added by community contributions (PRs #32813, #39378, #39646) and missed the earlier bulk migration.

Resolves #41703

## Changes

### Dataflow kernels (7 files) — `binary_ng/device/kernels_ng/dataflow/`
| File | Migration |
|------|-----------|
| `reader_interleaved_rm_col_bcast.cpp` | `experimental::Noc` + `experimental::CircularBuffer` |
| `reader_interleaved_rm_no_bcast.cpp` | `experimental::Noc` + `experimental::CircularBuffer` |
| `reader_interleaved_rm_row_bcast.cpp` | `experimental::Noc` + `experimental::CircularBuffer` |
| `reader_interleaved_rm_row_col_mixed_bcast.cpp` | `experimental::Noc` + `experimental::CircularBuffer` |
| `reader_interleaved_rm_scalar_bcast.cpp` | `experimental::Noc` + `experimental::CircularBuffer` |
| `reader_interleaved_rm_scalar_op.cpp` | `experimental::Noc` + `experimental::CircularBuffer` |
| `writer_interleaved_rm_no_bcast.cpp` | `experimental::Noc` + `experimental::CircularBuffer` |

All RM dataflow files migrate CB operations (`cb_reserve_back`, `cb_push_back`, `cb_wait_front`, `cb_pop_front`, `get_write_ptr`, `get_read_ptr`) to `CircularBuffer` methods and barriers (`noc_async_read_barrier`, `noc_async_write_barrier`) to `Noc` methods. Raw `noc_async_read/write` + `get_noc_addr()` retained due to RM alignment arithmetic.

### Compute kernels (6 files) — `binary_ng/device/kernels_ng/compute/`
| File | Migration |
|------|-----------|
| `eltwise_binary_row_bcast.cpp` | `experimental::CircularBuffer` (output CB) |
| `eltwise_binary_row_col_bcast.cpp` | `experimental::CircularBuffer` (output CB) |
| `eltwise_binary_sfpu_row_bcast.cpp` | `experimental::CircularBuffer` (output CB) |
| `eltwise_binary_sfpu_row_col_bcast.cpp` | `experimental::CircularBuffer` (output CB) |
| `eltwise_where_sfpu_row_bcast.cpp` | `experimental::CircularBuffer` (output CB) |
| `eltwise_where_sfpu_row_col_bcast.cpp` | `experimental::CircularBuffer` (output CB) |

Output CB (`c_2`) migrated to `experimental::CircularBuffer`. Other CB ops left as free functions due to complex `#if SRC_BCAST / SRC_BCAST_B / BCAST_INPUT` preprocessor branching.

### Other compute kernels (2 files)
| File | Migration |
|------|-----------|
| `unary/device/kernels/compute/lgamma_kernel.cpp` | Full `experimental::CircularBuffer` (input + output) |
| `unary_backward/tanh_bw/device/kernels/compute/eltwise_bw_tanh_deriv.cpp` | Full `experimental::CircularBuffer` (grad_out + input + grad_in) |

## CI

| Workflow | Run | Status |
|----------|-----|--------|
| Sanity tests | https://github.com/tenstorrent/tt-metal/actions/runs/24186359194 | 🔄 |
| Blackhole post-commit | https://github.com/tenstorrent/tt-metal/actions/runs/24186360690 | 🔄 |
| L2 nightly (eltwise) | https://github.com/tenstorrent/tt-metal/actions/runs/24186362118 | 🔄 |

## Test plan
- [ ] Sanity tests pass
- [ ] Blackhole post-commit passes
- [ ] L2 nightly eltwise tests pass
- [ ] Existing eltwise binary/unary tests pass
- [ ] Row-major binary eltwise tests pass
- [ ] lgamma and tanh backward tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)