### PR TITLE
sweeps: fix faster-fifo build failure on aarch64 Linux

### DIFF
--- a/tests/sweep_framework/requirements-sweeps.txt
+++ b/tests/sweep_framework/requirements-sweeps.txt
@@ -1,6 +1,6 @@
 termcolor
 beautifultable
-faster-fifo
+faster-fifo; platform_machine != "aarch64"  # no aarch64 Linux wheel; sdist broken
 # For PostgreSQL database connectivity
 psycopg2-binary == 2.9.11
 ijson

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -19,7 +19,10 @@ from queue import Empty
 # third party
 import enlighten
 import framework.tt_smi_util as tt_smi_util
-from faster_fifo import Queue
+try:
+    from faster_fifo import Queue  # faster IPC; not available on aarch64 Linux
+except ImportError:
+    from multiprocessing import Queue
 
 # tt
 from framework.device_fixtures import default_device

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -19,6 +19,7 @@ from queue import Empty
 # third party
 import enlighten
 import framework.tt_smi_util as tt_smi_util
+
 try:
     from faster_fifo import Queue  # faster IPC; not available on aarch64 Linux
 except ImportError:


### PR DESCRIPTION
### Problem
`faster-fifo` has no pre-built wheel for Linux/aarch64, and its 1.5.2 sdist is broken — the Cython-generated `faster_fifo.cpp` is missing from the tarball, causing a compile error.

### Fix
- Add `; platform_machine != "aarch64"` marker in `requirements-sweeps.txt` so aarch64 installs skip the package entirely.
- Add `try/except ImportError` fallback in `sweeps_runner.py` to use `multiprocessing.Queue` when `faster_fifo` is unavailable. Functionally equivalent; slightly slower on x86 platforms is never affected.