### PR TITLE
Matmul kernel argument index fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -916,9 +916,11 @@ void MinimalMatmulProgramFactory::override_runtime_arguments(
     auto& compute_runtime_args = GetRuntimeArgs(program, override_variables.compute_kernels_id);
 
     // RT args layout for in0: [in0_addr, in2_addr, in3_addr, is_sink, noc_coords(4), tile_ranges(4),
-    //   defer_write_k_block, max_defer_write_k_block, [optional: ternary_a_addr, ternary_b_addr], out_addrs(N)...]
+    //   defer_write_k_block, max_defer_write_k_block,
+    //   [optional: ternary_a_addr, ternary_b_addr, broadcast_ternary_b], out_addrs(N)...]
     // RT args layout for in1: [in1_addr, in2_addr, is_sink, noc_coords(4), tile_ranges(4),
-    //   defer_write_k_block, max_defer_write_k_block, [optional: ternary_a_addr, ternary_b_addr], out_addrs(N)...]
+    //   defer_write_k_block, max_defer_write_k_block,
+    //   [optional: ternary_a_addr, ternary_b_addr, broadcast_ternary_b], out_addrs(N)...]
     constexpr uint32_t in0_in0_addr_idx = 0;
     constexpr uint32_t in0_in2_addr_idx = 1;
     constexpr uint32_t in0_in3_addr_idx = 2;
@@ -934,8 +936,8 @@ void MinimalMatmulProgramFactory::override_runtime_arguments(
     bool has_fused_ternary =
         tensor_args.fused_ternary_input_a.has_value() && tensor_args.fused_ternary_input_b.has_value();
     // Output addresses start after max_defer_write_k_block and optional ternary addresses
-    uint32_t in0_out_addr_start_idx = has_fused_ternary ? 16 : 14;
-    uint32_t in1_out_addr_start_idx = has_fused_ternary ? 15 : 13;
+    uint32_t in0_out_addr_start_idx = has_fused_ternary ? 17 : 14;
+    uint32_t in1_out_addr_start_idx = has_fused_ternary ? 16 : 13;
 
     for (uint32_t i = 0; i < override_variables.num_cores; ++i) {
         CoreCoord core = override_variables.cores.at(i);


### PR DESCRIPTION
### Problem description

[PR 41495](https://github.com/tenstorrent/tt-metal/pull/41495) (Support non-broadcasted ternary inputs in MM/AGMM/RSMM) introduced a bug that caused the Wan pipeline to produce bad output with Linear topology.

### What's changed

Update indices of matmul kernel arguments when the fused ternary is used.

### Checklist
