### PR TITLE
[DS Blaze] All gather micro-op

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/kernels/all_gather_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/kernels/all_gather_kernel.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/all_gather.hpp"
+
+void kernel_main() {
+    constexpr bool is_gather_core = get_named_compile_time_arg_val("is_allgather_gather_core") == 1;
+    constexpr bool is_transport_core = get_named_compile_time_arg_val("is_allgather_transport_core") == 1;
+
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (is_gather_core) {
+        using GatherCT = deepseek_b1_ops::AllGather::GatherCTArgs<
+            get_named_compile_time_arg_val("allgather_gather_slice_size_bytes"),
+            get_named_compile_time_arg_val("allgather_gather_num_chunks"),
+            get_named_compile_time_arg_val("allgather_ring_size"),
+            get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot")>;
+
+        deepseek_b1_ops::AllGather::GatherArgs args{};
+        args.local_input_addr = get_common_arg_val<uint32_t>(0);
+        args.output_buffer_addr = get_common_arg_val<uint32_t>(1);
+        args.self_slot_index = get_common_arg_val<uint32_t>(2);
+        args.transport_scratch_base_addr = get_common_arg_val<uint32_t>(3);
+        args.transport_noc_x = get_common_arg_val<uint32_t>(4);
+        args.transport_noc_y = get_common_arg_val<uint32_t>(5);
+        args.handoff_sem_bank_addr = get_common_arg_val<uint32_t>(6);
+        args.recv_sem_addr = get_common_arg_val<uint32_t>(7);
+        args.r2_src_slot_index = get_common_arg_val<uint32_t>(8);
+
+        deepseek_b1_ops::AllGather::GatherController<GatherCT> controller;
+        controller(args);
+    }
+#endif
+
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+    if constexpr (is_transport_core) {
+        using TransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+            get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+            get_named_compile_time_arg_val("allgather_num_chunks"),
+            get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+            get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+            get_named_compile_time_arg_val("allgather_num_links"),
+            get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+            get_named_compile_time_arg_val("allgather_r2_active")>;
+
+        deepseek_b1_ops::AllGather::TransportArgs args{};
+        args.scratch_base_addr = get_common_arg_val<uint32_t>(0);
+        args.handoff_sem_bank_addr = get_common_arg_val<uint32_t>(1);
+        args.dest_output_base_addr = get_common_arg_val<uint32_t>(2);
+        args.r1_dest_slot_index = get_common_arg_val<uint32_t>(3);
+        args.dest_noc_x = get_common_arg_val<uint32_t>(4);
+        args.dest_noc_y = get_common_arg_val<uint32_t>(5);
+        args.dest_recv_sem_addr = get_common_arg_val<uint32_t>(6);
+        args.r2_dest_slot_index = get_common_arg_val<uint32_t>(7);
+        args.per_core_rta_start_idx = 0;
+
+        deepseek_b1_ops::AllGather::TransportSender<TransportCT> sender;
+        sender(args);
+    }
+#endif
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/kernels/all_gather_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/kernels/all_gather_kernel.cpp
@@ -5,58 +5,78 @@
 #include "../../../unified_kernels/kernel_utils.hpp"
 #include "../../../unified_kernels/all_gather.hpp"
 
+struct Core {
+    static constexpr bool is_gather_core = get_named_compile_time_arg_val("is_allgather_gather_core") == 1;
+    static constexpr bool is_transport_core = get_named_compile_time_arg_val("is_allgather_transport_core") == 1;
+};
+
 void kernel_main() {
-    constexpr bool is_gather_core = get_named_compile_time_arg_val("is_allgather_gather_core") == 1;
-    constexpr bool is_transport_core = get_named_compile_time_arg_val("is_allgather_transport_core") == 1;
+    // ====================================================================
+    // Arg setup
+    // ====================================================================
 
 #if defined(COMPILE_FOR_NCRISC)
-    if constexpr (is_gather_core) {
-        using GatherCT = deepseek_b1_ops::AllGather::GatherCTArgs<
-            get_named_compile_time_arg_val("allgather_gather_slice_size_bytes"),
-            get_named_compile_time_arg_val("allgather_gather_num_chunks"),
-            get_named_compile_time_arg_val("allgather_ring_size"),
-            get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot")>;
+    using GatherCT = deepseek_b1_ops::AllGather::GatherCTArgs<
+        get_named_compile_time_arg_val("allgather_gather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_gather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_ring_size"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot")>;
 
-        deepseek_b1_ops::AllGather::GatherArgs args{};
-        args.local_input_addr = get_common_arg_val<uint32_t>(0);
-        args.output_buffer_addr = get_common_arg_val<uint32_t>(1);
-        args.self_slot_index = get_common_arg_val<uint32_t>(2);
-        args.transport_scratch_base_addr = get_common_arg_val<uint32_t>(3);
-        args.transport_noc_x = get_common_arg_val<uint32_t>(4);
-        args.transport_noc_y = get_common_arg_val<uint32_t>(5);
-        args.handoff_sem_bank_addr = get_common_arg_val<uint32_t>(6);
-        args.recv_sem_addr = get_common_arg_val<uint32_t>(7);
-        args.r2_src_slot_index = get_common_arg_val<uint32_t>(8);
-
-        deepseek_b1_ops::AllGather::GatherController<GatherCT> controller;
-        controller(args);
+    deepseek_b1_ops::AllGather::GatherArgs gather_args{};
+    if constexpr (Core::is_gather_core) {
+        gather_args.local_input_addr = get_common_arg_val<uint32_t>(0);
+        gather_args.output_buffer_addr = get_common_arg_val<uint32_t>(1);
+        gather_args.self_slot_index = get_common_arg_val<uint32_t>(2);
+        gather_args.transport_scratch_base_addr = get_common_arg_val<uint32_t>(3);
+        gather_args.transport_noc_x = get_common_arg_val<uint32_t>(4);
+        gather_args.transport_noc_y = get_common_arg_val<uint32_t>(5);
+        gather_args.handoff_sem_bank_addr = get_common_arg_val<uint32_t>(6);
+        gather_args.recv_sem_addr = get_common_arg_val<uint32_t>(7);
+        gather_args.r2_src_slot_index = get_common_arg_val<uint32_t>(8);
     }
 #endif
 
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
-    if constexpr (is_transport_core) {
-        using TransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
-            get_named_compile_time_arg_val("allgather_slice_size_bytes"),
-            get_named_compile_time_arg_val("allgather_num_chunks"),
-            get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
-            get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
-            get_named_compile_time_arg_val("allgather_num_links"),
-            get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
-            get_named_compile_time_arg_val("allgather_r2_active")>;
+    using TransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+        get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+        get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+        get_named_compile_time_arg_val("allgather_num_links"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+        get_named_compile_time_arg_val("allgather_r2_active")>;
 
-        deepseek_b1_ops::AllGather::TransportArgs args{};
-        args.scratch_base_addr = get_common_arg_val<uint32_t>(0);
-        args.handoff_sem_bank_addr = get_common_arg_val<uint32_t>(1);
-        args.dest_output_base_addr = get_common_arg_val<uint32_t>(2);
-        args.r1_dest_slot_index = get_common_arg_val<uint32_t>(3);
-        args.dest_noc_x = get_common_arg_val<uint32_t>(4);
-        args.dest_noc_y = get_common_arg_val<uint32_t>(5);
-        args.dest_recv_sem_addr = get_common_arg_val<uint32_t>(6);
-        args.r2_dest_slot_index = get_common_arg_val<uint32_t>(7);
-        args.per_core_rta_start_idx = 0;
+    deepseek_b1_ops::AllGather::TransportArgs transport_args{};
+    if constexpr (Core::is_transport_core) {
+        transport_args.scratch_base_addr = get_common_arg_val<uint32_t>(0);
+        transport_args.handoff_sem_bank_addr = get_common_arg_val<uint32_t>(1);
+        transport_args.dest_output_base_addr = get_common_arg_val<uint32_t>(2);
+        transport_args.r1_dest_slot_index = get_common_arg_val<uint32_t>(3);
+        transport_args.dest_noc_x = get_common_arg_val<uint32_t>(4);
+        transport_args.dest_noc_y = get_common_arg_val<uint32_t>(5);
+        transport_args.dest_recv_sem_addr = get_common_arg_val<uint32_t>(6);
+        transport_args.r2_dest_slot_index = get_common_arg_val<uint32_t>(7);
+        transport_args.per_core_rta_start_idx = 0;
+    }
+#endif
 
+    // ====================================================================
+    // Op invocation
+    // ====================================================================
+
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (Core::is_gather_core) {
+        DeviceZoneScopedN("ALLGATHER_GATHER");
+        deepseek_b1_ops::AllGather::GatherController<GatherCT> controller;
+        controller(gather_args);
+    }
+#endif
+
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_transport_core) {
+        DeviceZoneScopedN("ALLGATHER_TRANSPORT");
         deepseek_b1_ops::AllGather::TransportSender<TransportCT> sender;
-        sender(args);
+        sender(transport_args);
     }
 #endif
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/op.py
@@ -506,8 +506,6 @@ class DeepseekMinimalAllGather:
 
         gather_core = config.gather_core
         transport_core = config.transport_core
-        gather_grid = config.gather_core_set
-        transport_grid = config.transport_core_set
         combined_grid = ttnn.CoreRangeSet(
             [ttnn.CoreRange(gather_core, gather_core), ttnn.CoreRange(transport_core, transport_core)]
         )

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/op.py
@@ -1,0 +1,577 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CCL All-Gather micro-op for a 4-device torused row ring.
+
+Two-core implementation:
+- Gather core: NCRISC controller (local copies, handoffs, receive waits).
+  BRISC and TRISC idle.
+- Transport core: BRISC = fwd sender, NCRISC = bwd sender.  TRISC idle.
+
+Algorithm (2-round neighbor exchange):
+  R0: cross-core write to transport scratch + handoff (unblocks R1 ASAP),
+      then local copy to own output slot
+  R1: bidirectional send of local slice; remote writes land on gather core
+  R1→R2: wait for forwarded slice, copy to transport scratch[1] + handoff
+  R2: pairwise exchange
+
+Semaphores (2 global):
+  handoff_sem on transport core — monotonic (0 → 1 → 2 → 0)
+  recv_sem on gather core — packed cumulative per-slot counter
+
+No circular buffers.  Raw L1 addresses from tensor shards.
+"""
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreRuntimeArgsDescriptor,
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+RECV_SEM_BITS_PER_SLOT = 4
+RING_SIZE = 4
+MAX_NUM_LINKS = 2
+
+
+def _get_neighbor_coord(mesh_shape, row, col, offset, cluster_axis=0):
+    if cluster_axis == 0:
+        return (row + offset) % mesh_shape[0], col
+    return row, (col + offset) % mesh_shape[1]
+
+
+# ---------------------------------------------------------------------------
+# Byte-oriented chunk config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ByteChunkConfig:
+    num_chunks: int
+    chunk_size_bytes: int
+    last_chunk_bytes: int
+
+
+def resolve_byte_chunk_config(slice_size_bytes, max_chunk_size_bytes=None):
+    max_payload = int(ttnn.get_tt_fabric_max_payload_size_bytes())
+    if max_chunk_size_bytes is not None:
+        max_payload = min(max_payload, int(max_chunk_size_bytes))
+    if max_payload <= 0:
+        raise ValueError(f"Invalid max payload: {max_payload}")
+
+    num_chunks = math.ceil(slice_size_bytes / max_payload)
+    chunk_size_bytes = min(slice_size_bytes, max_payload)
+    last_chunk_bytes = slice_size_bytes - (num_chunks - 1) * chunk_size_bytes
+
+    max_field_value = (1 << RECV_SEM_BITS_PER_SLOT) - 1
+    if num_chunks > max_field_value:
+        raise ValueError(
+            f"num_chunks={num_chunks} exceeds packed semaphore capacity "
+            f"({max_field_value}) for BitsPerSlot={RECV_SEM_BITS_PER_SLOT}"
+        )
+
+    return ByteChunkConfig(
+        num_chunks=num_chunks,
+        chunk_size_bytes=chunk_size_bytes,
+        last_chunk_bytes=last_chunk_bytes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Named compile-time arg schemas
+# ---------------------------------------------------------------------------
+
+
+def _transport_named_ct_schema(
+    slice_size_bytes=0,
+    num_chunks=0,
+    chunk_size_bytes=0,
+    last_chunk_bytes=0,
+    num_links=0,
+    recv_sem_bits_per_slot=RECV_SEM_BITS_PER_SLOT,
+    r2_active=0,
+):
+    return [
+        ("allgather_slice_size_bytes", int(slice_size_bytes)),
+        ("allgather_num_chunks", int(num_chunks)),
+        ("allgather_chunk_size_bytes", int(chunk_size_bytes)),
+        ("allgather_last_chunk_bytes", int(last_chunk_bytes)),
+        ("allgather_num_links", int(num_links)),
+        ("allgather_recv_sem_bits_per_slot", int(recv_sem_bits_per_slot)),
+        ("allgather_r2_active", int(r2_active)),
+    ]
+
+
+def _gather_named_ct_schema(
+    slice_size_bytes=0,
+    num_chunks=0,
+    ring_size=RING_SIZE,
+):
+    return [
+        ("allgather_gather_slice_size_bytes", int(slice_size_bytes)),
+        ("allgather_gather_num_chunks", int(num_chunks)),
+        ("allgather_ring_size", int(ring_size)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Common runtime arg schemas (positional common RT args)
+# ---------------------------------------------------------------------------
+
+
+def _gather_common_rt_schema(
+    local_input_addr=0,
+    output_buffer_addr=0,
+    self_slot_index=0,
+    transport_scratch_base_addr=0,
+    transport_noc_x=0,
+    transport_noc_y=0,
+    handoff_sem_bank_addr=0,
+    recv_sem_addr=0,
+    r2_src_slot_index=0,
+):
+    """Gather core NCRISC common RT args."""
+    return [
+        int(local_input_addr),
+        int(output_buffer_addr),
+        int(self_slot_index),
+        int(transport_scratch_base_addr),
+        int(transport_noc_x),
+        int(transport_noc_y),
+        int(handoff_sem_bank_addr),
+        int(recv_sem_addr),
+        int(r2_src_slot_index),
+    ]
+
+
+def _transport_common_rt_schema(
+    scratch_base_addr=0,
+    handoff_sem_bank_addr=0,
+    dest_output_base_addr=0,
+    r1_dest_slot_index=0,
+    dest_noc_x=0,
+    dest_noc_y=0,
+    dest_recv_sem_addr=0,
+    r2_dest_slot_index=0,
+):
+    """Transport core common RT args (shared by BRISC fwd and NCRISC bwd)."""
+    return [
+        int(scratch_base_addr),
+        int(handoff_sem_bank_addr),
+        int(dest_output_base_addr),
+        int(r1_dest_slot_index),
+        int(dest_noc_x),
+        int(dest_noc_y),
+        int(dest_recv_sem_addr),
+        int(r2_dest_slot_index),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AllGatherConfig
+# ---------------------------------------------------------------------------
+
+
+class AllGatherConfig:
+    """Standalone all-gather config for a 4-device torused ring.
+
+    Cores are derived from tensor shard grids:
+      gather_core  — from input_tensor_mesh shard grid start
+      transport_core — from scratch_tensor_mesh shard grid start
+
+    Public API mirrors the all-reduce config pattern:
+      Named CT:   get_ncrisc_named_ct_args, get_brisc_named_ct_args, get_trisc_named_ct_args
+      Common RT:  get_gather_ncrisc_common_rt_args, get_transport_common_rt_args
+      Per-core RT: get_transport_brisc_per_core_rt_args, get_transport_ncrisc_per_core_rt_args
+    """
+
+    def __init__(
+        self,
+        mesh_device,
+        input_tensor_mesh,
+        output_tensor_mesh,
+        scratch_tensor_mesh,
+        semaphores,
+        cluster_axis=0,
+        num_links=1,
+        max_chunk_size_bytes=None,
+    ):
+        self.mesh_device = mesh_device
+        self.cluster_axis = int(cluster_axis)
+        self.num_links = int(num_links)
+
+        self._resolve_role_assignment()
+
+        mesh_shape = mesh_device.shape
+        ring_size = mesh_shape[self.cluster_axis]
+        if ring_size != RING_SIZE:
+            raise ValueError(f"All-gather requires ring size {RING_SIZE}, got {ring_size}")
+        if len(semaphores) < 2:
+            raise ValueError(f"Need 2 semaphores (handoff + recv), got {len(semaphores)}")
+        if self.num_links < 1 or self.num_links > MAX_NUM_LINKS:
+            raise ValueError(f"num_links must be in [1, {MAX_NUM_LINKS}], got {self.num_links}")
+
+        input_per_device = ttnn.get_device_tensors(input_tensor_mesh)
+        output_per_device = ttnn.get_device_tensors(output_tensor_mesh)
+        scratch_per_device = ttnn.get_device_tensors(scratch_tensor_mesh)
+        self.input_per_device = input_per_device
+        self.output_per_device = output_per_device
+        self.scratch_per_device = scratch_per_device
+
+        # Derive cores from tensor shard grids
+        gather_grid_start = input_per_device[0].memory_config().shard_spec.grid.bounding_box().start
+        self.gather_core = ttnn.CoreCoord(int(gather_grid_start.x), int(gather_grid_start.y))
+
+        transport_grid_start = scratch_per_device[0].memory_config().shard_spec.grid.bounding_box().start
+        self.transport_core = ttnn.CoreCoord(int(transport_grid_start.x), int(transport_grid_start.y))
+
+        # Slice size from input tensor shard
+        input_shard = input_per_device[0].memory_config().shard_spec
+        element_size = 2  # bf16
+        shard_elements = input_shard.shape[0] * input_shard.shape[1]
+        self.slice_size_bytes = shard_elements * element_size
+
+        self.chunk = resolve_byte_chunk_config(self.slice_size_bytes, max_chunk_size_bytes)
+
+        # L1 addresses (uniform across devices for same tensor allocation)
+        self.input_addr = input_per_device[0].buffer_address()
+        self.output_addr = output_per_device[0].buffer_address()
+        self.scratch_base_addr = scratch_per_device[0].buffer_address()
+
+        # Global semaphore addresses
+        self.handoff_sem_addr = ttnn.get_global_semaphore_address(semaphores[0])
+        self.recv_sem_addr = ttnn.get_global_semaphore_address(semaphores[1])
+
+        # Physical NOC coords (uniform across devices)
+        ref_device = input_per_device[0].device()
+        gather_phys = ref_device.worker_core_from_logical_core(self.gather_core)
+        transport_phys = ref_device.worker_core_from_logical_core(self.transport_core)
+        self.gather_noc_x = gather_phys.x
+        self.gather_noc_y = gather_phys.y
+        self.transport_noc_x = transport_phys.x
+        self.transport_noc_y = transport_phys.y
+
+        self.gather_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(self.gather_core, self.gather_core)])
+        self.transport_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(self.transport_core, self.transport_core)])
+
+        # Per-device schedule
+        mesh_rows, mesh_cols = mesh_shape
+        self._per_device = {}
+        for row in range(mesh_rows):
+            for col in range(mesh_cols):
+                coord = ttnn.MeshCoordinate(row, col)
+
+                if self.cluster_axis == 0:
+                    self_rank = row
+                else:
+                    self_rank = col
+
+                fwd_row, fwd_col = _get_neighbor_coord(mesh_shape, row, col, +1, self.cluster_axis)
+                bwd_row, bwd_col = _get_neighbor_coord(mesh_shape, row, col, -1, self.cluster_axis)
+                fwd_coord = ttnn.MeshCoordinate(fwd_row, fwd_col)
+                bwd_coord = ttnn.MeshCoordinate(bwd_row, bwd_col)
+
+                fabric_node_by_direction = {
+                    +1: mesh_device.get_fabric_node_id(fwd_coord),
+                    -1: mesh_device.get_fabric_node_id(bwd_coord),
+                }
+
+                is_even = self_rank % 2 == 0
+                r2_direction = self._even_r2_fabric_direction if is_even else -self._even_r2_fabric_direction
+
+                brisc_r2_active = 1 if r2_direction == self._brisc_fabric_direction else 0
+                ncrisc_r2_active = 1 if r2_direction == self._ncrisc_fabric_direction else 0
+
+                # R2 forwards data that was received from the *opposite* direction
+                # in R1.  If R2 sends in direction d, the data came from -d:
+                #   r2_src_slot = (rank - d) % ring_size
+                # e.g. d=+1 (fwd) → src is rank-1 (bwd neighbor's data)
+                #      d=-1 (bwd) → src is rank+1 (fwd neighbor's data)
+                r2_src_slot = (self_rank - r2_direction) % RING_SIZE
+
+                self._per_device[coord] = {
+                    "self_rank": self_rank,
+                    "fabric_node_id": mesh_device.get_fabric_node_id(coord),
+                    "fabric_node_by_direction": fabric_node_by_direction,
+                    "brisc_r2_active": brisc_r2_active,
+                    "ncrisc_r2_active": ncrisc_r2_active,
+                    "r2_src_slot_index": r2_src_slot,
+                    "r1_dest_slot_index": self_rank,
+                    "r2_dest_slot_index": r2_src_slot,
+                }
+
+    # ======================================================================
+    # Named compile-time args
+    # ======================================================================
+
+    def get_ncrisc_named_ct_args(self, coord):
+        info = self._per_device[coord]
+        transport_ct = _transport_named_ct_schema(
+            slice_size_bytes=self.slice_size_bytes,
+            num_chunks=self.chunk.num_chunks,
+            chunk_size_bytes=self.chunk.chunk_size_bytes,
+            last_chunk_bytes=self.chunk.last_chunk_bytes,
+            num_links=self.num_links,
+            r2_active=info["ncrisc_r2_active"],
+        )
+        gather_ct = _gather_named_ct_schema(
+            slice_size_bytes=self.slice_size_bytes,
+            num_chunks=self.chunk.num_chunks,
+        )
+        return transport_ct + gather_ct
+
+    def get_brisc_named_ct_args(self, coord):
+        info = self._per_device[coord]
+        return _transport_named_ct_schema(
+            slice_size_bytes=self.slice_size_bytes,
+            num_chunks=self.chunk.num_chunks,
+            chunk_size_bytes=self.chunk.chunk_size_bytes,
+            last_chunk_bytes=self.chunk.last_chunk_bytes,
+            num_links=self.num_links,
+            r2_active=info["brisc_r2_active"],
+        )
+
+    def get_trisc_named_ct_args(self, coord):
+        return []
+
+    # ======================================================================
+    # Role assignment
+    # ======================================================================
+
+    def _resolve_role_assignment(self):
+        """Assign fabric directions to transport RISCs and define R2 parity.
+
+        Direction encoding: +1 = forward (next neighbor), -1 = backward (prev).
+
+        To swap which RISC sends in which direction: swap the two direction values.
+        To flip which parity group handles R2: negate _even_r2_fabric_direction.
+        """
+        self._brisc_fabric_direction = +1  # BRISC sends forward
+        self._ncrisc_fabric_direction = -1  # NCRISC sends backward
+        self._even_r2_fabric_direction = +1  # even ranks do R2 in fwd direction
+
+    # ======================================================================
+    # Compile-time core descriptors
+    # ======================================================================
+
+    def get_compile_time_core_descriptors(self):
+        """Return the list of UnifiedCompileTimeCoreDescriptor for all-gather cores."""
+        return [
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_allgather_gather_core",
+                core_range=self.gather_core_set,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_allgather_transport_core",
+                core_range=self.transport_core_set,
+                value=1,
+                other_value=0,
+            ),
+        ]
+
+    # ======================================================================
+    # Common runtime args
+    # ======================================================================
+
+    def get_gather_ncrisc_common_rt_args(self, coord):
+        info = self._per_device[coord]
+        return _gather_common_rt_schema(
+            local_input_addr=self.input_addr,
+            output_buffer_addr=self.output_addr,
+            self_slot_index=info["self_rank"],
+            transport_scratch_base_addr=self.scratch_base_addr,
+            transport_noc_x=self.transport_noc_x,
+            transport_noc_y=self.transport_noc_y,
+            handoff_sem_bank_addr=self.handoff_sem_addr,
+            recv_sem_addr=self.recv_sem_addr,
+            r2_src_slot_index=info["r2_src_slot_index"],
+        )
+
+    def get_transport_common_rt_args(self, coord):
+        """Common RT args shared by both transport BRISC (fwd) and NCRISC (bwd).
+
+        Destination NOC coords and L1 addresses are direction-independent
+        because all devices share the same physical layout.  The actual
+        fabric routing is determined by per-core RT args (fabric connection).
+        """
+        info = self._per_device[coord]
+        return _transport_common_rt_schema(
+            scratch_base_addr=self.scratch_base_addr,
+            handoff_sem_bank_addr=self.handoff_sem_addr,
+            dest_output_base_addr=self.output_addr,
+            r1_dest_slot_index=info["r1_dest_slot_index"],
+            dest_noc_x=self.gather_noc_x,
+            dest_noc_y=self.gather_noc_y,
+            dest_recv_sem_addr=self.recv_sem_addr,
+            r2_dest_slot_index=info["r2_dest_slot_index"],
+        )
+
+    # ======================================================================
+    # Per-core runtime args (fabric connections, one per link)
+    # ======================================================================
+
+    def _build_transport_per_core_rt_args(self, coord, program, core, dst_fabric_node_id):
+        """Build per-core RT args for one transport RISC direction.
+
+        Layout: [dst_mesh_id, dst_chip_id, <link 0 fabric args>, <link 1 fabric args>, ...]
+        The kernel reads dst_mesh_id / dst_chip_id once, then builds num_links
+        connections by iterating over the remaining args.
+        """
+        info = self._per_device[coord]
+        out = [
+            int(dst_fabric_node_id.mesh_id),
+            int(dst_fabric_node_id.chip_id),
+        ]
+        for link_idx in range(self.num_links):
+            out.extend(
+                ttnn.setup_fabric_connection(
+                    src_fabric_node_id=info["fabric_node_id"],
+                    dst_fabric_node_id=dst_fabric_node_id,
+                    link_idx=link_idx,
+                    program_descriptor=program,
+                    worker_core=core,
+                )
+            )
+        return out
+
+    def get_transport_brisc_per_core_rt_args(self, coord, program, core):
+        info = self._per_device[coord]
+        dst = info["fabric_node_by_direction"][self._brisc_fabric_direction]
+        return self._build_transport_per_core_rt_args(coord, program, core, dst)
+
+    def get_transport_ncrisc_per_core_rt_args(self, coord, program, core):
+        info = self._per_device[coord]
+        dst = info["fabric_node_by_direction"][self._ncrisc_fabric_direction]
+        return self._build_transport_per_core_rt_args(coord, program, core, dst)
+
+
+# ---------------------------------------------------------------------------
+# DeepseekMinimalAllGather
+# ---------------------------------------------------------------------------
+
+
+class DeepseekMinimalAllGather:
+    @staticmethod
+    def golden(input_tensors_per_device):
+        """Concatenate per-device inputs along the last dimension in rank order."""
+        return torch.cat(input_tensors_per_device, dim=-1)
+
+    @staticmethod
+    def get_num_semaphores():
+        """handoff_sem + recv_sem."""
+        return 2
+
+    @staticmethod
+    def create_semaphores(mesh_device):
+        num_semaphores = DeepseekMinimalAllGather.get_num_semaphores()
+        device_grid_size = mesh_device.compute_with_storage_grid_size()
+        available_cores = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+        )
+        return [ttnn.create_global_semaphore(mesh_device, available_cores, 0) for _ in range(num_semaphores)]
+
+    @staticmethod
+    def op(
+        input_tensor_mesh,
+        output_tensor_mesh,
+        scratch_tensor_mesh,
+        semaphores,
+        cluster_axis=0,
+        num_links=1,
+        max_chunk_size_bytes=None,
+    ):
+        mesh_device = input_tensor_mesh.device()
+        mesh_shape = mesh_device.shape
+        mesh_rows, mesh_cols = mesh_shape
+
+        config = AllGatherConfig(
+            mesh_device=mesh_device,
+            input_tensor_mesh=input_tensor_mesh,
+            output_tensor_mesh=output_tensor_mesh,
+            scratch_tensor_mesh=scratch_tensor_mesh,
+            semaphores=semaphores,
+            cluster_axis=cluster_axis,
+            num_links=num_links,
+            max_chunk_size_bytes=max_chunk_size_bytes,
+        )
+
+        gather_core = config.gather_core
+        transport_core = config.transport_core
+        gather_grid = config.gather_core_set
+        transport_grid = config.transport_core_set
+        combined_grid = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(gather_core, gather_core), ttnn.CoreRange(transport_core, transport_core)]
+        )
+
+        kernel_path = "models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/kernels/all_gather_kernel.cpp"
+
+        mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+
+        for row in range(mesh_rows):
+            for col in range(mesh_cols):
+                coord = ttnn.MeshCoordinate(row, col)
+
+                unified_kernel = UnifiedKernelDescriptor(
+                    kernel_source=kernel_path,
+                    core_ranges=combined_grid,
+                    ncrisc_named_compile_time_args=config.get_ncrisc_named_ct_args(coord),
+                    brisc_named_compile_time_args=config.get_brisc_named_ct_args(coord),
+                    trisc_named_compile_time_args=config.get_trisc_named_ct_args(coord),
+                    unified_compile_time_core_descriptors=config.get_compile_time_core_descriptors(),
+                    per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
+                        ncrisc_args=[(gather_core, []), (transport_core, [])],
+                        brisc_args=[(gather_core, []), (transport_core, [])],
+                        trisc_args=[],
+                    ),
+                    noc_mode=ttnn.NOC_MODE.DM_DYNAMIC_NOC,
+                )
+                kernel_result = unified_kernel.get_kernel_descriptors()
+                gather_group = kernel_result.get_group_by_arg("is_allgather_gather_core", 1)
+                transport_group = kernel_result.get_group_by_arg("is_allgather_gather_core", 0)
+                if gather_group is None or transport_group is None:
+                    raise ValueError("Expected gather and transport kernel groups")
+
+                program = ttnn.ProgramDescriptor(
+                    kernels=kernel_result.kernels,
+                    semaphores=[],
+                    cbs=[],
+                )
+
+                # Gather core common RT args
+                program.kernels[
+                    gather_group.ncrisc_kernel_index
+                ].common_runtime_args = config.get_gather_ncrisc_common_rt_args(coord)
+                program.kernels[gather_group.brisc_kernel_index].common_runtime_args = []
+                program.kernels[gather_group.trisc_kernel_index].common_runtime_args = []
+
+                # Transport core common RT args
+                transport_rt = config.get_transport_common_rt_args(coord)
+                program.kernels[transport_group.ncrisc_kernel_index].common_runtime_args = transport_rt
+                program.kernels[transport_group.brisc_kernel_index].common_runtime_args = transport_rt
+                program.kernels[transport_group.trisc_kernel_index].common_runtime_args = []
+
+                # Append fabric per-core RT args (one connection per link per direction)
+                brisc_per_core = program.kernels[transport_group.brisc_kernel_index].runtime_args[transport_core.x][
+                    transport_core.y
+                ]
+                brisc_per_core.extend(config.get_transport_brisc_per_core_rt_args(coord, program, transport_core))
+
+                ncrisc_per_core = program.kernels[transport_group.ncrisc_kernel_index].runtime_args[transport_core.x][
+                    transport_core.y
+                ]
+                ncrisc_per_core.extend(config.get_transport_ncrisc_per_core_rt_args(coord, program, transport_core))
+
+                mesh_program_descriptor[ttnn.MeshCoordinateRange(coord, coord)] = program
+
+        io_tensors = [input_tensor_mesh, output_tensor_mesh, scratch_tensor_mesh]
+        ttnn.generic_op(io_tensors, mesh_program_descriptor)
+        return output_tensor_mesh

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_gather.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN CCL All-Gather Test
+
+Tests the all-gather operation on a 4-device torused row ring where:
+1. Each device starts with a local shard on the gather core
+2. After all-gather, every device holds the concatenation of all 4 shards
+   in canonical rank order
+
+Topology: 4x1 submesh (single ring of 4 devices along row dimension).
+Tile: (1, 32) bf16.
+Sharding: HEIGHT_SHARDED on the gather core for input/output,
+          HEIGHT_SHARDED on the transport core for scratch.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import torch
+from loguru import logger
+from tracy import signpost
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.micro_ops.ccl_all_gather.op import DeepseekMinimalAllGather
+from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
+from models.perf.benchmarking_utils import BenchmarkProfiler
+
+GATHER_CORE = ttnn.CoreCoord(0, 0)
+TRANSPORT_CORE = ttnn.CoreCoord(0, 1)
+
+NUM_DEVICES = 4
+TILE_W = 32
+
+
+@dataclass(frozen=True)
+class AllGatherTestInputs:
+    output_shape: list[int]
+    input_tensors_per_device: list[torch.Tensor]
+    torch_expected: torch.Tensor
+    input_tensor_mesh: Any
+    output_tensor_mesh: Any
+    scratch_tensor_mesh: Any
+    semaphores: list[Any]
+
+
+def build_all_gather_test_inputs(
+    *,
+    mesh_device,
+    output_shape,
+    input_tensors_per_device=None,
+):
+    """Build test tensors for the 4-device all-gather.
+
+    Args:
+        output_shape: Full gathered output shape, e.g. [1, 896].
+            output_shape[1] must be divisible by NUM_DEVICES * TILE_W.
+        input_tensors_per_device: Optional list of NUM_DEVICES tensors.
+            If None, random tensors are generated.
+    """
+    tile_h = output_shape[0]
+    output_width = output_shape[1]
+    slice_width = output_width // NUM_DEVICES
+
+    if output_width % NUM_DEVICES != 0:
+        raise ValueError(f"output_width={output_width} must be divisible by NUM_DEVICES={NUM_DEVICES}")
+    if slice_width % TILE_W != 0:
+        raise ValueError(f"slice_width={slice_width} must be divisible by TILE_W={TILE_W}")
+
+    tile = ttnn.Tile((tile_h, TILE_W))
+
+    if input_tensors_per_device is None:
+        input_tensors_per_device = [torch.rand(tile_h, slice_width, dtype=torch.bfloat16) for _ in range(NUM_DEVICES)]
+
+    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(GATHER_CORE, GATHER_CORE)})
+    input_shard_spec = ttnn.ShardSpec(input_shard_grid, (tile_h, slice_width), ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+    )
+
+    input_tensor_mesh = ttnn.from_torch(
+        torch.cat(input_tensors_per_device, dim=0),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        tile=tile,
+        dtype=ttnn.bfloat16,
+        memory_config=input_mem_config,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+    )
+
+    output_shard_spec = ttnn.ShardSpec(input_shard_grid, (tile_h, output_width), ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+    )
+
+    output_tensor_mesh = ttnn.from_torch(
+        torch.zeros(tile_h * NUM_DEVICES, output_width, dtype=torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        tile=tile,
+        dtype=ttnn.bfloat16,
+        memory_config=output_mem_config,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+    )
+
+    scratch_width = slice_width * 2
+    scratch_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(TRANSPORT_CORE, TRANSPORT_CORE)})
+    scratch_shard_spec = ttnn.ShardSpec(scratch_shard_grid, (tile_h, scratch_width), ttnn.ShardOrientation.ROW_MAJOR)
+    scratch_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=scratch_shard_spec
+    )
+
+    scratch_tensor_mesh = ttnn.from_torch(
+        torch.zeros(tile_h * NUM_DEVICES, scratch_width, dtype=torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        tile=tile,
+        dtype=ttnn.bfloat16,
+        memory_config=scratch_mem_config,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+    )
+
+    torch_expected = DeepseekMinimalAllGather.golden(input_tensors_per_device)
+
+    semaphores = DeepseekMinimalAllGather.create_semaphores(mesh_device)
+    ttnn.synchronize_device(mesh_device)
+
+    return AllGatherTestInputs(
+        output_shape=output_shape,
+        input_tensors_per_device=input_tensors_per_device,
+        torch_expected=torch_expected,
+        input_tensor_mesh=input_tensor_mesh,
+        output_tensor_mesh=output_tensor_mesh,
+        scratch_tensor_mesh=scratch_tensor_mesh,
+        semaphores=semaphores,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verification helper
+# ---------------------------------------------------------------------------
+
+
+def _verify_all_gather_output(submesh, ttnn_result, inputs):
+    logger.info("Verifying all-gather results...")
+    tile_h = inputs.output_shape[0]
+
+    output_torch = ttnn.to_torch(
+        ttnn_result,
+        mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0),
+    )
+
+    all_passed = True
+    ref_device_output = output_torch[:tile_h, :]
+
+    for device_idx in range(NUM_DEVICES):
+        start_row = device_idx * tile_h
+        received = output_torch[start_row : start_row + tile_h, :]
+
+        assert received.shape == inputs.torch_expected.shape, (
+            f"Shape mismatch at device {device_idx}: " f"expected {inputs.torch_expected.shape}, got {received.shape}"
+        )
+
+        if device_idx != 0:
+            assert torch.equal(received, ref_device_output), f"Device {device_idx} output differs from device 0"
+
+        if not torch.allclose(received, inputs.torch_expected, rtol=1e-2, atol=1e-2):
+            logger.error(f"Output mismatch for device {device_idx}")
+            logger.error(f"Expected:\n{inputs.torch_expected[:2, :8]}")
+            logger.error(f"Received:\n{received[:2, :8]}")
+            all_passed = False
+        else:
+            logger.info(f"Device {device_idx}: PASSED")
+
+    assert all_passed, "Not all devices have the correct all-gathered data"
+    logger.info("CCL all-gather test passed!")
+
+
+def _verify_per_slot_identity(submesh, ttnn_result, inputs, expected_slot_tensors):
+    """Verify that each slot on each device contains exactly the expected tensor."""
+    tile_h = inputs.output_shape[0]
+    slice_width = inputs.output_shape[1] // NUM_DEVICES
+
+    output_torch = ttnn.to_torch(
+        ttnn_result,
+        mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0),
+    )
+
+    all_passed = True
+    for device_idx in range(NUM_DEVICES):
+        start_row = device_idx * tile_h
+        device_output = output_torch[start_row : start_row + tile_h, :]
+
+        for slot_idx in range(NUM_DEVICES):
+            col_start = slot_idx * slice_width
+            slot_data = device_output[:, col_start : col_start + slice_width]
+            expected = expected_slot_tensors[slot_idx]
+
+            if not torch.equal(slot_data, expected):
+                expected_val = float(slot_idx + 1)
+                actual_unique = slot_data.unique().tolist()
+                logger.error(
+                    f"Device {device_idx}, slot {slot_idx}: "
+                    f"expected all {expected_val}, got unique values {actual_unique}"
+                )
+                all_passed = False
+            else:
+                logger.info(f"Device {device_idx}, slot {slot_idx}: PASSED (all {float(slot_idx + 1)})")
+
+    assert all_passed, "Per-slot identity check failed"
+    logger.info("Deterministic fill test passed!")
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fill test (per-slot identity check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("output_shape", [[1, 7168]])
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "trace_region_size": 573440,
+        }
+    ],
+    indirect=True,
+)
+def test_ccl_all_gather_deterministic_fill(
+    bh_2d_mesh_device,
+    output_shape,
+    num_links,
+):
+    """Each device's input is filled with (device_idx + 1.0).
+
+    After all-gather, every device's output should have:
+      slot 0 = all 1.0, slot 1 = all 2.0, slot 2 = all 3.0, slot 3 = all 4.0
+    """
+    total_devices = bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]
+    if total_devices < NUM_DEVICES:
+        pytest.skip(f"Test requires {NUM_DEVICES} devices, only {total_devices} available")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((NUM_DEVICES, 1)))
+
+    tile_h = output_shape[0]
+    slice_width = output_shape[1] // NUM_DEVICES
+    fill_tensors = [
+        torch.full((tile_h, slice_width), fill_value=float(dev_idx + 1), dtype=torch.bfloat16)
+        for dev_idx in range(NUM_DEVICES)
+    ]
+
+    inputs = build_all_gather_test_inputs(
+        mesh_device=submesh,
+        output_shape=output_shape,
+        input_tensors_per_device=fill_tensors,
+    )
+
+    logger.info(f"Running deterministic fill all-gather: output_shape={output_shape}, num_links={num_links}")
+
+    ttnn_result = DeepseekMinimalAllGather.op(
+        inputs.input_tensor_mesh,
+        inputs.output_tensor_mesh,
+        inputs.scratch_tensor_mesh,
+        inputs.semaphores,
+        cluster_axis=0,
+        num_links=num_links,
+    )
+    ttnn.synchronize_device(submesh)
+
+    _verify_all_gather_output(submesh, ttnn_result, inputs)
+    _verify_per_slot_identity(submesh, ttnn_result, inputs, fill_tensors)
+
+
+# ---------------------------------------------------------------------------
+# Main trace-based test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("output_shape", [[1, 7168]])
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("num_iter, num_warmup_iter", [(30, 15)])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "trace_region_size": 573440,
+        }
+    ],
+    indirect=True,
+)
+def test_ccl_all_gather(
+    bh_2d_mesh_device,
+    output_shape,
+    num_links,
+    num_warmup_iter,
+    num_iter,
+):
+    if is_slow_dispatch():
+        pytest.skip("CCL all-gather trace test needs fast dispatch")
+
+    total_devices = bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]
+    if total_devices < NUM_DEVICES:
+        pytest.skip(f"Test requires {NUM_DEVICES} devices, only {total_devices} available")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((NUM_DEVICES, 1)))
+
+    inputs = build_all_gather_test_inputs(mesh_device=submesh, output_shape=output_shape)
+
+    logger.info(f"Running CCL all-gather: {NUM_DEVICES} devices, output_shape={output_shape}, num_links={num_links}")
+    profiler = BenchmarkProfiler()
+
+    logger.info("Compiling model")
+    ttnn_result = DeepseekMinimalAllGather.op(
+        inputs.input_tensor_mesh,
+        inputs.output_tensor_mesh,
+        inputs.scratch_tensor_mesh,
+        inputs.semaphores,
+        cluster_axis=0,
+        num_links=num_links,
+    )
+    ttnn.synchronize_device(submesh)
+
+    logger.info("Capturing warmup trace")
+    trace_id_warmup = ttnn.begin_trace_capture(submesh, cq_id=0)
+    for _ in range(num_warmup_iter):
+        ttnn_result = DeepseekMinimalAllGather.op(
+            inputs.input_tensor_mesh,
+            inputs.output_tensor_mesh,
+            inputs.scratch_tensor_mesh,
+            inputs.semaphores,
+            cluster_axis=0,
+            num_links=num_links,
+        )
+    ttnn.end_trace_capture(submesh, trace_id_warmup, cq_id=0)
+    ttnn.synchronize_device(submesh)
+
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(submesh, cq_id=0)
+    for _ in range(num_iter):
+        ttnn_result = DeepseekMinimalAllGather.op(
+            inputs.input_tensor_mesh,
+            inputs.output_tensor_mesh,
+            inputs.scratch_tensor_mesh,
+            inputs.semaphores,
+            cluster_axis=0,
+            num_links=num_links,
+        )
+    ttnn.end_trace_capture(submesh, trace_id, cq_id=0)
+    ttnn.synchronize_device(submesh)
+
+    logger.info("Executing warmup trace...")
+    profiler.start("deepseek-all-gather-warmup")
+    ttnn.execute_trace(submesh, trace_id_warmup, blocking=False)
+    ttnn.release_trace(submesh, trace_id_warmup)
+    ttnn.synchronize_device(submesh)
+    profiler.end("deepseek-all-gather-warmup")
+
+    logger.info("Starting Trace perf test...")
+    signpost("start")
+    profiler.start("deepseek-all-gather-trace")
+    ttnn.execute_trace(submesh, trace_id, blocking=False)
+    ttnn.release_trace(submesh, trace_id)
+    ttnn.synchronize_device(submesh)
+    profiler.end("deepseek-all-gather-trace")
+    signpost("stop")
+
+    _verify_all_gather_output(submesh, ttnn_result, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Feature-matrix test (shape, num_links, chunk sizing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("output_shape", [[1, 896], [1, 7168]])
+@pytest.mark.parametrize("num_links", [1, 2])
+@pytest.mark.parametrize(
+    "max_chunk_size_bytes",
+    [
+        None,
+        2048,
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "trace_region_size": 573440,
+        }
+    ],
+    indirect=True,
+)
+def test_ccl_all_gather_chunk_matrix(
+    bh_2d_mesh_device,
+    output_shape,
+    num_links,
+    max_chunk_size_bytes,
+):
+    total_devices = bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]
+    if total_devices < NUM_DEVICES:
+        pytest.skip(f"Test requires {NUM_DEVICES} devices, only {total_devices} available")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((NUM_DEVICES, 1)))
+
+    inputs = build_all_gather_test_inputs(mesh_device=submesh, output_shape=output_shape)
+
+    logger.info(
+        f"Running all-gather feature matrix: output_shape={output_shape}, "
+        f"num_links={num_links}, max_chunk_size_bytes={max_chunk_size_bytes}"
+    )
+    ttnn_result = DeepseekMinimalAllGather.op(
+        inputs.input_tensor_mesh,
+        inputs.output_tensor_mesh,
+        inputs.scratch_tensor_mesh,
+        inputs.semaphores,
+        cluster_axis=0,
+        num_links=num_links,
+        max_chunk_size_bytes=max_chunk_size_bytes,
+    )
+    ttnn.synchronize_device(submesh)
+
+    _verify_all_gather_output(submesh, ttnn_result, inputs)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_gather.py
@@ -16,6 +16,7 @@ Sharding: HEIGHT_SHARDED on the gather core for input/output,
           HEIGHT_SHARDED on the transport core for scratch.
 """
 
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -35,6 +36,36 @@ TRANSPORT_CORE = ttnn.CoreCoord(0, 1)
 
 NUM_DEVICES = 4
 TILE_W = 32
+
+ENV_NUM_LINKS = "CCL_ALL_GATHER_NUM_LINKS"
+ENV_MAX_PAYLOAD_SIZE = "CCL_ALL_GATHER_MAX_PAYLOAD_SIZE_BYTES"
+
+
+def _parse_env_int(name: str, value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise ValueError(f"{name} must be > 0, got {parsed}")
+    return parsed
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    return _parse_env_int(name, value)
+
+
+def _get_num_links_params(defaults: list[int]) -> list[int]:
+    value = os.getenv(ENV_NUM_LINKS)
+    if value is None or value.strip() == "":
+        return defaults
+    return [_parse_env_int(ENV_NUM_LINKS, value)]
+
+
+MAX_PAYLOAD_SIZE = _get_env_int(ENV_MAX_PAYLOAD_SIZE, 15232)
 
 
 @dataclass(frozen=True)
@@ -284,14 +315,14 @@ def test_ccl_all_gather_deterministic_fill(
 
 
 @pytest.mark.parametrize("output_shape", [[1, 7168]])
-@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("num_links", _get_num_links_params([1]))
 @pytest.mark.parametrize("num_iter, num_warmup_iter", [(30, 15)])
 @pytest.mark.parametrize(
     "device_params",
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": create_fabric_router_config(MAX_PAYLOAD_SIZE),
             "trace_region_size": 573440,
         }
     ],

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// All-gather for a 4-device torused row ring.
+//
+// Core assignment:
+//   gather core:    NCRISC = controller, BRISC/TRISC = idle
+//   transport core: BRISC = fwd sender, NCRISC = bwd sender, TRISC = idle
+//
+// Semaphores (2 total):
+//   handoff_sem on transport core — monotonic (0 → 1 → 2 → 0)
+//   recv_sem on gather core — packed cumulative per-slot counter
+//
+// Data flow (mcast-owned receives, sender-only forwarding):
+//   R0: cross-core write to scratch[0] + handoff (unblocks R1 ASAP),
+//       then local copy to own output slot
+//   R1: bidirectional send of local slice; remote writes land on gather core
+//   R1→R2: wait for forwarded slice, copy to scratch[1] + handoff
+//   R2: pairwise exchange of the forwarded slice
+
+#include "kernel_op_api.hpp"
+#include "kernel_utils.hpp"
+
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+#include "api/dataflow/dataflow_api.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include <array>
+#include <cstdint>
+#endif
+
+namespace deepseek_b1_ops {
+namespace AllGather {
+
+// ============================================================================
+// Packed receive-semaphore wait helper
+// ============================================================================
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+
+// Poll a packed per-slot field inside a cumulative receive semaphore until
+// the field reaches the expected chunk count.  Each slot occupies
+// BitsPerSlice bits; the field for slot_idx starts at bit
+// (slot_idx * BitsPerSlice).
+template <uint32_t NumChunksPerSlice, uint32_t BitsPerSlice = 4>
+FORCE_INLINE void wait_for_slot(volatile tt_l1_ptr uint32_t* sem_ptr, uint32_t slot_idx) {
+    static_assert(NumChunksPerSlice <= ((1u << BitsPerSlice) - 1u));
+
+    constexpr uint32_t field_mask = (1u << BitsPerSlice) - 1u;
+    const uint32_t shift = slot_idx * BitsPerSlice;
+
+    do {
+        invalidate_l1_cache();
+    } while (((*sem_ptr >> shift) & field_mask) < NumChunksPerSlice);
+}
+
+#endif  // COMPILE_FOR_NCRISC || COMPILE_FOR_BRISC
+
+// ============================================================================
+// Compile-time arg structs
+// ============================================================================
+
+static constexpr uint32_t MAX_NUM_LINKS = 2;
+
+// Transport core BRISC and NCRISC share this schema; r2_active differs.
+template <
+    uint32_t SliceSizeBytes,
+    uint32_t NumChunks,
+    uint32_t ChunkSizeBytes,
+    uint32_t LastChunkBytes,
+    uint32_t NumLinks,
+    uint32_t RecvSemBitsPerSlot,
+    uint32_t R2Active>
+struct TransportCTArgs {
+    static constexpr uint32_t slice_size_bytes = SliceSizeBytes;
+    static constexpr uint32_t num_chunks = NumChunks;
+    static constexpr uint32_t chunk_size_bytes = ChunkSizeBytes;
+    static constexpr uint32_t last_chunk_bytes = LastChunkBytes;
+    static constexpr uint32_t num_links = NumLinks;
+    static constexpr uint32_t recv_sem_bits_per_slot = RecvSemBitsPerSlot;
+    static constexpr bool r2_active = R2Active != 0;
+    static_assert(num_links >= 1 && num_links <= MAX_NUM_LINKS, "num_links out of range");
+};
+
+// Gather core NCRISC.
+template <uint32_t SliceSizeBytes, uint32_t NumChunks, uint32_t RingSize, uint32_t RecvSemBitsPerSlot>
+struct GatherCTArgs {
+    static constexpr uint32_t slice_size_bytes = SliceSizeBytes;
+    static constexpr uint32_t num_chunks = NumChunks;
+    static constexpr uint32_t ring_size = RingSize;
+    static constexpr uint32_t recv_sem_bits_per_slot = RecvSemBitsPerSlot;
+};
+
+// ============================================================================
+// Runtime arg structs
+// ============================================================================
+
+struct TransportArgs {
+    uint32_t scratch_base_addr;
+    uint32_t handoff_sem_bank_addr;
+    uint32_t dest_output_base_addr;
+    uint32_t r1_dest_slot_index;
+    uint32_t dest_noc_x;
+    uint32_t dest_noc_y;
+    uint32_t dest_recv_sem_addr;
+    uint32_t r2_dest_slot_index;
+    uint32_t per_core_rta_start_idx;
+};
+
+struct GatherArgs {
+    uint32_t local_input_addr;
+    uint32_t output_buffer_addr;
+    uint32_t self_slot_index;
+    uint32_t transport_scratch_base_addr;
+    uint32_t transport_noc_x;
+    uint32_t transport_noc_y;
+    uint32_t handoff_sem_bank_addr;
+    uint32_t recv_sem_addr;
+    uint32_t r2_src_slot_index;
+};
+
+// ============================================================================
+// Transport sender (BRISC fwd / NCRISC bwd on transport core)
+//
+// Multi-link: opens num_links connections and rotates chunks across them,
+// following the broadcast.hpp forward_chunks pattern.
+// ============================================================================
+
+template <typename CTArgs>
+class TransportSender {
+public:
+    void operator()(const TransportArgs& args) { impl(args); }
+
+private:
+    void impl([[maybe_unused]] const TransportArgs& args) {
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+        PacketHeaderPool::reset();
+
+        size_t arg_idx = size_t(args.per_core_rta_start_idx);
+        const uint32_t dst_mesh_id = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t dst_chip_id = get_arg_val<uint32_t>(arg_idx++);
+
+        std::array<tt::tt_fabric::WorkerToFabricEdmSender, CTArgs::num_links> connections;
+        std::array<volatile PACKET_HEADER_TYPE*, CTArgs::num_links> headers;
+        for (uint32_t link = 0; link < CTArgs::num_links; link++) {
+            connections[link] =
+                tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+            connections[link].open_start();
+            headers[link] = PacketHeaderPool::allocate_header();
+            fabric_set_unicast_route(headers[link], dst_chip_id, dst_mesh_id);
+            connections[link].open_finish();
+        }
+
+        const uint64_t dest_output_noc =
+            safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, args.dest_output_base_addr, 0);
+        const uint64_t dest_recv_sem_noc =
+            safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, args.dest_recv_sem_addr, 0);
+
+        volatile tt_l1_ptr uint32_t* handoff_sem_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.handoff_sem_bank_addr);
+
+        // Send a full slice (possibly multi-chunk) rotating across links.
+        auto send_slice = [&](uint32_t src_addr, uint32_t dest_slot_index) __attribute__((always_inline)) {
+            const uint32_t inc_value = 1u << (dest_slot_index * CTArgs::recv_sem_bits_per_slot);
+            const uint64_t dest_base = dest_output_noc + dest_slot_index * CTArgs::slice_size_bytes;
+
+            uint32_t current_link = 0;
+            for (uint32_t chunk_idx = 0; chunk_idx < CTArgs::num_chunks; chunk_idx++) {
+                const uint32_t chunk_offset = chunk_idx * CTArgs::chunk_size_bytes;
+                const uint32_t payload_bytes =
+                    (chunk_idx < CTArgs::num_chunks - 1) ? CTArgs::chunk_size_bytes : CTArgs::last_chunk_bytes;
+
+                headers[current_link]->to_noc_fused_unicast_write_atomic_inc(
+                    tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{
+                        dest_base + chunk_offset, dest_recv_sem_noc, inc_value, false},
+                    payload_bytes);
+                connections[current_link].wait_for_empty_write_slot();
+                connections[current_link].send_payload_without_header_non_blocking_from_address(
+                    src_addr + chunk_offset, payload_bytes);
+                connections[current_link].send_payload_flush_non_blocking_from_address(
+                    reinterpret_cast<uint32_t>(headers[current_link]), sizeof(PACKET_HEADER_TYPE));
+
+                if (++current_link == CTArgs::num_links) {
+                    current_link = 0;
+                    noc_async_writes_flushed();
+                }
+            }
+            // Trailing flush for partial rotation at end of slice
+            noc_async_writes_flushed();
+        };
+
+        // Round 1: send local slice to neighbor
+        noc_semaphore_wait_min(handoff_sem_ptr, 1);
+        send_slice(args.scratch_base_addr, args.r1_dest_slot_index);
+
+        if constexpr (CTArgs::r2_active) {
+            // Round 2: forward the received slice to pair partner
+            noc_semaphore_wait_min(handoff_sem_ptr, 2);
+            send_slice(args.scratch_base_addr + CTArgs::slice_size_bytes, args.r2_dest_slot_index);
+            noc_semaphore_set(handoff_sem_ptr, 0);
+        }
+
+        for (uint32_t link = 0; link < CTArgs::num_links; link++) {
+            connections[link].close();
+        }
+        noc_async_full_barrier();
+#endif
+    }
+};
+
+// ============================================================================
+// Gather controller (NCRISC on gather core)
+// ============================================================================
+
+template <typename CTArgs>
+class GatherController {
+public:
+    void operator()(const GatherArgs& args) { impl(args); }
+
+private:
+    void impl([[maybe_unused]] const GatherArgs& args) {
+#if defined(COMPILE_FOR_NCRISC)
+        const uint64_t handoff_sem_noc =
+            safe_get_noc_addr(args.transport_noc_x, args.transport_noc_y, args.handoff_sem_bank_addr, 0);
+        const uint64_t scratch_base_noc =
+            safe_get_noc_addr(args.transport_noc_x, args.transport_noc_y, args.transport_scratch_base_addr, 0);
+
+        volatile tt_l1_ptr uint32_t* recv_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_addr);
+
+        const uint32_t self_slot_offset = args.self_slot_index * CTArgs::slice_size_bytes;
+        const uint32_t r2_src_slot_offset = args.r2_src_slot_index * CTArgs::slice_size_bytes;
+
+        // Track which slots have been handled so the final wait is generic.
+        uint32_t done_mask = 0;
+        done_mask |= (1u << args.self_slot_index);
+
+        // Cross-core write to transport scratch[0] FIRST to unblock R1 ASAP.
+        noc_async_write(args.local_input_addr, scratch_base_noc, CTArgs::slice_size_bytes);
+        noc_async_writes_flushed();
+        noc_semaphore_inc(handoff_sem_noc, 1);  // handoff_sem: 0 → 1
+
+        // Local copy to own output slot (can overlap with R1 fabric sends).
+        noc_async_write(
+            args.local_input_addr, get_noc_addr(args.output_buffer_addr + self_slot_offset), CTArgs::slice_size_bytes);
+
+        // R1→R2 bridge: wait for the slot that must be forwarded.
+        wait_for_slot<CTArgs::num_chunks, CTArgs::recv_sem_bits_per_slot>(recv_sem_ptr, args.r2_src_slot_index);
+        done_mask |= (1u << args.r2_src_slot_index);
+
+        // Copy received slot to transport scratch[1].
+        const uint64_t scratch_r2_noc = scratch_base_noc + CTArgs::slice_size_bytes;
+        noc_async_write(args.output_buffer_addr + r2_src_slot_offset, scratch_r2_noc, CTArgs::slice_size_bytes);
+        noc_async_writes_flushed();
+        noc_semaphore_inc(handoff_sem_noc, 1);  // handoff_sem: 1 → 2
+
+        // Wait for all remaining slots (topology-agnostic).
+        for (uint32_t slot = 0; slot < CTArgs::ring_size; slot++) {
+            if (!(done_mask & (1u << slot))) {
+                wait_for_slot<CTArgs::num_chunks, CTArgs::recv_sem_bits_per_slot>(recv_sem_ptr, slot);
+            }
+        }
+        noc_semaphore_set(recv_sem_ptr, 0);
+        noc_async_full_barrier();
+#endif
+    }
+};
+
+}  // namespace AllGather
+}  // namespace deepseek_b1_ops


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-blaze/issues/90)

### Problem description
Provide context for the problem.

### What's changed

Two-core implementation:
- Gather core: NCRISC controller (local copies, handoffs, receive waits).
  BRISC and TRISC idle.
- Transport core: BRISC = fwd sender, NCRISC = bwd sender.  TRISC idle.

Algorithm (2-round neighbor exchange):
  R0: cross-core write to transport scratch + handoff (unblocks R1 ASAP),
      then local copy to own output slot
  R1: bidirectional send of local slice; remote writes land on gather core
  R1→R2: wait for forwarded slice, copy to transport scratch[1] + handoff
  R2: pairwise exchange

Semaphores (2 global):
  handoff_sem on transport core — monotonic (0 → 1 → 2 → 0)
  recv_sem on gather core — packed cumulative per-slot counter
### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aagarwal/blaze-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aagarwal/blaze-all-gather)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aagarwal/blaze-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aagarwal/blaze-all-gather)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aagarwal/blaze-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aagarwal/blaze-all-gather)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aagarwal/blaze-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aagarwal/blaze-all-gather)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aagarwal/blaze-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aagarwal/blaze-all-gather)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aagarwal/blaze-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aagarwal/blaze-all-gather)
  - [ ] `models-mandatory` preset (runs: [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
