### PR TITLE
compile_time_args.h: guard <string_view> behind KERNEL_COMPILE_TIME_ARG_MAP

### DIFF
--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -7,7 +7,9 @@
 
 #include <array>
 #include <cstdint>
+#ifdef KERNEL_COMPILE_TIME_ARG_MAP
 #include <string_view>
+#endif
 
 template <class T, class... Ts>
 FORCE_INLINE constexpr std::array<T, sizeof...(Ts)> make_array(Ts... values) {


### PR DESCRIPTION
Guards the `<string_view>` include behind `#ifdef KERNEL_COMPILE_TIME_ARG_MAP` since it is only needed for the named compile-time arg map feature. Reduces the header include chain for kernels that don't use that feature.