### PR TITLE
Fix conv2d DRAM slicing L1 estimation for tile-padded edge slices

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -589,11 +589,16 @@ public:
         auto compute_grid_size = device->compute_with_storage_grid_size();
         auto conv_config = this->conv_config;
 
-        auto [input_start, input_end] = get_input_slice(output_slice_start, output_slice_end);
+        auto [input_slicing, slice_padding] = get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_start, input_end] = input_slicing;
         uint32_t input_slice_height = std::get<0>(input_end) - std::get<0>(input_start);
         uint32_t input_slice_width = std::get<1>(input_end) - std::get<1>(input_start);
-        uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
-        uint32_t output_slice_width = std::get<1>(output_slice_end) - std::get<1>(output_slice_start);
+        // Use padded output dimensions to match what the halo op actually produces.
+        // The halo output is tile-aligned, so edge slices get additional padding
+        // (e.g., output width 4 pads to 32). Without this, the shard spec is computed
+        // for the unpadded dimensions, leading to L1 underestimation.
+        auto [output_slice_height, output_slice_width] = calculate_output_image_size(
+            {input_slice_height, input_slice_width}, kernel_size, stride, slice_padding, dilation);
 
         bool single_slice =
             (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));


### PR DESCRIPTION
### Summary

closes https://github.com/tenstorrent/tt-metal/issues/41918

`get_input_memory_config()` computed the shard spec using raw (unpadded) output dimensions, but the halo op produces tile-padded output. For edge slices where the output width isn't a multiple of 32, the halo op pads the output to the next tile boundary (e.g., width 4 → 32). The shard spec was computed for the unpadded width, resulting in a much smaller L1 estimate than the actual runtime usage. The auto-slicer accepted a slice count that didn't actually fit in L1, causing circular buffers to clash with L1 data buffers.

The fix changes `get_input_memory_config()` to use `get_input_slice_and_padding() + calculate_output_image_size()` instead of raw output dimensions. This matches what get_L1_usage() already does, so the planner now sees the same padded dimensions as the executor. 

Nightly L2 for convs -  https://github.com/tenstorrent/tt-metal/actions/runs/24564784684
Sanity tests - https://github.com/tenstorrent/tt-metal/actions/runs/24558782980
