### PR TITLE
DataFormat per-architecture legality checks

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -498,8 +498,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBF
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-// Data format legality: ValidateProgramSpec currently targets Quasar only, so is_supported_for_gen2 applies.
-TEST_F(ProgramSpecTestQuasar, DFBDataFormatNotSupportedOnTargetArchitectureFails) {
+TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -509,7 +508,7 @@ TEST_F(ProgramSpecTestQuasar, DFBDataFormatNotSupportedOnTargetArchitectureFails
     auto consumer = MakeMinimalComputeKernel("consumer", node);
     auto dfb = MakeMinimalDFB("dfb", node);
 
-    // Legacy Gen1 block-float format; is_supported_for_gen2(Bfp8) is false.
+    // Legacy block-float format; not supported on Quasar.
     dfb.data_format_metadata = tt::DataFormat::Bfp8;
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -498,6 +498,30 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBF
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
+// Data format legality: ValidateProgramSpec currently targets Quasar only, so is_supported_for_gen2 applies.
+TEST_F(ProgramSpecTestQuasar, DFBDataFormatNotSupportedOnTargetArchitectureFails) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer", node);
+    auto consumer = MakeMinimalComputeKernel("consumer", node);
+    auto dfb = MakeMinimalDFB("dfb", node);
+
+    // Legacy Gen1 block-float format; is_supported_for_gen2(Bfp8) is false.
+    dfb.data_format_metadata = tt::DataFormat::Bfp8;
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+
+    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+}
+
 // ============================================================================
 // SECTION 3: WorkerSpec Validation Tests
 // ============================================================================
@@ -851,7 +875,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
     auto dfb1 = MakeMinimalDFB("dfb1", node);
     dfb1.data_format_metadata = tt::DataFormat::Float16_b;
     auto dfb2 = MakeMinimalDFB("dfb2", node);
-    dfb2.data_format_metadata = tt::DataFormat::Bfp8_b;
+    dfb2.data_format_metadata = tt::DataFormat::Int8;
 
     BindDFBToKernel(producer, "dfb1", "out1", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(producer, "dfb2", "out2", KernelSpec::DFBEndpointType::PRODUCER);

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -11,6 +11,8 @@
 
 #include <fmt/base.h>
 
+#include <umd/device/types/arch.hpp>
+
 namespace tt {
 
 /**
@@ -50,17 +52,9 @@ enum class DataFormat : uint8_t {
 bool is_integer_format(DataFormat format);
 
 /**
- * @brief True if the format is supported by Gen1 Tensix hardware (Wormhole and Blackhole).
- * @details Source of truth: `tt_metal/hw/inc/internal/tt-1xx/wormhole/.../tensix_types.h` and
- *          `tt_metal/hw/inc/internal/tt-1xx/blackhole/tensix_types.h`.
+ * @brief Whether the data format is supported by the Tensix compute engine of a given architecture.
  */
-bool is_supported_for_gen1(DataFormat format);
-
-/**
- * @brief True if the format is supported by Gen2 Tensix hardware (Quasar and derivatives).
- * @details Source of truth: `tt_metal/hw/inc/internal/tt-2xx/quasar/tensix_types.h`.
- */
-bool is_supported_for_gen2(DataFormat format);
+bool is_data_format_supported(DataFormat format, ARCH arch);
 
 std::ostream& operator<<(std::ostream& os, const DataFormat& format);
 

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -32,7 +32,7 @@ enum class DataFormat : uint8_t {
     Bfp4_b = 7,
     Bfp2_b = 15,
     Lf8 = 10,
-    Fp8_e4m3 = 0x1A,
+    Fp8_e4m3 = 26,
     Int8 = 14,
     Tf32 = 4,
     UInt8 = 30,
@@ -40,10 +40,10 @@ enum class DataFormat : uint8_t {
     Int16 = 13,
     Int32 = 8,
     UInt32 = 24,
-    RawUInt8 = 0xf0,
-    RawUInt16 = 0xf1,
-    RawUInt32 = 0xf2,
-    Invalid = 0xff
+    RawUInt8 = 240,
+    RawUInt16 = 241,
+    RawUInt32 = 242,
+    Invalid = 255
 };
 
 /**

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -14,9 +14,10 @@
 namespace tt {
 
 /**
- * @brief Tensix data format enum, used across the entire SW+HW stack.
- * This enum is also replicated in tensix_types.h (LLK), but we don't want to include it here since the other data types
- * are not relevant.
+ * @brief Tensix data format enum.
+ * @details This enum contains the union of all data formats supported by Tensix hardware of all generations.
+ * Not all data formats are supported by all hardware generations; compatibility is legality checked at runtime.
+ * Architecture-specific data format enums are replicated in tensix_types.h (LLK).
  */
 enum class DataFormat : uint8_t {
     Float32 = 0,
@@ -47,6 +48,19 @@ enum class DataFormat : uint8_t {
  * @brief Evaluates to true if the data format is an integer type.
  */
 bool is_integer_format(DataFormat format);
+
+/**
+ * @brief True if the format is supported by Gen1 Tensix hardware (Wormhole and Blackhole).
+ * @details Source of truth: `tt_metal/hw/inc/internal/tt-1xx/wormhole/.../tensix_types.h` and
+ *          `tt_metal/hw/inc/internal/tt-1xx/blackhole/tensix_types.h`.
+ */
+bool is_supported_for_gen1(DataFormat format);
+
+/**
+ * @brief True if the format is supported by Gen2 Tensix hardware (Quasar and derivatives).
+ * @details Source of truth: `tt_metal/hw/inc/internal/tt-2xx/quasar/tensix_types.h`.
+ */
+bool is_supported_for_gen2(DataFormat format);
 
 std::ostream& operator<<(std::ostream& os, const DataFormat& format);
 

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -59,58 +59,74 @@ bool tt::is_integer_format(DataFormat format) {
         (format == DataFormat::RawUInt32) || (format == DataFormat::RawUInt16) || (format == DataFormat::RawUInt8));
 }
 
-bool tt::is_supported_for_gen1(DataFormat format) {
+// Translation unit-local implementation details.
+// We can remove the anonymous namespace after the tt_backend_api_types.hpp header is moved to the tt_metal namespace.
+namespace {
+
+// TT-1.x (Wormhole / Blackhole) host-side enumeration.
+bool is_supported_wormhole_blackhole(tt::DataFormat format, bool is_blackhole) {
     switch (format) {
-        case DataFormat::Float32:
-        case DataFormat::Float16:
-        case DataFormat::Bfp8:
-        case DataFormat::Bfp4:
-        case DataFormat::Bfp2:
-        case DataFormat::Float16_b:
-        case DataFormat::Bfp8_b:
-        case DataFormat::Bfp4_b:
-        case DataFormat::Bfp2_b:
-        case DataFormat::Lf8:
-        case DataFormat::Fp8_e4m3:
-        case DataFormat::Int8:
-        case DataFormat::Tf32:
-        case DataFormat::UInt8:
-        case DataFormat::UInt16:
-        case DataFormat::Int32:
-        case DataFormat::UInt32:
-        case DataFormat::RawUInt8:
-        case DataFormat::RawUInt16:
-        case DataFormat::RawUInt32: return true;
-        case DataFormat::Invalid:
+        case tt::DataFormat::Float32:
+        case tt::DataFormat::Float16:
+        case tt::DataFormat::Bfp8:
+        case tt::DataFormat::Bfp4:
+        case tt::DataFormat::Bfp2:
+        case tt::DataFormat::Float16_b:
+        case tt::DataFormat::Bfp8_b:
+        case tt::DataFormat::Bfp4_b:
+        case tt::DataFormat::Bfp2_b:
+        case tt::DataFormat::Lf8:
+        case tt::DataFormat::Int8:
+        case tt::DataFormat::Tf32:
+        case tt::DataFormat::UInt8:
+        case tt::DataFormat::UInt16:
+        case tt::DataFormat::Int32:
+        case tt::DataFormat::UInt32:
+        case tt::DataFormat::RawUInt8:
+        case tt::DataFormat::RawUInt16:
+        case tt::DataFormat::RawUInt32: return true;
+        case tt::DataFormat::Fp8_e4m3: return is_blackhole;
+        case tt::DataFormat::Invalid:
         default: return false;
     }
 }
 
-bool tt::is_supported_for_gen2(DataFormat format) {
+// TT-2.x (Quasar) host-side enumeration.
+bool is_supported_quasar(tt::DataFormat format) {
     switch (format) {
-        // Matches Quasar `DataFormat` encodings for Float32, Tf32, Float16, Float16_b, Int8, Int32; plus
-        // host-side raw tile buffers (opaque bytes; not a Tensix enum wire format).
-        case DataFormat::Float32:
-        case DataFormat::Tf32:
-        case DataFormat::Float16:
-        case DataFormat::Float16_b:
-        case DataFormat::Int8:
-        case DataFormat::Int32:
-        case DataFormat::RawUInt8:
-        case DataFormat::RawUInt16:
-        case DataFormat::RawUInt32: return true;
-        case DataFormat::Bfp8:
-        case DataFormat::Bfp4:
-        case DataFormat::Bfp2:
-        case DataFormat::Bfp8_b:
-        case DataFormat::Bfp4_b:
-        case DataFormat::Bfp2_b:
-        case DataFormat::Lf8:
-        case DataFormat::Fp8_e4m3:
-        case DataFormat::UInt8:
-        case DataFormat::UInt16:
-        case DataFormat::UInt32:
-        case DataFormat::Invalid:
+        case tt::DataFormat::Float32:
+        case tt::DataFormat::Tf32:
+        case tt::DataFormat::Float16:
+        case tt::DataFormat::Float16_b:
+        case tt::DataFormat::Int8:
+        case tt::DataFormat::Int32:
+        case tt::DataFormat::RawUInt8:
+        case tt::DataFormat::RawUInt16:
+        case tt::DataFormat::RawUInt32: return true;
+        case tt::DataFormat::Bfp8:
+        case tt::DataFormat::Bfp4:
+        case tt::DataFormat::Bfp2:
+        case tt::DataFormat::Bfp8_b:
+        case tt::DataFormat::Bfp4_b:
+        case tt::DataFormat::Bfp2_b:
+        case tt::DataFormat::Lf8:
+        case tt::DataFormat::Fp8_e4m3:
+        case tt::DataFormat::UInt8:
+        case tt::DataFormat::UInt16:
+        case tt::DataFormat::UInt32:
+        case tt::DataFormat::Invalid:
+        default: return false;
+    }
+}
+
+}  // namespace
+
+bool tt::is_data_format_supported(DataFormat format, ARCH arch) {
+    switch (arch) {
+        case ARCH::WORMHOLE_B0: return is_supported_wormhole_blackhole(format, /*is_blackhole=*/false);
+        case ARCH::BLACKHOLE: return is_supported_wormhole_blackhole(format, /*is_blackhole=*/true);
+        case ARCH::QUASAR: return is_supported_quasar(format);
+        case ARCH::Invalid:
         default: return false;
     }
 }

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -66,25 +66,25 @@ namespace {
 // TT-1.x (Wormhole / Blackhole) host-side enumeration.
 bool is_supported_wormhole_blackhole(tt::DataFormat format, bool is_blackhole) {
     switch (format) {
-        case tt::DataFormat::Float32:
-        case tt::DataFormat::Float16:
-        case tt::DataFormat::Bfp8:
-        case tt::DataFormat::Bfp4:
         case tt::DataFormat::Bfp2:
-        case tt::DataFormat::Float16_b:
-        case tt::DataFormat::Bfp8_b:
-        case tt::DataFormat::Bfp4_b:
         case tt::DataFormat::Bfp2_b:
-        case tt::DataFormat::Lf8:
+        case tt::DataFormat::Bfp4:
+        case tt::DataFormat::Bfp4_b:
+        case tt::DataFormat::Bfp8:
+        case tt::DataFormat::Bfp8_b:
+        case tt::DataFormat::Float16:
+        case tt::DataFormat::Float16_b:
+        case tt::DataFormat::Float32:
         case tt::DataFormat::Int8:
+        case tt::DataFormat::Int32:
+        case tt::DataFormat::Lf8:
+        case tt::DataFormat::RawUInt8:
+        case tt::DataFormat::RawUInt16:
+        case tt::DataFormat::RawUInt32:
         case tt::DataFormat::Tf32:
         case tt::DataFormat::UInt8:
         case tt::DataFormat::UInt16:
-        case tt::DataFormat::Int32:
-        case tt::DataFormat::UInt32:
-        case tt::DataFormat::RawUInt8:
-        case tt::DataFormat::RawUInt16:
-        case tt::DataFormat::RawUInt32: return true;
+        case tt::DataFormat::UInt32: return true;
         case tt::DataFormat::Fp8_e4m3: return is_blackhole;
         case tt::DataFormat::Invalid:
         default: return false;
@@ -94,27 +94,27 @@ bool is_supported_wormhole_blackhole(tt::DataFormat format, bool is_blackhole) {
 // TT-2.x (Quasar) host-side enumeration.
 bool is_supported_quasar(tt::DataFormat format) {
     switch (format) {
-        case tt::DataFormat::Float32:
-        case tt::DataFormat::Tf32:
         case tt::DataFormat::Float16:
         case tt::DataFormat::Float16_b:
+        case tt::DataFormat::Float32:
         case tt::DataFormat::Int8:
         case tt::DataFormat::Int32:
         case tt::DataFormat::RawUInt8:
         case tt::DataFormat::RawUInt16:
-        case tt::DataFormat::RawUInt32: return true;
-        case tt::DataFormat::Bfp8:
-        case tt::DataFormat::Bfp4:
+        case tt::DataFormat::RawUInt32:
+        case tt::DataFormat::Tf32: return true;
         case tt::DataFormat::Bfp2:
-        case tt::DataFormat::Bfp8_b:
-        case tt::DataFormat::Bfp4_b:
         case tt::DataFormat::Bfp2_b:
-        case tt::DataFormat::Lf8:
+        case tt::DataFormat::Bfp4:
+        case tt::DataFormat::Bfp4_b:
+        case tt::DataFormat::Bfp8:
+        case tt::DataFormat::Bfp8_b:
         case tt::DataFormat::Fp8_e4m3:
+        case tt::DataFormat::Invalid:
+        case tt::DataFormat::Lf8:
         case tt::DataFormat::UInt8:
         case tt::DataFormat::UInt16:
         case tt::DataFormat::UInt32:
-        case tt::DataFormat::Invalid:
         default: return false;
     }
 }
@@ -127,7 +127,7 @@ bool tt::is_data_format_supported(DataFormat format, ARCH arch) {
         case ARCH::BLACKHOLE: return is_supported_wormhole_blackhole(format, /*is_blackhole=*/true);
         case ARCH::QUASAR: return is_supported_quasar(format);
         case ARCH::Invalid:
-        default: return false;
+        default: TT_FATAL(false, "Unsupported architecture");
     }
 }
 

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -8,6 +8,7 @@
 #include <fmt/base.h>
 #include <enchantum/enchantum.hpp>
 #include <string_view>
+#include <tt_stl/assert.hpp>
 
 std::string tt::get_string(tt::ARCH arch) {
     switch (arch) {
@@ -97,24 +98,16 @@ bool is_supported_quasar(tt::DataFormat format) {
         case tt::DataFormat::Float16:
         case tt::DataFormat::Float16_b:
         case tt::DataFormat::Float32:
+        case tt::DataFormat::Fp8_e4m3:
         case tt::DataFormat::Int8:
         case tt::DataFormat::Int32:
+        case tt::DataFormat::Lf8:
         case tt::DataFormat::RawUInt8:
         case tt::DataFormat::RawUInt16:
         case tt::DataFormat::RawUInt32:
-        case tt::DataFormat::Tf32: return true;
-        case tt::DataFormat::Bfp2:
-        case tt::DataFormat::Bfp2_b:
-        case tt::DataFormat::Bfp4:
-        case tt::DataFormat::Bfp4_b:
-        case tt::DataFormat::Bfp8:
-        case tt::DataFormat::Bfp8_b:
-        case tt::DataFormat::Fp8_e4m3:
+        case tt::DataFormat::Tf32:
+        case tt::DataFormat::UInt8: return true;
         case tt::DataFormat::Invalid:
-        case tt::DataFormat::Lf8:
-        case tt::DataFormat::UInt8:
-        case tt::DataFormat::UInt16:
-        case tt::DataFormat::UInt32:
         default: return false;
     }
 }

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -59,6 +59,62 @@ bool tt::is_integer_format(DataFormat format) {
         (format == DataFormat::RawUInt32) || (format == DataFormat::RawUInt16) || (format == DataFormat::RawUInt8));
 }
 
+bool tt::is_supported_for_gen1(DataFormat format) {
+    switch (format) {
+        case DataFormat::Float32:
+        case DataFormat::Float16:
+        case DataFormat::Bfp8:
+        case DataFormat::Bfp4:
+        case DataFormat::Bfp2:
+        case DataFormat::Float16_b:
+        case DataFormat::Bfp8_b:
+        case DataFormat::Bfp4_b:
+        case DataFormat::Bfp2_b:
+        case DataFormat::Lf8:
+        case DataFormat::Fp8_e4m3:
+        case DataFormat::Int8:
+        case DataFormat::Tf32:
+        case DataFormat::UInt8:
+        case DataFormat::UInt16:
+        case DataFormat::Int32:
+        case DataFormat::UInt32:
+        case DataFormat::RawUInt8:
+        case DataFormat::RawUInt16:
+        case DataFormat::RawUInt32: return true;
+        case DataFormat::Invalid:
+        default: return false;
+    }
+}
+
+bool tt::is_supported_for_gen2(DataFormat format) {
+    switch (format) {
+        // Matches Quasar `DataFormat` encodings for Float32, Tf32, Float16, Float16_b, Int8, Int32; plus
+        // host-side raw tile buffers (opaque bytes; not a Tensix enum wire format).
+        case DataFormat::Float32:
+        case DataFormat::Tf32:
+        case DataFormat::Float16:
+        case DataFormat::Float16_b:
+        case DataFormat::Int8:
+        case DataFormat::Int32:
+        case DataFormat::RawUInt8:
+        case DataFormat::RawUInt16:
+        case DataFormat::RawUInt32: return true;
+        case DataFormat::Bfp8:
+        case DataFormat::Bfp4:
+        case DataFormat::Bfp2:
+        case DataFormat::Bfp8_b:
+        case DataFormat::Bfp4_b:
+        case DataFormat::Bfp2_b:
+        case DataFormat::Lf8:
+        case DataFormat::Fp8_e4m3:
+        case DataFormat::UInt8:
+        case DataFormat::UInt16:
+        case DataFormat::UInt32:
+        case DataFormat::Invalid:
+        default: return false;
+    }
+}
+
 std::ostream& tt::operator<<(std::ostream& os, const DataFormat& format) {
     switch (format) {
         case DataFormat::Bfp2: os << "Bfp2"; break;

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -60,10 +60,6 @@ bool tt::is_integer_format(DataFormat format) {
         (format == DataFormat::RawUInt32) || (format == DataFormat::RawUInt16) || (format == DataFormat::RawUInt8));
 }
 
-// Translation unit-local implementation details.
-// We can remove the anonymous namespace after the tt_backend_api_types.hpp header is moved to the tt_metal namespace.
-namespace {
-
 // TT-1.x (Wormhole / Blackhole) host-side enumeration.
 bool is_supported_wormhole_blackhole(tt::DataFormat format, bool is_blackhole) {
     switch (format) {
@@ -111,8 +107,6 @@ bool is_supported_quasar(tt::DataFormat format) {
         default: return false;
     }
 }
-
-}  // namespace
 
 bool tt::is_data_format_supported(DataFormat format, ARCH arch) {
     switch (arch) {

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -96,6 +96,7 @@ bool is_supported_quasar(tt::DataFormat format) {
         case tt::DataFormat::Float32:
         case tt::DataFormat::Fp8_e4m3:
         case tt::DataFormat::Int8:
+        case tt::DataFormat::Int16:
         case tt::DataFormat::Int32:
         case tt::DataFormat::Lf8:
         case tt::DataFormat::RawUInt8:

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -9,6 +9,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>  // fmt::formatter<tt::DataFormat> for TT_FATAL messages
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "impl/kernels/kernel.hpp"
@@ -423,17 +424,13 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Data format must be valid for the architecture
     for (const auto& dfb : spec.dataflow_buffers) {
         if (dfb.data_format_metadata.has_value()) {
-            if (is_gen2_arch()) {
-                TT_FATAL(
-                    tt::is_supported_for_gen2(dfb.data_format_metadata.value()),
-                    "DFB '{}' has a data format that is not supported on Gen2 architectures",
-                    dfb.unique_id);
-            } else if (is_gen1_arch()) {
-                TT_FATAL(
-                    tt::is_supported_for_gen1(dfb.data_format_metadata.value()),
-                    "DFB '{}' has a data format that is not supported on Gen1 architectures",
-                    dfb.unique_id);
-            }
+            const tt::ARCH arch = get_arch();
+            TT_FATAL(
+                tt::is_data_format_supported(dfb.data_format_metadata.value(), arch),
+                "DFB '{}' has data format '{}' which is not supported on architecture {}",
+                dfb.unique_id,
+                dfb.data_format_metadata.value(),
+                arch);
         }
     }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -422,9 +422,9 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     }
 
     // Data format must be valid for the architecture
+    const tt::ARCH arch = get_arch();
     for (const auto& dfb : spec.dataflow_buffers) {
         if (dfb.data_format_metadata.has_value()) {
-            const tt::ARCH arch = get_arch();
             TT_FATAL(
                 tt::is_data_format_supported(dfb.data_format_metadata.value(), arch),
                 "DFB '{}' has data format '{}' which is not supported on architecture {}",

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -420,6 +420,23 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
+    // Data format must be valid for the architecture
+    for (const auto& dfb : spec.dataflow_buffers) {
+        if (dfb.data_format_metadata.has_value()) {
+            if (is_gen2_arch()) {
+                TT_FATAL(
+                    tt::is_supported_for_gen2(dfb.data_format_metadata.value()),
+                    "DFB '{}' has a data format that is not supported on Gen2 architectures",
+                    dfb.unique_id);
+            } else if (is_gen1_arch()) {
+                TT_FATAL(
+                    tt::is_supported_for_gen1(dfb.data_format_metadata.value()),
+                    "DFB '{}' has a data format that is not supported on Gen1 architectures",
+                    dfb.unique_id);
+            }
+        }
+    }
+
     //////////////////////////////////
     // Validate SemaphoreSpecs
     //////////////////////////////////


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41872

### PR Type
New feature

### Problem description
Quasar Tensix supports a different set of data formats than WH/BH. 
It introduces some new formats, and drops support for some old formats.

To handle this in the host APIs, we need:
 - A `DataFormat` enum that contains the _union_ of all supported data formats across all architectures
 - Runtime legality checks to ensure that the selected `DataFormat` is compatible with the selected architecture. 

Unlike device code, host APIs must always be compile-time architecture-agnostic. (A user can write a single host program code capable of targeting different architectures.) Hence why we need a runtime check.

### What's changed
 - Add a new method to `tt_backend_api_types.hpp`: `is_dataformat_supported` and `is_supported_for_gen2`. (The new host APIs use "Gen1" for WH/BH and derivatives, "Gen2" for Quasar and derivatives)
 - Add a `DataFormat` legality check to the new Metal 2.0 host APIs. (These will soon be the only Program creation APIs for Quasar)
 - Add a test to check that Program creation with an incompatible data format fails

### Future
The data format query API should really be part of a general-purpose device query framework in Metalium. I'll move it when we get around to creating that. https://github.com/tenstorrent/tt-metal/issues/41870

### Checklist

- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/data-format-legality-checks-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/data-format-legality-checks-quasar) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/data-format-legality-checks-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/data-format-legality-checks-quasar) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/data-format-legality-checks-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/data-format-legality-checks-quasar) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/data-format-legality-checks-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/data-format-legality-checks-quasar) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/data-format-legality-checks-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/data-format-legality-checks-quasar) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/data-format-legality-checks-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/data-format-legality-checks-quasar) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/data-format-legality-checks-quasar) |