### PR TITLE
Support directly unpacking to DEST in llk_unpack_tilize

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	branch = main
 [submodule "tt_metal/third_party/tt_llk"]
 	path = tt_metal/third_party/tt_llk
-	url = https://github.com/polymage-labs/tt-llk.git
+	url = git@github.com:polymage-labs/tt-llk.git
 	branch = polymage/main

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	branch = main
 [submodule "tt_metal/third_party/tt_llk"]
 	path = tt_metal/third_party/tt_llk
-	url = https://github.com/tenstorrent/tt-llk.git
-	branch = main
+	url = https://github.com/polymage-labs/tt-llk.git
+	branch = polymage/main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,16 @@ if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.t
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")
 endif()
 
+# Sync submodule URLs to use the fork of tt-llk which uses branch `polymage/main`.
+execute_process(
+    COMMAND git submodule sync --recursive
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+execute_process(
+    COMMAND git submodule update --init --recursive
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 # Clear any compile options that may have been set by consuming projects that have leaked into us.
 set_directory_properties(
     PROPERTIES

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -7,18 +7,34 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
+#include "tensix_types.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
 
+// Generalized copy_dest_value that works with any DataFormat
+template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
+    constexpr uint8_t instr_mod_index = GetSfpLoadStoreInstrMod<DATA_FORMAT>();
+    // size of each tile in Dest is 64 rows
+    constexpr uint dst_tile_size = 64;
+    for (int d = 0; d < ITERATIONS; d++) {
+        TT_SFPLOAD(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_7, dst_index_in * dst_tile_size);
+        TT_SFPSTORE(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        dst_reg++;
+    }
+}
+
+// Deprecated: Use the DataFormat template parameter version instead
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void copy_dest_value(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out /* unused */) {
+[[deprecated("Use copy_dest_value<DataFormat, APPROXIMATION_MODE, ITERATIONS> instead")]]
+void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
         // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
         constexpr uint dst_tile_size_sfpi = 32;
-        dst_reg[dst_index_in0 * dst_tile_size_sfpi] = dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        dst_reg[dst_index_out * dst_tile_size_sfpi] = dst_reg[dst_index_in * dst_tile_size_sfpi];
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -20,11 +20,12 @@ void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const ui
     constexpr uint8_t instr_mod_index = GetSfpLoadStoreInstrMod<DATA_FORMAT>();
     // size of each tile in Dest is 64 rows
     constexpr uint dst_tile_size = 64;
-    for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_7, dst_index_in * dst_tile_size);
-        TT_SFPSTORE(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_7, dst_index_out * dst_tile_size);
-        dst_reg++;
-    }
+    #pragma GCC unroll(0)
+        for (int d = 0; d < ITERATIONS; d++) {
+            TT_SFPLOAD(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_7, dst_index_in * dst_tile_size);
+            TT_SFPSTORE(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_7, dst_index_out * dst_tile_size);
+            dst_reg++;
+        }
 }
 
 // Deprecated: Use the DataFormat template parameter version instead

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -5,21 +5,37 @@
 #pragma once
 
 #include "ckernel_sfpu_copy_dest_values.h"
-#include "llk_math_eltwise_binary_sfpu_params.h"
 #include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
 
 namespace ckernel {
 
+// Generalized version that takes a DataFormat template parameter.
+template <DataFormat DATA_FORMAT>
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
-    uint32_t dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    constexpr bool APPROXIMATE = 0;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::copy_dest_value<APPROXIMATE>, dst_index0, dst_index1, 0 /*odst not used*/, vector_mode);
+    uint32_t dst_index_in, uint32_t dst_index_out,
+    int vector_mode = VectorMode::RC) {
+  constexpr bool APPROXIMATE = 0;
+  _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+      sfpu::copy_dest_value<DATA_FORMAT, APPROXIMATE>, dst_index_in,
+      dst_index_out, 0 /*unused*/, vector_mode);
+}
+
+// Deprecated: Use the template version with DataFormat parameter instead
+[[deprecated("Use llk_math_eltwise_binary_sfpu_copy_dest_values<DataFormat> instead")]]
+void llk_math_eltwise_binary_sfpu_copy_dest_values(
+    uint32_t dst_index_in, uint32_t dst_index_out,
+    int vector_mode = VectorMode::RC) {
+  constexpr bool APPROXIMATE = 0;
+  _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+      sfpu::copy_dest_value<APPROXIMATE>, dst_index_in, dst_index_out,
+      0 /*unused*/, vector_mode);
 }
 
 inline void llk_math_eltwise_binary_sfpu_copy_dest_values_init() {
-    constexpr bool APPROXIMATE = 0;
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(sfpu::copy_dest_value_init);
+  constexpr bool APPROXIMATE = 0;
+  llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+      sfpu::copy_dest_value_init);
 }
 
-}  // namespace ckernel
+} // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -202,7 +202,8 @@ inline std::uint32_t get_output_tile_address(std::uint8_t output_id, std::uint32
     return pack_tile_addr;
 }
 
-template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, bool untilize = false>
+template <bool is_fp32_dest_acc_en, bool out_of_order_output = false,
+          bool untilize = false, bool revert_dst_invalid_bits = false>
 inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
 
@@ -210,7 +211,8 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
     std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-    _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
+    _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize,
+               revert_dst_invalid_bits>(tile_index, pack_tile_addr);
 }
 
 /*************************************************************************

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -21,13 +21,14 @@ void copy_dest_value(const uint dst_index_in, const uint dst_index_out,
   constexpr uint8_t instr_mod_index = GetSfpLoadStoreInstrMod<DATA_FORMAT>();
   // Size of each tile in Dest is 64 rows
   constexpr uint dst_tile_size = 64;
-  for (int d = 0; d < ITERATIONS; d++) {
-    TT_SFPLOAD(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_3,
-               dst_index_in * dst_tile_size);
-    TT_SFPSTORE(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_3,
-                dst_index_out * dst_tile_size);
-    dst_reg++;
-  }
+  #pragma GCC unroll(0)
+    for (int d = 0; d < ITERATIONS; d++) {
+      TT_SFPLOAD(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_3,
+                dst_index_in * dst_tile_size);
+      TT_SFPSTORE(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_3,
+                  dst_index_out * dst_tile_size);
+      dst_reg++;
+    }
 }
 
 // Deprecated: Use the DataFormat template parameter version instead

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -7,25 +7,47 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
+#include "tensix_types.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
 
+// Generalized copy_dest_value that works with any DataFormat
+template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void copy_dest_value(const uint dst_index_in, const uint dst_index_out,
+                     const uint /* unused */) {
+  constexpr uint8_t instr_mod_index = GetSfpLoadStoreInstrMod<DATA_FORMAT>();
+  // Size of each tile in Dest is 64 rows
+  constexpr uint dst_tile_size = 64;
+  for (int d = 0; d < ITERATIONS; d++) {
+    TT_SFPLOAD(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_3,
+               dst_index_in * dst_tile_size);
+    TT_SFPSTORE(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_3,
+                dst_index_out * dst_tile_size);
+    dst_reg++;
+  }
+}
+
+// Deprecated: Use the DataFormat template parameter version instead
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void copy_dest_value(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out /* unused */) {
-    for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-        constexpr uint dst_tile_size_sfpi = 32;
-        dst_reg[dst_index_in0 * dst_tile_size_sfpi] = dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        dst_reg++;
-    }
+[[deprecated("Use copy_dest_value<DataFormat, APPROXIMATION_MODE, ITERATIONS> instead")]]
+void copy_dest_value(const uint dst_index_in, const uint dst_index_out,
+                     const uint /* unused */) {
+  for (int d = 0; d < ITERATIONS; d++) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using
+    // sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+    dst_reg[dst_index_out * dst_tile_size_sfpi] =
+        dst_reg[dst_index_in * dst_tile_size_sfpi];
+    dst_reg++;
+  }
 }
 
 void copy_dest_value_init() {
-    // No initialization required
+    // No initialization required.
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -52,5 +52,18 @@ inline void calculate_mask_posinf() {
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_mask_neginf() {
+    const bool exponent_size_8 = true;
+    const int mask_val_idx = 32;
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat mask = dst_reg[mask_val_idx];
+        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) { dst_reg[0] = -std::numeric_limits<float>::infinity(); }
+        v_endif;
+        dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -10,16 +10,36 @@
 
 namespace ckernel {
 
+// Generalized version that takes a DataFormat template parameter
+template <DataFormat DATA_FORMAT>
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
-    uint32_t dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    uint32_t dst_index_in, uint32_t dst_index_out,
+    int vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::copy_dest_value<APPROXIMATE>, dst_index0, dst_index1, 0 /*odst not used*/, vector_mode);
+        sfpu::copy_dest_value<DATA_FORMAT, APPROXIMATE>,
+        dst_index_in, dst_index_out, 0 /*unused*/,
+        vector_mode);
 }
 
-inline void llk_math_eltwise_binary_sfpu_copy_dest_values_init() {
+// Deprecated: Use the template version with DataFormat parameter instead
+[[deprecated("Use llk_math_eltwise_binary_sfpu_copy_dest_values<DataFormat> instead")]]
+void llk_math_eltwise_binary_sfpu_copy_dest_values(
+    uint32_t dst_index_in, uint32_t dst_index_out,
+    int vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(sfpu::copy_dest_value_init);
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::copy_dest_value<APPROXIMATE>,
+        dst_index_in, dst_index_out, 0 /*unused*/,
+        vector_mode);
+}
+
+inline void
+llk_math_eltwise_binary_sfpu_copy_dest_values_init() {
+    constexpr bool APPROXIMATE = 0;
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused,
+                                      APPROXIMATE>(
+        sfpu::copy_dest_value_init);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -22,6 +22,12 @@ inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_m
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_mask_neginf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_mask_neginf<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask(
     uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
     if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -45,8 +45,16 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);
 
+    const bool unpack_to_dest_for_fp32_src =
+        is_32bit_input(unpack_src_format[operand_id], unpack_dst_format[operand_id]);
+
     _llk_unpack_tilize_init_(
-        unpack_src_format[operand_id], unpack_dst_format[operand_id], ct_dim, face_r_dim, narrow_tile);
+        unpack_src_format[operand_id],
+        unpack_dst_format[operand_id],
+        ct_dim,
+        face_r_dim,
+        narrow_tile,
+        unpack_to_dest_for_fp32_src);
 }
 
 inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
@@ -88,9 +96,19 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, s
     std::uint32_t base_address =
         get_local_cb_interface(operand_id).fifo_rd_ptr - 1;  // Remove header size added by descriptor
 
+    const bool unpack_to_dest_for_fp32_src =
+        is_32bit_input(unpack_src_format[operand_id], unpack_dst_format[operand_id]);
+
     WAYPOINT("UPTW");
     _llk_unpack_tilize_(
-        base_address, tile_index, unpack_src_format[operand_id], block_ct_dim, face_r_dim, num_faces, narrow_tile);
+        base_address,
+        tile_index,
+        unpack_src_format[operand_id],
+        block_ct_dim,
+        face_r_dim,
+        num_faces,
+        narrow_tile,
+        unpack_to_dest_for_fp32_src);
     WAYPOINT("UPTD");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -996,6 +996,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_state(
  * | id                           | Page id                              | uint32_t  | Any uint32_t number                            | True     |
  * | addrgen                      | Address generator object             | AddrGen   | N/A                                            | True     |
  * | dst_local_l1_addr            | Address in local L1 memory           | uint32_t  | 0..1MB                                         | True     |
+ * | size                         | Size of data in bytes                | uint32_t  | 0..NOC_MAX_BURST_SIZE MB                       | False    |
  * | offset                       | Custom address offset                | uint32_t  | 0..1MB                                         | False    |
  * | noc                          | Which NOC to use for the transaction | uint8_t   | 0 or 1                                         | False    |
  * | AddrGen (template parameter) | Address generator class              | typename  | Any AddrGen class in \a dataflow_api_addrgen.h | True     |
@@ -1006,6 +1007,7 @@ FORCE_INLINE void noc_async_read_page(
     const uint32_t id,
     const AddrGen& addrgen,
     uint32_t dst_local_l1_addr,
+    uint32_t size = 0,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
     static_assert(
@@ -1019,10 +1021,10 @@ FORCE_INLINE void noc_async_read_page(
         page_size = (1 << addrgen.log_base_2_of_page_size);
     }
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, page_size, -1);
+        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, size ? size : page_size, -1);
     }
     noc_async_read<NOC_MAX_BURST_SIZE + 1, false>(
-        addrgen.get_noc_addr(id, offset, noc), dst_local_l1_addr, page_size, noc);
+        addrgen.get_noc_addr(id, offset, noc), dst_local_l1_addr, size ? size : page_size, noc);
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/copy_dest_values.h
+++ b/tt_metal/include/compute_kernel_api/copy_dest_values.h
@@ -7,29 +7,63 @@
 #include "compute_kernel_api/common_globals.h"
 #ifdef TRISC_MATH
 #include "llk_math_eltwise_binary_sfpu_copy_dest_values.h"
+#include "ckernel_sfpu_copy_dest_values.h"
 #endif
 
 namespace ckernel {
 
 // clang-format off
 /**
- * Copies all values from the tile in idst1 to the tile in idst0 in the DST register buffer.
+ * Copies all values from the tile in idst_in to the tile in
+ * idst_out in the DST register buffer. This is a generalized
+ * version that takes a DataFormat template parameter.
  *
- * The DST register buffer must be in acquired state via *tile_regs_acquire* call. This call is blocking and is only
+ * The DST register buffer must be in acquired state via
+ * *tile_regs_acquire* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type                     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|--------------------------|-------------------------------------------------------|----------|
+ * | DATA_FORMAT    | The data format for copy operation                                    | DataFormat               | Any valid DataFormat enum value                       | True     |
+ * | idst_in        | The index of the tile in DST register buffer to copy values from      | uint32_t                 | Must be less than the size of the DST register buffer | True     |
+ * | idst_out       | The index of the tile in DST register buffer to copy values to        | uint32_t                 | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+template <DataFormat DATA_FORMAT>
+ALWI void copy_dest_values(uint32_t idst_in, uint32_t idst_out) {
+    MATH(llk_math_eltwise_binary_sfpu_copy_dest_values<
+         static_cast<DataFormat>(DATA_FORMAT)>(
+        idst_in, idst_out));
+}
+
+// clang-format off
+/**
+ * Copies all values from the tile in idst_in to the tile in
+ * idst_out in the DST register buffer.
+ *
+ * The DST register buffer must be in acquired state via
+ * *tile_regs_acquire* call. This call is blocking and is only
  * available on the compute engine.
  *
  * Return value: None
  *
  * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0          | The index of the tile in DST register buffer to copy values to        | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst1          | The index of the tile in DST register buffer to copy values from      | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst_in        | The index of the tile in DST register buffer to copy values from      | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst_out       | The index of the tile in DST register buffer to copy values to        | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void copy_dest_values(uint32_t idst0, uint32_t idst1) {
-    MATH(llk_math_eltwise_binary_sfpu_copy_dest_values(idst0, idst1));
+[[deprecated("Use copy_dest_values<DataFormat> instead")]]
+ALWI void copy_dest_values(uint32_t idst_in,
+                           uint32_t idst_out) {
+    MATH(llk_math_eltwise_binary_sfpu_copy_dest_values(
+        idst_in, idst_out));
 }
 
-ALWI void copy_dest_values_init() { MATH(llk_math_eltwise_binary_sfpu_copy_dest_values_init()); }
+ALWI void copy_dest_values_init() {
+    MATH(llk_math_eltwise_binary_sfpu_copy_dest_values_init());
+}
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/mask.h
+++ b/tt_metal/include/compute_kernel_api/mask.h
@@ -47,4 +47,8 @@ ALWI void mask_posinf_tile(uint32_t idst_data, uint32_t idst2_mask) {
     MATH((llk_math_eltwise_unary_sfpu_mask_posinf<true>(idst_data)));
 }
 
+ALWI void mask_neginf_tile(uint32_t idst_data, uint32_t idst2_mask) {
+    MATH((llk_math_eltwise_unary_sfpu_mask_neginf<true>(idst_data)));
+}
+
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/pack.h
+++ b/tt_metal/include/compute_kernel_api/pack.h
@@ -57,9 +57,10 @@ namespace ckernel {
  * | Function   | output_tile_index| The index of the tile in the output CB to copy to | uint32_t | Must be less than the size of the CB                 | False    |
  */
 // clang-format on
-template <bool out_of_order_output = false>
+template <bool out_of_order_output = false, bool revert_dst_invalid_bits = false>
 ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_index = 0) {
-    PACK((llk_pack<DST_ACCUM_MODE, out_of_order_output, false>(ifrom_dst, icb, output_tile_index)));
+    PACK((llk_pack<DST_ACCUM_MODE, out_of_order_output, false,
+                   revert_dst_invalid_bits>(ifrom_dst, icb, output_tile_index)));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -144,7 +144,7 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
         for (uint32_t c = 0; c < block_ct_dim; ++c) {
             UNPACK(
                 (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, c)));
-            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c)));
+            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c, icb)));
         }
 
         MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -209,7 +209,7 @@ ALWI void tilize_block(
 
         // Datacopy
         MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
-            0 /*dst index*/)));
+            0 /*dst index*/, icb)));
         PACK((llk_pack<DST_ACCUM_MODE, true, false>(0 /*tile index*/, ocb, t + output_tile_index)));
 
         // Release dest
@@ -241,7 +241,7 @@ ALWI void tilize_block_no_pack(uint32_t icb, uint32_t block, uint32_t dst_idx, u
     for (uint32_t t = 0; t < block; t++) {
         // Datacopy
         MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
-            dst_idx /*dst index*/)));
+            dst_idx /*dst index*/, icb)));
     }
 }
 

--- a/tt_metal/include/compute_kernel_api/untilize.h
+++ b/tt_metal/include/compute_kernel_api/untilize.h
@@ -66,7 +66,7 @@ ALWI void untilize_block(uint32_t icb, uint32_t full_ct_dim, uint32_t ocb) {
 
         // Datacopy
         for (uint32_t reg_id = 0; reg_id < block_ct_dim; reg_id++) {
-            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(reg_id)));
+            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(reg_id, icb)));
         }
 
         MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -118,6 +118,30 @@ bool get_fp32_dest_acc_en(const std::optional<DeviceComputeKernelConfig>& comput
         compute_kernel_config.value());
 }
 
+bool get_dst_full_sync_en(
+    const std::optional<DeviceComputeKernelConfig>&
+        compute_kernel_config) {
+    if (not compute_kernel_config.has_value()) {
+        return false;
+    }
+    return std::visit(
+        [](auto&& compute_kernel_config) -> bool {
+            using T =
+                std::decay_t<decltype(compute_kernel_config)>;
+            if constexpr (
+                std::is_same_v<
+                    T, GrayskullComputeKernelConfig> ||
+                std::is_same_v<
+                    T, WormholeComputeKernelConfig>) {
+                return compute_kernel_config
+                    .dst_full_sync_en;
+            } else {
+                TT_THROW("arch not supported");
+            }
+        },
+        compute_kernel_config.value());
+}
+
 MathFidelity get_math_fidelity(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     if (not compute_kernel_config.has_value()) {
         return MathFidelity::Invalid;

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -46,6 +46,7 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
         ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE);
 
 bool get_fp32_dest_acc_en(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
+bool get_dst_full_sync_en(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 MathFidelity get_math_fidelity(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 tt::ARCH get_arch_from_compute_config(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 ttnn::operations::compute_throttle_utils::ThrottleLevel get_throttle_level(


### PR DESCRIPTION
_llk_unpack_tilize_ was always unpacking operands to the source registers. As a result tilization of fp32 data with full precision was not possible. This commit adds an optional argument named unpack_to_dest_for_fp32_src to _llk_unpack_tilize_ which controls whether the operands will be directly unpacked to DEST registers when the source data format is fp32. TT-LLK submodule is updated for this change.