### PR TITLE
Fixes for non-traced prefill in Llama 70B GLX.

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -195,29 +195,6 @@ class Generator(WarmupForwardMixin):
         for ccl_obj in ccl_refs:
             ccl_obj._prefill_column_mask = tt_column_mask
 
-    def _reset_prefill_ccl_state(self):
-        # Compile-only prefill warmup reuses the same prefill TT_CCL object across
-        # sp0/sp1 phases. Reset its indices explicitly so the non-traced path starts
-        # from the same clean state as trace capture/replay.
-        ttnn.synchronize_device(self.mesh_device)
-
-        seen_ids = set()
-        ccl_refs = []
-        for ccl_name in ("tt_ccl", "tt_ccl_prefill", "tt_ccl_decode"):
-            ccl_obj = getattr(self.model, ccl_name, None)
-            if ccl_obj is not None and id(ccl_obj) not in seen_ids:
-                seen_ids.add(id(ccl_obj))
-                ccl_refs.append(ccl_obj)
-        for layer in self.model.layers:
-            attn_ccl = getattr(layer.attention, "tt_ccl", None)
-            if attn_ccl is not None and id(attn_ccl) not in seen_ids:
-                seen_ids.add(id(attn_ccl))
-                ccl_refs.append(attn_ccl)
-        for ccl_obj in ccl_refs:
-            reset_fn = getattr(ccl_obj, "reset_gather_and_buffer_idx", None)
-            if reset_fn is not None:
-                reset_fn()
-
     def prefill_warmup(
         self,
         tokens: torch.Tensor,
@@ -240,7 +217,6 @@ class Generator(WarmupForwardMixin):
         sampling_parameters_sweeped = False
 
         self.model.switch_mode("prefill")
-        self._reset_prefill_ccl_state()
         logger.info("Warming up prefill for all supported sequence lengths up to max sequence length")
         warmup_sequence_lengths = get_prefill_warmup_sequence_lengths(self.model.args.max_seq_len)
         block_size = get_block_size(kv_cache[0]) if kv_cache else 64
@@ -303,7 +279,6 @@ class Generator(WarmupForwardMixin):
         # replay. A decode→prefill mode-switch cycle flushes that state.
         self.model.switch_mode("decode")
         self.model.switch_mode("prefill")
-        self._reset_prefill_ccl_state()
 
         # Phase 2: sp1 traces (prefix caching): batch 1 only, one per supported length.
         # Uses a fixed cached prefix aligned to both SDPA chunk size and page block size.

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -163,7 +163,7 @@ class Generator(WarmupForwardMixin):
         ]
         self.tt_logits_accumulated_batched = []  # Temporary list for batched prefill
         self.prev_page_table = None
-        self.prefill_warmup_completed = False
+        self.already_warmed_up_prefill = False
         self.warming_up_prefill = False
         self.trace_ids_decode = defaultdict(lambda: None)  # {return_logits: {device_id: trace_id}}
         self.trace_inputs_decode = defaultdict(lambda: None)
@@ -195,6 +195,29 @@ class Generator(WarmupForwardMixin):
         for ccl_obj in ccl_refs:
             ccl_obj._prefill_column_mask = tt_column_mask
 
+    def _reset_prefill_ccl_state(self):
+        # Compile-only prefill warmup reuses the same prefill TT_CCL object across
+        # sp0/sp1 phases. Reset its indices explicitly so the non-traced path starts
+        # from the same clean state as trace capture/replay.
+        ttnn.synchronize_device(self.mesh_device)
+
+        seen_ids = set()
+        ccl_refs = []
+        for ccl_name in ("tt_ccl", "tt_ccl_prefill", "tt_ccl_decode"):
+            ccl_obj = getattr(self.model, ccl_name, None)
+            if ccl_obj is not None and id(ccl_obj) not in seen_ids:
+                seen_ids.add(id(ccl_obj))
+                ccl_refs.append(ccl_obj)
+        for layer in self.model.layers:
+            attn_ccl = getattr(layer.attention, "tt_ccl", None)
+            if attn_ccl is not None and id(attn_ccl) not in seen_ids:
+                seen_ids.add(id(attn_ccl))
+                ccl_refs.append(attn_ccl)
+        for ccl_obj in ccl_refs:
+            reset_fn = getattr(ccl_obj, "reset_gather_and_buffer_idx", None)
+            if reset_fn is not None:
+                reset_fn()
+
     def prefill_warmup(
         self,
         tokens: torch.Tensor,
@@ -207,7 +230,7 @@ class Generator(WarmupForwardMixin):
         tt_out_logits_all_users=None,
     ):
         # Avoids an infinite loop
-        self.prefill_warmup_completed = True
+        self.already_warmed_up_prefill = True
         self.warming_up_prefill = True
 
         # Llama70b always supports on-device sampling from metal
@@ -217,6 +240,7 @@ class Generator(WarmupForwardMixin):
         sampling_parameters_sweeped = False
 
         self.model.switch_mode("prefill")
+        self._reset_prefill_ccl_state()
         logger.info("Warming up prefill for all supported sequence lengths up to max sequence length")
         warmup_sequence_lengths = get_prefill_warmup_sequence_lengths(self.model.args.max_seq_len)
         block_size = get_block_size(kv_cache[0]) if kv_cache else 64
@@ -279,6 +303,7 @@ class Generator(WarmupForwardMixin):
         # replay. A decode→prefill mode-switch cycle flushes that state.
         self.model.switch_mode("decode")
         self.model.switch_mode("prefill")
+        self._reset_prefill_ccl_state()
 
         # Phase 2: sp1 traces (prefix caching): batch 1 only, one per supported length.
         # Uses a fixed cached prefix aligned to both SDPA chunk size and page block size.
@@ -337,7 +362,7 @@ class Generator(WarmupForwardMixin):
         if getattr(self, "_disable_prefill_tracing", False):
             enable_trace = False
 
-        if self.prefill_warmup_completed is False:
+        if not self.already_warmed_up_prefill:
             self.prefill_warmup(
                 tokens,
                 page_table,

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -825,7 +825,12 @@ class TtLlamaAttention(LightweightModule):
             attn_output_1QSD,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
-        ttnn.deallocate(attn_output_1QSD)
+        # In the prefix-cached path, attn_output_1QSD is a reshape/view of the
+        # persistent ATTN_REPLICATE all-gather buffer. Deallocating it here also
+        # deallocates the cached buffer, so later layers/warmup iterations see a
+        # Tensor object that exists but is no longer allocated.
+        if not use_chunked_sdpa:
+            ttnn.deallocate(attn_output_1QSD)
 
         if ring_distributed_sdpa:
             # Split the attention output into two chunks along the sequence dimension for ring all-gather


### PR DESCRIPTION
 State var rename to unify with tt_transformers.

### Summary
This fixes CI failures:
https://github.com/tenstorrent/tt-metal/actions/runs/24320287256/job/71005493127#step:7:597
https://github.com/tenstorrent/tt-metal/actions/runs/24294973674/job/70938615693#step:17:832

* Fix the Llama 70B GLX prefill warmup state name to match the existing tt_transformers convention, so the two-phase warmup path can reliably re-run prefill trace capture.
* Fix the real prefix-caching failure by preserving ownership of the persistent ATTN_REPLICATE all-gather buffer in attention, instead of deallocating a reshaped view and leaving a stale unallocated tensor behind.

### CI
https://github.com/tenstorrent/tt-metal/actions/runs/24338941068

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/fix-70b-notrace-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/fix-70b-notrace-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/fix-70b-notrace-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/fix-70b-notrace-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/fix-70b-notrace-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/fix-70b-notrace-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-70b-notrace-warmup) |