### PR TITLE
Fix failing CombineDeviceTensors test in T3K pipeline

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -27,6 +27,7 @@ using ::testing::SizeIs;
 using ::testing::ThrowsMessage;
 
 using MeshTensorTest = GenericMeshDeviceFixture;
+using MeshTensorTest1x2 = MeshDevice1x2Fixture;
 using MeshTensorTest2x4 = MeshDevice2x4Fixture;
 
 TEST(MeshTensorHostTest, ToHostAlreadyOnHost) {
@@ -290,6 +291,52 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
     EXPECT_EQ(partial_device_storage.get_coords()[1], (distributed::MeshCoordinate{0, 2}));
     EXPECT_EQ(partial_device_storage.get_coords()[2], (distributed::MeshCoordinate{1, 0}));
     EXPECT_EQ(partial_device_storage.get_coords()[3], (distributed::MeshCoordinate{1, 2}));
+}
+
+TEST_F(MeshTensorTest1x2, CombineDeviceTensors) {
+    const ttnn::Shape shape{1, 1, 32, 32};
+    const TensorSpec tensor_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    std::vector<float> host_data(shape.volume());
+    std::iota(host_data.begin(), host_data.end(), 0);
+
+    Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
+
+    Tensor device_tensor1 = to_device(input_host_tensor, mesh_device_.get());
+    Tensor device_tensor2 = to_device(input_host_tensor, mesh_device_.get());
+
+    auto device_tensors1 = get_device_tensors(device_tensor1);
+    auto device_tensors2 = get_device_tensors(device_tensor2);
+
+    EXPECT_THAT(device_tensors1, SizeIs(mesh_device_->num_devices()));
+    EXPECT_THAT(device_tensors2, SizeIs(mesh_device_->num_devices()));
+
+    // Try to aggregate shards from different mesh buffers.
+    EXPECT_THAT(
+        ([&]() {
+            std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors2[1]};
+            combine_device_tensors(shards_to_aggregate);
+        }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("tensor shards must be allocated on the same mesh buffer.")));
+
+    // Try to aggregate the same shard twice.
+    EXPECT_THAT(
+        ([&]() {
+            std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors1[0]};
+            combine_device_tensors(shards_to_aggregate);
+        }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("Found a tensor shard at duplicate coordinate")));
+
+    // Aggregate both shards in reverse order; verify coords come out sorted.
+    auto partial_tensor = combine_device_tensors(std::vector<Tensor>{device_tensors1[1], device_tensors1[0]});
+
+    const auto& partial_device_storage = partial_tensor.device_storage();
+    EXPECT_NO_THROW({ partial_device_storage.get_mesh_buffer(); });
+
+    ASSERT_THAT(partial_device_storage.get_coords(), SizeIs(2));
+    EXPECT_EQ(partial_device_storage.get_coords()[0], (distributed::MeshCoordinate{0, 0}));
+    EXPECT_EQ(partial_device_storage.get_coords()[1], (distributed::MeshCoordinate{0, 1}));
 }
 
 struct MeshTensorWriteTestParams {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -293,7 +293,8 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
     EXPECT_EQ(partial_device_storage.get_coords()[3], (distributed::MeshCoordinate{1, 2}));
 }
 
-TEST_F(MeshTensorTest1x2, CombineDeviceTensors) {
+// This is the mini version of MeshTensorTest2x4.CombineDeviceTensors above.
+TEST_F(MeshTensorTest1x2, CombineDeviceTensorsMini) {
     const ttnn::Shape shape{1, 1, 32, 32};
     const TensorSpec tensor_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -169,19 +169,13 @@ DeviceStorage DeviceStorage::combine_device_storages(
         "tensor shards must be allocated on the same mesh buffer.");
 
     std::set<distributed::MeshCoordinate> seen_coords;
-    std::vector<distributed::MeshCoordinate> joint_coords;
     for (const auto& storage : storages) {
         for (const auto& coord : storage.get().get_coords()) {
-            TT_FATAL(
-                seen_coords.insert(coord).second,
-                "Found a tensor shard at duplicate coordinate {}",
-                coord);
-            joint_coords.push_back(coord);
+            auto [_, coord_is_new] = seen_coords.insert(coord);
+            TT_FATAL(coord_is_new, "Found a tensor shard at duplicate coordinate {}", coord);
         }
     }
-    std::sort(joint_coords.begin(), joint_coords.end());
-
-    return DeviceStorage(model_storage, std::move(joint_coords));
+    return DeviceStorage(model_storage, {seen_coords.begin(), seen_coords.end()});
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <numeric>
 #include <functional>
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 #include <ttnn/tensor/layout/layout.hpp>
@@ -166,21 +166,22 @@ DeviceStorage DeviceStorage::combine_device_storages(
             storages.begin(),
             storages.end(),
             [&](const auto& storage) { return storage.get().mesh_buffer == model_storage.mesh_buffer; }),
-        "All DeviceStorages must point to the same device memory");
+        "tensor shards must be allocated on the same mesh buffer.");
 
-    auto num_coords = std::accumulate(storages.begin(), storages.end(), 0, [](size_t sum, const auto& storage) {
-        return sum + storage.get().get_coords().size();
-    });
-
-    std::unordered_set<distributed::MeshCoordinate> joint_coords;
-    joint_coords.reserve(num_coords);
+    std::set<distributed::MeshCoordinate> seen_coords;
+    std::vector<distributed::MeshCoordinate> joint_coords;
     for (const auto& storage : storages) {
-        auto other_coords = storage.get().get_coords();
-        joint_coords.insert(other_coords.begin(), other_coords.end());
+        for (const auto& coord : storage.get().get_coords()) {
+            TT_FATAL(
+                seen_coords.insert(coord).second,
+                "Found a tensor shard at duplicate coordinate {}",
+                coord);
+            joint_coords.push_back(coord);
+        }
     }
+    std::sort(joint_coords.begin(), joint_coords.end());
 
-    return DeviceStorage(
-        model_storage, std::vector<distributed::MeshCoordinate>(joint_coords.begin(), joint_coords.end()));
+    return DeviceStorage(model_storage, std::move(joint_coords));
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
Fixes `CombineDeviceTensors` test failure caused by PR #39872.

Failing CI run: https://github.com/tenstorrent/tt-metal/actions/runs/24220402376/job/70711142069

### Problem description
The `DeviceStorage` refactor in #41224 broke `CombineDeviceTensors` and was not caught because the test cases required a 2x4 MeshDevice (T3K) to execute.

Missed semantics:
- Error message was changed
- Explicit error when duplicated coords are detected
- coords needs to be sorted.

### What's changed

- Fixed all broken semantics.
- Added a mini version of the test that only requires 1x2 MeshDevice to allow easier checking.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [ ] Verification run: https://github.com/tenstorrent/tt-metal/actions/runs/24234945013/job/70756043655