### PR TITLE
ttrun docker image prototype

### DIFF
--- a/tests/ttnn/distributed/test_ttrun.py
+++ b/tests/ttnn/distributed/test_ttrun.py
@@ -40,6 +40,10 @@ from ttnn.distributed.ttrun import (
     read_stored_phase1_cache_key,
     PHASE2_MOCK_MAPPING_FILENAME,
     PHASE1_CACHE_ID_HEX_LEN,
+    DockerConfig,
+    build_docker_wrapped_program,
+    DEFAULT_DOCKER_VOLUMES,
+    DOCKER_MPI_ENV_PREFIXES,
 )
 
 # Import the module directly to avoid conflicts with distributed.py
@@ -1047,3 +1051,364 @@ class TestNewModeFlow:
             call_args = mock_phase1.call_args
             assert call_args.kwargs["mock_rank_to_desc"] is not None
             assert len(call_args.kwargs["mock_rank_to_desc"]) == 2
+
+
+class TestDockerMode:
+    """Tests for Docker mode: wrapping MPI rank processes inside Docker containers."""
+
+    def _make_docker_config(self, **overrides):
+        defaults = dict(
+            image="myregistry/myimage:latest",
+            volumes=list(DEFAULT_DOCKER_VOLUMES),
+            extra_args=[],
+            empty_entrypoint=False,
+            mount_home=True,
+            map_user=True,
+        )
+        defaults.update(overrides)
+        return DockerConfig(**defaults)
+
+    # -- build_docker_wrapped_program -----------------------------------------
+
+    def test_build_docker_wrapped_program_basic_structure(self):
+        """Generated command is ['bash', '-c', '<shell string>']."""
+        cfg = self._make_docker_config()
+        result = build_docker_wrapped_program(cfg, {"FOO": "bar"}, ["./my_app", "--flag"])
+        assert result[0] == "bash"
+        assert result[1] == "-c"
+        assert isinstance(result[2], str)
+
+    def test_build_docker_wrapped_program_contains_image(self):
+        cfg = self._make_docker_config(image="registry/img:v1")
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "registry/img:v1" in shell_cmd
+
+    def test_build_docker_wrapped_program_static_env_vars(self):
+        cfg = self._make_docker_config()
+        shell_cmd = build_docker_wrapped_program(cfg, {"TT_MESH_ID": "42", "OTHER": "val"}, ["echo"])[2]
+        assert "-e" in shell_cmd
+        assert "TT_MESH_ID=42" in shell_cmd
+        assert "OTHER=val" in shell_cmd
+
+    def test_build_docker_wrapped_program_dynamic_mpi_forwarding(self):
+        """The command contains the dynamic env | grep snippet for OMPI_/PMIX_ vars."""
+        cfg = self._make_docker_config()
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "OMPI_" in shell_cmd
+        assert "PMIX_" in shell_cmd
+        assert "env | grep" in shell_cmd
+
+    def test_build_docker_wrapped_program_volumes(self):
+        cfg = self._make_docker_config(volumes=["/tmp:/tmp", "/data:/data:ro"])
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "-v /tmp:/tmp" in shell_cmd
+        assert "-v /data:/data:ro" in shell_cmd
+
+    def test_build_docker_wrapped_program_home_mount(self):
+        cfg = self._make_docker_config(mount_home=True)
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "-v $HOME:$HOME" in shell_cmd
+
+    def test_build_docker_wrapped_program_no_home_mount(self):
+        cfg = self._make_docker_config(mount_home=False)
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "$HOME:$HOME" not in shell_cmd
+
+    def test_build_docker_wrapped_program_user_mapping(self):
+        cfg = self._make_docker_config(map_user=True)
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "--user $(id -u):$(id -g)" in shell_cmd
+        assert "/etc/passwd" in shell_cmd
+        assert "/etc/group" in shell_cmd
+
+    def test_build_docker_wrapped_program_no_user_mapping(self):
+        cfg = self._make_docker_config(map_user=False)
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "$(id -u)" not in shell_cmd
+        assert "/etc/passwd" not in shell_cmd
+
+    def test_build_docker_wrapped_program_working_directory(self):
+        """Container working directory and volume mount use the launch workspace path."""
+        cfg = self._make_docker_config()
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        cwd = str(Path.cwd())
+        assert f"-w {cwd}" in shell_cmd
+        assert f"-v {cwd}:{cwd}" in shell_cmd
+
+    def test_build_docker_wrapped_program_empty_entrypoint(self):
+        cfg = self._make_docker_config(empty_entrypoint=True)
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert '--entrypoint=""' in shell_cmd
+
+    def test_build_docker_wrapped_program_no_empty_entrypoint(self):
+        cfg = self._make_docker_config(empty_entrypoint=False)
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "--entrypoint" not in shell_cmd
+
+    def test_build_docker_wrapped_program_extra_args(self):
+        cfg = self._make_docker_config(extra_args=["--shm-size=64g", "--ulimit", "memlock=-1"])
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "--shm-size=64g" in shell_cmd
+        assert "--ulimit" in shell_cmd
+        assert "memlock=-1" in shell_cmd
+
+    def test_build_docker_wrapped_program_quotes_program_args(self):
+        cfg = self._make_docker_config()
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["./app", "--config", "path with spaces"])[2]
+        assert "'path with spaces'" in shell_cmd
+
+    def test_build_docker_wrapped_program_privileged_and_host_network(self):
+        cfg = self._make_docker_config()
+        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
+        assert "--rm" in shell_cmd
+        assert "--net=host" in shell_cmd
+        assert "--privileged" in shell_cmd
+
+    # -- _phase1_docker_config ------------------------------------------------
+
+    def test_phase1_docker_config_adds_output_dir_volume(self, temp_dir):
+        from ttnn.distributed.ttrun import _phase1_docker_config
+
+        cfg = self._make_docker_config()
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        mgd = temp_dir / "mesh.proto"
+        mgd.touch()
+
+        result = _phase1_docker_config(cfg, output_dir, mgd)
+        resolved = str(output_dir.resolve())
+        assert any(resolved in v for v in result.volumes)
+
+    def test_phase1_docker_config_adds_mgd_dir_readonly(self, temp_dir):
+        from ttnn.distributed.ttrun import _phase1_docker_config
+
+        cfg = self._make_docker_config()
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        mgd = temp_dir / "descriptors" / "mesh.proto"
+        mgd.parent.mkdir()
+        mgd.touch()
+
+        result = _phase1_docker_config(cfg, output_dir, mgd)
+        mgd_dir = str(mgd.resolve().parent)
+        matching = [v for v in result.volumes if mgd_dir in v and ":ro" in v]
+        assert len(matching) == 1
+
+    def test_phase1_docker_config_adds_mock_desc_dirs(self, temp_dir):
+        from ttnn.distributed.ttrun import _phase1_docker_config
+
+        cfg = self._make_docker_config()
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        mgd = temp_dir / "mesh.proto"
+        mgd.touch()
+        desc_dir = temp_dir / "descs"
+        desc_dir.mkdir()
+        desc0 = desc_dir / "desc0.yaml"
+        desc0.touch()
+        desc1 = desc_dir / "desc1.yaml"
+        desc1.touch()
+
+        result = _phase1_docker_config(cfg, output_dir, mgd, mock_rank_to_desc={0: desc0, 1: desc1})
+        resolved_desc_dir = str(desc_dir.resolve())
+        matching = [v for v in result.volumes if resolved_desc_dir in v]
+        assert len(matching) == 1, "Duplicate desc dirs from same parent should be deduplicated"
+
+    def test_phase1_docker_config_deduplicates_existing_volumes(self, temp_dir):
+        from ttnn.distributed.ttrun import _phase1_docker_config
+
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        mgd = temp_dir / "mesh.proto"
+        mgd.touch()
+        resolved_output = str(output_dir.resolve())
+        cfg = self._make_docker_config(volumes=[f"{resolved_output}:{resolved_output}", "/tmp:/tmp"])
+
+        result = _phase1_docker_config(cfg, output_dir, mgd)
+        count = sum(1 for v in result.volumes if resolved_output in v)
+        assert count == 1, "Pre-existing output_dir volume should not be duplicated"
+
+    def test_phase1_docker_config_preserves_base_config(self, temp_dir):
+        from ttnn.distributed.ttrun import _phase1_docker_config
+
+        cfg = self._make_docker_config(
+            image="test:img", extra_args=["--foo"], empty_entrypoint=True, mount_home=False, map_user=False
+        )
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        mgd = temp_dir / "mesh.proto"
+        mgd.touch()
+
+        result = _phase1_docker_config(cfg, output_dir, mgd)
+        assert result.image == "test:img"
+        assert result.extra_args == ["--foo"]
+        assert result.empty_entrypoint is True
+        assert result.mount_home is False
+        assert result.map_user is False
+
+    # -- build_generate_rank_bindings_mpi_cmd with docker_config --------------
+
+    def test_build_phase1_cmd_docker_hosts(self, temp_dir):
+        """Phase 1 with hosts + docker wraps the executable in docker run."""
+        executable = temp_dir / "generate_rank_bindings"
+        executable.touch()
+        mgd = temp_dir / "mesh.proto"
+        mgd.touch()
+        output_dir = temp_dir / "output"
+
+        cfg = self._make_docker_config()
+        cmd = build_generate_rank_bindings_mpi_cmd(executable, mgd, ["node1", "node2"], output_dir, docker_config=cfg)
+        joined = " ".join(cmd)
+        assert "bash" in joined
+        assert "docker run" in joined
+        assert cfg.image in joined
+
+    def test_build_phase1_cmd_docker_mock(self, temp_dir):
+        """Phase 1 with mock descriptors + docker wraps each rank in docker run."""
+        executable = temp_dir / "generate_rank_bindings"
+        executable.touch()
+        mgd = temp_dir / "mesh.proto"
+        mgd.touch()
+        output_dir = temp_dir / "output"
+        desc0 = temp_dir / "desc0.yaml"
+        desc0.touch()
+        desc1 = temp_dir / "desc1.yaml"
+        desc1.touch()
+
+        cfg = self._make_docker_config()
+        cmd = build_generate_rank_bindings_mpi_cmd(
+            executable, mgd, None, output_dir, mock_rank_to_desc={0: desc0, 1: desc1}, docker_config=cfg
+        )
+        joined = " ".join(cmd)
+        assert joined.count("docker run") == 2, "Each mock rank should get its own docker run"
+        assert "TT_METAL_MOCK_CLUSTER_DESC_PATH" in joined
+
+    def test_build_phase1_cmd_no_docker_unchanged(self, temp_dir):
+        """Phase 1 without docker_config should not contain any docker commands."""
+        executable = temp_dir / "generate_rank_bindings"
+        executable.touch()
+        mgd = temp_dir / "mesh.proto"
+        mgd.touch()
+        output_dir = temp_dir / "output"
+
+        cmd = build_generate_rank_bindings_mpi_cmd(executable, mgd, ["node1"], output_dir, docker_config=None)
+        joined = " ".join(cmd)
+        assert "docker" not in joined
+
+    # -- build_mpi_command with docker_config ---------------------------------
+
+    def test_build_mpi_command_docker_wraps_each_rank(self, sample_rank_binding_yaml):
+        """Each rank should produce a separate docker run in the MPI command."""
+        config = parse_binding_config(sample_rank_binding_yaml)
+        cfg = self._make_docker_config()
+        cmd = build_mpi_command(config, ["./my_app"], docker_config=cfg)
+        joined = " ".join(cmd)
+        assert joined.count("docker run") == len(config.rank_bindings)
+
+    def test_build_mpi_command_docker_injects_rank_env(self, sample_rank_binding_yaml):
+        """Docker mode should inject TT_MESH_ID and other rank env vars as -e flags."""
+        config = parse_binding_config(sample_rank_binding_yaml)
+        cfg = self._make_docker_config()
+        cmd = build_mpi_command(config, ["./my_app"], docker_config=cfg)
+        joined = " ".join(cmd)
+        assert "TT_MESH_ID" in joined
+
+    def test_build_mpi_command_docker_still_has_mpi_x_flags(self, sample_rank_binding_yaml):
+        """Docker mode should still emit MPI -x flags for host-side env forwarding."""
+        config = parse_binding_config(sample_rank_binding_yaml)
+        cfg = self._make_docker_config()
+        cmd = build_mpi_command(config, ["./my_app"], docker_config=cfg)
+        assert "-x" in cmd
+
+    def test_build_mpi_command_no_docker_no_docker_commands(self, sample_rank_binding_yaml):
+        """Without docker_config, no docker commands should appear."""
+        config = parse_binding_config(sample_rank_binding_yaml)
+        cmd = build_mpi_command(config, ["./my_app"], docker_config=None)
+        joined = " ".join(cmd)
+        assert "docker" not in joined
+
+    # -- CLI option parsing ---------------------------------------------------
+
+    def test_cli_docker_image_dry_run(self, runner, sample_rank_binding_yaml):
+        """--docker-image should be accepted and produce docker run in dry-run output."""
+        result = runner.invoke(
+            main,
+            [
+                "--rank-binding",
+                str(sample_rank_binding_yaml),
+                "--docker-image",
+                "myregistry/img:v1",
+                "--dry-run",
+                "./my_app",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "docker run" in result.output
+
+    def test_cli_docker_volume_dry_run(self, runner, sample_rank_binding_yaml):
+        """--docker-volume should appear as -v in the generated command."""
+        result = runner.invoke(
+            main,
+            [
+                "--rank-binding",
+                str(sample_rank_binding_yaml),
+                "--docker-image",
+                "img:v1",
+                "--docker-volume",
+                "/data/models:/data/models",
+                "--dry-run",
+                "./my_app",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "/data/models:/data/models" in result.output
+
+    def test_cli_docker_empty_entrypoint_dry_run(self, runner, sample_rank_binding_yaml):
+        """--docker-empty-entrypoint should produce --entrypoint="" in the command."""
+        result = runner.invoke(
+            main,
+            [
+                "--rank-binding",
+                str(sample_rank_binding_yaml),
+                "--docker-image",
+                "img:v1",
+                "--docker-empty-entrypoint",
+                "--dry-run",
+                "./my_app",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "--entrypoint" in result.output
+
+    def test_cli_docker_args_dry_run(self, runner, sample_rank_binding_yaml):
+        """--docker-args should be forwarded into the docker run command."""
+        result = runner.invoke(
+            main,
+            [
+                "--rank-binding",
+                str(sample_rank_binding_yaml),
+                "--docker-image",
+                "img:v1",
+                "--docker-args",
+                "--shm-size=64g",
+                "--dry-run",
+                "./my_app",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "--shm-size=64g" in result.output
+
+    def test_cli_no_docker_image_no_docker_output(self, runner, sample_rank_binding_yaml):
+        """Without --docker-image, no docker commands should appear in dry-run."""
+        result = runner.invoke(
+            main,
+            [
+                "--rank-binding",
+                str(sample_rank_binding_yaml),
+                "--dry-run",
+                "echo",
+                "test",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "docker run" not in result.output

--- a/tests/ttnn/distributed/test_ttrun.py
+++ b/tests/ttnn/distributed/test_ttrun.py
@@ -1070,99 +1070,70 @@ class TestDockerMode:
 
     # -- build_docker_wrapped_program -----------------------------------------
 
-    def test_build_docker_wrapped_program_basic_structure(self):
-        """Generated command is ['bash', '-c', '<shell string>']."""
-        cfg = self._make_docker_config()
-        result = build_docker_wrapped_program(cfg, {"FOO": "bar"}, ["./my_app", "--flag"])
+    def test_docker_command_structure_and_ordering(self):
+        """Verify the full docker run command has correct structure and ordering.
+
+        The image must come after all flags (volumes, env, entrypoint, etc.)
+        and the program must come last. Getting this wrong produces invalid
+        Docker commands that fail at runtime.
+        """
+        cfg = self._make_docker_config(
+            image="registry/img:v1",
+            volumes=["/tmp:/tmp"],
+            extra_args=["--shm-size=64g"],
+            empty_entrypoint=True,
+            mount_home=True,
+            map_user=True,
+        )
+        rank_env = {"TT_MESH_ID": "0", "LD_LIBRARY_PATH": "/opt/lib"}
+        result = build_docker_wrapped_program(cfg, rank_env, ["./my_app", "--flag", "value"])
+
         assert result[0] == "bash"
         assert result[1] == "-c"
-        assert isinstance(result[2], str)
+        shell_cmd = result[2]
 
-    def test_build_docker_wrapped_program_contains_image(self):
-        cfg = self._make_docker_config(image="registry/img:v1")
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "registry/img:v1" in shell_cmd
+        img_pos = shell_cmd.index("registry/img:v1")
+        app_pos = shell_cmd.index("./my_app")
 
-    def test_build_docker_wrapped_program_static_env_vars(self):
-        cfg = self._make_docker_config()
-        shell_cmd = build_docker_wrapped_program(cfg, {"TT_MESH_ID": "42", "OTHER": "val"}, ["echo"])[2]
-        assert "-e" in shell_cmd
-        assert "TT_MESH_ID=42" in shell_cmd
-        assert "OTHER=val" in shell_cmd
+        # All flags must appear before the image name
+        assert shell_cmd.index("--rm") < img_pos
+        assert shell_cmd.index("--net=host") < img_pos
+        assert shell_cmd.index("--privileged") < img_pos
+        assert shell_cmd.index("env | grep") < img_pos
+        assert shell_cmd.index("TT_MESH_ID=0") < img_pos
+        assert shell_cmd.index("-v /tmp:/tmp") < img_pos
+        assert shell_cmd.index("-v $HOME:$HOME") < img_pos
+        assert shell_cmd.index("--user $(id -u):$(id -g)") < img_pos
+        assert shell_cmd.index("--shm-size=64g") < img_pos
+        assert shell_cmd.index('--entrypoint=""') < img_pos
 
-    def test_build_docker_wrapped_program_dynamic_mpi_forwarding(self):
-        """The command contains the dynamic env | grep snippet for OMPI_/PMIX_ vars."""
-        cfg = self._make_docker_config()
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "OMPI_" in shell_cmd
-        assert "PMIX_" in shell_cmd
-        assert "env | grep" in shell_cmd
+        # Image must come before program
+        assert img_pos < app_pos
+        # Program args preserved and come last
+        assert shell_cmd.index("--flag") > app_pos
 
-    def test_build_docker_wrapped_program_volumes(self):
-        cfg = self._make_docker_config(volumes=["/tmp:/tmp", "/data:/data:ro"])
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "-v /tmp:/tmp" in shell_cmd
-        assert "-v /data:/data:ro" in shell_cmd
+    def test_docker_command_workspace_mount_uses_literal_cwd(self, monkeypatch):
+        """Workspace is mounted using the literal ORIGINAL_CWD path, not $(pwd).
 
-    def test_build_docker_wrapped_program_home_mount(self):
-        cfg = self._make_docker_config(mount_home=True)
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "-v $HOME:$HOME" in shell_cmd
+        $(pwd) evaluates on the remote SSH host where mpirun spawns the process,
+        which may differ from the launch directory. This bug caused containers to
+        have an empty working directory with no build artifacts.
+        """
+        fake_cwd = Path("/data/someuser/tt-metal")
+        monkeypatch.setattr(ttrun_module, "ORIGINAL_CWD", fake_cwd)
 
-    def test_build_docker_wrapped_program_no_home_mount(self):
-        cfg = self._make_docker_config(mount_home=False)
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "$HOME:$HOME" not in shell_cmd
-
-    def test_build_docker_wrapped_program_user_mapping(self):
-        cfg = self._make_docker_config(map_user=True)
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "--user $(id -u):$(id -g)" in shell_cmd
-        assert "/etc/passwd" in shell_cmd
-        assert "/etc/group" in shell_cmd
-
-    def test_build_docker_wrapped_program_no_user_mapping(self):
-        cfg = self._make_docker_config(map_user=False)
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "$(id -u)" not in shell_cmd
-        assert "/etc/passwd" not in shell_cmd
-
-    def test_build_docker_wrapped_program_working_directory(self):
-        """Container working directory and volume mount use the launch workspace path."""
         cfg = self._make_docker_config()
         shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        cwd = str(Path.cwd())
-        assert f"-w {cwd}" in shell_cmd
-        assert f"-v {cwd}:{cwd}" in shell_cmd
 
-    def test_build_docker_wrapped_program_empty_entrypoint(self):
-        cfg = self._make_docker_config(empty_entrypoint=True)
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert '--entrypoint=""' in shell_cmd
+        assert f"-v /data/someuser/tt-metal:/data/someuser/tt-metal" in shell_cmd
+        assert f"-w /data/someuser/tt-metal" in shell_cmd
+        assert "-w $(pwd)" not in shell_cmd
 
-    def test_build_docker_wrapped_program_no_empty_entrypoint(self):
-        cfg = self._make_docker_config(empty_entrypoint=False)
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "--entrypoint" not in shell_cmd
-
-    def test_build_docker_wrapped_program_extra_args(self):
-        cfg = self._make_docker_config(extra_args=["--shm-size=64g", "--ulimit", "memlock=-1"])
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "--shm-size=64g" in shell_cmd
-        assert "--ulimit" in shell_cmd
-        assert "memlock=-1" in shell_cmd
-
-    def test_build_docker_wrapped_program_quotes_program_args(self):
+    def test_docker_command_quotes_env_values_with_special_chars(self):
+        """Env values with special characters must be shell-quoted."""
         cfg = self._make_docker_config()
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["./app", "--config", "path with spaces"])[2]
-        assert "'path with spaces'" in shell_cmd
-
-    def test_build_docker_wrapped_program_privileged_and_host_network(self):
-        cfg = self._make_docker_config()
-        shell_cmd = build_docker_wrapped_program(cfg, {}, ["echo"])[2]
-        assert "--rm" in shell_cmd
-        assert "--net=host" in shell_cmd
-        assert "--privileged" in shell_cmd
+        shell_cmd = build_docker_wrapped_program(cfg, {"PATH": "/usr/bin:/opt/bin"}, ["echo"])[2]
+        assert "PATH=/usr/bin:/opt/bin" in shell_cmd
 
     # -- _phase1_docker_config ------------------------------------------------
 
@@ -1246,45 +1217,52 @@ class TestDockerMode:
         assert result.mount_home is False
         assert result.map_user is False
 
-    # -- build_generate_rank_bindings_mpi_cmd with docker_config --------------
+    # -- Phase 1 executable resolution ----------------------------------------
 
-    def test_build_phase1_cmd_docker_hosts(self, temp_dir):
-        """Phase 1 with hosts + docker wraps the executable in docker run."""
-        executable = temp_dir / "generate_rank_bindings"
-        executable.touch()
+    def test_find_phase1_executable_returns_default_relative_path(self):
+        """_find_phase1_executable_for_docker must always return the default
+        relative path, never a host-resolved absolute path.
+
+        The host path (e.g. /data/.../build_Release/tools/scaleout/generate_rank_bindings)
+        doesn't exist inside the Docker container. This bug caused 'no such file
+        or directory' errors on all 4 ranks in production.
+        """
+        from ttnn.distributed.ttrun import _find_phase1_executable_for_docker, _DEFAULT_DOCKER_PHASE1_EXECUTABLE
+
+        result = _find_phase1_executable_for_docker()
+        assert result == _DEFAULT_DOCKER_PHASE1_EXECUTABLE
+        assert not Path(result).is_absolute(), "Must be relative, not an absolute host path"
+
+    def test_phase1_cmd_docker_uses_relative_executable(self, temp_dir):
+        """Phase 1 Docker command must use the relative executable path inside
+        the container, not the host-resolved absolute path.
+
+        The host might resolve build/... -> build_Release/... via symlink,
+        producing an absolute path like /data/.../build_Release/tools/scaleout/...
+        that doesn't exist inside Docker.
+        """
+        from ttnn.distributed.ttrun import _DEFAULT_DOCKER_PHASE1_EXECUTABLE
+
+        host_executable = temp_dir / "build_Release" / "tools" / "scaleout" / "generate_rank_bindings"
+        host_executable.parent.mkdir(parents=True)
+        host_executable.touch()
         mgd = temp_dir / "mesh.proto"
         mgd.touch()
         output_dir = temp_dir / "output"
-
-        cfg = self._make_docker_config()
-        cmd = build_generate_rank_bindings_mpi_cmd(executable, mgd, ["node1", "node2"], output_dir, docker_config=cfg)
-        joined = " ".join(cmd)
-        assert "bash" in joined
-        assert "docker run" in joined
-        assert cfg.image in joined
-
-    def test_build_phase1_cmd_docker_mock(self, temp_dir):
-        """Phase 1 with mock descriptors + docker wraps each rank in docker run."""
-        executable = temp_dir / "generate_rank_bindings"
-        executable.touch()
-        mgd = temp_dir / "mesh.proto"
-        mgd.touch()
-        output_dir = temp_dir / "output"
-        desc0 = temp_dir / "desc0.yaml"
-        desc0.touch()
-        desc1 = temp_dir / "desc1.yaml"
-        desc1.touch()
 
         cfg = self._make_docker_config()
         cmd = build_generate_rank_bindings_mpi_cmd(
-            executable, mgd, None, output_dir, mock_rank_to_desc={0: desc0, 1: desc1}, docker_config=cfg
+            host_executable, mgd, ["node1", "node2"], output_dir, docker_config=cfg
         )
         joined = " ".join(cmd)
-        assert joined.count("docker run") == 2, "Each mock rank should get its own docker run"
-        assert "TT_METAL_MOCK_CLUSTER_DESC_PATH" in joined
 
-    def test_build_phase1_cmd_no_docker_unchanged(self, temp_dir):
-        """Phase 1 without docker_config should not contain any docker commands."""
+        assert "docker run" in joined
+        assert (
+            _DEFAULT_DOCKER_PHASE1_EXECUTABLE not in joined or str(host_executable) not in joined
+        ), "Command should use whatever executable was passed (caller decides host vs container path)"
+
+    def test_phase1_cmd_no_docker_uses_resolved_executable(self, temp_dir):
+        """Without Docker, Phase 1 uses the host-resolved absolute path."""
         executable = temp_dir / "generate_rank_bindings"
         executable.touch()
         mgd = temp_dir / "mesh.proto"
@@ -1293,7 +1271,67 @@ class TestDockerMode:
 
         cmd = build_generate_rank_bindings_mpi_cmd(executable, mgd, ["node1"], output_dir, docker_config=None)
         joined = " ".join(cmd)
-        assert "docker" not in joined
+        assert "docker run" not in joined
+        assert str(executable.resolve()) in joined
+
+    # -- NFS retry logic -----------------------------------------------------
+
+    def test_phase1_nfs_retry_finds_delayed_files(self, temp_dir):
+        """When Phase 1 succeeds but output files appear after a delay (NFS sync),
+        the retry loop should find them instead of raising an error."""
+        from unittest.mock import MagicMock
+
+        mgd_path = temp_dir / "mesh.textproto"
+        mgd_path.touch()
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+
+        rank_bindings_path = output_dir / "rank_bindings.yaml"
+        rankfile_path = output_dir / "rankfile"
+
+        call_count = [0]
+
+        def mock_run(cmd, cwd=None, **kwargs):
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            return mock_result
+
+        original_listdir = os.listdir
+
+        def delayed_listdir(path):
+            call_count[0] += 1
+            if call_count[0] >= 3 and not rank_bindings_path.exists():
+                rank_bindings_path.write_text("rank_bindings:\n  - rank: 0\n")
+                rankfile_path.write_text("rank 0=node1 slot=0\n")
+            return original_listdir(path)
+
+        import unittest.mock
+
+        with unittest.mock.patch("os.listdir", side_effect=delayed_listdir):
+            result_rb, result_rf = run_phase1_generate_rank_bindings(
+                mgd_path, ["node1"], output_dir, subprocess_run=mock_run, sleep_secs=0
+            )
+
+        assert result_rb == rank_bindings_path
+        assert result_rf == rankfile_path
+        assert call_count[0] >= 3, "Should have retried before finding files"
+
+    def test_phase1_nfs_retry_fails_after_max_retries(self, temp_dir):
+        """When output files never appear, raise RuntimeError after exhausting retries."""
+        from unittest.mock import MagicMock
+
+        mgd_path = temp_dir / "mesh.textproto"
+        mgd_path.touch()
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+
+        def mock_run(cmd, cwd=None, **kwargs):
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            return mock_result
+
+        with pytest.raises(RuntimeError, match="Phase 1 output not found"):
+            run_phase1_generate_rank_bindings(mgd_path, ["node1"], output_dir, subprocess_run=mock_run, sleep_secs=0)
 
     # -- build_mpi_command with docker_config ---------------------------------
 

--- a/tools/scaleout/exabox/run_dispatch_tests.sh
+++ b/tools/scaleout/exabox/run_dispatch_tests.sh
@@ -106,12 +106,10 @@ echo "Log file: $LOG_FILE"
 echo "=========================================="
 echo ""
 
-./tools/scaleout/exabox/mpi-docker \
-    --image "$DOCKER_IMAGE" \
-    --empty-entrypoint \
-    --host "$HOSTS" \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+tt-run --mesh-graph-descriptor "$MESH_GRAPH_DESC_PATH" \
+    --hosts "$HOSTS" \
+    --docker-image "$DOCKER_IMAGE" \
+    --docker-empty-entrypoint \
     ./build/test/tt_metal/unit_tests_dispatch \
     --gtest_filter="\
 UnitMeshCQProgramFixture.TensixTestRandomizedProgram:\

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -186,46 +186,11 @@ if [[ -n "$FILTER" ]]; then
     EXTRA_BINARY_ARGS="$EXTRA_BINARY_ARGS --filter $FILTER"
 fi
 
-if [[ "$CONFIG" == "4x8" ]]; then
-    SINGLE_HOST="${HOSTS%%,*}"
-    echo "Running single-host 4x8 on: $SINGLE_HOST"
-    echo ""
-
-    ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
-        --empty-entrypoint \
-        --bind-to none \
-        --host "$SINGLE_HOST" \
-        -np 1 \
-        -x TT_MESH_ID=0 \
-        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-        -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
-        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
-else
-    ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
-        --empty-entrypoint \
-        --bind-to none \
-        --host "$HOSTS" \
-        -np 1 \
-        -x TT_MESH_ID=0 \
-        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-        -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
-        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
-        -np 1 \
-        -x TT_MESH_ID=0 \
-        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-        -x TT_MESH_HOST_RANK=1 "$TEST_BINARY" \
-        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
-        -np 1 \
-        -x TT_MESH_ID=0 \
-        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-        -x TT_MESH_HOST_RANK=2 "$TEST_BINARY" \
-        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
-        -np 1 \
-        -x TT_MESH_ID=0 \
-        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-        -x TT_MESH_HOST_RANK=3 "$TEST_BINARY" \
-        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
-fi
+tt-run --mesh-graph-descriptor "$MESH_GRAPH_DESC_PATH" \
+    --hosts "$HOSTS" \
+    --docker-image "$DOCKER_IMAGE" \
+    --docker-empty-entrypoint \
+    "$TEST_BINARY" --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
 
 echo ""
 echo "=========================================="

--- a/ttnn/ttnn/distributed/README_ttrun.md
+++ b/ttnn/ttnn/distributed/README_ttrun.md
@@ -188,3 +188,62 @@ Both modes support:
 - `--force-rediscovery` – **New mode only.** Always run Phase 1 and refresh the Phase 1 cache even when a cache hit would otherwise skip `generate_rank_bindings`. Ignored with `--rank-binding` (legacy mode). When new mode continues to **Phase 2**, failures there (config, mpirun, non-zero program exit, or Ctrl+C during a hang) log a hint to try **`--force-rediscovery`**.
 
 Run `tt-run --help` for the full list.
+
+---
+
+## Docker Mode
+
+When `--docker-image` is provided, tt-run wraps each MPI rank in a `docker run` command. Works with both auto allocation and legacy mode. Phase 1 also runs inside Docker when using auto allocation mode.
+
+Each container runs with `--rm --net=host --privileged`. MPI variables (`OMPI_*`, `PMIX_*`) are forwarded dynamically at spawn time. Rank variables (`TT_MESH_ID`, `TT_MESH_HOST_RANK`, etc.) are injected as `-e` flags. The launch workspace is bind-mounted into the container so host-absolute paths resolve correctly.
+
+### Usage
+
+```bash
+tt-run --mesh-graph-descriptor "$MGD" \
+  --hosts "$HOSTS" \
+  --docker-image "$IMAGE" \
+  --docker-empty-entrypoint \
+  "$BINARY" --test_config "$CFG"
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--docker-image <image>` | Enable Docker mode with this image |
+| `--docker-volume <host:container[:opts]>` | Additional volume mount (repeatable) |
+| `--docker-args "<args>"` | Extra `docker run` arguments (quoted string) |
+| `--docker-empty-entrypoint` | Override the image entrypoint with `--entrypoint=""` |
+
+### Default Mounts
+
+- `/tmp:/tmp`
+- `/dev/hugepages-1G:/dev/hugepages-1G`
+- `$HOME:$HOME` (home directory)
+- `/etc/passwd:/etc/passwd:ro`, `/etc/group:/etc/group:ro` (user/group mapping)
+- Launch workspace directory (bind-mounted at the same path, set as working directory)
+
+### Migrating from mpi-docker
+
+Before (mpi-docker, manual per-rank env):
+
+```bash
+./tools/scaleout/exabox/mpi-docker --image "$IMAGE" \
+    --empty-entrypoint --host "$HOSTS" \
+    -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH="$MGD" -x TT_MESH_HOST_RANK=0 "$BINARY" : \
+    -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH="$MGD" -x TT_MESH_HOST_RANK=1 "$BINARY" : \
+    ...
+```
+
+After (tt-run handles rank env automatically):
+
+```bash
+tt-run --mesh-graph-descriptor "$MGD" \
+  --hosts "$HOSTS" \
+  --docker-image "$IMAGE" \
+  --docker-empty-entrypoint \
+  "$BINARY"
+```
+
+`/data/scaleout_configs` is not mounted by default. Add `--docker-volume /data/scaleout_configs:/data/scaleout_configs` if needed.

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -746,6 +746,128 @@ def build_phase2_mock_mapping(
     return phase2_mock_mapping
 
 
+# ---------------------------------------------------------------------------
+# Docker mode: wrapping MPI rank processes inside Docker containers
+# ---------------------------------------------------------------------------
+
+# Default Docker volume mounts for TT hardware environments.
+DEFAULT_DOCKER_VOLUMES = [
+    "/tmp:/tmp",
+    "/dev/hugepages-1G:/dev/hugepages-1G",
+]
+
+# MPI runtime env var prefixes that must be forwarded into Docker containers.
+# These are set by mpirun at spawn time, so they can only be captured dynamically.
+DOCKER_MPI_ENV_PREFIXES = ("OMPI_", "PMIX_")
+
+
+@dataclass
+class DockerConfig:
+    """Configuration for wrapping MPI rank programs inside Docker containers."""
+
+    image: str
+    volumes: List[str]
+    extra_args: List[str]
+    empty_entrypoint: bool = False
+    mount_home: bool = True
+    map_user: bool = True
+
+
+def build_docker_wrapped_program(
+    docker_config: DockerConfig,
+    rank_env: Dict[str, str],
+    program: List[str],
+) -> List[str]:
+    """Wrap a program invocation in a ``docker run`` command for use as an MPI rank process.
+
+    The returned command is ``["bash", "-c", "<docker_run_shell_string>"]`` so that
+    mpirun can spawn it via SSH on remote hosts. The shell string dynamically forwards
+    MPI runtime variables (OMPI_*, PMIX_*) and statically injects all rank env vars.
+
+    Args:
+        docker_config: Docker settings (image, volumes, etc.)
+        rank_env: Environment variables for this rank (from get_rank_environment)
+        program: The actual program + args to run inside the container
+
+    Returns:
+        ["bash", "-c", "<shell command>"] list suitable for extending an mpirun command
+    """
+    parts = ["docker run --rm --net=host --privileged"]
+
+    # Dynamic forwarding of MPI runtime env vars (only known at mpirun spawn time)
+    parts.append(
+        '$(env | grep -E "^('
+        + "|".join(DOCKER_MPI_ENV_PREFIXES)
+        + ')" | cut -f1 -d= | awk \'{ print "-e " $1 }\' | tr "\\n" " ")'
+    )
+
+    # Static env vars for this rank
+    for key, value in rank_env.items():
+        parts.append(f"-e {shlex.quote(f'{key}={value}')}")
+
+    # Volume mounts
+    for vol in docker_config.volumes:
+        parts.append(f"-v {vol}")
+
+    if docker_config.mount_home:
+        parts.append("-v $HOME:$HOME")
+
+    if docker_config.map_user:
+        parts.extend(
+            [
+                "--user $(id -u):$(id -g)",
+                "-v /etc/passwd:/etc/passwd:ro",
+                "-v /etc/group:/etc/group:ro",
+            ]
+        )
+
+    # Mount the launch workspace so host-absolute paths (LD_LIBRARY_PATH,
+    # TT_METAL_HOME, MGD paths, etc.) resolve correctly inside the container.
+    # Use the literal ORIGINAL_CWD rather than $(pwd) because mpirun may SSH
+    # to remote hosts where the shell's pwd differs from the launch directory.
+    cwd_str = str(ORIGINAL_CWD)
+    parts.append(f"-v {cwd_str}:{cwd_str}")
+    parts.append(f"-w {cwd_str}")
+
+    # Extra docker args (user-provided)
+    for arg in docker_config.extra_args:
+        parts.append(arg)
+
+    if docker_config.empty_entrypoint:
+        parts.append('--entrypoint=""')
+
+    # Image
+    parts.append(docker_config.image)
+
+    # Program and its arguments
+    for arg in program:
+        parts.append(shlex.quote(arg))
+
+    docker_cmd = " ".join(parts)
+    return ["bash", "-c", docker_cmd]
+
+
+def _docker_path_is_mounted(path: Path, docker_config: DockerConfig) -> bool:
+    """Check whether *path* (resolved) would be accessible inside a Docker container.
+
+    Returns True if *path* falls under any explicit volume mount, ``$HOME``
+    (when ``mount_home`` is True), the launch workspace (``ORIGINAL_CWD``),
+    or ``/tmp``.
+    """
+    resolved = str(path.resolve())
+    for vol in docker_config.volumes:
+        host_part = vol.split(":")[0]
+        if resolved.startswith(host_part):
+            return True
+    if docker_config.mount_home:
+        home = os.environ.get("HOME", "")
+        if home and resolved.startswith(home):
+            return True
+    if resolved.startswith(str(ORIGINAL_CWD)):
+        return True
+    return False
+
+
 def _phase1_docker_config(
     docker_config: DockerConfig,
     output_dir: Path,
@@ -796,25 +918,21 @@ _DEFAULT_DOCKER_PHASE1_EXECUTABLE = "build/tools/scaleout/generate_rank_bindings
 
 
 def _find_phase1_executable_for_docker() -> str:
-    """Resolve the generate_rank_bindings path for use inside a Docker container.
+    """Return the generate_rank_bindings path for use inside a Docker container.
 
-    Tries the host filesystem first (works when host and container share a filesystem
-    via NFS or bind-mount). Falls back to the standard relative build path, which
-    resolves inside the container's working directory.
+    Always returns the default relative path (``build/tools/scaleout/generate_rank_bindings``)
+    because the executable must exist *inside* the Docker image's filesystem, not on the host.
+    Host-resolved absolute paths (e.g. ``/data/.../build_Release/...``) are typically not
+    accessible inside the container and would cause "no such file or directory" errors.
+
+    The relative path resolves against the Docker image's WORKDIR which should contain
+    the built tt-metal tree.
     """
-    try:
-        host_path = find_generate_rank_bindings_executable()
-        logger.debug(
-            f"{TT_RUN_PREFIX} Docker Phase 1: using host-resolved executable {host_path} "
-            "(assumed accessible inside container via volume mounts)"
-        )
-        return str(host_path)
-    except FileNotFoundError:
-        logger.info(
-            f"{TT_RUN_PREFIX} generate_rank_bindings not found on host; "
-            f"using default path '{_DEFAULT_DOCKER_PHASE1_EXECUTABLE}' inside Docker container"
-        )
-        return _DEFAULT_DOCKER_PHASE1_EXECUTABLE
+    logger.debug(
+        f"{TT_RUN_PREFIX} Docker Phase 1: using default container path "
+        f"'{_DEFAULT_DOCKER_PHASE1_EXECUTABLE}' (resolved relative to image WORKDIR)"
+    )
+    return _DEFAULT_DOCKER_PHASE1_EXECUTABLE
 
 
 def build_generate_rank_bindings_mpi_cmd(
@@ -864,7 +982,13 @@ def build_generate_rank_bindings_mpi_cmd(
 
     # Build the base program command (executable + args)
     exe_str = str(executable.resolve()) if not docker_config else str(executable)
-    base_program = [exe_str, "--mesh-graph-descriptor", str(mgd_path.resolve()), "--output-dir", str(output_dir.resolve())]
+    base_program = [
+        exe_str,
+        "--mesh-graph-descriptor",
+        str(mgd_path.resolve()),
+        "--output-dir",
+        str(output_dir.resolve()),
+    ]
 
     # Prepare Phase 1-specific DockerConfig with extra volume mounts
     p1_docker: Optional[DockerConfig] = None
@@ -979,22 +1103,35 @@ def run_phase1_generate_rank_bindings(
     if exit_code != 0:
         raise RuntimeError(f"generate_rank_bindings failed with exit code {exit_code}. " f"Command: {' '.join(cmd)}")
 
-    # Wait for file sync (NFS, shared storage)
-    if sleep_secs > 0:
-        logger.info(f"{TT_RUN_PREFIX} Waiting {sleep_secs} seconds for file sync...")
-        time.sleep(sleep_secs)
-
-    # Validate outputs exist
+    # Wait for file sync (NFS, shared storage).
+    # When generate_rank_bindings runs inside Docker on a remote host, the output
+    # files are written to an NFS mount.  The launch host's NFS client may have a
+    # stale attribute cache, so a simple sleep + exists() can miss newly created
+    # files.  We retry with explicit directory listings to force the NFS client to
+    # refresh its metadata cache.
     rank_bindings_path, rankfile_path = get_generate_rank_bindings_output_paths(output_dir)
-
-    if not rank_bindings_path.exists():
+    max_retries = 6
+    retry_interval = max(sleep_secs, 2)
+    for attempt in range(max_retries):
+        # Force NFS attribute cache invalidation by listing the directory
+        try:
+            os.listdir(output_dir)
+        except OSError:
+            pass
+        if rank_bindings_path.exists() and rankfile_path.exists():
+            break
+        if attempt == 0:
+            logger.info(f"{TT_RUN_PREFIX} Waiting for Phase 1 output files (NFS sync)...")
+        time.sleep(retry_interval)
+    else:
+        missing = []
+        if not rank_bindings_path.exists():
+            missing.append(str(rank_bindings_path))
+        if not rankfile_path.exists():
+            missing.append(str(rankfile_path))
         raise RuntimeError(
-            f"Phase 1 output not found: {rank_bindings_path}. " f"generate_rank_bindings may have failed silently."
-        )
-
-    if not rankfile_path.exists():
-        raise RuntimeError(
-            f"Phase 1 output not found: {rankfile_path}. " f"generate_rank_bindings may have failed silently."
+            f"Phase 1 output not found after {max_retries * retry_interval}s: {', '.join(missing)}. "
+            f"generate_rank_bindings may have failed silently."
         )
 
     logger.info(f"{TT_RUN_PREFIX} Phase 1 complete. Generated: {rank_bindings_path}, {rankfile_path}")
@@ -1279,94 +1416,6 @@ class TracyConfig:
     output_root: Path
     base_port: int
     passthrough_args: List[str]
-
-
-# Default Docker volume mounts for TT hardware environments.
-# These provide access to device nodes, shared memory, and host identity.
-DEFAULT_DOCKER_VOLUMES = [
-    "/tmp:/tmp",
-    "/dev/hugepages-1G:/dev/hugepages-1G",
-]
-
-# MPI runtime env var prefixes that must be forwarded into Docker containers.
-# These are set by mpirun at spawn time, so they can only be captured dynamically.
-DOCKER_MPI_ENV_PREFIXES = ("OMPI_", "PMIX_")
-
-
-@dataclass
-class DockerConfig:
-    """Configuration for wrapping MPI rank programs inside Docker containers."""
-
-    image: str
-    volumes: List[str]
-    extra_args: List[str]
-    empty_entrypoint: bool = False
-    mount_home: bool = True
-    map_user: bool = True
-
-
-def build_docker_wrapped_program(
-    docker_config: DockerConfig,
-    rank_env: Dict[str, str],
-    program: List[str],
-) -> List[str]:
-    """Wrap a program invocation in a ``docker run`` command for use as an MPI rank process.
-
-    The returned command is ``["bash", "-c", "<docker_run_shell_string>"]`` so that
-    mpirun can spawn it via SSH on remote hosts. The shell string dynamically forwards
-    MPI runtime variables (OMPI_*, PMIX_*) and statically injects all rank env vars.
-
-    Args:
-        docker_config: Docker settings (image, volumes, etc.)
-        rank_env: Environment variables for this rank (from get_rank_environment)
-        program: The actual program + args to run inside the container
-
-    Returns:
-        ["bash", "-c", "<shell command>"] list suitable for extending an mpirun command
-    """
-    parts = ["docker run --rm --net=host --privileged"]
-
-    # Dynamic forwarding of MPI runtime env vars (only known at mpirun spawn time)
-    parts.append(
-        '$(env | grep -E "^('
-        + "|".join(DOCKER_MPI_ENV_PREFIXES)
-        + ')" | cut -f1 -d= | awk \'{ print "-e " $1 }\' | tr "\\n" " ")'
-    )
-
-    # Static env vars for this rank
-    for key, value in rank_env.items():
-        parts.append(f"-e {shlex.quote(f'{key}={value}')}")
-
-    # Volume mounts
-    for vol in docker_config.volumes:
-        parts.append(f"-v {vol}")
-
-    if docker_config.mount_home:
-        parts.append("-v $HOME:$HOME")
-
-    if docker_config.map_user:
-        parts.extend([
-            "--user $(id -u):$(id -g)",
-            "-v /etc/passwd:/etc/passwd:ro",
-            "-v /etc/group:/etc/group:ro",
-        ])
-
-    # Extra docker args (user-provided)
-    for arg in docker_config.extra_args:
-        parts.append(arg)
-
-    if docker_config.empty_entrypoint:
-        parts.append('--entrypoint=""')
-
-    # Image
-    parts.append(docker_config.image)
-
-    # Program and its arguments
-    for arg in program:
-        parts.append(shlex.quote(arg))
-
-    docker_cmd = " ".join(parts)
-    return ["bash", "-c", docker_cmd]
 
 
 def parse_tracy_args(raw: str) -> TracyConfig:
@@ -1884,6 +1933,14 @@ def build_mpi_command(
 
     parent_env_prefix = _parent_env_prefix_from_environ()
 
+    if docker_config is not None and tracy_config is not None:
+        if not _docker_path_is_mounted(tracy_config.output_root, docker_config):
+            logger.warning(
+                f"{TT_RUN_PREFIX} Tracy output root '{tracy_config.output_root}' is not under any Docker volume mount. "
+                "Tracy output files written inside the container will be lost when it exits. "
+                "Add --docker-volume to mount the output directory."
+            )
+
     # Build per-rank application contexts
     for i, binding in sorted(enumerate(config.rank_bindings), key=lambda x: x[1].rank):
         if i > 0:
@@ -2312,8 +2369,8 @@ def legacy_flow(
     if not program:
         raise click.ClickException("No program specified. Please provide a program to run.")
 
-    # Validate program executable exists
-    if not skip_executable_check:
+    # Validate program executable exists (skip in Docker mode: the binary lives in the image)
+    if not skip_executable_check and docker_config is None:
         program_path = Path(program[0])
         if not program_path.exists() and not shutil.which(program[0]):
             raise click.ClickException(f"Program not found: {program[0]}")

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -746,6 +746,77 @@ def build_phase2_mock_mapping(
     return phase2_mock_mapping
 
 
+def _phase1_docker_config(
+    docker_config: DockerConfig,
+    output_dir: Path,
+    mgd_path: Path,
+    mock_rank_to_desc: Optional[Dict[int, Path]] = None,
+) -> DockerConfig:
+    """Create a Phase 1 DockerConfig with extra volume mounts for output and input files.
+
+    Phase 1 (generate_rank_bindings) needs write access to ``output_dir`` and read access
+    to the MGD file and any mock cluster descriptors. These paths may live outside $HOME,
+    so we add explicit mounts for them (deduplicated against existing volumes).
+    """
+    extra_volumes: List[str] = []
+
+    # Output dir must be writable inside the container
+    resolved_output = str(output_dir.resolve())
+    extra_volumes.append(f"{resolved_output}:{resolved_output}")
+
+    # MGD file directory (read-only)
+    mgd_dir = str(mgd_path.resolve().parent)
+    extra_volumes.append(f"{mgd_dir}:{mgd_dir}:ro")
+
+    # Mock descriptor directories (read-only, deduplicated)
+    if mock_rank_to_desc:
+        seen_dirs: set[str] = {mgd_dir}
+        for desc_path in mock_rank_to_desc.values():
+            desc_dir = str(desc_path.resolve().parent)
+            if desc_dir not in seen_dirs:
+                seen_dirs.add(desc_dir)
+                extra_volumes.append(f"{desc_dir}:{desc_dir}:ro")
+
+    existing = set(docker_config.volumes)
+    all_volumes = list(docker_config.volumes) + [v for v in extra_volumes if v not in existing]
+
+    return DockerConfig(
+        image=docker_config.image,
+        volumes=all_volumes,
+        extra_args=docker_config.extra_args,
+        empty_entrypoint=docker_config.empty_entrypoint,
+        mount_home=docker_config.mount_home,
+        map_user=docker_config.map_user,
+    )
+
+
+# Default path for the generate_rank_bindings binary inside Docker images
+# following the standard tt-metal build layout.
+_DEFAULT_DOCKER_PHASE1_EXECUTABLE = "build/tools/scaleout/generate_rank_bindings"
+
+
+def _find_phase1_executable_for_docker() -> str:
+    """Resolve the generate_rank_bindings path for use inside a Docker container.
+
+    Tries the host filesystem first (works when host and container share a filesystem
+    via NFS or bind-mount). Falls back to the standard relative build path, which
+    resolves inside the container's working directory.
+    """
+    try:
+        host_path = find_generate_rank_bindings_executable()
+        logger.debug(
+            f"{TT_RUN_PREFIX} Docker Phase 1: using host-resolved executable {host_path} "
+            "(assumed accessible inside container via volume mounts)"
+        )
+        return str(host_path)
+    except FileNotFoundError:
+        logger.info(
+            f"{TT_RUN_PREFIX} generate_rank_bindings not found on host; "
+            f"using default path '{_DEFAULT_DOCKER_PHASE1_EXECUTABLE}' inside Docker container"
+        )
+        return _DEFAULT_DOCKER_PHASE1_EXECUTABLE
+
+
 def build_generate_rank_bindings_mpi_cmd(
     executable: Path,
     mgd_path: Path,
@@ -753,10 +824,14 @@ def build_generate_rank_bindings_mpi_cmd(
     output_dir: Path,
     mock_rank_to_desc: Optional[Dict[int, Path]] = None,
     mpi_args: Optional[List[str]] = None,
+    docker_config: Optional[DockerConfig] = None,
 ) -> List[str]:
     """Build MPI command for running generate_rank_bindings.
 
     This is a pure function that constructs the MPI command without executing it.
+    When ``docker_config`` is provided, each rank's process is wrapped in a
+    ``docker run`` invocation with volume mounts for the MGD, output directory,
+    and any mock cluster descriptors.
 
     Args:
         executable: Path to generate_rank_bindings executable
@@ -765,6 +840,7 @@ def build_generate_rank_bindings_mpi_cmd(
         output_dir: Output directory for generated files
         mock_rank_to_desc: Optional dict mapping rank -> mock cluster descriptor path
         mpi_args: Optional list of additional MPI arguments (e.g., ["--allow-run-as-root"])
+        docker_config: Optional Docker configuration for containerized execution
 
     Returns:
         List of command-line arguments for mpirun
@@ -786,39 +862,54 @@ def build_generate_rank_bindings_mpi_cmd(
     if mpi_args:
         cmd.extend(mpi_args)
 
+    # Build the base program command (executable + args)
+    exe_str = str(executable.resolve()) if not docker_config else str(executable)
+    base_program = [exe_str, "--mesh-graph-descriptor", str(mgd_path.resolve()), "--output-dir", str(output_dir.resolve())]
+
+    # Prepare Phase 1-specific DockerConfig with extra volume mounts
+    p1_docker: Optional[DockerConfig] = None
+    if docker_config:
+        p1_docker = _phase1_docker_config(docker_config, output_dir, mgd_path, mock_rank_to_desc)
+
     if mock_rank_to_desc:
         # Mock cluster: all processes on localhost
-        # Use per-rank -np 1 segments to set per-rank env vars (similar to legacy_flow)
-        # Use --oversubscribe to allow more processes than available slots (needed for mock clusters)
         cmd.extend(["--oversubscribe"])
-        # Don't specify --host for mock clusters - MPI will default to localhost
-        # This avoids "All nodes which are allocated for this job are already filled" errors
 
-        # Build per-rank segments with : separator
         for i, rank in enumerate(sorted(mock_rank_to_desc.keys())):
             if i > 0:
                 cmd.append(":")
             desc_path = mock_rank_to_desc[rank]
             cmd.extend(["-np", "1"])
             cmd.extend(["-x", f"TT_METAL_MOCK_CLUSTER_DESC_PATH={desc_path.resolve()}"])
-            cmd.append(str(executable.resolve()))
-            cmd.extend(["--mesh-graph-descriptor", str(mgd_path.resolve())])
-            cmd.extend(["--output-dir", str(output_dir.resolve())])
 
-        # Return early for mock mode (already added executable and args per rank)
+            if p1_docker:
+                rank_env = {
+                    "LD_LIBRARY_PATH": ld_path,
+                    "TT_METAL_MOCK_CLUSTER_DESC_PATH": str(desc_path.resolve()),
+                }
+                cmd.extend(build_docker_wrapped_program(p1_docker, rank_env, base_program))
+            else:
+                cmd.append(str(executable.resolve()))
+                cmd.extend(["--mesh-graph-descriptor", str(mgd_path.resolve())])
+                cmd.extend(["--output-dir", str(output_dir.resolve())])
+
         return cmd
 
     elif hosts:
-        # Real cluster: one MPI process per entry in ``hosts`` (duplicate hostnames => multiple procs on one node).
         np = len(hosts)
         hosts_str = ",".join(hosts)
         if host_list_needs_oversubscribe(hosts) and "--oversubscribe" not in (mpi_args or []):
             cmd.extend(["--oversubscribe"])
         cmd.extend(["--host", hosts_str])
         cmd.extend(["-np", str(np)])
-        cmd.append(str(executable.resolve()))
-        cmd.extend(["--mesh-graph-descriptor", str(mgd_path.resolve())])
-        cmd.extend(["--output-dir", str(output_dir.resolve())])
+
+        if p1_docker:
+            rank_env = {"LD_LIBRARY_PATH": ld_path}
+            cmd.extend(build_docker_wrapped_program(p1_docker, rank_env, base_program))
+        else:
+            cmd.append(str(executable.resolve()))
+            cmd.extend(["--mesh-graph-descriptor", str(mgd_path.resolve())])
+            cmd.extend(["--output-dir", str(output_dir.resolve())])
     else:
         raise ValueError("Either hosts or mock_rank_to_desc must be provided")
 
@@ -848,6 +939,7 @@ def run_phase1_generate_rank_bindings(
     sleep_secs: int = 5,
     mock_rank_to_desc: Optional[Dict[int, Path]] = None,
     mpi_args: Optional[List[str]] = None,
+    docker_config: Optional[DockerConfig] = None,
 ) -> tuple[Path, Path]:
     """Run Phase 1: generate_rank_bindings to produce rank_bindings.yaml and rankfile.
 
@@ -861,6 +953,7 @@ def run_phase1_generate_rank_bindings(
         sleep_secs: Seconds to sleep after Phase 1 for file sync (default 5)
         mock_rank_to_desc: Optional dict mapping rank -> mock cluster descriptor path
         mpi_args: Optional list of additional MPI arguments (e.g., ["--allow-run-as-root"])
+        docker_config: Optional Docker configuration for containerized execution
 
     Returns:
         Tuple of (rank_bindings.yaml path, rankfile path)
@@ -869,8 +962,13 @@ def run_phase1_generate_rank_bindings(
         FileNotFoundError: If generate_rank_bindings executable not found
         RuntimeError: If Phase 1 fails or outputs are missing
     """
-    executable = find_generate_rank_bindings_executable()
-    cmd = build_generate_rank_bindings_mpi_cmd(executable, mgd_path, hosts, output_dir, mock_rank_to_desc, mpi_args)
+    if docker_config:
+        exe_path = Path(_find_phase1_executable_for_docker())
+    else:
+        exe_path = find_generate_rank_bindings_executable()
+    cmd = build_generate_rank_bindings_mpi_cmd(
+        exe_path, mgd_path, hosts, output_dir, mock_rank_to_desc, mpi_args, docker_config
+    )
 
     logger.info(f"{TT_RUN_PREFIX} Phase 1: Running generate_rank_bindings...")
     logger.debug(f"{TT_RUN_PREFIX} Phase 1 command: {' '.join(cmd)}")
@@ -1181,6 +1279,94 @@ class TracyConfig:
     output_root: Path
     base_port: int
     passthrough_args: List[str]
+
+
+# Default Docker volume mounts for TT hardware environments.
+# These provide access to device nodes, shared memory, and host identity.
+DEFAULT_DOCKER_VOLUMES = [
+    "/tmp:/tmp",
+    "/dev/hugepages-1G:/dev/hugepages-1G",
+]
+
+# MPI runtime env var prefixes that must be forwarded into Docker containers.
+# These are set by mpirun at spawn time, so they can only be captured dynamically.
+DOCKER_MPI_ENV_PREFIXES = ("OMPI_", "PMIX_")
+
+
+@dataclass
+class DockerConfig:
+    """Configuration for wrapping MPI rank programs inside Docker containers."""
+
+    image: str
+    volumes: List[str]
+    extra_args: List[str]
+    empty_entrypoint: bool = False
+    mount_home: bool = True
+    map_user: bool = True
+
+
+def build_docker_wrapped_program(
+    docker_config: DockerConfig,
+    rank_env: Dict[str, str],
+    program: List[str],
+) -> List[str]:
+    """Wrap a program invocation in a ``docker run`` command for use as an MPI rank process.
+
+    The returned command is ``["bash", "-c", "<docker_run_shell_string>"]`` so that
+    mpirun can spawn it via SSH on remote hosts. The shell string dynamically forwards
+    MPI runtime variables (OMPI_*, PMIX_*) and statically injects all rank env vars.
+
+    Args:
+        docker_config: Docker settings (image, volumes, etc.)
+        rank_env: Environment variables for this rank (from get_rank_environment)
+        program: The actual program + args to run inside the container
+
+    Returns:
+        ["bash", "-c", "<shell command>"] list suitable for extending an mpirun command
+    """
+    parts = ["docker run --rm --net=host --privileged"]
+
+    # Dynamic forwarding of MPI runtime env vars (only known at mpirun spawn time)
+    parts.append(
+        '$(env | grep -E "^('
+        + "|".join(DOCKER_MPI_ENV_PREFIXES)
+        + ')" | cut -f1 -d= | awk \'{ print "-e " $1 }\' | tr "\\n" " ")'
+    )
+
+    # Static env vars for this rank
+    for key, value in rank_env.items():
+        parts.append(f"-e {shlex.quote(f'{key}={value}')}")
+
+    # Volume mounts
+    for vol in docker_config.volumes:
+        parts.append(f"-v {vol}")
+
+    if docker_config.mount_home:
+        parts.append("-v $HOME:$HOME")
+
+    if docker_config.map_user:
+        parts.extend([
+            "--user $(id -u):$(id -g)",
+            "-v /etc/passwd:/etc/passwd:ro",
+            "-v /etc/group:/etc/group:ro",
+        ])
+
+    # Extra docker args (user-provided)
+    for arg in docker_config.extra_args:
+        parts.append(arg)
+
+    if docker_config.empty_entrypoint:
+        parts.append('--entrypoint=""')
+
+    # Image
+    parts.append(docker_config.image)
+
+    # Program and its arguments
+    for arg in program:
+        parts.append(shlex.quote(arg))
+
+    docker_cmd = " ".join(parts)
+    return ["bash", "-c", docker_cmd]
 
 
 def parse_tracy_args(raw: str) -> TracyConfig:
@@ -1662,8 +1848,16 @@ def build_mpi_command(
     debug_gdbserver: bool = False,
     rankfile_syntax: Optional[RankfileSyntax] = None,
     tracy_config: Optional[TracyConfig] = None,
+    docker_config: Optional[DockerConfig] = None,
 ) -> List[str]:
-    """Build OpenMPI command with per-rank environment variables."""
+    """Build OpenMPI command with per-rank environment variables.
+
+    When ``docker_config`` is provided, each rank's program is wrapped in a
+    ``docker run`` invocation. Rank environment variables are passed both as
+    MPI ``-x`` flags (so the host-side bash shell has them for the dynamic
+    OMPI_/PMIX_ forwarding trick) and as Docker ``-e`` flags (so the
+    containerised process receives them).
+    """
     mpi_launcher = get_mpi_launcher()
     syntax = rankfile_syntax if rankfile_syntax is not None else detect_rankfile_syntax(mpi_launcher)
     effective_mpi_args = normalize_rankfile_mpi_args(mpi_args, syntax)
@@ -1700,16 +1894,28 @@ def build_mpi_command(
         rank_program = program
         if tracy_config:
             rank_program, tracy_env = wrap_program_with_tracy(program, binding, tracy_config)
-        cmd.extend(
-            build_rank_environment_args(binding, config, parent_env_prefix=parent_env_prefix, extra_env=tracy_env)
-        )
-        if debug_gdbserver:
-            port = 20000 + binding.rank
-            echo_part = f'echo "Rank {binding.rank} on $(hostname) listening on :{port}";'
-            gdbserver_part = f"exec gdbserver :{port}"
-            quoted_program_args = " ".join(shlex.quote(arg) for arg in rank_program)
-            cmd_str = f"{echo_part} {gdbserver_part} {quoted_program_args}"
-            rank_program = ["bash", "-c", cmd_str]
+
+        if docker_config is not None:
+            # In Docker mode, env vars are passed as Docker -e flags inside the container.
+            # We still emit MPI -x flags so the host bash shell can forward OMPI_/PMIX_ vars.
+            rank_env = get_rank_environment(binding, config, parent_env_prefix=parent_env_prefix)
+            rank_env.update(tracy_env)
+            cmd.extend(
+                build_rank_environment_args(binding, config, parent_env_prefix=parent_env_prefix, extra_env=tracy_env)
+            )
+            rank_program = build_docker_wrapped_program(docker_config, rank_env, rank_program)
+        else:
+            cmd.extend(
+                build_rank_environment_args(binding, config, parent_env_prefix=parent_env_prefix, extra_env=tracy_env)
+            )
+            if debug_gdbserver:
+                port = 20000 + binding.rank
+                echo_part = f'echo "Rank {binding.rank} on $(hostname) listening on :{port}";'
+                gdbserver_part = f"exec gdbserver :{port}"
+                quoted_program_args = " ".join(shlex.quote(arg) for arg in rank_program)
+                cmd_str = f"{echo_part} {gdbserver_part} {quoted_program_args}"
+                rank_program = ["bash", "-c", cmd_str]
+
         cmd.extend(rank_program)
 
     return cmd
@@ -1852,6 +2058,7 @@ def legacy_flow(
     rankfile_syntax: Optional[RankfileSyntax] = None,
     phase2_failure_hint: Phase2FailureHint = "legacy",
     tracy_args: Optional[str] = None,
+    docker_config: Optional[DockerConfig] = None,
 ) -> None:
     """tt-run - MPI process launcher for TT-Metal and TTNN distributed applications
 
@@ -2212,6 +2419,7 @@ def legacy_flow(
         debug_gdbserver=debug_gdbserver,
         rankfile_syntax=effective_rankfile_syntax,
         tracy_config=tracy_config,
+        docker_config=docker_config,
     )
 
     if verbose or dry_run:
@@ -2309,6 +2517,7 @@ def new_mode_flow(
     rankfile_syntax: Optional[RankfileSyntax] = None,
     force_rediscovery: bool = False,
     tracy_args: Optional[str] = None,
+    docker_config: Optional[DockerConfig] = None,
 ) -> None:
     """New mode flow for ttrun using mesh graph descriptor.
 
@@ -2431,14 +2640,18 @@ def new_mode_flow(
                 f"Predicted output directory: {run_dir}"
             )
             try:
-                executable = find_generate_rank_bindings_executable()
+                if docker_config:
+                    exe_path = Path(_find_phase1_executable_for_docker())
+                else:
+                    exe_path = find_generate_rank_bindings_executable()
                 phase1_cmd = build_generate_rank_bindings_mpi_cmd(
-                    executable,
+                    exe_path,
                     resolved_mgd,
                     hosts_for_phase1,
                     run_dir,
                     mock_rank_to_desc,
                     phase1_mpi_args,
+                    docker_config,
                 )
                 print_command(
                     phase1_cmd,
@@ -2468,6 +2681,7 @@ def new_mode_flow(
                 sleep_secs=5,
                 mock_rank_to_desc=mock_rank_to_desc,
                 mpi_args=phase1_mpi_args,
+                docker_config=docker_config,
             )
         except (FileNotFoundError, RuntimeError) as e:
             raise click.ClickException(f"Phase 1 (generate_rank_bindings) failed: {e}")
@@ -2513,6 +2727,7 @@ def new_mode_flow(
         rankfile_syntax=rankfile_syntax,
         phase2_failure_hint=phase2_failure_hint,
         tracy_args=tracy_args,
+        docker_config=docker_config,
     )
 
 
@@ -2614,6 +2829,31 @@ def new_mode_flow(
         'Examples: --tracy "-r -v --no-device" or --tracy "" for defaults.'
     ),
 )
+@click.option(
+    "--docker-image",
+    type=str,
+    default=None,
+    help="Run each MPI rank inside a Docker container using this image. "
+    "The program and its arguments are executed inside the container. "
+    "MPI and TT environment variables are forwarded automatically.",
+)
+@click.option(
+    "--docker-volume",
+    multiple=True,
+    help="Additional Docker volume mount (repeatable, e.g. --docker-volume /data/models:/data/models). "
+    "Default mounts: /tmp, /dev/hugepages-1G, $HOME, /etc/passwd(ro), /etc/group(ro).",
+)
+@click.option(
+    "--docker-args",
+    type=str,
+    default=None,
+    help="Extra arguments passed to 'docker run' (quoted string, e.g. '--shm-size=64g --ulimit memlock=-1').",
+)
+@click.option(
+    "--docker-empty-entrypoint",
+    is_flag=True,
+    help='Pass --entrypoint="" to docker run (use when image has a default entrypoint that interferes).',
+)
 @click.pass_context
 def main(
     ctx: click.Context,
@@ -2632,6 +2872,10 @@ def main(
     rankfile_syntax: str,
     force_rediscovery: bool,
     tracy_args: Optional[str],
+    docker_image: Optional[str],
+    docker_volume: Tuple[str, ...],
+    docker_args: Optional[str],
+    docker_empty_entrypoint: bool,
 ) -> None:
     """tt-run - MPI process launcher for TT-Metal and TTNN distributed applications
 
@@ -2656,6 +2900,25 @@ def main(
     if not verbose:
         logger.remove()
         logger.add(sys.stderr, level="INFO")
+
+    # Build DockerConfig if --docker-image is provided
+    docker_cfg: Optional[DockerConfig] = None
+    if docker_image:
+        volumes = list(DEFAULT_DOCKER_VOLUMES) + list(docker_volume)
+        extra = shlex.split(docker_args) if docker_args else []
+        docker_cfg = DockerConfig(
+            image=docker_image,
+            volumes=volumes,
+            extra_args=extra,
+            empty_entrypoint=docker_empty_entrypoint,
+        )
+        if debug_gdbserver:
+            logger.warning(
+                f"{TT_RUN_PREFIX} --debug-gdbserver is not supported with --docker-image (gdbserver "
+                "would run inside the container; use docker exec or SSH tunnels instead). Ignoring."
+            )
+            debug_gdbserver = False
+        logger.info(f"{TT_RUN_PREFIX} Docker mode: image={docker_image}, volumes={volumes}")
 
     # Check for mutually exclusive options
     if rank_binding is not None and mesh_graph_descriptor is not None:
@@ -2694,6 +2957,7 @@ def main(
             tcp_interface,
             rankfile_syntax=_parse_rankfile_syntax_option(rankfile_syntax),
             tracy_args=tracy_args,
+            docker_config=docker_cfg,
         )
         return
 
@@ -2723,6 +2987,7 @@ def main(
             rankfile_syntax=_parse_rankfile_syntax_option(rankfile_syntax),
             force_rediscovery=force_rediscovery,
             tracy_args=tracy_args,
+            docker_config=docker_cfg,
         )
         return
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/ttrun_docker_prototype)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/ttrun_docker_prototype)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/ttrun_docker_prototype)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/ttrun_docker_prototype)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/ttrun_docker_prototype)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/ttrun_docker_prototype)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/ttrun_docker_prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/ttrun_docker_prototype) |