### PR TITLE
#0: Flip attention matmul weights to bfp4

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -339,7 +339,7 @@ def create_decoder_block_tensors(
     trans_mat_replicated = torch_trans_mat.repeat(1, 1, qrope_num_cores + kv_cache_branch_rope_crs.num_cores(), 1)
     ttnn_trans_mat = ttnn.from_torch(
         trans_mat_replicated,
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat4_b,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
         memory_config=trans_mem,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -502,7 +502,7 @@ def test_attention_block(
 
     ttnn_trans_mat = ttnn.from_torch(
         trans_mat_replicated,
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat4_b,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
         memory_config=trans_mem_config,
@@ -1111,7 +1111,10 @@ def test_attention_block(
     for device_idx in range(mesh_rows * mesh_cols):
         received = output_torch[device_idx : device_idx + 1, :]
 
-        passing, pcc = comp_pcc(torch_output_expected, received, 0.997)
+        # Low position_ids exercise a nearly-empty KV cache, which amplifies bfp4 q-matmul
+        # quantization error; PCC recovers to >= 0.997 by position 511.
+        pcc_threshold = 0.99 if position_id < 511 else 0.997
+        passing, pcc = comp_pcc(torch_output_expected, received, pcc_threshold)
         max_diff = torch.max(torch.abs(torch_output_expected - received)).item()
         logger.info(f"Device {device_idx} Attention Block Output PCC: {pcc} Max Diff: {max_diff}")
         if not passing:

--- a/models/demos/deepseek_v3_b1/weights/specs/overlap_configs.py
+++ b/models/demos/deepseek_v3_b1/weights/specs/overlap_configs.py
@@ -356,8 +356,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
 
     def tp4_merged_fusion_group_spec(
         self,
-        o_proj_dtype: ttnn.DataType = ttnn.DataType.BFLOAT8_B,
-        mla_proj_dtype: ttnn.DataType = ttnn.DataType.BFLOAT8_B,
+        o_proj_dtype: ttnn.DataType = ttnn.DataType.BFLOAT4_B,
+        mla_proj_dtype: ttnn.DataType = ttnn.DataType.BFLOAT4_B,
     ) -> FusionGroupSpec:
         """Build merged spec: TP4 o_proj + gate_mm + norms + q_ab + kv_a in one buffer."""
         q_cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
@@ -401,7 +401,7 @@ class KVB12_PROJ_SingleDeviceOverlapSpec:
         default_factory=lambda: OverlappedTensorSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
             raw_tensor_shape=(8192, 512),
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=ttnn.DataType.BFLOAT4_B,
             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             tp_dim=(None, 0),
         )
@@ -415,7 +415,7 @@ class KVB12_PROJ_SingleDeviceOverlapSpec:
                 }
             ),
             raw_tensor_shape=(512, 8192),
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=ttnn.DataType.BFLOAT4_B,
             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             tp_dim=(None, 0),
         )

--- a/models/demos/deepseek_v3_b1/weights/transforms/attention.py
+++ b/models/demos/deepseek_v3_b1/weights/transforms/attention.py
@@ -122,7 +122,7 @@ def fuse_q_ab_kv_a(
     kv_a_proj_weights: torch.Tensor,
     device,
     *,
-    dtype: ttnn.DataType = ttnn.bfloat8_b,
+    dtype: ttnn.DataType = ttnn.bfloat4_b,
     move_to_device: bool = True,
 ) -> dict[str, OverlappedTensor]:
     """Fuse q_a, q_b, and kv_a projection weights into one overlapped buffer."""
@@ -143,7 +143,7 @@ def fuse_o_proj_gate_mm_norms(
     ffn_norm: torch.Tensor,
     device,
     *,
-    o_proj_dtype: ttnn.DataType = ttnn.bfloat8_b,
+    o_proj_dtype: ttnn.DataType = ttnn.bfloat4_b,
     move_to_device: bool = True,
 ) -> dict[str, OverlappedTensor]:
     """Fuse o_proj, gate_mm, and RMSNorm weights into one overlapped buffer."""
@@ -179,9 +179,9 @@ def fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
     kv_a_proj_weights: torch.Tensor,
     device,
     *,
-    o_proj_dtype: ttnn.DataType = ttnn.bfloat8_b,
-    q_ab_dtype: ttnn.DataType = ttnn.bfloat8_b,
-    kv_a_dtype: ttnn.DataType = ttnn.bfloat8_b,
+    o_proj_dtype: ttnn.DataType = ttnn.bfloat4_b,
+    q_ab_dtype: ttnn.DataType = ttnn.bfloat4_b,
+    kv_a_dtype: ttnn.DataType = ttnn.bfloat4_b,
     move_to_device: bool = True,
 ) -> dict[str, OverlappedTensor]:
     """Fuse TP4 ``shuffle_q_a`` o_proj, norms, and q_a / q_b / kv_a into one per-core L1 buffer.
@@ -256,7 +256,7 @@ def fuse_kv_b12(
     kv_b2_proj_weights: torch.Tensor,
     device,
     *,
-    dtype: ttnn.DataType = ttnn.bfloat8_b,
+    dtype: ttnn.DataType = ttnn.bfloat4_b,
     move_to_device: bool = True,
 ) -> dict[str, OverlappedTensor]:
     """Fuse kv_b1 and kv_b2 projection weights into one overlapped buffer."""


### PR DESCRIPTION
### Ticket
None

### Problem description
Flipping attention weights to bfp4 gives us more SRAM back for hot experts.

### What's changed
Convert the full set of MLA matmul weights from bfp8 to bfp4: q_a_proj,
q_b_proj, kv_a_proj, kv_b1_proj, kv_b2_proj, o_proj, and the trans_mat
RoPE rotation matrix.

Default dtypes in overlap_configs.py and all fuse_* helpers are now
bfloat4_b; no CB-sharing or fuse-helper changes are needed because every
attention matmul weight lives in the same dtype + tile.

Decoder sweep across seq lens {0, 127, 511, 1023, 2047, 4096, 6644,
9916, 11664} all PASS. Lower PCC threshold (0.99) is applied in
test_attention_block at position_id < 511 only — low-seq-len cases
exercise a nearly-empty KV cache which amplifies bfp4 quantization
error; PCC recovers to >= 0.997 by position 511.

Evals with teacher-forcing for bfp4 attention are more or less the same as bfp8:
- BFP8 reference: 0.896
- BFP4 attention: 0.885


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bliu/deepseek)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/deepseek): https://github.com/tenstorrent/tt-metal/actions/runs/24689944403
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/deepseek)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=worktree-bfp4-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-bfp4-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=worktree-bfp4-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:worktree-bfp4-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=worktree-bfp4-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-bfp4-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=worktree-bfp4-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-bfp4-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=worktree-bfp4-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-bfp4-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=worktree-bfp4-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-bfp4-attention)