### PR TITLE
Add SRAM hot expert slots and on-device expert frequency tracking

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -49,6 +49,7 @@ class DecoderStage(StageKind):
         num_routed_experts: int,
         use_hardcoded_expert_index: bool,
         enable_routing: bool,
+        freq_window_size: int = 0,
     ) -> None:
         if state_dict is None and weights is None:
             raise ValueError("Either state_dict or weights must be provided")
@@ -65,6 +66,7 @@ class DecoderStage(StageKind):
         self._num_routed_experts = num_routed_experts
         self._use_hardcoded_expert_index = use_hardcoded_expert_index
         self._enable_routing = enable_routing
+        self._freq_window_size = freq_window_size
         self._state: dict[str, Any] = {}
 
     def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
@@ -177,6 +179,9 @@ class DecoderStage(StageKind):
             persistent_next_iter_semaphore=self._state.get("persistent_next_iter_semaphore"),
             persistent_mode=self._persistent_mode,
             is_torus=self._is_torus,
+            sram_slots=d.get("sram_slots"),
+            expert_freq_tensor=d.get("expert_freq_tensor"),
+            freq_window_size=self._freq_window_size,
         )
 
     def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
@@ -229,6 +234,24 @@ class DecoderStage(StageKind):
                 is_moe=False,
                 preloaded_weights=self._weights,
             )
+        # Create expert frequency tracking tensor on sender core (MoE layers only)
+        if self._is_moe:
+            sender_core = ttnn.CoreCoord(mesh_device.compute_with_storage_grid_size().x - 1, self.MOE_SENDER_CORE.y)
+            sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core, sender_core)])
+            freq_shard_spec = ttnn.ShardSpec(sender_core_grid, (1, 257), ttnn.ShardOrientation.ROW_MAJOR)
+            freq_mem_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, freq_shard_spec
+            )
+            expert_freq_tensor = ttnn.from_torch(
+                torch.zeros((1, 257), dtype=torch.int32),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=mesh_device,
+                memory_config=freq_mem_config,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
+            d["expert_freq_tensor"] = expert_freq_tensor
+
         ttnn.synchronize_device(mesh_device)
 
         recv_socket = pipeline_block.get_downstream_socket()
@@ -254,6 +277,15 @@ class DecoderStage(StageKind):
     def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
         DecoderBlock.execute(*self._state["decoder_program_context"])
 
+    def read_expert_frequencies(self) -> torch.Tensor:
+        """Read expert frequency counters from device. Shape ``(256,)`` uint32."""
+        freq_tensor = self._state["d"].get("expert_freq_tensor")
+        if freq_tensor is None:
+            raise RuntimeError("Expert frequency tracking is not enabled (not an MoE stage)")
+        raw = ttnn.to_torch(freq_tensor, mesh_composer=ttnn.ListMeshToTensor(freq_tensor.device()))
+        # Each device has its own (1, 257) tensor; return list of per-device (256,) counts
+        return [r.squeeze(0)[:256] for r in raw]
+
 
 class MoEDecoderStage(DecoderStage):
     """Decoder stage: bcast + fused attention + MoE + reduce-to-one.
@@ -278,6 +310,7 @@ class MoEDecoderStage(DecoderStage):
         use_hardcoded_expert_index: bool = False,
         enable_routing: bool = True,
         is_torus: bool = True,
+        freq_window_size: int = 0,
     ) -> None:
         super().__init__(
             state_dict,
@@ -291,6 +324,7 @@ class MoEDecoderStage(DecoderStage):
             num_routed_experts=num_routed_experts,
             use_hardcoded_expert_index=use_hardcoded_expert_index,
             enable_routing=enable_routing,
+            freq_window_size=freq_window_size,
         )
 
 

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -39,6 +39,7 @@ from models.demos.deepseek_v3_b1.weights.prepare import (
     prepare_mtp_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
+    prepare_sram_slots,
 )
 
 
@@ -51,7 +52,14 @@ class WeightProvider(Protocol):
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
         ...
 
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+    def load_moe_layer(
+        self,
+        layer_id: int,
+        device: ttnn.MeshDevice,
+        *,
+        num_sram_slots: int = 0,
+        initial_sram_experts: list[int] | None = None,
+    ) -> DeepSeekV3MoELayerWeights:
         ...
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
@@ -242,7 +250,14 @@ class CacheWeightProvider:
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
         return prepare_lm_head_weights(self._state_dict, device, cache_config=self._cache_config(device))
 
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+    def load_moe_layer(
+        self,
+        layer_id: int,
+        device: ttnn.MeshDevice,
+        *,
+        num_sram_slots: int = 0,
+        initial_sram_experts: list[int] | None = None,
+    ) -> DeepSeekV3MoELayerWeights:
         """Load MoE layer from tensor cache; routed experts use fast dispatch, rest uses slow dispatch."""
         t_load = time.perf_counter()
         cache_config = self._cache_config(device)
@@ -307,6 +322,21 @@ class CacheWeightProvider:
         assert isinstance(attn.gate_mm, OverlappedTensor)
         assert attn.gate_bias is not None
         assert isinstance(routed, MoERoutedExpertWeights)
+
+        sram_slots = None
+        if num_sram_slots > 0:
+            assert initial_sram_experts is not None and len(initial_sram_experts) == num_sram_slots
+            t0 = time.perf_counter()
+            sram_slots = prepare_sram_slots(
+                device,
+                self._state_dict,
+                layer_id,
+                initial_sram_experts,
+                move_to_device=True,
+            )
+            sram_s = time.perf_counter() - t0
+            logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_sram_slots {sram_s:.3f}s")
+
         return DeepSeekV3MoELayerWeights(
             q_a_proj=attn.q_a_proj,
             q_b_proj=attn.q_b_proj,
@@ -326,6 +356,7 @@ class CacheWeightProvider:
             routed_gate_proj=routed.routed_gate_proj,
             routed_up_proj=routed.routed_up_proj,
             routed_down_proj=routed.routed_down_proj,
+            sram_slots=sram_slots,
         )
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
@@ -373,10 +404,23 @@ class SyntheticWeightProvider:
             move_to_device=True,
         )
 
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+    def load_moe_layer(
+        self,
+        layer_id: int,
+        device: ttnn.MeshDevice,
+        *,
+        num_sram_slots: int = 0,
+        initial_sram_experts: list[int] | None = None,
+    ) -> DeepSeekV3MoELayerWeights:
         sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
         return prepare_moe_layer_weights(
-            device, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS, move_to_device=True
+            device,
+            sd,
+            layer_id,
+            num_routed_experts=NUM_ROUTED_EXPERTS,
+            move_to_device=True,
+            num_sram_slots=num_sram_slots,
+            initial_sram_experts=initial_sram_experts,
         )
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
@@ -403,13 +447,22 @@ class StateDictWeightProvider:
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
         return prepare_lm_head_weights(self._state_dict, device, move_to_device=True)
 
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+    def load_moe_layer(
+        self,
+        layer_id: int,
+        device: ttnn.MeshDevice,
+        *,
+        num_sram_slots: int = 0,
+        initial_sram_experts: list[int] | None = None,
+    ) -> DeepSeekV3MoELayerWeights:
         return prepare_moe_layer_weights(
             device,
             self._state_dict,
             layer_id,
             num_routed_experts=NUM_ROUTED_EXPERTS,
             move_to_device=True,
+            num_sram_slots=num_sram_slots,
+            initial_sram_experts=initial_sram_experts,
         )
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -200,6 +200,9 @@ class DecoderBlock:
         persistent_next_iter_semaphore=None,
         persistent_mode=False,
         is_torus=True,
+        sram_slots=None,
+        expert_freq_tensor=None,
+        freq_window_size=0,
     ):
         """Build io_tensors and mesh_program_descriptor without executing.
 
@@ -291,6 +294,9 @@ class DecoderBlock:
             persistent_mode=persistent_mode,
             bcast_sender_coord=sender_coord,
             is_torus=is_torus,
+            sram_slots=sram_slots,
+            expert_freq_tensor=expert_freq_tensor,
+            freq_window_size=freq_window_size,
         )
 
         moe._build_descriptors()

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -416,11 +416,9 @@ void kernel_main() {
                 get_named_compile_time_arg_val("gate_output_cb"),
                 get_named_compile_time_arg_val("gate_output_indices_cb")>;
 
-#ifdef ENABLE_FREQ_TRACKING
             // Expert frequency tracking (raw L1 buffer, not a CB)
             static constexpr uint32_t expert_freq_l1_addr = get_named_compile_time_arg_val("expert_freq_l1_addr");
             static constexpr uint32_t freq_window_size = get_named_compile_time_arg_val("freq_window_size");
-#endif
 
             // Index Mcast (sender)
             deepseek_b1_ops::Mcast::SenderArgs index_mcast_args{
@@ -1087,7 +1085,6 @@ void kernel_main() {
             gate();
         }
 
-#ifdef ENABLE_FREQ_TRACKING
         // 4a. Update expert frequency counters (sender core BRISC only)
         {
             DeviceZoneScopedN("FREQ_UPDATE");
@@ -1115,7 +1112,6 @@ void kernel_main() {
             }
 #endif
         }
-#endif  // ENABLE_FREQ_TRACKING
 
         // 5. Mcast Index: Broadcast expert indices to gate_proj cores only
         // Uses dedicated mcast with IsReceiverCore=is_gate_proj_core so only gate_proj

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -416,6 +416,12 @@ void kernel_main() {
                 get_named_compile_time_arg_val("gate_output_cb"),
                 get_named_compile_time_arg_val("gate_output_indices_cb")>;
 
+#ifdef ENABLE_FREQ_TRACKING
+            // Expert frequency tracking (raw L1 buffer, not a CB)
+            static constexpr uint32_t expert_freq_l1_addr = get_named_compile_time_arg_val("expert_freq_l1_addr");
+            static constexpr uint32_t freq_window_size = get_named_compile_time_arg_val("freq_window_size");
+#endif
+
             // Index Mcast (sender)
             deepseek_b1_ops::Mcast::SenderArgs index_mcast_args{
                 get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
@@ -1080,6 +1086,36 @@ void kernel_main() {
             deepseek_b1_ops::DeepseekMoeGate::Op<Moe::Routed::GateCTArgs, Core::is_sender_core> gate;
             gate();
         }
+
+#ifdef ENABLE_FREQ_TRACKING
+        // 4a. Update expert frequency counters (sender core BRISC only)
+        {
+            DeviceZoneScopedN("FREQ_UPDATE");
+#if defined(COMPILE_FOR_BRISC)
+            if constexpr (Core::is_sender_core && expert_freq_l1_addr != 0) {
+                volatile tt_l1_ptr uint32_t* freq_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(expert_freq_l1_addr);
+
+                // Tumbling window reset
+                uint32_t iter = freq_ptr[256] + 1;
+                constexpr bool use_full_range = (freq_window_size == 0);
+                bool reset = use_full_range ? (iter == 0) : (iter >= freq_window_size);
+                if (reset) {
+                    for (uint32_t j = 0; j < 257; j++) freq_ptr[j] = 0;
+                    iter = 0;
+                }
+                freq_ptr[256] = iter;
+
+                // Increment the 8 selected experts
+                volatile tt_l1_ptr uint16_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
+                    get_read_ptr(get_named_compile_time_arg_val("gate_output_indices_cb")));
+                for (uint32_t i = 0; i < 8; i++) {
+                    freq_ptr[static_cast<uint32_t>(index_ptr[i])]++;
+                }
+            }
+#endif
+        }
+#endif  // ENABLE_FREQ_TRACKING
 
         // 5. Mcast Index: Broadcast expert indices to gate_proj cores only
         // Uses dedicated mcast with IsReceiverCore=is_gate_proj_core so only gate_proj

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -4775,8 +4775,6 @@ class MoeOp:
             defines += [("ENABLE_BCAST", "1")]
         if self.ctx.reconfig_moe_cbs:
             defines += [("RECONFIG_MOE_CBS", "1")]
-        if self.ctx.expert_freq_tensor is not None:
-            defines += [("ENABLE_FREQ_TRACKING", "1")]
         return defines
 
     def _build_descriptors(self):

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -123,6 +123,13 @@ class MoeContext:
     # CB reconfig
     reconfig_moe_cbs: bool = False
 
+    # SRAM (L1) hot expert slots (None when no SRAM experts configured)
+    sram_slots: Any = None
+
+    # Expert frequency tracking (None when disabled)
+    expert_freq_tensor: Any = None
+    freq_window_size: int = 0  # 0 = full uint32 range
+
 
 @dataclass
 class _MoeRoutedExpertContext:
@@ -1693,6 +1700,12 @@ class MoeRoutedExpertOp:
             ("mul_cb_scalar_src", ctx.mul_cb_scalar_src),
             ("mul_cb_scalar", ctx.mul_cb_scalar),
             ("mul_scalar_index_offset", mesh_chip_id if ctx.enable_routing else 0),
+            # Expert frequency tracking
+            (
+                "expert_freq_l1_addr",
+                ctx.expert_freq_tensor.buffer_address() if ctx.expert_freq_tensor is not None else 0,
+            ),
+            ("freq_window_size", ctx.freq_window_size),
             # Mul writer
             ("mul_cb_out", ctx.mul_cb_out),
             ("mul_num_tiles", ctx.mul_num_tiles),
@@ -4453,6 +4466,9 @@ class MoeOp:
         downstream_sockets=None,
         persistent_next_iter_semaphore=None,
         persistent_mode=False,
+        sram_slots=None,
+        expert_freq_tensor=None,
+        freq_window_size=0,
     ):
         """Setup both routed and shared expert contexts, then overlap CBs with SDPA buffers."""
         self.noc_mode = noc_mode
@@ -4594,6 +4610,9 @@ class MoeOp:
             bcast_semaphores=bcast_semaphores,
             bcast_sender_coord=bcast_sender_coord,
             socket=socket,
+            sram_slots=sram_slots,
+            expert_freq_tensor=expert_freq_tensor,
+            freq_window_size=freq_window_size,
         )
 
         # Shared descriptors (populated by _build_descriptors)
@@ -4733,6 +4752,12 @@ class MoeOp:
             io_tensors += [ctx.bcast_input_tensor]
         if ctx.bcast_intermediate_tensor is not None:
             io_tensors += [ctx.bcast_intermediate_tensor]
+        if ctx.sram_slots is not None:
+            # Pin SRAM expert fused buffers (gate_up per slot + shared down buffer)
+            io_tensors += ctx.sram_slots._gate_up_fused
+            io_tensors += [ctx.sram_slots.down_fused]
+        if ctx.expert_freq_tensor is not None:
+            io_tensors += [ctx.expert_freq_tensor]
         return io_tensors
 
     def _build_kernel_defines(self):
@@ -4750,6 +4775,8 @@ class MoeOp:
             defines += [("ENABLE_BCAST", "1")]
         if self.ctx.reconfig_moe_cbs:
             defines += [("RECONFIG_MOE_CBS", "1")]
+        if self.ctx.expert_freq_tensor is not None:
+            defines += [("ENABLE_FREQ_TRACKING", "1")]
         return defines
 
     def _build_descriptors(self):
@@ -4865,6 +4892,9 @@ class MoeOp:
         # Per-worker downstream sockets for reduce workers to send reduced output
         downstream_sockets=None,
         cb_id_context=None,
+        # Expert frequency tracking
+        expert_freq_tensor=None,
+        freq_window_size=0,
     ):
         """
         Execute the full fused MoE operation (routed + shared expert).
@@ -4939,6 +4969,8 @@ class MoeOp:
             cb_id_context=cb_id_context,
             persistent_next_iter_semaphore=persistent_next_iter_semaphore,
             persistent_mode=persistent_mode,
+            expert_freq_tensor=expert_freq_tensor,
+            freq_window_size=freq_window_size,
         )
 
         # ==================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -4754,7 +4754,7 @@ class MoeOp:
             io_tensors += [ctx.bcast_intermediate_tensor]
         if ctx.sram_slots is not None:
             # Pin SRAM expert fused buffers (gate_up per slot + shared down buffer)
-            io_tensors += ctx.sram_slots._gate_up_fused
+            io_tensors += ctx.sram_slots.gate_up_fused
             io_tensors += [ctx.sram_slots.down_fused]
         if ctx.expert_freq_tensor is not None:
             io_tensors += [ctx.expert_freq_tensor]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -841,6 +841,10 @@ def create_decoder_block_tensors(
         "shared_down_weights_tensor": layer.shared_down_proj,
         "shared_k_parallel": SharedExpert.K_PARALLEL,
         "shared_n_parallel": SharedExpert.N_PARALLEL,
+        # SRAM hot expert slots (None when not configured)
+        "sram_slots": getattr(layer, "sram_slots", None),
+        # Expert frequency tracking tensor (created by decoder_stage, not here)
+        "expert_freq_tensor": None,
         # Reduce-to-one
         "reduce_intermediate_tensors": intermediate_tensors,
         "reduce_output_tensor": reduce_output_tensor,

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -196,17 +196,16 @@ class SramExpertSlots:
     """Fixed SRAM (L1) slots for hot routed experts.
 
     Each slot holds gate/up/down weights in the same layout as the shared expert.
-    Slots are allocated at init and can be swapped at runtime via :func:`swap_sram_expert`.
+    Slots are allocated at weight preparation time and remain static during inference.
     """
 
     num_slots: int
-    slot_experts: list[int]  # slot i → global expert index currently loaded
+    slot_experts: list[int]  # slot i → global expert index loaded
     gate_proj: list[OverlappedTensor]  # one per slot
     up_proj: list[OverlappedTensor]  # one per slot
     down_proj: list[OverlappedTensor]  # views into down_fused
     down_fused: ttnn.Tensor  # shared fused buffer for all down slots
-    _gate_up_fused: list[ttnn.Tensor]  # underlying fused buffers per slot (for swap rebuild)
-    _down_torch: list[torch.Tensor]  # preprocessed down tensors per slot (for rebuild)
+    gate_up_fused: list[ttnn.Tensor]  # underlying fused buffers per slot (for L1 pinning)
 
 
 @dataclass
@@ -1432,7 +1431,7 @@ def prepare_sram_slots(
     gate_proj_list: list[OverlappedTensor] = []
     up_proj_list: list[OverlappedTensor] = []
     gate_up_fused_list: list[ttnn.Tensor] = []
-    down_torch_list: list[torch.Tensor] = []
+    down_preprocessed: list[torch.Tensor] = []
 
     for slot_idx, expert_idx in enumerate(initial_expert_indices):
         assert 0 <= expert_idx < NUM_ROUTED_EXPERTS, f"Expert index {expert_idx} out of range [0, {NUM_ROUTED_EXPERTS})"
@@ -1463,13 +1462,13 @@ def prepare_sram_slots(
 
         # Down: same pipeline as shared expert
         down_pre = shared_down_torch_for_cache(down_w, moe_tp, mesh_shape)
-        down_torch_list.append(down_pre)
+        down_preprocessed.append(down_pre)
 
         logger.debug("  SRAM slot {} ← expert {} prepared", slot_idx, expert_idx)
 
     # Pack all down_proj into a single overlap buffer
     down_views, down_fused = build_sram_down_overlap(
-        down_torch_list,
+        down_preprocessed,
         device,
         dtype=dtype,
         move_to_device=move_to_device,
@@ -1488,82 +1487,8 @@ def prepare_sram_slots(
         up_proj=up_proj_list,
         down_proj=down_views,
         down_fused=down_fused,
-        _gate_up_fused=gate_up_fused_list,
-        _down_torch=down_torch_list,
+        gate_up_fused=gate_up_fused_list,
     )
-
-
-def swap_sram_expert(
-    slots: SramExpertSlots,
-    slot_idx: int,
-    new_expert_idx: int,
-    gate_weight: torch.Tensor,
-    up_weight: torch.Tensor,
-    down_weight: torch.Tensor,
-    device,
-    *,
-    dtype: ttnn.DataType = ttnn.bfloat4_b,
-) -> None:
-    """Swap a cold expert into an SRAM slot, preserving L1 buffer addresses.
-
-    The caller provides raw HF-layout weight tensors (transposed to
-    ``(in_features, out_features)``):
-
-    - ``gate_weight``: ``(7168, 2048)``
-    - ``up_weight``: ``(7168, 2048)``
-    - ``down_weight``: ``(2048, 7168)``
-
-    Uses ``ttnn.copy`` to overwrite the existing device buffers so that
-    L1 addresses remain stable across swaps.
-    """
-    assert 0 <= slot_idx < slots.num_slots, f"slot_idx {slot_idx} out of range [0, {slots.num_slots})"
-    assert 0 <= new_expert_idx < NUM_ROUTED_EXPERTS
-
-    _, moe_tp = _tp_factors(device)
-    mesh_rows = device.shape[0] if device.get_num_devices() > 1 else 1
-    mesh_cols = device.shape[1] if device.get_num_devices() > 1 else 1
-    mesh_shape = (mesh_rows, mesh_cols)
-
-    logger.info(
-        "Swapping SRAM slot {} ← expert {} (was expert {})", slot_idx, new_expert_idx, slots.slot_experts[slot_idx]
-    )
-
-    # 1. Preprocess gate/up and build new fused buffer
-    preprocessed = preprocess_gate_up(gate_weight, up_weight, moe_tp, mesh_rows, mesh_cols)
-    gate_ov, up_ov, new_gu_fused = _build_sram_gate_up(
-        preprocessed["shared_gate_proj"],
-        preprocessed["shared_up_proj"],
-        device,
-        dtype=dtype,
-    )
-    # Copy into existing device buffer to preserve L1 address
-    ttnn.copy(new_gu_fused, slots._gate_up_fused[slot_idx])
-    ttnn.deallocate(new_gu_fused)
-    # Update views — byte offsets are stable since layout is identical;
-    # point fused_tensor back at the stable buffer.
-    gate_ov.fused_tensor = slots._gate_up_fused[slot_idx]
-    up_ov.fused_tensor = slots._gate_up_fused[slot_idx]
-    slots.gate_proj[slot_idx] = gate_ov
-    slots.up_proj[slot_idx] = up_ov
-
-    # 2. Preprocess down and rebuild entire down overlap
-    down_pre = shared_down_torch_for_cache(down_weight, moe_tp, mesh_shape)
-    slots._down_torch[slot_idx] = down_pre
-    new_down_views, new_down_fused = build_sram_down_overlap(
-        slots._down_torch,
-        device,
-        dtype=dtype,
-    )
-    # Copy into existing device buffer
-    ttnn.copy(new_down_fused, slots.down_fused)
-    ttnn.deallocate(new_down_fused)
-    # Update views to point at the stable fused buffer
-    for i, view in enumerate(new_down_views):
-        view.fused_tensor = slots.down_fused
-        slots.down_proj[i] = view
-
-    # 3. Update mapping
-    slots.slot_experts[slot_idx] = new_expert_idx
 
 
 def prepare_dense_layer_weights(

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -17,7 +17,7 @@ with :class:`~weights.cache.CacheConfig` and the ``prepare_*`` functions
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -35,7 +35,7 @@ from models.demos.deepseek_v3_b1.weights.cache import (
     SourceTensorSelection,
     TensorTarget,
 )
-from models.demos.deepseek_v3_b1.weights.overlap.packing import OverlappedTensor
+from models.demos.deepseek_v3_b1.weights.overlap.packing import OverlapEntry, OverlappedTensor, overlap_tensors
 from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
     DOWN_PROJ_SINGLE_DEVICE_SPEC,
     GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
@@ -53,6 +53,7 @@ from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_
 from models.demos.deepseek_v3_b1.weights.transforms.attention import preprocess_kv_b12, preprocess_q_ab_kv_a
 from models.demos.deepseek_v3_b1.weights.transforms.moe import (
     _tp_factors,
+    build_sram_down_overlap,
     mlp_routed_dense_stacked_torch_for_cache,
     moe_routed_expert_torch_for_cache,
     preprocess_gate_up,
@@ -191,6 +192,24 @@ class MoERoutedExpertWeights:
 
 
 @dataclass
+class SramExpertSlots:
+    """Fixed SRAM (L1) slots for hot routed experts.
+
+    Each slot holds gate/up/down weights in the same layout as the shared expert.
+    Slots are allocated at init and can be swapped at runtime via :func:`swap_sram_expert`.
+    """
+
+    num_slots: int
+    slot_experts: list[int]  # slot i → global expert index currently loaded
+    gate_proj: list[OverlappedTensor]  # one per slot
+    up_proj: list[OverlappedTensor]  # one per slot
+    down_proj: list[OverlappedTensor]  # views into down_fused
+    down_fused: ttnn.Tensor  # shared fused buffer for all down slots
+    _gate_up_fused: list[ttnn.Tensor]  # underlying fused buffers per slot (for swap rebuild)
+    _down_torch: list[torch.Tensor]  # preprocessed down tensors per slot (for rebuild)
+
+
+@dataclass
 class DeepSeekV3DenseLayerWeights:
     """Weights for a dense layer (0..first_k_dense_replace-1).
 
@@ -260,6 +279,9 @@ class DeepSeekV3MoELayerWeights:
     routed_gate_proj: list[ttnn.Tensor]
     routed_up_proj: list[ttnn.Tensor]
     routed_down_proj: list[ttnn.Tensor]
+
+    # Optional SRAM (L1) hot expert slots
+    sram_slots: SramExpertSlots | None = None
 
 
 @dataclass
@@ -1317,6 +1339,233 @@ def prepare_routed_expert_weights(
         )
 
 
+def _build_sram_gate_up(
+    gate_preprocessed: torch.Tensor,
+    up_preprocessed: torch.Tensor,
+    device,
+    *,
+    dtype: ttnn.DataType = ttnn.bfloat4_b,
+    move_to_device: bool = True,
+) -> tuple[OverlappedTensor, OverlappedTensor, ttnn.Tensor]:
+    """Build a single SRAM slot's gate/up fused buffer.
+
+    Returns ``(gate_ov, up_ov, fused_tensor)``.
+    """
+    cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+    gate_up_dict = overlap_tensors(
+        [
+            [
+                OverlapEntry(
+                    "gate_proj",
+                    gate_preprocessed,
+                    replace(
+                        cfg.gate_shard_spec,
+                        raw_tensor_shape=tuple(gate_preprocessed.shape),
+                        dtype=dtype,
+                        logical_tensor_shape=cfg.gate_proj_shape,
+                    ),
+                ),
+            ],
+            [
+                OverlapEntry(
+                    "up_proj",
+                    up_preprocessed,
+                    replace(
+                        cfg.up_shard_spec,
+                        raw_tensor_shape=tuple(up_preprocessed.shape),
+                        dtype=dtype,
+                        logical_tensor_shape=cfg.up_proj_shape,
+                    ),
+                ),
+            ],
+        ],
+        device=device,
+        move_to_device=move_to_device,
+    )
+    gate_ov = gate_up_dict["gate_proj"]
+    up_ov = gate_up_dict["up_proj"]
+    return gate_ov, up_ov, gate_ov.fused_tensor
+
+
+def prepare_sram_slots(
+    device,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    initial_expert_indices: list[int],
+    *,
+    move_to_device: bool = False,
+    dtype: ttnn.DataType = ttnn.bfloat4_b,
+) -> SramExpertSlots:
+    """Allocate SRAM slots and populate with initial routed expert weights.
+
+    Each slot's gate/up uses the same L1 layout as the shared expert
+    (``GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC``).  All slots' down_proj
+    are packed into a single overlap buffer on the 112 matmul cores
+    (``DOWN_PROJ_SINGLE_DEVICE_SPEC``).
+
+    Args:
+        device: Device or mesh device.
+        state_dict: HuggingFace state dict with expert weights.
+        layer_idx: Decoder layer index.
+        initial_expert_indices: Global expert indices to load into each slot.
+        move_to_device: Whether to place tensors on device.
+        dtype: Weight dtype (default bfloat4_b).
+
+    Returns:
+        Populated :class:`SramExpertSlots`.
+    """
+    _, moe_tp = _tp_factors(device)
+    assert moe_tp > 1, "SRAM slots require TP > 1 (multi-device mesh)"
+    mesh_rows = device.shape[0] if device.get_num_devices() > 1 else 1
+    mesh_cols = device.shape[1] if device.get_num_devices() > 1 else 1
+    mesh_shape = (mesh_rows, mesh_cols)
+    num_slots = len(initial_expert_indices)
+
+    logger.info(
+        "Preparing {} SRAM slots for layer {} (experts: {})",
+        num_slots,
+        layer_idx,
+        initial_expert_indices,
+    )
+    t0 = time.perf_counter()
+
+    gate_proj_list: list[OverlappedTensor] = []
+    up_proj_list: list[OverlappedTensor] = []
+    gate_up_fused_list: list[ttnn.Tensor] = []
+    down_torch_list: list[torch.Tensor] = []
+
+    for slot_idx, expert_idx in enumerate(initial_expert_indices):
+        assert 0 <= expert_idx < NUM_ROUTED_EXPERTS, f"Expert index {expert_idx} out of range [0, {NUM_ROUTED_EXPERTS})"
+        # Load and transpose expert weights (HF stores as (out_features, in_features))
+        gate_key = _key(layer_idx, f"mlp.experts.{expert_idx}.gate_proj.weight")
+        up_key = _key(layer_idx, f"mlp.experts.{expert_idx}.up_proj.weight")
+        down_key = _key(layer_idx, f"mlp.experts.{expert_idx}.down_proj.weight")
+
+        gate_w = state_dict[gate_key].T.contiguous()  # (7168, 2048)
+        up_w = state_dict[up_key].T.contiguous()  # (7168, 2048)
+        down_w = state_dict[down_key].T.contiguous()  # (2048, 7168)
+
+        # Gate/Up: same pipeline as shared expert
+        preprocessed = preprocess_gate_up(gate_w, up_w, moe_tp, mesh_rows, mesh_cols)
+        gate_pre = preprocessed["shared_gate_proj"]
+        up_pre = preprocessed["shared_up_proj"]
+
+        gate_ov, up_ov, gu_fused = _build_sram_gate_up(
+            gate_pre,
+            up_pre,
+            device,
+            dtype=dtype,
+            move_to_device=move_to_device,
+        )
+        gate_proj_list.append(gate_ov)
+        up_proj_list.append(up_ov)
+        gate_up_fused_list.append(gu_fused)
+
+        # Down: same pipeline as shared expert
+        down_pre = shared_down_torch_for_cache(down_w, moe_tp, mesh_shape)
+        down_torch_list.append(down_pre)
+
+        logger.debug("  SRAM slot {} ← expert {} prepared", slot_idx, expert_idx)
+
+    # Pack all down_proj into a single overlap buffer
+    down_views, down_fused = build_sram_down_overlap(
+        down_torch_list,
+        device,
+        dtype=dtype,
+        move_to_device=move_to_device,
+    )
+
+    logger.info(
+        "SRAM slots for layer {} done in {:.3f}s ({} slots)",
+        layer_idx,
+        time.perf_counter() - t0,
+        num_slots,
+    )
+    return SramExpertSlots(
+        num_slots=num_slots,
+        slot_experts=list(initial_expert_indices),
+        gate_proj=gate_proj_list,
+        up_proj=up_proj_list,
+        down_proj=down_views,
+        down_fused=down_fused,
+        _gate_up_fused=gate_up_fused_list,
+        _down_torch=down_torch_list,
+    )
+
+
+def swap_sram_expert(
+    slots: SramExpertSlots,
+    slot_idx: int,
+    new_expert_idx: int,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    device,
+    *,
+    dtype: ttnn.DataType = ttnn.bfloat4_b,
+) -> None:
+    """Swap a cold expert into an SRAM slot, preserving L1 buffer addresses.
+
+    The caller provides raw HF-layout weight tensors (transposed to
+    ``(in_features, out_features)``):
+
+    - ``gate_weight``: ``(7168, 2048)``
+    - ``up_weight``: ``(7168, 2048)``
+    - ``down_weight``: ``(2048, 7168)``
+
+    Uses ``ttnn.copy`` to overwrite the existing device buffers so that
+    L1 addresses remain stable across swaps.
+    """
+    assert 0 <= slot_idx < slots.num_slots, f"slot_idx {slot_idx} out of range [0, {slots.num_slots})"
+    assert 0 <= new_expert_idx < NUM_ROUTED_EXPERTS
+
+    _, moe_tp = _tp_factors(device)
+    mesh_rows = device.shape[0] if device.get_num_devices() > 1 else 1
+    mesh_cols = device.shape[1] if device.get_num_devices() > 1 else 1
+    mesh_shape = (mesh_rows, mesh_cols)
+
+    logger.info(
+        "Swapping SRAM slot {} ← expert {} (was expert {})", slot_idx, new_expert_idx, slots.slot_experts[slot_idx]
+    )
+
+    # 1. Preprocess gate/up and build new fused buffer
+    preprocessed = preprocess_gate_up(gate_weight, up_weight, moe_tp, mesh_rows, mesh_cols)
+    gate_ov, up_ov, new_gu_fused = _build_sram_gate_up(
+        preprocessed["shared_gate_proj"],
+        preprocessed["shared_up_proj"],
+        device,
+        dtype=dtype,
+    )
+    # Copy into existing device buffer to preserve L1 address
+    ttnn.copy(new_gu_fused, slots._gate_up_fused[slot_idx])
+    ttnn.deallocate(new_gu_fused)
+    # Update views — byte offsets are stable since layout is identical;
+    # point fused_tensor back at the stable buffer.
+    gate_ov.fused_tensor = slots._gate_up_fused[slot_idx]
+    up_ov.fused_tensor = slots._gate_up_fused[slot_idx]
+    slots.gate_proj[slot_idx] = gate_ov
+    slots.up_proj[slot_idx] = up_ov
+
+    # 2. Preprocess down and rebuild entire down overlap
+    down_pre = shared_down_torch_for_cache(down_weight, moe_tp, mesh_shape)
+    slots._down_torch[slot_idx] = down_pre
+    new_down_views, new_down_fused = build_sram_down_overlap(
+        slots._down_torch,
+        device,
+        dtype=dtype,
+    )
+    # Copy into existing device buffer
+    ttnn.copy(new_down_fused, slots.down_fused)
+    ttnn.deallocate(new_down_fused)
+    # Update views to point at the stable fused buffer
+    for i, view in enumerate(new_down_views):
+        view.fused_tensor = slots.down_fused
+        slots.down_proj[i] = view
+
+    # 3. Update mapping
+    slots.slot_experts[slot_idx] = new_expert_idx
+
+
 def prepare_dense_layer_weights(
     device,
     state_dict: dict[str, torch.Tensor],
@@ -1376,11 +1625,17 @@ def prepare_moe_layer_weights(
     bspm_dir: Path | None = None,
     bspm_variant: str = "B",
     bspm_budget: float = 3.5,
+    num_sram_slots: int = 0,
+    initial_sram_experts: list[int] | None = None,
 ) -> DeepSeekV3MoELayerWeights:
     """Prepare fused weights for a single MoE decoder layer.
 
     ``bspm_dir``, when provided, must be the model-specific BSPM subdirectory
     (e.g. ``results/deepseek-r1-0528``), not the results root.
+
+    When ``num_sram_slots > 0``, SRAM (L1) slots are allocated and populated
+    with the experts listed in ``initial_sram_experts``.  DRAM copies remain
+    unchanged.  Requires multi-device (TP > 1).
     """
     logger.info("Preparing MoE layer {}...", layer_idx)
     t0 = time.perf_counter()
@@ -1410,6 +1665,24 @@ def prepare_moe_layer_weights(
     assert isinstance(attn.gate_mm, OverlappedTensor)
     assert attn.gate_bias is not None
     assert isinstance(routed, MoERoutedExpertWeights)
+
+    sram_slots = None
+    if num_sram_slots > 0:
+        if initial_sram_experts is None:
+            raise ValueError("initial_sram_experts must be provided when num_sram_slots > 0")
+        if len(initial_sram_experts) != num_sram_slots:
+            raise ValueError(
+                f"initial_sram_experts length ({len(initial_sram_experts)}) "
+                f"must match num_sram_slots ({num_sram_slots})"
+            )
+        sram_slots = prepare_sram_slots(
+            device,
+            state_dict,
+            layer_idx,
+            initial_sram_experts,
+            move_to_device=move_to_device,
+        )
+
     result = DeepSeekV3MoELayerWeights(
         q_a_proj=attn.q_a_proj,
         q_b_proj=attn.q_b_proj,
@@ -1429,6 +1702,7 @@ def prepare_moe_layer_weights(
         routed_gate_proj=routed.routed_gate_proj,
         routed_up_proj=routed.routed_up_proj,
         routed_down_proj=routed.routed_down_proj,
+        sram_slots=sram_slots,
     )
     logger.info("MoE layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
     return result

--- a/models/demos/deepseek_v3_b1/weights/transforms/moe.py
+++ b/models/demos/deepseek_v3_b1/weights/transforms/moe.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.weights.overlap.packing import OverlapEntry, OverlappedTensor, overlap_tensors
+from models.demos.deepseek_v3_b1.weights.overlap.spec import OverlappedTensorSpec
 from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
     DOWN_PROJ_SINGLE_DEVICE_SPEC,
     GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
@@ -313,3 +314,51 @@ def create_moe_routed_expert_tensors(
         return tensors
 
     return upload(gate_proj_weights), upload(up_proj_weights), upload(down_proj_weights)
+
+
+def build_sram_down_overlap(
+    down_tensors: list[torch.Tensor],
+    device,
+    *,
+    dtype: ttnn.DataType = ttnn.bfloat4_b,
+    move_to_device: bool = True,
+) -> tuple[list[OverlappedTensor], ttnn.Tensor]:
+    """Pack N SRAM expert down_proj tensors into a single L1 overlap buffer.
+
+    Each tensor must be the output of :func:`shared_down_torch_for_cache`
+    (TP-concatenated, ready for overlap packing).
+
+    Returns:
+        ``(views, fused_tensor)`` — per-slot :class:`OverlappedTensor` views
+        and the underlying fused buffer.
+    """
+    dp_spec = DOWN_PROJ_SINGLE_DEVICE_SPEC
+    matmul_core_grid = dp_spec.build_matmul_core_grid()
+
+    is_multi_device = device.get_num_devices() > 1
+    tp_dim: tuple[int | None, int | None] = (0, 1) if is_multi_device else (None, None)
+
+    entries = [
+        OverlapEntry(
+            f"sram_down_{i}",
+            t,
+            OverlappedTensorSpec(
+                core_range_set=matmul_core_grid,
+                raw_tensor_shape=tuple(t.shape),
+                dtype=dtype,
+                sharding=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                tp_dim=tp_dim,
+            ),
+        )
+        for i, t in enumerate(down_tensors)
+    ]
+
+    result = overlap_tensors(
+        [entries],
+        device=device,
+        move_to_device=move_to_device,
+    )
+
+    views = [result[f"sram_down_{i}"] for i in range(len(down_tensors))]
+    fused = views[0].fused_tensor
+    return views, fused


### PR DESCRIPTION
Adds two features for DeepSeek V3 B1 MoE hot/cold expert management:

1. SRAM (L1) resident expert slots: Fixed slots that hold routed expert weights in L1 using the same layout as the shared expert. Supports runtime swapping via ttnn.copy() to preserve L1 addresses. Controlled via num_sram_slots/initial_sram_experts parameters.

2. On-device expert frequency tracking: A 257-entry uint32 buffer on the sender core (256 frequency counters + 1 iteration counter) that accumulates expert selection counts in the kernel between gate and index mcast. Uses a configurable tumbling window (freq_window_size=0 for full uint32 range, or capped at N tokens) with automatic reset on overflow. Guarded by ENABLE_FREQ_TRACKING compile define.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-hot-experts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=worktree-hot-experts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-hot-experts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-hot-experts) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:worktree-hot-experts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=worktree-hot-experts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:worktree-hot-experts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:worktree-hot-experts) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-hot-experts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=worktree-hot-experts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-hot-experts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-hot-experts) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-hot-experts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=worktree-hot-experts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-hot-experts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-hot-experts) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-hot-experts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=worktree-hot-experts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-hot-experts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-hot-experts) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-hot-experts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=worktree-hot-experts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-hot-experts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-hot-experts) |