### PR TITLE
Enable progress monitoring and worker logging by default in fabric test runner

### DIFF
--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -23,6 +23,8 @@ Optional:
     --test-config <path>                Path to test configuration file
                                         (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
+    --no-show-progress                  Disable real-time progress monitoring (enabled by default)
+    --no-show-workers                   Disable per-device worker/location logging (enabled by default)
     --help                              Display this help message and exit
 
 Example:
@@ -44,6 +46,8 @@ MESH_GRAPH_DESC_PATH_EXPLICIT=false
 TEST_BINARY="./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric"
 TEST_CONFIG="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
 FILTER=""
+SHOW_PROGRESS=true
+SHOW_WORKERS=true
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -118,6 +122,14 @@ while [[ $# -gt 0 ]]; do
             FILTER="$2"
             shift 2
             ;;
+        --no-show-progress)
+            SHOW_PROGRESS=false
+            shift
+            ;;
+        --no-show-workers)
+            SHOW_WORKERS=false
+            shift
+            ;;
         --help)
             show_help
             exit 0
@@ -180,7 +192,12 @@ echo ""
 
 EXTRA_BINARY_ARGS=""
 if [[ "$TEST_BINARY" == *test_tt_fabric ]]; then
-    EXTRA_BINARY_ARGS="--show-progress --show-workers"
+    if [[ "$SHOW_PROGRESS" == true ]]; then
+        EXTRA_BINARY_ARGS+=" --show-progress"
+    fi
+    if [[ "$SHOW_WORKERS" == true ]]; then
+        EXTRA_BINARY_ARGS+=" --show-workers"
+    fi
 fi
 if [[ -n "$FILTER" ]]; then
     EXTRA_BINARY_ARGS="$EXTRA_BINARY_ARGS --filter $FILTER"

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -5,31 +5,44 @@ show_help() {
     cat << EOF
 Usage: $0 --hosts <comma-separated-host-list> --image <docker-image> [OPTIONS]
 
-Run fabric tests on 4x8, 4x32, or 8x16 cluster configuration.
+Run fabric tests on a cluster configuration.
+
+Supported configurations:
+    4x8   - Single Galaxy, 1 host, 8x4 mesh
+    4x32  - Single pod, 4 hosts, 32x4 mesh (quad Galaxy linear)
+    8x16  - Single pod, 4 hosts, 16x8 mesh (quad Galaxy 2x2 grid)
+    sp4   - SuperPod 4, 16 hosts (4 pods x 4 hosts), 4 meshes with 2D torus XY
 
 Required Options:
-    --hosts <host-list>                 Comma-separated list of hosts (single host for 4x8)
+    --hosts <host-list>                 Comma-separated list of hosts (1 for 4x8, 4 for 4x32/8x16, 16 for sp4)
     --image <docker-image>              Docker image to use
 
 Optional:
-    --config <4x8|4x32|8x16>           Mesh configuration (default: 4x32)
+    --config <4x8|4x32|8x16|sp4>       Mesh configuration (default: 4x32)
     --output <directory>                Output directory for log files (default: fabric_test_logs)
     --mesh-graph-desc-path <path>       Path to mesh graph descriptor file (overrides --config)
                                         4x8 default:  tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
                                         4x32 default: tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
                                         8x16 default: tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+                                        sp4 default:  tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_torus_xy_graph_descriptor.textproto
     --test-binary <path>                Path to test binary
                                         (default: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric)
     --test-config <path>                Path to test configuration file
-                                        (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
+                                        4x8/4x32/8x16 default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
+                                        sp4 default:            tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_multi_mesh.yaml
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
     --no-show-progress                  Disable real-time progress monitoring (enabled by default)
     --no-show-workers                   Disable per-device worker/location logging (enabled by default)
     --help                              Display this help message and exit
 
-Example:
-    $0 --hosts bh-glx-c01u02,bh-glx-c01u08 \\
-       --image ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest
+Example (single pod):
+    $0 --hosts bh-glx-c05u02,bh-glx-c05u08,bh-glx-c06u02,bh-glx-c06u08 \\
+       --image ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:latest
+
+Example (sp4 - 16 hosts across 4 pods):
+    $0 --config sp4 \\
+       --hosts pod0-g0,pod0-g1,pod0-g2,pod0-g3,pod1-g0,...,pod3-g3 \\
+       --image ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:latest
 EOF
 }
 
@@ -40,11 +53,15 @@ OUTPUT_DIR="fabric_test_logs"
 MESH_GRAPH_DESC_PATH_4x8="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_4x32="tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_8x16="tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
+MESH_GRAPH_DESC_PATH_SP4="tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_torus_xy_graph_descriptor.textproto"
 CONFIG="4x32"
 MESH_GRAPH_DESC_PATH=""
 MESH_GRAPH_DESC_PATH_EXPLICIT=false
 TEST_BINARY="./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric"
-TEST_CONFIG="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
+TEST_CONFIG=""
+TEST_CONFIG_EXPLICIT=false
+TEST_CONFIG_DEFAULT="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
+TEST_CONFIG_SP4="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_multi_mesh.yaml"
 FILTER=""
 SHOW_PROGRESS=true
 SHOW_WORKERS=true
@@ -73,8 +90,8 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             CONFIG="$2"
-            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" ]]; then
-                echo "Error: --config must be one of '4x8', '4x32', or '8x16'"
+            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" && "$CONFIG" != "sp4" ]]; then
+                echo "Error: --config must be one of '4x8', '4x32', '8x16', or 'sp4'"
                 echo ""
                 show_help
                 exit 1
@@ -112,6 +129,7 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             TEST_CONFIG="$2"
+            TEST_CONFIG_EXPLICIT=true
             shift 2
             ;;
         --filter)
@@ -166,6 +184,17 @@ if [[ "$MESH_GRAPH_DESC_PATH_EXPLICIT" == false ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x32"
     elif [[ "$CONFIG" == "8x16" ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_8x16"
+    elif [[ "$CONFIG" == "sp4" ]]; then
+        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_SP4"
+    fi
+fi
+
+# Set test config based on config if not explicitly provided
+if [[ "$TEST_CONFIG_EXPLICIT" == false ]]; then
+    if [[ "$CONFIG" == "sp4" ]]; then
+        TEST_CONFIG="$TEST_CONFIG_SP4"
+    else
+        TEST_CONFIG="$TEST_CONFIG_DEFAULT"
     fi
 fi
 
@@ -216,6 +245,91 @@ if [[ "$CONFIG" == "4x8" ]]; then
         -x TT_MESH_ID=0 \
         -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
         -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
+elif [[ "$CONFIG" == "sp4" ]]; then
+    ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
+        --empty-entrypoint \
+        --bind-to none \
+        --host "$HOSTS" \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=1 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=2 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=0 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=3 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=1 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=1 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=1 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=1 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=2 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=1 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=3 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=2 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=2 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=1 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=2 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=2 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=2 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=3 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=3 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=3 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=1 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=3 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=2 "$TEST_BINARY" \
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS : \
+        -np 1 \
+        -x TT_MESH_ID=3 \
+        -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
+        -x TT_MESH_HOST_RANK=3 "$TEST_BINARY" \
         --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
 else
     ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

When fabric tests are run at customer/data center installs via `run_fabric_tests.sh`, a hung test produces no diagnostic output. The operator sees a frozen terminal with no indication of which device, tray, or ASIC is responsible. The `test_tt_fabric` binary already supports `--show-progress` and `--show-workers` flags (added in #41084 and #41258), but the runner script does not pass them, so they are effectively unused in production runs.

### What's changed

`run_fabric_tests.sh` now passes `--show-progress` and `--show-workers` to every MPI rank by default. This enables:

- **Per-device worker logging** — before each test, each rank logs its sender/receiver counts with physical location labels (`hostname(Rank)/Tray/ASIC`).
- **Real-time progress monitoring** — during execution, a live progress line shows packet counts, throughput, ETA, and number of devices completed.
- **Hung device warnings** — if a device makes no progress for 30 seconds, a warning is emitted identifying it by physical Tray/ASIC location.

Both flags can be independently disabled with `--no-show-progress` and `--no-show-workers` for cases where the extra output is not wanted (e.g. automated perf benchmarking).


### Testing

Ran full run_fabric_tests.sh suite of tests on a B67 quad, it succeeded, I couldn't replicate the hang unfortunately

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/fabric_tests_progress)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/fabric_tests_progress)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/fabric_tests_progress)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [#2592](https://github.com/tenstorrent/tt-metal/actions/runs/24337886645) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [#17456](https://github.com/tenstorrent/tt-metal/actions/runs/24396086620) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [#5144](https://github.com/tenstorrent/tt-metal/actions/runs/24334699143) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/fabric_tests_progress) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/fabric_tests_progress) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/fabric_tests_progress)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/fabric_tests_progress) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/fabric_tests_progress) |