### PR TITLE
Add Dockerfile.ai-kernel for AI kernel team dev image

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -443,6 +443,7 @@ docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/ @abhullar-tt @r
 
 # misc
 dockerfile/** @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+dockerfile/teams/Dockerfile.ai-kernel @stevendae @cmaryan @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 
 # tt-train
 # primary owners

--- a/dockerfile/teams/Dockerfile.ai-kernel
+++ b/dockerfile/teams/Dockerfile.ai-kernel
@@ -1,0 +1,37 @@
+# Team AI-kernel image on top of tt-metal dev
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
+
+LABEL org.opencontainers.image.source="https://github.com/tenstorrent/tt-metal"
+LABEL org.opencontainers.image.description="AI kernel team image layered on tt-metal dev"
+
+############################################
+# Install ONLY missing OS tools
+# tmux: multiplexer for IRD/remote dev; htop: process viewer; ca-certificates: HTTPS;
+# gnupg: GPG keys for external apt repos (e.g. GitHub CLI).
+############################################
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    tmux \
+    htop \
+    ca-certificates \
+    gnupg \
+ && rm -rf /var/lib/apt/lists/*
+
+############################################
+# Install GitHub CLI (gh): PRs, repos, workflows from terminal/CI
+# Keyring dearmor, add repo, install gh.
+############################################
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y gh \
+ && rm -rf /var/lib/apt/lists/*
+
+############################################
+# Install Claude Code (native installer); symlink into PATH
+############################################
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+ && ln -s /root/.local/bin/claude /usr/local/bin/claude || true

--- a/dockerfile/teams/Dockerfile.ai-kernel
+++ b/dockerfile/teams/Dockerfile.ai-kernel
@@ -34,4 +34,5 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
 # Install Claude Code (native installer); symlink into PATH
 ############################################
 RUN curl -fsSL https://claude.ai/install.sh | bash \
- && ln -s /root/.local/bin/claude /usr/local/bin/claude || true
+ && [ -x /root/.local/bin/claude ] \
+ && ln -sf /root/.local/bin/claude /usr/local/bin/claude


### PR DESCRIPTION
Layer on tt-metalium ubuntu-22.04-dev-amd64 with tmux, htop, GitHub CLI, and Claude Code for quick ai kernel gen workflows:

https://github.com/tenstorrent/tt-metal/pkgs/container/tt-metal%2Ftt-metalium%2Fubuntu-22.04-ai-kernel-dev-amd64

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
