### PR TITLE
Migrate tanhshrink from composite to single-pass SFPU kernel

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_tanh.h"
+
+namespace ckernel::sfpu {
+
+// Tanhshrink(x) = x - tanh(x)
+// Single-pass SFPU kernel that computes tanh in-register and subtracts
+// from the original value, avoiding multi-tile composite decomposition.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_tanhshrink() {
+    if constexpr (APPROXIMATION_MODE) {
+        sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = l_reg[sfpi::LRegs::LReg1];
+        sfpi::vUInt l2 = l_reg[sfpi::LRegs::LReg2];
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat v = sfpi::dst_reg[0];
+            sfpi::vFloat tanh_v = sfpi::lut(v, l0, l1, l2);
+            sfpi::dst_reg[0] = v - tanh_v;
+            sfpi::dst_reg++;
+        }
+
+        l_reg[sfpi::LRegs::LReg0] = l0;
+        l_reg[sfpi::LRegs::LReg1] = l1;
+        l_reg[sfpi::LRegs::LReg2] = l2;
+    } else {
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat v = sfpi::dst_reg[0];
+
+            sfpi::vFloat tanh_v;
+            if constexpr (is_fp32_dest_acc_en) {
+                tanh_v = _sfpu_tanh_fp32_accurate_<is_fp32_dest_acc_en>(v);
+            } else {
+                tanh_v = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(v);
+                tanh_v = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(tanh_v, 0));
+            }
+
+            sfpi::dst_reg[0] = v - tanh_v;
+            sfpi::dst_reg++;
+        }
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -9,6 +9,7 @@
 #include "ckernel_sfpu_softsign.h"
 #include "ckernel_sfpu_softshrink.h"
 #include "ckernel_sfpu_hardshrink.h"
+#include "ckernel_sfpu_tanhshrink.h"
 #include "ckernel_sfpu_celu.h"
 
 namespace ckernel {
@@ -69,6 +70,29 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+}
+
+// tanhshrink
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+inline void llk_math_eltwise_unary_sfpu_tanhshrink_init() {
+    if constexpr (APPROXIMATE) {
+        ckernel::sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>();
+    } else {
+        if constexpr (is_fp32_dest_acc_en) {
+            ckernel::sfpu::sigmoid_init<false>();
+        } else {
+            sfpi::vConstFloatPrgm0 = 5.876733921468257904052734375e-3;
+            sfpi::vConstFloatPrgm1 = -6.6649019718170166015625e-2;
+            sfpi::vConstFloatPrgm2 = 0.281917631626129150390625;
+        }
+    }
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tanhshrink, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_tanhshrink(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_tanhshrink<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 
 // hardshrink

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -128,6 +128,7 @@ enum class SfpuType {
     lcm,
     softshrink,
     hardshrink,
+    tanhshrink,
     hardsigmoid,
     threshold,
     where,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_tanh.h"
+
+namespace ckernel::sfpu {
+
+// Tanhshrink(x) = x - tanh(x)
+// Single-pass SFPU kernel that computes tanh in-register and subtracts
+// from the original value, avoiding multi-tile composite decomposition.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_tanhshrink() {
+    if constexpr (APPROXIMATION_MODE) {
+        sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = l_reg[sfpi::LRegs::LReg1];
+        sfpi::vUInt l2 = l_reg[sfpi::LRegs::LReg2];
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat v = sfpi::dst_reg[0];
+            sfpi::vFloat tanh_v = sfpi::lut(v, l0, l1, l2);
+            sfpi::dst_reg[0] = v - tanh_v;
+            sfpi::dst_reg++;
+        }
+
+        l_reg[sfpi::LRegs::LReg0] = l0;
+        l_reg[sfpi::LRegs::LReg1] = l1;
+        l_reg[sfpi::LRegs::LReg2] = l2;
+    } else {
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat v = sfpi::dst_reg[0];
+
+            sfpi::vFloat tanh_v;
+            if constexpr (is_fp32_dest_acc_en) {
+                tanh_v = _sfpu_tanh_fp32_accurate_<is_fp32_dest_acc_en>(v);
+            } else {
+                tanh_v = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(v);
+                tanh_v = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(tanh_v, 0));
+            }
+
+            sfpi::dst_reg[0] = v - tanh_v;
+            sfpi::dst_reg++;
+        }
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -9,6 +9,7 @@
 #include "ckernel_sfpu_softsign.h"
 #include "ckernel_sfpu_softshrink.h"
 #include "ckernel_sfpu_hardshrink.h"
+#include "ckernel_sfpu_tanhshrink.h"
 #include "ckernel_sfpu_celu.h"
 
 namespace ckernel {
@@ -68,6 +69,29 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+}
+
+// tanhshrink
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+inline void llk_math_eltwise_unary_sfpu_tanhshrink_init() {
+    if constexpr (APPROXIMATE) {
+        ckernel::sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>();
+    } else {
+        if constexpr (is_fp32_dest_acc_en) {
+            ckernel::sfpu::sigmoid_init<false>();
+        } else {
+            sfpi::vConstFloatPrgm0 = 5.876733921468257904052734375e-3;
+            sfpi::vConstFloatPrgm1 = -6.6649019718170166015625e-2;
+            sfpi::vConstFloatPrgm2 = 0.281917631626129150390625;
+        }
+    }
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tanhshrink, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_tanhshrink(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_tanhshrink<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 
 // hardshrink

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -128,6 +128,7 @@ enum class SfpuType {
     lcm,
     softshrink,
     hardshrink,
+    tanhshrink,
     hardsigmoid,
     threshold,
     where,

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
@@ -126,4 +126,29 @@ ALWI void hardshrink_tile(uint32_t idst, uint32_t param0) {
  */
 ALWI void hardshrink_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardshrink_init<APPROX>())); }
 
+// clang-format off
+/**
+* Performs element-wise tanhshrink operation on each element of a tile
+* in DST register at index idst. The DST register buffer must be in
+* acquired state via *acquire_dst* call. This call is blocking and is only
+* available on the compute engine.
+*
+* Formula: tanhshrink(x) = x - tanh(x)
+*
+* Return value: None
+*
+* | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+* |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+* | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+*/
+// clang-format on
+ALWI void tanhshrink_tile(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_tanhshrink<APPROX, DST_ACCUM_MODE>(idst)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void tanhshrink_tile_init() { MATH((llk_math_eltwise_unary_sfpu_tanhshrink_init<APPROX, DST_ACCUM_MODE>())); }
+
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -93,6 +93,7 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::CLAMP_TSS: return "SFPU_OP_CLAMP_INCLUDE";
         case UnaryOpType::SOFTSHRINK:
         case UnaryOpType::HARDSHRINK:
+        case UnaryOpType::TANHSHRINK:
         case UnaryOpType::SOFTSIGN:
         case UnaryOpType::HARDSIGMOID:
         case UnaryOpType::CELU: return "SFPU_OP_ACTIVATIONS_INCLUDE";
@@ -795,7 +796,7 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
         case UnaryOpType::BITCAST:
             // Bitcast uses identity kernel (copy_tile + pack_tile) - no LLK needed
             // Parameters are input_dtype and output_dtype, but we don't need them for the kernel
-        case UnaryOpType::TANHSHRINK:
+        case UnaryOpType::TANHSHRINK: return {"tanhshrink_tile_init();", fmt::format("tanhshrink_tile({});", idst)};
         case UnaryOpType::HARDSWISH:
         case UnaryOpType::LOGSIGMOID: return {};
         case UnaryOpType::HARDMISH: return {"hardmish_tile_init();", fmt::format("hardmish_tile({});", idst)};
@@ -1018,12 +1019,6 @@ std::string_view get_compute_kernel_path(UnaryOpType op_type, std::optional<Data
             }
             return "lgamma_kernel.cpp";
         case UnaryOpType::MISH: return "mish_kernel.cpp";
-        case UnaryOpType::TANHSHRINK:
-            if (input_dtype.has_value() && input_dtype.value() == DataType::FLOAT32) {
-                return "tanhshrink_sfpu_kernel.cpp";
-            } else {
-                return "tanhshrink_kernel.cpp";
-            }
         case UnaryOpType::IDENTITY: return "eltwise_identity_kernel.cpp";
         case UnaryOpType::WHERE_TSS: return "where_tss_kernel.cpp";
         case UnaryOpType::HARDSWISH:


### PR DESCRIPTION
## Summary
- Migrates `tanhshrink` from a composite op (tanh + subtract) to a dedicated single-pass SFPU kernel
- Adds new `ckernel_sfpu_tanhshrink.h` SFPU kernel for both Wormhole B0 and Blackhole architectures
- Registers `tanhshrink` as a native SFPU activation type, removing the composite fallback in `unary_op_utils.cpp`

## Changes
- **LLK kernels**: New `ckernel_sfpu_tanhshrink.h` implementing `x - tanh(x)` in a single SFPU pass (Wormhole B0 + Blackhole)
- **LLK API**: Added `tanhshrink` activation functions in `llk_math_eltwise_unary_sfpu_activations.h`
- **SFPU types**: Added `TANHSHRINK` enum to `llk_sfpu_types.h`
- **Compute API**: Registered `tanhshrink` in `activations.h`
- **Op utils**: Simplified `tanhshrink` dispatch to use the native kernel instead of composite

## Test plan
- [ ] Run `ttperf tanhshrink` to verify correctness and measure kernel performance
- [ ] Compare DEVICE KERNEL DURATION against main branch (composite implementation)
- [ ] Test on both Wormhole B0 and Blackhole architectures
- [ ] Run existing tanhshrink unit tests: `pytest tests/ttnn/unit_tests/operations/eltwise/test_unary.py -k tanhshrink`

🤖 Generated with [Claude Code](https://claude.com/claude-code)