### PR TITLE
[QSR] Enabled eltwise_binary w/ dest_acc

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -180,7 +180,7 @@ bool single_core_reconfig(
     vector<uint32_t> compute_kernel_args = {};
     std::map<std::string, std::string> defines;
 
-    defines["DST_ACCUM_MODE"] = "1";  // Needed always in order for reader kernel to load data from CB2
+    defines["LOAD_BUF2_DATA"] = "1";  // Needed always in order for reader kernel to load data from CB2
     defines["EXPLICIT_RECONFIG"] = test_config.explicit_reconfig ? "1" : "0";
     defines["SPLIT_SRC_RECONFIG"] = test_config.split_src_reconfig ? "1" : "0";
     defines["BLOCK_COPY"] = test_config.block_copy ? "1" : "0";

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -425,6 +425,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -448,6 +449,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSub) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -471,6 +473,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -495,6 +498,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -519,6 +523,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -543,6 +548,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -635,6 +641,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAdd) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -658,6 +665,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSub) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -681,6 +689,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -706,6 +715,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -731,6 +741,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }
@@ -756,6 +767,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
             }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -216,11 +216,12 @@ bool single_core_binary(
             defines["FULL_INIT"] = "1";
         }
         if (test_config.acc_to_dest) {
-            defines["DST_ACCUM_MODE"] = "1";
-            defines["ELTWISE_OP_INIT"] = defines["ELTWISE_OP"] + "_init";
-            if (test_config.binary_op == "mul") {
-                defines["MUL_TILES_WITH_DST_ACCUM"] = "1";
-            }
+            defines["LOAD_BUF2_DATA"] = "1";
+            defines["ACC_TO_DEST"] = "1";
+        }
+        defines["ELTWISE_OP_INIT"] = defines["ELTWISE_OP"] + "_init";
+        if (test_config.binary_op == "mul") {
+            defines["MUL_TILES_WITH_DST_ACCUM"] = "1";
         }
     }
 
@@ -248,7 +249,10 @@ bool single_core_binary(
             "tt_metal/kernels/compute/eltwise_binary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarComputeConfig{
-                .num_threads_per_cluster = 1, .math_fidelity = test_config.math_fidelity, .fp32_dest_acc_en = test_config.acc_to_dest, .compile_args = compute_cta, .defines = defines});
+                .num_threads_per_cluster = 1,
+                .math_fidelity = test_config.math_fidelity,
+                .compile_args = compute_cta,
+                .defines = defines});
 
         tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
             program_, inp0_dfb, reader_kernel, binary_kernel);

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -248,7 +248,7 @@ bool single_core_binary(
             "tt_metal/kernels/compute/eltwise_binary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarComputeConfig{
-                .num_threads_per_cluster = 1, .math_fidelity = test_config.math_fidelity, .compile_args = compute_cta, .defines = defines});
+                .num_threads_per_cluster = 1, .math_fidelity = test_config.math_fidelity, .fp32_dest_acc_en = test_config.acc_to_dest, .compile_args = compute_cta, .defines = defines});
 
         tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
             program_, inp0_dfb, reader_kernel, binary_kernel);
@@ -689,9 +689,6 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
-    if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "DestAcc test support will be added with DestReuse bring-up";
-    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -709,14 +706,14 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
-    if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "DestAcc test support will be added with DestReuse bring-up";
-    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -734,14 +731,14 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
-    if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "DestAcc test support will be added with DestReuse bring-up";
-    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -759,6 +756,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
@@ -70,33 +70,33 @@ void kernel_main() {
     // This input populates dest with values before binary operation
     // executes, this is used to test eltwise binary with dest re-use
     // and eltwise binary with dest accumulation
-#if defined(DST_ACCUM_MODE) || defined(ELTWISE_DEST_REUSE_TYPE)
+#if defined(DST_ACCUM_MODE) || defined(LOAD_BUF2_DATA) || defined(ELTWISE_DEST_REUSE_TYPE)
     uint32_t src2_addr = get_arg_val<uint32_t>(5);
     uint32_t src2_bank_id = get_arg_val<uint32_t>(6);
 
-    #ifdef ARCH_QUASAR
-        constexpr uint32_t dfb_in2_id = get_compile_time_arg_val(2);
-        experimental::DataflowBuffer dfb2(dfb_in2_id);
-        uint32_t ublock_size_bytes_2 = dfb2.get_entry_size() * ublock_size_tiles;
-    #else
-        constexpr uint32_t cb_id_in2 = 2;
-        experimental::CircularBuffer cb2(cb_id_in2);
-        uint32_t ublock_size_bytes_2 = cb2.get_tile_size() * ublock_size_tiles;
-    #endif
+#ifdef ARCH_QUASAR
+    constexpr uint32_t dfb_in2_id = get_compile_time_arg_val(2);
+    experimental::DataflowBuffer dfb2(dfb_in2_id);
+    uint32_t ublock_size_bytes_2 = dfb2.get_entry_size() * ublock_size_tiles;
+#else
+    constexpr uint32_t cb_id_in2 = 2;
+    experimental::CircularBuffer cb2(cb_id_in2);
+    uint32_t ublock_size_bytes_2 = cb2.get_tile_size() * ublock_size_tiles;
+#endif
 
     for (uint32_t i=0; i<num_tiles; i += ublock_size_tiles) {
         uint64_t src2_noc_addr = get_noc_addr_from_bank_id<true>(src2_bank_id, src2_addr);
-        #ifdef ARCH_QUASAR
-            dfb2.reserve_back(ublock_size_tiles);
-            noc.async_read(dram_src, dfb2, ublock_size_bytes_2, {.bank_id = src2_bank_id, .addr = src2_addr}, {});
-            noc.async_read_barrier();
-            dfb2.push_back(ublock_size_tiles);
-        #else
-            cb2.reserve_back(ublock_size_tiles);
-            noc.async_read(dram_src, cb2, ublock_size_bytes_2, {.bank_id = src2_bank_id, .addr = src2_addr}, {});
-            noc.async_read_barrier();
-            cb2.push_back(ublock_size_tiles);
-        #endif
+#ifdef ARCH_QUASAR
+        dfb2.reserve_back(ublock_size_tiles);
+        noc.async_read(dram_src, dfb2, ublock_size_bytes_2, {.bank_id = src2_bank_id, .addr = src2_addr}, {});
+        noc.async_read_barrier();
+        dfb2.push_back(ublock_size_tiles);
+#else
+        cb2.reserve_back(ublock_size_tiles);
+        noc.async_read(dram_src, cb2, ublock_size_bytes_2, {.bank_id = src2_bank_id, .addr = src2_addr}, {});
+        noc.async_read_barrier();
+        cb2.push_back(ublock_size_tiles);
+#endif
         src2_addr += ublock_size_bytes_2;
     }
 #endif

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -20,18 +20,17 @@
  * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
  *     when input is Tf32 format. Only applicable to ELWMUL.
  * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB
- * @param acc_to_dest: Currently unused on Quasar. Will be adding support for accumulation to dest.
+ * @param acc_to_dest: Flag to control if the result should be accumulated with the current dest
  */
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_eltwise_binary_init([[maybe_unused]] const std::uint32_t acc_to_dest = 0) {
+inline void llk_math_eltwise_binary_init(const std::uint32_t acc_to_dest = 0) {
     static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
-    // TODO: Once runtime asserts are added for Quasar, assert that acc_to_dest is unused
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, false /* enable_direct_indexing */, binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, false /* enable_direct_indexing */, binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE, acc_to_dest);
 }
 
 /**
@@ -45,7 +44,7 @@ inline void llk_math_eltwise_binary_init([[maybe_unused]] const std::uint32_t ac
  * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB
  * @param operand_A: Logical dataflow buffer id for input A, used to derive the tensor shape
  * @param operand_B: Unused on Quasar. Present for API compatibility.
- * @param acc_to_dest: Currently unused on Quasar. Will be adding support for accumulation to dest.
+ * @param acc_to_dest: Flag to control if the result should be accumulated with the current dest
  */
 template <
     EltwiseBinaryType eltwise_binary_type,
@@ -53,14 +52,13 @@ template <
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init_with_operands(
-    const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, [[maybe_unused]] const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
     static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
-    // TODO: Once runtime asserts are added for Quasar, assert that acc_to_dest is unused
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const ckernel::TensorShape tensor_shape_A = get_operand_tensor_shape(operand_id);
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, false /* enable_direct_indexing */, binary_reuse_dest>(tensor_shape_A);
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, false /* enable_direct_indexing */, binary_reuse_dest>(tensor_shape_A, acc_to_dest);
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -27,10 +27,11 @@ template <
     BroadcastType src_b_bcast_type,
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_eltwise_binary_init(const std::uint32_t acc_to_dest = 0) {
+inline void llk_math_eltwise_binary_init(bool acc_to_dest = false) {
     static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, false /* enable_direct_indexing */, binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE, acc_to_dest);
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, binary_reuse_dest>(
+        ckernel::DEFAULT_TENSOR_SHAPE, acc_to_dest);
 }
 
 /**
@@ -52,13 +53,13 @@ template <
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init_with_operands(
-    const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, bool acc_to_dest = false) {
     static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const ckernel::TensorShape tensor_shape_A = get_operand_tensor_shape(operand_id);
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, false /* enable_direct_indexing */, binary_reuse_dest>(tensor_shape_A, acc_to_dest);
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, binary_reuse_dest>(tensor_shape_A, acc_to_dest);
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -97,8 +97,9 @@ ALWI void binary_tiles_init(
  */
 // clang-format on
 ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE()) {
-    // For WH/BH, acc_to_dest is unused and defaulted behaviour is to accumulate to dest. 
-    // For Quasar, there is more control to control acc_to_dest. For back-compatibility with existing kernels, acc_to_dest is defaulted to true.
+    // For WH/BH, acc_to_dest is unused and defaulted behaviour is to accumulate to dest.
+    // For Quasar, there is more control to control acc_to_dest. For back-compatibility with existing kernels,
+    // acc_to_dest is defaulted to true.
     binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, true, call_line);
 }
 

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -97,26 +97,7 @@ ALWI void binary_tiles_init(
  */
 // clang-format on
 ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE()) {
-    // For WH/BH, acc_to_dest is unused and defaulted behaviour is to accumulate to dest.
-    // For Quasar, there is more control to control acc_to_dest. For back-compatibility with existing kernels,
-    // acc_to_dest is defaulted to true.
-    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, true, call_line);
-}
-
-
-// clang-format off
-/**
- * Short init function
- *
- * | Argument       | Description                                                   | Type     | Valid Range | Required |
- * |----------------|---------------------------------------------------------------|----------|-------------|----------|
- * | icb0           | The identifier of the circular buffer (CB) containing A       | uint32_t | 0 to 31     | True     |
- * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t | 0 to 31     | True     |
- * | acc_to_dest    | If true, operation = A * B + dst_tile_idx of add_tiles        | bool     | 0,1         | False    |
- */
-// clang-format on
-ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest, uint32_t call_line = __builtin_LINE()) {
-    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, acc_to_dest, call_line);
+    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, false, call_line);
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -97,7 +97,9 @@ ALWI void binary_tiles_init(
  */
 // clang-format on
 ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE()) {
-    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, false, call_line);
+    // For WH/BH, acc_to_dest is unused and defaulted behaviour is to accumulate to dest. 
+    // For Quasar, there is more control to control acc_to_dest. For back-compatibility with existing kernels, acc_to_dest is defaulted to true.
+    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, true, call_line);
 }
 
 
@@ -112,7 +114,7 @@ ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __bu
  * | acc_to_dest    | If true, operation = A * B + dst_tile_idx of add_tiles        | bool     | 0,1         | False    |
  */
 // clang-format on
-ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false, uint32_t call_line = __builtin_LINE()) {
+ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest, uint32_t call_line = __builtin_LINE()) {
     binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, acc_to_dest, call_line);
 }
 

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -100,6 +100,7 @@ ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __bu
     binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, false, call_line);
 }
 
+
 // clang-format off
 /**
  * Short init function
@@ -108,7 +109,22 @@ ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __bu
  * |----------------|---------------------------------------------------------------|----------|-------------|----------|
  * | icb0           | The identifier of the circular buffer (CB) containing A       | uint32_t | 0 to 31     | True     |
  * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t | 0 to 31     | True     |
- * | acc_to_dest    | If true, operation = A + B + dst_tile_idx of add_tiles | bool     | 0,1         | False |
+ * | acc_to_dest    | If true, operation = A * B + dst_tile_idx of add_tiles        | bool     | 0,1         | False    |
+ */
+// clang-format on
+ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false, uint32_t call_line = __builtin_LINE()) {
+    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, acc_to_dest, call_line);
+}
+
+// clang-format off
+/**
+ * Short init function
+ *
+ * | Argument       | Description                                                   | Type     | Valid Range | Required |
+ * |----------------|---------------------------------------------------------------|----------|-------------|----------|
+ * | icb0           | The identifier of the circular buffer (CB) containing A       | uint32_t | 0 to 31     | True     |
+ * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t | 0 to 31     | True     |
+ * | acc_to_dest    | If true, operation = A + B + dst_tile_idx of add_tiles        | bool     | 0,1         | False    |
  */
 // clang-format on
 ALWI void add_tiles_init(
@@ -124,7 +140,7 @@ ALWI void add_tiles_init(
  * |----------------|---------------------------------------------------------------|----------|-------------|----------|
  * | icb0           | The identifier of the circular buffer (CB) containing A       | uint32_t | 0 to 31     | True     |
  * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t | 0 to 31     | True     |
- * | acc_to_dest    | If true, operation = A - B + dst_tile_idx of sub_tiles | bool     | 0,1         | False |
+ * | acc_to_dest    | If true, operation = A - B + dst_tile_idx of sub_tiles        | bool     | 0,1         | False    |
  */
 // clang-format on
 ALWI void sub_tiles_init(

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -97,7 +97,24 @@ ALWI void binary_tiles_init(
  */
 // clang-format on
 ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE()) {
-    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, false, call_line);
+    // acc_to_dest is unused for WH/BH and accumulation is default behaviour.
+    // For back compatibility with Quasar, acc_to_dest=true in this API for all ops.
+    // More control is provided with 3-arg version of init API.
+    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, true, call_line);
+}
+
+// clang-format off
+/**
+ * Short init function
+ *
+ * | Argument       | Description                                                   | Type     | Valid Range | Required |
+ * |----------------|---------------------------------------------------------------|----------|-------------|----------|
+ * | icb0           | The identifier of the circular buffer (CB) containing A       | uint32_t | 0 to 31     | True     |
+ * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t acc_to_dest, uint32_t call_line = __builtin_LINE()) {
+    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, acc_to_dest, call_line);
 }
 
 // clang-format off

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -91,8 +91,12 @@ void kernel_main() {
 
 #ifdef DST_ACCUM_MODE
 // The following define is needed for WH/BH if mul_tiles/_init is used
-#if defined(MUL_TILES_WITH_DST_ACCUM) && !defined(ARCH_QUASAR)
+#if defined(MUL_TILES_WITH_DST_ACCUM)
+    #ifdef ARCH_QUASAR
+        ELTWISE_OP_INIT(dfb_in0.get_id(), dfb_in1.get_id());
+    #else
         ELTWISE_OP_INIT(cb_inp0, cb_inp1);
+    #endif
 #else
     #ifdef ARCH_QUASAR
         ELTWISE_OP_INIT(dfb_in0.get_id(), dfb_in1.get_id(), true);

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -71,25 +71,25 @@ void kernel_main() {
         #endif
         tile_regs_acquire();
 
-#if defined(DST_ACCUM_MODE) || defined(ELTWISE_DEST_REUSE_TYPE)
-    #ifdef ARCH_QUASAR
-            dfb_in2.wait_front(per_core_block_size);
-            copy_tile_to_dst_init_short(dfb_in2.get_id());
-            for (uint32_t i = 0; i < per_core_block_size; ++i) {
-                copy_tile(dfb_in2.get_id(), i, i);  // copy from c_in[0] to DST[0]
-            }
-            dfb_in2.pop_front(per_core_block_size);
-    #else
-            cb_wait_front(cb_in2, per_core_block_size);
-            copy_tile_to_dst_init_short(cb_in2);
-            for (uint32_t i = 0; i < per_core_block_size; ++i) {
-                copy_tile(cb_in2, i, i);  // copy from c_in[0] to DST[0]
-            }
-            cb_pop_front(cb_in2, per_core_block_size);
-    #endif
+#if defined(DST_ACCUM_MODE) || defined(ACC_TO_DEST) || defined(ELTWISE_DEST_REUSE_TYPE)
+#ifdef ARCH_QUASAR
+        dfb_in2.wait_front(per_core_block_size);
+        copy_tile_to_dst_init_short(dfb_in2.get_id());
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(dfb_in2.get_id(), i, i);  // copy from c_in[0] to DST[0]
+        }
+        dfb_in2.pop_front(per_core_block_size);
+#else
+        cb_wait_front(cb_in2, per_core_block_size);
+        copy_tile_to_dst_init_short(cb_in2);
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in2, i, i);  // copy from c_in[0] to DST[0]
+        }
+        cb_pop_front(cb_in2, per_core_block_size);
+#endif
 #endif
 
-#ifdef DST_ACCUM_MODE
+#if defined(DST_ACCUM_MODE) || defined(ACC_TO_DEST)
 // The following define is needed for WH/BH if mul_tiles/_init is used
 #if defined(MUL_TILES_WITH_DST_ACCUM)
     #ifdef ARCH_QUASAR

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -90,13 +90,9 @@ void kernel_main() {
 #endif
 
 #ifdef DST_ACCUM_MODE
-// The following define is needed if mul_tiles/_init is used
-#ifdef MUL_TILES_WITH_DST_ACCUM
-    #ifdef ARCH_QUASAR
-        ELTWISE_OP_INIT(dfb_in0.get_id(), dfb_in1.get_id());
-    #else
+// The following define is needed for WH/BH if mul_tiles/_init is used
+#if defined(MUL_TILES_WITH_DST_ACCUM) && !defined(ARCH_QUASAR)
         ELTWISE_OP_INIT(cb_inp0, cb_inp1);
-    #endif
 #else
     #ifdef ARCH_QUASAR
         ELTWISE_OP_INIT(dfb_in0.get_id(), dfb_in1.get_id(), true);

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1934,6 +1934,43 @@ class EltwiseBinaryGolden(FidelityMasking):
             return quantize_mx_tensor_chunked(operand, fmt)
         return to_tensor(operand, data_format)
 
+    def _compute_eltwise(
+        self, op, t1, t2, math_format_for_fidelity, math_fidelity, keep_float32=False
+    ):
+        """Compute a single eltwise operation with fidelity masking.
+
+        Args:
+            keep_float32: When True, return float32 result without rounding to
+                bfloat16. For better precision.
+        """
+        MATH_FIDELITY_TO_ITER_COUNT = {
+            MathFidelity.LoFi: 0,
+            MathFidelity.HiFi2: 1,
+            MathFidelity.HiFi3: 2,
+            MathFidelity.HiFi4: 3,
+        }
+        fidelity_iter_count = MATH_FIDELITY_TO_ITER_COUNT[math_fidelity]
+
+        if keep_float32:
+            t1 = t1.to(torch.float32)
+            t2 = t2.to(torch.float32)
+
+        if op == MathOperation.Elwmul:
+            result = None
+            for fidelity_iter in range(fidelity_iter_count + 1):
+                t1, t2 = self._apply_fidelity_masking(
+                    math_format_for_fidelity, t1, t2, fidelity_iter
+                )
+                phase_result = self.ops[op](t1, t2)
+                if fidelity_iter == 0:
+                    result = phase_result
+                else:
+                    result += phase_result
+        else:
+            result = self.ops[op](t1, t2)
+
+        return result
+
     def __call__(
         self,
         op,
@@ -1943,7 +1980,13 @@ class EltwiseBinaryGolden(FidelityMasking):
         math_fidelity,
         input_format=None,
         input_format_B=None,
+        acc_to_dest=False,
+        tile_shape=None,
+        num_tiles_per_accumulation=1,
     ):
+        if tile_shape is None:
+            tile_shape = construct_tile_shape()
+
         if op not in self.ops:
             raise ValueError(f"Unsupported Eltwise operation: {op}")
 
@@ -1968,28 +2011,47 @@ class EltwiseBinaryGolden(FidelityMasking):
 
         t1, t2 = operand1, operand2
 
-        # Step 2: Compute the operation (with fidelity masking for Elwmul).
-        MATH_FIDELITY_TO_ITER_COUNT = {
-            MathFidelity.LoFi: 0,
-            MathFidelity.HiFi2: 1,
-            MathFidelity.HiFi3: 2,
-            MathFidelity.HiFi4: 3,
-        }
-        fidelity_iter_count = MATH_FIDELITY_TO_ITER_COUNT[math_fidelity]
+        # Step 2: Calculate the eltwise result
+        if acc_to_dest:
+            # The concept of tile should only be used when we have accumulation, otherwise we can use the entire tensor.
+            tile_size = tile_shape.total_tile_size()
+            num_total_tiles = t1.numel() // tile_size
+            num_blocks = num_total_tiles // num_tiles_per_accumulation
 
-        if op == MathOperation.Elwmul:
-            result = None
-            for fidelity_iter in range(fidelity_iter_count + 1):
-                t1, t2 = self._apply_fidelity_masking(
-                    math_format_for_fidelity, t1, t2, fidelity_iter
-                )
-                phase_result = self.ops[op](t1, t2)
-                if fidelity_iter == 0:
-                    result = phase_result
-                else:
-                    result += phase_result
+            t1_tiles = t1.view(num_total_tiles, tile_size)
+            t2_tiles = t2.view(num_total_tiles, tile_size)
+
+            accumulated = []
+            for block in range(num_blocks):
+                block_acc = None
+                for tile in range(num_tiles_per_accumulation):
+                    idx = block * num_tiles_per_accumulation + tile
+                    tile_result_f32 = self._compute_eltwise(
+                        op,
+                        t1_tiles[idx],
+                        t2_tiles[idx],
+                        math_format_for_fidelity,
+                        math_fidelity,
+                        keep_float32=True,
+                    )
+                    if block_acc is None:
+                        block_acc = tile_result_f32.to(torch.bfloat16)
+                    else:
+                        # Add in better precision and then convert to lower precision.
+                        block_acc = (block_acc.to(torch.float32) + tile_result_f32).to(
+                            torch.bfloat16
+                        )
+                accumulated.append(block_acc)
+
+            result = torch.cat(accumulated)
         else:
-            result = self.ops[op](t1, t2)
+            result = self._compute_eltwise(
+                op,
+                t1,
+                t2,
+                math_format_for_fidelity,
+                math_fidelity,
+            )
 
         # Step 3: Quantize output to match what hardware packs back into L1.
         if data_format == DataFormat.Bfp4_b:

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -25,13 +25,16 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
+    ACC_TO_DEST,
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    INPUT_TILE_CNT,
     MATH_FIDELITY,
     MATH_OP,
     NUM_FACES,
+    NUM_TILES_IN_BLOCK,
+    OUTPUT_TILE_CNT,
     TEST_FACE_DIMS,
-    TILE_COUNT,
 )
 from helpers.utils import passed_test
 
@@ -40,6 +43,12 @@ ELTWISE_DIMENSIONS = [
     for dest_sync in (DestSync.Half, DestSync.Full)
     for dims in generate_unary_input_dimensions(DestAccumulation.No, dest_sync)
 ]
+from helpers.tile_shape import construct_tile_shape
+
+
+# For acc_to_dest setting, accumulate two result tiles into dest. Can be extended.
+def get_num_tiles_per_accumulation(acc_to_dest: bool) -> int:
+    return 2 if acc_to_dest else 1
 
 
 @pytest.mark.quasar
@@ -68,6 +77,7 @@ ELTWISE_DIMENSIONS = [
         ImpliedMathFormat.Yes,
     ],
     dest_sync_dims_dest_acc=ELTWISE_DIMENSIONS,
+    acc_to_dest=[False, True],
     num_faces=[4],
 )
 def test_eltwise_binary(
@@ -76,11 +86,12 @@ def test_eltwise_binary(
     math_fidelity,
     implied_math_format,
     dest_sync_dims_dest_acc,
+    acc_to_dest,
     num_faces,
     boot_mode=BootMode.DEFAULT,
 ):
-
     dest_sync_mode, input_dimensions, dest_acc = dest_sync_dims_dest_acc
+    tile_shape = construct_tile_shape()
 
     # Math fidelity only affects multiplication operations
     if (
@@ -96,12 +107,26 @@ def test_eltwise_binary(
     ):
         pytest.skip("MX formats require implied_math_format=Yes on Quasar")
 
+    num_tiles_per_accumulation = get_num_tiles_per_accumulation(acc_to_dest)
+    total_tiles = (
+        input_dimensions[0] * input_dimensions[1]
+    ) // tile_shape.total_tile_size()
+
+    if (
+        acc_to_dest and total_tiles < num_tiles_per_accumulation
+    ) or total_tiles % num_tiles_per_accumulation != 0:
+        pytest.skip("Not enough tiles for dest accumulation")
+
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
         output_format=formats.output_format,
+    )
+
+    tile_cnt_res = src_A.numel() // (
+        tile_shape.total_tile_size() * num_tiles_per_accumulation
     )
 
     generate_golden = get_golden_generator(EltwiseBinaryGolden)
@@ -112,6 +137,9 @@ def test_eltwise_binary(
         formats.output_format,
         math_fidelity,
         input_format=formats.input_format,
+        acc_to_dest=acc_to_dest,
+        tile_shape=tile_shape,
+        num_tiles_per_accumulation=num_tiles_per_accumulation,
     )
 
     configuration = TestConfig(
@@ -122,11 +150,14 @@ def test_eltwise_binary(
             MATH_OP(mathop=mathop),
             IMPLIED_MATH_FORMAT(implied_math_format),
             DEST_SYNC(dest_sync_mode),
+            ACC_TO_DEST(acc_to_dest),
         ],
         runtimes=[
-            TILE_COUNT(tile_cnt_A),
+            INPUT_TILE_CNT(tile_cnt_A),
+            OUTPUT_TILE_CNT(tile_cnt_res),
             NUM_FACES(num_faces),
             TEST_FACE_DIMS(),
+            NUM_TILES_IN_BLOCK(num_tiles_per_accumulation),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -136,7 +167,7 @@ def test_eltwise_binary(
             formats.output_format,
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_A,
-            tile_count_res=tile_cnt_A,
+            tile_count_res=tile_cnt_res,
             num_faces=num_faces,
         ),
         # Determine unpack_to_dest based on format and accumulation mode

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -36,6 +36,7 @@ from helpers.test_variant_parameters import (
     OUTPUT_TILE_CNT,
     TEST_FACE_DIMS,
 )
+from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
 
 ELTWISE_DIMENSIONS = [
@@ -43,7 +44,6 @@ ELTWISE_DIMENSIONS = [
     for dest_sync in (DestSync.Half, DestSync.Full)
     for dims in generate_unary_input_dimensions(DestAccumulation.No, dest_sync)
 ]
-from helpers.tile_shape import construct_tile_shape
 
 
 # For acc_to_dest setting, accumulate two result tiles into dest. Can be extended.

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -117,8 +117,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     // Binary with reuse_dest: SrcA = DEST (from datacopy), SrcB = unpacked B. Compute op(SrcA, SrcB) -> DEST.
-    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY, false /*EN_DI*/, REUSE_DEST_TYPE>(
-        ckernel::DEFAULT_TENSOR_SHAPE); // tiny-tile testing not yet supported
+    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY, REUSE_DEST_TYPE>(ckernel::DEFAULT_TENSOR_SHAPE); // tiny-tile testing not yet supported
 
     for (int block = 0; block < num_blocks; block++)
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -65,8 +65,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Initialize binary operands unpacker - unpack 1 tile per MOP run
     _llk_unpack_binary_operands_init_(buf_desc_id_a, buf_desc_id_b, 1);
 
-    // Unpack all tiles for both operands
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    for (int i = 0; i < params.INPUT_TILE_CNT; ++i)
     {
         _llk_unpack_binary_operands_(i, i);
     }
@@ -102,12 +101,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
 
     // Initialize eltwise binary operation with default 32x32 tensor shape
-    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE); // tiny-tile testing not yet supported
+    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE, ACC_TO_DEST); // tiny-tile testing not yet supported
 
     // Perform eltwise binary operation for each tile
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    int tile_idx        = 0;
+    int remaining_tiles = params.INPUT_TILE_CNT;
+
+    while (remaining_tiles)
     {
-        _llk_math_eltwise_binary_(i);
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile) // number of result tiles to accumulate
+        {
+            _llk_math_eltwise_binary_(tile_idx);
+        }
+        tile_idx++;
+        remaining_tiles -= params.NUM_TILES_IN_BLOCK;
     }
 
     // Signal math completion
@@ -153,7 +160,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_(buf_desc_id, 1);
 
     // Pack all result tiles
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    for (int i = 0; i < params.OUTPUT_TILE_CNT; ++i)
     {
         _llk_pack_(i, i);
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -114,7 +114,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_eltwise_binary_(tile_idx);
         }
         tile_idx++;
-        remaining_tiles -= params.NUM_TILES_IN_BLOCK;
+        remaining_tiles -= std::min(remaining_tiles, static_cast<int>(params.NUM_TILES_IN_BLOCK));
     }
 
     // Signal math completion

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -65,7 +65,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Initialize binary operands unpacker - unpack 1 tile per MOP run
     _llk_unpack_binary_operands_init_(buf_desc_id_a, buf_desc_id_b, 1);
 
-    for (int i = 0; i < params.INPUT_TILE_CNT; ++i)
+    for (std::uint32_t i = 0; i < static_cast<std::uint32_t>(params.INPUT_TILE_CNT); ++i)
     {
         _llk_unpack_binary_operands_(i, i);
     }
@@ -104,17 +104,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE, ACC_TO_DEST); // tiny-tile testing not yet supported
 
     // Perform eltwise binary operation for each tile
-    int tile_idx        = 0;
-    int remaining_tiles = params.INPUT_TILE_CNT;
-
-    while (remaining_tiles)
+    std::uint32_t dest_idx = 0;
+    for (std::uint32_t remaining_tiles = static_cast<std::uint32_t>(params.INPUT_TILE_CNT); remaining_tiles > 0;
+         remaining_tiles -= std::min(remaining_tiles, params.NUM_TILES_IN_BLOCK))
     {
-        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile) // number of result tiles to accumulate
+        const std::uint32_t num_tiles_in_block = std::min(remaining_tiles, params.NUM_TILES_IN_BLOCK);
+        for (std::uint32_t tile = 0; tile < num_tiles_in_block; ++tile)
         {
-            _llk_math_eltwise_binary_(tile_idx);
+            _llk_math_eltwise_binary_(dest_idx);
         }
-        tile_idx++;
-        remaining_tiles -= std::min(remaining_tiles, static_cast<int>(params.NUM_TILES_IN_BLOCK));
+        ++dest_idx;
     }
 
     // Signal math completion
@@ -160,7 +159,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_(buf_desc_id, 1);
 
     // Pack all result tiles
-    for (int i = 0; i < params.OUTPUT_TILE_CNT; ++i)
+    for (std::uint32_t i = 0; i < static_cast<std::uint32_t>(params.OUTPUT_TILE_CNT); ++i)
     {
         _llk_pack_(i, i);
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
@@ -12,20 +12,20 @@ using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
 
-template <EltwiseBinaryType ELTWISE_BINARY_TYPE, std::uint8_t CLR_SRC, std::uint8_t EN_DST_ACCUM, std::uint8_t SRCB_BROADCAST_TYPE, std::uint8_t ADDR_MOD>
-constexpr std::uint32_t eltwise_binary_func()
+template <EltwiseBinaryType ELTWISE_BINARY_TYPE, std::uint8_t CLR_SRC, std::uint8_t SRCB_BROADCAST_TYPE, std::uint8_t ADDR_MOD>
+constexpr std::uint32_t eltwise_binary_func(std::uint8_t EN_DST_ACC)
 {
     if constexpr (ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWADD)
     {
-        return TT_OP_ELWADD(CLR_SRC, EN_DST_ACCUM, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
+        return TT_OP_ELWADD(CLR_SRC, EN_DST_ACC, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
     }
     else if constexpr (ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWSUB)
     {
-        return TT_OP_ELWSUB(CLR_SRC, EN_DST_ACCUM, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
+        return TT_OP_ELWSUB(CLR_SRC, EN_DST_ACC, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
     }
     else
     {
-        return TT_OP_ELWMUL(CLR_SRC, EN_DST_ACCUM, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
+        return TT_OP_ELWMUL(CLR_SRC, EN_DST_ACC, SRCB_BROADCAST_TYPE, ADDR_MOD, 0);
     }
 }
 
@@ -68,19 +68,19 @@ template <
     EltwiseBinaryType ELTWISE_BINARY_TYPE,
     ckernel::MathFidelity MATH_FIDELITY_TYPE,
     EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& tensor_shape, bool acc_to_dest = false)
 {
     const std::uint32_t rows_per_mop_run =
         (reuse_dest != EltwiseBinaryReuseDestType::NONE) ? tensor_shape.face_r_dim : (tensor_shape.total_num_faces() * tensor_shape.face_r_dim);
     constexpr bool high_fidelity = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
     static_assert(!(high_fidelity && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
-    // For reuse_dest + Elwmul we need dest accumulation (dest = old_dest + srcA*srcB) ; LoFi alone sets EN_DST_ACC_EN=0.
-    constexpr std::uint32_t EN_DST_ACC_EN =
-        (reuse_dest != EltwiseBinaryReuseDestType::NONE && ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWMUL) ? 1u : (high_fidelity ? 1u : 0u);
+    // For reuse_dest + Elwmul we need dest accumulation (dest = old_dest + srcA*srcB) ; LoFi alone sets EN_DST_ACC=0.
+    const std::uint32_t EN_DST_ACC =
+        acc_to_dest ? 1u
+                    : ((reuse_dest != EltwiseBinaryReuseDestType::NONE && ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWMUL) ? 1u : (high_fidelity ? 1u : 0u));
 
-    constexpr std::uint8_t addrmod_fid = high_fidelity ? ADDR_MOD_2 : ADDR_MOD_0;
-    constexpr static std::uint32_t eltwise_binary_op =
-        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, EN_DST_ACC_EN, p_elwise::SRCB_NO_BCAST, addrmod_fid>();
+    constexpr std::uint8_t addrmod_fid    = high_fidelity ? ADDR_MOD_2 : ADDR_MOD_0;
+    const std::uint32_t eltwise_binary_op = eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, p_elwise::SRCB_NO_BCAST, addrmod_fid>(EN_DST_ACC);
 
     if constexpr (reuse_dest != EltwiseBinaryReuseDestType::NONE)
     {
@@ -98,15 +98,15 @@ inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& ten
         const std::uint32_t MOP_OUTER_LOOP     = (rows_per_mop_run >> math_rows_log2(ELTWISE_MATH_ROWS));
         constexpr std::uint32_t MOP_INNER_LOOP = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
 
-        constexpr static std::uint32_t eltwise_binary_op_clr_valid =
-            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_setrwc::CLR_AB, EN_DST_ACC_EN, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1>();
+        const std::uint32_t eltwise_binary_op_clr_valid =
+            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_setrwc::CLR_AB, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1>(EN_DST_ACC);
         ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, eltwise_binary_op);
         temp.set_last_outer_loop_instr(eltwise_binary_op_clr_valid);
 
         if (high_fidelity)
         {
-            constexpr static std::uint32_t eltwise_binary_op_clr_fidelity =
-                eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, EN_DST_ACC_EN, p_elwise::SRCB_NO_BCAST, ADDR_MOD_0>();
+            const std::uint32_t eltwise_binary_op_clr_fidelity =
+                eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, p_elwise::SRCB_NO_BCAST, ADDR_MOD_0>(EN_DST_ACC);
             temp.set_last_inner_loop_instr(eltwise_binary_op_clr_fidelity); // clear math fidelity
         }
 
@@ -118,14 +118,14 @@ inline void _llk_math_eltwise_binary_mop_config_(const ckernel::TensorShape& ten
 // Direct Indexing Method
 //----------------------
 template <EltwiseBinaryType ELTWISE_BINARY_TYPE, ckernel::MathFidelity MATH_FIDELITY_TYPE>
-inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& tensor_shape, bool acc_to_dest = false)
 {
     const std::uint32_t total_num_rows_per_tile = tensor_shape.total_num_faces() * tensor_shape.face_r_dim;
     const std::uint32_t REPLAY_BUF_LEN          = (total_num_rows_per_tile >> math_rows_log2(ELTWISE_MATH_ROWS));
     const std::uint32_t MOP_INNER_LOOP          = to_underlying(MATH_FIDELITY_TYPE) + 1;
     constexpr bool high_fidelity                = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
     static_assert(!(high_fidelity && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
-    const std::uint32_t EN_DST_ACC_EN = high_fidelity;
+    const std::uint32_t EN_DST_ACC = acc_to_dest ? 1u : static_cast<std::uint32_t>(high_fidelity);
 
     load_replay_buf(
         0u,
@@ -139,7 +139,7 @@ inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& 
             {
                 eltwise_di_binary_func<ELTWISE_BINARY_TYPE>(
                     p_elwise::CLR_NONE,
-                    EN_DST_ACC_EN,
+                    EN_DST_ACC,
                     p_elwise::SRCB_NO_BCAST,
                     (i * ELTWISE_MATH_ROWS) >> 2, // Srcb addr
                     (i * ELTWISE_MATH_ROWS) >> 2, // Srca addr
@@ -151,7 +151,7 @@ inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& 
             {
                 eltwise_di_binary_func<ELTWISE_BINARY_TYPE>(
                     p_elwise::CLR_NONE,
-                    EN_DST_ACC_EN,
+                    EN_DST_ACC,
                     p_elwise::SRCB_NO_BCAST,
                     ((REPLAY_BUF_LEN - 1) * ELTWISE_MATH_ROWS) >> 2,  // Srcb addr
                     ((REPLAY_BUF_LEN - 1) * ELTWISE_MATH_ROWS) >> 2,  // Srca addr
@@ -162,7 +162,7 @@ inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& 
             {
                 eltwise_di_binary_func<ELTWISE_BINARY_TYPE>(
                     p_setrwc::CLR_AB,
-                    EN_DST_ACC_EN,
+                    EN_DST_ACC,
                     p_elwise::SRCB_NO_BCAST,
                     ((REPLAY_BUF_LEN - 1) * ELTWISE_MATH_ROWS) >> 2,  // Srcb addr
                     ((REPLAY_BUF_LEN - 1) * ELTWISE_MATH_ROWS) >> 2,  // Srca addr
@@ -240,17 +240,17 @@ template <
     ckernel::MathFidelity MATH_FIDELITY_TYPE,
     bool EN_DI                            = false,
     EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape& tensor_shape, bool acc_to_dest = false)
 {
     if constexpr (EN_DI)
     {
         _llk_math_eltwise_di_binary_addrmod_<MATH_FIDELITY_TYPE>();
-        _llk_math_eltwise_di_binary_mop_config_<ELTWISE_BINARY_TYPE, MATH_FIDELITY_TYPE>(tensor_shape);
+        _llk_math_eltwise_di_binary_mop_config_<ELTWISE_BINARY_TYPE, MATH_FIDELITY_TYPE>(tensor_shape, acc_to_dest);
     }
     else
     {
         _llk_math_eltwise_binary_addrmod_<MATH_FIDELITY_TYPE>();
-        _llk_math_eltwise_binary_mop_config_<ELTWISE_BINARY_TYPE, MATH_FIDELITY_TYPE, reuse_dest>(tensor_shape);
+        _llk_math_eltwise_binary_mop_config_<ELTWISE_BINARY_TYPE, MATH_FIDELITY_TYPE, reuse_dest>(tensor_shape, acc_to_dest);
     }
 
     if constexpr (reuse_dest != EltwiseBinaryReuseDestType::NONE)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
@@ -13,7 +13,7 @@ using namespace ckernel::trisc;
 using namespace ckernel::math;
 
 template <EltwiseBinaryType ELTWISE_BINARY_TYPE, std::uint8_t CLR_SRC, std::uint8_t SRCB_BROADCAST_TYPE, std::uint8_t ADDR_MOD>
-constexpr std::uint32_t eltwise_binary_func(std::uint8_t EN_DST_ACC)
+inline std::uint32_t eltwise_binary_func(std::uint8_t EN_DST_ACC)
 {
     if constexpr (ELTWISE_BINARY_TYPE == EltwiseBinaryType::ELWADD)
     {
@@ -238,8 +238,8 @@ inline void _llk_math_eltwise_di_binary_addrmod_()
 template <
     EltwiseBinaryType ELTWISE_BINARY_TYPE,
     ckernel::MathFidelity MATH_FIDELITY_TYPE,
-    bool EN_DI                            = false,
-    EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE>
+    EltwiseBinaryReuseDestType reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool EN_DI                            = false>
 inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape& tensor_shape, bool acc_to_dest = false)
 {
     if constexpr (EN_DI)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_broadcast.h
@@ -31,20 +31,19 @@ inline void _llk_math_eltwise_binary_broadcast_mop_config_(const TileShape& tile
                                              ? p_elwise::SRCB_BCAST_COL
                                              : ((BROADCAST_TYPE == BroadcastType::ROW) ? p_elwise::SRCB_BCAST_ROW : p_elwise::SRCB_BCAST_ALL);
 
-    constexpr std::uint32_t EN_DST_ACC_EN = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
-    static_assert(!(EN_DST_ACC_EN && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
+    constexpr std::uint32_t EN_DST_ACC = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
+    static_assert(!(EN_DST_ACC && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
 
     const std::uint32_t MOP_OUTER_LOOP = tile_shape.num_faces;
     const std::uint32_t MOP_INNER_LOOP = num_eltwise_instrn_per_face;
 
-    constexpr static std::uint32_t eltwise_binary_op =
-        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, EN_DST_ACC_EN, SRCB_BROADCAST_TYPE, ADDR_MOD_0>();
-    constexpr static std::uint32_t eltwise_binary_op_clr_srcAB_valid =
-        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_SRCAB_VLD, EN_DST_ACC_EN, SRCB_BROADCAST_TYPE, ADDR_MOD_1>();
+    const std::uint32_t eltwise_binary_op = eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_NONE, SRCB_BROADCAST_TYPE, ADDR_MOD_0>(EN_DST_ACC);
+    const std::uint32_t eltwise_binary_op_clr_srcAB_valid =
+        eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_SRCAB_VLD, SRCB_BROADCAST_TYPE, ADDR_MOD_1>(EN_DST_ACC);
 
     constexpr std::uint32_t replay_buf_len = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 0 : to_underlying(MATH_FIDELITY_TYPE) - 1;
 
-    if constexpr (EN_DST_ACC_EN)
+    if constexpr (EN_DST_ACC)
     {
         load_replay_buf<0, replay_buf_len>(
             // Lambda function to load reply buffer
@@ -62,15 +61,15 @@ inline void _llk_math_eltwise_binary_broadcast_mop_config_(const TileShape& tile
     ROW -> Unpacker unpacks 4 (default in 32x32 tile) faces: F0, F1, F0, F1, SrcB Inc = 0
     COL -> Unpacker unpacks 4 (default in 32x32 tile) faces: F0, F0, F2, F2, SrcB Inc += ELTWISE_MATH_ROWS
     */
-    ckernel_template temp = EN_DST_ACC_EN ? ckernel_template(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), eltwise_binary_op)
-                                          : ckernel_template(MOP_OUTER_LOOP, MOP_INNER_LOOP, eltwise_binary_op);
+    ckernel_template temp = EN_DST_ACC ? ckernel_template(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), eltwise_binary_op)
+                                       : ckernel_template(MOP_OUTER_LOOP, MOP_INNER_LOOP, eltwise_binary_op);
 
     // Only need to clear per face for ROW/COL, since SCALAR only has 1 face from the unpacker
     if constexpr (BROADCAST_TYPE != BroadcastType::SCALAR)
     {
         constexpr std::uint32_t ADDR_MOD = (BROADCAST_TYPE == BroadcastType::COL) ? ADDR_MOD_2 : ADDR_MOD_0;
-        constexpr static std::uint32_t eltwise_binary_op_clr_srcB =
-            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_SRCB_VLD, EN_DST_ACC_EN, SRCB_BROADCAST_TYPE, ADDR_MOD>();
+        const std::uint32_t eltwise_binary_op_clr_srcB =
+            eltwise_binary_func<ELTWISE_BINARY_TYPE, p_elwise::CLR_SRCB_VLD, SRCB_BROADCAST_TYPE, ADDR_MOD>(EN_DST_ACC);
         temp.set_last_inner_loop_instr(eltwise_binary_op_clr_srcB);
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39753

### Problem description
Need to propagate LLK implementations for Eltwise Binary + Dest Accumulation for Quasar to metal.

### What's changed
Propagated LLK implementations for Eltwise Binary for Quasar to metal

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
  - [ ] `models-mandatory` preset (runs: [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-dest-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gdsingh/qsr-eltwise-binary-dest-acc)