### PR TITLE
[Deepseek] Implement prefill warmup for vLLM

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -170,7 +170,9 @@ class DeepseekGenerator(WarmupForwardMixin):
         sample_on_device: bool = False,
         enable_mtp: bool = False,
         sampling_params: SamplingParams | None = None,
+        vllm_context: bool = False,
     ) -> None:
+        self.vllm_context = vllm_context  # track if Generator is initialized in vLLM context
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
         self.cache_dir = cache_dir
@@ -300,9 +302,28 @@ class DeepseekGenerator(WarmupForwardMixin):
         self._prepare_weight_configs(cache_dir)
         self._assert_mtp_available()
 
+    def _get_prefill_warmup_prompt_lens(self) -> list[int]:
+        """Build and cache supported prefill warmup lengths.
+
+        The list starts at ``ttnn.TILE_SIZE`` and doubles each step
+        (tile, 2*tile, 4*tile, ...), then includes ``hf_config.max_seq_len``
+        to guarantee coverage of the configured maximum sequence length.
+        Returned values are unique and sorted in ascending order.
+        """
+        if hasattr(self, "_prefill_warmup_prompt_lens"):
+            return self._prefill_warmup_prompt_lens
+        prompt_lens_set: set[int] = set()
+        prompt_len = ttnn.TILE_SIZE
+        while prompt_len <= self.hf_config.max_seq_len:
+            prompt_lens_set.add(prompt_len)
+            prompt_len *= 2
+        prompt_lens_set.add(self.hf_config.max_seq_len)
+        self._prefill_warmup_prompt_lens = sorted(prompt_lens_set)
+        return self._prefill_warmup_prompt_lens
+
     def _validate_and_initialize_sampling(
         self,
-        sampling_params: SamplingParams | None,
+        new_sampling_params: SamplingParams | None,
         sample_on_device: bool,
         enable_trace: bool = False,
         enable_mtp: bool = False,
@@ -310,60 +331,49 @@ class DeepseekGenerator(WarmupForwardMixin):
         if enable_mtp and sample_on_device:
             raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
 
-        current_sampling_params = getattr(self, "sampling_params", None)
-        params_same = (
-            sampling_params is not None
-            and current_sampling_params is not None
-            and self._are_sampling_params_same(sampling_params, current_sampling_params)
-        )
-        if not params_same:
-            self.sampling_generator = None
-            self.sampling_params = None
-
-        if not sample_on_device:
-            self.sampling_generator = None
-
-        if getattr(self, "sampling_generator", None) is not None:
-            return
-
         self.sample_on_device = sample_on_device
+        previous_sampling_params = getattr(self, "sampling_params", None)
+
         # sampling params of all users are assumed to be the same default values if not provided.
-        self.sampling_params = (
-            self._to_local_sampling_params(sampling_params)
-            if sampling_params is not None
+        normalized_sampling_params = (
+            self._to_local_sampling_params(new_sampling_params)
+            if new_sampling_params is not None
             else SamplingParams(
                 temperature=[DEFAULT_SAMPLING_TEMPERATURE] * self.batch_size,
                 top_p=[DEFAULT_SAMPLING_TOP_P] * self.batch_size,
                 top_k=[DEFAULT_SAMPLING_TOP_K] * self.batch_size,
             )
         )
-        if self._get_sampling_value(self.sampling_params.top_k, 0) == 0 and sample_on_device:
-            raise SystemExit(
-                "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
-            )
-        if sample_on_device:
-            enable_internal_trace_sampling = enable_trace and self.sample_on_device
-            self.sampling_args = make_deepseek_sampling_args(
-                self.mesh_device,
-                self.hf_config.vocab_size,
-                max_batch_size=self.batch_size_per_row,
-            )
-            self.sampling_generator = SamplingGenerator(
-                args=self.sampling_args,
-                mesh_device=self.mesh_device,
-                tt_ccl=self.ccl,
-                enable_internal_trace=enable_internal_trace_sampling,
+
+        if self.sample_on_device:
+            params_same = previous_sampling_params is not None and self._are_sampling_params_same(
+                normalized_sampling_params, previous_sampling_params
             )
 
-            self._reset_sampling_state(self.sampling_params, self.batch_size, self.batch_size_per_row)
+            if self._get_sampling_value(normalized_sampling_params.top_k, 0) == 0:
+                raise SystemExit(
+                    "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
+                )
 
-        logger.info(f"Sampling mode: {'device' if sample_on_device else 'host'}")
-        logger.info(
-            f"Sampling parameters for first user (other users may have different values): "
-            + f"temperature={self._get_sampling_value(self.sampling_params.temperature, 0)}, "
-            + f"top_p={self._get_sampling_value(self.sampling_params.top_p, 0)}, "
-            + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
-        )
+            if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
+                # sampling generator exists; reset if params are different
+                if not params_same:
+                    self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
+            else:
+                # create new sampling generator
+                enable_internal_trace_sampling = enable_trace
+                self.sampling_args = make_deepseek_sampling_args(
+                    self.mesh_device, self.hf_config.vocab_size, max_batch_size=self.batch_size_per_row
+                )
+                self.sampling_generator = SamplingGenerator(
+                    args=self.sampling_args,
+                    mesh_device=self.mesh_device,
+                    tt_ccl=self.ccl,
+                    enable_internal_trace=enable_internal_trace_sampling,
+                )
+                self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
+
+        self.sampling_params = normalized_sampling_params
 
     def _to_local_sampling_params(self, params_obj) -> SamplingParams:
         """Project duck-typed sampling params to local SamplingParams fields."""
@@ -761,7 +771,10 @@ class DeepseekGenerator(WarmupForwardMixin):
         )
 
     def _sample_tokens_device(
-        self, logits: ttnn.Tensor, enable_trace: bool = False, user_slots: list[int] | None = None
+        self,
+        logits: ttnn.Tensor,
+        enable_trace: bool = False,
+        user_slots: list[int] | None = None,
     ) -> ttnn.Tensor:
         sampling_batch_size = self.sampling_generator.tt_sampling.max_batch_size
         sampling_logits = logits
@@ -2208,6 +2221,20 @@ class DeepseekGenerator(WarmupForwardMixin):
             out.append(1)
         return out
 
+    def _pad_seq_len_to_warmup_prompt_lens(self, seq_len: int) -> int:
+        """Return the smallest supported prefill length >= seq_len.
+
+        Raise ValueError if seq_len is larger than all values in the list
+        returned by _get_prefill_warmup_prompt_lens().
+        """
+        for supported_len in self._get_prefill_warmup_prompt_lens():
+            if seq_len <= supported_len:
+                return supported_len
+
+        raise ValueError(
+            f"seq_len {seq_len} is greater than all supported prefill lengths {self._get_prefill_warmup_prompt_lens()}"
+        )
+
     def _prefill(
         self,
         tokens: torch.Tensor,
@@ -2231,6 +2258,28 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         tokens = tokens.view(1, 1, -1)
         seq_len = tokens.shape[-1]
+        if self.vllm_context:
+            # In vLLM context, we perform warmup for prefill and decode.
+            # prefill warmup is performed for all supported prompt lengths in the list returned by _get_prefill_warmup_prompt_lens()
+            # We need to pad the seq_len to the closest supported warmup prompt length, otherwise memory corruption can happen.
+            # The memory corruption happens when any new device memory is allocated when trace is active.
+            max_supported_seq_len = max(self._get_prefill_warmup_prompt_lens())
+            if seq_len > max_supported_seq_len:
+                raise ValueError(
+                    f"seq_len {seq_len} is greater than {max_supported_seq_len}. "
+                    "Crash here early rather than wait for memory corruption to happen and crash later."
+                )
+            padded_seq_len = self._pad_seq_len_to_warmup_prompt_lens(seq_len)
+            if padded_seq_len > seq_len:
+                pad_token_id = getattr(self, "pad_token_id", 0)
+                pad_tokens = torch.full(
+                    (tokens.shape[0], tokens.shape[1], padded_seq_len - seq_len),
+                    pad_token_id,
+                    dtype=tokens.dtype,
+                    device=tokens.device,
+                )
+                tokens = torch.cat((tokens, pad_tokens), dim=-1)
+                seq_len = padded_seq_len
 
         # Prepare TT inputs for prefill - reshape to [1, 1, actual_seq_len]
         tt_tokens = ttnn.from_torch(
@@ -2833,9 +2882,55 @@ class DeepseekGenerator(WarmupForwardMixin):
                 ttnn.ReadDeviceProfiler(self.mesh_device)
             return logits.squeeze(0).squeeze(0)
 
+    def _get_warmup_page_size(self) -> int:
+        for attr_name in ("page_size", "block_size", "kv_cache_page_size"):
+            value = getattr(self, attr_name, None)
+            if isinstance(value, int) and value > 0:
+                return value
+        for container_name in ("model_args", "model_config", "config"):
+            container = getattr(self, container_name, None)
+            if container is None:
+                continue
+            for attr_name in ("page_size", "block_size", "kv_cache_page_size"):
+                value = getattr(container, attr_name, None)
+                if isinstance(value, int) and value > 0:
+                    return value
+        return 1
+
+    def _build_warmup_page_table(self, prompt_len: int) -> torch.Tensor:
+        page_size = self._get_warmup_page_size()
+        num_pages = max(1, (prompt_len + page_size - 1) // page_size)
+        return torch.arange(num_pages, dtype=torch.int32).unsqueeze(0)
+
     def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device) -> None:
-        logger.warning("Warmup model prefill not implemented for DeepseekGenerator")
-        logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator")
+        if enable_trace:
+            logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator; skipping warmup.")
+            return
+
+        user_id = 0
+        for sample_on_device in [False, True]:
+            for prompt_len in self._get_prefill_warmup_prompt_lens():
+                tokens = torch.zeros(1, prompt_len, dtype=torch.int32)
+                # TODO: MTP path warmup needed?
+                page_table = self._build_warmup_page_table(prompt_len)
+                prefill_logits = self._prefill(
+                    tokens=tokens,
+                    user_id=user_id,
+                    sample_on_device=sample_on_device,
+                    page_table=page_table,
+                    return_last_hidden=False,
+                )
+                if sample_on_device:
+                    self._validate_and_initialize_sampling(
+                        None,
+                        sample_on_device,
+                        enable_trace=enable_trace,
+                    )
+
+                    prefill_logits = self._slice_last_token_logits(prefill_logits, prompt_len, expand_to_batch=True)
+                    self._sample_tokens_device(prefill_logits, user_slots=[user_id])
+
+        logger.info("Prefill warmup completed.")
 
     def get_kv_cache(self):
         assert self.model_state is not None, "Model state is not initialized"

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -284,6 +284,8 @@ class DeepseekGenerator(WarmupForwardMixin):
         self._mtp_predict_trace_rot_idxs: ttnn.Tensor | None = None
         self._mtp_predict_trace_output: ttnn.Tensor | None = None
         self._mtp_predict_trace_page_table: ttnn.Tensor | None = None
+        self._sampling_trace_logits_device: ttnn.Tensor | None = None
+        self._sampling_trace_logits_host: ttnn.Tensor | None = None
         self.enable_trace = enable_trace
         self.enable_mem_profile = enable_mem_profile
         self.signpost = signpost
@@ -672,6 +674,12 @@ class DeepseekGenerator(WarmupForwardMixin):
             ):
                 ttnn.deallocate(self._mtp_predict_trace_page_table)
                 del self._mtp_predict_trace_page_table
+            if self._sampling_trace_logits_device is not None:
+                ttnn.deallocate(self._sampling_trace_logits_device)
+                del self._sampling_trace_logits_device
+            if self._sampling_trace_logits_host is not None:
+                ttnn.deallocate(self._sampling_trace_logits_host)
+                del self._sampling_trace_logits_host
         except Exception as e:
             logger.warning(f"Failed to cleanup trace state: {e}")
 
@@ -779,10 +787,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         sampling_batch_size = self.sampling_generator.tt_sampling.max_batch_size
         sampling_logits = logits
         if logits.shape[2] != sampling_batch_size:
-            if enable_trace:
-                raise ValueError(
-                    f"Device sampling trace requires logits batch {sampling_batch_size}, got {logits.shape[2]}"
-                )
             if logits.shape[2] <= 0 or logits.shape[2] > sampling_batch_size:
                 raise ValueError(
                     f"Device sampling expects logits batch in [1, {sampling_batch_size}], got {logits.shape[2]}"
@@ -796,8 +800,30 @@ class DeepseekGenerator(WarmupForwardMixin):
             )
             filler = ttnn.repeat(filler_row, (1, 1, sampling_batch_size - logits.shape[2], 1))
             ttnn.deallocate(filler_row)
-            sampling_logits = ttnn.concat([logits, filler], dim=2)
+            padded_logits = ttnn.concat([logits, filler], dim=2)
             ttnn.deallocate(filler)
+            if enable_trace:
+                if (
+                    self._sampling_trace_logits_device is None
+                    or self._sampling_trace_logits_host is None
+                    or self._sampling_trace_logits_device.shape != padded_logits.shape
+                ):
+                    if self._sampling_trace_logits_device is not None:
+                        ttnn.deallocate(self._sampling_trace_logits_device)
+                    if self._sampling_trace_logits_host is not None:
+                        ttnn.deallocate(self._sampling_trace_logits_host)
+                    self._sampling_trace_logits_device = ttnn.allocate_tensor_on_device(
+                        padded_logits.spec, self.mesh_device
+                    )
+                    self._sampling_trace_logits_host = ttnn.allocate_tensor_on_host(
+                        padded_logits.spec, self.mesh_device
+                    )
+                ttnn.copy_device_to_host_tensor(padded_logits, self._sampling_trace_logits_host)
+                ttnn.copy_host_to_device_tensor(self._sampling_trace_logits_host, self._sampling_trace_logits_device)
+                ttnn.deallocate(padded_logits)
+                sampling_logits = self._sampling_trace_logits_device
+            else:
+                sampling_logits = padded_logits
 
         self.sampling_generator.seed_manager.get_new_values(user_slots)
         self.sampling_generator.enable_internal_trace = enable_trace
@@ -805,7 +831,8 @@ class DeepseekGenerator(WarmupForwardMixin):
             tt_out = self.sampling_generator.sample(sampling_logits, enable_trace=enable_trace)
         finally:
             if sampling_logits is not logits:
-                ttnn.deallocate(sampling_logits)
+                if sampling_logits is not self._sampling_trace_logits_device:
+                    ttnn.deallocate(sampling_logits)
 
         if isinstance(tt_out, tuple):
             tt_tokens, tt_log_probs = tt_out
@@ -821,18 +848,26 @@ class DeepseekGenerator(WarmupForwardMixin):
             tt_out_tok,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, -1), mesh_shape=tuple(mesh_device.shape)),
         )
-        if composed.ndim == 4:
-            if tt_out_tok.shape[-2] == batch_size_per_row:
-                tokens = composed[:, :, :, 0]
-            elif tt_out_tok.shape[-1] == batch_size_per_row:
-                tokens = composed[:, :, 0, :batch_size_per_row]
-            else:
-                tokens = composed
-            tokens = tokens.reshape(-1)
-        else:
-            tokens = composed.reshape(-1)
-        batch_size = batch_size_per_row * int(mesh_device.shape[0])
-        return tokens[:batch_size].to(torch.int64)
+        tokens = composed.reshape(-1)
+        rows = int(mesh_device.shape[0])
+        if rows <= 0:
+            raise RuntimeError(f"Invalid mesh row count: {rows}")
+        if tokens.numel() % rows != 0:
+            raise RuntimeError(
+                f"Unexpected sampled token shape {tuple(composed.shape)} for mesh rows={rows}; "
+                f"cannot derive per-row token layout."
+            )
+
+        # Sampling can run with padded per-row batches (e.g. 32) even when active users per row are smaller
+        # (e.g. 8). Select only the first `batch_size_per_row` users from each row to avoid returning filler rows.
+        per_row_tokens = tokens.view(rows, tokens.numel() // rows)
+        if batch_size_per_row > per_row_tokens.shape[1]:
+            raise RuntimeError(
+                f"Requested {batch_size_per_row} tokens/row, but sampled output has only {per_row_tokens.shape[1]} "
+                f"tokens/row (composed shape={tuple(composed.shape)})."
+            )
+        active_tokens = per_row_tokens[:, :batch_size_per_row]
+        return active_tokens.reshape(-1).to(torch.int64)
 
     def _tt_from_hidden_states_step(
         self,

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -70,6 +70,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             cache_dir=Path(cache_dir),
             tokenizer=tokenizer,
             max_seq_len=max_seq_len,
+            vllm_context=True,
         )
 
         return model
@@ -112,7 +113,11 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         )
         num_of_users = tokens.shape[0]
         if sample_on_device:
-            self._validate_and_initialize_sampling(sampling_params, sample_on_device)
+            self._validate_and_initialize_sampling(
+                sampling_params,
+                sample_on_device,
+                enable_trace=False,
+            )
 
         user_outputs = []
         for i in range(num_of_users):
@@ -181,13 +186,18 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         read_from_device = kwargs.get("read_from_device", True)
         sampling_params = kwargs.get("sampling_params", None)
         sample_on_device = bool(sampling_params is not None)
+
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):
             self.set_kv_cache(kv_cache)
 
         tokens_step = kwargs["tokens"].squeeze(1)
         if sample_on_device:
-            self._validate_and_initialize_sampling(sampling_params, sample_on_device, enable_trace=enable_trace)
+            self._validate_and_initialize_sampling(
+                sampling_params,
+                sample_on_device,
+                enable_trace=enable_trace,
+            )
         decode_step_output = super().decode_forward(
             tokens=tokens_step,
             start_pos=kwargs["start_pos"],
@@ -197,7 +207,10 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         )
 
         if sample_on_device:
-            decode_output = self._sample_tokens_device(decode_step_output, enable_trace=enable_trace)
+            decode_output = self._sample_tokens_device(
+                decode_step_output,
+                enable_trace=enable_trace,
+            )
             if read_from_device:
                 decode_output = self._tokens_from_device(
                     decode_output, self.mesh_device, batch_size_per_row=self.batch_size_per_row


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40958

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/deepseek_warmup_vllm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/deepseek_warmup_vllm)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/deepseek_warmup_vllm)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/deepseek_warmup_vllm)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/deepseek_warmup_vllm)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/deepseek_warmup_vllm)
  - [ ] `models-mandatory` preset (runs: [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/deepseek_warmup_vllm) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/deepseek_warmup_vllm) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/deepseek_warmup_vllm) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/deepseek_warmup_vllm) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/deepseek_warmup_vllm) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/deepseek_warmup_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/deepseek_warmup_vllm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/deepseek_warmup_vllm) |