### PR TITLE
[skip ci] Fix codeowners files to protect CCL and TM files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -291,6 +291,7 @@ tests/ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstor
 tests/ttnn/multidevice_perf_tests/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/nightly/t3000/ccl/test_all_reduce.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/nightly/tg/ccl/test_all_reduce.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/nightly/blackhole/ccl @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/gtests/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/eltwise/ @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -270,6 +270,22 @@ ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/ 
 ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/codeowner-bypass
 ttnn/api/tools/profiler/ @mo-tenstorrent @abhullar-tt @tenstorrent/codeowner-bypass
+
+tests/ttnn/stress_tests/test_ccl.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/ttnn/stress_tests/test_data_movement.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+
+tests/tt_eager/python_api_testing/unit_testing/misc/test_concat.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_fill_rm.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_move.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_reshape.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_test.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_test.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+
+
 tests/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @bbradelTT @tenstorrent/codeowner-bypass
 tests/ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra
 tests/ttnn/multidevice_perf_tests/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
@@ -281,7 +297,7 @@ tests/ttnn/unit_tests/operations/eltwise/ @tenstorrent/metalium-developers-eltwi
 tests/ttnn/unit_tests/gtests/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/matmul/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/data_movement/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
-tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_for_conv.py @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/ttnn/nightly/unit_tests/operations/data_movement/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 /tests/ttnn/**/unit_tests/operations/fused/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 /tests/ttnn/**/unit_tests/operations/reduce/ @tenstorrent/metalium-developers-external-experience @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/**/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -271,8 +271,7 @@ ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/
 ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/codeowner-bypass
 ttnn/api/tools/profiler/ @mo-tenstorrent @abhullar-tt @tenstorrent/codeowner-bypass
 
-tests/ttnn/stress_tests/test_ccl.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
-tests/ttnn/stress_tests/test_data_movement.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+
 
 tests/tt_eager/python_api_testing/unit_testing/misc/test_concat.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/tt_eager/python_api_testing/unit_testing/misc/test_fill_rm.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
@@ -291,14 +290,16 @@ tests/ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstor
 tests/ttnn/multidevice_perf_tests/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/nightly/t3000/ccl/test_all_reduce.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/nightly/tg/ccl/test_all_reduce.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
-tests/nightly/blackhole/ccl @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/nightly/blackhole/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/gtests/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/eltwise/ @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/gtests/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/matmul/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/data_movement/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
-tests/ttnn/nightly/unit_tests/operations/data_movement/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/ttnn/nightly/unit_tests/operations/data_movement/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/ttnn/stress_tests/test_ccl.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/ttnn/stress_tests/test_data_movement.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 /tests/ttnn/**/unit_tests/operations/fused/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 /tests/ttnn/**/unit_tests/operations/reduce/ @tenstorrent/metalium-developers-external-experience @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/**/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass


### PR DESCRIPTION
Some of my team's files were not protected, in particular on the testing side, adding protection
