### PR TITLE
[Clean up]: Update dfb implicit sync apis to use noc.async_read/write with txn id mode enabled

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -33,8 +33,8 @@ void kernel_main() {
     uint32_t consumer_idx = 0;
 #endif
 
-    DPRINT << "consumer_idx: " << consumer_idx << " num_entries_per_consumer: " << num_entries_per_consumer << ENDL();
-    DEVICE_PRINT("consumer_idx: {} num_entries_per_consumer: {}\n", consumer_idx, num_entries_per_consumer);
+    // DPRINT << "consumer_idx: " << consumer_idx << " num_entries_per_consumer: " << num_entries_per_consumer << ENDL();
+    // DEVICE_PRINT("consumer_idx: {} num_entries_per_consumer: {}\n", consumer_idx, num_entries_per_consumer);
 
     uint32_t entry_size = dfb.get_entry_size();
     const auto tensor_accessor = TensorAccessor(dst_args, dst_addr_base, entry_size);
@@ -46,11 +46,11 @@ void kernel_main() {
         } else {
             page_id = chunk_offset + tile_id * num_consumers + consumer_idx;
         }
-        DPRINT << "consumer tile id " << tile_id << " page id " << page_id << ENDL();
-        DEVICE_PRINT("consumer tile id {} page id {}\n", tile_id, page_id);
+        // DPRINT << "consumer tile id " << tile_id << " page id " << page_id << ENDL();
+        // DEVICE_PRINT("consumer tile id {} page id {}\n", tile_id, page_id);
         if constexpr (implicit_sync) {
 #ifdef ARCH_QUASAR
-            dfb.write_out(noc, tensor_accessor, {.page_id = page_id});
+            noc.async_write<experimental::Noc::TxnIdMode::ENABLED>(dfb, tensor_accessor, {}, {.page_id = page_id});
 #endif
         } else {
             dfb.wait_front(1);
@@ -60,9 +60,9 @@ void kernel_main() {
         }
     }
     dfb.finish();
-    DPRINT << "CBW" << ENDL();
-    DEVICE_PRINT("CBW\n");
-    noc.async_write_barrier();
-    DPRINT << "CBWD" << ENDL();
-    DEVICE_PRINT("CBWD\n");
+    // DPRINT << "CBW" << ENDL();
+    // DEVICE_PRINT("CBW\n");
+    dfb.write_barrier(noc);
+    // DPRINT << "CBWD" << ENDL();
+    // DEVICE_PRINT("CBWD\n");
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -37,23 +37,17 @@ void kernel_main() {
     uint32_t producer_idx = 0;
 #endif
 
-    // DPRINT << "producer_idx: " << producer_idx << " num_entries_per_producer: " << num_entries_per_producer <<
-    // ENDL(); DEVICE_PRINT("producer_idx: {} num_entries_per_producer: {}\n", producer_idx, num_entries_per_producer);
-
     uint32_t entry_size = dfb.get_entry_size();
     const auto tensor_accessor = TensorAccessor(src_args, src_addr_base, entry_size);
-
-    DPRINT << "HERE" << ENDL();
-    DEVICE_PRINT("HERE\n");
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
         const uint32_t page_id = blocked_consumer ? chunk_offset + producer_idx * num_entries_per_producer + tile_id
                                                   : chunk_offset + tile_id * num_producers + producer_idx;
-        DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
-        DEVICE_PRINT("producer tile id {} page id {}\n", tile_id, page_id);
+        // DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
+        // DEVICE_PRINT("producer tile id {} page id {}\n", tile_id, page_id);
         if constexpr (implicit_sync) {
 #ifdef ARCH_QUASAR
-            dfb.read_in(noc, tensor_accessor, {.page_id = page_id});
+            noc.async_read<experimental::Noc::TxnIdMode::ENABLED>(tensor_accessor, dfb, {.page_id = page_id}, {});
 #endif
         } else {
             dfb.reserve_back(1);
@@ -62,9 +56,9 @@ void kernel_main() {
             dfb.push_back(1);
         }
     }
-    DPRINT << "PFW" << ENDL();
-    DEVICE_PRINT("PFW\n");
+    // DPRINT << "PFW" << ENDL();
+    // DEVICE_PRINT("PFW\n");
     dfb.finish();
-    DPRINT << "PFD" << ENDL();
-    DEVICE_PRINT("PFD\n");
+    // DPRINT << "PFD" << ENDL();
+    // DEVICE_PRINT("PFD\n");
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
 
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
 #ifdef ARCH_QUASAR
-            dfb.read_in(noc, src_dram, {.bank_id = src_bank_id, .addr = tlocal_src_addr});
+            noc.async_read<experimental::Noc::TxnIdMode::ENABLED>(src_dram, dfb, {.bank_id = src_bank_id, .addr = tlocal_src_addr}, {});
 #else
             dfb.reserve_back(ublock_size_tiles);
             noc.async_read(src_dram, dfb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = tlocal_src_addr}, {});

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
 
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
 #ifdef ARCH_QUASAR
-            dfb.write_out(noc, dst_dram, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
+            noc.async_write<experimental::Noc::TxnIdMode::ENABLED>(dfb, dst_dram, {}, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
 #else
             dfb.wait_front(ublock_size_tiles);
             noc.async_write(dfb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
@@ -51,11 +51,7 @@ void kernel_main() {
         dfb.finish();
 
 #ifdef ARCH_QUASAR
-        // TODO: This will be replaced with some dfb.commit or noc.async_write_barrier call
-        LocalDFBInterface& local_dfb_interface = g_dfb_interface[cb_id];
-        for (uint32_t i = 0; i < local_dfb_interface.num_txn_ids; i++) {
-            noc.async_write_barrier<experimental::Noc::BarrierMode::TXN_ID>(local_dfb_interface.txn_ids[i]);
-        }
+        dfb.write_barrier(noc);
 #endif
     }
 #ifndef ARCH_QUASAR

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -50,17 +50,7 @@ public:
     void pop_front(uint16_t num_entries) { pop_front_impl(num_entries); }
     // Explicit sync APIs end
 
-#ifdef ARCH_QUASAR
-#ifndef COMPILE_FOR_TRISC
-    // Implicit sync APIs
-    template <typename Src>
-    void read_in(const Noc& noc, const Src& src, const typename noc_traits_t<Src>::src_args_type& src_args);
-
-    template <typename Dst>
-    void write_out(const Noc& noc, const Dst& dst, const typename noc_traits_t<Dst>::dst_args_type& dst_args);
-    // Implicit sync APIs end
-#endif
-#else  // tt-1xx
+#ifndef ARCH_QUASAR
 #ifndef COMPILE_FOR_TRISC
     bool pages_reservable_at_back(int32_t num_pages) const;
     bool pages_available_at_front(int32_t num_pages) const;
@@ -76,6 +66,12 @@ public:
 #endif
 
     void finish() { finish_impl(); }
+
+#ifndef COMPILE_FOR_TRISC
+    // This should not be used on WH/BH if the read into/write out of the DFB uses transaction ids because the transaction ids are not tracked.
+    // Instead, use noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid)
+    void write_barrier(const Noc &noc) const { write_barrier_impl(noc); }
+#endif
 
     uint32_t get_write_ptr() const { return get_write_ptr_impl(); }
     uint32_t get_read_ptr()  const { return get_read_ptr_impl(); }
@@ -93,11 +89,24 @@ private:
     void finish_impl();
     uint32_t get_write_ptr_impl() const;
     uint32_t get_read_ptr_impl()  const;
+#ifndef COMPILE_FOR_TRISC
+    void write_barrier_impl(const Noc &noc) const;
+#endif
 
 #ifdef ARCH_QUASAR
     template <bool is_producer>
     void handle_final_credits(uint16_t transactions_issued, uint8_t txn_id_index);
-#endif
+
+#ifndef COMPILE_FOR_TRISC
+    friend class Noc;  // grants Noc::async_read/write access to prepare_*/commit_* implicit-sync helpers
+
+    uint32_t prepare_implicit_read();
+    void commit_implicit_read();
+
+    uint32_t prepare_implicit_write();
+    void commit_implicit_write();
+#endif // !COMPILE_FOR_TRISC
+#endif // ARCH_QUASAR
 
     void release_scoped_lock() {
         // TODO: Unregister with the debugger
@@ -122,12 +131,12 @@ private:
 
 template <>
 struct noc_traits_t<DataflowBuffer> {
-    struct src_args_type {
-        uint32_t offset_bytes{};
-    };
-    struct dst_args_type {
-        uint32_t offset_bytes{};
-    };
+
+    // Alias the struct defined in noc.h so that noc_traits_t<DataflowBuffer>::src/dst_args_type
+    // stays consistent with the DFB-specific Noc overload signatures.
+    using src_args_type = DataflowBufferArgs;
+    using dst_args_type = DataflowBufferArgs;
+
     struct dst_args_mcast_type {
         uint32_t noc_x_start{};
         uint32_t noc_y_start{};

--- a/tt_metal/hw/inc/experimental/noc.h
+++ b/tt_metal/hw/inc/experimental/noc.h
@@ -9,6 +9,14 @@
 namespace experimental {
 
 struct MulticastEndpoint;
+class DataflowBuffer;
+
+// Concrete arg struct for the DFB-specific Noc overloads.
+// Defined here so noc.h can use it in async_read/async_write specializations defined in
+// dataflow_buffer.h which includes noc.h
+struct DataflowBufferArgs {
+    uint32_t offset_bytes{};
+};
 
 template <typename T>
 struct noc_traits_t {
@@ -566,6 +574,40 @@ public:
      * core.
      */
     void async_full_barrier() const { noc_async_full_barrier(noc_id_); }
+
+#ifdef ARCH_QUASAR
+    /**
+     * @brief Implicit-sync read into a DataflowBuffer.
+     *
+     * Selects this overload when TxnIdMode::ENABLED is specified and the destination is a DataflowBuffer
+     * No txn id is accepted here because the DataflowBuffer manages txn_ids internally
+     * via its private prepare/commit helpers
+     * Size of the read is not accepted here because the DataflowBuffer provides parameters for the read internally.
+     */
+    template <TxnIdMode txn_id_mode, typename Src>
+    std::enable_if_t<txn_id_mode == TxnIdMode::ENABLED>
+    async_read(
+        const Src& src,
+        DataflowBuffer& dst,
+        const src_args_t<Src>& src_args,
+        const DataflowBufferArgs& dst_args = {}) const;
+
+    /**
+     * @brief Implicit-sync write from a DataflowBuffer.
+     *
+     * Selects this overload when TxnIdMode::ENABLED is specified and the source is a
+     * DataflowBuffer. No txn id is accepted here because the DataflowBuffer manages txn_ids internally
+     * via its private prepare/commit helpers.
+     * Size of the write is not accepted here because the DataflowBuffer provides parameters for the write internally.
+     */
+    template <TxnIdMode txn_id_mode, typename Dst>
+    std::enable_if_t<txn_id_mode == TxnIdMode::ENABLED>
+    async_write(
+        DataflowBuffer& src,
+        const Dst& dst,
+        const DataflowBufferArgs& src_args,
+        const dst_args_t<Dst>& dst_args) const;
+#endif
 
 private:
     uint8_t noc_id_;

--- a/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
@@ -108,6 +108,10 @@ inline bool DataflowBuffer::pages_reservable_at_back(int32_t num_pages) const { 
 
 inline bool DataflowBuffer::pages_available_at_front(int32_t num_pages) const { return cb_pages_available_at_front(logical_dfb_id_, num_pages); }
 
+inline void DataflowBuffer::write_barrier_impl(const Noc &noc) const {
+    noc.async_write_barrier();
+}
+
 #endif
 
 inline void DataflowBuffer::finish_impl() {}

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -167,70 +167,6 @@ inline uint32_t DataflowBuffer::get_read_ptr_impl() const {
 }
 
 #ifndef COMPILE_FOR_TRISC
-
-template <typename Src>
-inline void DataflowBuffer::read_in(
-    const Noc& noc, const Src& src, const typename noc_traits_t<Src>::src_args_type& src_args) {
-    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-    uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-    uint8_t tc_id = dfb::get_counter_id(packed_tc);
-
-    // Wait for entries that were previously read across all transaction ids to be posted. Need to do this because HW
-    // doesn't track pending posts. When this condition is met, we know previous reads were committed.
-    while (fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
-
-    // Make sure there is space for the new tile
-    while (fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
-
-    noc.async_read<Noc::TxnIdMode::ENABLED>(src, *this, get_entry_size(), src_args, {}, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ptxn_id_index_]);
-
-    local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (local_dfb_interface_.stride_size);
-    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr >= local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
-    }
-
-    ptiles_read_++;
-    // Move to next txn id when we have read in num tiles per DM producer.
-    // This is safe because we ensure previously read entries are posted before reading in more data
-    if (ptiles_read_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
-        ptxn_id_index_ = (ptxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
-        ptxn_id_loop_cnt_++;
-    }
-
-    local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-}
-
-template <typename Dst>
-inline void DataflowBuffer::write_out(
-    const Noc& noc, const Dst& dst, const typename noc_traits_t<Dst>::dst_args_type& dst_args) {
-    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-    uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-    uint8_t tc_id = dfb::get_counter_id(packed_tc);
-
-    // Wait for entries that were previously written across all transaction ids to be acked. Need to do this because HW
-    // doesn't track pending acks. When this condition is met, we know previous writes were issued.
-    while (fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
-
-    while (fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
-
-    noc.async_write<Noc::TxnIdMode::ENABLED>(*this, dst, get_entry_size(), {}, dst_args, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ctxn_id_index_]);
-
-    local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (local_dfb_interface_.stride_size);
-    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr >= local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
-    }
-
-    ctiles_written_++;
-    // Move to next txn id when the DM has written its threshold per transaction id.
-    // This is safe because we ensure previous writes are acked before trying to write more data
-    if (ctiles_written_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
-        ctxn_id_index_ = (ctxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
-        ctxn_id_loop_cnt_++;
-    }
-
-    local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-}
-
 template <bool is_producer>
 inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, uint8_t txn_id_index) {
     // Determine the txn_id for the last batch. If transactions_issued lands exactly on
@@ -314,6 +250,129 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
             }
         }
     }
+}
+
+
+// Consumer barrier: waits outbound write from DFB writes to arrive at their destination
+// Falls back to a full barrier when no txn_ids are assigned
+inline void DataflowBuffer::write_barrier_impl(const Noc &noc) const {
+    if (local_dfb_interface_.num_txn_ids == 0) {
+        noc.async_write_barrier();
+        return;
+    } else {
+        for (uint8_t i = 0; i < local_dfb_interface_.num_txn_ids; i++) {
+            noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(local_dfb_interface_.txn_ids[i]);
+        }
+    }
+}
+
+// Preamble for implicit-sync read: spin until previous reads are posted and there is space in the tile counters.
+// Returns the txn_id to stamp on the next NOC read.
+inline uint32_t DataflowBuffer::prepare_implicit_read() {
+    ASSERT(local_dfb_interface_.num_txn_ids > 0);
+    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+    uint8_t tc_id = dfb::get_counter_id(packed_tc);
+    while (fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+    while (fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
+    return local_dfb_interface_.txn_ids[ptxn_id_index_];
+}
+
+// Postamble for implicit-sync read: advance wr_ptr, tile/txn counters, and tc_idx.
+inline void DataflowBuffer::commit_implicit_read() {
+    ASSERT(local_dfb_interface_.num_txn_ids > 0);
+    local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += local_dfb_interface_.stride_size;
+    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr >=
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr =
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+    }
+    ptiles_read_++;
+    if (ptiles_read_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
+        ptxn_id_index_ = (ptxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
+        ptxn_id_loop_cnt_++;
+    }
+    local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+}
+
+// Preamble for implicit-sync write: spin until previous writes are acked and data is available in the tile counters.
+// Returns the txn_id to stamp on the next NOC write.
+inline uint32_t DataflowBuffer::prepare_implicit_write() {
+    ASSERT(local_dfb_interface_.num_txn_ids > 0);
+    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+    uint8_t tc_id = dfb::get_counter_id(packed_tc);
+    while (fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+    while (fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
+    return local_dfb_interface_.txn_ids[ctxn_id_index_];
+}
+
+// Postamble for implicit-sync write: advance rd_ptr, tile/txn counters, and tc_idx.
+inline void DataflowBuffer::commit_implicit_write() {
+    ASSERT(local_dfb_interface_.num_txn_ids > 0);
+    local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += local_dfb_interface_.stride_size;
+    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr >=
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr =
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+    }
+    ctiles_written_++;
+    if (ctiles_written_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
+        ctxn_id_index_ = (ctxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
+        ctxn_id_loop_cnt_++;
+    }
+    local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+}
+
+// Out-of-line definitions of Noc DFB-specific implicit-sync overloads.
+// These are member functions of Noc but must be defined here because they need the complete
+// DataflowBuffer type (circular dependency: dataflow_buffer.h includes noc.h, not vice versa).
+
+template <Noc::TxnIdMode txn_id_mode, typename Src>
+std::enable_if_t<txn_id_mode == Noc::TxnIdMode::ENABLED>
+Noc::async_read(
+    const Src& src,
+    DataflowBuffer& dst,
+    const typename noc_traits_t<Src>::src_args_type& src_args,
+    const DataflowBufferArgs& dst_args) const {
+    uint32_t txn_id = dst.prepare_implicit_read();
+    noc_async_read_set_trid(txn_id, noc_id_);
+    while (noc_available_transactions(noc_id_, txn_id) < ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2));
+    noc_async_read<NOC_MAX_BURST_SIZE + 1, true>(
+        get_src_ptr<AddressType::NOC>(src, src_args),
+        get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+        dst.get_entry_size(),
+        noc_id_,
+        NOC_UNICAST_WRITE_VC);
+    dst.commit_implicit_read();
+}
+
+template <Noc::TxnIdMode txn_id_mode, typename Dst>
+std::enable_if_t<txn_id_mode == Noc::TxnIdMode::ENABLED>
+Noc::async_write(
+    DataflowBuffer& src,
+    const Dst& dst,
+    const DataflowBufferArgs& src_args,
+    const typename noc_traits_t<Dst>::dst_args_type& dst_args) const {
+    uint32_t txn_id = src.prepare_implicit_write();
+    auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
+    auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, src_addr, dst_noc_addr, size_bytes, -1, posted, noc_id_);
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id_, dst_noc_addr, src_addr, src.get_entry_size());
+    ncrisc_noc_fast_write_any_len<noc_mode, true, /*one_packet*/false>(
+        noc_id_,
+        write_cmd_buf,
+        src_addr,
+        dst_noc_addr,
+        src.get_entry_size(),
+        NOC_UNICAST_WRITE_VC,
+        false,   // mcast
+        false,   // linked
+        1,       // num_dests
+        true,    // multicast_path_reserve
+        false,   // posted == false (Noc::ResponseMode::NON_POSTED)
+        txn_id);
+    src.commit_implicit_write();
 }
 
 #endif  // !COMPILE_FOR_TRISC


### PR DESCRIPTION
### Summary
Using implicit sync apis with DFB issues noc reads/writes without having to do push_back/reserve_back/wait_front/pop_front but currently uses dfb.read_in/dfb.write_out apis. 

This pr introduces noc.async_write/noc.async_read specializations for DFBs to allow these apis to allow implicit and explicit sync to look more similar. 
The implicit sync apis require user to call the noc apis with `TxnIdMode::ENABLED` but doesn't accept trid as a parameter because the runtime hides trid assignment/management. Implicit sync also reads one entry (i.e. tile) at a time so the size of the noc transaction is also not accepted. 

Also added a dfb.write_barrier api to ensure barrier is called on the correct transaction ids. read barrier variant is not needed because the isr doesn't fire until reads land.

FYI @bbradelTT @fvranicTT @amokanTT 

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-txn-ids) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-txn-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-txn-ids) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-txn-ids) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-txn-ids) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/dfb-txn-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-txn-ids) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-txn-ids) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-txn-ids) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-txn-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-txn-ids) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-txn-ids) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-txn-ids) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-txn-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-txn-ids) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-txn-ids) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-txn-ids) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-txn-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-txn-ids) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-txn-ids) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-txn-ids) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-txn-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-txn-ids) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-txn-ids) |