### PR TITLE
Apply fixes to test attention block

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -377,22 +377,23 @@ def test_attention_block(
     # Fused matmul1 (q_a_proj packed), matmul2 (q_b_proj shuffled), and DKV matmul (kv_a_proj)
     # weights as overlapped tensors sharing a single L1 buffer via BlitzDecodeWeights.
     bdw = BlitzDecodeWeights(submesh)
-    (
-        matmul_weights_overlapped,
-        matmul2_weights_overlapped,
-        dkv_matmul_weights_overlapped,
-    ) = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(
+    q_kv_weights = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(
         torch_matmul_weights,
         torch_matmul2_weights_full_unshuffled,
         torch_dkv_matmul_weights,
     )
+    matmul_weights_overlapped = q_kv_weights["q_a_proj"]
+    matmul2_weights_overlapped = q_kv_weights["q_b_proj"]
+    dkv_matmul_weights_overlapped = q_kv_weights["kv_a_proj"]
 
     # Matmul3 / kv_b1_proj weights — fused with kv_b2_proj via BlitzDecodeWeights
     torch_matmul3_weights_flat = torch_matmul3_weights.reshape(num_tp * NUM_QNOPE_HEADS * QNOPE_HEAD_DIM, QNOPE_OUT_DIM)
-    matmul3_weights_overlapped, kv_b2_overlapped = bdw.get_tt_kv_b12_proj_weights(
+    kv_b12_weights = bdw.get_tt_kv_b12_proj_weights(
         torch_matmul3_weights_flat,
         torch_kv_b2_proj_weights,
     )
+    matmul3_weights_overlapped = kv_b12_weights["kv_b1_proj"]
+    kv_b2_overlapped = kv_b12_weights["kv_b2_proj"]
 
     # SDPA input tensor - height sharded on SDPA input grid (cols 0-3, rows 1-2)
     # After 3-phase CreateQHeads tilization:
@@ -494,14 +495,7 @@ def test_attention_block(
     torch_dkv_rmsnorm_gamma = torch.randn((1, KNOPE_DIM), dtype=torch.bfloat16)
 
     # Fused o_proj, gate_mm, and RMSNorm gammas — we only need the 3 gamma overlapped views.
-    (
-        o_proj_overlapped,  # o_proj
-        _,  # gate_mm
-        gamma_overlapped,
-        rmsnorm2_gamma_overlapped,
-        dkv_rmsnorm_gamma_overlapped,
-        _,  # ffn_norm
-    ) = bdw.get_tt_o_proj_and_gate_mm_weights(
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
         torch_o_proj_weights,
         torch_gate_mm_weights,
         torch_gamma,
@@ -509,6 +503,10 @@ def test_attention_block(
         torch_dkv_rmsnorm_gamma,
         torch_ffn_norm,
     )
+    o_proj_overlapped = o_norms["o_proj"]
+    gamma_overlapped = o_norms["attn_norm"]
+    rmsnorm2_gamma_overlapped = o_norms["q_norm"]
+    dkv_rmsnorm_gamma_overlapped = o_norms["kv_norm"]
 
     # KRoPE cos/sin: DRAM INTERLEAVED (each krope core reads its width slice)
     krope_num_cores = kv_cache_branch_rope_crs.num_cores()


### PR DESCRIPTION
Blaze test attention block test was expecting a tuple output rather than a dictionary output that the API now produces, fixing this