### PR TITLE
Initial optimization for rope

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -986,7 +986,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("qkv_rope_cos_sin_cb"),
         get_named_compile_time_arg_val("qrope_trans_mat_cb"),
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
-        get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
         get_named_compile_time_arg_val("qrope_output_cb"),
         get_common_arg_val<uint32_t>(15),  // qrope_trans_mat_addr
     };
@@ -1040,7 +1039,6 @@ void kernel_main() {
     constexpr uint32_t krope_cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb");
     constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
     constexpr uint32_t krope_rotated_in_interm_cb = get_named_compile_time_arg_val("krope_rotated_in_interm_cb");
-    constexpr uint32_t krope_cos_sin_interm_cb = get_named_compile_time_arg_val("krope_cos_sin_interm_cb");
     constexpr uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
 
     // Compute args: all CB indices
@@ -1049,7 +1047,6 @@ void kernel_main() {
         .cos_sin_cb = krope_cos_sin_cb,
         .trans_mat_cb = krope_trans_mat_cb,
         .rotated_in_interm_cb = krope_rotated_in_interm_cb,
-        .cos_sin_interm_cb = krope_cos_sin_interm_cb,
         .out_cb = krope_output_cb,
         .trans_mat_address_override = get_common_arg_val<uint32_t>(15),
     };

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -885,7 +885,6 @@ class AttentionBlock:
         qrope_rotated_input_interm_cb = cb_id_context.get_cb_id(
             data_format, TD_1x32
         )  # Rotated input intermediate CB for RoPE
-        qrope_cos_sin_interm_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin intermediate CB for RoPE
         # KV cache branch
         dkv_matmul_output_cb = matmul_output_cb  # Reuse matmul1 output CB ID (disjoint grids: rows 0-7 vs rows 8-9)
         kv_rmsnorm_input_cb = rmsnorm2_input_cb  # Reuse rmsnorm2 input CB ID (disjoint grids: rows 0-7 vs rows 8-9)
@@ -1173,13 +1172,12 @@ class AttentionBlock:
         ]
         # BRISC: no-op (empty args)
         qrope_brisc_named_compile_time_args = []
-        # TRISC: in_cb, cos_sin_cb, trans_mat_cb, rotated_in_interm_cb, cos_sin_interm_cb, out_cb, Wt, Ht
+        # TRISC: in_cb, cos_sin_cb, trans_mat_cb, rotated_in_interm_cb, out_cb, Wt, Ht
         qrope_trisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
             ("qkv_rope_cos_sin_cb", qkv_rope_cos_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
-            ("qrope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
             ("qrope_output_cb", qrope_output_cb),
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
@@ -1461,7 +1459,6 @@ class AttentionBlock:
             ("krope_cos_sin_cb", qkv_rope_cos_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
-            ("krope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
             ("krope_output_cb", krope_output_cb),
             ("krope_Wt", krope_Wt),
             ("krope_Ht", krope_Ht),
@@ -2261,25 +2258,6 @@ class AttentionBlock:
             )
         ]
         sdpa_out_interm_running_offset_qrope += qrope_rotated_input_interm_cb_descriptor.total_size  # +128 B
-
-        # CB 21: Cos/Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
-        # at offset 14016 B. This CB is consumed before SDPA runs.
-        qrope_cos_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            qrope_cos_sin_interm_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_qrope,  # 28352 B
-            total_size=qrope_interm_tile_size * 2,
-            core_ranges=full_device_grid,
-        )
-        qrope_cos_sin_interm_cb_descriptor.format_descriptors = [
-            ttnn.CBFormatDescriptor(
-                buffer_index=qrope_cos_sin_interm_cb,
-                data_format=data_format,
-                page_size=TILE_1x32.get_tile_size(data_format),
-                tile=ttnn.TileDescriptor(TILE_1x32),
-            )
-        ]
-        sdpa_out_interm_running_offset_qrope += qrope_cos_sin_interm_cb_descriptor.total_size
 
         sdpa_out_interm_running_offset = max(sdpa_out_interm_running_offset, sdpa_out_interm_running_offset_qrope)
 
@@ -3324,7 +3302,6 @@ class AttentionBlock:
             create_q_heads_out_cb_descriptor,
             qkv_rope_cos_sin_cb_descriptor,
             qrope_rotated_input_interm_cb_descriptor,
-            qrope_cos_sin_interm_cb_descriptor,
             dkv_matmul_output_cb_descriptor,
             kv_rmsnorm_input_cb_descriptor,
             kv_rmsnorm_output_cb_descriptor,

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -1025,7 +1025,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("qkv_rope_cos_sin_cb"),
         get_named_compile_time_arg_val("qrope_trans_mat_cb"),
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
-        get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
         get_named_compile_time_arg_val("qrope_output_cb"),
         get_common_arg_val<uint32_t>(15),  // qrope_trans_mat_addr
     };
@@ -1079,7 +1078,6 @@ void kernel_main() {
     constexpr uint32_t krope_cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb");
     constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
     constexpr uint32_t krope_rotated_in_interm_cb = get_named_compile_time_arg_val("krope_rotated_in_interm_cb");
-    constexpr uint32_t krope_cos_sin_interm_cb = get_named_compile_time_arg_val("krope_cos_sin_interm_cb");
     constexpr uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
 
     // Compute args: all CB indices
@@ -1088,7 +1086,6 @@ void kernel_main() {
         .cos_sin_cb = krope_cos_sin_cb,
         .trans_mat_cb = krope_trans_mat_cb,
         .rotated_in_interm_cb = krope_rotated_in_interm_cb,
-        .cos_sin_interm_cb = krope_cos_sin_interm_cb,
         .out_cb = krope_output_cb,
         .trans_mat_address_override = get_common_arg_val<uint32_t>(15),
     };

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -159,7 +159,6 @@ void kernel_main() {
     constexpr uint32_t cos_sin_cb = get_named_compile_time_arg_val("cos_sin_cb");
     constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
     constexpr uint32_t rotated_in_interm_cb = get_named_compile_time_arg_val("rotated_in_interm_cb");
-    constexpr uint32_t cos_sin_interm_cb = get_named_compile_time_arg_val("cos_sin_interm_cb");
     constexpr uint32_t k_rope_output_cb = get_named_compile_time_arg_val("out_cb");
 
     // Compute args: all CB indices
@@ -168,7 +167,6 @@ void kernel_main() {
         .cos_sin_cb = cos_sin_cb,
         .trans_mat_cb = trans_mat_cb,
         .rotated_in_interm_cb = rotated_in_interm_cb,
-        .cos_sin_interm_cb = cos_sin_interm_cb,
         .out_cb = k_rope_output_cb,
     };
     deepseek_compute_kernel_init();

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -138,7 +138,6 @@ class KVCacheBranch:
         cos_sin_cb = 0  # tile (NCRISC reads from DRAM)
         trans_mat_cb = 2  # 1x32 tile, 64 bytes (sharded, 1 tile per core) - actually 32x32 for matmul
         rotated_input_interm_cb = 3  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
-        cos_sin_interm_cb = 4  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
         dkv_matmul_input_cb = 6  # 1x32 tile, 64 bytes (224 tiles = 1x7168)
         dkv_matmul_output_cb = 7  # 1x32 tile, 64 bytes (1 tile per core for rope input)
         dkv_matmul_weights_cb = 8  # 32x32 tile, 2048 bytes (sharded weights)
@@ -289,7 +288,6 @@ class KVCacheBranch:
             ("cos_sin_cb", cos_sin_cb),
             ("trans_mat_cb", trans_mat_cb),
             ("rotated_in_interm_cb", rotated_input_interm_cb),
-            ("cos_sin_interm_cb", cos_sin_interm_cb),
             ("out_cb", k_rope_output_cb),
             ("Wt", krope_Wt),
             ("Ht", krope_Ht),
@@ -386,18 +384,6 @@ class KVCacheBranch:
             total_size=1 * krope_tile_size,
             core_ranges=krope_core_grid,
             format_descriptors=[rotated_interm_format],
-        )
-
-        cos_sin_interm_format = ttnn.CBFormatDescriptor(
-            buffer_index=cos_sin_interm_cb,
-            data_format=data_format,
-            page_size=krope_tile_size,
-            tile=krope_tile_descriptor,
-        )
-        cos_sin_interm_cb_descriptor = ttnn.CBDescriptor(
-            total_size=2 * krope_tile_size,
-            core_ranges=krope_core_grid,
-            format_descriptors=[cos_sin_interm_format],
         )
 
         k_rope_output_cb_format = ttnn.CBFormatDescriptor(
@@ -515,7 +501,6 @@ class KVCacheBranch:
                 cos_sin_cb_descriptor,
                 trans_mat_cb_descriptor,
                 rotated_interm_cb_descriptor,
-                cos_sin_interm_cb_descriptor,
                 k_rope_output_cb_descriptor,
             ],
             semaphores=[

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -659,7 +659,6 @@ if constexpr (!Core::skip_ccl) {
         get_named_compile_time_arg_val("qrope_cos_sin_cb"),
         get_named_compile_time_arg_val("qrope_trans_mat_cb"),
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
-        get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
         get_named_compile_time_arg_val("qrope_output_cb"),
     };
 
@@ -710,7 +709,6 @@ if constexpr (!Core::skip_ccl) {
     constexpr uint32_t krope_cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb");
     constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
     constexpr uint32_t krope_rotated_in_interm_cb = get_named_compile_time_arg_val("krope_rotated_in_interm_cb");
-    constexpr uint32_t krope_cos_sin_interm_cb = get_named_compile_time_arg_val("krope_cos_sin_interm_cb");
     constexpr uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
 
     // Compute args: all CB indices
@@ -719,7 +717,6 @@ if constexpr (!Core::skip_ccl) {
         .cos_sin_cb = krope_cos_sin_cb,
         .trans_mat_cb = krope_trans_mat_cb,
         .rotated_in_interm_cb = krope_rotated_in_interm_cb,
-        .cos_sin_interm_cb = krope_cos_sin_interm_cb,
         .out_cb = krope_output_cb,
     };
 

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -556,7 +556,6 @@ class PreSDPA:
         qrope_cos_sin_cb = 17  # Cos/Sin CB for RoPE
         qrope_trans_mat_cb = 19  # Trans_mat CB for RoPE
         qrope_rotated_input_interm_cb = 20  # Rotated input intermediate CB for RoPE
-        qrope_cos_sin_interm_cb = 21  # Cos/Sin intermediate CB for RoPE
         # KV cache branch
         dkv_matmul_weights_cb = 23  # DKV Matmul weights CB
         dkv_matmul_output_cb = 24  # DKV Matmul output CB, 64 bytes (1 tile per core for rope input)
@@ -790,7 +789,6 @@ class PreSDPA:
             ("qrope_cos_sin_cb", qrope_cos_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
-            ("qrope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
             ("qrope_output_cb", qrope_output_cb),
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
@@ -1072,7 +1070,6 @@ class PreSDPA:
             ("krope_cos_sin_cb", krope_cos_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
-            ("krope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
             ("krope_output_cb", krope_output_cb),
             ("krope_Wt", krope_Wt),
             ("krope_Ht", krope_Ht),
@@ -1632,23 +1629,7 @@ class PreSDPA:
                     )
                 ]
                 sdpa_out_interm_running_offset += qrope_rotated_input_interm_cb_descriptor.total_size
-                # CB 21: Cos/Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
-                # This CB is consumed before SDPA runs.
-                qrope_cos_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    qrope_cos_sin_interm_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,
-                    total_size=qrope_interm_tile_size * 2,
-                )
-                qrope_cos_sin_interm_cb_descriptor.format_descriptors = [
-                    ttnn.CBFormatDescriptor(
-                        buffer_index=qrope_cos_sin_interm_cb,
-                        data_format=data_format,
-                        page_size=TILE_1x32.get_tile_size(data_format),
-                        tile=ttnn.TileDescriptor(TILE_1x32),
-                    )
-                ]
-                sdpa_out_interm_running_offset += qrope_cos_sin_interm_cb_descriptor.total_size
+
                 # CB 31: CreateQHeads intermediate buffer (row-major data before tilization)
                 # Senders write row-major data here via NOC, receiver marks pages, TRISC tilizes to output
                 # Allocated on union of sender (QNOPE/QROPE) and receiver (SDPA Input) grids
@@ -2303,7 +2284,6 @@ class PreSDPA:
                     qrope_cos_sin_cb_descriptor,
                     qrope_trans_mat_cb_descriptor,
                     qrope_rotated_input_interm_cb_descriptor,
-                    qrope_cos_sin_interm_cb_descriptor,
                     dkv_matmul_weights_cb_descriptor,
                     dkv_matmul_output_cb_descriptor,
                     kv_rmsnorm_input_cb_descriptor,

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
@@ -68,7 +68,6 @@ void kernel_main() {
     constexpr uint32_t cos_sin_cb = get_named_compile_time_arg_val("cos_sin_cb");
     constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
     constexpr uint32_t rotated_in_interm_cb = get_named_compile_time_arg_val("rotated_in_interm_cb");
-    constexpr uint32_t cos_sin_interm_cb = get_named_compile_time_arg_val("cos_sin_interm_cb");
     constexpr uint32_t out_cb = get_named_compile_time_arg_val("out_cb");
 
     // Compute args: all CB indices
@@ -77,7 +76,6 @@ void kernel_main() {
         .cos_sin_cb = cos_sin_cb,
         .trans_mat_cb = trans_mat_cb,
         .rotated_in_interm_cb = rotated_in_interm_cb,
-        .cos_sin_interm_cb = cos_sin_interm_cb,
         .out_cb = out_cb,
     };
     deepseek_compute_kernel_init();

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
@@ -131,7 +131,6 @@ class RopeSingleCore:
         trans_mat_cb = 3  # c_3
         output_cb = 16  # c_16 (output operands start at 16)
         rotated_input_interm_cb = 24  # c_24
-        cos_sin_interm_cb = 25  # c_25
 
         # Create tile descriptor
         tile_descriptor = ttnn.TileDescriptor(tile)
@@ -174,18 +173,6 @@ class RopeSingleCore:
             format_descriptors=[rotated_interm_format],
         )
 
-        cos_sin_interm_format = ttnn.CBFormatDescriptor(
-            buffer_index=cos_sin_interm_cb,
-            data_format=data_format,
-            page_size=tile_size,
-            tile=tile_descriptor,
-        )
-        cos_sin_interm_cb_descriptor = ttnn.CBDescriptor(
-            total_size=2 * num_interm_tiles * tile_size,
-            core_ranges=core_grid,
-            format_descriptors=[cos_sin_interm_format],
-        )
-
         # ========================================================================
         # Unified Kernel Descriptor (handles NCRISC, BRISC, TRISC)
         # ========================================================================
@@ -220,7 +207,6 @@ class RopeSingleCore:
             ("cos_sin_cb", cos_sin_cb),
             ("trans_mat_cb", trans_mat_cb),
             ("rotated_in_interm_cb", rotated_input_interm_cb),
-            ("cos_sin_interm_cb", cos_sin_interm_cb),
             ("out_cb", output_cb),
             ("Wt", head_dim_per_core_t),
             ("Ht", 1),
@@ -267,7 +253,6 @@ class RopeSingleCore:
                 trans_mat_cb_descriptor,
                 output_cb_descriptor,
                 rotated_interm_cb_descriptor,
-                cos_sin_interm_cb_descriptor,
             ],
         )
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
@@ -83,7 +83,6 @@ struct Rope {
         uint32_t cos_sin_cb;
         uint32_t trans_mat_cb;
         uint32_t rotated_in_interm_cb;
-        uint32_t cos_sin_interm_cb;
         uint32_t out_cb;
         uint32_t trans_mat_address_override = 0;  // byte address; overrides trans_mat read ptr if > 0
     };
@@ -159,10 +158,12 @@ struct Rope {
             // ================================================================
             for (uint32_t ht = 0; ht < Ht; ht++) {
                 reconfig_data_format_srca<false, true>(args.trans_mat_cb);
+                mm_init_short(args.in_cb, args.trans_mat_cb);
 
                 // Reserve intermediate and output buffers
+                // TODO: If we have bcast with dest reuse, we can get rid of rotated_in_interm_cb
+                // Currently it doesn't look like there is too much cost for this since it's overlapped with cos mul
                 cb_reserve_back(args.rotated_in_interm_cb, Wt);
-                cb_reserve_back(args.cos_sin_interm_cb, Wt * 2);
                 cb_reserve_back(args.out_cb, Wt);
 
                 cb_wait_front(args.in_cb, Wt);
@@ -170,7 +171,6 @@ struct Rope {
                 // ============================================================
                 // Step 1: rotated = input @ trans_mat (matmul for rotate_half)
                 // ============================================================
-                mm_init_short(args.in_cb, args.trans_mat_cb);
                 tile_regs_acquire();
                 for (uint32_t j = 0; j < Wt; ++j) {
                     matmul_tiles(args.in_cb, args.trans_mat_cb, j, 0, j);
@@ -182,59 +182,35 @@ struct Rope {
                 }
                 tile_regs_release();
                 cb_push_back(args.rotated_in_interm_cb, Wt);
-                cb_wait_front(args.rotated_in_interm_cb, Wt);
 
+                // multiply does dest accum by default, so we add sin and cos by writing to same dest regs
                 // ============================================================
-                // Step 2: sin_interm = rotated * sin (broadcast multiply)
+                // Step 2: cos_interm = input * cos (broadcast multiply)
                 // ============================================================
-                reconfig_data_format_srca<false, true>(args.rotated_in_interm_cb);
-                mul_bcast_rows_init_short(args.rotated_in_interm_cb, args.cos_sin_cb);
-                tile_regs_acquire();
-                for (uint32_t j = 0; j < Wt; ++j) {
-                    mul_tiles_bcast<BroadcastType::ROW>(args.rotated_in_interm_cb, args.cos_sin_cb, j, Wt + j, j);
-                }
-                tile_regs_commit();
-                tile_regs_wait();
-                for (uint32_t j = 0; j < Wt; ++j) {
-                    pack_tile(j, args.cos_sin_interm_cb);
-                }
-                tile_regs_release();
-                cb_push_back(args.cos_sin_interm_cb, Wt);
-                cb_pop_front(args.rotated_in_interm_cb, Wt);
-
-                // ============================================================
-                // Step 3: cos_interm = input * cos (broadcast multiply)
-                // ============================================================
+                reconfig_data_format_srca<false, true>(args.in_cb);
+                mul_bcast_rows_init_short(args.in_cb, args.cos_sin_cb);
                 tile_regs_acquire();
                 for (uint32_t j = 0; j < Wt; ++j) {
                     mul_tiles_bcast<BroadcastType::ROW>(args.in_cb, args.cos_sin_cb, j, j, j);
                 }
-                tile_regs_commit();
-                tile_regs_wait();
-                for (uint32_t j = 0; j < Wt; ++j) {
-                    pack_tile(j, args.cos_sin_interm_cb);
-                }
-                tile_regs_release();
-                cb_push_back(args.cos_sin_interm_cb, Wt);
-                cb_pop_front(args.in_cb, Wt);
 
                 // ============================================================
-                // Step 4: output = cos_interm + sin_interm (add)
+                // Step 3: sin_interm = rotated * sin (broadcast multiply)
                 // ============================================================
-                cb_wait_front(args.cos_sin_interm_cb, Wt * 2);
-                add_tiles_init(args.cos_sin_interm_cb, args.cos_sin_interm_cb);
-                tile_regs_acquire();
+                cb_wait_front(args.rotated_in_interm_cb, Wt);
                 for (uint32_t j = 0; j < Wt; ++j) {
-                    add_tiles(args.cos_sin_interm_cb, args.cos_sin_interm_cb, j, Wt + j, j);
+                    mul_tiles_bcast<BroadcastType::ROW>(args.rotated_in_interm_cb, args.cos_sin_cb, j, Wt + j, j);
                 }
+
                 tile_regs_commit();
                 tile_regs_wait();
                 for (uint32_t j = 0; j < Wt; ++j) {
-                    pack_tile(j, args.out_cb, j);
+                    pack_tile(j, args.out_cb);
                 }
                 tile_regs_release();
                 cb_push_back(args.out_cb, Wt);
-                cb_pop_front(args.cos_sin_interm_cb, Wt * 2);
+                cb_pop_front(args.in_cb, Wt);
+                cb_pop_front(args.rotated_in_interm_cb, Wt);
             }
 
             // ================================================================


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We were using an extra CB for cos sin interm, as well as a separate add operation to add cos and sin interm. We were serializing pack->unpack with between step 1 and 2, and then step 2 and 3.

### What's changed
Use dest accumulation to perform the add of cos interm and sin interm, so we no longer need the intermediate buffer. Move cos interm calculation first so we overlap pack of rotated_in_interm_cb with cos interm, so we minimize serialization with sin interm computation. Further work could be to use bcast with dest reuse to avoid needing rotated_in_interm_cb and packing it out.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/rope)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/rope)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/rope)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/rope)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/rope)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/rope)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
