### PR TITLE
fix scatter/gather: use logical_shape().rank() for dim normalization

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
@@ -161,11 +161,11 @@ Tensor gather(
     const std::optional<CoreRangeSet>& sub_core_grids) {
     // Input tensor
     const ttnn::Shape& original_input_tensor_lshape = input_tensor.logical_shape();
-    const auto input_tensor_rank = input_tensor.padded_shape().rank();
+    const auto input_tensor_rank = input_tensor.logical_shape().rank();
 
     // Index tensor
     const auto& original_index_tensor_lshape = input_index_tensor.logical_shape();
-    const auto index_tensor_rank = input_index_tensor.padded_shape().rank();
+    const auto index_tensor_rank = input_index_tensor.logical_shape().rank();
 
     // Check for early exit for empty tensors tensors
     if (original_input_tensor_lshape == ttnn::Shape{}) {

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/scatter.cpp
@@ -278,7 +278,7 @@ Tensor scatter(
     const std::optional<std::string>& opt_reduction_string,
     const std::optional<CoreRangeSet>& sub_core_grid) {
     const ttnn::Shape& original_input_tensor_lshape = input_tensor.logical_shape();
-    const auto input_tensor_rank = input_tensor.padded_shape().rank();
+    const auto input_tensor_rank = input_tensor.logical_shape().rank();
 
     using namespace operations::data_movement::CMAKE_UNIQUE_NAMESPACE;
 


### PR DESCRIPTION
### Problem

PR #41548 fixed negative-dim crashes in `ttnn::scatter` and `ttnn::gather` but introduced a new bug: dim normalization used `padded_shape().rank()` instead of `logical_shape().rank()`.

For a 1D tensor `[100]` in `TILE_LAYOUT`:
- `padded_shape().rank()` = 2 (padded to `[1, 128]`)
- `logical_shape().rank()` = 1

This causes `dim=-1` to normalize to `1` (not `0`), which then fails `validate_inputs()` whose rank check uses `logical_shape()`:
```
TT_FATAL: dim must follow the condition -input_rank <= dim < input_rank (dim: 1, rank: 1)
```

### Fix

Swap `padded_shape().rank()` → `logical_shape().rank()` in both `scatter.cpp` and `gather.cpp`. One line each.