### PR TITLE
Fix missing NOC barriers and incorrect mcast_num_dests in SDPA readers

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -919,25 +919,23 @@ struct Slice {
     uint32_t get_d3_size() const { return d3_end - d3_start; }
 };
 
+// Fetch tiles via NOC reads into a given L1 address. No CB lifecycle — caller manages
+// cb_reserve_back / cb_push_back. Used by forwarding paths that mcast before pushing.
 template <typename CatAddrGeneratorType>
-void read_block(
+void fetch_block(
     const CatAddrGeneratorType& cat_addr_generator,
     const Slice& src_slice,
     const uint32_t end_seq_tile,
-    const uint32_t cb_id,
+    const uint32_t dst_addr,
     const uint32_t tile_bytes,
     const bool transpose) {
     const uint32_t src_rows = src_slice.get_d2_size();
     const uint32_t src_cols = src_slice.get_d3_size();
-    const uint32_t num_tiles = src_rows * src_cols;
-    cb_reserve_back(cb_id, num_tiles);
-    const uint32_t base_write_ptr = get_write_ptr(cb_id);
     uint32_t outer_ptr_stride = transpose ? tile_bytes : src_cols * tile_bytes;
     uint32_t inner_ptr_stride = transpose ? tile_bytes * src_rows : tile_bytes;
 
-    uint32_t barrier_count = 0;
     for (uint32_t row = 0; row < src_rows; ++row) {
-        uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
+        uint32_t write_ptr = dst_addr + row * outer_ptr_stride;
         for (uint32_t col = 0; col < src_cols; ++col) {
             uint32_t did_read = cat_addr_generator.maybe_read_tile(
                 src_slice.d0,
@@ -951,6 +949,19 @@ void read_block(
         }
     }
     noc_async_read_barrier();
+}
+
+template <typename CatAddrGeneratorType>
+void read_block(
+    const CatAddrGeneratorType& cat_addr_generator,
+    const Slice& src_slice,
+    const uint32_t end_seq_tile,
+    const uint32_t cb_id,
+    const uint32_t tile_bytes,
+    const bool transpose) {
+    const uint32_t num_tiles = src_slice.get_d2_size() * src_slice.get_d3_size();
+    cb_reserve_back(cb_id, num_tiles);
+    fetch_block(cat_addr_generator, src_slice, end_seq_tile, get_write_ptr(cb_id), tile_bytes, transpose);
     cb_push_back(cb_id, num_tiles);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -6,28 +6,24 @@
 #include "api/dataflow/dataflow_api.h"
 #include "dataflow_common.hpp"
 
-// Read a KV chunk into a CB for L1-L1 forwarding.
-// Skips intermediate read barriers (single barrier at end) for lower latency.
-// Returns the CB write pointer (start address of the data) for use as the forwarding source.
+// Fetch a KV chunk into L1 for forwarding. No CB lifecycle — caller manages
+// cb_reserve_back / cb_push_back. Single read barrier at end for lower latency.
 template <uint32_t tile_bytes, bool transpose, typename ReaderType>
-FORCE_INLINE uint32_t read_chunk_for_forwarding(
+FORCE_INLINE void read_chunk_for_forwarding(
     const ReaderType& reader,
-    const uint32_t cb_id,
+    const uint32_t dst_addr,
     uint32_t start_tile_id,
     const uint32_t src_rows,
     const uint32_t src_cols,
     const uint32_t dst_rows,
     const uint32_t dst_cols,
     const uint32_t skip_src_cols = 0) {
-    const uint32_t num_tiles = dst_rows * dst_cols;
-    cb_reserve_back(cb_id, num_tiles);
-    const uint32_t base_write_ptr = get_write_ptr(cb_id);
     const uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
     const uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
 
     uint32_t tile_id = start_tile_id;
     for (uint32_t row = 0; row < src_rows; ++row) {
-        uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
+        uint32_t write_ptr = dst_addr + row * outer_ptr_stride;
         for (uint32_t col = 0; col < src_cols; ++col) {
             noc_async_read_tile(tile_id++, reader, write_ptr);
             write_ptr += inner_ptr_stride;
@@ -40,12 +36,10 @@ FORCE_INLINE uint32_t read_chunk_for_forwarding(
                 continue;
             }
             uint32_t tile_idx = transpose ? col * dst_rows + row : row * dst_cols + col;
-            fill_tile_zeros<tile_bytes, false>(cb_id, tile_idx);
+            fill_zeros_async(dst_addr + tile_idx * tile_bytes, tile_bytes);
         }
     }
     noc_async_read_barrier();
-    cb_push_back(cb_id, num_tiles);
-    return base_write_ptr;
 }
 
 void kernel_main() {
@@ -437,8 +431,16 @@ void kernel_main() {
                                 );
                             } else {
                                 if (should_forward) {
-                                    cb_k_start_address = read_chunk_for_forwarding<k_tile_bytes, true>(
-                                        k_reader, cb_k_in, k_start_tile_id, kv_row_tile_count, DHt, Sk_chunk_t, DHt);
+                                    cb_reserve_back(cb_k_in, k_chunk_tiles);
+                                    cb_k_start_address = get_write_ptr(cb_k_in);
+                                    read_chunk_for_forwarding<k_tile_bytes, true>(
+                                        k_reader,
+                                        cb_k_start_address,
+                                        k_start_tile_id,
+                                        kv_row_tile_count,
+                                        DHt,
+                                        Sk_chunk_t,
+                                        DHt);
                                 } else {
                                     read_chunk_with_padding<k_tile_bytes>(
                                         k_reader,
@@ -472,6 +474,8 @@ void kernel_main() {
                                     mcast_num_dests,
                                     true /* linked: semaphore mcast follows */);
                                 noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                                noc_async_writes_flushed();
+                                cb_push_back(cb_k_in, k_chunk_tiles);
                             } else {
                                 uint64_t k_unicast_data_addr =
                                     get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
@@ -523,6 +527,7 @@ void kernel_main() {
                         if (should_forward) {
                             if constexpr (!mcast_enabled) {
                                 noc_async_writes_flushed();
+                                cb_push_back(cb_k_in, k_chunk_tiles);
                                 noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
                             }
                         }
@@ -584,9 +589,11 @@ void kernel_main() {
                                     skip_src_cols);
                             } else {
                                 if (should_forward) {
-                                    cb_v_start_address = read_chunk_for_forwarding<v_tile_bytes, false>(
+                                    cb_reserve_back(cb_v_in, v_chunk_tiles);
+                                    cb_v_start_address = get_write_ptr(cb_v_in);
+                                    read_chunk_for_forwarding<v_tile_bytes, false>(
                                         v_reader,
-                                        cb_v_in,
+                                        cb_v_start_address,
                                         v_start_tile_id,
                                         kv_row_tile_count,
                                         vDHt,
@@ -609,7 +616,8 @@ void kernel_main() {
                             }
                         }
 
-                        // Forward V chunk to next core(s) if applicable
+                        // Forward V chunk to next core(s) before push_back — prevents compute from
+                        // popping the buffer while the mcast is still reading from it.
                         if (should_forward) {
                             noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
                             noc_semaphore_set(sender_semaphore_addr_ptr, 0);
@@ -626,9 +634,12 @@ void kernel_main() {
                                 uint64_t v_unicast_data_addr =
                                     get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
                                 noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
-                                noc_async_writes_flushed();
+                            }
+                            noc_async_writes_flushed();
+                            if constexpr (!mcast_enabled) {
                                 noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
                             }
+                            cb_push_back(cb_v_in, v_chunk_tiles);
                         }
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -475,7 +475,9 @@ void kernel_main() {
                                     true /* linked: semaphore mcast follows */);
                                 noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
                                 noc_async_writes_flushed();
-                                cb_push_back(cb_k_in, k_chunk_tiles);
+                                if (!should_receive) {
+                                    cb_push_back(cb_k_in, k_chunk_tiles);
+                                }
                             } else {
                                 uint64_t k_unicast_data_addr =
                                     get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
@@ -527,7 +529,9 @@ void kernel_main() {
                         if (should_forward) {
                             if constexpr (!mcast_enabled) {
                                 noc_async_writes_flushed();
-                                cb_push_back(cb_k_in, k_chunk_tiles);
+                                if (!should_receive) {
+                                    cb_push_back(cb_k_in, k_chunk_tiles);
+                                }
                                 noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
                             }
                         }
@@ -639,7 +643,9 @@ void kernel_main() {
                             if constexpr (!mcast_enabled) {
                                 noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
                             }
-                            cb_push_back(cb_v_in, v_chunk_tiles);
+                            if (!should_receive) {
+                                cb_push_back(cb_v_in, v_chunk_tiles);
+                            }
                         }
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -291,29 +291,27 @@ void kernel_main() {
                     }
                 }
 
-                // K: either read locally (injector or not participant) or receive from previous core
+                // K: get data into CB buffer
                 cb_reserve_back(cb_k_in, k_chunk_tiles);
                 uint32_t cb_k_start_address = get_write_ptr(cb_k_in);
                 if (should_receive) {
-                    // Receive forwarded K chunk from previous core
                     noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
                     noc_semaphore_inc(sender_semaphore_noc_addr, 1);
                     noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                    cb_push_back(cb_k_in, k_chunk_tiles);
                 } else {
-                    read_block(
+                    fetch_block(
                         kv_chunk_is_joint ? joint_k_generator
                                           : (ring_iter == 0 ? local_k_generator : gathered_k_generator),
                         k_slice,
                         end_seq_tile,
-                        cb_k_in,
+                        cb_k_start_address,
                         k_tile_bytes,
                         true /*transpose*/
                     );
                 }
 
-                // Forward K chunk to next core(s): initiate async write (NOC write channel)
-                // For mcast: send linked data + companion semaphore back-to-back.
+                // Forward K to next core(s) before push_back — prevents compute from
+                // popping the buffer while the mcast is still reading from it.
                 if (should_forward) {
                     noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
                     noc_semaphore_set(sender_semaphore_addr_ptr, 0);
@@ -330,10 +328,15 @@ void kernel_main() {
                         uint64_t k_unicast_data_addr =
                             get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
                         noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
-                        noc_async_writes_flushed();
+                    }
+                    noc_async_writes_flushed();
+                    if constexpr (!mcast_enabled) {
                         noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
                     }
                 }
+
+                // Make K available to compute
+                cb_push_back(cb_k_in, k_chunk_tiles);
 
                 // Download Q on the first K iteration — after K is downloaded and forwarded.
                 // Push Q one subblock at a time so compute can start QK matmul incrementally.
@@ -367,28 +370,27 @@ void kernel_main() {
                     q_pushed = true;
                 }
 
-                // V: either read locally (injector or not participant) or receive from previous core
+                // V: get data into CB buffer
                 cb_reserve_back(cb_v_in, v_chunk_tiles);
                 uint32_t cb_v_start_address = get_write_ptr(cb_v_in);
                 if (should_receive) {
-                    // Receive forwarded V chunk from previous core
                     noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
                     noc_semaphore_inc(sender_semaphore_noc_addr, 1);
                     noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                    cb_push_back(cb_v_in, v_chunk_tiles);
                 } else {
-                    read_block(
+                    fetch_block(
                         kv_chunk_is_joint ? joint_v_generator
                                           : (ring_iter == 0 ? local_v_generator : gathered_v_generator),
                         v_slice,
                         end_seq_tile,
-                        cb_v_in,
+                        cb_v_start_address,
                         v_tile_bytes,
                         false /*transpose*/
                     );
                 }
 
-                // Forward V chunk to next core(s) if applicable
+                // Forward V to next core(s) before push_back — prevents compute from
+                // popping the buffer while the mcast is still reading from it.
                 if (should_forward) {
                     noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
                     noc_semaphore_set(sender_semaphore_addr_ptr, 0);
@@ -405,10 +407,15 @@ void kernel_main() {
                         uint64_t v_unicast_data_addr =
                             get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
                         noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
-                        noc_async_writes_flushed();
+                    }
+                    noc_async_writes_flushed();
+                    if constexpr (!mcast_enabled) {
                         noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
                     }
                 }
+
+                // Make V available to compute
+                cb_push_back(cb_v_in, v_chunk_tiles);
             }
         }
         if (KV_chunks_processed_in_iter % 2 == 0) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1039,9 +1039,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                 const CoreCoord rect_start = CoreCoord{min_x, injector_y};
                 const CoreCoord rect_end = CoreCoord{max_x, injector_y};
 
-                const uint32_t injector_x = core_work[injector_idx].physical_core.x;
-                const bool injector_inside_rect = (injector_x > min_x && injector_x < max_x);
-                const uint32_t mcast_num_dests = injector_inside_rect ? chain_size : num_receivers;
+                const uint32_t mcast_num_dests = num_receivers;
 
                 auto& injector_chain = core_chain_info[injector_idx];
                 injector_chain.use_mcast = true;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -1222,11 +1222,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                 const CoreCoord rect_start = CoreCoord{min_x, injector_y};
                 const CoreCoord rect_end = CoreCoord{max_x, injector_y};
 
-                // When the injector is geometrically inside the mcast rect (not at min or max X),
-                // the hardware counts it as a destination slot, so num_dests must include it.
-                const uint32_t injector_x = core_work[injector_idx].physical_core.x;
-                const bool injector_inside_rect = (injector_x > min_x && injector_x < max_x);
-                const uint32_t mcast_num_dests = injector_inside_rect ? chain_size : num_receivers;
+                const uint32_t mcast_num_dests = num_receivers;
 
                 // Configure injector
                 auto& injector_chain = core_chain_info[injector_idx];


### PR DESCRIPTION
## Problem

Two bugs found by running with `TT_METAL_WATCHER=1 TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=1` (NOC sanitize overhead normally masks these races).

### 1. Missing write barrier before cb_push_back in KV forwarding (reader_interleaved.cpp, ring_joint_reader.cpp, dataflow_common.hpp)

When a core reads K/V from DRAM and mcasts it to receiver cores, `cb_push_back` was called before the mcast write was flushed. This allows compute to `pop_front` and start overwriting the buffer while the mcast is still reading from it. Fix: defer `cb_push_back` until after `noc_async_writes_flushed()`, so the mcast completes before compute can touch the buffer. Also extract `fetch_block` from `read_block` to cleanly separate NOC reads from CB lifecycle in forwarding paths.

### 2. Incorrect mcast_num_dests when injector is inside mcast rectangle (sdpa_program_factory.cpp, ring_joint_sdpa_program_factory.cpp)

When the injector core is geometrically inside the mcast rectangle, `mcast_num_dests` was set to `chain_size` (injector + receivers) instead of `num_receivers`. Since the injector does not do loopback, the hardware waits for an ack from the injector that never arrives. This causes `noc_async_write_barrier()` to hang permanently. Fix: always use `num_receivers` for `mcast_num_dests`.

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/fix_barrier_sdpa_reader)](https://github.com/tenstorrent/tt-metal/actions/runs/24280734618)
- [x] [![Nightly tt-metal L2 tests (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/fix_barrier_sdpa_reader)](https://github.com/tenstorrent/tt-metal/actions/runs/24280736904)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/fix_barrier_sdpa_reader)](https://github.com/tenstorrent/tt-metal/actions/runs/24280735879) (same failure as main)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/fix_barrier_sdpa_reader)](https://github.com/tenstorrent/tt-metal/actions/runs/24280735118)
- [x] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=skrstic/fix_barrier_sdpa_reader)](https://github.com/tenstorrent/tt-metal/actions/runs/24280736635) (same failures as main)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/fix_barrier_sdpa_reader)](https://github.com/tenstorrent/tt-metal/actions/runs/24280734112)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/fix_barrier_sdpa_reader)](https://github.com/tenstorrent/tt-metal/actions/runs/24280735505) (same failure as main)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/fix_barrier_sdpa_reader)](https://github.com/tenstorrent/tt-metal/actions/runs/24280736290) (same failures as main)

## Performance

No performance impact. Tracy-profiled Math Util is unchanged.