### PR TITLE
#41802: Fix tanhshrink doc test passing unsupported kwarg

### DIFF
--- a/tests/ttnn/docs_examples/test_eltwise_unary_examples.py
+++ b/tests/ttnn/docs_examples/test_eltwise_unary_examples.py
@@ -772,7 +772,7 @@ def test_tanhshrink(device):
     )
 
     # Apply tanh shrink function
-    output = ttnn.tanhshrink(tensor, fast_and_approximate_mode=False)
+    output = ttnn.tanhshrink(tensor)
     logger.info(f"Tanh shrink: {output}")
 
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41802

### Problem description
`test_tanhshrink` doc example test fails with `TypeError` because it passes `fast_and_approximate_mode=False` to `ttnn.tanhshrink`, which does not accept that parameter. Other unary ops like `tanh`, `gelu`, `exp` etc. do support it, but `tanhshrink` does not.

### What's changed
Removed the unsupported `fast_and_approximate_mode=False` keyword argument from the `ttnn.tanhshrink()` call in `test_tanhshrink`. Verified all other `fast_and_approximate_mode` usages in the file are valid.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dchen/tanhshrink_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dchen/tanhshrink_doc)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dchen/tanhshrink_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dchen/tanhshrink_doc)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/tanhshrink_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/tanhshrink_doc)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early