### PR TITLE
 [skip ci] Fix the folder where the slack_message.json file is expected to be.

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -63,12 +63,17 @@ jobs:
           SLACK_CHANNEL_ID: ${{ inputs.slack_channel_id != '' && inputs.slack_channel_id || secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
 
       - name: Export triage result for data pipeline
-        if: ${{ !cancelled() && hashFiles('output/slack_message.json') != '' }}
+        if: ${{ !cancelled() }}
         shell: bash
         run: |
-          JOB_ID=$(jq -r '.failing_run_url' output/slack_message.json \
+          SLACK_MSG=".auto_triage/output/slack_message.json"
+          if [ ! -f "$SLACK_MSG" ]; then
+            echo "$SLACK_MSG not found, skipping"
+            exit 0
+          fi
+          JOB_ID=$(jq -r '.failing_run_url' "$SLACK_MSG" \
                    | grep -oE '/job/[0-9]+' | grep -oE '[0-9]+')
           jq -n --arg job_id "$JOB_ID" \
              --arg run_id "$GITHUB_RUN_ID" \
              '{github_job_id: ($job_id|tonumber),
-               auto_triage_run_id: ($run_id|tonumber)}' > output/auto_triage_result.json
+              auto_triage_run_id: ($run_id|tonumber)}' > .auto_triage/output/auto_triage_result.json


### PR DESCRIPTION
### Ticket
#0

### Problem description

The correct path is `.auto_triage/output/slack_message.json`, not `output/slack_message.json`

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dimitri/fix-auto-triage-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dimitri/fix-auto-triage-pipeline)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dimitri/fix-auto-triage-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dimitri/fix-auto-triage-pipeline)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dimitri/fix-auto-triage-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dimitri/fix-auto-triage-pipeline)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dimitri/fix-auto-triage-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dimitri/fix-auto-triage-pipeline)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dimitri/fix-auto-triage-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dimitri/fix-auto-triage-pipeline)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dimitri/fix-auto-triage-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dimitri/fix-auto-triage-pipeline)
  - [ ] `models-mandatory` preset (runs: [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
