### PR TITLE
[Feature] Add Quasar 2x3 simulation core descriptor

### DIFF
--- a/tt_metal/core_descriptors/quasar_simulation_2x3_arch.yaml
+++ b/tt_metal/core_descriptors/quasar_simulation_2x3_arch.yaml
@@ -1,0 +1,32 @@
+# Anything using [[#, #]] is logical coordinates (Can be relative)
+# relative index: 0 means first row, -1 means last row of functional grid...
+
+# product name:
+#   num of HW command queues:
+#     core descriptor config
+
+unharvested:
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 1]
+        end: [1, 1]
+
+
+      dispatch_cores:
+        []
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 1]
+        end: [1, 1]
+
+
+      dispatch_cores:
+        []
+
+      dispatch_core_type:
+        "tensix"

--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -58,8 +58,8 @@ uint8_t my_relative_y_ __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
-uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
-uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
+bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
+bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
 int32_t bank_to_dram_offset[NUM_DRAM_BANKS] __attribute__((used));
 int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -82,8 +82,8 @@ uint32_t crta_count __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
-uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
-uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
+bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
+bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
 int32_t bank_to_dram_offset[NUM_DRAM_BANKS] __attribute__((used));
 int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 uint8_t prev_noc_mode = DM_DEDICATED_NOC;

--- a/tt_metal/hw/firmware/src/tt-1xx/drisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/drisc.cc
@@ -27,8 +27,8 @@ uint8_t my_y[NUM_NOCS] __attribute__((used));
 uint8_t my_logical_x_ __attribute__((used));
 uint8_t my_logical_y_ __attribute__((used));
 
-uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
-uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
+bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
+bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
 int32_t bank_to_dram_offset[NUM_DRAM_BANKS] __attribute__((used));
 int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
@@ -47,8 +47,8 @@ uint32_t crta_count __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
-uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
-uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
+bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
+bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
 int32_t bank_to_dram_offset[NUM_DRAM_BANKS] __attribute__((used));
 int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
@@ -53,8 +53,8 @@ uint8_t my_relative_y_ __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
-uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
-uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
+bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
+bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
 int32_t bank_to_dram_offset[NUM_DRAM_BANKS] __attribute__((used));
 int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
@@ -52,9 +52,9 @@ uint32_t crta_count __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
-uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
+bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
 int32_t bank_to_dram_offset[NUM_DRAM_BANKS] __attribute__((used));
-uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
+bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
 int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 
 // These arrays are used to store the worker logical to virtual coordinate mapping

--- a/tt_metal/hw/firmware/src/tt-1xx/subordinate_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/subordinate_erisc.cc
@@ -72,8 +72,8 @@ uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
-uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
-uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
+bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
+bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
 int32_t bank_to_dram_offset[NUM_DRAM_BANKS] __attribute__((used));
 int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -54,8 +54,8 @@ thread_local uint32_t crta_count __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
-uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
-uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
+bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used));
+bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used));
 int32_t bank_to_dram_offset[NUM_DRAM_BANKS] __attribute__((used));
 int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_common.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_common.h
@@ -14,9 +14,18 @@ constexpr uint8_t noc_mode = NOC_MODE;
 extern uint8_t noc_index;
 // noc_mode may switch dynamically while in the firmware, so we can't define it here.
 #endif
-extern uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];
+// Use uint32_t entries when uint16_t array sizes would be unaligned (not a multiple of 4 bytes),
+// which would cause l1_to_local_mem_copy to read from misaligned L1 addresses.
+// With NUM_NOCS=1 for Quasar, odd bank counts produce non-4-byte-aligned table sizes.
+#if defined(ARCH_QUASAR) && (NUM_DRAM_BANKS % 2 != 0 || NUM_L1_BANKS % 2 != 0)
+typedef uint32_t bank_noc_xy_t;
+#else
+typedef uint16_t bank_noc_xy_t;
+#endif
+
+extern bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];
 extern int32_t bank_to_dram_offset[NUM_DRAM_BANKS];
-extern uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS];
+extern bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS];
 extern int32_t bank_to_l1_offset[NUM_L1_BANKS];
 
 #ifdef ARCH_QUASAR

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -71,9 +71,15 @@ inline void do_thread_crt1(uint32_t tt_l1_ptr* data_image) {
 
 inline void noc_bank_table_init(uint64_t mem_bank_to_noc_addr) {
     int32_t dram_to_noc_size_bytes = sizeof(dram_bank_to_noc_xy);
+    int32_t l1_to_noc_size_bytes = sizeof(l1_bank_to_noc_xy);
+#ifdef ARCH_QUASAR
+    // Quasar 1x3 and 2x3 simulation configs have few DRAM/L1 banks, so table sizes may not be 4 byte aligned.
+    // round_up_to_mult_of_4 ensures l1_to_local_mem_copy doesn't read from misaligned L1 addresses.
+    dram_to_noc_size_bytes = round_up_to_mult_of_4(dram_to_noc_size_bytes);
+    l1_to_noc_size_bytes = round_up_to_mult_of_4(l1_to_noc_size_bytes);
+#endif
     l1_to_local_mem_copy(
         (uint*)dram_bank_to_noc_xy, (uint tt_l1_ptr*)mem_bank_to_noc_addr, dram_to_noc_size_bytes >> 2);
-    int32_t l1_to_noc_size_bytes = sizeof(l1_bank_to_noc_xy);
     l1_to_local_mem_copy(
         (uint*)l1_bank_to_noc_xy,
         (uint tt_l1_ptr*)(mem_bank_to_noc_addr + dram_to_noc_size_bytes),

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -29,9 +29,18 @@
 
 constexpr size_t round_up_to_mult_of_4(size_t value) { return ((value + 3) / 4) * 4; }
 
-extern uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];
+// Use uint32_t entries when uint16_t array sizes would be unaligned (not a multiple of 4 bytes),
+// which would cause l1_to_local_mem_copy to read from misaligned L1 addresses.
+// With NUM_NOCS=1 for Quasar, odd bank counts produce non-4-byte-aligned table sizes.
+#if defined(ARCH_QUASAR) && (NUM_DRAM_BANKS % 2 != 0 || NUM_L1_BANKS % 2 != 0)
+typedef uint32_t bank_noc_xy_t;
+#else
+typedef uint16_t bank_noc_xy_t;
+#endif
+
+extern bank_noc_xy_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];
 extern int32_t bank_to_dram_offset[NUM_DRAM_BANKS];
-extern uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS];
+extern bank_noc_xy_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS];
 extern int32_t bank_to_l1_offset[NUM_L1_BANKS];
 
 // These arrays are used to store the worker logical to virtual coordinate mapping. Only
@@ -70,14 +79,12 @@ inline void do_thread_crt1(uint32_t tt_l1_ptr* data_image) {
 }
 
 inline void noc_bank_table_init(uint64_t mem_bank_to_noc_addr) {
-    int32_t dram_to_noc_size_bytes = sizeof(dram_bank_to_noc_xy);
-    int32_t l1_to_noc_size_bytes = sizeof(l1_bank_to_noc_xy);
-#ifdef ARCH_QUASAR
-    // Quasar 1x3 and 2x3 simulation configs have few DRAM/L1 banks, so table sizes may not be 4 byte aligned.
-    // round_up_to_mult_of_4 ensures l1_to_local_mem_copy doesn't read from misaligned L1 addresses.
-    dram_to_noc_size_bytes = round_up_to_mult_of_4(dram_to_noc_size_bytes);
-    l1_to_noc_size_bytes = round_up_to_mult_of_4(l1_to_noc_size_bytes);
-#endif
+    constexpr int32_t dram_to_noc_size_bytes = sizeof(dram_bank_to_noc_xy);
+    constexpr int32_t l1_to_noc_size_bytes = sizeof(l1_bank_to_noc_xy);
+    static_assert(
+        dram_to_noc_size_bytes % 4 == 0, "dram_bank_to_noc_xy size must be 4-byte aligned for l1_to_local_mem_copy");
+    static_assert(
+        l1_to_noc_size_bytes % 4 == 0, "l1_bank_to_noc_xy size must be 4-byte aligned for l1_to_local_mem_copy");
     l1_to_local_mem_copy(
         (uint*)dram_bank_to_noc_xy, (uint tt_l1_ptr*)mem_bank_to_noc_addr, dram_to_noc_size_bytes >> 2);
     l1_to_local_mem_copy(

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -559,8 +559,15 @@ void RiscFirmwareInitializer::initialize_device_bank_to_noc_tables(
     const HalProgrammableCoreType& core_type,
     CoreCoord virtual_core,
     std::optional<CoreCoord> end_core) {
-    const uint32_t dram_to_noc_sz_in_bytes = dram_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
-    const uint32_t l1_to_noc_sz_in_bytes = l1_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
+    uint32_t dram_to_noc_sz_in_bytes = dram_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
+    uint32_t l1_to_noc_sz_in_bytes = l1_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
+    // Quasar 1x3 and 2x3 simulation configs have few DRAM/L1 banks, so table sizes may not be 4-byte aligned.
+    // l1_to_local_mem_copy on the firmware side reads 4-byte words, so misaligned offsets cause hangs. Align sizes to 4
+    // bytes to match firmware expectations.
+    if (cluster_.arch() == tt::ARCH::QUASAR) {
+        dram_to_noc_sz_in_bytes = tt::align(dram_to_noc_sz_in_bytes, 4u);
+        l1_to_noc_sz_in_bytes = tt::align(l1_to_noc_sz_in_bytes, 4u);
+    }
     const uint32_t dram_offset_sz_in_bytes = dram_bank_offset_map_[device_id].size() * sizeof(int32_t);
     const uint32_t l1_offset_sz_in_bytes = l1_bank_offset_map_[device_id].size() * sizeof(int32_t);
 

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -5,6 +5,7 @@
 #include "risc_firmware_initializer.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <future>
 #include <set>
 
@@ -559,15 +560,34 @@ void RiscFirmwareInitializer::initialize_device_bank_to_noc_tables(
     const HalProgrammableCoreType& core_type,
     CoreCoord virtual_core,
     std::optional<CoreCoord> end_core) {
-    uint32_t dram_to_noc_sz_in_bytes = dram_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
-    uint32_t l1_to_noc_sz_in_bytes = l1_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
-    // Quasar 1x3 and 2x3 simulation configs have few DRAM/L1 banks, so table sizes may not be 4-byte aligned.
-    // l1_to_local_mem_copy on the firmware side reads 4-byte words, so misaligned offsets cause hangs. Align sizes to 4
-    // bytes to match firmware expectations.
-    if (cluster_.arch() == tt::ARCH::QUASAR) {
-        dram_to_noc_sz_in_bytes = tt::align(dram_to_noc_sz_in_bytes, 4u);
-        l1_to_noc_sz_in_bytes = tt::align(l1_to_noc_sz_in_bytes, 4u);
+    // Firmware uses bank_noc_xy_t (uint32_t for Quasar configs with odd bank counts, uint16_t otherwise)
+    // to ensure table sizes are always 4-byte aligned for l1_to_local_mem_copy. Match that here.
+    const uint32_t dram_noc_xy_size = dram_bank_to_noc_xy_[device_id].size();
+    const uint32_t l1_noc_xy_size = l1_bank_to_noc_xy_[device_id].size();
+    const uint32_t num_nocs = hal_.get_num_nocs();
+    const bool use_u32_entries = (cluster_.arch() == tt::ARCH::QUASAR) &&
+                                 ((dram_noc_xy_size / num_nocs) % 2 != 0 || (l1_noc_xy_size / num_nocs) % 2 != 0);
+
+    std::vector<uint32_t> dram_noc_xy_padded, l1_noc_xy_padded;
+    void* dram_noc_data;
+    void* l1_noc_data;
+    uint32_t dram_to_noc_sz_in_bytes;
+    uint32_t l1_to_noc_sz_in_bytes;
+
+    if (use_u32_entries) {
+        dram_noc_xy_padded.assign(dram_bank_to_noc_xy_[device_id].begin(), dram_bank_to_noc_xy_[device_id].end());
+        l1_noc_xy_padded.assign(l1_bank_to_noc_xy_[device_id].begin(), l1_bank_to_noc_xy_[device_id].end());
+        dram_noc_data = dram_noc_xy_padded.data();
+        l1_noc_data = l1_noc_xy_padded.data();
+        dram_to_noc_sz_in_bytes = dram_noc_xy_size * sizeof(uint32_t);
+        l1_to_noc_sz_in_bytes = l1_noc_xy_size * sizeof(uint32_t);
+    } else {
+        dram_noc_data = dram_bank_to_noc_xy_[device_id].data();
+        l1_noc_data = l1_bank_to_noc_xy_[device_id].data();
+        dram_to_noc_sz_in_bytes = dram_noc_xy_size * sizeof(uint16_t);
+        l1_to_noc_sz_in_bytes = l1_noc_xy_size * sizeof(uint16_t);
     }
+
     const uint32_t dram_offset_sz_in_bytes = dram_bank_offset_map_[device_id].size() * sizeof(int32_t);
     const uint32_t l1_offset_sz_in_bytes = l1_bank_offset_map_[device_id].size() * sizeof(int32_t);
 
@@ -582,21 +602,11 @@ void RiscFirmwareInitializer::initialize_device_bank_to_noc_tables(
     if (end_core.has_value()) {
         auto start_core = virtual_core;
         cluster_.noc_multicast_write(
-            dram_bank_to_noc_xy_[device_id].data(),
-            dram_to_noc_sz_in_bytes,
-            device_id,
-            start_core,
-            end_core.value(),
-            mem_bank_to_noc_addr);
+            dram_noc_data, dram_to_noc_sz_in_bytes, device_id, start_core, end_core.value(), mem_bank_to_noc_addr);
 
         uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
         cluster_.noc_multicast_write(
-            l1_bank_to_noc_xy_[device_id].data(),
-            l1_to_noc_sz_in_bytes,
-            device_id,
-            start_core,
-            end_core.value(),
-            l1_noc_addr);
+            l1_noc_data, l1_to_noc_sz_in_bytes, device_id, start_core, end_core.value(), l1_noc_addr);
 
         uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
         cluster_.noc_multicast_write(
@@ -617,17 +627,10 @@ void RiscFirmwareInitializer::initialize_device_bank_to_noc_tables(
             l1_offset_addr);
     } else {
         cluster_.write_core(
-            dram_bank_to_noc_xy_[device_id].data(),
-            dram_to_noc_sz_in_bytes,
-            tt_cxy_pair(device_id, virtual_core),
-            mem_bank_to_noc_addr);
+            dram_noc_data, dram_to_noc_sz_in_bytes, tt_cxy_pair(device_id, virtual_core), mem_bank_to_noc_addr);
 
         uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
-        cluster_.write_core(
-            l1_bank_to_noc_xy_[device_id].data(),
-            l1_to_noc_sz_in_bytes,
-            tt_cxy_pair(device_id, virtual_core),
-            l1_noc_addr);
+        cluster_.write_core(l1_noc_data, l1_to_noc_sz_in_bytes, tt_cxy_pair(device_id, virtual_core), l1_noc_addr);
 
         uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
         cluster_.write_core(

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -64,7 +64,7 @@ inline std::string get_core_descriptor_file(
                 case tt::ARCH::WORMHOLE_B0: return core_desc_dir + "wormhole_b0_versim_1x1_arch.yaml";
                 case tt::ARCH::BLACKHOLE: return core_desc_dir + "blackhole_simulation_1x2_arch.yaml";
                 case tt::ARCH::QUASAR:
-                    // Small Quasar sims: x_size=1 → 1x3, x_size=2 → 2x3
+                    // Small Quasar sims: x_size=1 -> 1x3, x_size=2 -> 2x3
                     if (grid_size.x >= 2) {
                         return core_desc_dir + "quasar_simulation_2x3_arch.yaml";
                     }

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -52,53 +52,53 @@ inline std::string get_core_descriptor_file(
     }
     core_desc_dir += "tt_metal/core_descriptors/";
 
-    bool use_small_core_desc_yaml = false; // override to a different core descriptor for small RTL sims
     if (env.get_rtoptions().get_simulator_enabled()) {
         auto soc_desc = tt::umd::SimulationChip::get_soc_descriptor_path_from_simulator_path(
             env.get_rtoptions().get_simulator_path());
         tt_xy_pair grid_size = tt::umd::SocDescriptor::get_grid_size_from_soc_descriptor_path(soc_desc);
-        if (grid_size.y <= 2 || grid_size.x <= 2) {  // these SOC descriptors declare a 2x2 grid
-            use_small_core_desc_yaml = true;
+        if (grid_size.y <= 2 || grid_size.x <= 2) {  // small simulation grids (any dimension <= 2)
+            switch (arch) {
+                default:
+                    throw std::runtime_error(
+                        "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
+                case tt::ARCH::WORMHOLE_B0: return core_desc_dir + "wormhole_b0_versim_1x1_arch.yaml";
+                case tt::ARCH::BLACKHOLE: return core_desc_dir + "blackhole_simulation_1x2_arch.yaml";
+                case tt::ARCH::QUASAR:
+                    // Small Quasar sims: x_size=1 → 1x3, x_size=2 → 2x3
+                    if (grid_size.x >= 2) {
+                        return core_desc_dir + "quasar_simulation_2x3_arch.yaml";
+                    }
+                    return core_desc_dir + "quasar_simulation_1x3_arch.yaml";
+            };
         }
     }
-    if (use_small_core_desc_yaml) {
-        switch (arch) {
-            default:
-                throw std::runtime_error(
-                    "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
-            case tt::ARCH::WORMHOLE_B0: return core_desc_dir + "wormhole_b0_versim_1x1_arch.yaml";
-            case tt::ARCH::BLACKHOLE: return core_desc_dir + "blackhole_simulation_1x2_arch.yaml";
-            case tt::ARCH::QUASAR: return core_desc_dir + "quasar_simulation_1x3_arch.yaml";
-        };
-    } else {
-        // Check if fabric tensix is enabled based on fabric tensix config
-        tt_fabric::FabricTensixConfig fabric_tensix_config = env.get_fabric_tensix_config();
-        bool use_fabric_tensix = (fabric_tensix_config != tt_fabric::FabricTensixConfig::DISABLED);
+    // Check if fabric tensix is enabled based on fabric tensix config
+    tt_fabric::FabricTensixConfig fabric_tensix_config = env.get_fabric_tensix_config();
+    bool use_fabric_tensix = (fabric_tensix_config != tt_fabric::FabricTensixConfig::DISABLED);
 
-        auto core_type = get_core_type_from_config(dispatch_core_config);
-        switch (arch) {
-            default:
-                throw std::runtime_error(
-                    "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
-            case tt::ARCH::WORMHOLE_B0:
-                if (core_type == CoreType::ETH) {
-                    return core_desc_dir + "wormhole_b0_80_arch_eth_dispatch.yaml";
-                } else if (use_fabric_tensix) {
-                    return core_desc_dir + "wormhole_b0_80_arch_fabric_mux.yaml";
-                } else {
-                    return core_desc_dir + "wormhole_b0_80_arch.yaml";
-                }
-            case tt::ARCH::BLACKHOLE:
-                if (core_type == CoreType::ETH) {
-                    return core_desc_dir + "blackhole_140_arch_eth_dispatch.yaml";
-                } else if (use_fabric_tensix) {
-                    return core_desc_dir + "blackhole_140_arch_fabric_mux.yaml";
-                } else {
-                    return core_desc_dir + "blackhole_140_arch.yaml";
-                }
-            case tt::ARCH::QUASAR: return core_desc_dir + "quasar_simulation_8x4_arch.yaml";
-        };
-    }
+    auto core_type = get_core_type_from_config(dispatch_core_config);
+    switch (arch) {
+        default:
+            throw std::runtime_error(
+                "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
+        case tt::ARCH::WORMHOLE_B0:
+            if (core_type == CoreType::ETH) {
+                return core_desc_dir + "wormhole_b0_80_arch_eth_dispatch.yaml";
+            } else if (use_fabric_tensix) {
+                return core_desc_dir + "wormhole_b0_80_arch_fabric_mux.yaml";
+            } else {
+                return core_desc_dir + "wormhole_b0_80_arch.yaml";
+            }
+        case tt::ARCH::BLACKHOLE:
+            if (core_type == CoreType::ETH) {
+                return core_desc_dir + "blackhole_140_arch_eth_dispatch.yaml";
+            } else if (use_fabric_tensix) {
+                return core_desc_dir + "blackhole_140_arch_fabric_mux.yaml";
+            } else {
+                return core_desc_dir + "blackhole_140_arch.yaml";
+            }
+        case tt::ARCH::QUASAR: return core_desc_dir + "quasar_simulation_8x4_arch.yaml";
+    };
     return "";
 }
 


### PR DESCRIPTION
#41793 

Adds support for a 2x3 Quasar simulation grid by introducing a new core descriptor (`quasar_simulation_2x3_arch.yaml`) and updating the descriptor selection logic to distinguish between 1x3 and 2x3 small Quasar simulations.

The 1x3 and 2x3 configurations expose an odd number of DRAM/L1 banks, which results in bank table sizes that aren't naturally 4-byte aligned. This wasn't a problem with the 1x3 config because the table sizes are small enough that the word count passed to `l1_to_local_mem_copy` truncates to 0, effectively making the copy a no-op. Since `l1_to_local_mem_copy` reads 4-byte words, in order to support this, bank table elements are now `uint32_t` when the bank count is odd, otherwise they remain as `uint16_t`.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_2x3_core_desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_2x3_core_desc)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_2x3_core_desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_2x3_core_desc)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_2x3_core_desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_2x3_core_desc)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_2x3_core_desc) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_2x3_core_desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_2x3_core_desc) | [#2524](https://github.com/tenstorrent/tt-metal/actions/runs/24260220858) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_2x3_core_desc) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_2x3_core_desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_2x3_core_desc) | [#17339](https://github.com/tenstorrent/tt-metal/actions/runs/24260227386) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_2x3_core_desc) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_2x3_core_desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_2x3_core_desc) | [#5097](https://github.com/tenstorrent/tt-metal/actions/runs/24260239157) |