### PR TITLE
SDXL unseting throttle for bh

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -96,6 +96,11 @@ class TtSDXLPipeline(LightweightModule):
 
         if is_wormhole_b0():
             os.environ["TT_MM_THROTTLE_PERF"] = "5"
+        else:
+            prev_throttle = os.environ.pop("TT_MM_THROTTLE_PERF", None)
+            if prev_throttle is not None:
+                logger.warning(f"GGG Throttle level was {prev_throttle}, unseting it for blackhole")
+
         if pipeline_config.is_galaxy:
             grid_override = os.environ.get("TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE")
             logger.info(f"Checking TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE for Galaxy, current value: {grid_override}")

--- a/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -99,7 +99,7 @@ class TtSDXLPipeline(LightweightModule):
         else:
             prev_throttle = os.environ.pop("TT_MM_THROTTLE_PERF", None)
             if prev_throttle is not None:
-                logger.warning(f"Throttle level was {prev_throttle}, unseting it for blackhole")
+                logger.warning(f"Throttle level was {prev_throttle}, unsetting it for blackhole")
 
         if pipeline_config.is_galaxy:
             grid_override = os.environ.get("TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE")

--- a/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -99,7 +99,7 @@ class TtSDXLPipeline(LightweightModule):
         else:
             prev_throttle = os.environ.pop("TT_MM_THROTTLE_PERF", None)
             if prev_throttle is not None:
-                logger.warning(f"GGG Throttle level was {prev_throttle}, unseting it for blackhole")
+                logger.warning(f"Throttle level was {prev_throttle}, unseting it for blackhole")
 
         if pipeline_config.is_galaxy:
             grid_override = os.environ.get("TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE")


### PR DESCRIPTION
### Problem description
Bad perf on blackhole when running with inference server, in tt-inference-server throttle is set by default for SDXL

example run: [link](https://github.com/tenstorrent/tt-shield/actions/runs/24011503759/job/70025134518)

| Source | Num Requests | Inference Steps | TTFT (ms) | Steps/Sec |
|--------|--------------|-----------------|-----------|-----------|
| image  |          100 |              20 |    3311.5 |      6.04 |

### What's changed
- throttle disabled for blackhole

### Checklist
- [ ] [Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/24192057175) ⚠️ failing but same error on main [link](https://github.com/tenstorrent/tt-metal/actions/runs/24218076627/job/70703898935)
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/24235327648) passed ✅
- [ ] [sdxl accuracy](https://github.com/tenstorrent/tt-shield/actions/runs/24191819592) passed ✅
- [ ] [sdxl inference: bh-qb-ge](https://github.com/tenstorrent/tt-shield/actions/runs/24195557402) passed ✅

### Notes
inference server value results on QB2 after fix, [link](https://github.com/tenstorrent/tt-shield/actions/runs/24195557402):
| Source | Num Requests | Inference Steps | TTFT (ms) | Steps/Sec |
|--------|--------------|-----------------|-----------|-----------|
| image  |          100 |              20 |    2061.2 |       9.7 |


