### PR TITLE
Add sequential tests to fabric neighbor exchange sanity test suite

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_neighbor_exchange.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_neighbor_exchange.yaml
@@ -3,6 +3,39 @@ allocation_policies:
       max_configs_per_core: 1
 
 Tests:
+
+  - name: "LinearSequentialNeighborExchange"
+    fabric_setup:
+      topology: Linear
+
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
+      num_links: [1, 2]
+
+    defaults:
+      ftype: unicast
+      size: 32
+      num_packets: 30000
+
+    patterns:
+      - type: sequential_neighbor_exchange
+
+  - name: "MeshSequentialNeighborExchange"
+    fabric_setup:
+      topology: Mesh
+
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
+      num_links: [1, 2]
+
+    defaults:
+      ftype: unicast
+      size: 32
+      num_packets: 30000
+
+    patterns:
+      - type: sequential_neighbor_exchange
+
   - name: "LinearNeighborExchange"
     fabric_setup:
       topology: Linear

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -329,18 +329,35 @@ void TestContext::compile_programs() {
     }
 
     if (show_workers_) {
+        auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
         for (const auto& [coord, test_device] : test_devices_) {
             const auto& node_id = test_device.get_node_id();
             const auto& senders = test_device.get_senders();
             const auto& receivers = test_device.get_receivers();
-            if (!senders.empty() || !receivers.empty()) {
-                log_info(
-                    tt::LogTest,
-                    "Device {}: {} sender(s), {} receiver(s)",
-                    tt::tt_fabric::fabric_tests::format_device_label(node_id),
-                    senders.size(),
-                    receivers.size());
+            if (senders.empty() && receivers.empty()) {
+                continue;
             }
+
+            std::string eth_info;
+            for (const auto& [core, sender] : senders) {
+                for (const auto& [cfg, key] : sender.get_configs()) {
+                    auto eth_chans =
+                        control_plane.get_active_fabric_eth_channels_in_direction(node_id, key.direction);
+                    auto ch = key.link_idx < eth_chans.size() ? std::to_string(eth_chans.at(key.link_idx)) : "?";
+                    if (!eth_info.empty()) {
+                        eth_info += ", ";
+                    }
+                    eth_info += std::string(enchantum::to_string(key.direction)) + "[" + std::to_string(key.link_idx) + "]=ch" + ch;
+                }
+            }
+
+            log_info(
+                tt::LogTest,
+                "Device {}: {} sender(s), {} receiver(s){}",
+                tt::tt_fabric::fabric_tests::format_device_label(node_id),
+                senders.size(),
+                receivers.size(),
+                eth_info.empty() ? "" : "; sender eth channels: " + eth_info);
         }
     }
 

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -22,6 +22,7 @@ Optional:
                                         (default: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric)
     --test-config <path>                Path to test configuration file
                                         (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
+    --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
     --help                              Display this help message and exit
 
 Example:
@@ -42,6 +43,7 @@ MESH_GRAPH_DESC_PATH=""
 MESH_GRAPH_DESC_PATH_EXPLICIT=false
 TEST_BINARY="./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric"
 TEST_CONFIG="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
+FILTER=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -108,6 +110,14 @@ while [[ $# -gt 0 ]]; do
             TEST_CONFIG="$2"
             shift 2
             ;;
+        --filter)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --filter requires a non-empty value"
+                exit 1
+            fi
+            FILTER="$2"
+            shift 2
+            ;;
         --help)
             show_help
             exit 0
@@ -161,6 +171,9 @@ echo "Output directory: $OUTPUT_DIR"
 echo "Mesh graph descriptor: $MESH_GRAPH_DESC_PATH"
 echo "Test binary: $TEST_BINARY"
 echo "Test config: $TEST_CONFIG"
+if [[ -n "$FILTER" ]]; then
+    echo "Filter: $FILTER"
+fi
 echo "Log file: $LOG_FILE"
 echo "=========================================="
 echo ""
@@ -168,6 +181,9 @@ echo ""
 EXTRA_BINARY_ARGS=""
 if [[ "$TEST_BINARY" == *test_tt_fabric ]]; then
     EXTRA_BINARY_ARGS="--show-progress --show-workers"
+fi
+if [[ -n "$FILTER" ]]; then
+    EXTRA_BINARY_ARGS="$EXTRA_BINARY_ARGS --filter $FILTER"
 fi
 
 if [[ "$CONFIG" == "4x8" ]]; then


### PR DESCRIPTION
### Problem description
Need a way to see individual connections and if they go wrong in testing fabric neighbor exchange

### What's changed
Added sequential tests
Sequential tests run each connection on the board once.
With --show-progress and --show-workers, shows which connection is ran on each iteration, allows for easy tracing of problematic links.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/fabric-neighbor-exchange-add-sequential-tests)
  - [ ] `models-mandatory` preset (runs: [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
