### PR TITLE
Add Wormhole SDPA no-mop matmul, blocked pack, and blocked sub support

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "experimental/llk_math_eltwise_binary_custom.h"
+#include "llk_assert.h"
+#include "llk_math_common_api.h"
+
+/*************************************************************************
+ * LLK MATH ELTWISE BINARY CUSTOM - SDPA specialized blocked sub path
+ *************************************************************************/
+
+template <MathFidelity math_fidelity>
+inline void llk_math_eltwise_binary_sub_bcast_cols_init_custom(
+    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_id = get_operand_id(operandA);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_eltwise_binary_init_custom_<EltwiseBinaryType::ELWSUB, BroadcastType::COL, math_fidelity>(
+        num_faces, acc_to_dest);
+}
+
+template <bool is_fp32_dest_acc_en = false>
+inline void llk_math_eltwise_binary_sub_bcast_cols_custom(
+    const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
+    LLK_ASSERT(
+        (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "dst_index out of range");
+
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+    _llk_math_eltwise_binary_bcast_reuse_custom_(ct_dim);
+    math::clear_dst_reg_addr();
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -30,6 +30,6 @@ inline void llk_math_eltwise_binary_sub_bcast_cols_custom(
         "dst_index out of range");
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
-    _llk_math_eltwise_binary_bcast_reuse_custom_(ct_dim);
+    _llk_math_sub_bcast_cols_reuse_custom_(ct_dim);
     math::clear_dst_reg_addr();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_matmul_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_matmul_custom_api.h
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include "llk_math_common_api.h"
+
 #include "experimental/llk_math_matmul_custom_no_mop.h"
+#include "llk_math_common_api.h"
 
 /*************************************************************************
  * LLK MATMUL NO MOP
@@ -33,12 +34,26 @@ inline void llk_math_matmul_init_no_mop(
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul_no_mop(
-    const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
+    const std::uint32_t dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
     _llk_math_matmul_no_mop_<math_fidelity, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
 }
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
-inline void llk_math_matmul_reinit_no_mop(const bool transpose = false) {
-    matmul_configure_addrmod_reinit<math_fidelity, THROTTLE_LEVEL>(transpose);
-    math::reset_counters(p_setrwc::SET_ABD_F);
+inline void llk_math_matmul_reinit_no_mop(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const bool transpose = false,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1) {
+    const std::uint32_t in0_id = get_operand_id(operandA);
+    const std::uint32_t in1_id = get_operand_id(operandB);
+
+    const std::uint32_t in0_tile_r_dim = get_operand_tile_r_dim(in0_id);
+    const std::uint32_t in0_tile_c_dim = get_operand_tile_c_dim(in0_id);
+    const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
+    const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
+
+    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM);
+    matmul_reinit_no_mop<math_fidelity, THROTTLE_LEVEL>(
+        transpose, ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
+#include "llk_unpack_common_api.h"
+
+/*************************************************************************
+ * LLK UNPACK AB SUB BCAST COL CUSTOM - SDPA specialized blocked sub path
+ *************************************************************************/
+
+template <BroadcastType BType = BroadcastType::COL>
+inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operandA_id);
+    const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
+    const bool narrow_tile = get_operand_narrow_tile(operandA_id);
+
+    _llk_unpack_AB_sub_bcast_col_init_custom_<BType>(face_r_dim, num_faces, narrow_tile);
+}
+
+template <BroadcastType BType = BroadcastType::COL>
+inline void llk_unpack_AB_sub_bcast_col_custom(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b,
+    const std::uint32_t ct_dim = 1) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
+
+    const std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
+    const std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
+    const std::uint32_t address_a = base_address_a + offset_address_a;
+
+    const std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    const std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
+    const std::uint32_t address_b = base_address_b + offset_address_b;
+
+    _llk_unpack_AB_sub_bcast_col_custom_<BType>(address_a, address_b, ct_dim);
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -25,8 +25,8 @@
  *************************************************************************/
 
 // TODO NC: Remove as the part of tt-metal#34499
-template <bool untilize = false, bool zero_output = false>
-inline void llk_pack_mop_config(const uint32_t output) {
+template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
+inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
     const std::uint32_t output_id = get_output_id(output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -34,7 +34,7 @@ inline void llk_pack_mop_config(const uint32_t output) {
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
     _llk_pack_mop_config_<untilize, zero_output>(
-        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
+        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
 inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
@@ -99,7 +99,7 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
 }
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
-inline void llk_pack_init(const std::uint32_t pack_output = 16) {
+inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1) {
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
@@ -112,7 +112,13 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
         "");
 
     _llk_pack_init_<untilize, zero_output>(
-        pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
+        pack_dst_format[output_id],
+        pack_src_format[output_id],
+        face_r_dim,
+        num_faces,
+        partial_face,
+        narrow_tile,
+        num_tiles);
 }
 
 template <bool out_of_order_output, bool untilize>

--- a/tt_metal/hw/inc/api/compute/experimental/matmul_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/matmul_custom.h
@@ -101,7 +101,11 @@ ALWI void mm_no_mop_reinit_short(
     uint32_t rt_dim = 1,
     uint32_t kt_dim = 1) {
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim)));
+#if defined(ARCH_BLACKHOLE)
     MATH((llk_math_matmul_reinit_no_mop<MATH_FIDELITY, MM_THROTTLE>(transpose)));
+#else
+    MATH((llk_math_matmul_reinit_no_mop<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim)));
+#endif
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/matmul_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/matmul_custom.h
@@ -26,6 +26,8 @@ namespace ckernel {
 /**
  * Short initialization for the no-MOP matmul block operation. Configures only the unpacker and math
  * engine, without touching hardware configuration or pack. Safe to call at any point mid-kernel.
+ * On Wormhole, the current no-MOP implementation is intentionally scoped to the SDPA full-tile,
+ * throttle-0 path.
  *
  * Return value: None
  *
@@ -89,6 +91,7 @@ ALWI void matmul_block_no_mop(
 /**
  * Lightweight no-MOP matmul reinit for steady-state loops where tile formats/dim assumptions
  * are unchanged. Reprograms unpack matmul setup and restores math addrmods without full init.
+ * On Wormhole, this reinit path is only intended for the SDPA full-tile, throttle-0 use case.
  *
  * Return value: None
  */

--- a/tt_metal/hw/inc/api/compute/experimental/sdpa_sub_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/sdpa_sub_custom.h
@@ -6,17 +6,17 @@
 
 #include "api/compute/common.h"
 
-#if defined(TRISC_MATH) && defined(ARCH_BLACKHOLE)
+#if defined(TRISC_MATH) && (defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE))
 #include "experimental/llk_math_eltwise_binary_custom_api.h"
 #endif
 
-#if defined(TRISC_UNPACK) && defined(ARCH_BLACKHOLE)
+#if defined(TRISC_UNPACK) && (defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE))
 #include "experimental/llk_unpack_AB_sub_bcast_col_custom_api.h"
 #endif
 
 namespace ckernel {
 
-#ifdef ARCH_BLACKHOLE
+#if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
 
 ALWI void sub_bcast_cols_init_short_custom(uint32_t icb0, uint32_t icb1, uint32_t ct_dim, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, icb1, call_line);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -120,7 +120,6 @@ ALWI void recip_tile_first_column_wh_idst0_direct() {
 // WH, blocked pack only pays off once the per-row width is large enough;
 // narrower writes fall back to regular tile-by-tile packing to avoid the
 // packer reconfiguration overhead.
-template <bool blocked_pack = false>
 ALWI void pack_contiguous_rows(
     uint32_t out_cb,
     uint32_t row_base,
@@ -129,7 +128,7 @@ ALWI void pack_contiguous_rows(
     uint32_t col_base,
     uint32_t pack_width) {
     uint32_t dst_index = 0;
-    const bool use_blocked_pack_width = blocked_pack && should_use_blocked_pack_width(pack_width);
+    const bool use_blocked_pack_width = should_use_blocked_pack_width(pack_width);
     for (uint32_t row = 0; row < row_count; ++row) {
         uint32_t out_tile_index = (row_base + row) * row_stride + col_base;
         if (use_blocked_pack_width) {
@@ -147,7 +146,7 @@ ALWI void pack_contiguous_rows(
  * Blocked subblock matmul with absolute offset packing.
  * Always uses pack_tile<true> at row-major positions in out_cb.
  */
-template <bool transpose, uint32_t in1_stride, uint32_t out_num_cols, bool blocked_pack = false>
+template <bool transpose, uint32_t in1_stride, uint32_t out_num_cols>
 SDPA_NOINLINE void blocked_matmul_and_pack(
     uint32_t in0_cb,
     uint32_t in1_cb,
@@ -174,8 +173,8 @@ SDPA_NOINLINE void blocked_matmul_and_pack(
     tile_regs_commit();
 
     tile_regs_wait();
-    pack_contiguous_rows<blocked_pack>(
-        out_cb, row_subblock_idx * subblock_h, subblock_h, out_num_cols, out_col_offset, subblock_w);
+    configure_row_pack_width(out_cb, subblock_w);
+    pack_contiguous_rows(out_cb, row_subblock_idx * subblock_h, subblock_h, out_num_cols, out_col_offset, subblock_w);
     if (trigger_reduce) {
         PACK((t6_semaphore_post<p_stall::NONE>(semaphore::FPU_SFPU)));
     }
@@ -254,7 +253,7 @@ void reduce_c_row_group(
  * In-place sub_exp on cb_qkt_im: subtracts max, applies exp with ReLU clamping,
  * writes back to same positions. Accumulates row sums into reduce_cb.
  */
-template <bool profiling_enabled, uint32_t scale_fp32, bool blocked_pack = false>
+template <bool profiling_enabled, uint32_t scale_fp32>
 SDPA_NOINLINE void sub_exp_block_bcast_cols(
     uint32_t inout_cb,
     uint32_t max_cb,
@@ -309,13 +308,9 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
     {
         MaybeDeviceZoneScopedN(profiling_enabled, "PACK SUB_EXP");
         // Pack back to inout_cb at the same absolute positions
-        pack_contiguous_rows<blocked_pack>(
-            inout_cb, max_row_base, tiles_per_row, cols_in_row, global_col_base, tiles_per_column);
-
-        // Reduce to reduce_cb: first tile of first kt_subblock overwrites, rest accumulate
-        if constexpr (blocked_pack) {
-            configure_single_tile_pack(reduce_cb);
-        }
+        configure_row_pack_width(inout_cb, tiles_per_column);
+        pack_contiguous_rows(inout_cb, max_row_base, tiles_per_row, cols_in_row, global_col_base, tiles_per_column);
+        configure_single_tile_pack(reduce_cb);
         {
             uint32_t dst_index = 0;
 #pragma GCC unroll 1
@@ -340,9 +335,7 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
 
     // Restore packer ReLU config after all exp operations complete
     PACK((llk_pack_relu_config(ReluType::NO_RELU)));
-    if (blocked_pack && should_use_blocked_pack_width(tiles_per_column)) {
-        configure_pack_width(reduce_cb, tiles_per_column);
-    }
+    configure_row_pack_width(inout_cb, tiles_per_column);
     PACK((llk_pack_reconfig_l1_acc(0)));
 }
 
@@ -449,7 +442,7 @@ void salad_correct_fused(
         if (use_blocked_out_pack) {
             configure_pack_width(out_out_cb, cur_cols);
         }
-        pack_contiguous_rows<true>(out_out_cb, write_row_base, tiles_per_row, tiles_per_column, col_base, cur_cols);
+        pack_contiguous_rows(out_out_cb, write_row_base, tiles_per_row, tiles_per_column, col_base, cur_cols);
         dst_index = tiles_per_row * cur_cols;
         if (fuse_sum_here) {
             configure_single_tile_pack(sum_out_cb);
@@ -741,7 +734,7 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
                 }
-                sub_exp_block_bcast_cols<profiling_enabled, scale_fp32, true /*blocked_pack*/>(
+                sub_exp_block_bcast_cols<profiling_enabled, scale_fp32>(
                     cb_qkt_im,
                     cur.max,
                     cur.sum,
@@ -765,7 +758,7 @@ static void sdpa_inner_loop_step(
                 }
                 // The last subblock posts the semaphore — one post per reduce.
                 bool kt_trigger_reduce = reduce_trigger && (kt_subblock == kt_num_full_subblocks - 1);
-                blocked_matmul_and_pack<true, KT_stride, KT_stride, true /*blocked_pack*/>(
+                blocked_matmul_and_pack<true, KT_stride, KT_stride>(
                     cb_q_in,
                     cb_kt_in,
                     cb_qkt_im,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -90,6 +90,30 @@ ALWI bool configure_row_pack_width(uint32_t cb, uint32_t pack_width) {
     return use_blocked_pack_width;
 }
 
+#if defined(TRISC_MATH) && defined(ARCH_WORMHOLE)
+ALWI void recip_tile_first_column_wh_idst0_direct() {
+    // WH SDPA normalize always operates on DST tile 0. The generic unary-SFPU
+    // launcher around recip_tile_first_column() records a larger replay program
+    // than this path needs. Keep the first-column reciprocal math identical,
+    // but inline only the VectorMode::C traversal so the replay stays within
+    // the SFPU replay slots and does not overwrite the no-mop matmul region.
+    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+    math::set_addr_mod_base();
+
+#pragma GCC unroll 0
+    for (int face = 0; face < 2; face++) {
+        calculate_recip_first_column();
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
+    }
+
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU);
+    math::clear_addr_mod_base();
+}
+#endif
+
 // Packs row slices into absolute CB positions with a fixed row stride.
 // Use this for out-of-order/output-indexed writes where each row starts at
 // row_base * row_stride + col_base and spans pack_width consecutive tiles. On
@@ -486,7 +510,7 @@ void normalize_row_streaming(
             MATH((recip_tile<false>(0, (int)VectorMode::C)));
 #else
             recip_tile_init();
-            MATH((recip_tile_first_column(0)));
+            MATH((recip_tile_first_column_wh_idst0_direct()));
 #endif
             tile_regs_commit();
 
@@ -993,18 +1017,7 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
                 }
-                const bool needs_strong_phase2_reinit = is_last_iter && (q_subblock > 1);
-#if defined(ARCH_WORMHOLE)
-                if (needs_strong_phase2_reinit) {
-                    // WH row normalization runs reciprocal on the math pipe during the final K chunk.
-                    // Later phase-2 QKTV row groups in that same q-chunk re-enter no-mop matmul on
-                    // the same pipe, so rebuild the matmul program before the next row-group matmul.
-                    mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
-                } else
-#endif
-                {
-                    mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
-                }
+                mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                     blocked_matmul_and_pack<false, vDHt, vDHt>(
                         cb_qkt_im,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -10,9 +10,11 @@
 
 #include <type_traits>
 
-#ifdef ARCH_BLACKHOLE
+#if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
 #include "api/compute/experimental/matmul_custom.h"
 #include "api/compute/experimental/sdpa_sub_custom.h"
+#endif
+#ifdef ARCH_BLACKHOLE
 // BH has ample code size headroom; allow normal inlining and GCC IPA-CP cloning (no noinline/noclone).
 #define SDPA_NOINLINE
 #else
@@ -72,6 +74,50 @@ struct RingAccumulatorState {
 
 // Sentinel for "no CB" — beyond the valid 0-31 range.
 constexpr uint32_t INVALID_CB = 32;
+// On WH, blocked-pack reconfiguration costs more than it saves for narrow row packs.
+constexpr uint32_t MIN_BLOCKED_PACK_TILES = 8;
+ALWI bool should_use_blocked_pack_width(uint32_t pack_width) { return pack_width >= MIN_BLOCKED_PACK_TILES; }
+
+ALWI void configure_pack_width(uint32_t cb, uint32_t pack_width) {
+    PACK((llk_pack_mop_config<false, false, false>(cb, pack_width)));
+}
+
+ALWI void configure_single_tile_pack(uint32_t cb) { configure_pack_width(cb, 1); }
+
+ALWI bool configure_row_pack_width(uint32_t cb, uint32_t pack_width) {
+    const bool use_blocked_pack_width = should_use_blocked_pack_width(pack_width);
+    configure_pack_width(cb, use_blocked_pack_width ? pack_width : 1);
+    return use_blocked_pack_width;
+}
+
+// Packs row slices into absolute CB positions with a fixed row stride.
+// Use this for out-of-order/output-indexed writes where each row starts at
+// row_base * row_stride + col_base and spans pack_width consecutive tiles. On
+// WH, blocked pack only pays off once the per-row width is large enough;
+// narrower writes fall back to regular tile-by-tile packing to avoid the
+// packer reconfiguration overhead.
+template <bool blocked_pack = false>
+ALWI void pack_contiguous_rows(
+    uint32_t out_cb,
+    uint32_t row_base,
+    uint32_t row_count,
+    uint32_t row_stride,
+    uint32_t col_base,
+    uint32_t pack_width) {
+    uint32_t dst_index = 0;
+    const bool use_blocked_pack_width = blocked_pack && should_use_blocked_pack_width(pack_width);
+    for (uint32_t row = 0; row < row_count; ++row) {
+        uint32_t out_tile_index = (row_base + row) * row_stride + col_base;
+        if (use_blocked_pack_width) {
+            pack_tile<true>(dst_index, out_cb, out_tile_index);
+            dst_index += pack_width;
+        } else {
+            for (uint32_t col = 0; col < pack_width; ++col) {
+                pack_tile<true>(dst_index++, out_cb, out_tile_index + col);
+            }
+        }
+    }
+}
 
 /**
  * Blocked subblock matmul with absolute offset packing.
@@ -96,37 +142,16 @@ SDPA_NOINLINE void blocked_matmul_and_pack(
     uint32_t in0_index = in0_index_start;
     uint32_t in1_index = in1_index_start;
     for (uint32_t inner = 0; inner < inner_dim; ++inner) {
-#ifdef ARCH_BLACKHOLE
         matmul_block_no_mop(
             in0_cb, in1_cb, in0_index, in1_index, dst_index, transpose, subblock_w, subblock_h, matmul_stride);
-#else
-        matmul_block(in0_cb, in1_cb, in0_index, in1_index, dst_index, transpose, subblock_w, subblock_h, matmul_stride);
-#endif
         in0_index++;
         in1_index += in1_stride;
     }
     tile_regs_commit();
 
     tile_regs_wait();
-    uint32_t dst_idx = 0;
-#ifdef ARCH_BLACKHOLE
-    if constexpr (blocked_pack) {
-        for (uint32_t r = 0; r < subblock_h; r++) {
-            uint32_t out_row_offset = (r + row_subblock_idx * subblock_h) * out_num_cols;
-            pack_tile<true>(dst_idx, out_cb, out_row_offset + out_col_offset);
-            dst_idx += subblock_w;
-        }
-    } else
-#endif
-    {
-        for (uint32_t r = 0; r < subblock_h; r++) {
-            uint32_t out_row_offset = (r + row_subblock_idx * subblock_h) * out_num_cols;
-            for (uint32_t c = 0; c < subblock_w; c++) {
-                pack_tile<true>(dst_idx, out_cb, out_row_offset + out_col_offset + c);
-                dst_idx++;
-            }
-        }
-    }
+    pack_contiguous_rows<blocked_pack>(
+        out_cb, row_subblock_idx * subblock_h, subblock_h, out_num_cols, out_col_offset, subblock_w);
     if (trigger_reduce) {
         PACK((t6_semaphore_post<p_stall::NONE>(semaphore::FPU_SFPU)));
     }
@@ -221,12 +246,7 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
 
     {
         MaybeDeviceZoneScopedN(profiling_enabled, "SUB_EXP_BLOCK_INIT");
-#ifdef ARCH_BLACKHOLE
         sub_bcast_cols_init_short_custom(inout_cb, max_cb, tiles_per_column);
-#else
-        sub_bcast_cols_init_short(inout_cb, max_cb);
-#endif
-        PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
     }
 
     // inout_cb assumed ready (max_cb was already computed from it)
@@ -238,22 +258,16 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
         MaybeDeviceZoneScopedN(profiling_enabled, "SUB");
         uint32_t dst_index = 0;
         for (uint32_t i = 0; i < tiles_per_row; i++) {
-#ifdef ARCH_BLACKHOLE
             uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base;
             sub_tiles_bcast_cols_custom(
                 inout_cb, max_cb, in0_tile_index, max_row_base + i, dst_index, tiles_per_column);
             dst_index += tiles_per_column;
-#else
-            for (uint32_t j = 0; j < tiles_per_column; j++) {
-                uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
-                sub_tiles_bcast_cols(inout_cb, max_cb, in0_tile_index, max_row_base + i, dst_index++);
-            }
-#endif
         }
     }
     tile_regs_commit();
 
     tile_regs_wait();
+    PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
     {
         MaybeDeviceZoneScopedN(profiling_enabled, "EXP");
         uint32_t dst_index = 0;
@@ -271,46 +285,28 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
     {
         MaybeDeviceZoneScopedN(profiling_enabled, "PACK SUB_EXP");
         // Pack back to inout_cb at the same absolute positions
-        uint32_t dst_index = 0;
-#ifdef ARCH_BLACKHOLE
-        if constexpr (blocked_pack) {
-            for (uint32_t i = 0; i < tiles_per_row; i++) {
-                uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base;
-                pack_tile<true>(dst_index, inout_cb, in0_tile_index);
-                dst_index += tiles_per_column;
-            }
-        } else
-#endif
-        {
-#pragma GCC unroll 1
-            for (uint32_t i = 0; i < tiles_per_row; i++) {
-#pragma GCC unroll 1
-                for (uint32_t j = 0; j < tiles_per_column; ++j) {
-                    uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
-                    pack_tile<true>(dst_index++, inout_cb, in0_tile_index);
-                }
-            }
-        }
+        pack_contiguous_rows<blocked_pack>(
+            inout_cb, max_row_base, tiles_per_row, cols_in_row, global_col_base, tiles_per_column);
 
         // Reduce to reduce_cb: first tile of first kt_subblock overwrites, rest accumulate
-#ifdef ARCH_BLACKHOLE
         if constexpr (blocked_pack) {
-            PACK((llk_pack_mop_config<false, false, false>(reduce_cb, 1)));
+            configure_single_tile_pack(reduce_cb);
         }
-#endif
-        dst_index = 0;
+        {
+            uint32_t dst_index = 0;
 #pragma GCC unroll 1
-        for (uint32_t i = 0; i < tiles_per_row; i++) {
-            if (global_col_base > 0) {
-                PACK((llk_pack_reconfig_l1_acc(1)));
-            } else {
-                PACK((llk_pack_reconfig_l1_acc(0)));
-            }
-#pragma GCC unroll 1
-            for (uint32_t j = 0; j < tiles_per_column; ++j) {
-                pack_tile<true>(dst_index++, reduce_cb, max_row_base + i);
-                if (global_col_base == 0 && j == 0) {
+            for (uint32_t i = 0; i < tiles_per_row; i++) {
+                if (global_col_base > 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
+                } else {
+                    PACK((llk_pack_reconfig_l1_acc(0)));
+                }
+#pragma GCC unroll 1
+                for (uint32_t j = 0; j < tiles_per_column; ++j) {
+                    pack_tile<true>(dst_index++, reduce_cb, max_row_base + i);
+                    if (global_col_base == 0 && j == 0) {
+                        PACK((llk_pack_reconfig_l1_acc(1)));
+                    }
                 }
             }
         }
@@ -320,11 +316,9 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
 
     // Restore packer ReLU config after all exp operations complete
     PACK((llk_pack_relu_config(ReluType::NO_RELU)));
-#ifdef ARCH_BLACKHOLE
-    if constexpr (blocked_pack) {
-        PACK((llk_pack_mop_config<false, false, false>(reduce_cb, tiles_per_column)));
+    if (blocked_pack && should_use_blocked_pack_width(tiles_per_column)) {
+        configure_pack_width(reduce_cb, tiles_per_column);
     }
-#endif
     PACK((llk_pack_reconfig_l1_acc(0)));
 }
 
@@ -411,6 +405,7 @@ void salad_correct_fused(
             (col_base + col_batch <= tiles_per_column) ? col_batch : (last_batch_rem > 0 ? last_batch_rem : col_batch);
         const bool is_last_out_batch = (col_base + cur_cols >= tiles_per_column);
         const bool fuse_sum_here = can_fuse_last && is_last_out_batch;
+        const bool use_blocked_out_pack = should_use_blocked_pack_width(cur_cols);
 
         tile_regs_acquire();
         uint32_t dst_index = 0;
@@ -427,33 +422,20 @@ void salad_correct_fused(
         }
         tile_regs_commit();
         tile_regs_wait();
-        dst_index = 0;
-#ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_mop_config<false, false, false>(out_out_cb, cur_cols)));
-        for (uint32_t i = 0; i < tiles_per_row; i++) {
-            uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base;
-            pack_tile<true>(dst_index, out_out_cb, out_tile_index);
-            dst_index += cur_cols;
+        if (use_blocked_out_pack) {
+            configure_pack_width(out_out_cb, cur_cols);
         }
-#else
-        for (uint32_t i = 0; i < tiles_per_row; i++) {
-            for (uint32_t j = 0; j < cur_cols; j++) {
-                uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base + j;
-                pack_tile<true>(dst_index++, out_out_cb, out_tile_index);
-            }
-        }
-#endif
+        pack_contiguous_rows<true>(out_out_cb, write_row_base, tiles_per_row, tiles_per_column, col_base, cur_cols);
+        dst_index = tiles_per_row * cur_cols;
         if (fuse_sum_here) {
-#ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config<false, false, false>(sum_out_cb, 1)));
-#endif
+            configure_single_tile_pack(sum_out_cb);
             for (uint32_t i = 0; i < tiles_per_row; i++) {
                 pack_tile<true>(dst_index++, sum_out_cb, write_row_base + i);
             }
         }
-#ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_mop_config<false, false, false>(out_out_cb, 1)));
-#endif
+        if (use_blocked_out_pack) {
+            configure_single_tile_pack(out_out_cb);
+        }
         tile_regs_release();
     }
 
@@ -464,9 +446,7 @@ void salad_correct_fused(
         }
         tile_regs_commit();
         tile_regs_wait();
-#ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_mop_config<false, false, false>(sum_out_cb, 1)));
-#endif
+        configure_single_tile_pack(sum_out_cb);
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             pack_tile<true>(i, sum_out_cb, write_row_base + i);
         }
@@ -716,9 +696,7 @@ static void sdpa_inner_loop_step(
     // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
     // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
-#ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, actual_sbw)));
-#endif
+    const bool use_blocked_qkt_pack = configure_row_pack_width(cb_qkt_im, actual_sbw);
     cb_wait_front(cb_kt_in, DHt * KT_stride);
 
     for (uint32_t q_subblock = 0; q_subblock < q_num_subblocks; q_subblock++) {
@@ -732,11 +710,7 @@ static void sdpa_inner_loop_step(
         if constexpr (!uniform_unpack_format) {
             reconfig_data_format(cb_kt_in, cb_q_in);
         }
-#ifdef ARCH_BLACKHOLE
         mm_no_mop_init_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
-#else
-        mm_block_init_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
-#endif
         for (uint32_t kt_subblock = 0; kt_subblock < kt_num_full_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
@@ -752,18 +726,13 @@ static void sdpa_inner_loop_step(
                     kt_subblock * actual_sbw,
                     qkt_subblock_h,
                     actual_sbw);
-
                 if constexpr (!uniform_pack_format) {
                     pack_reconfig_data_format(cb_qkt_im);
                 }
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_kt_in, cb_q_in);
                 }
-#ifdef ARCH_BLACKHOLE
                 mm_no_mop_reinit_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
-#else
-                mm_block_init_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
-#endif
             }
             {
                 MaybeDeviceZoneScopedN(profiling_enabled, "Q@KT MM+Pack");
@@ -820,9 +789,7 @@ static void sdpa_inner_loop_step(
         {
             MaybeDeviceZoneScopedN(profiling_enabled, "Reduce max");
             cb_reserve_back(cur.max, qkt_subblock_h);
-#ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config<false, false, false>(cur.max, 1)));
-#endif
+            configure_single_tile_pack(cur.max);
             // Use reduce_trigger to enable early reduce start (before all matmul output is ready).
             // When reduce_trigger=true, the packer signals the unpacker via semaphore after partial output.
             reduce_c_row_group<cb_qkt_im, cb_identity_scale_in, KT_stride>(
@@ -838,9 +805,7 @@ static void sdpa_inner_loop_step(
             if (save_max_cb != INVALID_CB) {
                 cb_push_back(save_max_cb, qkt_subblock_h);
             }
-#ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config<false, false, false>(cur.max, actual_sbw)));
-#endif
+            configure_pack_width(cur.max, use_blocked_qkt_pack ? actual_sbw : 1);
         }
 
         q_index_offset += qkt_subblock_h * in0_block_w;
@@ -893,9 +858,7 @@ static void sdpa_inner_loop_step(
         cb_reserve_back(out_cb, qktv_output_num_tiles);
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
-#ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, 1)));
-#endif
+        configure_single_tile_pack(cb_qkt_im);
         {
             MaybeDeviceZoneScopedN(profiling_enabled, "Softmax(Q@KT)@V");
             // Split-drain: interleave per-column-subblock sub_exp with partial V matmul.
@@ -912,7 +875,6 @@ static void sdpa_inner_loop_step(
                     kt_sub * actual_sbw,
                     qkt_subblock_h,
                     actual_sbw);
-
                 if (kt_sub == 0) {
                     cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
                     cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
@@ -927,11 +889,7 @@ static void sdpa_inner_loop_step(
                     if constexpr (!uniform_unpack_format) {
                         reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
                     }
-#ifdef ARCH_BLACKHOLE
                     mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, matmul_inner);
-#else
-                    mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, matmul_inner);
-#endif
                     for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                         blocked_matmul_and_pack<false, vDHt, vDHt>(
                             cb_qkt_im,
@@ -1035,11 +993,18 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
                 }
-#ifdef ARCH_BLACKHOLE
-                mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
-#else
-                mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
+                const bool needs_strong_phase2_reinit = is_last_iter && (q_subblock > 1);
+#if defined(ARCH_WORMHOLE)
+                if (needs_strong_phase2_reinit) {
+                    // WH row normalization runs reciprocal on the math pipe during the final K chunk.
+                    // Later phase-2 QKTV row groups in that same q-chunk re-enter no-mop matmul on
+                    // the same pipe, so rebuild the matmul program before the next row-group matmul.
+                    mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
+                } else
 #endif
+                {
+                    mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
+                }
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                     blocked_matmul_and_pack<false, vDHt, vDHt>(
                         cb_qkt_im,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -114,13 +114,9 @@ ALWI void recip_tile_first_column_wh_idst0_direct() {
 }
 #endif
 
-// Packs row slices into absolute CB positions with a fixed row stride.
-// Use this for out-of-order/output-indexed writes where each row starts at
-// row_base * row_stride + col_base and spans pack_width consecutive tiles. On
-// WH, blocked pack only pays off once the per-row width is large enough;
-// narrower writes fall back to regular tile-by-tile packing to avoid the
-// packer reconfiguration overhead.
-ALWI void pack_contiguous_rows(
+// Raw pack: caller must have already called configure_row_pack_width(out_cb, pack_width).
+// Use this in tight loops after configuring once at the loop boundary.
+ALWI void pack_contiguous_rows_nocfg(
     uint32_t out_cb,
     uint32_t row_base,
     uint32_t row_count,
@@ -142,6 +138,18 @@ ALWI void pack_contiguous_rows(
     }
 }
 
+// Safe pack: configures MOP then packs. Use for one-off calls or first-in-group.
+ALWI void pack_contiguous_rows(
+    uint32_t out_cb,
+    uint32_t row_base,
+    uint32_t row_count,
+    uint32_t row_stride,
+    uint32_t col_base,
+    uint32_t pack_width) {
+    configure_row_pack_width(out_cb, pack_width);
+    pack_contiguous_rows_nocfg(out_cb, row_base, row_count, row_stride, col_base, pack_width);
+}
+
 /**
  * Blocked subblock matmul with absolute offset packing.
  * Always uses pack_tile<true> at row-major positions in out_cb.
@@ -159,7 +167,8 @@ SDPA_NOINLINE void blocked_matmul_and_pack(
     uint32_t subblock_h,
     uint32_t inner_dim,
     uint32_t matmul_stride,
-    bool trigger_reduce = false) {
+    bool trigger_reduce = false,
+    bool skip_pack_configure = false) {
     tile_regs_acquire();
     uint32_t dst_index = 0;
     uint32_t in0_index = in0_index_start;
@@ -173,8 +182,11 @@ SDPA_NOINLINE void blocked_matmul_and_pack(
     tile_regs_commit();
 
     tile_regs_wait();
-    configure_row_pack_width(out_cb, subblock_w);
-    pack_contiguous_rows(out_cb, row_subblock_idx * subblock_h, subblock_h, out_num_cols, out_col_offset, subblock_w);
+    if (!skip_pack_configure) {
+        configure_row_pack_width(out_cb, subblock_w);
+    }
+    pack_contiguous_rows_nocfg(
+        out_cb, row_subblock_idx * subblock_h, subblock_h, out_num_cols, out_col_offset, subblock_w);
     if (trigger_reduce) {
         PACK((t6_semaphore_post<p_stall::NONE>(semaphore::FPU_SFPU)));
     }
@@ -262,7 +274,8 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
     uint32_t q_subblock,
     uint32_t global_col_base,
     uint32_t sbh,
-    uint32_t sbw) {
+    uint32_t sbw,
+    bool skip_pack_configure = false) {
     const uint32_t tiles_per_row = sbh;
     const uint32_t tiles_per_column = sbw;
     const uint32_t max_row_base = q_subblock * tiles_per_row;
@@ -307,9 +320,16 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
 
     {
         MaybeDeviceZoneScopedN(profiling_enabled, "PACK SUB_EXP");
-        // Pack back to inout_cb at the same absolute positions
-        configure_row_pack_width(inout_cb, tiles_per_column);
-        pack_contiguous_rows(inout_cb, max_row_base, tiles_per_row, cols_in_row, global_col_base, tiles_per_column);
+        // Pack back to inout_cb at the same absolute positions.
+        // In Phase 1, the caller pre-configures (cb_qkt_im, actual_sbw) before the kt loop
+        // and blocked_matmul_and_pack restores it after each sub_exp. Skip the redundant
+        // reconfigure here when the caller guarantees the state.
+        if (skip_pack_configure) {
+            pack_contiguous_rows_nocfg(
+                inout_cb, max_row_base, tiles_per_row, cols_in_row, global_col_base, tiles_per_column);
+        } else {
+            pack_contiguous_rows(inout_cb, max_row_base, tiles_per_row, cols_in_row, global_col_base, tiles_per_column);
+        }
         configure_single_tile_pack(reduce_cb);
         {
             uint32_t dst_index = 0;
@@ -335,7 +355,6 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
 
     // Restore packer ReLU config after all exp operations complete
     PACK((llk_pack_relu_config(ReluType::NO_RELU)));
-    configure_row_pack_width(inout_cb, tiles_per_column);
     PACK((llk_pack_reconfig_l1_acc(0)));
 }
 
@@ -371,6 +390,7 @@ SDPA_NOINLINE void sub_exp_first_col_blocks(
         }
         PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
+        configure_single_tile_pack(out_cb);
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             pack_tile<false>(i, out_cb);
         }
@@ -422,7 +442,6 @@ void salad_correct_fused(
             (col_base + col_batch <= tiles_per_column) ? col_batch : (last_batch_rem > 0 ? last_batch_rem : col_batch);
         const bool is_last_out_batch = (col_base + cur_cols >= tiles_per_column);
         const bool fuse_sum_here = can_fuse_last && is_last_out_batch;
-        const bool use_blocked_out_pack = should_use_blocked_pack_width(cur_cols);
 
         tile_regs_acquire();
         uint32_t dst_index = 0;
@@ -439,9 +458,6 @@ void salad_correct_fused(
         }
         tile_regs_commit();
         tile_regs_wait();
-        if (use_blocked_out_pack) {
-            configure_pack_width(out_out_cb, cur_cols);
-        }
         pack_contiguous_rows(out_out_cb, write_row_base, tiles_per_row, tiles_per_column, col_base, cur_cols);
         dst_index = tiles_per_row * cur_cols;
         if (fuse_sum_here) {
@@ -449,9 +465,6 @@ void salad_correct_fused(
             for (uint32_t i = 0; i < tiles_per_row; i++) {
                 pack_tile<true>(dst_index++, sum_out_cb, write_row_base + i);
             }
-        }
-        if (use_blocked_out_pack) {
-            configure_single_tile_pack(out_out_cb);
         }
         tile_regs_release();
     }
@@ -484,6 +497,7 @@ void normalize_row_streaming(
     uint32_t scratch_cb,
     uint32_t normalized_out_cb,
     uint32_t sbh) {
+    configure_single_tile_pack(scratch_cb);
     for (uint32_t s = 0; s < sbh; s++) {
         // 1+2. Fused matmul_reduce + recip: sum × col_identity → recip → 1/sum in scratch
         {
@@ -548,34 +562,6 @@ void normalize_row_streaming(
 }
 
 // ===================== Streaming SDPA Core Functions =====================
-
-/**
- * L1-accumulate ring mask tiles onto QKT for one row group (q_subblock).
- * Copies mask tiles from cb_mask_in and adds them in-place to cb_qkt_im using L1 accumulation.
- */
-template <uint32_t Sk_chunk_t, uint32_t cb_mask_in, uint32_t cb_qkt_im, uint32_t dst_size>
-static void apply_ring_mask_to_qkt(uint32_t q_subblock, uint32_t sbh) {
-    for (uint32_t row = 0; row < sbh; row++) {
-        uint32_t out_row_offset = (q_subblock * sbh + row) * Sk_chunk_t;
-        uint32_t mask_row_offset = (q_subblock * sbh + row) * Sk_chunk_t;
-        copy_tile_to_dst_init_short(cb_mask_in);
-        PACK((llk_pack_reconfig_l1_acc(1)));
-        for (uint32_t base = 0; base < Sk_chunk_t; base += dst_size) {
-            uint32_t batch = (Sk_chunk_t - base < dst_size) ? (Sk_chunk_t - base) : dst_size;
-            tile_regs_acquire();
-            for (uint32_t i = 0; i < batch; i++) {
-                copy_tile(cb_mask_in, mask_row_offset + base + i, i);
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            for (uint32_t i = 0; i < batch; i++) {
-                pack_tile<true>(i, cb_qkt_im, out_row_offset + base + i);
-            }
-            tile_regs_release();
-        }
-        PACK((llk_pack_reconfig_l1_acc(0)));
-    }
-}
 
 /**
  * L1-accumulate a single mask tile onto one position in out_cb.
@@ -713,7 +699,6 @@ static void sdpa_inner_loop_step(
     // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
     // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
-    const bool use_blocked_qkt_pack = configure_row_pack_width(cb_qkt_im, actual_sbw);
     cb_wait_front(cb_kt_in, DHt * KT_stride);
 
     for (uint32_t q_subblock = 0; q_subblock < q_num_subblocks; q_subblock++) {
@@ -728,6 +713,12 @@ static void sdpa_inner_loop_step(
             reconfig_data_format(cb_kt_in, cb_q_in);
         }
         mm_no_mop_init_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
+        // Configure pack once before the kt loop for cb_qkt_im. Both sub_exp
+        // and blocked_matmul_and_pack skip their internal configure (same cb+width).
+        // sub_exp's configure_single_tile_pack(reduce_cb) clobbers the global to 1,
+        // so blocked_matmul_and_pack must reconfigure when q_subblock > 0.
+        // When q_subblock == 0, no sub_exp → global stays set → skip there too.
+        configure_row_pack_width(cb_qkt_im, actual_sbw);
         for (uint32_t kt_subblock = 0; kt_subblock < kt_num_full_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
@@ -742,7 +733,8 @@ static void sdpa_inner_loop_step(
                     prev_q_subblock,
                     kt_subblock * actual_sbw,
                     qkt_subblock_h,
-                    actual_sbw);
+                    actual_sbw,
+                    /*skip_pack_configure=*/true);
                 if constexpr (!uniform_pack_format) {
                     pack_reconfig_data_format(cb_qkt_im);
                 }
@@ -770,7 +762,8 @@ static void sdpa_inner_loop_step(
                     qkt_subblock_h,
                     in0_block_w,
                     in0_block_w,
-                    kt_trigger_reduce);
+                    kt_trigger_reduce,
+                    /*skip_pack_configure=*/q_subblock == 0);
                 kt_index_offset += actual_sbw;
             }
         }
@@ -785,6 +778,7 @@ static void sdpa_inner_loop_step(
         // mask at active_Sk-1 instead of Sk_chunk_t-1.
         if constexpr (use_ring_mask) {
             if (apply_mask && lw_partial_tile_idx > 0) {
+                configure_single_tile_pack(cb_qkt_im);
                 copy_tile_to_dst_init_short(cb_mask_in);
                 PACK((llk_pack_reconfig_l1_acc(1)));
                 apply_lightweight_mask_streaming<KT_stride>(
@@ -822,7 +816,6 @@ static void sdpa_inner_loop_step(
             if (save_max_cb != INVALID_CB) {
                 cb_push_back(save_max_cb, qkt_subblock_h);
             }
-            configure_pack_width(cur.max, use_blocked_qkt_pack ? actual_sbw : 1);
         }
 
         q_index_offset += qkt_subblock_h * in0_block_w;
@@ -875,7 +868,6 @@ static void sdpa_inner_loop_step(
         cb_reserve_back(out_cb, qktv_output_num_tiles);
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
-        configure_single_tile_pack(cb_qkt_im);
         {
             MaybeDeviceZoneScopedN(profiling_enabled, "Softmax(Q@KT)@V");
             // Split-drain: interleave per-column-subblock sub_exp with partial V matmul.
@@ -907,6 +899,8 @@ static void sdpa_inner_loop_step(
                         reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
                     }
                     mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, matmul_inner);
+                    // Configure once before v_subblock loop; skip inside.
+                    configure_row_pack_width(out_cb, qktv_subblock_w);
                     for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                         blocked_matmul_and_pack<false, vDHt, vDHt>(
                             cb_qkt_im,
@@ -919,7 +913,9 @@ static void sdpa_inner_loop_step(
                             qktv_subblock_w,
                             qktv_h,
                             matmul_inner,
-                            KT_stride);
+                            KT_stride,
+                            /*trigger_reduce=*/false,
+                            /*skip_pack_configure=*/true);
                         v_index_offset += qktv_subblock_w;
                     }
                     if constexpr (!uniform_unpack_format) {
@@ -1011,6 +1007,8 @@ static void sdpa_inner_loop_step(
                     reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
                 }
                 mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
+                // Configure once before v_subblock loop; skip inside.
+                configure_row_pack_width(out_cb, qktv_subblock_w);
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                     blocked_matmul_and_pack<false, vDHt, vDHt>(
                         cb_qkt_im,
@@ -1023,7 +1021,9 @@ static void sdpa_inner_loop_step(
                         qktv_subblock_w,
                         cur_h,
                         active_Sk,
-                        KT_stride);
+                        KT_stride,
+                        /*trigger_reduce=*/false,
+                        /*skip_pack_configure=*/true);
                     v_index_offset += qktv_subblock_w;
                 }
                 if constexpr (!uniform_unpack_format) {


### PR DESCRIPTION
## Summary

- Extend Blackhole-only SDPA no-mop matmul, blocked pack, and blocked sub compute paths to Wormhole
- Add Wormhole experimental LLK API wrappers for matmul (`llk_math_matmul_custom_api.h`), sub-bcast-col (`llk_unpack_AB_sub_bcast_col_custom_api.h`, `llk_math_eltwise_binary_custom_api.h`), and blocked pack (`llk_pack_api.h`)
- Unify `compute_streaming.hpp`: remove `#ifdef ARCH_BLACKHOLE` guards around no-mop matmul, blocked sub, and blocked pack paths so both BH and WH share the same code
- Add replay-safe WH reciprocal (`recip_tile_first_column_wh_idst0_direct`) that stays within SFPU replay slots without overwriting the no-mop matmul replay region
- Add `pack_contiguous_rows<blocked_pack>` helper to replace duplicated pack loops across matmul, sub-exp, and correction phases
- Fix `sdpa_perf_utils` API call mismatches in sprint test (`num_cores` → `compute_cores`, missing `d_v` arg)

## Test plan
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic%2Fwormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/runs/24196726008)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic%2Fwormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/runs/24196728456)
- [ ] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic%2Fwormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/runs/24196731076)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic%2Fwormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/runs/24196733278)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/wormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [#2725](https://github.com/tenstorrent/tt-metal/actions/runs/24405505900) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/wormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [#17473](https://github.com/tenstorrent/tt-metal/actions/runs/24405508842) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/wormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [#5192](https://github.com/tenstorrent/tt-metal/actions/runs/24405511185) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/wormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [#828](https://github.com/tenstorrent/tt-metal/actions/runs/24191538921) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/wormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/wormhole-sdpa-pack-sub-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/wormhole-sdpa-pack-sub-matmul) |