### PR TITLE
Refactor DecoderBlock tensor setup and remove test-code imports from runtime path

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -12,6 +12,8 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3.reference.modeling_deepseek import yarn_get_mscale
+from models.demos.deepseek_v3.tt.rope import get_cos_sin_matrix, get_rot_transformation_mat
 from models.demos.deepseek_v3_b1.demo.stage import (
     ACTIVATION_FIFO_SIZE,
     ACTIVATION_PAGE_SIZE_BYTES,
@@ -22,12 +24,672 @@ from models.demos.deepseek_v3_b1.demo.stage import (
 from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBlock
 from models.demos.deepseek_v3_b1.fused_ops.decoder_block.op import DecoderBlock
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
+from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
-
-# TODO: This shouldn't live in the test file; we should refactor this
-from models.demos.deepseek_v3_b1.tests.unit_tests.test_decoder_block import create_decoder_block_tensors
+from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import RoutedExpert, SharedExpert
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_pre_sdpa import deinterleave_kv_cache
 from models.demos.deepseek_v3_b1.utils import get_pinned_optimal_dram_bank_to_logical_worker_assignment
-from models.demos.deepseek_v3_b1.weights.prepare import DeepSeekV3DenseLayerWeights, DeepSeekV3MoELayerWeights
+from models.demos.deepseek_v3_b1.weights.prepare import (
+    DeepSeekV3DenseLayerWeights,
+    DeepSeekV3MoELayerWeights,
+    create_gate_indices_tensor,
+    prepare_dense_layer_weights,
+    prepare_moe_layer_weights,
+)
+
+
+def create_decoder_block_tensors(
+    submesh,
+    mesh_rows,
+    mesh_cols,
+    sender_row,
+    sender_col,
+    position_id,
+    state_dict,
+    layer_idx,
+    max_seq_len,
+    reduce_root_coord=ttnn.MeshCoordinate(1, 1),
+    *,
+    is_moe: bool = True,
+    num_routed_experts: int = 0,
+    preloaded_weights=None,
+    validate_debug_tensors: bool = False,
+    torch_input=None,
+):
+    """Create all tensors required by DecoderBlock.op().
+
+    Returns a dict with all attention + FFN + shared expert + reduce tensors.
+    Intermediate torch CPU tensors (torch_input, torch_kv_cache, etc.) are
+    included so that callers (e.g. golden-reference builders) can reuse them.
+    """
+    if preloaded_weights is None and state_dict is None:
+        raise ValueError("Either state_dict or preloaded_weights must be provided")
+    torch.manual_seed(0)
+    num_devices = mesh_rows * mesh_cols
+    device_grid_size = submesh.compute_with_storage_grid_size()
+    mesh_mapper = ttnn.ReplicateTensorToMesh(submesh)
+
+    # TODO: Shouldn't hardcode this here
+    class _RopeConfig:
+        qk_rope_head_dim = 64
+        rope_theta = 10000.0
+        rope_scaling = {
+            "factor": 40,
+            "original_max_position_embeddings": 4096,
+            "beta_fast": 32,
+            "beta_slow": 1,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        }
+
+    _RopeConfig.max_seq_len = max_seq_len
+
+    # ── Constants for runtime tensors ──
+    QNOPE_HEAD_DIM = 128
+    QROPE_HEAD_DIM = _RopeConfig.qk_rope_head_dim
+    QNOPE_OUT_DIM = 512
+    KNOPE_DIM = 512
+    KROPE_DIM = 64
+
+    M = 1
+    K = 7168
+    output_size = 7168
+    shape = (1, K)
+    q_head_dim = QNOPE_HEAD_DIM + QROPE_HEAD_DIM
+    mscale = yarn_get_mscale(
+        _RopeConfig.rope_scaling["factor"],
+        _RopeConfig.rope_scaling["mscale_all_dim"],
+    )
+    scale = q_head_dim**-0.5 * mscale * mscale
+    kvpe_dim = KNOPE_DIM + KROPE_DIM
+
+    QNOPE_GRID_COLS = 8
+    QROPE_GRID_COLS = 4
+    matmul2_grid_y = 8
+    qrope_num_cores = QROPE_GRID_COLS * matmul2_grid_y
+
+    NUM_SDPA_WORKERS = 8
+    SDPA_L_HEIGHT = 8
+    SDPA_L_WIDTH = 512 * NUM_SDPA_WORKERS
+    SDPA_MS_WIDTH = 32 * NUM_SDPA_WORKERS
+
+    mcast_core_x = device_grid_size.x - 1
+    mcast_core_y = 9
+    mcast_core = ttnn.CoreCoord(mcast_core_x, mcast_core_y)
+    tile = ttnn.Tile([1, 32])
+
+    kv_cache_branch_start_offset = (0, 8)
+    kv_cache_branch_rope_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(8 + kv_cache_branch_start_offset[0], kv_cache_branch_start_offset[1]),
+                ttnn.CoreCoord(8 + kv_cache_branch_start_offset[0], 1 + kv_cache_branch_start_offset[1]),
+            )
+        }
+    )
+
+    # ── SDPA KV cache buffer ──
+    kv_cache_num_cores_x = device_grid_size.x
+    kv_cache_num_cores_y = device_grid_size.y
+    kv_cache_num_cores = kv_cache_num_cores_x * kv_cache_num_cores_y
+    kv_cache_shard_height = 256
+    kv_cache_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(kv_cache_num_cores_x - 1, kv_cache_num_cores_y - 1))}
+        ),
+        (kv_cache_shard_height, kvpe_dim),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sdpa_kv_cache_buffer = ttnn.from_torch(
+        torch.randn((kv_cache_shard_height * kv_cache_num_cores, kvpe_dim), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, kv_cache_shard_spec
+        ),
+        mesh_mapper=mesh_mapper,
+    )
+
+    # ── SDPA output intermediate buffer ──
+    sdpa_out_interm_num_cores = device_grid_size.x * device_grid_size.y
+    sdpa_out_interm_num_slots = 5  # MoE needs 36864 bytes/shard; 5 slots × 17 tiles × 512 = 43520
+    sdpa_out_interm_shard_height = sdpa_out_interm_num_slots * 8
+    sdpa_out_interm_shard_width = 17 * 32
+    sdpa_out_interm_total_height = sdpa_out_interm_shard_height * sdpa_out_interm_num_cores
+    sdpa_out_interm_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))}
+        ),
+        (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sdpa_out_interm_buffer = ttnn.from_torch(
+        torch.zeros((sdpa_out_interm_total_height, sdpa_out_interm_shard_width), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, sdpa_out_interm_shard_spec
+        ),
+        mesh_mapper=mesh_mapper,
+        tile=ttnn.Tile([8, 32]),
+    )
+
+    if torch_input is None:
+        torch_input = torch.randn(shape, dtype=torch.bfloat16)
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # All weights via prepare_* functions or preloaded
+    # ══════════════════════════════════════════════════════════════════════════
+    if preloaded_weights is not None:
+        layer = preloaded_weights
+    else:
+        if is_moe:
+            layer = prepare_moe_layer_weights(
+                submesh,
+                state_dict,
+                layer_idx,
+                num_routed_experts=num_routed_experts,
+                move_to_device=True,
+            )
+        else:
+            layer = prepare_dense_layer_weights(submesh, state_dict, layer_idx, move_to_device=True)
+
+    # ── FFN final output config (DRAM streaming matmul output grid) ──
+    gate_proj_noc = ttnn.NOC.NOC_0
+    gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(submesh, gate_proj_noc)
+    gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in gate_proj_worker_cores])
+    num_gate_proj_cores = len(gate_proj_worker_cores)
+    final_output_width_per_core = RoutedExpert.FINAL_OUTPUT_WIDTH_PER_CORE
+    final_output_total_width = final_output_width_per_core * num_gate_proj_cores
+    num_banks = submesh.dram_grid_size().x
+    tile_w = RoutedExpert.TILE_W
+    down_proj_N_padded = ((K + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+    per_core_down_proj_N = down_proj_N_padded // num_banks
+
+    final_output_shard_spec = ttnn.ShardSpec(
+        gate_proj_core_ranges,
+        (1, final_output_width_per_core),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    final_output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, final_output_shard_spec
+    )
+
+    # ── MoE-only: gate indices and output buffers ──
+    if is_moe:
+        input_core = ttnn.CoreCoord(device_grid_size.x - 1, RoutedExpert.INPUT_CORE_Y)
+        input_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(input_core, input_core)])
+
+        ttnn_gate_indices = create_gate_indices_tensor(submesh, input_core_grid, mesh_mapper=mesh_mapper)
+
+        tile_1x16 = ttnn.Tile((1, 16))
+        gate_output_shard_spec = ttnn.ShardSpec(input_core_grid, (1, 16), ttnn.ShardOrientation.ROW_MAJOR)
+        gate_output_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gate_output_shard_spec
+        )
+        gate_output_scores_tensor = ttnn.from_torch(
+            torch.zeros((1, 16), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=gate_output_mem_config,
+            tile=tile_1x16,
+            mesh_mapper=mesh_mapper,
+        )
+        gate_output_indices_tensor = ttnn.from_torch(
+            torch.zeros((1, 16), dtype=torch.uint16),
+            dtype=ttnn.uint16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=gate_output_mem_config,
+            tile=tile_1x16,
+            mesh_mapper=mesh_mapper,
+        )
+        moe_ref_gate_output_scores = None
+        moe_ref_gate_output_indices = None
+        if validate_debug_tensors:
+            moe_ref_gate_output_scores = ttnn.from_torch(
+                torch.zeros((1, 16), dtype=torch.bfloat16),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=submesh,
+                memory_config=gate_output_mem_config,
+                tile=tile_1x16,
+                mesh_mapper=mesh_mapper,
+            )
+            moe_ref_gate_output_indices = ttnn.from_torch(
+                torch.zeros((1, 16), dtype=torch.uint16),
+                dtype=ttnn.uint16,
+                layout=ttnn.TILE_LAYOUT,
+                device=submesh,
+                memory_config=gate_output_mem_config,
+                tile=tile_1x16,
+                mesh_mapper=mesh_mapper,
+            )
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Attention input/intermediate/output mesh tensors
+    # ══════════════════════════════════════════════════════════════════════════
+    sender_coord = ttnn.MeshCoordinate(sender_row, sender_col)
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(mcast_core, mcast_core)}), shape, ttnn.ShardOrientation.ROW_MAJOR
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    device_tensors = []
+    for row in range(mesh_rows):
+        for col in range(mesh_cols):
+            if row == sender_row and col == sender_col:
+                device_tensors.append(torch_input)
+            else:
+                device_tensors.append(torch.zeros_like(torch_input))
+
+    input_tensor_mesh = ttnn.from_torch(
+        torch.cat(device_tensors, dim=0),
+        device=submesh,
+        layout=ttnn.TILE_LAYOUT,
+        tile=tile,
+        dtype=ttnn.bfloat16,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.ShardTensorToMesh(submesh, dim=0),
+    )
+
+    # ── RoPE TTNN tensors ──
+    qrope_dram_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    position_ids = torch.tensor([position_id])
+
+    cos_sin_4d, sin_sin_4d = get_cos_sin_matrix(_RopeConfig)
+    torch_cos = cos_sin_4d.squeeze(0).squeeze(0)  # [max_seq_len, dim]
+    torch_sin = sin_sin_4d.squeeze(0).squeeze(0)  # [max_seq_len, dim]
+    torch_trans_mat = get_rot_transformation_mat()
+
+    ttnn_qrope_cos = ttnn.from_torch(
+        torch_cos.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=qrope_dram_mem,
+        tile=tile,
+        mesh_mapper=mesh_mapper,
+    )
+    ttnn_qrope_sin = ttnn.from_torch(
+        torch_sin.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=qrope_dram_mem,
+        tile=tile,
+        mesh_mapper=mesh_mapper,
+    )
+    ttnn_krope_cos = ttnn.from_torch(
+        torch_cos.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=qrope_dram_mem,
+        tile=tile,
+        mesh_mapper=mesh_mapper,
+    )
+    ttnn_krope_sin = ttnn.from_torch(
+        torch_sin.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=qrope_dram_mem,
+        tile=tile,
+        mesh_mapper=mesh_mapper,
+    )
+
+    # ── Trans mat ──
+    qrope_grid = ttnn.CoreRange(
+        ttnn.CoreCoord(QNOPE_GRID_COLS, 0), ttnn.CoreCoord(QNOPE_GRID_COLS + QROPE_GRID_COLS - 1, matmul2_grid_y - 1)
+    )
+    trans_mat_crs = kv_cache_branch_rope_crs.merge(ttnn.CoreRangeSet({qrope_grid}))
+    trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
+    trans_shard_spec = ttnn.ShardSpec(trans_mat_crs, (ttnn.TILE_SIZE, ttnn.TILE_SIZE), ttnn.ShardOrientation.ROW_MAJOR)
+    trans_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, trans_shard_spec)
+    trans_mat_replicated = torch_trans_mat.repeat(1, 1, qrope_num_cores + kv_cache_branch_rope_crs.num_cores(), 1)
+    ttnn_trans_mat = ttnn.from_torch(
+        trans_mat_replicated,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=trans_mem,
+        tile=trans_tile,
+        mesh_mapper=mesh_mapper,
+    )
+
+    # ── Position IDs ──
+    pos_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+    )
+    pos_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(pos_core_grid, (1, 1), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    ttnn_position_ids = ttnn.from_torch(
+        torch.full((device_grid_size.x * device_grid_size.y, 1), position_id, dtype=torch.int32),
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=submesh,
+        memory_config=pos_mem,
+        mesh_mapper=mesh_mapper,
+    )
+
+    # ── KV Cache (ND sharded DRAM) ──
+    program_config = FlashMLADecode.ProgramConfig(k_chunk_size=128, exp_approx_mode=False)
+    grid = program_config.grid
+    kv_nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, program_config.k_chunk_size, kvpe_dim],
+        grid=grid.optimal_dram_grid(),
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    kv_mem = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=kv_nd_shard_spec)
+    num_sp = mesh_rows
+    dcs = program_config.device_chunk_size
+    torch_kv_cache = torch.zeros((1, 1, max_seq_len, kvpe_dim), dtype=torch.bfloat16)
+    torch_kv_cache[:, :, :position_id, :] = torch.randn(1, 1, position_id, kvpe_dim, dtype=torch.bfloat16)
+    torch_kv_cache_shuffled = deinterleave_kv_cache(torch_kv_cache, dcs, num_sp)
+    kv_cache_2d_mesh_mapper = ttnn.ShardTensor2dMesh(submesh, mesh_shape=(mesh_rows, mesh_cols), dims=(2, None))
+    ttnn_kv_cache = ttnn.from_torch(
+        torch_kv_cache_shuffled,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=kv_mem,
+        mesh_mapper=kv_cache_2d_mesh_mapper,
+    )
+
+    # ── KV cache clone for standalone AttentionBlock.op sanity check ──
+    ttnn_kv_cache_attn_ref = None
+    if validate_debug_tensors:
+        ttnn_kv_cache_attn_ref = ttnn.from_torch(
+            torch_kv_cache_shuffled,
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=kv_mem,
+            mesh_mapper=kv_cache_2d_mesh_mapper,
+        )
+
+    # ── SDPA output tensor ──
+    s1_cores, _ = FlashMLADecode.ProgramConfig.grid.BLOCKS[0]
+    sdpa_input_output_grid_crs = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in s1_cores]
+    )
+    HEADS_PER_ROW = 8
+    SDPA_INPUT_NUM_CORES = len(s1_cores)
+    sdpa_tile = ttnn.Tile([8, 32])
+    sdpa_input_output_shard_spec = ttnn.ShardSpec(
+        sdpa_input_output_grid_crs, (HEADS_PER_ROW, QNOPE_OUT_DIM), ttnn.ShardOrientation.ROW_MAJOR
+    )
+    sdpa_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, sdpa_input_output_shard_spec
+    )
+    ttnn_sdpa_output = None
+    if validate_debug_tensors:
+        ttnn_sdpa_output = ttnn.from_torch(
+            torch.zeros((SDPA_INPUT_NUM_CORES * HEADS_PER_ROW, QNOPE_OUT_DIM), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=sdpa_mem,
+            mesh_mapper=mesh_mapper,
+            tile=sdpa_tile,
+        )
+
+    # ── Post-SDPA tensors ──
+    a_tile = ttnn.Tile([M, 32])
+    shard_mesh_mapper = ttnn.ShardTensorToMesh(submesh, dim=0)
+    gather_core = ttnn.CoreCoord(12, 9)
+    gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
+
+    # ── Attention block output / MoE residual input (overlapped with sdpa_kv_cache_buffer) ──
+    # These are temporally disjoint: the kv cache on core (12,9) is done after SDPA,
+    # so the attention output and MoE residual input can reuse that L1 region.
+    a_tile_size = a_tile.get_tile_size(ttnn.bfloat16)  # 1×32 tile → 64 bytes
+    num_output_tiles = output_size // 32  # 7168 / 32 = 224 tiles
+    output_shard_spec = ttnn.ShardSpec(gather_core_grid, (M, output_size), ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+    mesh_output_torch = torch.cat([torch.zeros((M, output_size), dtype=torch.bfloat16)] * num_devices, dim=0)
+    attn_output = ttnn.from_torch(
+        mesh_output_torch,
+        device=submesh,
+        layout=ttnn.TILE_LAYOUT,
+        tile=a_tile,
+        dtype=ttnn.bfloat16,
+        memory_config=output_mem_config,
+        mesh_mapper=shard_mesh_mapper,
+    )
+    attn_ref_output = None
+    if validate_debug_tensors:
+        attn_ref_output = ttnn.from_torch(
+            mesh_output_torch,
+            device=submesh,
+            layout=ttnn.TILE_LAYOUT,
+            tile=a_tile,
+            dtype=ttnn.bfloat16,
+            memory_config=output_mem_config,
+            mesh_mapper=shard_mesh_mapper,
+        )
+
+    # ── SDPA worker/forwarder tensors ──
+    sdpa_output_cores = FlashMLADecode.ProgramConfig.grid.output_cores(0, NUM_SDPA_WORKERS)
+    sdpa_worker_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in sdpa_output_cores]
+    )
+    sdpa_l_per_worker = SDPA_L_WIDTH // NUM_SDPA_WORKERS
+    sdpa_ms_per_worker = SDPA_MS_WIDTH // NUM_SDPA_WORKERS
+
+    sdpa_recv_per_worker = sdpa_l_per_worker + sdpa_ms_per_worker
+    sdpa_recv_shard_shape = (2 * SDPA_L_HEIGHT, sdpa_recv_per_worker)
+    sdpa_recv_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(sdpa_worker_grid, sdpa_recv_shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    sdpa_recv_full_width = sdpa_recv_per_worker * NUM_SDPA_WORKERS
+    mesh_recv = torch.cat(
+        [torch.zeros((2 * SDPA_L_HEIGHT, sdpa_recv_full_width), dtype=torch.bfloat16)] * num_devices, dim=0
+    )
+    ttnn_sdpa_intermediate_recv = ttnn.from_torch(
+        mesh_recv,
+        device=submesh,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=sdpa_recv_mem,
+        tile=sdpa_tile,
+        mesh_mapper=shard_mesh_mapper,
+    )
+
+    sdpa_forwarder_cores = [ttnn.CoreCoord(9, 8), ttnn.CoreCoord(10, 8)]
+    sdpa_forwarder_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in sdpa_forwarder_cores])
+    sdpa_fwd_buffer_bytes = compute_forwarder_scratch_size(
+        batch_size=SDPA_L_HEIGHT,
+        l_width=sdpa_l_per_worker,
+        num_cores=NUM_SDPA_WORKERS,
+    )
+    sdpa_fwd_total_elements = sdpa_fwd_buffer_bytes // 2
+    # THIS BUFFER SIZE IS NOT CORRECT BECAUSE WE'RE INCORRECTLY DIVIDING BY 2
+    # TODO: Plan to remove this scratch buffer entirely once we reduce cb memory usage currently being overlapped with this buffer.
+    sdpa_fwd_per_forwarder = sdpa_fwd_total_elements // 2
+    sdpa_forwarder_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(sdpa_forwarder_grid, (1, sdpa_fwd_per_forwarder), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mesh_fwd_scratch = torch.cat([torch.zeros((1, sdpa_fwd_total_elements), dtype=torch.bfloat16)] * num_devices, dim=0)
+    ttnn_sdpa_forwarder_scratch = ttnn.from_torch(
+        mesh_fwd_scratch,
+        device=submesh,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=sdpa_forwarder_mem,
+        mesh_mapper=shard_mesh_mapper,
+    )
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Reduce-to-one tensors
+    # ══════════════════════════════════════════════════════════════════════════
+    reduce_mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)], submesh.shape)
+    reduce_mesh_mapper = ttnn.create_mesh_mapper(submesh, reduce_mesh_mapper_config)
+    tile_1x32 = ttnn.Tile([1, 32])
+
+    # Single intermediate tensor with 3x shard width for all 3 reduction rounds
+    orig_shard_spec = final_output_mem_config.shard_spec
+    intermediate_shard_shape = [orig_shard_spec.shape[0], orig_shard_spec.shape[1] * 3]
+    intermediate_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            orig_shard_spec.grid,
+            intermediate_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    intermediate_tensors = ttnn.from_torch(
+        torch.zeros([4, 2, final_output_total_width * 3], dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=intermediate_mem_config,
+        tile=tile_1x32,
+        mesh_mapper=reduce_mesh_mapper,
+    )
+
+    shard_cores_list = ttnn.corerange_to_cores(gate_proj_core_ranges, row_wise=True)
+    aggregator_core = shard_cores_list[0]
+    reduce_output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(aggregator_core, aggregator_core)})
+    reduce_output_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(reduce_output_shard_grid, (1, final_output_total_width), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    reduce_output_tensor = ttnn.from_torch(
+        torch.zeros([4, 2, final_output_total_width], dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=reduce_output_mem,
+        tile=tile_1x32,
+        mesh_mapper=reduce_mesh_mapper,
+    )
+
+    # ── Standalone MoE ref reduce tensors (MoE only) ──
+    if is_moe:
+        moe_ref_reduce_intermediate = None
+        moe_ref_reduce_output = None
+        if validate_debug_tensors:
+            moe_ref_reduce_intermediate = ttnn.from_torch(
+                torch.zeros([4, 2, final_output_total_width * 3], dtype=torch.bfloat16),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=submesh,
+                memory_config=intermediate_mem_config,
+                tile=tile_1x32,
+                mesh_mapper=reduce_mesh_mapper,
+            )
+            moe_ref_reduce_output = ttnn.from_torch(
+                torch.zeros([4, 2, final_output_total_width], dtype=torch.bfloat16),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=submesh,
+                memory_config=reduce_output_mem,
+                tile=tile_1x32,
+                mesh_mapper=reduce_mesh_mapper,
+            )
+
+    sender_core_from_residual = attn_output.memory_config().shard_spec.grid.bounding_box().end
+    mcast_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), sender_core_from_residual)])
+
+    # ── Routed weight tensors differ between MoE (list) and dense (single tensor) ──
+    routed_gate = layer.routed_gate_proj[0] if is_moe else layer.routed_gate_proj
+    routed_up = layer.routed_up_proj[0] if is_moe else layer.routed_up_proj
+    routed_down = layer.routed_down_proj[0] if is_moe else layer.routed_down_proj
+
+    result = {
+        # Attention weights (from prepare_*_layer_weights)
+        "gamma_overlapped": layer.attn_norm,
+        "matmul_weights_overlapped": layer.q_a_proj,
+        "rmsnorm2_gamma_overlapped": layer.q_norm,
+        "matmul2_weights_overlapped": layer.q_b_proj,
+        "matmul3_weights_overlapped": layer.kv_b1_proj,
+        "dkv_matmul_weights_overlapped": layer.kv_a_proj,
+        "dkv_rmsnorm_gamma_overlapped": layer.kv_norm,
+        "kv_b2_overlapped": layer.kv_b2_proj,
+        "o_proj_overlapped": layer.o_proj,
+        "ffn_norm_overlapped": layer.ffn_norm,
+        # Attention activation/buffer tensors
+        "input_tensor_mesh": input_tensor_mesh,
+        "ttnn_qrope_sin": ttnn_qrope_sin,
+        "ttnn_qrope_cos": ttnn_qrope_cos,
+        "ttnn_trans_mat": ttnn_trans_mat,
+        "ttnn_krope_cos": ttnn_krope_cos,
+        "ttnn_krope_sin": ttnn_krope_sin,
+        "ttnn_kv_cache": ttnn_kv_cache,
+        "ttnn_kv_cache_attn_ref": ttnn_kv_cache_attn_ref,
+        "ttnn_position_ids": ttnn_position_ids,
+        "scale": scale,
+        "sdpa_kv_cache_buffer": sdpa_kv_cache_buffer,
+        "sdpa_out_interm_buffer": sdpa_out_interm_buffer,
+        "ttnn_sdpa_output": ttnn_sdpa_output,
+        "sender_coord": sender_coord,
+        "ttnn_sdpa_input_l": None,
+        "ttnn_sdpa_input_ms": None,
+        "ttnn_sdpa_output_l": None,
+        "ttnn_sdpa_intermediate_recv": ttnn_sdpa_intermediate_recv,
+        "ttnn_sdpa_forwarder_scratch": ttnn_sdpa_forwarder_scratch,
+        "device_chunk_size": program_config.device_chunk_size,
+        "ttnn_attention_block_output": attn_output,
+        "ttnn_attn_ref_output": attn_ref_output,
+        # FFN tensors (attn_output IS the FFN residual input — overlapped with kv cache)
+        "ttnn_residual_mcast_src": attn_output,
+        "gate_proj_weights": routed_gate,
+        "up_proj_weights": routed_up,
+        "down_proj_weights": routed_down,
+        "final_output_mem_config": final_output_mem_config,
+        "final_output_total_width": final_output_total_width,
+        # Shared expert weights
+        "shared_gate_weights_overlapped": layer.shared_gate_proj,
+        "shared_up_weights_overlapped": layer.shared_up_proj,
+        "shared_down_weights_tensor": layer.shared_down_proj,
+        "shared_k_parallel": SharedExpert.K_PARALLEL,
+        "shared_n_parallel": SharedExpert.N_PARALLEL,
+        # Reduce-to-one
+        "reduce_intermediate_tensors": intermediate_tensors,
+        "reduce_output_tensor": reduce_output_tensor,
+        "reduce_root_coord": reduce_root_coord,
+        "num_gate_proj_cores": num_gate_proj_cores,
+        "per_core_down_proj_N": per_core_down_proj_N,
+        "mcast_grid": mcast_grid,
+        # Intermediate CPU tensors (for golden-reference builders)
+        "torch_input": torch_input,
+        "torch_kv_cache": torch_kv_cache,
+        "torch_sin": torch_sin,
+        "torch_cos": torch_cos,
+        "torch_position_ids": position_ids,
+    }
+    # MoE-only keys
+    if is_moe:
+        result.update(
+            {
+                "gate_mm_overlapped": layer.gate_mm,
+                "ttnn_gate_bias": layer.gate_bias,
+                "ttnn_gate_indices": ttnn_gate_indices,
+                "gate_output_scores_tensor": gate_output_scores_tensor,
+                "gate_output_indices_tensor": gate_output_indices_tensor,
+                "moe_ref_gate_output_scores": moe_ref_gate_output_scores,
+                "moe_ref_gate_output_indices": moe_ref_gate_output_indices,
+                "moe_ref_reduce_intermediate": moe_ref_reduce_intermediate,
+                "moe_ref_reduce_output": moe_ref_reduce_output,
+            }
+        )
+    return result
 
 
 class DecoderStage(StageKind):

--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -27,9 +27,11 @@ from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
 from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
-from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import RoutedExpert, SharedExpert
-from models.demos.deepseek_v3_b1.tests.unit_tests.test_pre_sdpa import deinterleave_kv_cache
-from models.demos.deepseek_v3_b1.utils import get_pinned_optimal_dram_bank_to_logical_worker_assignment
+from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert, SharedExpert
+from models.demos.deepseek_v3_b1.utils import (
+    deinterleave_kv_cache,
+    get_pinned_optimal_dram_bank_to_logical_worker_assignment,
+)
 from models.demos.deepseek_v3_b1.weights.prepare import (
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3MoELayerWeights,
@@ -452,8 +454,6 @@ def create_decoder_block_tensors(
     # ── Attention block output / MoE residual input (overlapped with sdpa_kv_cache_buffer) ──
     # These are temporally disjoint: the kv cache on core (12,9) is done after SDPA,
     # so the attention output and MoE residual input can reuse that L1 region.
-    a_tile_size = a_tile.get_tile_size(ttnn.bfloat16)  # 1×32 tile → 64 bytes
-    num_output_tiles = output_size // 32  # 7168 / 32 = 224 tiles
     output_shard_spec = ttnn.ShardSpec(gather_core_grid, (M, output_size), ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
     mesh_output_torch = torch.cat([torch.zeros((M, output_size), dtype=torch.bfloat16)] * num_devices, dim=0)

--- a/models/demos/deepseek_v3_b1/model_dimensions.py
+++ b/models/demos/deepseek_v3_b1/model_dimensions.py
@@ -23,3 +23,31 @@ class LogicalModelDimensions:
     MOE_INTERMEDIATE_SIZE = 2048
     INTERMEDIATE_SIZE = 18432
     GATE_NUM_INDICES = 256
+
+
+class RoutedExpert:
+    """MoE routed-expert kernel layout constants."""
+
+    M = 1
+    K = 7168
+    N_PER_CORE = 32
+    NUM_CORES = 8
+    GATE_PROJ_N = 2048
+    GATE_EPS = 1e-20
+    GATE_SCALING_FACTOR = 2.5
+    TILE_W = 32
+    FINAL_OUTPUT_WIDTH_PER_CORE = 32 * 32  # 1024
+    INPUT_CORE_Y = 9
+    SEED = 0
+    GATE_PROJ_EXPERT_SEED = 0
+    UP_PROJ_EXPERT_SEED = 256
+    DOWN_PROJ_EXPERT_SEED = 512
+
+
+class SharedExpert:
+    """MoE shared-expert kernel layout constants."""
+
+    K_PARALLEL = 8
+    N_PARALLEL = 8
+    N_PER_CORE = 64
+    SEED = 100

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -22,8 +22,7 @@ from models.demos.deepseek_v3_b1.fused_ops.pre_sdpa.op import PreSDPA
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
-from models.demos.deepseek_v3_b1.tests.unit_tests.test_pre_sdpa import deinterleave_kv_cache
-from models.demos.deepseek_v3_b1.utils import generate_mm_weights
+from models.demos.deepseek_v3_b1.utils import deinterleave_kv_cache, generate_mm_weights
 from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
     KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
     O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_reduce_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_reduce_pipeline.py
@@ -23,9 +23,9 @@ from models.common.utility_functions import comp_pcc, is_slow_dispatch
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
+from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
     ROUTED_EXPERT_LAYER_IDX,
-    RoutedExpert,
     create_routed_expert_tensors,
     create_shared_expert_tensors,
     extract_routed_expert_output,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -21,12 +21,12 @@ from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBl
 from models.demos.deepseek_v3_b1.fused_ops.decoder_block.op import DecoderBlock
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
+from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert
 from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
     DENSE_LAYER_IDX,
     DENSE_SHARED_N,
     ROUTED_EXPERT_LAYER_IDX,
-    RoutedExpert,
     extract_routed_expert_output,
 )
 from models.demos.deepseek_v3_b1.weights.prepare import get_layer_raw_tensors

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -16,30 +16,20 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
-from models.demos.deepseek_v3.reference.modeling_deepseek import yarn_get_mscale
-from models.demos.deepseek_v3.tt.rope import get_cos_sin_matrix, get_rot_transformation_mat
+from models.demos.deepseek_v3_b1.demo.decoder_stage import create_decoder_block_tensors
 from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBlock
 from models.demos.deepseek_v3_b1.fused_ops.decoder_block.op import DecoderBlock
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
-from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
     DENSE_LAYER_IDX,
     DENSE_SHARED_N,
     ROUTED_EXPERT_LAYER_IDX,
     RoutedExpert,
-    SharedExpert,
     extract_routed_expert_output,
 )
-from models.demos.deepseek_v3_b1.tests.unit_tests.test_pre_sdpa import deinterleave_kv_cache
-from models.demos.deepseek_v3_b1.utils import get_pinned_optimal_dram_bank_to_logical_worker_assignment
-from models.demos.deepseek_v3_b1.weights.prepare import (
-    create_gate_indices_tensor,
-    get_layer_raw_tensors,
-    prepare_dense_layer_weights,
-    prepare_moe_layer_weights,
-)
+from models.demos.deepseek_v3_b1.weights.prepare import get_layer_raw_tensors
 
 
 def _decode_expert_upload_mode(expert_upload_mode: str) -> tuple[int, int | None]:
@@ -65,807 +55,175 @@ def _decode_expert_upload_mode(expert_upload_mode: str) -> tuple[int, int | None
 
 
 # ============================================================================
-# Unified decoder block tensor setup
+# Test helpers: expert rigging + golden reference tensors
 # ============================================================================
-def create_decoder_block_tensors(
+
+
+def rig_experts(state_dict, layer_idx, rigged_group_count):
+    """Rig expert routing bias in state_dict for deterministic test routing.
+
+    Generates RMS-normalized input for stability with rigged routing,
+    modifies state_dict bias entries, and returns the rigged configuration.
+
+    Returns (rigged_group_ids, rigged_expert_ids, torch_input).
+    """
+    K = 7168
+    shape = (1, K)
+    torch_input_f32 = torch.randn(shape, dtype=torch.float32)
+    torch_input_f32 = torch_input_f32 / torch.sqrt(torch_input_f32.pow(2).mean(dim=-1, keepdim=True) + 1e-6)
+    torch_input = torch_input_f32.to(torch.bfloat16)
+
+    g = torch.Generator()
+    g.manual_seed(2026)
+    if not (1 <= rigged_group_count <= 8):
+        raise ValueError(f"rigged_group_count must be in [1, 8], got {rigged_group_count}")
+    num_selected_groups = min(4, rigged_group_count)
+    rigged_group_ids = torch.randperm(rigged_group_count, generator=g)[:num_selected_groups].tolist()
+
+    total_rigged_experts = 8
+    experts_per_group = [1] * num_selected_groups
+    remaining = total_rigged_experts - num_selected_groups
+    for _ in range(remaining):
+        chosen_group = int(torch.randint(0, num_selected_groups, (1,), generator=g).item())
+        experts_per_group[chosen_group] += 1
+
+    rigged_expert_ids = {
+        grp: torch.randperm(32, generator=g)[:num_experts].tolist()
+        for grp, num_experts in zip(rigged_group_ids, experts_per_group, strict=True)
+    }
+
+    rigged_bias = torch.full((8, 32), -10.0, dtype=torch.bfloat16)
+    for grp in rigged_group_ids:
+        for exp in rigged_expert_ids[grp]:
+            rigged_bias[grp, exp] = 10.0
+    state_dict[f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"] = rigged_bias.reshape(-1).contiguous()
+    logger.info(
+        f"Rigged experts enabled: groups={rigged_group_ids}, "
+        f"experts={[(grp, rigged_expert_ids[grp]) for grp in rigged_group_ids]}"
+    )
+
+    return rigged_group_ids, rigged_expert_ids, torch_input
+
+
+def create_decoder_golden_tensors(
+    d,
     submesh,
-    mesh_rows,
-    mesh_cols,
-    sender_row,
-    sender_col,
-    position_id,
     state_dict,
     layer_idx,
-    max_seq_len,
-    reduce_root_coord=ttnn.MeshCoordinate(1, 1),
     *,
-    is_moe: bool = True,
-    num_routed_experts: int = 0,
-    preloaded_weights=None,
-    rigged_group_count: int | None = None,
-    validate_debug_tensors: bool = False,
+    is_moe,
+    num_routed_experts=0,
+    rigged_group_ids=None,
+    rigged_expert_ids=None,
 ):
-    """Create all tensors required by DecoderBlock.op().
+    """Build golden PyTorch reference tensors for decoder validation.
 
-    Three modes of operation:
-    - **preloaded_weights mode** (production): pass a DeepSeekV3MoELayerWeights from
-      load_moe_layer. Skips weight processing and golden tensors.
-    - **state_dict + is_moe=True** (MoE tests): calls
-      prepare_moe_layer_weights, builds MoE golden tensors.
-    - **state_dict + is_moe=False** (dense tests): calls
-      prepare_dense_layer_weights, builds dense golden tensors.
-
-    Returns a dict with all attention + FFN + shared expert + reduce tensors.
+    Reads intermediate CPU tensors and the on-device KV cache from d
+    (the output of create_decoder_block_tensors).
     """
-    if preloaded_weights is None and state_dict is None:
-        raise ValueError("Either state_dict or preloaded_weights must be provided")
-    torch.manual_seed(0)
-    num_devices = mesh_rows * mesh_cols
-    device_grid_size = submesh.compute_with_storage_grid_size()
-    mesh_mapper = ttnn.ReplicateTensorToMesh(submesh)
-
-    # TODO: Shouldn't hardcode this here
-    class _RopeConfig:
-        qk_rope_head_dim = 64
-        rope_theta = 10000.0
-        rope_scaling = {
-            "factor": 40,
-            "original_max_position_embeddings": 4096,
-            "beta_fast": 32,
-            "beta_slow": 1,
-            "mscale": 1.0,
-            "mscale_all_dim": 1.0,
-        }
-
-    _RopeConfig.max_seq_len = max_seq_len
-
-    # ── Constants for runtime tensors ──
     QNOPE_HEAD_DIM = 128
-    QROPE_HEAD_DIM = _RopeConfig.qk_rope_head_dim
-    QNOPE_OUT_DIM = 512
-    KNOPE_DIM = 512
-    KROPE_DIM = 64
-
-    M = 1
     K = 7168
-    output_size = 7168
-    shape = (1, K)
-    q_head_dim = QNOPE_HEAD_DIM + QROPE_HEAD_DIM
-    mscale = yarn_get_mscale(
-        _RopeConfig.rope_scaling["factor"],
-        _RopeConfig.rope_scaling["mscale_all_dim"],
-    )
-    scale = q_head_dim**-0.5 * mscale * mscale
-    kvpe_dim = KNOPE_DIM + KROPE_DIM
 
-    QNOPE_GRID_COLS = 8
-    QROPE_GRID_COLS = 4
-    matmul2_grid_y = 8
-    qrope_num_cores = QROPE_GRID_COLS * matmul2_grid_y
+    kv_cache_bfp8_before_op = ttnn.to_torch(d["ttnn_kv_cache"], mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
 
-    NUM_SDPA_WORKERS = 8
-    SDPA_L_HEIGHT = 8
-    SDPA_L_WIDTH = 512 * NUM_SDPA_WORKERS
-    SDPA_MS_WIDTH = 32 * NUM_SDPA_WORKERS
+    (
+        golden_torch_matmul_weights,
+        golden_torch_matmul2_weights,
+        golden_torch_dkv_matmul_weights,
+        golden_kv_b1,
+        golden_kv_b2,
+        golden_torch_o_proj_weights,
+        golden_torch_gamma,
+        golden_torch_rmsnorm2_gamma,
+        golden_torch_dkv_rmsnorm_gamma,
+        ffn_norm,
+    ) = get_layer_raw_tensors(state_dict, layer_idx)
 
-    mcast_core_x = device_grid_size.x - 1
-    mcast_core_y = 9
-    mcast_core = ttnn.CoreCoord(mcast_core_x, mcast_core_y)
-    tile = ttnn.Tile([1, 32])
+    total_kv_heads = golden_kv_b1.shape[0] // QNOPE_HEAD_DIM
+    kv_lora_rank = golden_kv_b1.shape[1]
+    golden_torch_matmul3_weights = golden_kv_b1.reshape(total_kv_heads, QNOPE_HEAD_DIM, kv_lora_rank)
 
-    kv_cache_branch_start_offset = (0, 8)
-    kv_cache_branch_rope_crs = ttnn.CoreRangeSet(
-        {
-            ttnn.CoreRange(
-                ttnn.CoreCoord(8 + kv_cache_branch_start_offset[0], kv_cache_branch_start_offset[1]),
-                ttnn.CoreCoord(8 + kv_cache_branch_start_offset[0], 1 + kv_cache_branch_start_offset[1]),
-            )
-        }
-    )
+    golden_total_qnope_heads = total_kv_heads
+    golden_total_qrope_heads = total_kv_heads
 
-    # ── SDPA KV cache buffer ──
-    kv_cache_num_cores_x = device_grid_size.x
-    kv_cache_num_cores_y = device_grid_size.y
-    kv_cache_num_cores = kv_cache_num_cores_x * kv_cache_num_cores_y
-    kv_cache_shard_height = 256
-    kv_cache_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(kv_cache_num_cores_x - 1, kv_cache_num_cores_y - 1))}
-        ),
-        (kv_cache_shard_height, kvpe_dim),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    sdpa_kv_cache_buffer = ttnn.from_torch(
-        torch.randn((kv_cache_shard_height * kv_cache_num_cores, kvpe_dim), dtype=torch.bfloat16),
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, kv_cache_shard_spec
-        ),
-        mesh_mapper=mesh_mapper,
-    )
+    golden_moe_rmsnorm_gamma = ffn_norm.to(torch.bfloat16).float()
 
-    # ── SDPA output intermediate buffer ──
-    sdpa_out_interm_num_cores = device_grid_size.x * device_grid_size.y
-    sdpa_out_interm_num_slots = 5  # MoE needs 36864 bytes/shard; 5 slots × 17 tiles × 512 = 43520
-    sdpa_out_interm_shard_height = sdpa_out_interm_num_slots * 8
-    sdpa_out_interm_shard_width = 17 * 32
-    sdpa_out_interm_total_height = sdpa_out_interm_shard_height * sdpa_out_interm_num_cores
-    sdpa_out_interm_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))}
-        ),
-        (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    sdpa_out_interm_buffer = ttnn.from_torch(
-        torch.zeros((sdpa_out_interm_total_height, sdpa_out_interm_shard_width), dtype=torch.bfloat16),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, sdpa_out_interm_shard_spec
-        ),
-        mesh_mapper=mesh_mapper,
-        tile=ttnn.Tile([8, 32]),
-    )
+    def _sd_key(suffix):
+        return f"model.layers.{layer_idx}.{suffix}"
 
-    if rigged_group_count is not None:
-        # Use deterministic RMS-normalized input to avoid oversized constant-direction activations.
-        # (all-ones can produce brittle saturation in downstream low-precision paths)
-        torch_input_f32 = torch.randn(shape, dtype=torch.float32)
-        torch_input_f32 = torch_input_f32 / torch.sqrt(torch_input_f32.pow(2).mean(dim=-1, keepdim=True) + 1e-6)
-        torch_input = torch_input_f32.to(torch.bfloat16)
-    else:
-        torch_input = torch.randn(shape, dtype=torch.bfloat16)
-
-    rigged_group_ids = None
-    rigged_expert_ids = None
-    if rigged_group_count is not None and is_moe and preloaded_weights is None:
-        # Pseudo-random rigging within uploaded groups:
-        # - pick up to 4 groups among [0 .. rigged_group_count-1]
-        # - pick exactly 8 total experts, split pseudo-randomly across selected groups
-        g = torch.Generator()
-        g.manual_seed(2026)
-        if not (1 <= rigged_group_count <= 8):
-            raise ValueError(f"rigged_group_count must be in [1, 8], got {rigged_group_count}")
-        num_selected_groups = min(4, rigged_group_count)
-        rigged_group_ids = torch.randperm(rigged_group_count, generator=g)[:num_selected_groups].tolist()
-
-        total_rigged_experts = 8
-        # Start with one expert per selected group, then randomly distribute the remainder.
-        experts_per_group = [1] * num_selected_groups
-        remaining = total_rigged_experts - num_selected_groups
-        for _ in range(remaining):
-            chosen_group = int(torch.randint(0, num_selected_groups, (1,), generator=g).item())
-            experts_per_group[chosen_group] += 1
-
-        rigged_expert_ids = {
-            grp: torch.randperm(32, generator=g)[:num_experts].tolist()
-            for grp, num_experts in zip(rigged_group_ids, experts_per_group, strict=True)
-        }
-
-        rigged_bias = torch.full((8, 32), -10.0, dtype=torch.bfloat16)
-        for grp in rigged_group_ids:
-            for exp in rigged_expert_ids[grp]:
-                rigged_bias[grp, exp] = 10.0
-        state_dict[f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"] = rigged_bias.reshape(-1).contiguous()
-        logger.info(
-            f"Rigged experts enabled: groups={rigged_group_ids}, "
-            f"experts={[(grp, rigged_expert_ids[grp]) for grp in rigged_group_ids]}"
-        )
-
-    # ══════════════════════════════════════════════════════════════════════════
-    # All weights via prepare_* functions or preloaded
-    # ══════════════════════════════════════════════════════════════════════════
-    if preloaded_weights is not None:
-        layer = preloaded_weights
-    else:
-        if is_moe:
-            layer = prepare_moe_layer_weights(
-                submesh,
-                state_dict,
-                layer_idx,
-                num_routed_experts=num_routed_experts,
-                move_to_device=True,
-            )
-        else:
-            layer = prepare_dense_layer_weights(submesh, state_dict, layer_idx, move_to_device=True)
-
-    # ── FFN final output config (DRAM streaming matmul output grid) ──
-    gate_proj_noc = ttnn.NOC.NOC_0
-    gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(submesh, gate_proj_noc)
-    gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in gate_proj_worker_cores])
-    num_gate_proj_cores = len(gate_proj_worker_cores)
-    final_output_width_per_core = RoutedExpert.FINAL_OUTPUT_WIDTH_PER_CORE
-    final_output_total_width = final_output_width_per_core * num_gate_proj_cores
-    num_banks = submesh.dram_grid_size().x
-    tile_w = RoutedExpert.TILE_W
-    down_proj_N_padded = ((K + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
-    per_core_down_proj_N = down_proj_N_padded // num_banks
-
-    final_output_shard_spec = ttnn.ShardSpec(
-        gate_proj_core_ranges,
-        (1, final_output_width_per_core),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    final_output_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, final_output_shard_spec
-    )
-
-    # ── MoE-only: gate indices and output buffers ──
     if is_moe:
-        input_core = ttnn.CoreCoord(device_grid_size.x - 1, RoutedExpert.INPUT_CORE_Y)
-        input_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(input_core, input_core)])
-
-        ttnn_gate_indices = create_gate_indices_tensor(submesh, input_core_grid, mesh_mapper=mesh_mapper)
-
-        tile_1x16 = ttnn.Tile((1, 16))
-        gate_output_shard_spec = ttnn.ShardSpec(input_core_grid, (1, 16), ttnn.ShardOrientation.ROW_MAJOR)
-        gate_output_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gate_output_shard_spec
+        golden_moe_shared_gate = state_dict[_sd_key("mlp.shared_experts.gate_proj.weight")].T.contiguous()
+        golden_moe_shared_up = state_dict[_sd_key("mlp.shared_experts.up_proj.weight")].T.contiguous()
+        golden_moe_shared_down = state_dict[_sd_key("mlp.shared_experts.down_proj.weight")].T.contiguous()
+        golden_moe_routing_weights = state_dict[_sd_key("mlp.gate.weight")].T.contiguous()
+        golden_moe_bias = (
+            state_dict[_sd_key("mlp.gate.e_score_correction_bias")].reshape(1, 8, 32).contiguous().to(torch.bfloat16)
         )
-        gate_output_scores_tensor = ttnn.from_torch(
-            torch.zeros((1, 16), dtype=torch.bfloat16),
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            device=submesh,
-            memory_config=gate_output_mem_config,
-            tile=tile_1x16,
-            mesh_mapper=mesh_mapper,
-        )
-        gate_output_indices_tensor = ttnn.from_torch(
-            torch.zeros((1, 16), dtype=torch.uint16),
-            dtype=ttnn.uint16,
-            layout=ttnn.TILE_LAYOUT,
-            device=submesh,
-            memory_config=gate_output_mem_config,
-            tile=tile_1x16,
-            mesh_mapper=mesh_mapper,
-        )
-        moe_ref_gate_output_scores = None
-        moe_ref_gate_output_indices = None
-        if validate_debug_tensors:
-            moe_ref_gate_output_scores = ttnn.from_torch(
-                torch.zeros((1, 16), dtype=torch.bfloat16),
-                dtype=ttnn.bfloat16,
-                layout=ttnn.TILE_LAYOUT,
-                device=submesh,
-                memory_config=gate_output_mem_config,
-                tile=tile_1x16,
-                mesh_mapper=mesh_mapper,
-            )
-            moe_ref_gate_output_indices = ttnn.from_torch(
-                torch.zeros((1, 16), dtype=torch.uint16),
-                dtype=ttnn.uint16,
-                layout=ttnn.TILE_LAYOUT,
-                device=submesh,
-                memory_config=gate_output_mem_config,
-                tile=tile_1x16,
-                mesh_mapper=mesh_mapper,
-            )
+        golden_moe_gate_proj_dict = {}
+        golden_moe_up_proj_dict = {}
+        golden_moe_down_proj_dict = {}
+        for e in range(num_routed_experts):
+            w_g = state_dict[_sd_key(f"mlp.experts.{e}.gate_proj.weight")].T.contiguous()
+            golden_moe_gate_proj_dict[e] = w_g.reshape(1, 1, K, -1)
+            w_u = state_dict[_sd_key(f"mlp.experts.{e}.up_proj.weight")].T.contiguous()
+            golden_moe_up_proj_dict[e] = w_u.reshape(1, 1, K, -1)
+            w_d = state_dict[_sd_key(f"mlp.experts.{e}.down_proj.weight")].T.contiguous()
+            golden_moe_down_proj_dict[e] = w_d.reshape(1, 1, -1, K)
+    else:
+        gate_full = state_dict[_sd_key("mlp.gate_proj.weight")].T.contiguous()
+        up_full = state_dict[_sd_key("mlp.up_proj.weight")].T.contiguous()
+        down_full = state_dict[_sd_key("mlp.down_proj.weight")].T.contiguous()
+        golden_moe_shared_gate = gate_full[:, :DENSE_SHARED_N].contiguous()
+        golden_moe_shared_up = up_full[:, :DENSE_SHARED_N].contiguous()
+        golden_moe_shared_down = down_full[:DENSE_SHARED_N, :].contiguous()
+        golden_moe_routing_weights = None
+        golden_moe_bias = None
+        golden_moe_gate_proj_dict = {}
+        golden_moe_up_proj_dict = {}
+        golden_moe_down_proj_dict = {}
+        for e in range(8):
+            start = DENSE_SHARED_N + e * RoutedExpert.GATE_PROJ_N
+            end = start + RoutedExpert.GATE_PROJ_N
+            golden_moe_gate_proj_dict[e] = gate_full[:, start:end].reshape(1, 1, K, -1)
+            golden_moe_up_proj_dict[e] = up_full[:, start:end].reshape(1, 1, K, -1)
+            golden_moe_down_proj_dict[e] = down_full[start:end, :].reshape(1, 1, -1, K)
 
-    # ══════════════════════════════════════════════════════════════════════════
-    # Attention input/intermediate/output mesh tensors
-    # ══════════════════════════════════════════════════════════════════════════
-    sender_coord = ttnn.MeshCoordinate(sender_row, sender_col)
-    shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({ttnn.CoreRange(mcast_core, mcast_core)}), shape, ttnn.ShardOrientation.ROW_MAJOR
-    )
-    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-
-    device_tensors = []
-    for row in range(mesh_rows):
-        for col in range(mesh_cols):
-            if row == sender_row and col == sender_col:
-                device_tensors.append(torch_input)
-            else:
-                device_tensors.append(torch.zeros_like(torch_input))
-
-    input_tensor_mesh = ttnn.from_torch(
-        torch.cat(device_tensors, dim=0),
-        device=submesh,
-        layout=ttnn.TILE_LAYOUT,
-        tile=tile,
-        dtype=ttnn.bfloat16,
-        memory_config=mem_config,
-        mesh_mapper=ttnn.ShardTensorToMesh(submesh, dim=0),
-    )
-
-    # ── RoPE TTNN tensors ──
-    qrope_dram_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
-    position_ids = torch.tensor([position_id])
-
-    cos_sin_4d, sin_sin_4d = get_cos_sin_matrix(_RopeConfig)
-    torch_cos = cos_sin_4d.squeeze(0).squeeze(0)  # [max_seq_len, dim]
-    torch_sin = sin_sin_4d.squeeze(0).squeeze(0)  # [max_seq_len, dim]
-    torch_trans_mat = get_rot_transformation_mat()
-
-    ttnn_qrope_cos = ttnn.from_torch(
-        torch_cos.unsqueeze(0).unsqueeze(0),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=qrope_dram_mem,
-        tile=tile,
-        mesh_mapper=mesh_mapper,
-    )
-    ttnn_qrope_sin = ttnn.from_torch(
-        torch_sin.unsqueeze(0).unsqueeze(0),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=qrope_dram_mem,
-        tile=tile,
-        mesh_mapper=mesh_mapper,
-    )
-    ttnn_krope_cos = ttnn.from_torch(
-        torch_cos.unsqueeze(0).unsqueeze(0),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=qrope_dram_mem,
-        tile=tile,
-        mesh_mapper=mesh_mapper,
-    )
-    ttnn_krope_sin = ttnn.from_torch(
-        torch_sin.unsqueeze(0).unsqueeze(0),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=qrope_dram_mem,
-        tile=tile,
-        mesh_mapper=mesh_mapper,
-    )
-
-    # ── Trans mat ──
-    qrope_grid = ttnn.CoreRange(
-        ttnn.CoreCoord(QNOPE_GRID_COLS, 0), ttnn.CoreCoord(QNOPE_GRID_COLS + QROPE_GRID_COLS - 1, matmul2_grid_y - 1)
-    )
-    trans_mat_crs = kv_cache_branch_rope_crs.merge(ttnn.CoreRangeSet({qrope_grid}))
-    trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
-    trans_shard_spec = ttnn.ShardSpec(trans_mat_crs, (ttnn.TILE_SIZE, ttnn.TILE_SIZE), ttnn.ShardOrientation.ROW_MAJOR)
-    trans_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, trans_shard_spec)
-    trans_mat_replicated = torch_trans_mat.repeat(1, 1, qrope_num_cores + kv_cache_branch_rope_crs.num_cores(), 1)
-    ttnn_trans_mat = ttnn.from_torch(
-        trans_mat_replicated,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=trans_mem,
-        tile=trans_tile,
-        mesh_mapper=mesh_mapper,
-    )
-
-    # ── Position IDs ──
-    pos_core_grid = ttnn.CoreRangeSet(
-        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
-    )
-    pos_mem = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(pos_core_grid, (1, 1), ttnn.ShardOrientation.ROW_MAJOR),
-    )
-    ttnn_position_ids = ttnn.from_torch(
-        torch.full((device_grid_size.x * device_grid_size.y, 1), position_id, dtype=torch.int32),
-        dtype=ttnn.int32,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=submesh,
-        memory_config=pos_mem,
-        mesh_mapper=mesh_mapper,
-    )
-
-    # ── KV Cache (ND sharded DRAM) ──
-    program_config = FlashMLADecode.ProgramConfig(k_chunk_size=128, exp_approx_mode=False)
-    grid = program_config.grid
-    kv_nd_shard_spec = ttnn.NdShardSpec(
-        shard_shape=[1, 1, program_config.k_chunk_size, kvpe_dim],
-        grid=grid.optimal_dram_grid(),
-        orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
-    )
-    kv_mem = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=kv_nd_shard_spec)
-    num_sp = mesh_rows
-    dcs = program_config.device_chunk_size
-    torch_kv_cache = torch.zeros((1, 1, max_seq_len, kvpe_dim), dtype=torch.bfloat16)
-    torch_kv_cache[:, :, :position_id, :] = torch.randn(1, 1, position_id, kvpe_dim, dtype=torch.bfloat16)
-    torch_kv_cache_shuffled = deinterleave_kv_cache(torch_kv_cache, dcs, num_sp)
-    kv_cache_2d_mesh_mapper = ttnn.ShardTensor2dMesh(submesh, mesh_shape=(mesh_rows, mesh_cols), dims=(2, None))
-    ttnn_kv_cache = ttnn.from_torch(
-        torch_kv_cache_shuffled,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=kv_mem,
-        mesh_mapper=kv_cache_2d_mesh_mapper,
-    )
-    kv_cache_bfp8_before_op = ttnn.to_torch(ttnn_kv_cache, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
-
-    # ── KV cache clone for standalone AttentionBlock.op sanity check ──
-    ttnn_kv_cache_attn_ref = None
-    if validate_debug_tensors:
-        ttnn_kv_cache_attn_ref = ttnn.from_torch(
-            torch_kv_cache_shuffled,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            device=submesh,
-            memory_config=kv_mem,
-            mesh_mapper=kv_cache_2d_mesh_mapper,
-        )
-
-    # ── SDPA output tensor ──
     s1_cores, _ = FlashMLADecode.ProgramConfig.grid.BLOCKS[0]
-    sdpa_input_output_grid_crs = ttnn.CoreRangeSet(
-        [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in s1_cores]
-    )
     HEADS_PER_ROW = 8
     SDPA_INPUT_NUM_CORES = len(s1_cores)
-    sdpa_tile = ttnn.Tile([8, 32])
-    sdpa_input_output_shard_spec = ttnn.ShardSpec(
-        sdpa_input_output_grid_crs, (HEADS_PER_ROW, QNOPE_OUT_DIM), ttnn.ShardOrientation.ROW_MAJOR
-    )
-    sdpa_mem = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, sdpa_input_output_shard_spec
-    )
-    ttnn_sdpa_output = None
-    if validate_debug_tensors:
-        ttnn_sdpa_output = ttnn.from_torch(
-            torch.zeros((SDPA_INPUT_NUM_CORES * HEADS_PER_ROW, QNOPE_OUT_DIM), dtype=torch.bfloat16),
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            device=submesh,
-            memory_config=sdpa_mem,
-            mesh_mapper=mesh_mapper,
-            tile=sdpa_tile,
-        )
 
-    # ── Post-SDPA tensors ──
-    a_tile = ttnn.Tile([M, 32])
-    shard_mesh_mapper = ttnn.ShardTensorToMesh(submesh, dim=0)
-    gather_core = ttnn.CoreCoord(12, 9)
-    gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
-
-    # ── Attention block output / MoE residual input (overlapped with sdpa_kv_cache_buffer) ──
-    # These are temporally disjoint: the kv cache on core (12,9) is done after SDPA,
-    # so the attention output and MoE residual input can reuse that L1 region.
-    a_tile_size = a_tile.get_tile_size(ttnn.bfloat16)  # 1×32 tile → 64 bytes
-    num_output_tiles = output_size // 32  # 7168 / 32 = 224 tiles
-    output_shard_spec = ttnn.ShardSpec(gather_core_grid, (M, output_size), ttnn.ShardOrientation.ROW_MAJOR)
-    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
-    mesh_output_torch = torch.cat([torch.zeros((M, output_size), dtype=torch.bfloat16)] * num_devices, dim=0)
-    attn_output = ttnn.from_torch(
-        mesh_output_torch,
-        device=submesh,
-        layout=ttnn.TILE_LAYOUT,
-        tile=a_tile,
-        dtype=ttnn.bfloat16,
-        memory_config=output_mem_config,
-        mesh_mapper=shard_mesh_mapper,
-    )
-    attn_ref_output = None
-    if validate_debug_tensors:
-        attn_ref_output = ttnn.from_torch(
-            mesh_output_torch,
-            device=submesh,
-            layout=ttnn.TILE_LAYOUT,
-            tile=a_tile,
-            dtype=ttnn.bfloat16,
-            memory_config=output_mem_config,
-            mesh_mapper=shard_mesh_mapper,
-        )
-
-    # ── SDPA worker/forwarder tensors ──
-    sdpa_output_cores = FlashMLADecode.ProgramConfig.grid.output_cores(0, NUM_SDPA_WORKERS)
-    sdpa_worker_grid = ttnn.CoreRangeSet(
-        [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in sdpa_output_cores]
-    )
-    sdpa_l_per_worker = SDPA_L_WIDTH // NUM_SDPA_WORKERS
-    sdpa_ms_per_worker = SDPA_MS_WIDTH // NUM_SDPA_WORKERS
-
-    sdpa_recv_per_worker = sdpa_l_per_worker + sdpa_ms_per_worker
-    sdpa_recv_shard_shape = (2 * SDPA_L_HEIGHT, sdpa_recv_per_worker)
-    sdpa_recv_mem = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(sdpa_worker_grid, sdpa_recv_shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
-    )
-    sdpa_recv_full_width = sdpa_recv_per_worker * NUM_SDPA_WORKERS
-    mesh_recv = torch.cat(
-        [torch.zeros((2 * SDPA_L_HEIGHT, sdpa_recv_full_width), dtype=torch.bfloat16)] * num_devices, dim=0
-    )
-    ttnn_sdpa_intermediate_recv = ttnn.from_torch(
-        mesh_recv,
-        device=submesh,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=sdpa_recv_mem,
-        tile=sdpa_tile,
-        mesh_mapper=shard_mesh_mapper,
-    )
-
-    sdpa_forwarder_cores = [ttnn.CoreCoord(9, 8), ttnn.CoreCoord(10, 8)]
-    sdpa_forwarder_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in sdpa_forwarder_cores])
-    sdpa_fwd_buffer_bytes = compute_forwarder_scratch_size(
-        batch_size=SDPA_L_HEIGHT,
-        l_width=sdpa_l_per_worker,
-        num_cores=NUM_SDPA_WORKERS,
-    )
-    sdpa_fwd_total_elements = sdpa_fwd_buffer_bytes // 2
-    # THIS BUFFER SIZE IS NOT CORRECT BECAUSE WE'RE INCORRECTLY DIVIDING BY 2
-    # TODO: Plan to remove this scratch buffer entirely once we reduce cb memory usage currently being overlapped with this buffer.
-    sdpa_fwd_per_forwarder = sdpa_fwd_total_elements // 2
-    sdpa_forwarder_mem = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(sdpa_forwarder_grid, (1, sdpa_fwd_per_forwarder), ttnn.ShardOrientation.ROW_MAJOR),
-    )
-    mesh_fwd_scratch = torch.cat([torch.zeros((1, sdpa_fwd_total_elements), dtype=torch.bfloat16)] * num_devices, dim=0)
-    ttnn_sdpa_forwarder_scratch = ttnn.from_torch(
-        mesh_fwd_scratch,
-        device=submesh,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        memory_config=sdpa_forwarder_mem,
-        mesh_mapper=shard_mesh_mapper,
-    )
-
-    # ══════════════════════════════════════════════════════════════════════════
-    # Reduce-to-one tensors
-    # ══════════════════════════════════════════════════════════════════════════
-    reduce_mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)], submesh.shape)
-    reduce_mesh_mapper = ttnn.create_mesh_mapper(submesh, reduce_mesh_mapper_config)
-    tile_1x32 = ttnn.Tile([1, 32])
-
-    # Single intermediate tensor with 3x shard width for all 3 reduction rounds
-    orig_shard_spec = final_output_mem_config.shard_spec
-    intermediate_shard_shape = [orig_shard_spec.shape[0], orig_shard_spec.shape[1] * 3]
-    intermediate_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(
-            orig_shard_spec.grid,
-            intermediate_shard_shape,
-            ttnn.ShardOrientation.ROW_MAJOR,
-        ),
-    )
-    intermediate_tensors = ttnn.from_torch(
-        torch.zeros([4, 2, final_output_total_width * 3], dtype=torch.bfloat16),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=intermediate_mem_config,
-        tile=tile_1x32,
-        mesh_mapper=reduce_mesh_mapper,
-    )
-
-    shard_cores_list = ttnn.corerange_to_cores(gate_proj_core_ranges, row_wise=True)
-    aggregator_core = shard_cores_list[0]
-    reduce_output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(aggregator_core, aggregator_core)})
-    reduce_output_mem = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(reduce_output_shard_grid, (1, final_output_total_width), ttnn.ShardOrientation.ROW_MAJOR),
-    )
-    reduce_output_tensor = ttnn.from_torch(
-        torch.zeros([4, 2, final_output_total_width], dtype=torch.bfloat16),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=reduce_output_mem,
-        tile=tile_1x32,
-        mesh_mapper=reduce_mesh_mapper,
-    )
-
-    # ── Standalone MoE ref reduce tensors (MoE only) ──
-    if is_moe:
-        moe_ref_reduce_intermediate = None
-        moe_ref_reduce_output = None
-        if validate_debug_tensors:
-            moe_ref_reduce_intermediate = ttnn.from_torch(
-                torch.zeros([4, 2, final_output_total_width * 3], dtype=torch.bfloat16),
-                dtype=ttnn.bfloat16,
-                layout=ttnn.TILE_LAYOUT,
-                device=submesh,
-                memory_config=intermediate_mem_config,
-                tile=tile_1x32,
-                mesh_mapper=reduce_mesh_mapper,
-            )
-            moe_ref_reduce_output = ttnn.from_torch(
-                torch.zeros([4, 2, final_output_total_width], dtype=torch.bfloat16),
-                dtype=ttnn.bfloat16,
-                layout=ttnn.TILE_LAYOUT,
-                device=submesh,
-                memory_config=reduce_output_mem,
-                tile=tile_1x32,
-                mesh_mapper=reduce_mesh_mapper,
-            )
-
-    sender_core_from_residual = attn_output.memory_config().shard_spec.grid.bounding_box().end
-    mcast_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), sender_core_from_residual)])
-
-    # ══════════════════════════════════════════════════════════════════════════
-    # Golden model PyTorch tensors (only when state_dict is available)
-    # ══════════════════════════════════════════════════════════════════════════
-    golden = {}
-    if state_dict is not None:
-
-        def _sd_key(suffix):
-            return f"model.layers.{layer_idx}.{suffix}"
-
-        (
-            golden_torch_matmul_weights,
-            golden_torch_matmul2_weights,
-            golden_torch_dkv_matmul_weights,
-            golden_kv_b1,
-            golden_kv_b2,
-            golden_torch_o_proj_weights,
-            golden_torch_gamma,
-            golden_torch_rmsnorm2_gamma,
-            golden_torch_dkv_rmsnorm_gamma,
-            ffn_norm,
-        ) = get_layer_raw_tensors(state_dict, layer_idx)
-
-        total_kv_heads = golden_kv_b1.shape[0] // QNOPE_HEAD_DIM
-        kv_lora_rank = golden_kv_b1.shape[1]
-        golden_torch_matmul3_weights = golden_kv_b1.reshape(total_kv_heads, QNOPE_HEAD_DIM, kv_lora_rank)
-
-        golden_total_qnope_heads = total_kv_heads
-        golden_total_qrope_heads = total_kv_heads
-
-        # ── Golden FFN tensors (MoE vs dense differ in key paths and weight layout) ──
-        golden_moe_rmsnorm_gamma = ffn_norm.to(torch.bfloat16).float()
-        if is_moe:
-            golden_moe_shared_gate = state_dict[_sd_key("mlp.shared_experts.gate_proj.weight")].T.contiguous()
-            golden_moe_shared_up = state_dict[_sd_key("mlp.shared_experts.up_proj.weight")].T.contiguous()
-            golden_moe_shared_down = state_dict[_sd_key("mlp.shared_experts.down_proj.weight")].T.contiguous()
-            golden_moe_routing_weights = state_dict[_sd_key("mlp.gate.weight")].T.contiguous()
-            golden_moe_bias = (
-                state_dict[_sd_key("mlp.gate.e_score_correction_bias")]
-                .reshape(1, 8, 32)
-                .contiguous()
-                .to(torch.bfloat16)
-            )
-            golden_moe_gate_proj_dict = {}
-            golden_moe_up_proj_dict = {}
-            golden_moe_down_proj_dict = {}
-            for e in range(num_routed_experts):
-                w_g = state_dict[_sd_key(f"mlp.experts.{e}.gate_proj.weight")].T.contiguous()
-                golden_moe_gate_proj_dict[e] = w_g.reshape(1, 1, K, -1)
-                w_u = state_dict[_sd_key(f"mlp.experts.{e}.up_proj.weight")].T.contiguous()
-                golden_moe_up_proj_dict[e] = w_u.reshape(1, 1, K, -1)
-                w_d = state_dict[_sd_key(f"mlp.experts.{e}.down_proj.weight")].T.contiguous()
-                golden_moe_down_proj_dict[e] = w_d.reshape(1, 1, -1, K)
-        else:
-            gate_full = state_dict[_sd_key("mlp.gate_proj.weight")].T.contiguous()
-            up_full = state_dict[_sd_key("mlp.up_proj.weight")].T.contiguous()
-            down_full = state_dict[_sd_key("mlp.down_proj.weight")].T.contiguous()
-            golden_moe_shared_gate = gate_full[:, :DENSE_SHARED_N].contiguous()
-            golden_moe_shared_up = up_full[:, :DENSE_SHARED_N].contiguous()
-            golden_moe_shared_down = down_full[:DENSE_SHARED_N, :].contiguous()
-            golden_moe_routing_weights = None
-            golden_moe_bias = None
-            golden_moe_gate_proj_dict = {}
-            golden_moe_up_proj_dict = {}
-            golden_moe_down_proj_dict = {}
-            for e in range(8):
-                start = DENSE_SHARED_N + e * RoutedExpert.GATE_PROJ_N
-                end = start + RoutedExpert.GATE_PROJ_N
-                golden_moe_gate_proj_dict[e] = gate_full[:, start:end].reshape(1, 1, K, -1)
-                golden_moe_up_proj_dict[e] = up_full[:, start:end].reshape(1, 1, K, -1)
-                golden_moe_down_proj_dict[e] = down_full[start:end, :].reshape(1, 1, -1, K)
-
-        golden = {
-            "golden_torch_input": torch_input,
-            "golden_torch_gamma": golden_torch_gamma,
-            "golden_torch_matmul_weights": golden_torch_matmul_weights,
-            "golden_torch_rmsnorm2_gamma": golden_torch_rmsnorm2_gamma,
-            "golden_torch_matmul2_weights": golden_torch_matmul2_weights,
-            "golden_torch_matmul3_weights": golden_torch_matmul3_weights,
-            "golden_torch_sin": torch_sin,
-            "golden_torch_cos": torch_cos,
-            "golden_position_ids": position_ids,
-            "golden_torch_dkv_matmul_weights": golden_torch_dkv_matmul_weights,
-            "golden_torch_dkv_rmsnorm_gamma": golden_torch_dkv_rmsnorm_gamma,
-            "golden_torch_kv_cache": torch_kv_cache,
-            "golden_scale": scale,
-            "golden_torch_kv_b2_proj_weights": golden_kv_b2,
-            "golden_torch_o_proj_weights": golden_torch_o_proj_weights,
-            "golden_total_qnope_heads": golden_total_qnope_heads,
-            "golden_total_qrope_heads": golden_total_qrope_heads,
-            "golden_kv_cache_bfp8_before_op": kv_cache_bfp8_before_op,
-            "golden_sdpa_slice_size": SDPA_INPUT_NUM_CORES * HEADS_PER_ROW,
-            "golden_moe_rmsnorm_gamma": golden_moe_rmsnorm_gamma,
-            "golden_moe_shared_gate": golden_moe_shared_gate,
-            "golden_moe_shared_up": golden_moe_shared_up,
-            "golden_moe_shared_down": golden_moe_shared_down,
-            "golden_moe_routing_weights": golden_moe_routing_weights,
-            "golden_moe_bias": golden_moe_bias,
-            "golden_moe_gate_proj_dict": golden_moe_gate_proj_dict,
-            "golden_moe_up_proj_dict": golden_moe_up_proj_dict,
-            "golden_moe_down_proj_dict": golden_moe_down_proj_dict,
-            "rigged_group_ids": rigged_group_ids,
-            "rigged_expert_ids": rigged_expert_ids,
-        }
-
-    # ── Routed weight tensors differ between MoE (list) and dense (single tensor) ──
-    routed_gate = layer.routed_gate_proj[0] if is_moe else layer.routed_gate_proj
-    routed_up = layer.routed_up_proj[0] if is_moe else layer.routed_up_proj
-    routed_down = layer.routed_down_proj[0] if is_moe else layer.routed_down_proj
-
-    result = {
-        # Attention weights (from prepare_*_layer_weights)
-        "gamma_overlapped": layer.attn_norm,
-        "matmul_weights_overlapped": layer.q_a_proj,
-        "rmsnorm2_gamma_overlapped": layer.q_norm,
-        "matmul2_weights_overlapped": layer.q_b_proj,
-        "matmul3_weights_overlapped": layer.kv_b1_proj,
-        "dkv_matmul_weights_overlapped": layer.kv_a_proj,
-        "dkv_rmsnorm_gamma_overlapped": layer.kv_norm,
-        "kv_b2_overlapped": layer.kv_b2_proj,
-        "o_proj_overlapped": layer.o_proj,
-        "ffn_norm_overlapped": layer.ffn_norm,
-        # Attention activation/buffer tensors
-        "input_tensor_mesh": input_tensor_mesh,
-        "ttnn_qrope_sin": ttnn_qrope_sin,
-        "ttnn_qrope_cos": ttnn_qrope_cos,
-        "ttnn_trans_mat": ttnn_trans_mat,
-        "ttnn_krope_cos": ttnn_krope_cos,
-        "ttnn_krope_sin": ttnn_krope_sin,
-        "ttnn_kv_cache": ttnn_kv_cache,
-        "ttnn_kv_cache_attn_ref": ttnn_kv_cache_attn_ref,
-        "ttnn_position_ids": ttnn_position_ids,
-        "scale": scale,
-        "sdpa_kv_cache_buffer": sdpa_kv_cache_buffer,
-        "sdpa_out_interm_buffer": sdpa_out_interm_buffer,
-        "ttnn_sdpa_output": ttnn_sdpa_output,
-        "sender_coord": sender_coord,
-        "ttnn_sdpa_input_l": None,
-        "ttnn_sdpa_input_ms": None,
-        "ttnn_sdpa_output_l": None,
-        "ttnn_sdpa_intermediate_recv": ttnn_sdpa_intermediate_recv,
-        "ttnn_sdpa_forwarder_scratch": ttnn_sdpa_forwarder_scratch,
-        "device_chunk_size": program_config.device_chunk_size,
-        "ttnn_attention_block_output": attn_output,
-        "ttnn_attn_ref_output": attn_ref_output,
-        # FFN tensors (attn_output IS the FFN residual input — overlapped with kv cache)
-        "ttnn_residual_mcast_src": attn_output,
-        "gate_proj_weights": routed_gate,
-        "up_proj_weights": routed_up,
-        "down_proj_weights": routed_down,
-        "final_output_mem_config": final_output_mem_config,
-        "final_output_total_width": final_output_total_width,
-        # Shared expert weights
-        "shared_gate_weights_overlapped": layer.shared_gate_proj,
-        "shared_up_weights_overlapped": layer.shared_up_proj,
-        "shared_down_weights_tensor": layer.shared_down_proj,
-        "shared_k_parallel": SharedExpert.K_PARALLEL,
-        "shared_n_parallel": SharedExpert.N_PARALLEL,
-        # Reduce-to-one
-        "reduce_intermediate_tensors": intermediate_tensors,
-        "reduce_output_tensor": reduce_output_tensor,
-        "reduce_root_coord": reduce_root_coord,
-        "num_gate_proj_cores": num_gate_proj_cores,
-        "per_core_down_proj_N": per_core_down_proj_N,
-        "mcast_grid": mcast_grid,
-        **golden,
+    return {
+        "golden_torch_input": d["torch_input"],
+        "golden_torch_gamma": golden_torch_gamma,
+        "golden_torch_matmul_weights": golden_torch_matmul_weights,
+        "golden_torch_rmsnorm2_gamma": golden_torch_rmsnorm2_gamma,
+        "golden_torch_matmul2_weights": golden_torch_matmul2_weights,
+        "golden_torch_matmul3_weights": golden_torch_matmul3_weights,
+        "golden_torch_sin": d["torch_sin"],
+        "golden_torch_cos": d["torch_cos"],
+        "golden_position_ids": d["torch_position_ids"],
+        "golden_torch_dkv_matmul_weights": golden_torch_dkv_matmul_weights,
+        "golden_torch_dkv_rmsnorm_gamma": golden_torch_dkv_rmsnorm_gamma,
+        "golden_torch_kv_cache": d["torch_kv_cache"],
+        "golden_scale": d["scale"],
+        "golden_torch_kv_b2_proj_weights": golden_kv_b2,
+        "golden_torch_o_proj_weights": golden_torch_o_proj_weights,
+        "golden_total_qnope_heads": golden_total_qnope_heads,
+        "golden_total_qrope_heads": golden_total_qrope_heads,
+        "golden_kv_cache_bfp8_before_op": kv_cache_bfp8_before_op,
+        "golden_sdpa_slice_size": SDPA_INPUT_NUM_CORES * HEADS_PER_ROW,
+        "golden_moe_rmsnorm_gamma": golden_moe_rmsnorm_gamma,
+        "golden_moe_shared_gate": golden_moe_shared_gate,
+        "golden_moe_shared_up": golden_moe_shared_up,
+        "golden_moe_shared_down": golden_moe_shared_down,
+        "golden_moe_routing_weights": golden_moe_routing_weights,
+        "golden_moe_bias": golden_moe_bias,
+        "golden_moe_gate_proj_dict": golden_moe_gate_proj_dict,
+        "golden_moe_up_proj_dict": golden_moe_up_proj_dict,
+        "golden_moe_down_proj_dict": golden_moe_down_proj_dict,
+        "rigged_group_ids": rigged_group_ids,
+        "rigged_expert_ids": rigged_expert_ids,
     }
-    # MoE-only keys
-    if is_moe:
-        result.update(
-            {
-                "gate_mm_overlapped": layer.gate_mm,
-                "ttnn_gate_bias": layer.gate_bias,
-                "ttnn_gate_indices": ttnn_gate_indices,
-                "gate_output_scores_tensor": gate_output_scores_tensor,
-                "gate_output_indices_tensor": gate_output_indices_tensor,
-                "moe_ref_gate_output_scores": moe_ref_gate_output_scores,
-                "moe_ref_gate_output_indices": moe_ref_gate_output_indices,
-                "moe_ref_reduce_intermediate": moe_ref_reduce_intermediate,
-                "moe_ref_reduce_output": moe_ref_reduce_output,
-            }
-        )
-    return result
 
 
 @pytest.mark.parametrize(
@@ -994,6 +352,14 @@ def test_decoder(
         num_routed_experts=effective_num_routed_experts,
     )
 
+    rigged_group_ids = None
+    rigged_expert_ids = None
+    torch_input = None
+    if rigged_group_count is not None:
+        rigged_group_ids, rigged_expert_ids, torch_input = rig_experts(
+            state_dict, ROUTED_EXPERT_LAYER_IDX, rigged_group_count
+        )
+
     logger.info("Creating decoder block tensors...")
     d = create_decoder_block_tensors(
         submesh,
@@ -1007,9 +373,22 @@ def test_decoder(
         max_seq_len=max_seq_len,
         is_moe=True,
         num_routed_experts=effective_num_routed_experts,
-        rigged_group_count=rigged_group_count,
         validate_debug_tensors=validate_standalone_mla or validate_standalone_moe,
+        torch_input=torch_input,
     )
+
+    logger.info("Creating golden reference tensors...")
+    golden = create_decoder_golden_tensors(
+        d,
+        submesh,
+        state_dict,
+        ROUTED_EXPERT_LAYER_IDX,
+        is_moe=True,
+        num_routed_experts=effective_num_routed_experts,
+        rigged_group_ids=rigged_group_ids,
+        rigged_expert_ids=rigged_expert_ids,
+    )
+    d.update(golden)
 
     num_cores = device_grid_size.x * device_grid_size.y
     available_cores = ttnn.num_cores_to_corerangeset(num_cores, device_grid_size, row_wise=True)
@@ -1480,6 +859,16 @@ def test_decoder_mlp(
         max_seq_len=max_seq_len,
         is_moe=False,
     )
+
+    logger.info("Creating golden reference tensors...")
+    golden = create_decoder_golden_tensors(
+        d,
+        submesh,
+        state_dict,
+        DENSE_LAYER_IDX,
+        is_moe=False,
+    )
+    d.update(golden)
 
     num_cores = device_grid_size.x * device_grid_size.y
     available_cores = ttnn.num_cores_to_corerangeset(num_cores, device_grid_size, row_wise=True)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_15_stages.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_15_stages.py
@@ -25,9 +25,9 @@ from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
+from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
     ROUTED_EXPERT_LAYER_IDX,
-    RoutedExpert,
     create_routed_expert_tensors,
     create_shared_expert_tensors,
 )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -85,28 +85,7 @@ class RoutedExpertTensors(NamedTuple):
 # ============================================================================
 # Constants (namespaced by usage)
 # ============================================================================
-class RoutedExpert:
-    M = 1
-    K = 7168
-    N_PER_CORE = 32  # routing matmul width per core
-    NUM_CORES = 8  # routing matmul cores
-    GATE_PROJ_N = 2048
-    GATE_EPS = 1e-20
-    GATE_SCALING_FACTOR = 2.5
-    TILE_W = 32  # for padding math
-    FINAL_OUTPUT_WIDTH_PER_CORE = 32 * 32  # 1024
-    INPUT_CORE_Y = 9  # for ttnn.CoreCoord(device_grid_size.x - 1, INPUT_CORE_Y)
-    SEED = 0
-    GATE_PROJ_EXPERT_SEED = 0
-    UP_PROJ_EXPERT_SEED = 256
-    DOWN_PROJ_EXPERT_SEED = 512
-
-
-class SharedExpert:
-    K_PARALLEL = 8
-    N_PARALLEL = 8
-    N_PER_CORE = 64  # N = N_PER_CORE * DownProj.NUM_MATMUL_CORES in helper
-    SEED = 100
+from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert, SharedExpert
 
 
 class SDPA:

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -23,28 +23,12 @@ from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import (
     build_broadcast_test_inputs,
     create_fabric_router_config,
 )
-from models.demos.deepseek_v3_b1.utils import generate_mm_weights
+from models.demos.deepseek_v3_b1.utils import deinterleave_kv_cache, generate_mm_weights
 from models.demos.deepseek_v3_b1.weights.transforms.attention import (
     fuse_kv_b12,
     fuse_o_proj_gate_mm_norms,
     fuse_q_ab_kv_a,
 )
-
-
-def deinterleave_kv_cache(kv: torch.Tensor, device_chunk_size: int, num_devices: int) -> torch.Tensor:
-    """Reorder a round-robin interleaved KV cache for ShardTensor2dMesh.
-
-    The global KV cache is written in round-robin device_chunk_size blocks:
-      [dev0_chunk0 | dev1_chunk0 | ... | devN_chunk0 | dev0_chunk1 | ...]
-    ShardTensor2dMesh splits dim-2 contiguously, so each device would
-    receive the wrong data.  This function reorders to:
-      [dev0_chunk0 | dev0_chunk1 | ... | dev1_chunk0 | dev1_chunk1 | ...]
-    so that after the contiguous split each device gets its own chunks.
-    """
-    b, h, seq, d = kv.shape
-    num_chunks = seq // device_chunk_size
-    chunks_per_device = num_chunks // num_devices
-    return kv.reshape(b, h, chunks_per_device, num_devices, device_chunk_size, d).transpose(2, 3).reshape(b, h, seq, d)
 
 
 def test_get_device_mla_work_assignment():

--- a/models/demos/deepseek_v3_b1/utils.py
+++ b/models/demos/deepseek_v3_b1/utils.py
@@ -4,7 +4,25 @@
 
 import struct
 
+import torch
+
 import ttnn
+
+
+def deinterleave_kv_cache(kv: torch.Tensor, device_chunk_size: int, num_devices: int) -> torch.Tensor:
+    """Reorder a round-robin interleaved KV cache for ShardTensor2dMesh.
+
+    The global KV cache is written in round-robin device_chunk_size blocks:
+      [dev0_chunk0 | dev1_chunk0 | ... | devN_chunk0 | dev0_chunk1 | ...]
+    ShardTensor2dMesh splits dim-2 contiguously, so each device would
+    receive the wrong data.  This function reorders to:
+      [dev0_chunk0 | dev0_chunk1 | ... | dev1_chunk0 | dev1_chunk1 | ...]
+    so that after the contiguous split each device gets its own chunks.
+    """
+    b, h, seq, d = kv.shape
+    num_chunks = seq // device_chunk_size
+    chunks_per_device = num_chunks // num_devices
+    return kv.reshape(b, h, chunks_per_device, num_devices, device_chunk_size, d).transpose(2, 3).reshape(b, h, seq, d)
 
 
 def float_to_bfloat16_packed(value):


### PR DESCRIPTION
### Summary

This PR decouples DecoderBlock tensor/weight setup from test-only paths and makes decoder tensor creation reusable across production and golden-reference flows. It also centralizes DeepSeek V3 B1 shape/constants so runtime and tests use a shared source of truth.

### Whats changed

- Refactored `models/demos/deepseek_v3_b1/demo/decoder_stage.py` to introduce a reusable `create_decoder_block_tensors(...)` flow that can operate from either `state_dict` or preloaded weights.
- Reworked decoder stage setup/program-context construction to use the refactored tensor bundle and keep MoE vs dense handling explicit.
- Removed production-path dependence on test modules by replacing test-file imports/constants with shared constants.
- Updated impacted unit tests (`test_decoder_block.py`, `test_moe_mlp.py`, `test_pre_sdpa.py`, `test_attention_block.py`, `test_bcast_moe_reduce_pipeline.py`, `test_moe_15_stages.py`) to import new shared constants/helpers from non-test runtime modules.

### CI

- [x] BH post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/24247840033