### PR TITLE
Fix use-after-free in gpt-oss

### DIFF
--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_tensors.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_tensors.py
@@ -128,6 +128,9 @@ def gpt_oss_prepare_expert_tensors_ttnn(
     topk_indices_rm = ttnn.to_layout(topk_expert_indices, ttnn.ROW_MAJOR_LAYOUT)
     topk_indices_rm = ttnn.reshape(topk_indices_rm, shape=(batch_size_per_device, 1, seq_len, num_experts_per_tok))
 
+    # Note: topk_expert_weights is not converted to ROW_MAJOR here as it's used later
+    # in the decode_forward after combine. We return it reshaped but in original layout.
+
     return hidden_rm, topk_indices_rm, topk_expert_weights
 
 

--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_tensors.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_tensors.py
@@ -128,9 +128,6 @@ def gpt_oss_prepare_expert_tensors_ttnn(
     topk_indices_rm = ttnn.to_layout(topk_expert_indices, ttnn.ROW_MAJOR_LAYOUT)
     topk_indices_rm = ttnn.reshape(topk_indices_rm, shape=(batch_size_per_device, 1, seq_len, num_experts_per_tok))
 
-    # Note: topk_expert_weights is not converted to ROW_MAJOR here as it's used later
-    # in the decode_forward after combine. We return it reshaped but in original layout.
-
     return hidden_rm, topk_indices_rm, topk_expert_weights
 
 
@@ -412,7 +409,7 @@ def _run_prepare_expert_tensors_test(
     )
 
     def op_fn():
-        return gpt_oss_prepare_expert_tensors_ttnn(
+        hidden_rm, indices_rm, _ = gpt_oss_prepare_expert_tensors_ttnn(
             tt_hidden_states,
             tt_topk_indices,
             tt_topk_weights,
@@ -421,6 +418,10 @@ def _run_prepare_expert_tensors_test(
             hidden_size,
             num_experts_per_tok,
         )
+        # Only return tensors that own their own device buffer.
+        # The weights output is a reshape-view aliasing the input's buffer;
+        # deallocating it would free the input and crash subsequent iterations.
+        return (hidden_rm, indices_rm)
 
     # Device performance measurement mode (when env var is set)
     if os.getenv(DEVICE_PERF_ENV_VAR) is not None:


### PR DESCRIPTION
## Summary

Fixes the `Tensor is not allocated` crash in `test_gpt_oss_prepare_expert_tensors[trace-program_cache-decode]`, observed in CI run [(Galaxy) perf tests #105](https://github.com/tenstorrent/tt-metal/actions/runs/24280279612/job/70901335229).

### Problem: deallocating the output deallocates the input

`gpt_oss_prepare_expert_tensors_ttnn` reshapes `topk_expert_weights` with a no-op reshape (input and output shapes are identical). `ttnn.reshape` returns a **view** that shares the same device buffer as the input — no new memory is allocated.

The perf measurement loop calls `ttnn.deallocate` on all outputs between iterations to free device memory. When it deallocates this weights view, it frees the underlying buffer, which is also the input tensor's buffer. On the next iteration, the input is dead and any operation on it crashes.

In short: **output is a view of the input → deallocate output → input's buffer is freed → next iteration uses freed input → crash**.

### Fix

The perf loop (`op_fn`) now discards the weights view and only returns tensors that own their own device buffers. The weights view shares the input's memory and should not be deallocated. The perf loop never inspects output values — it only exercises the ops and frees intermediates.

## Verification run
- https://github.com/tenstorrent/tt-metal/actions/runs/24315157135/job/70991859669

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/gpt-oss-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/gpt-oss-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/gpt-oss-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/gpt-oss-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/gpt-oss-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/gpt-oss-deallocated-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/gpt-oss-deallocated-tensor) |