### PR TITLE
[skip ci] #0: skip mm bias tests failing in L2 nightly

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -10,6 +10,29 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.unit_tests.operations.matmul.test_matmul_deepseek import _run_matmul_2d_interleaved_in0_sharded_in1
 
 
+def _skip_matmul_2d_interleaved_sharded_dtype_bias_sweep_known_failures(
+    has_bias: bool,
+    in0_dtype,
+    in1_dtype,
+    out_dtype,
+    bias_dtype,
+) -> bool:
+    """
+    Combinations that fail assert_numeric_metrics: reference is BF16-only while device uses mixed dtypes
+    on ttnn.linear (see _run_matmul_2d_interleaved_in0_sharded_in1).
+    """
+    if not has_bias:
+        return False
+    if out_dtype == ttnn.bfloat8_b:
+        return True
+    if bias_dtype == ttnn.bfloat8_b:
+        return not (
+            (in1_dtype == ttnn.bfloat16 and in0_dtype == ttnn.bfloat8_b)
+            or (in1_dtype == ttnn.bfloat8_b and in0_dtype == ttnn.bfloat8_b)
+        )
+    return not (in1_dtype == ttnn.bfloat16 or (in1_dtype == ttnn.float32 and in0_dtype == ttnn.float32))
+
+
 @pytest.mark.parametrize(
     "batch_size, channel_a, channel_b, m_size, k_size, n_size, has_bias",
     [
@@ -244,6 +267,11 @@ def test_matmul_2d_interleaved_sharded_dtype_bias_sweep(
     across various data type combinations for inputs, outputs, and bias,
     restricted to batch == 1 so that ttnn.Linear() can be used with bias.
     """
+    if _skip_matmul_2d_interleaved_sharded_dtype_bias_sweep_known_failures(
+        has_bias, in0_dtype, in1_dtype, out_dtype, bias_dtype
+    ):
+        pytest.skip("Known PCC failure: BF16-only PyTorch golden vs mixed-dtype linear. Issue #41801")
+
     expected_pcc = 0.99
 
     _run_matmul_2d_interleaved_in0_sharded_in1(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
L2 nightly is failing in main on a matmul pytest with bias

### What's changed
- Skip the 61 failing tests
- Put in a link to an issue to look at fixing the problem

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-0_mm_bias_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-0_mm_bias_skip)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-0_mm_bias_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-0_mm_bias_skip)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-0_mm_bias_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-0_mm_bias_skip)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-0_mm_bias_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-0_mm_bias_skip)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-0_mm_bias_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-0_mm_bias_skip)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-0_mm_bias_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-0_mm_bias_skip)
  - [ ] `models-mandatory` preset (runs: [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
