### PR TITLE
[Feature] use xxhash for stable hash

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -35,6 +35,7 @@
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
+#include <tt_stl/fmt.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -29,10 +29,12 @@ endif()
 ############################################################################################################################
 
 CPMAddPackage(NAME xxHash GITHUB_REPOSITORY Cyan4973/xxHash GIT_TAG v0.8.2 DOWNLOAD_ONLY YES)
-if(xxHash_ADDED)
+if(NOT TARGET xxHash)
     add_library(xxHash INTERFACE)
-    add_library(xxHash::xxHash ALIAS xxHash)
     target_include_directories(xxHash SYSTEM INTERFACE "$<BUILD_INTERFACE:${xxHash_SOURCE_DIR}>")
+endif()
+if(NOT TARGET xxHash::xxHash)
+    add_library(xxHash::xxHash ALIAS xxHash)
 endif()
 
 ############################################################################################################################

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -25,6 +25,17 @@ if(NOT HWLOC_LIBRARY)
 endif()
 
 ############################################################################################################################
+# xxHash : https://github.com/Cyan4973/xxHash
+############################################################################################################################
+
+CPMAddPackage(NAME xxHash GITHUB_REPOSITORY Cyan4973/xxHash GIT_TAG v0.8.2 DOWNLOAD_ONLY YES)
+if(xxHash_ADDED)
+    add_library(xxHash INTERFACE)
+    add_library(xxHash::xxHash ALIAS xxHash)
+    target_include_directories(xxHash SYSTEM INTERFACE "$<BUILD_INTERFACE:${xxHash_SOURCE_DIR}>")
+endif()
+
+############################################################################################################################
 # Boost
 ############################################################################################################################
 

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
         umd::tt-umd
         simde::simde
         Taskflow::Taskflow
+        xxHash
     PRIVATE
         Metalium::Metal::Hardware
         Tracy::TracyClient

--- a/tt_metal/common/stable_hash.hpp
+++ b/tt_metal/common/stable_hash.hpp
@@ -10,6 +10,7 @@
 
 #define XXH_INLINE_ALL
 #include "xxhash.h"
+#undef XXH_INLINE_ALL
 
 namespace tt {
 

--- a/tt_metal/common/stable_hash.hpp
+++ b/tt_metal/common/stable_hash.hpp
@@ -14,36 +14,20 @@
 namespace tt {
 
 // Stable hash for cache paths and persistence.
-//
-// Uses xxHash (XXH3_64bits) for speed and collision resistance.
-// XXH3 is significantly faster than FNV1a on large inputs thanks to
-// vectorised instruction use and better mixing.  The streaming API
-// (XXH3_state_t) allows incremental feeding, matching the old
-// FNV1a::update() pattern.
-//
-// NOTE: This is a drop-in replacement for the previous FNV1a class.
-//       Hash values are NOT compatible with old caches — a one-time
-//       cache rebuild will happen automatically.
 class StableHasher {
 public:
     StableHasher() { XXH3_64bits_reset(&state_); }
 
     void update(uint64_t data) { XXH3_64bits_update(&state_, &data, sizeof(data)); }
 
-    // Bulk update from a raw pointer range — the fast path.
-    // Passes the entire region to xxHash in a single call.
     void update(const void* data, std::size_t size) { XXH3_64bits_update(&state_, data, size); }
 
-    // Contiguous char* range — delegates to the bulk overload.
-    // Preferred over the generic iterator template for buffered reads.
     void update(const char* begin, const char* end) {
         if (begin < end) {
             XXH3_64bits_update(&state_, begin, static_cast<std::size_t>(end - begin));
         }
     }
 
-    // Generic iterator range fallback — element by element.
-    // Prefer the pointer overloads above for contiguous data.
     template <typename ForwardIterator>
     void update(ForwardIterator begin, ForwardIterator end) {
         for (auto it = begin; it != end; ++it) {
@@ -58,9 +42,5 @@ public:
 private:
     XXH3_state_t state_;
 };
-
-// Backward-compatible alias — existing call sites use tt::FNV1a.
-// TODO(#41672): Migrate callers to StableHasher, then remove this alias.
-using FNV1a = StableHasher;
 
 }  // namespace tt

--- a/tt_metal/common/stable_hash.hpp
+++ b/tt_metal/common/stable_hash.hpp
@@ -5,25 +5,45 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <string>
+
+#define XXH_INLINE_ALL
+#include "xxhash.h"
 
 namespace tt {
 
-// Stable hash for cache paths and persistence. std::hash is not guaranteed to be
-// stable across runs or implementations.
-class FNV1a {
+// Stable hash for cache paths and persistence.
+//
+// Uses xxHash (XXH3_64bits) for speed and collision resistance.
+// XXH3 is significantly faster than FNV1a on large inputs thanks to
+// vectorised instruction use and better mixing.  The streaming API
+// (XXH3_state_t) allows incremental feeding, matching the old
+// FNV1a::update() pattern.
+//
+// NOTE: This is a drop-in replacement for the previous FNV1a class.
+//       Hash values are NOT compatible with old caches — a one-time
+//       cache rebuild will happen automatically.
+class StableHasher {
 public:
-    // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-    static constexpr uint64_t FNV_PRIME = 0x100000001b3;
-    static constexpr uint64_t FNV_OFFSET = 0xcbf29ce484222325;
+    StableHasher() { XXH3_64bits_reset(&state_); }
 
-    FNV1a(uint64_t offset = FNV_OFFSET) : hash_(offset) {}
+    void update(uint64_t data) { XXH3_64bits_update(&state_, &data, sizeof(data)); }
 
-    void update(uint64_t data) {
-        hash_ ^= data;
-        hash_ *= FNV_PRIME;
+    // Bulk update from a raw pointer range — the fast path.
+    // Passes the entire region to xxHash in a single call.
+    void update(const void* data, std::size_t size) { XXH3_64bits_update(&state_, data, size); }
+
+    // Contiguous char* range — delegates to the bulk overload.
+    // Preferred over the generic iterator template for buffered reads.
+    void update(const char* begin, const char* end) {
+        if (begin < end) {
+            XXH3_64bits_update(&state_, begin, static_cast<std::size_t>(end - begin));
+        }
     }
 
+    // Generic iterator range fallback — element by element.
+    // Prefer the pointer overloads above for contiguous data.
     template <typename ForwardIterator>
     void update(ForwardIterator begin, ForwardIterator end) {
         for (auto it = begin; it != end; ++it) {
@@ -31,12 +51,16 @@ public:
         }
     }
 
-    void update(const std::string& s) { update(s.begin(), s.end()); }
+    void update(const std::string& s) { XXH3_64bits_update(&state_, s.data(), s.size()); }
 
-    uint64_t digest() const { return hash_; }
+    uint64_t digest() const { return XXH3_64bits_digest(&state_); }
 
 private:
-    uint64_t hash_;
+    XXH3_state_t state_;
 };
+
+// Backward-compatible alias — existing call sites use tt::FNV1a.
+// TODO(#41672): Migrate callers to StableHasher, then remove this alias.
+using FNV1a = StableHasher;
 
 }  // namespace tt

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -407,7 +407,7 @@ std::string ComputeKernel::config_hash() const {
 }
 
 uint64_t Kernel::compute_hash() const {
-    tt::FNV1a hasher;
+    tt::StableHasher hasher;
     for (const auto& [define, value] : this->defines_) {
         hasher.update(define);
         hasher.update(value);

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -15,13 +15,14 @@
 #include "core_coord.hpp"
 #include "hal_types.hpp"
 #include "jit_build/jit_build_settings.hpp"
-#include "jit_build/jit_build_options.hpp"
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel_source.hpp"
 #include <enchantum/enchantum.hpp>
 #include "tt_cluster.hpp"
 
 namespace tt::tt_metal {
+
+class JitBuildOptions;
 
 enum Eth : uint8_t {
     SENDER = 0,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -165,7 +165,7 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions&
     // Store the build key into the KernelCompile hash. This will be unique per command queue
     // configuration (necessary for dispatch kernels).
     // watcher/dprint enabled are accounted for in the build key.
-    tt::FNV1a hasher;
+    tt::StableHasher hasher;
     hasher.update(build_key);
     hasher.update(stable_hash_hlk_desc(build_options.hlk_desc));
     hasher.update(kernel->compute_hash());

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -288,7 +288,7 @@ void JitBuildEnv::init(
     this->lflags_ += "-Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -nostartfiles ";
 
     // Need to capture more info in build key to prevent stale binaries from being reused.
-    tt::FNV1a hasher;
+    tt::StableHasher hasher;
     hasher.update(build_key);
     hasher.update(enchantum::to_underlying(this->arch_));
     hasher.update(cflags_);
@@ -431,7 +431,7 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
     // (e.g. after a code change that modifies HAL output), the hash changes and cached
     // objects are invalidated, preventing stale binaries from being reused.
     {
-        tt::FNV1a hasher;
+        tt::StableHasher hasher;
         hasher.update(env_.gpp_);
         hasher.update(cflags_);
         hasher.update(defines_);

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -84,7 +84,7 @@ std::map<std::string, std::string> initialize_device_kernel_defines(const JitDev
 
 uint64_t compute_build_key(const JitDeviceConfig& config, const llrt::RunTimeOptions& rtoptions) {
     // Collect all the parameters that affect the build configuration
-    FNV1a hasher;
+    StableHasher hasher;
 
     hasher.update(static_cast<uint32_t>(config.dispatch_core_type));
     hasher.update(static_cast<uint32_t>(config.dispatch_core_axis));

--- a/tt_metal/jit_build/depend.cpp
+++ b/tt_metal/jit_build/depend.cpp
@@ -67,7 +67,7 @@ ParsedDependencies parse_dependency_file(std::istream& file) {
 namespace {
 
 uint64_t hash_file_content(std::istream& file) {
-    tt::FNV1a hasher;
+    tt::StableHasher hasher;
     char buf[65536];
     for (;;) {
         file.read(buf, sizeof(buf));

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -106,7 +106,7 @@ public:
 }  // namespace tt
 
 inline uint64_t stable_hash_hlk_desc(const tt::tt_hlk_desc& obj) {
-    tt::FNV1a hasher;
+    tt::StableHasher hasher;
     for (size_t i = 0; i < obj.buf_dataformat_arr.size(); i++) {
         hasher.update(static_cast<uint64_t>(obj.get_buf_dataformat(i)));
         hasher.update(static_cast<uint64_t>(obj.get_buf_tile_r_dim(i)));

--- a/tt_metal/llrt/hal/tt-2xx/CMakeLists.txt
+++ b/tt_metal/llrt/hal/tt-2xx/CMakeLists.txt
@@ -40,4 +40,5 @@ target_link_libraries(
         umd::tt-umd
         TT::STL
         tt-logger::tt-logger
+        xxHash
 )

--- a/tt_metal/llrt/hal/tt-2xx/CMakeLists.txt
+++ b/tt_metal/llrt/hal/tt-2xx/CMakeLists.txt
@@ -40,5 +40,4 @@ target_link_libraries(
         umd::tt-umd
         TT::STL
         tt-logger::tt-logger
-        xxHash
 )

--- a/tt_metal/tools/precompile_fw/CMakeLists.txt
+++ b/tt_metal/tools/precompile_fw/CMakeLists.txt
@@ -7,6 +7,7 @@ target_link_libraries(
         tt_metal
         Metalium::Metal::Hardware
         yaml-cpp::yaml-cpp
+        xxHash
 )
 
 target_include_directories(precompile_fw PRIVATE ${PROJECT_SOURCE_DIR}/tt_metal)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41672

### Problem description
> xxHash is significantly faster than FNV1a, especially on large inputs, due to its optimized, modern hashing algorithms that make better use of CPU instructions. It also offers stronger collision resistance, reducing the likelihood of hash collisions compared to FNV1a's relatively weak mixing and smaller internal state.

### What's changed
Added an external dependency on xxHash and removed FNV1a implementation.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/xxhash)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/xxhash)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/xxhash)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/xxhash)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/xxhash)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/xxhash)
  - [ ] `models-mandatory` preset (runs: [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/xxhash) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/xxhash) | [#2541](https://github.com/tenstorrent/tt-metal/actions/runs/24266636798) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/xxhash) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/xxhash) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/xxhash) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/xxhash) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/xxhash) | [#5107](https://github.com/tenstorrent/tt-metal/actions/runs/24266642553) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/xxhash) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/xxhash) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/xxhash) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/xxhash) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/xxhash) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/xxhash) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/xxhash) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/xxhash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/xxhash) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/xxhash) |