### PR TITLE
[Bug Fix]: Fix stack usage measurement on Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -94,16 +94,17 @@ void RunOneTest(
     }
 
     // Create compute kernels
-    // TODO: Watcher features are temporarily skipped on Quasar until basic runtime bring-up for TRISCs is complete
-    auto num_processor_classes = hal.get_processor_classes_count(HalProgrammableCoreType::TENSIX);
-    if (!is_quasar && num_processor_classes > 1) {
-        auto num_compute_types = hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 1);
+    if (is_quasar) {
+        experimental::quasar::CreateKernel(
+            program_, path, coord, experimental::quasar::QuasarComputeConfig{.compile_args = compile_args});
+    } else {
         CreateKernel(program_, path, coord, ComputeConfig{.compile_args = compile_args});
-        for (uint32_t type_idx = 0; type_idx < num_compute_types; type_idx++) {
-            uint32_t processor_idx =
-                hal.get_processor_index(HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, type_idx);
-            add_expected_msg(hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, processor_idx, false));
-        }
+    }
+    auto num_compute_types = hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 1);
+    for (uint32_t type_idx = 0; type_idx < num_compute_types; type_idx++) {
+        uint32_t processor_idx =
+            hal.get_processor_index(HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, type_idx);
+        add_expected_msg(hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, processor_idx, false));
     }
 
     // Also run on idle ethernet, if present

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -28,7 +28,8 @@ void RunOneTest(
     MeshWatcherFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     unsigned free,
-    std::optional<uint32_t> quasar_dms_per_kernel = std::nullopt) {
+    std::optional<uint32_t> quasar_dms_per_kernel = std::nullopt,
+    bool is_legacy_kernel = false) {
     const auto& hal = MetalContext::instance().hal();
     const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
     const std::string path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp";
@@ -74,7 +75,9 @@ void RunOneTest(
                 path,
                 coord,
                 tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                    .num_threads_per_cluster = dms_per_kernel, .compile_args = compile_args});
+                    .num_threads_per_cluster = dms_per_kernel,
+                    .compile_args = compile_args,
+                    .is_legacy_kernel = is_legacy_kernel});
         }
     } else {
         // BH/WH:
@@ -137,6 +140,7 @@ struct StackUsageTestParams {
     unsigned free_bytes;
     std::optional<uint32_t> quasar_dms_per_kernel;  // nullopt = default (all DMs), value = multi-kernel mode
     bool quasar_only;                               // If true, skip on non-Quasar
+    bool is_legacy_kernel;                          // If true, use legacy kernel mode on Quasar
 };
 
 class StackUsageTest : public MeshWatcherFixture, public ::testing::WithParamInterface<StackUsageTestParams> {};
@@ -152,7 +156,7 @@ TEST_P(StackUsageTest, TestWatcherStackUsage) {
     for (auto& mesh_device : this->devices_) {
         this->RunTestOnDevice(
             [&params](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) {
-                RunOneTest(f, d, params.free_bytes, params.quasar_dms_per_kernel);
+                RunOneTest(f, d, params.free_bytes, params.quasar_dms_per_kernel, params.is_legacy_kernel);
             },
             mesh_device);
     }
@@ -163,9 +167,12 @@ INSTANTIATE_TEST_SUITE_P(
     StackUsageTest,
     ::testing::Values(
         // Standard tests (all architectures, default Quasar uses single kernel with all DMs)
-        StackUsageTestParams{"StackUsage0", 0, std::nullopt, false},
-        StackUsageTestParams{"StackUsage16", 16, std::nullopt, false},
+        StackUsageTestParams{"StackUsage0", 0, std::nullopt, false, false},
+        StackUsageTestParams{"StackUsage16", 16, std::nullopt, false, false},
         // Quasar only: multi-kernel mode (launch 8 kernels in total, each mapped to a unique DM each)
-        StackUsageTestParams{"StackUsage0_QuasarMultiKernel", 0, 1, true},
-        StackUsageTestParams{"StackUsage16_QuasarMultiKernel", 16, 1, true}),
+        StackUsageTestParams{"StackUsage0_QuasarMultiKernel", 0, 1, true, false},
+        StackUsageTestParams{"StackUsage16_QuasarMultiKernel", 16, 1, true, false},
+        // Quasar only: legacy kernel mode
+        StackUsageTestParams{"StackUsage0_QuasarLegacy", 0, 1, true, true},
+        StackUsageTestParams{"StackUsage16_QuasarLegacy", 16, 1, true, true}),
     [](const ::testing::TestParamInfo<StackUsageTestParams>& info) { return info.param.test_name; });

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp
@@ -14,7 +14,10 @@ void kernel_main() {
     uint32_t *sp;
     asm ("mv %0,sp" : "=r"(sp));
 
-    // Do not scribble above stack pointer.
-    if (sp > point)
+    // When usage == 0 we're testing full-overflow detection; write
+    // unconditionally since SP may already be below the stack base
+    // on cores with small stacks
+    if (sp > point || usage == 0) {
         *point = 0;
+    }
 }

--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -32,8 +32,8 @@ extern "C" [[gnu::section(".start")]]
 uint32_t _start() {
     // Enable GPREL optimizations.
     // asm("0: .reloc 0b, R_RISCV_NONE, __global_pointer$");
-    mark_stack_usage();
 #if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
+    mark_stack_usage();
     wait_for_go_message();
 #ifdef KERNEL_RUN_TIME
     uint64_t end_time = c_tensix_core::read_wall_clock() + KERNEL_RUN_TIME;
@@ -83,11 +83,15 @@ uint32_t _start() {
     wait_for_go_message();
     {
         DeviceZoneScopedMainChildN("BRISC-KERNEL");
-        EARLY_RETURN_FOR_DEBUG
 
         // Setup after the go signal so the previous kernel has completed.
         num_sw_threads = launch_msg->kernel_config.num_sw_threads[hartid];
         my_thread_id = launch_msg->kernel_config.kernel_thread_id[hartid];
+
+        // Paint stack after all thread_local writes and CRT init are done.
+        mark_stack_usage();
+
+        EARLY_RETURN_FOR_DEBUG
 
         WAYPOINT("K");
         kernel_main();

--- a/tt_metal/hw/firmware/src/tt-2xx/trisck.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisck.cc
@@ -46,8 +46,8 @@ extern "C" [[gnu::section(".start")]]
 uint32_t _start() {
     // Enable GPREL optimizations.
     // asm("0: .reloc 0b, R_RISCV_NONE, __global_pointer$");
-    mark_stack_usage();
 #if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
+    mark_stack_usage();
     wait_for_go_message();
     DPRINT << "DEBUG_NULL_KERNELS got go message" << ENDL();
     DEVICE_PRINT("DEBUG_NULL_KERNELS got go message\n");
@@ -87,7 +87,12 @@ uint32_t _start() {
     RecordPerfCounters();
 
     DeviceZoneScopedMainChildN("TRISC-KERNEL");
+
+    // Paint stack after all thread_local writes and CRT init are done.
+    mark_stack_usage();
+
     EARLY_RETURN_FOR_DEBUG
+
     WAYPOINT("K");
     run_kernel();
     WAYPOINT("KD");

--- a/tt_metal/hw/inc/internal/debug/stack_usage.h
+++ b/tt_metal/hw/inc/internal/debug/stack_usage.h
@@ -20,9 +20,7 @@ constexpr uint32_t stack_usage_pattern = 0xBABABABA;
 static inline uint32_t* get_stack_base() {
 #if defined(ARCH_QUASAR)
     extern thread_local uint32_t __stack_base_lwm[];
-    extern char __stack_base_offset;
-    uint32_t* __stack_base = &__stack_base_lwm[uintptr_t(&__stack_base_offset)];
-    return __stack_base;
+    return __stack_base_lwm;
 #else
     extern uint32_t __stack_base[];
     return __stack_base;


### PR DESCRIPTION
### Ticket
NA

### Problem description
Stack usage reporting on Quasar was always showing "0 bytes free (OVERFLOW)" for all cores, even with minimal stack usage. 
Two root causes: 
1. `mark_stack_usage()` was called before `do_thread_crt1()` and thread_local variable writes, which overwrote the painted pattern at the stack base.
2. `get_stack_base()` was indexing `__stack_base_lwm[&__stack_base_offset]` with a manual offset, but since `__stack_base_lwm` is a thread_local TLS symbol, the per-thread offset is already handled by TLS and the extra indexing was unnecessary.

### What's changed
- `stack_usage.h`: Simplified ARCH_QUASAR path in get_stack_base() to use the per-thread TLS symbol __stack_base_lwm.
- dmk.cc / trisck.cc: Moved `mark_stack_usage()` after `do_thread_crt1()` and all thread_local variable assignments so the painted pattern isn't clobbered.
- `watcher_stack.cpp`: Handle the case where SP is already below the stack base by unconditionally scribbling when testing full-overflow detection.
- `test_stack_usage.cpp`: Added compute kernel dispatch to run stack usage tests on all 4 NEO engines.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/quasar_fix_stack_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/quasar_fix_stack_usage)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/quasar_fix_stack_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/quasar_fix_stack_usage)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/quasar_fix_stack_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/quasar_fix_stack_usage)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/quasar_fix_stack_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/quasar_fix_stack_usage)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/quasar_fix_stack_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/quasar_fix_stack_usage)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/quasar_fix_stack_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/quasar_fix_stack_usage)
  - [ ] `models-mandatory` preset (runs: [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Click a pipeline name to open the workflow dispatch page._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml) | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) |
| [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) | ❌ | [#5100](https://github.com/tenstorrent/tt-metal/actions/runs/24261243164) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml) *(opt-in)* | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml) *(opt-in)* | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml) *(opt-in)* | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml) |