### PR TITLE
[Test]: Correct src address that data is written to for tensix to dm dfb tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -259,14 +259,22 @@ void run_single_dfb_program(
 
     // For Tensix → DM: pre-fill each core's DFB L1 with its input chunk so the
     // Tensix producer kernel can read from L1 while DM consumer drains to DRAM.
+    //
+    // l1_by_core addresses are not populated until allocate_dataflow_buffers() runs
+    // during program compilation. Since this is a single-DFB test it is always placed at the L1 base allocator address.
     if (producer_type == DFBPorCType::TENSIX) {
-        for (const auto& group : dfb->groups) {
-            for (const auto& [core, alloc_addr] : group.l1_by_core) {
-                const uint32_t co = core_to_chunk_offset.at(core);
-                std::vector<uint32_t> slice(
-                    input.begin() + co * entry_size / sizeof(uint32_t),
-                    input.begin() + co * entry_size / sizeof(uint32_t) + words_per_core);
-                detail::WriteToDeviceL1(device, core, alloc_addr, slice);
+        const uint32_t dfb_l1_addr =
+            static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+        for (const CoreRange& cr : core_range_set.ranges()) {
+            for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
+                for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
+                    const CoreCoord core(x, y);
+                    const uint32_t co = core_to_chunk_offset.at(core);
+                    std::vector<uint32_t> slice(
+                        input.begin() + co * entry_size / sizeof(uint32_t),
+                        input.begin() + co * entry_size / sizeof(uint32_t) + words_per_core);
+                    detail::WriteToDeviceL1(device, core, dfb_l1_addr, slice);
+                }
             }
         }
     }


### PR DESCRIPTION
### Summary
Tensix to DM DFB tests were failing because they were writing to sram before dfb address was allocated. We don't expose the DFB addresses so these tests now take advantage of knowing there is only 1 dfb and it starts allocation from base allocator address

### CI Status
_Auto-generated on every push. Click a pipeline name to open the workflow dispatch page._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml) | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) |
| [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) | https://github.com/tenstorrent/tt-metal/actions/runs/24269505333 | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml) *(opt-in)* | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml) *(opt-in)* | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml) *(opt-in)* | ➖ | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml) |