### PR TITLE
SDXL nightly frequent BH fix

### DIFF
--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
@@ -95,8 +95,8 @@ def _build_reference_weights(peft_sd):
     indirect=True,
 )
 @pytest.mark.skipif(
-    get_device_name() != "n150",
-    reason="test_lora_fusion runs only on n150",
+    get_device_name() not in ["n150", "p150"],
+    reason="test_lora_fusion runs only on n150 and p150",
 )
 @torch.no_grad()
 def test_lora_fusion_pcc(mesh_device, lora_path):


### PR DESCRIPTION
### Problem description
Failing [fd-nightly / Nightly BH stable_diffusion_xl_base](https://github.com/tenstorrent/tt-metal/actions/runs/24228466065/job/70735241476#logs)

### What's changed
- lora_fusion won't be skipped for `p150` also

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/24241107559) passed ✅ 
