### PR TITLE
#41136: port more matmul kernel to device 2.0 api

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -21,7 +21,6 @@ void kernel_main() {
     constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(2);
     constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(3);
     // in0 mcast args
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(6);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(7);
     // block args
@@ -31,9 +30,6 @@ void kernel_main() {
     constexpr uint32_t in0_mcast_dest_noc_start_y = get_compile_time_arg_val(10);
     constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(11);
     constexpr uint32_t in0_mcast_dest_noc_end_y = get_compile_time_arg_val(12);
-    // in0 semaphore always valid
-    uint32_t in0_mcast_sender_valid_semaphore = get_semaphore(get_compile_time_arg_val(13));
-
     constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(14);
     constexpr uint32_t in0_block_w = get_compile_time_arg_val(15);
     constexpr uint32_t in0_block_h = in0_block_num_tiles / in0_block_w;
@@ -71,13 +67,6 @@ void kernel_main() {
     receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-
-    const uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x,
-        in0_mcast_dest_noc_start_y,
-        in0_mcast_dest_noc_end_x,
-        in0_mcast_dest_noc_end_y,
-        in0_mcast_receiver_semaphore_addr);
 
     uint32_t local_read_addr = cb_in2.get_read_ptr();
 
@@ -199,8 +188,20 @@ void kernel_main() {
                      .addr = l1_write_addr_in0},
                     true);
 #endif
-                noc_semaphore_set_multicast_loopback_src(
-                    in0_mcast_sender_valid_semaphore, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
+                // Set local semaphore to VALID. For single-core configurations, this is all we need.
+                receiver_sem.set(VALID);
+                if constexpr (in0_mcast_num_cores > 1) {
+                    receiver_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                        noc,
+                        in0_mcast_dest_noc_start_x,
+                        in0_mcast_dest_noc_start_y,
+                        in0_mcast_dest_noc_end_x,
+                        in0_mcast_dest_noc_end_y,
+                        in0_mcast_num_cores);
+                    // Flush to ensure the NoC has read the VALID value from receiver_sem's L1
+                    // address before the next iteration overwrites it with INVALID.
+                    noc.async_writes_flushed();
+                }
 
                 local_read_addr += in0_block_size_bytes;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -156,7 +156,7 @@ void kernel_main() {
 
     for (uint32_t b = 0; b < in0_B; ++b) {
         if constexpr (batchB > 0) {
-            noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
+            noc.async_read(s_sparsity, cb_sparsity, sparsity_pagesize, {.page_id = b}, {.offset_bytes = 0});
             noc.async_read_barrier();
         }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -28,8 +28,6 @@ void kernel_main() {
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(7);
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(8);
     // in0 mcast args
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(9));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(10));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(11);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(12);
     constexpr uint32_t num_x = get_compile_time_arg_val(13);
@@ -76,16 +74,6 @@ void kernel_main() {
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
     experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(10));
 
-    // L1 array for valid semaphore value
-    constexpr uint32_t cb_l1_array = get_named_compile_time_arg_val("cb_l1_array");
-    experimental::CircularBuffer cb_l1(cb_l1_array);
-    uint32_t in0_mcast_sender_semaphore_valid_addr = cb_l1.get_write_ptr();
-    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_valid_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_valid_addr);
-    // Set up local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    in0_mcast_sender_semaphore_valid_addr_ptr[0] =
-        VALID;  // Load const 1 to be used as semaphore valid value sent from sender to receivers
-
     constexpr uint32_t num_remote_senders = (num_blocks_inner_dim + num_blocks_per_shard - 1) / num_blocks_per_shard;
     uint32_t remote_sender_noc_x[num_remote_senders];
     uint32_t remote_sender_noc_y[num_remote_senders];
@@ -112,13 +100,6 @@ void kernel_main() {
             }
         }
     }
-    uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x,
-        in0_mcast_dest_noc_start_y,
-        in0_mcast_dest_noc_end_x,
-        in0_mcast_dest_noc_end_y,
-        in0_mcast_receiver_semaphore_addr);
-
     receiver_sem.set(VALID);
 
     cb_in2.reserve_back(batch * in0_block_num_tiles);
@@ -302,15 +283,14 @@ void kernel_main() {
                             }
 
                             // We should also multicast the flag to destinations
-                            if constexpr (in0_mcast_num_cores == 1) {
-                                // All work is done on one core (the current one).
-                                // noc_semaphore_set_multicast_loopback_src is a no-op in this case.
-                                // Data needs to be written directly in the core.
-                                receiver_sem.set(VALID);
-                            } else {
-                                noc_semaphore_set_multicast_loopback_src(
-                                    in0_mcast_sender_semaphore_valid_addr,
-                                    in0_mcast_receiver_semaphore_noc_addr,
+                            receiver_sem.set(VALID);
+                            if constexpr (in0_mcast_num_cores > 1) {
+                                receiver_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                                    noc,
+                                    in0_mcast_dest_noc_start_x,
+                                    in0_mcast_dest_noc_start_y,
+                                    in0_mcast_dest_noc_end_x,
+                                    in0_mcast_dest_noc_end_y,
                                     in0_mcast_num_cores);
                             }
                         } else {
@@ -331,21 +311,28 @@ void kernel_main() {
                                 true);
 
                             // We should also multicast the flag to destinations
-                            noc_semaphore_set_multicast(
-                                in0_mcast_sender_semaphore_valid_addr,
-                                in0_mcast_receiver_semaphore_noc_addr,
+                            receiver_sem.set(VALID);
+                            receiver_sem.set_multicast(
+                                noc,
+                                in0_mcast_dest_noc_start_x,
+                                in0_mcast_dest_noc_start_y,
+                                in0_mcast_dest_noc_end_x,
+                                in0_mcast_dest_noc_end_y,
                                 in0_mcast_num_cores);
                         }
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                         // same vc even though cmd bufs are different Also, this only works because we are setting VCs
                         // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                        // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
-                        // which means data could be changed before
-                        //  write is issued.
-                        noc.async_writes_flushed();
-#endif
 
+                        // Flush is required because the semaphore multicast reads receiver_sem's L1
+                        // address as the source value. Without a flush, the CPU can proceed to the next
+                        // iteration and overwrite receiver_sem to INVALID before the NoC has read the
+                        // VALID value from L1, causing receivers to see INVALID and hang.
+                        // In single-core receiver-grid configurations, semaphore multicast may be compiled out;
+                        // in that case, skip the flush to avoid an unnecessary stall.
+                        if constexpr (!(core_in_in0_receiver_mcast_grid && (in0_mcast_num_cores == 1))) {
+                            noc.async_writes_flushed();
+                        }
                     } else if constexpr (core_in_in0_receiver_mcast_grid) {
                         // Increment remote sender's semaphore using pre-computed coordinates
                         sender_sem.up(noc, remote_sender_noc_x[block_id], remote_sender_noc_y[block_id], 1);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -13,6 +13,8 @@
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
 #include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
@@ -45,7 +47,6 @@ void do_signaling(const experimental::Noc& noc, uint32_t& rt_args_idx) {
     const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t pv_semaphore = get_semaphore(pv_semaphore_id);
     experimental::Semaphore<> pv_sem(pv_semaphore_id);
     const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
     if (is_privilaged) {
@@ -55,13 +56,13 @@ void do_signaling(const experimental::Noc& noc, uint32_t& rt_args_idx) {
         const uint32_t multicast_end_x = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t multicast_end_y = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t num_signalling_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
-        const uint32_t signalling_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-        const uint64_t signalling_semaphore_address =
-            get_noc_multicast_addr(multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, 0) |
-            signalling_semaphore;
+        const uint32_t signalling_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+        experimental::Semaphore<> sig_sem(signalling_semaphore_id);
         pv_sem.wait(target_sem_value);
         pv_sem.set(1);
-        noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
+        sig_sem.set(1);
+        sig_sem.set_multicast(
+            noc, multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, num_signalling_semaphores);
     } else {
         pv_sem.up(noc, pv_core_x, pv_core_y, 1);
         noc.async_atomic_barrier();
@@ -169,15 +170,21 @@ void kernel_main() {
                 cb_in1.reserve_back(in1_block_num_tiles);
                 l1_write_addr_in1 = cb_in1.get_write_ptr();
 
+                experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
                 for (uint32_t h = 0; h < in1_block_height_in_tiles; ++h) {
                     uint32_t curr_l1_read_addr_in1 = l1_read_addr_in1;
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
-                        noc_async_read_one_packet_with_state<true, true>(
-                            in1_base_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
+                        noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                            dram_bank, curr_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, vc);
+                        noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                            dram_bank,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                            curr_page_size,
+                            {.bank_id = dram_bank_id, .addr = in1_tensor_addr + curr_l1_read_addr_in1},
+                            {},
+                            vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -72,8 +72,9 @@ void kernel_main() {
     uint32_t l1_read_addr_in1 = 0;
     constexpr DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
-    uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-    noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_page_size, vc);
+    experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
+    noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+        dram_bank, in1_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, vc);
 
 #ifdef ARCH_GRAYSKULL
     for (uint32_t block = 0; block < num_blocks; ++block) {
@@ -82,7 +83,13 @@ void kernel_main() {
         l1_write_addr_in1 = cb_in1.get_write_ptr();
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_one_packet_with_state<true, true>(in1_base_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
+            noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                dram_bank,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                in1_page_size,
+                {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
+                {},
+                vc);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -102,17 +109,21 @@ void kernel_main() {
     uint32_t l1_write_addr_in1_start = cb_in1.get_write_ptr();
     l1_write_addr_in1 = l1_write_addr_in1_start;
     for (uint32_t block = 0; block < num_blocks; ++block) {
-        noc_async_read_set_trid(curr_block_trid);
-
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_one_packet_with_state_with_trid(
-                in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
+            noc.async_read<experimental::Noc::TxnIdMode::ENABLED, NOC_MAX_BURST_SIZE>(
+                dram_bank,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                in1_page_size,
+                {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
+                {},
+                vc,
+                curr_block_trid);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
 
         if (num_free_blocks_in_buffer == 2) {
-            noc_async_read_barrier_with_trid(block_trid_to_wait);
+            noc.async_read_barrier<experimental::Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
             cb_in1.push_back(in1_block_num_tiles);
             // wait for next block trid
             block_trid_to_wait = block_trid_to_wait == 3 ? 1 : (block_trid_to_wait + 1);
@@ -132,7 +143,7 @@ void kernel_main() {
         l1_write_addr_in1 = l1_write_addr_in1_start + l1_write_addr_in1_offset;
     }
     // last block to wait
-    noc_async_read_barrier_with_trid(block_trid_to_wait);
+    noc.async_read_barrier<experimental::Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
     cb_in1.push_back(in1_block_num_tiles);
 #endif
 
@@ -142,11 +153,17 @@ void kernel_main() {
     uint32_t l1_write_addr_in3 = cb_in3.get_write_ptr();
     uint32_t l1_read_addr_in3 = 0;
 
-    uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
-    noc_async_read_one_packet_set_state<true>(in3_base_addr, in3_page_size, vc);
+    noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+        dram_bank, in3_page_size, {.bank_id = dram_bank_id, .addr = in3_tensor_addr}, vc);
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
-        noc_async_read_one_packet_with_state<true, true>(in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+        noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+            dram_bank,
+            experimental::CoreLocalMem<uint32_t>(l1_write_addr_in3),
+            in3_page_size,
+            {.bank_id = dram_bank_id, .addr = in3_tensor_addr + l1_read_addr_in3},
+            {},
+            vc);
         l1_read_addr_in3 += in3_page_size;
         l1_write_addr_in3 += in3_page_size;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -245,7 +245,7 @@ void kernel_main() {
 #endif  // IN1_DRAM_HEIGHT_SHARDED
 
         if constexpr (batchB > 0) {
-            noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
+            noc.async_read(s_sparsity, cb_sparsity, sparsity_pagesize, {.page_id = b}, {.offset_bytes = 0});
             noc.async_read_barrier();
         }
 
@@ -290,14 +290,18 @@ void kernel_main() {
                         uint32_t l1_write_addr_in1_offset = 0;
                         uint32_t next_bank_id_and_dram_stride_index = 0;
 
+                        experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(
-                                current_dram_bank_id[next_bank_id_and_dram_stride_index], in1_tensor_addr);
-
+                            uint32_t shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t shard_base_addr = in1_tensor_addr;
                             if (i == 0) {
-                                in1_base_addr += dram_tensor_start_offset;
+                                shard_base_addr += dram_tensor_start_offset;
                             }
-                            noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_single_tile_size_bytes, vc);
+                            noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                dram_bank,
+                                in1_single_tile_size_bytes,
+                                {.bank_id = shard_bank_id, .addr = shard_base_addr},
+                                vc);
 
                             uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
                             uint32_t l1_write_addr_in1 = cb_in1.get_write_ptr() + l1_write_addr_in1_offset;
@@ -309,8 +313,15 @@ void kernel_main() {
                                 uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
                                 uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
-                                    noc_async_read_one_packet_with_state<true, true>(
-                                        in1_base_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc);
+                                    noc.async_read_with_state<
+                                        experimental::Noc::VcSelection::CUSTOM,
+                                        NOC_MAX_BURST_SIZE>(
+                                        dram_bank,
+                                        experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1_temp),
+                                        in1_single_tile_size_bytes,
+                                        {.bank_id = shard_bank_id, .addr = shard_base_addr + l1_read_addr_in1_temp},
+                                        {},
+                                        vc);
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
                                     l1_write_addr_in1_temp += in1_single_tile_size_bytes;
                                 }
@@ -476,18 +487,22 @@ void kernel_main() {
                         uint32_t l1_write_addr_in3_offset = 0;
                         uint32_t next_bank_id_and_dram_stride_index = 0;
 
+                        experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> bias_dram_bank;
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(
-                                current_dram_bank_id[next_bank_id_and_dram_stride_index], in3_tensor_addr);
-
+                            uint32_t bias_shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t bias_shard_base_addr = in3_tensor_addr;
                             if (i == 0) {
                                 // dram_tensor_start_offset is in in1 tile bytes; convert to
                                 // bias tile bytes since bias_dtype may differ from in1_dtype.
-                                in3_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
-                                                 bias_single_tile_size_bytes;
+                                bias_shard_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
+                                                        bias_single_tile_size_bytes;
                             }
 
-                            noc_async_read_one_packet_set_state<true>(in3_base_addr, bias_single_tile_size_bytes, vc);
+                            noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                bias_dram_bank,
+                                bias_single_tile_size_bytes,
+                                {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr},
+                                vc);
 
                             uint32_t l1_read_addr_in3 = 0;
                             l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
@@ -498,8 +513,13 @@ void kernel_main() {
                                 in1_single_tile_size_bytes;
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
-                                noc_async_read_one_packet_with_state<true, true>(
-                                    in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+                                noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                    bias_dram_bank,
+                                    experimental::CoreLocalMem<uint32_t>(l1_write_addr_in3),
+                                    bias_single_tile_size_bytes,
+                                    {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr + l1_read_addr_in3},
+                                    {},
+                                    vc);
                                 l1_read_addr_in3 += bias_single_tile_size_bytes;
                                 l1_write_addr_in3 += bias_single_tile_size_bytes;
                                 in3_block_size_bytes += bias_single_tile_size_bytes;


### PR DESCRIPTION
### Ticket
Link to Github Issue #41136

### Problem description
A new device 1.1 / 2.0 api has been created. Initial port PRs missed some code.

### What's changed
- add more uses of the new apis for matmul kernels
- add a couple of async_writes_flushed() calls that are now needed. Explanation from AI:
Here is the explanation.
The receiver_sem.set(VALID) calls were added in the migrated code at lines 269 and 297 because the migration changed which L1 address is used as the source for the semaphore multicast, which required explicitly writing VALID to the receiver semaphore before each multicast.
Original code
The original code used a separate, immutable L1 location (in0_mcast_sender_semaphore_valid_addr, obtained from cb_l1_array) as the source for the multicast:
```
// Initialization (once, before the loop):
in0_mcast_sender_semaphore_valid_addr_ptr[0] = VALID;
// In the loop (sender path, core_in_in0_receiver_mcast_grid):
if constexpr (in0_mcast_num_cores == 1) {
    receiver_sem.set(VALID);  // direct local write for single-core case
} else {
    noc_semaphore_set_multicast_loopback_src(
        in0_mcast_sender_semaphore_valid_addr,   // <-- reads from SEPARATE L1 addr (always VALID)
        in0_mcast_receiver_semaphore_noc_addr,   // <-- writes to receiver sem on all cores
        in0_mcast_num_cores);
}
```
The noc_semaphore_set_multicast_loopback_src reads 4 bytes from in0_mcast_sender_semaphore_valid_addr (a CB write pointer that was set to VALID once and never modified) and multicasts that value to the receiver semaphore address on all cores. Since the loopback variant includes the source core as a destination, the sender's own receiver semaphore was set to VALID via the NoC write — no explicit receiver_sem.set(VALID) was needed (except for the trivial in0_mcast_num_cores == 1 case).
Migrated code
The migration eliminated the separate cb_l1_array storage and instead uses receiver_sem.set_multicast(...), which reads from the receiver semaphore's own L1 address as the source:
```
// In the loop (sender path, core_in_in0_receiver_mcast_grid):
receiver_sem.set(VALID);   // <-- MUST explicitly write VALID here first
if constexpr (in0_mcast_num_cores > 1) {
    receiver_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(...);
    // reads from receiver_sem's L1 addr and multicasts to all cores
}
```
Semaphore::set_multicast reads the value to multicast from the semaphore object's own local_l1_addr_ (i.e., the receiver semaphore itself). Since receiver_sem.set(INVALID) is called at the start of each iteration (line 141), the receiver semaphore contains INVALID at the point where the multicast happens. Therefore, receiver_sem.set(VALID) must be called immediately before set_multicast to ensure the NoC reads VALID (not INVALID) from that L1 address.
The same logic applies to the not-in-receiver-grid path (line 297): even though EXCLUDE_SRC mode is used (so the sender doesn't receive the loopback write), the set_multicast still reads from receiver_sem's L1 address as the source value, so it must contain VALID.
Summary
The receiver_sem.set(VALID) calls at lines 269 and 297 are necessary because Semaphore::set_multicast uses the semaphore's own L1 address as both the source to read from and the destination to write to on remote cores. Since the semaphore is reset to INVALID at each loop iteration start, VALID must be written to it before each multicast so the NoC reads the correct value.[4:43 PM]The migration changed the multicast source to receiver_sem's own L1 address. This address is not immutable — it is overwritten to INVALID at the start of the next loop iteration (line 141: receiver_sem.set(INVALID)). This creates a race:

CPU writes the set_multicast command to the NoC write command buffer (source = receiver_sem's L1 addr, which currently contains VALID)
CPU continues executing — passes receiver_sem.wait(VALID) immediately (the local value is already VALID), does cb_in0.push_back(), enters the next iteration
CPU executes receiver_sem.set(INVALID) — overwrites the source L1 address
NoC hardware finally processes the multicast command, reads from the source L1 address — but it now contains INVALID
NoC multicasts INVALID to all receivers — they wait forever
On Wormhole, this race can manifest because the CPU can run ahead of the NoC command buffer processing. The original code was immune because the source address was constant.

Device perf passes https://github.com/tenstorrent/tt-metal/actions/runs/24205685211
Model perf passes https://github.com/tenstorrent/tt-metal/actions/runs/24205759768


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-41136_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-41136_mm_m20)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-41136_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-41136_mm_m20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-41136_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-41136_mm_m20)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-41136_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-41136_mm_m20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-41136_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-41136_mm_m20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-41136_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-41136_mm_m20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
