### PR TITLE
fix pack_untilize/dst_untilize: get_id() -> get_cb_id() for CircularBuffer

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
@@ -45,9 +45,9 @@ void kernel_main() {
     constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
 
 #ifndef ARCH_QUASAR
-    compute_kernel_hw_startup(cb_in0.get_id(), cb_out0.get_id());
-    copy_tile_to_dst_init_short(cb_in0.get_id());
-    pack_untilize_dest_init<block_ct_dim, full_ct_dim>(cb_out0.get_id(), num_rows_per_face, num_faces);
+    compute_kernel_hw_startup(cb_in0.get_cb_id(), cb_out0.get_cb_id());
+    copy_tile_to_dst_init_short(cb_in0.get_cb_id());
+    pack_untilize_dest_init<block_ct_dim, full_ct_dim>(cb_out0.get_cb_id(), num_rows_per_face, num_faces);
 
     for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
         cb_out0.reserve_back(full_ct_dim);
@@ -55,18 +55,18 @@ void kernel_main() {
             cb_in0.wait_front(block_ct_dim);
             tile_regs_acquire();
             for (uint32_t i = 0; i < block_ct_dim; ++i) {
-                copy_tile(cb_in0.get_id(), i, i);
+                copy_tile(cb_in0.get_cb_id(), i, i);
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_untilize_dest<block_ct_dim, full_ct_dim>(cb_out0.get_id(), 1, b, num_rows_per_face, num_faces);
+            pack_untilize_dest<block_ct_dim, full_ct_dim>(cb_out0.get_cb_id(), 1, b, num_rows_per_face, num_faces);
             tile_regs_release();
             cb_in0.pop_front(block_ct_dim);
         }
         cb_out0.push_back(full_ct_dim);
     }
 
-    pack_untilize_uninit(cb_out0.get_id());
+    pack_untilize_uninit(cb_out0.get_cb_id());
 #else
     compute_kernel_hw_startup(dfb_in0.get_id(), dfb_out0.get_id());
     copy_tile_to_dst_init_short(dfb_in0.get_id());

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
@@ -42,21 +42,21 @@ void kernel_main() {
     constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
 
 #ifndef ARCH_QUASAR
-    compute_kernel_hw_startup(cb_in0.get_id(), cb_out0.get_id());
-    pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in0.get_id(), cb_out0.get_id());
+    compute_kernel_hw_startup(cb_in0.get_cb_id(), cb_out0.get_cb_id());
+    pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in0.get_cb_id(), cb_out0.get_cb_id());
 
     for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
         cb_out0.reserve_back(full_ct_dim);
 
         for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
             cb_in0.wait_front(block_ct_dim);
-            pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in0.get_id(), 1, cb_out0.get_id(), b);
+            pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in0.get_cb_id(), 1, cb_out0.get_cb_id(), b);
             cb_in0.pop_front(block_ct_dim);
         }
         cb_out0.push_back(full_ct_dim);
     }
 
-    pack_untilize_uninit(cb_out0.get_id());
+    pack_untilize_uninit(cb_out0.get_cb_id());
 #else
     compute_kernel_hw_startup(dfb_in0.get_id(), dfb_out0.get_id());
     pack_untilize_init<block_ct_dim, full_ct_dim>(dfb_in0.get_id(), dfb_out0.get_id());


### PR DESCRIPTION
PR #41299 (Quasar pack untilize, Apr 8) added the non-QSR code paths using cb.get_id(), but experimental::CircularBuffer only has get_cb_id() -- get_id() belongs to DataflowBuffer (the QSR type).

Fixes TensixComputePackUntilize* compile failures on WH and BH. Two files, mechanical rename in the #ifndef ARCH_QUASAR blocks only.