### PR TITLE
MoE: Arbitrary experts per device

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -182,6 +182,7 @@ ttnn/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
 ttnn/**/*nanobind* @tenstorrent/metalium-developers-ttnn-core @nsextonTT @tenstorrent/codeowner-bypass
 ttnn/tutorials/ @tenstorrent/metalium-developers-ttnn-core @aczajkowskiTT @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass
+ttnn/ttnn/operations/_experimental/moe_compute_utils.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/moreh.py @razorback3 @dongjin-na @ayerofieiev-tt @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/conv2d.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/pool.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -181,8 +181,8 @@ ttnn/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
 # nanobind
 ttnn/**/*nanobind* @tenstorrent/metalium-developers-ttnn-core @nsextonTT @tenstorrent/codeowner-bypass
 ttnn/tutorials/ @tenstorrent/metalium-developers-ttnn-core @aczajkowskiTT @tenstorrent/codeowner-bypass
+ttnn/ttnn/_experimental/moe_compute_utils.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass
-ttnn/ttnn/operations/_experimental/moe_compute_utils.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/moreh.py @razorback3 @dongjin-na @ayerofieiev-tt @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/conv2d.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/pool.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -17,6 +17,8 @@ from tests.nightly.tg.ccl.moe.test_selective_combine_6U import device_mesh_itera
 from tests.nightly.t3000.ccl.test_all_to_all_combine import get_batch_cluster_idxr, get_cluster_dims
 
 from models.common.utility_functions import comp_pcc
+from models.perf.benchmarking_utils import BenchmarkProfiler
+from tracy import signpost
 
 MESH_GRAPH_DESC_1x16 = (
     "tests/tt_metal/tt_fabric/custom_mesh_descriptors/single_galaxy_1x16_torus_graph_descriptor.textproto"
@@ -932,6 +934,52 @@ def create_sharded_memory_config(core_range_set, tensor_shape, dtype):
     )
 
 
+def _run_op_with_trace(num_iters, op_func, mesh_device, profiler, profile_name="moe-compute"):
+    # compile run:
+    logger.info("Compiling model")
+    outputs = op_func()
+    ttnn.synchronize_device(mesh_device)
+
+    logger.info("Capturing Warmup")
+
+    logger.info(f"Capturing Warmup trace")
+    trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    outputs = op_func()
+    ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+    logger.info("Warmup done")
+
+    logger.info(f"Capturing Trace for {num_iters} iterations")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    all_outputs = []
+    for _ in range(num_iters):
+        outputs = op_func()
+        all_outputs.append(outputs)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    logger.info("Starting Trace perf test...")
+    profiler.start(f"{profile_name}-trace-warmup")
+    ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id_warmup)
+    ttnn.synchronize_device(mesh_device)
+    profiler.end(f"{profile_name}-trace-warmup")
+
+    signpost("start")
+    profiler.start(f"{profile_name}-trace")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+    profiler.end(f"{profile_name}-trace")
+    signpost("stop")
+
+    time_taken = profiler.get_duration(f"{profile_name}-trace") - profiler.get_duration(f"{profile_name}-trace-warmup")
+    time_taken_us = time_taken / num_iters * 1000000
+    logger.info(f"Time taken e2e: {time_taken_us:.2f} us")
+
+    return all_outputs, time_taken_us
+
+
 # Requires TT_MESH_GRAPH_DESC_PATH to be set to the 1x16 or 1x8 mesh descriptor before running
 @pytest.mark.skipif(
     not (is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_1x16) or is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_1x8)),
@@ -974,17 +1022,16 @@ def create_sharded_memory_config(core_range_set, tensor_shape, dtype):
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize("cluster_axis", [1])
-@pytest.mark.parametrize("experts_per_device", [2])  # , 3, 4])
+@pytest.mark.parametrize("experts_per_device", [2, 3, 4])
 @pytest.mark.parametrize("tokens_per_device", [32])  # Collapsed batch * seq_len
 @pytest.mark.parametrize(
-    "selected_experts_k, num_layers, num_iterations",
-    [(1, 1, 1)],
-    #     [(1, 1, 1), (8, 5, 1)],
-    #     ids=["perf", "accuracy"],
+    "selected_experts_k, num_layers, num_iterations, measure_perf",
+    [(1, 1, 5, True), (8, 5, 3, False)],
+    ids=["perf", "accuracy"],
 )
 @pytest.mark.parametrize("N, hidden_size", [(2048, 7168)])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("enable_trace", [False])
+@pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize("output_height_shard_dim", [4])
 @pytest.mark.parametrize("output_width_shard_dim", [4])
 def test_moe_compute(
@@ -996,6 +1043,7 @@ def test_moe_compute(
     selected_experts_k,
     num_layers,
     num_iterations,
+    measure_perf,
     N,
     hidden_size,
     output_height_shard_dim,
@@ -1038,6 +1086,8 @@ def test_moe_compute(
     )
     logger.info(f"  hidden_size: {hidden_size}")
     logger.info(f"  dtype: {dtype}")
+    logger.info(f"  num_iterations: {num_iterations}")
+    logger.info(f"  measure_perf: {measure_perf}, enable_trace: {enable_trace}")
 
     #########################################
     # CREATE TILIZE INPUT TENSORS AND GOLDENS
@@ -1318,6 +1368,107 @@ def test_moe_compute(
     ]
 
     #########################################
+    # HELPER FUNCTIONS FOR PERFORMANCE MEASUREMENT
+    #########################################
+
+    def prepare_layer_inputs(layer_id):
+        """Prepare inputs for a specific layer by moving from DRAM to L1"""
+        if num_layers == 1:
+            # Already in L1
+            return tt_sparse_buffers[0], tt_expert_indices_buffers[0], tt_expert_scores_buffers[0]
+        else:
+            tt_sparse_buffer = ttnn.to_memory_config(tt_sparse_buffers[layer_id], memory_config=sparse_mem_config)
+            tt_expert_indices = ttnn.to_memory_config(
+                tt_expert_indices_buffers[layer_id], memory_config=expert_indices_mem_config
+            )
+            tt_expert_scores = ttnn.to_memory_config(
+                tt_expert_scores_buffers[layer_id], memory_config=expert_scores_mem_config
+            )
+            return tt_sparse_buffer, tt_expert_indices, tt_expert_scores
+
+    def deallocate_layer_inputs(tt_sparse_buffer, tt_expert_indices, tt_expert_scores):
+        """Deallocate L1 inputs if using multiple layers"""
+        if num_layers != 1:
+            ttnn.deallocate(tt_sparse_buffer)
+            ttnn.deallocate(tt_expert_indices)
+            ttnn.deallocate(tt_expert_scores)
+
+    def convert_outputs_to_dram(outputs):
+        """Convert L1 outputs to DRAM and deallocate L1 versions"""
+        l1_per_expert, l1_activation, l1_e_t, _, l1_matmul, combine = outputs
+
+        # Convert to DRAM
+        dram_per_expert = ttnn.to_memory_config(l1_per_expert, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        dram_activation = ttnn.to_memory_config(l1_activation, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        dram_e_t = ttnn.to_memory_config(l1_e_t, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        dram_matmul = ttnn.to_memory_config(l1_matmul, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        # Deallocate L1 versions
+        ttnn.deallocate(l1_per_expert)
+        ttnn.deallocate(l1_activation)
+        ttnn.deallocate(l1_e_t)
+        ttnn.deallocate(l1_matmul)
+
+        return (dram_per_expert, dram_activation, dram_e_t, dram_matmul, combine)
+
+    def run_op_inner(tt_sparse_buffer, tt_expert_indices, tt_expert_scores, layer_id):
+        """Core moe_compute operation - used for performance measurement"""
+        return ttnn.experimental.moe_compute(
+            tt_sparse_buffer,
+            tt_expert_indices,
+            tt_expert_scores,
+            tt_expert_mapping,
+            tt_w0_w1,
+            tt_w2,
+            layer_id=layer_id,
+            output_height_shard_dim=output_height_shard_dim,
+            output_width_shard_dim=output_width_shard_dim,
+            cluster_axis=cluster_axis,
+            mux_core_range_set=mux_core_range_set,
+            optional_output_tensor=tt_combine_output_tensors[layer_id],
+            optional_cross_device_semaphore=combine_barrier_semaphore,
+        )
+
+    def run_op_perf():
+        """Performance-optimized version that runs multiple iterations but only saves last output"""
+        last_outputs_by_layer = []
+
+        # Pre-allocate all inputs in L1
+        prepared_inputs = []
+        for layer_id in range(num_layers):
+            inputs = prepare_layer_inputs(layer_id)
+            prepared_inputs.append(inputs)
+
+        # Run multiple iterations, only keep last one
+        for iter_idx in range(num_iterations):
+            layer_outputs = []
+            for layer_id in range(num_layers):
+                tt_sparse_buffer, tt_expert_indices, tt_expert_scores = prepared_inputs[layer_id]
+                outputs = run_op_inner(tt_sparse_buffer, tt_expert_indices, tt_expert_scores, layer_id)
+
+                # Only save outputs on last iteration
+                if iter_idx == num_iterations - 1:
+                    layer_outputs.append(outputs)
+
+            # Update last outputs
+            if iter_idx == num_iterations - 1:
+                last_outputs_by_layer = layer_outputs
+
+        # Clean up inputs and convert outputs to DRAM
+        final_outputs = []
+        for layer_id in range(num_layers):
+            # Deallocate inputs
+            tt_sparse_buffer, tt_expert_indices, tt_expert_scores = prepared_inputs[layer_id]
+            deallocate_layer_inputs(tt_sparse_buffer, tt_expert_indices, tt_expert_scores)
+
+            # Convert outputs to DRAM
+            if last_outputs_by_layer:
+                dram_outputs = convert_outputs_to_dram(last_outputs_by_layer[layer_id])
+                final_outputs.append(dram_outputs)
+
+        return final_outputs
+
+    #########################################
     # RUN OP
     #########################################
 
@@ -1325,86 +1476,38 @@ def test_moe_compute(
         moe_compute_outputs = []
 
         for layer_id in range(num_layers):
-            # if only running a single layer, we can fit the single set of inputs in L1 initially
-            # otherwise with multiple layers, and multiple sets of inputs, we need to move inputs into L1 before a given
-            if num_layers == 1:
-                tt_sparse_buffer = tt_sparse_buffers[0]
-                tt_expert_indices = tt_expert_indices_buffers[0]
-                tt_expert_scores = tt_expert_scores_buffers[0]
-            else:
-                tt_sparse_buffer = ttnn.to_memory_config(tt_sparse_buffers[layer_id], memory_config=sparse_mem_config)
-                tt_expert_indices = ttnn.to_memory_config(
-                    tt_expert_indices_buffers[layer_id], memory_config=expert_indices_mem_config
-                )
-                tt_expert_scores = ttnn.to_memory_config(
-                    tt_expert_scores_buffers[layer_id], memory_config=expert_scores_mem_config
-                )
+            # Prepare layer inputs
+            tt_sparse_buffer, tt_expert_indices, tt_expert_scores = prepare_layer_inputs(layer_id)
 
-            # run the op
-            (
-                l1_per_expert_total_tokens_output_tensor,
-                l1_expert_activation_output_tensor,
-                l1_e_t_output_tensor,
-                _,  # tile layout output of selective tilize (same buffer as output)
-                l1_matmul_output_tensor,
-                combine_output_tensor,
-            ) = ttnn.experimental.moe_compute(
-                tt_sparse_buffer,
-                tt_expert_indices,
-                tt_expert_scores,
-                tt_expert_mapping,
-                tt_w0_w1,
-                tt_w2,
-                layer_id=layer_id,
-                output_height_shard_dim=output_height_shard_dim,
-                output_width_shard_dim=output_width_shard_dim,
-                cluster_axis=cluster_axis,
-                mux_core_range_set=mux_core_range_set,
-                optional_output_tensor=tt_combine_output_tensors[layer_id],
-                optional_cross_device_semaphore=combine_barrier_semaphore,
-            )
+            # Run core moe_compute operation
+            outputs = run_op_inner(tt_sparse_buffer, tt_expert_indices, tt_expert_scores, layer_id)
 
-            # deallocate L1 inputs
-            # if running with multiple layers, we have to deallocate previous inputs to free up L1 space
-            # we still have the DRAM version of the input tensor after deallocating the L1 version
-            if num_layers != 1:
-                ttnn.deallocate(tt_sparse_buffer)
-                ttnn.deallocate(tt_expert_indices)
-                ttnn.deallocate(tt_expert_scores)
+            # Deallocate L1 inputs
+            deallocate_layer_inputs(tt_sparse_buffer, tt_expert_indices, tt_expert_scores)
 
-            # convert outputs to DRAM (we don't have enough L1 space to leave outputs in L1 when running multiple invocations)
-            dram_per_expert_total_tokens_output_tensor = ttnn.to_memory_config(
-                l1_per_expert_total_tokens_output_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG
-            )
-            dram_expert_activation_output_tensor = ttnn.to_memory_config(
-                l1_expert_activation_output_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG
-            )
-            dram_e_t_output_tensor = ttnn.to_memory_config(l1_e_t_output_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-            dram_matmul_output_tensor = ttnn.to_memory_config(
-                l1_matmul_output_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG
-            )
-
-            # # deallocate L1 outputs
-            ttnn.deallocate(l1_per_expert_total_tokens_output_tensor)
-            ttnn.deallocate(l1_expert_activation_output_tensor)
-            ttnn.deallocate(l1_e_t_output_tensor)
-            ttnn.deallocate(l1_matmul_output_tensor)
-
-            # save outputs to verify later
-            moe_compute_output = (
-                dram_per_expert_total_tokens_output_tensor,
-                dram_expert_activation_output_tensor,
-                dram_e_t_output_tensor,
-                dram_matmul_output_tensor,
-                combine_output_tensor,
-            )
+            # Convert outputs to DRAM and save
+            moe_compute_output = convert_outputs_to_dram(outputs)
             moe_compute_outputs.append(moe_compute_output)
 
         return moe_compute_outputs
 
     logger.info(f"\n========== Running op ==========")
+
+    # Initialize profiler based on test parameters
+    profiler = None
+    if measure_perf and enable_trace:
+        logger.info("Running in performance measurement mode")
+        profiler = BenchmarkProfiler()
+
     moe_compute_outputs = []
-    if enable_trace:
+    avg_latency_us = None
+
+    if profiler is not None:
+        # Use profiler for trace performance measurement with run_op_perf
+        all_outputs, avg_latency_us = _run_op_with_trace(num_iterations, run_op_perf, mesh_device, profiler)
+        moe_compute_outputs = all_outputs
+    elif enable_trace:
+        # Regular trace execution without profiling
         # Compile the op
         for i in range(num_iterations):
             run_op()
@@ -1422,6 +1525,7 @@ def test_moe_compute(
         ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
         logger.info(f"Done executing trace")
     else:
+        # Non-trace execution
         for i in range(num_iterations):
             moe_compute_output = run_op()
             ttnn.synchronize_device(mesh_device)
@@ -1526,6 +1630,31 @@ def test_moe_compute(
             " to the double buffer scheme"
         )
     logger.info(f"\nCombine Output Tensor Verification: {'PASSED' if combine_all_passed else 'FAILED'}")
+
+    # Report performance results if in perf mode
+    if avg_latency_us is not None:
+        logger.info("\n========== Performance Results ==========")
+        logger.info(f"Test Configuration:")
+        logger.info(f"  Mesh shape: {mesh_shape}")
+        logger.info(f"  Total experts: {experts}")
+        logger.info(f"  Selected experts (k): {selected_experts_k}")
+        logger.info(f"  Tokens per device: {tokens_per_device}")
+        logger.info(f"  Hidden size: {hidden_size}")
+        logger.info(f"  N (intermediate size): {N}")
+        logger.info(f"  Trace enabled: {enable_trace}")
+        logger.info(f"  Number of iterations: {num_iterations}")
+        logger.info(f"\nPerformance:")
+        logger.info(f"  Average E2E latency: {avg_latency_us:.2f} us")
+
+        # Calculate throughput if possible
+        total_tokens = (
+            tokens_per_device * mesh_shape[cluster_axis]
+            if cluster_axis is not None
+            else tokens_per_device * num_devices
+        )
+        tokens_per_second = (total_tokens * 1000000.0) / avg_latency_us
+        logger.info(f"  Throughput: {tokens_per_second:.2f} tokens/second")
+        logger.info("==========================================\n")
 
     assert per_expert_tokens_all_passed, "Per expert total tokens tensor verification failed!"
     assert activation_all_passed, "Expert activation tensor verification failed!"

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -40,14 +40,17 @@ def validate_per_expert_tokens(
     # L1 alignment constant (16 bytes)
     l1_alignment = 16
 
-    # Validate shape: [num_devices, aligned_row_elements]
-    # Row is experts_per_device uint32s, aligned to 16 bytes
+    # Validate shape: [num_devices, num_cores, aligned_row_elements]
+    # Row is experts_per_device uint32s, aligned to 16 bytes. Replicated on every core
     per_expert_row_bytes = ((experts_per_device * 4 + l1_alignment - 1) // l1_alignment) * l1_alignment
     per_expert_row_elements = per_expert_row_bytes // 4
-    expected_per_expert_shape = (num_devices, per_expert_row_elements)
+    # Note: the bounding box containing tilize, matmul, combine cores spans the whole grid.
+    core_range = mesh_device.compute_with_storage_grid_size()
+    num_cores = core_range.x * core_range.y
+    expected_per_expert_shape = (num_devices * num_cores, per_expert_row_elements)
 
     # Convert per_expert_total_tokens tensor to torch
-    # Shape per device: [1, aligned_elements] as uint32
+    # Shape per device: [num_cores (70), aligned_elements] as uint32
     per_expert_total_tokens_torch = ttnn.to_torch(
         per_expert_total_tokens_output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)
     )
@@ -58,21 +61,25 @@ def validate_per_expert_tokens(
         f"got {per_expert_total_tokens_torch.shape}"
     )
 
+    per_expert_total_tokens_torch = per_expert_total_tokens_torch.reshape(
+        (num_devices, num_cores, per_expert_row_elements)
+    )
     for device_idx in range(num_devices):
-        device_counts = per_expert_total_tokens_torch[device_idx].flatten()
+        for c in range(num_cores):
+            device_counts = per_expert_total_tokens_torch[device_idx][c]
 
-        for local_exp_idx in range(experts_per_device):
-            expected_count = expert_token_counts[device_idx, local_exp_idx].item()
-            actual_count = device_counts[local_exp_idx].item()
+            for local_exp_idx in range(experts_per_device):
+                expected_count = expert_token_counts[device_idx, local_exp_idx].item()
+                actual_count = device_counts[local_exp_idx].item()
 
-            if actual_count != expected_count:
-                logger.warning(
-                    f"  Device {device_idx}, Expert {local_exp_idx}: "
-                    f"count mismatch - expected {expected_count}, got {actual_count}"
-                )
-                per_expert_tokens_all_passed = False
-            else:
-                logger.info(f"  Device {device_idx}, Expert {local_exp_idx}: count={actual_count} PASSED")
+                if actual_count != expected_count:
+                    logger.warning(
+                        f"  Device {device_idx}, Expert {local_exp_idx}: "
+                        f"count mismatch - expected {expected_count}, got {actual_count}"
+                    )
+                    per_expert_tokens_all_passed = False
+                else:
+                    logger.info(f"  Device {device_idx}, Expert {local_exp_idx}: count={actual_count} PASSED")
 
     return per_expert_tokens_all_passed
 

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -17,8 +17,6 @@ from tests.nightly.tg.ccl.moe.test_selective_combine_6U import device_mesh_itera
 from tests.nightly.t3000.ccl.test_all_to_all_combine import get_batch_cluster_idxr, get_cluster_dims
 
 from models.common.utility_functions import comp_pcc
-from models.perf.benchmarking_utils import BenchmarkProfiler
-from tracy import signpost
 
 MESH_GRAPH_DESC_1x16 = (
     "tests/tt_metal/tt_fabric/custom_mesh_descriptors/single_galaxy_1x16_torus_graph_descriptor.textproto"
@@ -934,52 +932,6 @@ def create_sharded_memory_config(core_range_set, tensor_shape, dtype):
     )
 
 
-def _run_op_with_trace(num_iters, op_func, mesh_device, profiler, profile_name="moe-compute"):
-    # compile run:
-    logger.info("Compiling model")
-    outputs = op_func()
-    ttnn.synchronize_device(mesh_device)
-
-    logger.info("Capturing Warmup")
-
-    logger.info(f"Capturing Warmup trace")
-    trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-    outputs = op_func()
-    ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
-    ttnn.synchronize_device(mesh_device)
-    logger.info("Warmup done")
-
-    logger.info(f"Capturing Trace for {num_iters} iterations")
-    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-    all_outputs = []
-    for _ in range(num_iters):
-        outputs = op_func()
-        all_outputs.append(outputs)
-    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
-    ttnn.synchronize_device(mesh_device)
-
-    logger.info("Starting Trace perf test...")
-    profiler.start(f"{profile_name}-trace-warmup")
-    ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
-    ttnn.release_trace(mesh_device, trace_id_warmup)
-    ttnn.synchronize_device(mesh_device)
-    profiler.end(f"{profile_name}-trace-warmup")
-
-    signpost("start")
-    profiler.start(f"{profile_name}-trace")
-    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
-    ttnn.release_trace(mesh_device, trace_id)
-    ttnn.synchronize_device(mesh_device)
-    profiler.end(f"{profile_name}-trace")
-    signpost("stop")
-
-    time_taken = profiler.get_duration(f"{profile_name}-trace") - profiler.get_duration(f"{profile_name}-trace-warmup")
-    time_taken_us = time_taken / num_iters * 1000000
-    logger.info(f"Time taken e2e: {time_taken_us:.2f} us")
-
-    return all_outputs, time_taken_us
-
-
 # Requires TT_MESH_GRAPH_DESC_PATH to be set to the 1x16 or 1x8 mesh descriptor before running
 @pytest.mark.skipif(
     not (is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_1x16) or is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_1x8)),
@@ -1025,8 +977,8 @@ def _run_op_with_trace(num_iters, op_func, mesh_device, profiler, profile_name="
 @pytest.mark.parametrize("experts_per_device", [2, 3, 4])
 @pytest.mark.parametrize("tokens_per_device", [32])  # Collapsed batch * seq_len
 @pytest.mark.parametrize(
-    "selected_experts_k, num_layers, num_iterations, measure_perf",
-    [(1, 1, 5, True), (8, 5, 3, False)],
+    "selected_experts_k, num_layers, num_iterations",
+    [(1, 1, 5), (8, 5, 3)],
     ids=["perf", "accuracy"],
 )
 @pytest.mark.parametrize("N, hidden_size", [(2048, 7168)])
@@ -1043,7 +995,6 @@ def test_moe_compute(
     selected_experts_k,
     num_layers,
     num_iterations,
-    measure_perf,
     N,
     hidden_size,
     output_height_shard_dim,
@@ -1087,7 +1038,7 @@ def test_moe_compute(
     logger.info(f"  hidden_size: {hidden_size}")
     logger.info(f"  dtype: {dtype}")
     logger.info(f"  num_iterations: {num_iterations}")
-    logger.info(f"  measure_perf: {measure_perf}, enable_trace: {enable_trace}")
+    logger.info(f"  enable_trace: {enable_trace}")
 
     #########################################
     # CREATE TILIZE INPUT TENSORS AND GOLDENS
@@ -1368,7 +1319,7 @@ def test_moe_compute(
     ]
 
     #########################################
-    # HELPER FUNCTIONS FOR PERFORMANCE MEASUREMENT
+    # HELPER FUNCTIONS
     #########################################
 
     def prepare_layer_inputs(layer_id):
@@ -1412,7 +1363,7 @@ def test_moe_compute(
         return (dram_per_expert, dram_activation, dram_e_t, dram_matmul, combine)
 
     def run_op_inner(tt_sparse_buffer, tt_expert_indices, tt_expert_scores, layer_id):
-        """Core moe_compute operation - used for performance measurement"""
+        """Core moe_compute operation"""
         return ttnn.experimental.moe_compute(
             tt_sparse_buffer,
             tt_expert_indices,
@@ -1428,45 +1379,6 @@ def test_moe_compute(
             optional_output_tensor=tt_combine_output_tensors[layer_id],
             optional_cross_device_semaphore=combine_barrier_semaphore,
         )
-
-    def run_op_perf():
-        """Performance-optimized version that runs multiple iterations but only saves last output"""
-        last_outputs_by_layer = []
-
-        # Pre-allocate all inputs in L1
-        prepared_inputs = []
-        for layer_id in range(num_layers):
-            inputs = prepare_layer_inputs(layer_id)
-            prepared_inputs.append(inputs)
-
-        # Run multiple iterations, only keep last one
-        for iter_idx in range(num_iterations):
-            layer_outputs = []
-            for layer_id in range(num_layers):
-                tt_sparse_buffer, tt_expert_indices, tt_expert_scores = prepared_inputs[layer_id]
-                outputs = run_op_inner(tt_sparse_buffer, tt_expert_indices, tt_expert_scores, layer_id)
-
-                # Only save outputs on last iteration
-                if iter_idx == num_iterations - 1:
-                    layer_outputs.append(outputs)
-
-            # Update last outputs
-            if iter_idx == num_iterations - 1:
-                last_outputs_by_layer = layer_outputs
-
-        # Clean up inputs and convert outputs to DRAM
-        final_outputs = []
-        for layer_id in range(num_layers):
-            # Deallocate inputs
-            tt_sparse_buffer, tt_expert_indices, tt_expert_scores = prepared_inputs[layer_id]
-            deallocate_layer_inputs(tt_sparse_buffer, tt_expert_indices, tt_expert_scores)
-
-            # Convert outputs to DRAM
-            if last_outputs_by_layer:
-                dram_outputs = convert_outputs_to_dram(last_outputs_by_layer[layer_id])
-                final_outputs.append(dram_outputs)
-
-        return final_outputs
 
     #########################################
     # RUN OP
@@ -1493,21 +1405,9 @@ def test_moe_compute(
 
     logger.info(f"\n========== Running op ==========")
 
-    # Initialize profiler based on test parameters
-    profiler = None
-    if measure_perf and enable_trace:
-        logger.info("Running in performance measurement mode")
-        profiler = BenchmarkProfiler()
-
     moe_compute_outputs = []
-    avg_latency_us = None
 
-    if profiler is not None:
-        # Use profiler for trace performance measurement with run_op_perf
-        all_outputs, avg_latency_us = _run_op_with_trace(num_iterations, run_op_perf, mesh_device, profiler)
-        moe_compute_outputs = all_outputs
-    elif enable_trace:
-        # Regular trace execution without profiling
+    if enable_trace:
         # Compile the op
         for i in range(num_iterations):
             run_op()
@@ -1630,31 +1530,6 @@ def test_moe_compute(
             " to the double buffer scheme"
         )
     logger.info(f"\nCombine Output Tensor Verification: {'PASSED' if combine_all_passed else 'FAILED'}")
-
-    # Report performance results if in perf mode
-    if avg_latency_us is not None:
-        logger.info("\n========== Performance Results ==========")
-        logger.info(f"Test Configuration:")
-        logger.info(f"  Mesh shape: {mesh_shape}")
-        logger.info(f"  Total experts: {experts}")
-        logger.info(f"  Selected experts (k): {selected_experts_k}")
-        logger.info(f"  Tokens per device: {tokens_per_device}")
-        logger.info(f"  Hidden size: {hidden_size}")
-        logger.info(f"  N (intermediate size): {N}")
-        logger.info(f"  Trace enabled: {enable_trace}")
-        logger.info(f"  Number of iterations: {num_iterations}")
-        logger.info(f"\nPerformance:")
-        logger.info(f"  Average E2E latency: {avg_latency_us:.2f} us")
-
-        # Calculate throughput if possible
-        total_tokens = (
-            tokens_per_device * mesh_shape[cluster_axis]
-            if cluster_axis is not None
-            else tokens_per_device * num_devices
-        )
-        tokens_per_second = (total_tokens * 1000000.0) / avg_latency_us
-        logger.info(f"  Throughput: {tokens_per_second:.2f} tokens/second")
-        logger.info("==========================================\n")
 
     assert per_expert_tokens_all_passed, "Per expert total tokens tensor verification failed!"
     assert activation_all_passed, "Expert activation tensor verification failed!"

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -974,16 +974,17 @@ def create_sharded_memory_config(core_range_set, tensor_shape, dtype):
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize("cluster_axis", [1])
-@pytest.mark.parametrize("experts_per_device", [2, 3])
+@pytest.mark.parametrize("experts_per_device", [2])  # , 3, 4])
 @pytest.mark.parametrize("tokens_per_device", [32])  # Collapsed batch * seq_len
 @pytest.mark.parametrize(
     "selected_experts_k, num_layers, num_iterations",
-    [(1, 1, 1), (8, 5, 1)],
-    ids=["perf", "accuracy"],
+    [(1, 1, 1)],
+    #     [(1, 1, 1), (8, 5, 1)],
+    #     ids=["perf", "accuracy"],
 )
 @pytest.mark.parametrize("N, hidden_size", [(2048, 7168)])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("enable_trace", [False, True])
+@pytest.mark.parametrize("enable_trace", [False])
 @pytest.mark.parametrize("output_height_shard_dim", [4])
 @pytest.mark.parametrize("output_width_shard_dim", [4])
 def test_moe_compute(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/reader.cpp
@@ -127,7 +127,7 @@ void kernel_main() {
     // read dense token counts
     cb_reserve_back(token_counts_cb_id, 1);
     const uint32_t token_counts_l1_addr = get_read_ptr(token_counts_cb_id);
-    const uint64_t token_counts_noc_addr = get_noc_addr(0, token_counts_addrgen, /*offset=*/0, /*noc=*/1);
+    const uint64_t token_counts_noc_addr = token_counts_addrgen.get_noc_addr(0, /*offset=*/0, /*noc=*/1);
     noc_async_read(token_counts_noc_addr, token_counts_l1_addr, token_counts_page_size_bytes, /*noc=*/1);
     noc_async_read_barrier(/*noc=*/1);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -323,11 +323,10 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     const auto token_counts_data_format = datatype_to_dataformat_converter(dense_token_counts_tensor.dtype());
     // offset into token maps, number of tokens, offset into activations
     const auto token_offset_count_bytes_per_expert = 3 * tt::datum_size(token_counts_data_format);
-    const auto dram_alignment = hal::get_dram_alignment();
     constexpr auto token_counts_cb_id = tt::CBIndex::c_5;
-    const auto token_counts_element_size = dense_token_counts_tensor.element_size();
+    const auto token_counts_tensor_page_size_bytes = dense_token_counts_tensor.tensor_spec().compute_page_size_bytes();
     const uint32_t aligned_token_counts_buffer_size = tt::align(
-        (token_counts_element_size + token_offset_count_bytes_per_expert) * experts_per_device, dram_alignment);
+        token_counts_tensor_page_size_bytes + token_offset_count_bytes_per_expert * experts_per_device, l1_alignment);
     CircularBufferConfig cb_token_counts_config =
         CircularBufferConfig(aligned_token_counts_buffer_size, {{token_counts_cb_id, token_counts_data_format}})
             .set_page_size(token_counts_cb_id, aligned_token_counts_buffer_size);
@@ -386,7 +385,7 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
         {"aligned_token_activations_page_size_bytes", aligned_token_activations_page_size_bytes},
         {"activations_stride_elm", activations_stride_elm},
         {"dense_token_maps_page_size_bytes", aligned_dense_token_maps_page_size_bytes},
-        {"token_counts_page_size_bytes", aligned_token_counts_buffer_size},
+        {"token_counts_page_size_bytes", token_counts_tensor_page_size_bytes},
         {"dense_token_maps_stride_elm", dense_token_maps_stride_elm},
         {"num_local_experts", experts_per_device},
         {"num_token_parallel_cores", num_token_parallel_cores},

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -301,7 +301,8 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
 
     const auto input_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     // input sharded buffer
-    constexpr auto data_cb_id = tt::CBIndex::c_15;
+    // start at this cb index so we don't clash with compute when fused
+    constexpr auto data_cb_id = tt::CBIndex::c_3;
     CircularBufferConfig cb_data_config = CircularBufferConfig(buffer_size_bytes, {{data_cb_id, input_data_format}})
                                               .set_page_size(data_cb_id, buffer_size_bytes)
                                               .set_globally_allocated_address(*input_tensor.buffer());
@@ -309,7 +310,7 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     // dense_token_maps_tensor page buffer
     // tensor pages are padded for alignment
     const uint32_t dense_token_maps_stride_elm = dense_token_maps_tensor.logical_shape()[-1] / total_tokens;
-    constexpr auto dense_token_maps_cb_id = tt::CBIndex::c_1;
+    constexpr auto dense_token_maps_cb_id = tt::CBIndex::c_4;
     const uint32_t aligned_dense_token_maps_buffer_size_bytes =
         tt::align(experts_per_device * aligned_dense_token_maps_page_size_bytes, l1_alignment);
     const auto dense_token_maps_data_format = datatype_to_dataformat_converter(dense_token_maps_tensor.dtype());
@@ -323,7 +324,7 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     // offset into token maps, number of tokens, offset into activations
     const auto token_offset_count_bytes_per_expert = 3 * tt::datum_size(token_counts_data_format);
     const auto dram_alignment = hal::get_dram_alignment();
-    constexpr auto token_counts_cb_id = tt::CBIndex::c_2;
+    constexpr auto token_counts_cb_id = tt::CBIndex::c_5;
     const auto token_counts_element_size = dense_token_counts_tensor.element_size();
     const uint32_t aligned_token_counts_buffer_size = tt::align(
         (token_counts_element_size + token_offset_count_bytes_per_expert) * experts_per_device, dram_alignment);
@@ -337,7 +338,7 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
 
     const auto token_activations_page_size_bytes = token_activations_tensor.tensor_spec().compute_page_size_bytes();
     const auto aligned_token_activations_page_size_bytes = tt::align(token_activations_page_size_bytes, l1_alignment);
-    constexpr auto token_activations_cb_id = tt::CBIndex::c_3;
+    constexpr auto token_activations_cb_id = tt::CBIndex::c_6;
     CircularBufferConfig cb_token_activations_config =
         CircularBufferConfig(
             aligned_token_activations_page_size_bytes, {{token_activations_cb_id, tt::DataFormat::UInt32}})
@@ -345,7 +346,7 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
 
     // client interface
     constexpr auto num_headers = 3;  // data unicast headers and atomic inc multicast headers
-    constexpr auto client_interface_cb_id = tt::CBIndex::c_4;
+    constexpr auto client_interface_cb_id = tt::CBIndex::c_7;
     CircularBufferConfig client_interface_cb_config =
         CircularBufferConfig(num_headers * CLIENT_INTERFACE_SIZE, {{client_interface_cb_id, tt::DataFormat::UInt32}})
             .set_page_size(client_interface_cb_id, CLIENT_INTERFACE_SIZE);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -47,17 +47,17 @@ void kernel_main() {
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
     // CBs
-    constexpr auto cb_s2c_in = tt::CBIndex::c_0;
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_1;
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_3;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
+    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
+    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
 
-    constexpr auto cb_c2s_out = tt::CBIndex::c_14;
+    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
 
     // CB Aliases
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_1;
+    constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;  // reuse cb_r2c_w0_w1
 
     // Constants for MoE
     constexpr uint32_t num_w0_w1_tiles_h = moe_ring::NUM_W0_W1_TILES_H;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -129,16 +129,14 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* cb_w2c_md_read_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md, 0));
 
-    // Precompute NUM_CHUNKS_PER_EXPERT
-    volatile tt_l1_ptr uint32_t* metadata_ready_semaphore_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_w2c_md_read_ptr[0]);
-    uint32_t encoded_metadata_value = *metadata_ready_semaphore_ptr;
+    // Read per-expert token counts from CB
+    volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
 
-    constexpr uint32_t BITS_PER_EXPERT = 10;
-    constexpr uint32_t EXPERT_MASK = 0x3FFu;
+    // Precompute NUM_CHUNKS_PER_EXPERT
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
-        uint32_t num_tokens = (encoded_metadata_value >> (1 + BITS_PER_EXPERT * expert_id)) & EXPERT_MASK;
+        uint32_t num_tokens = num_tokens_per_expert_ptr[expert_id];
         NUM_CHUNKS_PER_EXPERT[expert_id] = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -32,7 +32,6 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_named_compile_time_arg_val("num_cores");
 
     // For synchronization with tilize cores
-    constexpr uint32_t per_expert_total_tokens_cb_id = get_named_compile_time_arg_val("per_expert_total_tokens_cb_id");
     constexpr uint32_t tokens_per_chunk = get_named_compile_time_arg_val("tokens_per_chunk");
 
     // Run-time arguments
@@ -131,7 +130,7 @@ void kernel_main() {
 
     // Read per-expert token counts from CB
     volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_w2c_md_read_ptr[0]);
 
     // Precompute NUM_CHUNKS_PER_EXPERT
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -161,6 +161,7 @@ void kernel_main() {
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
         uint32_t num_tokens = num_tokens_per_expert_ptr[expert_id];
+        DPRINT << "e: " << expert_id << " count: " << num_tokens << "\n";
         NUM_CHUNKS_PER_EXPERT[expert_id] = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -51,16 +51,16 @@ void kernel_main() {
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
     // CBs
-    constexpr auto cb_s2c_in = tt::CBIndex::c_0;
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_1;
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_3;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
+    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
+    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
 
     // CB Aliases
-    constexpr auto cb_c2s_out = tt::CBIndex::c_0;
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_1;
+    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
+    constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;   // reuse cb_r2c_w0_w1
 
     // Tile sizes
     constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -161,7 +161,6 @@ void kernel_main() {
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
         uint32_t num_tokens = num_tokens_per_expert_ptr[expert_id];
-        DPRINT << "e: " << expert_id << " count: " << num_tokens << "\n";
         NUM_CHUNKS_PER_EXPERT[expert_id] = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -153,16 +153,14 @@ void kernel_main() {
     uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
 
-    // Precompute NUM_CHUNKS_PER_EXPERT
-    volatile tt_l1_ptr uint32_t* metadata_ready_semaphore_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(metadata_ready_semaphore_id));
-    uint32_t encoded_metadata_value = *metadata_ready_semaphore_ptr;
+    // Read per-expert token counts from CB
+    volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
 
-    constexpr uint32_t BITS_PER_EXPERT = 10;
-    constexpr uint32_t EXPERT_MASK = 0x3FFu;
+    // Precompute NUM_CHUNKS_PER_EXPERT
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
-        uint32_t num_tokens = (encoded_metadata_value >> (1 + BITS_PER_EXPERT * expert_id)) & EXPERT_MASK;
+        uint32_t num_tokens = num_tokens_per_expert_ptr[expert_id];
         NUM_CHUNKS_PER_EXPERT[expert_id] = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
@@ -154,17 +154,15 @@ void kernel_main() {
     cb_reserve_back(cb_w2c_md, 2);
     cb_push_back(cb_w2c_md, 2);
 
-    // Precompute NUM_CHUNKS_PER_EXPERT
-    volatile tt_l1_ptr uint32_t* metadata_ready_semaphore_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(metadata_ready_semaphore_id));
-    uint32_t encoded_metadata_value = *metadata_ready_semaphore_ptr;
+    // Read per-expert token counts from CB
+    volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
 
-    constexpr uint32_t BITS_PER_EXPERT = 10;
-    constexpr uint32_t EXPERT_MASK = 0x3FFu;
+    // Precompute NUM_CHUNKS_PER_EXPERT
     uint32_t NUM_TOKENS_PER_EXPERT[num_experts];
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
-        uint32_t num_tokens = (encoded_metadata_value >> (1 + BITS_PER_EXPERT * expert_id)) & EXPERT_MASK;
+        uint32_t num_tokens = num_tokens_per_expert_ptr[expert_id];
         NUM_TOKENS_PER_EXPERT[expert_id] = num_tokens;
         NUM_CHUNKS_PER_EXPERT[expert_id] = detail::div_up(num_tokens, tokens_per_chunk);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
@@ -145,18 +145,20 @@ void kernel_main() {
 
     // Signal to the compute core that num_tokens_per_expert has arrived.
     // We also use this CB to transfer (from the writer to compute) 2 semaphore addresses:
-    // - 0: address of semaphore used to send metadata (number of tokens per expert)
+    // - 0: address of L1 page (CB) used to send metadata (number of tokens per expert)
     // - 1: address of semaphore used to notify matmuls cores that tilized chunks have arrived
+
+    // Read per-expert token counts from CB
+    const auto num_tokens_per_expert_addr = get_read_ptr(per_expert_total_tokens_cb_id);
+    volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(num_tokens_per_expert_addr);
+
     volatile tt_l1_ptr uint32_t* cb_w2c_md_write_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_w2c_md));
-    cb_w2c_md_write_ptr[0] = get_semaphore(metadata_ready_semaphore_id);
+    cb_w2c_md_write_ptr[0] = num_tokens_per_expert_addr;
     cb_w2c_md_write_ptr[1] = get_semaphore(matmul_chunk_ready_semaphore_id);
     cb_reserve_back(cb_w2c_md, 2);
     cb_push_back(cb_w2c_md, 2);
-
-    // Read per-expert token counts from CB
-    volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
 
     // Precompute NUM_CHUNKS_PER_EXPERT
     uint32_t NUM_TOKENS_PER_EXPERT[num_experts];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
@@ -60,16 +60,16 @@ void kernel_main() {
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
     // CBs
-    constexpr auto cb_s2c_in = tt::CBIndex::c_0;
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_1;
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_3;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
+    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
+    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
 
     // CB Aliases
-    constexpr auto cb_c2s_out = tt::CBIndex::c_14;
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_1;
+    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
+    constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;   // reuse cb_r2c_w0_w1
 
     // Tile sizes
     constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -358,6 +358,16 @@ void kernel_main() {
     constexpr uint32_t matmul_mcast_end_y = get_named_compile_time_arg_val("matmul_mcast_end_y");
     constexpr uint32_t matmul_bounding_box_num_cores = get_named_compile_time_arg_val("matmul_bounding_box_num_cores");
 
+    // All worker cores multicast coordinates
+    constexpr uint32_t all_worker_cores_mcast_start_x =
+        get_named_compile_time_arg_val("all_worker_cores_mcast_start_x");
+    constexpr uint32_t all_worker_cores_mcast_start_y =
+        get_named_compile_time_arg_val("all_worker_cores_mcast_start_y");
+    constexpr uint32_t all_worker_cores_mcast_end_x = get_named_compile_time_arg_val("all_worker_cores_mcast_end_x");
+    constexpr uint32_t all_worker_cores_mcast_end_y = get_named_compile_time_arg_val("all_worker_cores_mcast_end_y");
+    constexpr uint32_t all_worker_cores_bounding_box_num_cores =
+        get_named_compile_time_arg_val("all_worker_cores_bounding_box_num_cores");
+
     // Coordinates for combine signalling seminc
     constexpr uint32_t combine_sync_noc_x = get_named_compile_time_arg_val("combine_sync_noc_x");
     constexpr uint32_t combine_sync_noc_y = get_named_compile_time_arg_val("combine_sync_noc_y");
@@ -851,29 +861,38 @@ void kernel_main() {
 
         // == 1 ==
 
-        // Determine encoded value
-        // NOTE: can handle up to 3 experts:
-        // - 1 valid bit
-        // - 10 bits per expert, valid num_tokens is [0, 512]
-        // - 32 bits available in semaphore (4 Bytes), 0 value reserved as init value
+        // Get pointer to token counts
         volatile tt_l1_ptr uint32_t* num_tokens_per_expert =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
 
-        constexpr uint32_t bits_per_expert = 10;
-        constexpr uint32_t expert_mask = 0x3FFu;
-        uint32_t encoded_value = 1u;  // flag bit
-        for (uint32_t e = 0; e < experts_per_device; ++e) {
-            encoded_value |= (num_tokens_per_expert[e] & expert_mask) << (1 + bits_per_expert * e);
-        }
-
-        // set local semaphore value
-        volatile tt_l1_ptr uint32_t* metadata_ready_semaphore_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(metadata_ready_semaphore_id));
-        *metadata_ready_semaphore_ptr = encoded_value;
+        // Write raw token counts to the CB (already in the correct location)
+        // The counts are already written during the metadata aggregation phase above
 
         // == 2 ==
 
-        // get mcast address
+        // Multicast the per-expert token counts to ALL worker cores (tilize + matmul + combine)
+        uint64_t all_worker_cores_expert_counts_mcast_addr = get_safe_multicast_noc_addr(
+            all_worker_cores_mcast_start_x,
+            all_worker_cores_mcast_start_y,
+            all_worker_cores_mcast_end_x,
+            all_worker_cores_mcast_end_y,
+            get_read_ptr(per_expert_total_tokens_cb_id));
+
+        noc_async_write_multicast(
+            get_read_ptr(per_expert_total_tokens_cb_id),
+            all_worker_cores_expert_counts_mcast_addr,
+            experts_per_device * sizeof(uint32_t),
+            all_worker_cores_bounding_box_num_cores - 1);  // Exclude self
+
+        // Ensure multicast completes before signaling semaphore
+        noc_async_writes_flushed();
+
+        // == 3 ==
+
+        // Signal readiness via semaphore (no encoded data, just a ready flag)
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+
+        // get mcast address for semaphore
         uint64_t matmul_metadata_ready_semaphore_mcast_addr = get_safe_multicast_noc_addr(
             matmul_mcast_start_x,
             matmul_mcast_start_y,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -844,13 +844,13 @@ void kernel_main() {
                 tilize_mcast_end_y,
                 metadata_ready_semaphore_addr);
 
-            // Flush writes since we change the local value of metadata_ready_semaphore when signalling
-            // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
-            noc_async_writes_flushed();
-
             // Multicast the value 1 to all non-drain tilize cores
             noc_semaphore_set_multicast(
                 metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
+
+            // Flush writes since we change the local value of metadata_ready_semaphore when signalling
+            // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
+            noc_async_writes_flushed();
         }
 
         /*
@@ -885,7 +885,7 @@ void kernel_main() {
             all_worker_cores_bounding_box_num_cores - 1);  // Exclude self
 
         // Ensure multicast completes before signaling semaphore
-        noc_async_writes_flushed();
+        noc_async_write_barrier();
 
         // == 3 ==
 
@@ -965,8 +965,8 @@ void kernel_main() {
 
         // write out per_expert_total_tokens_output_tensor
         // tensor is a single page
-        l1_read_addr = get_read_ptr(per_expert_total_tokens_cb_id);
-        noc_async_write_page(0, per_expert_total_tokens_output_tensor_addr_gen, l1_read_addr);
+        // l1_read_addr = get_read_ptr(per_expert_total_tokens_cb_id);
+        // noc_async_write_page(0, per_expert_total_tokens_output_tensor_addr_gen, l1_read_addr);
 
         // Explicit write barrier for expert_activation DRAM write, e_t L1 write, and per_expert_total_tokens L1 write
         // (drain core only issued these writes)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -868,7 +868,7 @@ void kernel_main() {
         noc_async_write_multicast(
             get_read_ptr(per_expert_total_tokens_cb_id),
             all_worker_cores_expert_counts_mcast_addr,
-            experts_per_device * sizeof(uint32_t),
+            per_expert_total_tokens_output_page_size,
             all_worker_cores_bounding_box_num_cores - 1);  // Exclude self
 
         // Ensure multicast completes before signaling semaphore

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -844,33 +844,20 @@ void kernel_main() {
                 tilize_mcast_end_y,
                 metadata_ready_semaphore_addr);
 
-            // Multicast the value 1 to all non-drain tilize cores
-            noc_semaphore_set_multicast(
-                metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
-
             // Flush writes since we change the local value of metadata_ready_semaphore when signalling
             // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
             noc_async_writes_flushed();
+
+            // Multicast the value 1 to all non-drain tilize cores
+            noc_semaphore_set_multicast(
+                metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
         }
 
-        /*
-         * Send metadata to MM cores (repeat for both bounding boxes):
-         * 1) Encode number of tokens per expert into the semaphore (plus a valid bit)
-         * 2) Signal the metadata via semaphore to MM cores
-         */
-
-        // == 1 ==
-
-        // Get pointer to token counts
         volatile tt_l1_ptr uint32_t* num_tokens_per_expert =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
 
-        // Write raw token counts to the CB (already in the correct location)
-        // The counts are already written during the metadata aggregation phase above
-
-        // == 2 ==
-
         // Multicast the per-expert token counts to ALL worker cores (tilize + matmul + combine)
+        // this might be overkill, only matmul and combine need this right now but we can just do one big MC
         uint64_t all_worker_cores_expert_counts_mcast_addr = get_safe_multicast_noc_addr(
             all_worker_cores_mcast_start_x,
             all_worker_cores_mcast_start_y,
@@ -887,9 +874,7 @@ void kernel_main() {
         // Ensure multicast completes before signaling semaphore
         noc_async_write_barrier();
 
-        // == 3 ==
-
-        // Signal readiness via semaphore (no encoded data, just a ready flag)
+        // Signal readiness via semaphore
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
 
         // get mcast address for semaphore
@@ -963,16 +948,10 @@ void kernel_main() {
             l1_read_addr += e_t_output_page_size;
         }
 
-        // write out per_expert_total_tokens_output_tensor
-        // tensor is a single page
-        // l1_read_addr = get_read_ptr(per_expert_total_tokens_cb_id);
-        // noc_async_write_page(0, per_expert_total_tokens_output_tensor_addr_gen, l1_read_addr);
-
-        // Explicit write barrier for expert_activation DRAM write, e_t L1 write, and per_expert_total_tokens L1 write
-        // (drain core only issued these writes)
         noc_async_write_barrier();
 
-        // signal to A2A combine that metadata is available
+        // signal to A2A combine that metadata is available. Separate signal from matmul because e_t write is also
+        // needed.
         const uint64_t combine_sync_noc_addr =
             safe_get_noc_addr(combine_sync_noc_x, combine_sync_noc_y, combine_sync_addr, 1);
         noc_semaphore_inc(combine_sync_noc_addr, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -844,13 +844,13 @@ void kernel_main() {
                 tilize_mcast_end_y,
                 metadata_ready_semaphore_addr);
 
-            // Multicast the value 1 to all non-drain tilize cores
-            noc_semaphore_set_multicast(
-                metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
-
             // Flush writes since we change the local value of metadata_ready_semaphore when signalling
             // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
             noc_async_writes_flushed();
+
+            // Multicast the value 1 to all non-drain tilize cores
+            noc_semaphore_set_multicast(
+                metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
         }
 
         /*

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -65,15 +65,13 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
     // This data will be replicated on all cores
     auto per_expert_total_tokens_row_bytes = tt::align(experts_per_device * sizeof(uint32_t), l1_alignment);
     auto per_expert_total_tokens_row_elements = tt::div_up(per_expert_total_tokens_row_bytes, sizeof(uint32_t));
-    auto tilize_per_expert_total_tokens_shape = ttnn::Shape({1, per_expert_total_tokens_row_elements});
+    auto tilize_per_expert_total_tokens_shape = ttnn::Shape({num_cores, per_expert_total_tokens_row_elements});
 
     const ttnn::MemoryConfig tilize_per_expert_total_tokens_sharded_memory_config = ttnn::MemoryConfig{
         tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
         tt::tt_metal::BufferType::L1,
         tt::tt_metal::ShardSpec(
-            shard_cores,
-            {num_cores, tilize_per_expert_total_tokens_shape[-1]},
-            tt::tt_metal::ShardOrientation::ROW_MAJOR),
+            shard_cores, {1, per_expert_total_tokens_row_elements}, tt::tt_metal::ShardOrientation::ROW_MAJOR),
     };
 
     auto tilize_per_expert_total_tokens_spec = TensorSpec(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -64,7 +64,7 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
     // Output 0: Per expert total tokens tensor
     // This data will be replicated on all cores
     auto per_expert_total_tokens_row_bytes = tt::align(experts_per_device * sizeof(uint32_t), l1_alignment);
-    auto per_expert_total_tokens_row_elements = per_expert_total_tokens_row_bytes / sizeof(uint32_t);
+    auto per_expert_total_tokens_row_elements = tt::div_up(per_expert_total_tokens_row_bytes, sizeof(uint32_t));
     auto tilize_per_expert_total_tokens_shape = ttnn::Shape({1, per_expert_total_tokens_row_elements});
 
     const ttnn::MemoryConfig tilize_per_expert_total_tokens_sharded_memory_config = ttnn::MemoryConfig{

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -53,19 +53,35 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
         tilize_input_shape[0] *
         tilize_input_shape[1];  // tokens_per_device from input, total tokens across all dispatch devices (512)
 
+    const CoreCoord worker_grid_size = mesh_device->compute_with_storage_grid_size();
+    const CoreRangeSet shard_cores =
+        CoreRangeSet({CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1})});
+    const auto num_cores = shard_cores.num_cores();
+
     //-------------------------------------------------------------------------
     // Tilize outputs
     //-------------------------------------------------------------------------
     // Output 0: Per expert total tokens tensor
+    // This data will be replicated on all cores
     auto per_expert_total_tokens_row_bytes = tt::align(experts_per_device * sizeof(uint32_t), l1_alignment);
     auto per_expert_total_tokens_row_elements = per_expert_total_tokens_row_bytes / sizeof(uint32_t);
     auto tilize_per_expert_total_tokens_shape = ttnn::Shape({1, per_expert_total_tokens_row_elements});
+
+    const ttnn::MemoryConfig tilize_per_expert_total_tokens_sharded_memory_config = ttnn::MemoryConfig{
+        tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        tt::tt_metal::BufferType::L1,
+        tt::tt_metal::ShardSpec(
+            shard_cores,
+            {num_cores, tilize_per_expert_total_tokens_shape[-1]},
+            tt::tt_metal::ShardOrientation::ROW_MAJOR),
+    };
+
     auto tilize_per_expert_total_tokens_spec = TensorSpec(
-        Shape(tilize_per_expert_total_tokens_shape),
+        tilize_per_expert_total_tokens_shape,
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::UINT32,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
-            tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1)));
+            tilize_per_expert_total_tokens_sharded_memory_config);
 
     // Output 1: Expert activation tensor
     // Each row: [token_id, k_indices[experts_per_device], scores[experts_per_device]]
@@ -76,7 +92,7 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
     uint32_t activation_total_bytes = total_tokens * activation_row_bytes;
     auto tilize_expert_activation_shape = ttnn::Shape({1, activation_total_bytes / sizeof(uint32_t)});
     auto tilize_expert_activation_spec = TensorSpec(
-        Shape(tilize_expert_activation_shape),
+        tilize_expert_activation_shape,
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::UINT32,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
@@ -104,8 +120,6 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
      * MM: Used as input CB (where tilized chunks arrive)
      * Combine: Stores output of MM, for input to combine
      */
-    CoreCoord worker_grid_size = mesh_device->compute_with_storage_grid_size();
-    CoreRangeSet shard_cores = CoreRangeSet({CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1})});
     ttnn::MemoryConfig output_sharded_memory_config = ttnn::MemoryConfig{
         tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
         tt::tt_metal::BufferType::L1,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -81,7 +81,7 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::UINT32,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
-            tilize_per_expert_total_tokens_sharded_memory_config);
+            tilize_per_expert_total_tokens_sharded_memory_config));
 
     // Output 1: Expert activation tensor
     // Each row: [token_id, k_indices[experts_per_device], scores[experts_per_device]]

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -409,11 +409,11 @@ MoEComputeMeshWorkloadFactory::create_at(
      */
     uint32_t tilize_output_cb_id = tt::CBIndex::c_0;
     [[maybe_unused]] uint32_t cb_s2c_in_id = tt::CBIndex::c_0;
-    uint32_t matmul_writer_cb_id = tt::CBIndex::c_1
+    uint32_t matmul_writer_cb_id = tt::CBIndex::c_1;
 
-        // after determining the total number of tokens for each expert, this buffer will store the total number of
-        // tokens for each expert to pass to the other kernels
-        uint32_t per_expert_total_tokens_cb_id = tt::CBIndex::c_2;
+    // after determining the total number of tokens for each expert, this buffer will store the total number of
+    // tokens for each expert to pass to the other kernels
+    uint32_t per_expert_total_tokens_cb_id = tt::CBIndex::c_2;
 
     // All cores (not just Tilize and Matmul)
     const CoreRangeSet shard_cores = tilize_output_tensor.memory_config().shard_spec()->grid;
@@ -440,7 +440,8 @@ MoEComputeMeshWorkloadFactory::create_at(
         tilize_output_tensor.buffer());
     tt::tt_metal::CBHandle matmul_writer_cb_handle = std::get<1>(matmul_writer_cb);
 
-    auto tt::tt_metal::create_cb(
+    // global tensor backed CB to communicate active tokens per expert
+    const auto expert_token_cb = tt::tt_metal::create_cb(
         per_expert_total_tokens_cb_id,
         program,
         all_worker_cores_range_set,
@@ -448,6 +449,7 @@ MoEComputeMeshWorkloadFactory::create_at(
         1,
         tt::tt_metal::datatype_to_dataformat_converter(tilize_per_expert_total_tokens_output_tensor.dtype()),
         tilize_per_expert_total_tokens_output_tensor.buffer());
+    const auto expert_tokens_cb_handle = std::get<1>(expert_token_cb);
 
     //-------------------------------------------------------------------------
     // Tilize CBs
@@ -637,11 +639,11 @@ MoEComputeMeshWorkloadFactory::create_at(
     // Define the CB configuration as a tuple: name, CBIndex, DataFormat, tiles_per_cb
     // Note: cb_s2c_in and cb_c2s_out are handled separately as it is allocated on Tilize, Matmul, and Combine cores
     const std::vector<std::tuple<std::string, tt::CBIndex, tt::DataFormat, bool, uint32_t>> matmul_cb_specs0 = {
-        {"cb_r2c_w0", tt::CBIndex::c_1, tt::DataFormat::Bfp4_b, true, 14 * 6},
-        {"cb_c2w_rdy", tt::CBIndex::c_2, tt::DataFormat::Float32, false, 1},
-        {"cb_w2c_rdy", tt::CBIndex::c_3, tt::DataFormat::Float32, false, 1},
-        {"cb_s2c_in2", tt::CBIndex::c_4, tt::DataFormat::Float16_b, true, 6 * 12},
-        {"cb_w2c_md", tt::CBIndex::c_5, tt::DataFormat::UInt32, false, 2},
+        {"cb_r2c_w0", tt::CBIndex::c_3, tt::DataFormat::Bfp4_b, true, 14 * 6},
+        {"cb_c2w_rdy", tt::CBIndex::c_4, tt::DataFormat::Float32, false, 1},
+        {"cb_w2c_rdy", tt::CBIndex::c_5, tt::DataFormat::Float32, false, 1},
+        {"cb_s2c_in2", tt::CBIndex::c_6, tt::DataFormat::Float16_b, true, 6 * 12},
+        {"cb_w2c_md", tt::CBIndex::c_7, tt::DataFormat::UInt32, false, 2},
     };
 
     std::map<std::string, tt::tt_metal::CBHandle> matmul_cb_handles;
@@ -1202,6 +1204,7 @@ MoEComputeMeshWorkloadFactory::create_at(
          .matmul_writer_cb_handle = matmul_writer_cb_handle,
          .combine_kernel_handles = {combine_reader_kernel_id, combine_writer_kernel_id},
          .combine_data_cb_handle = combine_data_cb_handle,
+         .expert_tokens_cb_handle = expert_tokens_cb_handle,
          .combine_cores = combine_cores,
          .combine_global_semaphores = {init_barrier_semaphore, final_barrier_semaphore}}};
 }
@@ -1228,6 +1231,9 @@ void MoEComputeMeshWorkloadFactory::override_runtime_arguments(
 
         tt::tt_metal::UpdateDynamicCircularBufferAddress(
             program, shared_variables.matmul_writer_cb_handle, *tilize_output_tensor.buffer());
+
+        tt::tt_metal::UpdateDynamicCircularBufferAddress(
+            program, shared_variables.expert_tokens_cb_handle, *tilize_per_expert_total_tokens_output_tensor.buffer());
 
         //-------------------------------------------------------------------------
         // Tilize

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -47,6 +47,7 @@ std::tuple<
     CoreRangeSet,            // T + MM CoreRangeSet
     CoreRangeSet,            // Combine CoreRangeSet
     CoreRangeSet,            // C + MM CoreRangeSet
+    CoreRangeSet,            // All worker cores (T + MM + C)
     std::vector<CoreCoord>,  // Combine vector of CoreCoord
     CoreRange,               // T bounding box
     CoreRange>               // MM bounding box
@@ -91,6 +92,9 @@ get_cores(ttnn::MeshDevice* mesh_device) {
     // MatMul + combine CoreRangeSet, needed for semaphores
     const auto combine_matmul_core_range_set = combine_core_range_set.merge(matmul_core_range_set);
 
+    // All worker cores (tilize + matmul + combine)
+    const CoreRangeSet all_worker_cores_range_set = tilize_matmul_core_range_set.merge(combine_core_range_set);
+
     TT_FATAL(!combine_bounding_box.intersects(tilize_bounding_box), "combine and tilize bounding boxes cannot overlap");
     TT_FATAL(!combine_bounding_box.intersects(matmul_bounding_box), "combine and matmul bounding boxes cannot overlap");
 
@@ -102,6 +106,7 @@ get_cores(ttnn::MeshDevice* mesh_device) {
         tilize_matmul_core_range_set,
         combine_core_range_set,
         combine_matmul_core_range_set,
+        all_worker_cores_range_set,
         combine_cores,
         tilize_bounding_box,
         matmul_bounding_box};
@@ -125,7 +130,7 @@ namespace ttnn::experimental::prim {
 
 // expose a helper function so callers know what cores are available for subsequently running a2a combine
 std::vector<ttnn::CoreCoord> get_moe_combine_cores(ttnn::MeshDevice* mesh_device) {
-    constexpr auto combine_cores_return_index = 7;
+    constexpr auto combine_cores_return_index = 8;
 
     const auto get_cores_return = get_cores(mesh_device);
 
@@ -279,6 +284,7 @@ MoEComputeMeshWorkloadFactory::create_at(
          tilize_matmul_core_range_set,
          combine_core_range_set,
          combine_matmul_core_range_set,
+         all_worker_cores_range_set,
          combine_cores,
          tilize_bounding_box,
          matmul_bounding_box] = get_cores(mesh_device);
@@ -289,11 +295,17 @@ MoEComputeMeshWorkloadFactory::create_at(
     const uint32_t tilize_bounding_box_num_cores = tilize_bounding_box.size();
     const uint32_t matmul_bounding_box_num_cores = matmul_bounding_box.size();
 
+    // All worker cores bounding box
+    const CoreRange all_worker_cores_bounding_box = all_worker_cores_range_set.bounding_box();
+    const uint32_t all_worker_cores_bounding_box_num_cores = all_worker_cores_bounding_box.size();
+
     // Logical mcast bounding box coordinates
     const CoreCoord tilize_mcast_start_logical = tilize_bounding_box.start_coord;
     const CoreCoord tilize_mcast_end_logical = tilize_bounding_box.end_coord;
     const CoreCoord matmul_mcast_start_logical = matmul_bounding_box.start_coord;
     const CoreCoord matmul_mcast_end_logical = matmul_bounding_box.end_coord;
+    const CoreCoord all_worker_cores_mcast_start_logical = all_worker_cores_bounding_box.start_coord;
+    const CoreCoord all_worker_cores_mcast_end_logical = all_worker_cores_bounding_box.end_coord;
 
     // Convert to physical NOC coordinates
     const CoreCoord tilize_mcast_start_physical =
@@ -302,6 +314,10 @@ MoEComputeMeshWorkloadFactory::create_at(
     const CoreCoord matmul_mcast_start_physical =
         mesh_device->worker_core_from_logical_core(matmul_mcast_start_logical);
     const CoreCoord matmul_mcast_end_physical = mesh_device->worker_core_from_logical_core(matmul_mcast_end_logical);
+    const CoreCoord all_worker_cores_mcast_start_physical =
+        mesh_device->worker_core_from_logical_core(all_worker_cores_mcast_start_logical);
+    const CoreCoord all_worker_cores_mcast_end_physical =
+        mesh_device->worker_core_from_logical_core(all_worker_cores_mcast_end_logical);
 
     //-------------------------------------------------------------------------
     // Tilize semaphores
@@ -393,7 +409,11 @@ MoEComputeMeshWorkloadFactory::create_at(
      */
     uint32_t tilize_output_cb_id = tt::CBIndex::c_0;
     [[maybe_unused]] uint32_t cb_s2c_in_id = tt::CBIndex::c_0;
-    uint32_t matmul_writer_cb_id = tt::CBIndex::c_14; // TODO, cleaner to make this c_1 and change all the others
+    uint32_t matmul_writer_cb_id = tt::CBIndex::c_1
+
+        // after determining the total number of tokens for each expert, this buffer will store the total number of
+        // tokens for each expert to pass to the other kernels
+        uint32_t per_expert_total_tokens_cb_id = tt::CBIndex::c_2;
 
     // All cores (not just Tilize and Matmul)
     const CoreRangeSet shard_cores = tilize_output_tensor.memory_config().shard_spec()->grid;
@@ -420,39 +440,45 @@ MoEComputeMeshWorkloadFactory::create_at(
         tilize_output_tensor.buffer());
     tt::tt_metal::CBHandle matmul_writer_cb_handle = std::get<1>(matmul_writer_cb);
 
+    auto tt::tt_metal::create_cb(
+        per_expert_total_tokens_cb_id,
+        program,
+        all_worker_cores_range_set,
+        tilize_per_expert_total_tokens_output_page_size,
+        1,
+        tt::tt_metal::datatype_to_dataformat_converter(tilize_per_expert_total_tokens_output_tensor.dtype()),
+        tilize_per_expert_total_tokens_output_tensor.buffer());
+
     //-------------------------------------------------------------------------
     // Tilize CBs
     //-------------------------------------------------------------------------
 
-    // after determining the total number of tokens for each expert, this buffer will store the total number of tokens
-    // for each expert to pass to the other kernels
-    uint32_t per_expert_total_tokens_cb_id = tt::CBIndex::c_1;
     // CB for passing total_chunks from writer to compute
-    uint32_t total_chunks_cb_id = tt::CBIndex::c_2;
+    uint32_t total_chunks_cb_id = tt::CBIndex::c_3;
     // full indices buffer
-    uint32_t indices_tensor_cb_id = tt::CBIndex::c_3;
+    uint32_t indices_tensor_cb_id = tt::CBIndex::c_4;
     // full mapping buffer
-    uint32_t mapping_tensor_cb_id = tt::CBIndex::c_4;
+    uint32_t mapping_tensor_cb_id = tt::CBIndex::c_5;
     // full scores buffer
-    uint32_t scores_tensor_cb_id = tt::CBIndex::c_5;
+    uint32_t scores_tensor_cb_id = tt::CBIndex::c_6;
     // Send preparation buffer [E, T] for untilize, capped by -1 to indicate no more tokens to send for this expert
-    uint32_t e_t_cb_id = tt::CBIndex::c_6;
+    uint32_t e_t_cb_id = tt::CBIndex::c_7;
     // tilize input buffer for tokens to be tilized (row-major from reader)
-    uint32_t tilize_input_cb_id = tt::CBIndex::c_7;
+    uint32_t tilize_input_cb_id = tt::CBIndex::c_8;
     // Experts activation buffer [T, 2*E + 1] each row is {token id, expert_0_activated, expert_1_activated,...,
     // expert_0_score, expert_1_score, ...} k+1 if not activated, k value in the indices tensor for that token if
     // activated
-    uint32_t expert_activation_cb_id = tt::CBIndex::c_8;
+    uint32_t expert_activation_cb_id = tt::CBIndex::c_9;
     // BRISC's e_t buffer for parallel metadata processing (BRISC processes tokens/2 to tokens)
-    uint32_t brisc_e_t_cb_id = tt::CBIndex::c_19;
+    uint32_t brisc_e_t_cb_id = tt::CBIndex::c_10;
     // BRISC's per-expert token counts to communicate to NCRISC after parallel processing
-    uint32_t brisc_expert_counts_cb_id = tt::CBIndex::c_10;
+    uint32_t brisc_expert_counts_cb_id = tt::CBIndex::c_11;
     // BRISC's expert activation buffer for parallel processing
-    uint32_t brisc_expert_activation_cb_id = tt::CBIndex::c_11;
+    uint32_t brisc_expert_activation_cb_id = tt::CBIndex::c_12;
     // BRISC's activated token count (single uint32_t)
-    uint32_t brisc_activated_count_cb_id = tt::CBIndex::c_12;
+    uint32_t brisc_activated_count_cb_id = tt::CBIndex::c_13;
 
-    uint32_t remote_counts_cb_id = tt::CBIndex::c_13;
+    uint32_t remote_counts_cb_id = tt::CBIndex::c_14;
 
     const auto tilize_input_data_format = tt::tt_metal::datatype_to_dataformat_converter(tilize_input_tensor.dtype());
     const auto tilize_indices_data_format =
@@ -469,14 +495,6 @@ MoEComputeMeshWorkloadFactory::create_at(
         tilize_subtoken_bytes_aligned;
 
     constexpr uint32_t tokens_per_chunk = 32;  // Hardcoding for now, can adjust when tiny tiles support added
-
-    tt::tt_metal::create_cb(
-        per_expert_total_tokens_cb_id,
-        program,
-        tilize_core_range_set,
-        tilize_per_expert_total_tokens_output_page_size,
-        1,
-        tt::tt_metal::datatype_to_dataformat_converter(tilize_per_expert_total_tokens_output_tensor.dtype()));
 
     // e_t buffer entry size must be 16B aligned for NOC DMA during BRISC->NCRISC merge
     tt::tt_metal::create_cb(
@@ -725,8 +743,7 @@ MoEComputeMeshWorkloadFactory::create_at(
         {"mesh_rows", mesh_view.num_rows()},
         {"mesh_cols", mesh_view.num_cols()},
         {"linearized_mesh_coord", linearized_mesh_coord},
-        {"cluster_axis",
-         (uint32_t)(args.combine_params.axis.has_value() ? args.combine_params.axis.value() : 1)},
+        {"cluster_axis", (uint32_t)(args.combine_params.axis.has_value() ? args.combine_params.axis.value() : 1)},
 
         // Coordinates for non-drain-sync to drain-sync synchronization
         {"drain_core_noc_x", (uint32_t)tilize_drain_core_physical.x},
@@ -753,6 +770,13 @@ MoEComputeMeshWorkloadFactory::create_at(
         {"matmul_mcast_end_x", (uint32_t)matmul_mcast_end_physical.x},
         {"matmul_mcast_end_y", (uint32_t)matmul_mcast_end_physical.y},
         {"matmul_bounding_box_num_cores", matmul_bounding_box_num_cores},
+
+        // All worker cores multicast coordinates
+        {"all_worker_cores_mcast_start_x", (uint32_t)all_worker_cores_mcast_start_physical.x},
+        {"all_worker_cores_mcast_start_y", (uint32_t)all_worker_cores_mcast_start_physical.y},
+        {"all_worker_cores_mcast_end_x", (uint32_t)all_worker_cores_mcast_end_physical.x},
+        {"all_worker_cores_mcast_end_y", (uint32_t)all_worker_cores_mcast_end_physical.y},
+        {"all_worker_cores_bounding_box_num_cores", all_worker_cores_bounding_box_num_cores},
 
         // Semaphores
         {"partial_metadata_ready_semaphore_id", tilize_partial_metadata_ready_semaphore_id},

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.hpp
@@ -37,6 +37,9 @@ struct MoEComputeMeshWorkloadFactory {
         // CB handle for combine global sharded input tensor
         tt::tt_metal::CBHandle combine_data_cb_handle;
 
+        // CB handle for token counts per expert
+        tt::tt_metal::CBHandle expert_tokens_cb_handle;
+
         // Combine cores
         std::vector<CoreCoord> combine_cores;
 

--- a/ttnn/ttnn/_experimental/README.md
+++ b/ttnn/ttnn/_experimental/README.md
@@ -20,9 +20,9 @@ To add a new experimental module:
 
 The `moe` module in this directory can be imported as:
 ```python
-from ttnn.experimental.moe.utils import cluster_distance
+from ttnn.experimental.moe_compute_utils import cluster_distance
 # or
-import ttnn.experimental.moe
+import ttnn.experimental.moe_compute_utils
 ```
 
 This approach avoids conflicts with the `experimental_loader` while allowing us to extend the experimental namespace.

--- a/ttnn/ttnn/_experimental/moe_compute_utils.py
+++ b/ttnn/ttnn/_experimental/moe_compute_utils.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import math
-from typing import Iterable
+from typing import Sequence
 
 import ttnn
 
@@ -26,7 +26,7 @@ def cluster_distance(d0: int, d1: int, mesh_shape: tuple[int, int], cluster_axis
 def map_shared_experts(
     expert_mapping_tensor: "torch.Tensor",
     shared_expert_ids_to_devices: dict[int, list[int]],
-    mesh_shape: Iterable[int],
+    mesh_shape: Sequence[int],
     cluster_axis: int,
 ) -> "torch.Tensor":
     """
@@ -55,7 +55,6 @@ def map_shared_experts(
 
     Raises:
         RuntimeError: If shared experts are not distributed evenly across devices.
-        RuntimeError: If more than 3 experts per device would result (current limitation).
         RuntimeError: If shared expert IDs are not contiguous with routed expert IDs.
 
     Notes:
@@ -85,7 +84,7 @@ def map_shared_experts(
     if list(range(routed_experts)) + sorted([se for se in shared_expert_ids_to_devices]) != list(
         range(routed_experts + shared_experts)
     ):
-        raise RuntimeError("Shared expert IDs should be a contigious continuation of routed expert IDs ")
+        raise RuntimeError("Shared expert IDs should be a contiguous continuation of routed expert IDs ")
 
     routed_and_shared_expert_mapping = torch.cat(
         [expert_mapping_tensor, torch.zeros((devices, shared_experts), dtype=expert_mapping_tensor.dtype)], dim=1

--- a/ttnn/ttnn/_experimental/moe_compute_utils.py
+++ b/ttnn/ttnn/_experimental/moe_compute_utils.py
@@ -82,10 +82,6 @@ def map_shared_experts(
     if not len(set(shared_experts_per_device)) == 1:
         raise RuntimeError("Shared Experts must be distributed such that all devices have an equal number of experts")
 
-    # this is a fairly soft limitation at the moment, small changes to moe_compute are required to lift it
-    if shared_experts_per_device[0] + routed_experts_per_device > 3:
-        raise RuntimeError("At the moment MoE supports up to 3 experts per device")
-
     if list(range(routed_experts)) + sorted([se for se in shared_expert_ids_to_devices]) != list(
         range(routed_experts + shared_experts)
     ):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41132?issue=tenstorrent%7Ctt-metal%7C41816#issuecomment-4215933021

### Problem description
General MoE implementations require > 3 experts per device.

### What's changed
- The number of experts per device in the optimized MoE implementation was limited because the number of active tokens/expert was communicated throughout the fused ops by encoding values in a 32 bit semaphore; only enough bits for three experts. I moved this communication to a sharded L1 tensor.
- A2A combine still loads a page of this tensor to get the token counts but it's replicated so any page will do.
- No measurable impact on perf.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/moe-arbitrary-experts-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device)

- [x] TG e2e https://github.com/tenstorrent/tt-metal/actions/runs/24411062194

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/moe-arbitrary-experts-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [#2738](https://github.com/tenstorrent/tt-metal/actions/runs/24411023236) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/moe-arbitrary-experts-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/moe-arbitrary-experts-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/moe-arbitrary-experts-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/moe-arbitrary-experts-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/moe-arbitrary-experts-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/moe-arbitrary-experts-per-device) |