### PR TITLE
Bug: Start using JitBuildState::get_target_name instead of GetRiscName

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -435,7 +435,7 @@ void DevicePrintImpl::print_buffer_data(
                 hal.get_processor_class_and_type_from_index(programmable_core_type, header->risc_id);
             const auto& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
                 device_id, programmable_core_type_idx, static_cast<uint32_t>(processor_class), processor_type_idx);
-            auto risc_name = build_state.get_target_name();
+            const auto& risc_name = build_state.get_target_name();
             auto elf_path = std::filesystem::path(kernel_path) / risc_name / (risc_name + ".elf");
             risc_data.kernel_elf_path = elf_path.string();
             risc_data.kernel_elf_parser = DevicePrintParser::get_parser_for_elf(elf_path);

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -431,9 +431,11 @@ void DevicePrintImpl::print_buffer_data(
 
             // Find elf path from inspector using kernel id
             auto kernel_path = Inspector::get_kernel_path_from_watcher_kernel_id(header->info_id);
-            auto risc_name = GetRiscName(cluster, hal, device_id, logical_core, header->risc_id);
-            std::transform(
-                risc_name.begin(), risc_name.end(), risc_name.begin(), [](auto c) { return std::tolower(c); });
+            auto [processor_class, processor_type_idx] =
+                hal.get_processor_class_and_type_from_index(programmable_core_type, header->risc_id);
+            const auto& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+                device_id, programmable_core_type_idx, static_cast<uint32_t>(processor_class), processor_type_idx);
+            auto risc_name = build_state.get_target_name();
             auto elf_path = std::filesystem::path(kernel_path) / risc_name / (risc_name + ".elf");
             risc_data.kernel_elf_path = elf_path.string();
             risc_data.kernel_elf_parser = DevicePrintParser::get_parser_for_elf(elf_path);


### PR DESCRIPTION
`GetRiscName()` doesn't return the same value as `JitBuildState::get_target_name()` for idle ETH.
Updating `DevicePrintImpl::print_buffer_data()` to start using `JitBuildState` for getting kernel path.

Closes #41867.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/bug_fix_41867) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/bug_fix_41867)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/bug_fix_41867) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/bug_fix_41867) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/bug_fix_41867) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/bug_fix_41867)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/bug_fix_41867) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/bug_fix_41867) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/bug_fix_41867) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/bug_fix_41867)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/bug_fix_41867) | [#5116](https://github.com/tenstorrent/tt-metal/actions/runs/24273913544) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/bug_fix_41867) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/bug_fix_41867)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/bug_fix_41867) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/bug_fix_41867) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/bug_fix_41867) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/bug_fix_41867)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/bug_fix_41867) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/bug_fix_41867) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/bug_fix_41867) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/bug_fix_41867)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/bug_fix_41867) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/bug_fix_41867) |