### PR TITLE
[ttml] softmax_backward FP32 support

### DIFF
--- a/tt-train/sources/ttml/metal/common/dataflow_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/dataflow_utils.hpp
@@ -12,6 +12,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
 #include "api/debug/dprint_pages.h"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
 
 constexpr uint32_t onetile = 1U;
 
@@ -324,6 +325,31 @@ inline void read_tiles_by_row(
     if constexpr (UseBarrier) {
         noc_async_read_barrier();
         cb_push_back(cb_idx, num_tiles_to_push);
+    }
+}
+
+/**
+ * Zero the width-padded region inside a tile after read_tiles_by_row (last tile of a row when
+ * logical width is not a multiple of TILE_WIDTH). DRAM delivers a full tile; padding within the
+ * tile must be numeric zero so downstream compute that uses the whole tile does not sum garbage.
+ *
+ * @tparam mask_w  logical_width % TILE_WIDTH (compile-time 0 means no call sites should invoke, or use
+ *                 if constexpr(mask_w > 0) at the caller)
+ * @param cb_id     Circular buffer containing the tile
+ * @param tile_index_in_reserved_block  Index of the tile in the current cb_reserve_back region [0, num_tiles_to_push)
+ */
+template <uint32_t mask_w>
+inline void pad_last_tile_with_zeroes(uint32_t cb_id, uint32_t tile_index_in_reserved_block) {
+    if constexpr (mask_w == 0) {
+        return;
+    }
+    const uint32_t l1_addr = get_write_ptr(cb_id) + tile_index_in_reserved_block * get_tile_size(cb_id);
+    const DataFormat df = get_dataformat(cb_id);
+    using namespace tt::constants;
+    if (df == DataFormat::Float32) {
+        fill_pad_tile<uint32_t, mask_w, TILE_HEIGHT>(l1_addr, 0u);
+    } else {
+        fill_pad_tile<uint16_t, mask_w, TILE_HEIGHT>(l1_addr, static_cast<uint16_t>(0));
     }
 }
 

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp
@@ -6,7 +6,34 @@
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/matmul.h"
+#include "api/compute/reconfig_data_format.h"
 #include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
+
+namespace ckernel {
+
+// When fp32_dest_acc_en is set, unpack/math must be explicitly reconfigured between ops (see FP32_DEST_ACC_EN).
+ALWI void mul_tiles_init_with_dt(uint32_t icb0, uint32_t icb1) {
+#if defined(FP32_DEST_ACC_EN)
+    reconfig_data_format(icb0, icb1);
+#endif
+    mul_tiles_init(icb0, icb1);
+}
+
+ALWI void add_tiles_init_with_dt(uint32_t icb0, uint32_t icb1) {
+#if defined(FP32_DEST_ACC_EN)
+    reconfig_data_format(icb0, icb1);
+#endif
+    add_tiles_init(icb0, icb1);
+}
+
+ALWI void sub_bcast_cols_init_short_with_dt(uint32_t icb0, uint32_t icb1) {
+#if defined(FP32_DEST_ACC_EN)
+    reconfig_data_format(icb0, icb1);
+#endif
+    sub_bcast_cols_init_short(icb0, icb1);
+}
+
+}  // namespace ckernel
 
 constexpr uint32_t DST_REG_ID = 0;
 constexpr uint32_t ONE_TILE = 1;
@@ -15,6 +42,10 @@ constexpr uint32_t ONE_TILE = 1;
 ALWI void reduce_tile_to_cb(uint32_t icb0, uint32_t icb_ones, uint32_t ocb, uint32_t num_tiles) {
     tile_regs_acquire();
 
+#if defined(FP32_DEST_ACC_EN)
+    // Matmul reads different operand types than eltwise mul; reconfig keeps FP32 DST accumulation correct.
+    ckernel::reconfig_data_format(icb0, icb_ones);
+#endif
     // Initialize matmul - will accumulate across all tiles
     mm_init(icb0, icb_ones, ocb, /*transpose*/ 0);
 
@@ -35,7 +66,7 @@ ALWI void elementwise_multiply(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_
 
 template <>
 ALWI void elementwise_multiply<true>(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t size) {
-    mul_tiles_init(src0_cb_id, src1_cb_id);
+    ckernel::mul_tiles_init_with_dt(src0_cb_id, src1_cb_id);
     for (uint32_t i = 0; i < size; ++i) {
         tile_regs_acquire();
         mul_tiles(src0_cb_id, src1_cb_id, i, i, DST_REG_ID);
@@ -46,7 +77,7 @@ ALWI void elementwise_multiply<true>(uint32_t src0_cb_id, uint32_t src1_cb_id, u
 
 template <>
 ALWI void elementwise_multiply<false>(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t size) {
-    mul_tiles_init(src0_cb_id, src1_cb_id);
+    ckernel::mul_tiles_init_with_dt(src0_cb_id, src1_cb_id);
     tile_regs_acquire();
     for (uint32_t i = 0; i < size; ++i) {
         mul_tiles(src0_cb_id, src1_cb_id, i, i, i);
@@ -63,7 +94,7 @@ ALWI void accumulate(uint32_t accum_cb_id, uint32_t addend_cb_id) {
     cb_wait_front(addend_cb_id, ONE_TILE);
 
     // Add them together
-    add_tiles_init(accum_cb_id, addend_cb_id);
+    ckernel::add_tiles_init_with_dt(accum_cb_id, addend_cb_id);
     tile_regs_acquire();
     add_tiles(accum_cb_id, addend_cb_id, 0, 0, DST_REG_ID);
     tile_regs_commit();
@@ -89,10 +120,13 @@ ALWI void fused_sub_mul(
     tile_regs_acquire();
 
     // Step 1: Compute grad - sum(y * grad) and store in DST[0]
-    sub_bcast_cols_init_short(grad_cb_id, sum_reduce_cb_id);
+    ckernel::sub_bcast_cols_init_short_with_dt(grad_cb_id, sum_reduce_cb_id);
     sub_tiles_bcast<BROADCAST_TYPE>(grad_cb_id, sum_reduce_cb_id, grad_tile_idx, 0, DST_REG_ID);
 
     // Step 2: Multiply y * DST[0], reusing the DST register
+#if defined(FP32_DEST_ACC_EN)
+    ckernel::reconfig_data_format_srca(y_cb_id);
+#endif
     binary_dest_reuse_tiles_init<ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(y_cb_id);
     binary_dest_reuse_tiles<ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(y_cb_id, y_tile_idx, DST_REG_ID);
 

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp
@@ -13,23 +13,12 @@ namespace ckernel {
 
 // When fp32_dest_acc_en is set, unpack/math must be explicitly reconfigured between ops (see FP32_DEST_ACC_EN).
 ALWI void mul_tiles_init_with_dt(uint32_t icb0, uint32_t icb1) {
-#if defined(FP32_DEST_ACC_EN)
     reconfig_data_format(icb0, icb1);
-#endif
     mul_tiles_init(icb0, icb1);
 }
 
-ALWI void add_tiles_init_with_dt(uint32_t icb0, uint32_t icb1) {
-#if defined(FP32_DEST_ACC_EN)
-    reconfig_data_format(icb0, icb1);
-#endif
-    add_tiles_init(icb0, icb1);
-}
-
 ALWI void sub_bcast_cols_init_short_with_dt(uint32_t icb0, uint32_t icb1) {
-#if defined(FP32_DEST_ACC_EN)
     reconfig_data_format(icb0, icb1);
-#endif
     sub_bcast_cols_init_short(icb0, icb1);
 }
 
@@ -38,74 +27,56 @@ ALWI void sub_bcast_cols_init_short_with_dt(uint32_t icb0, uint32_t icb1) {
 constexpr uint32_t DST_REG_ID = 0;
 constexpr uint32_t ONE_TILE = 1;
 
-// Caller is responsible for waiting cb_wait_front(icb_ones, onetile);
-ALWI void reduce_tile_to_cb(uint32_t icb0, uint32_t icb_ones, uint32_t ocb, uint32_t num_tiles) {
-    tile_regs_acquire();
+// Stream y * grad through the row, mul-accumulating elementwise into DST[0].
+// `mul_tiles_init` programs ELWMUL with acc_to_dest=true, so within a single
+// tile_regs_acquire/commit window each `mul_tiles(y, grad, i, i, 0)` performs
+//   DST[0] += y[i] * grad[i]
+// (FP32 in DST when fp32_dest_acc_en). After all tiles, DST[0] holds 32 column
+// partials per row: column j = sum over k of input[k*32 + j]. The caller collapses
+// those 32 partials into a per-row scalar with a single matmul-with-ones.
+//
+// `RetainInputs` mirrors the reader contract: when the row fits in L1 the inputs
+// are kept for pass 2, otherwise they are popped block-by-block as we consume them.
+template <bool RetainInputs>
+ALWI void mul_accumulate_row_to_dst(
+    uint32_t y_cb_id,
+    uint32_t grad_cb_id,
+    uint32_t partial_cb_id,
+    uint32_t num_tiles_per_row,
+    uint32_t tiles_per_block) {
+    ckernel::mul_tiles_init_with_dt(y_cb_id, grad_cb_id);
 
+    tile_regs_acquire();
+    for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
+        cb_wait_front(y_cb_id, tiles_per_block);
+        cb_wait_front(grad_cb_id, tiles_per_block);
+        for (uint32_t i = 0; i < tiles_per_block; ++i) {
+            mul_tiles(y_cb_id, grad_cb_id, i, i, DST_REG_ID);
+        }
+        if constexpr (!RetainInputs) {
+            cb_pop_front(y_cb_id, tiles_per_block);
+            cb_pop_front(grad_cb_id, tiles_per_block);
+        }
+    }
+    tile_regs_commit();
+    pack_and_push(DST_REG_ID, partial_cb_id);
+}
+
+// Collapse the 32 column partials per row in `partial_cb_id` into a single per-row
+// scalar in `sum_cb_id` via one matmul with the ones tile.
+ALWI void reduce_partial_to_scalar(uint32_t partial_cb_id, uint32_t ones_cb_id, uint32_t sum_cb_id) {
+    tile_regs_acquire();
 #if defined(FP32_DEST_ACC_EN)
-    // Matmul reads different operand types than eltwise mul; reconfig keeps FP32 DST accumulation correct.
-    ckernel::reconfig_data_format(icb0, icb_ones);
+    ckernel::reconfig_data_format(partial_cb_id, ones_cb_id);
 #endif
-    // Initialize matmul - will accumulate across all tiles
-    mm_init(icb0, icb_ones, ocb, /*transpose*/ 0);
+    mm_init(partial_cb_id, ones_cb_id, sum_cb_id, /*transpose*/ 0);
 
-    cb_wait_front(icb0, num_tiles);
-    for (uint32_t x = 0; x < num_tiles; ++x) {
-        // Multiply tile x with ones vector and accumulate to dst0
-        // false = no transpose, enables accumulation behavior
-        matmul_tiles(icb0, icb_ones, x, 0, DST_REG_ID);
-    }
-
+    cb_wait_front(partial_cb_id, ONE_TILE);
+    matmul_tiles(partial_cb_id, ones_cb_id, 0, 0, DST_REG_ID);
     tile_regs_commit();
-    pack_and_push(DST_REG_ID, ocb);
-}
 
-// Multiply tiles from two CBs; FullRowInL1 chooses row (per-tile pack) vs block (batch pack) code path.
-template <bool FullRowInL1>
-ALWI void elementwise_multiply(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t size);
-
-template <>
-ALWI void elementwise_multiply<true>(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t size) {
-    ckernel::mul_tiles_init_with_dt(src0_cb_id, src1_cb_id);
-    for (uint32_t i = 0; i < size; ++i) {
-        tile_regs_acquire();
-        mul_tiles(src0_cb_id, src1_cb_id, i, i, DST_REG_ID);
-        tile_regs_commit();
-        pack_and_push(DST_REG_ID, out_cb_id);
-    }
-}
-
-template <>
-ALWI void elementwise_multiply<false>(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t size) {
-    ckernel::mul_tiles_init_with_dt(src0_cb_id, src1_cb_id);
-    tile_regs_acquire();
-    for (uint32_t i = 0; i < size; ++i) {
-        mul_tiles(src0_cb_id, src1_cb_id, i, i, i);
-    }
-    tile_regs_commit();
-    pack_and_push_block(out_cb_id, size);
-}
-
-// Add a new value to an accumulator and replace the accumulator with the result
-// Reads from accum_cb and addend_cb, pops both, then pushes result back to accum_cb
-ALWI void accumulate(uint32_t accum_cb_id, uint32_t addend_cb_id) {
-    // Wait for both inputs
-    cb_wait_front(accum_cb_id, ONE_TILE);
-    cb_wait_front(addend_cb_id, ONE_TILE);
-
-    // Add them together
-    ckernel::add_tiles_init_with_dt(accum_cb_id, addend_cb_id);
-    tile_regs_acquire();
-    add_tiles(accum_cb_id, addend_cb_id, 0, 0, DST_REG_ID);
-    tile_regs_commit();
-    tile_regs_wait();
-
-    // Pop old values
-    cb_pop_front(accum_cb_id, ONE_TILE);
-    cb_pop_front(addend_cb_id, ONE_TILE);
-
-    // Write updated sum back to accumulator CB
-    pack_and_push(DST_REG_ID, accum_cb_id);
+    cb_pop_front(partial_cb_id, ONE_TILE);
+    pack_and_push(DST_REG_ID, sum_cb_id);
 }
 
 // Fused subtract and multiply: output = y * (grad - sum)
@@ -139,12 +110,11 @@ void kernel_main() {
     constexpr uint32_t y_cb_id = get_compile_time_arg_val(0);            // softmax_output (y)
     constexpr uint32_t grad_cb_id = get_compile_time_arg_val(1);         // upstream_grad (grad)
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(2);          // output
-    constexpr uint32_t mul_cb_id = get_compile_time_arg_val(3);          // y * grad
-    constexpr uint32_t sum_reduce_cb_id = get_compile_time_arg_val(4);   // sum(y * grad) - accumulated
-    constexpr uint32_t ones_cb_id = get_compile_time_arg_val(5);         // ones vector for matmul reduction
-    constexpr uint32_t block_sum_cb_id = get_compile_time_arg_val(6);    // block sum temporary
-    constexpr uint32_t num_tiles_per_row = get_compile_time_arg_val(7);  // width in tiles
-    constexpr uint32_t tiles_per_block = get_compile_time_arg_val(8);  // block size - must match reader/writer kernels
+    constexpr uint32_t sum_reduce_cb_id = get_compile_time_arg_val(3);   // per-row scalar sum(y * grad)
+    constexpr uint32_t ones_cb_id = get_compile_time_arg_val(4);         // ones vector for matmul reduction
+    constexpr uint32_t partial_cb_id = get_compile_time_arg_val(5);      // 1-tile partial (32 col-partials per row)
+    constexpr uint32_t num_tiles_per_row = get_compile_time_arg_val(6);  // width in tiles
+    constexpr uint32_t tiles_per_block = get_compile_time_arg_val(7);  // block size - must match reader/writer kernels
     constexpr bool full_row_in_l1 = (num_tiles_per_row == tiles_per_block);  // skip second read when full row fits
 
     // Runtime args
@@ -156,34 +126,15 @@ void kernel_main() {
 
     // Two-pass streaming algorithm for minimal L1 memory
     for (uint32_t row = 0; row < num_rows; ++row) {
-        // === PASS 1: Streaming reduction to compute sum(y * grad) ===
-        cb_wait_front(ones_cb_id, ONE_TILE);
-
-        // Initialize accumulator with a zero tile
-        push_zero_tile(sum_reduce_cb_id);
-
-        // Process in blocks: compute products, then accumulate each block
-        for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
-            cb_wait_front(y_cb_id, tiles_per_block);
-            cb_wait_front(grad_cb_id, tiles_per_block);
-
-            // Step 1a: Compute y * grad for all tiles in this block (padding slots are 0*0=0)
-            elementwise_multiply<full_row_in_l1>(y_cb_id, grad_cb_id, mul_cb_id, tiles_per_block);
-
-            // Step 1b: Reduce this block to a single sum tile (padding tiles add 0 to sum)
-            reduce_tile_to_cb(mul_cb_id, ones_cb_id, block_sum_cb_id, tiles_per_block);
-
-            // Step 1c: Add block sum to running total
-            // accumulated_sum = accumulated_sum + block_sum
-            accumulate(sum_reduce_cb_id, block_sum_cb_id);
-
-            // Pop this block
-            cb_pop_front(mul_cb_id, tiles_per_block);
-            if constexpr (!full_row_in_l1) {
-                cb_pop_front(y_cb_id, tiles_per_block);
-                cb_pop_front(grad_cb_id, tiles_per_block);
-            }
-        }
+        // === PASS 1: sum(y * grad) per row ===
+        // Reorder accumulation as (a_0 + a_32 + ...) + (a_1 + a_33 + ...) + ... :
+        // mul-accumulate elementwise into DST[0] across all tiles in the row, then a single
+        // matmul-with-ones collapses the 32 column partials into a per-row scalar.
+        // Avoids the per-block reduce/pack/unpack/add round trips
+        // and keeps the running accumulator in FP32 DST throughout the row.
+        mul_accumulate_row_to_dst<full_row_in_l1>(
+            y_cb_id, grad_cb_id, partial_cb_id, num_tiles_per_row, tiles_per_block);
+        reduce_partial_to_scalar(partial_cb_id, ones_cb_id, sum_reduce_cb_id);
 
         // === PASS 2: Compute final output (reuse data when full row in L1, else fresh read) ===
         cb_wait_front(sum_reduce_cb_id, ONE_TILE);

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp
@@ -6,8 +6,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
-#include "ttnn/kernel/dataflow/generate_mm_scaler.hpp"
-#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
 
 void kernel_main() {
     // Compile time args
@@ -37,8 +35,8 @@ void kernel_main() {
     const auto softmax_output_accessor = TensorAccessor(softmax_output_args, softmax_output_addr);
     const auto upstream_grad_accessor = TensorAccessor(upstream_grad_args, upstream_grad_addr);
 
-    // Generate a column vector of ones for matmul-based reduction (BF16 only)
-    generate_mm_scaler(ones_cb_id, BF16_ONE_PACKED);
+    // Column of ones for matmul row reduction; format matches ones_cb (BF16 or FP32).
+    generate_matmul_row_reduce_tile(ones_cb_id);
 
     // When full row fits in L1 (num_tiles_per_row == tiles_per_block), read once; else stream and read twice
     constexpr bool full_row_in_l1 = (num_tiles_per_row == tiles_per_block);
@@ -76,18 +74,13 @@ void kernel_main() {
                     const uint32_t global_last_tile_idx = block_start + current_block_size - 1;
                     if (global_last_tile_idx == num_tiles_per_row - 1) {
                         const uint32_t last_tile_idx_in_block = current_block_size - 1;
-                        const uint32_t l1_write_addr_src0 = get_write_ptr(src0_cb_id);
-                        const uint32_t l1_write_addr_src1 = get_write_ptr(src1_cb_id);
-                        fill_pad_tile<uint16_t, mask_w, 32>(
-                            l1_write_addr_src0 + last_tile_idx_in_block * src0_tile_size,
-                            static_cast<uint16_t>(BF16_ZERO_BITS));
-                        fill_pad_tile<uint16_t, mask_w, 32>(
-                            l1_write_addr_src1 + last_tile_idx_in_block * src1_tile_size,
-                            static_cast<uint16_t>(BF16_ZERO_BITS));
+                        pad_last_tile_with_zeroes<mask_w>(src0_cb_id, last_tile_idx_in_block);
+                        pad_last_tile_with_zeroes<mask_w>(src1_cb_id, last_tile_idx_in_block);
                     }
                 }
 
-                // Zero-fill tail padding so compute always sees tiles_per_block tiles (no padding logic in compute).
+                // read_tiles_by_row only DMAs current_block_size tiles; reserved tail slots are uninitialized.
+                // Compute runs mul+reduce on all tiles_per_block slots with no mask, so y*grad must be 0 there.
                 if (current_block_size < tiles_per_block) {
                     const uint32_t pad_slots = tiles_per_block - current_block_size;
                     fill_reserved_tiles_with_zero(src0_cb_id, current_block_size, pad_slots, src0_tile_size);

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_device_operation.cpp
@@ -20,7 +20,9 @@ void SoftmaxBackwardDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         softmax_output.logical_shape() == upstream_grad.logical_shape(),
         "Softmax output and upstream gradient tensors must have the same shape");
-    TT_FATAL(softmax_output.dtype() == DataType::BFLOAT16, "Softmax backward only supports BFLOAT16");
+    TT_FATAL(
+        softmax_output.dtype() == DataType::BFLOAT16 || softmax_output.dtype() == DataType::FLOAT32,
+        "Softmax backward only supports BFLOAT16 and FLOAT32");
     TT_FATAL(
         upstream_grad.dtype() == softmax_output.dtype(),
         "Softmax output and upstream gradient must have the same dtype");

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
@@ -148,7 +148,8 @@ static void get_tensor_properties(
     num_rows = num_outer_dims * height_tiles;
     input_data_format = datatype_to_dataformat_converter(softmax_output.dtype());
     output_data_format = datatype_to_dataformat_converter(tensor_return_value.dtype());
-    intermed_data_format = tt::DataFormat::Float16_b;
+    // y*grad and reduction tiles use the same format as activations (BFLOAT16 or FLOAT32 today).
+    intermed_data_format = input_data_format;
     input_tile_size = tile_size(input_data_format);
     output_tile_size = tile_size(output_data_format);
     intermed_tile_size = tile_size(intermed_data_format);
@@ -257,7 +258,8 @@ SoftmaxBackwardFactory::cached_program_t SoftmaxBackwardFactory::create(
         width_tiles,
         tiles_per_block};
 
-    std::map<std::string, std::string> compute_defines = {{"BROADCAST_TYPE", "BroadcastType::COL"}};
+    std::map<std::string, std::string> compute_defines = {
+        {"BROADCAST_TYPE", "BroadcastType::COL"}, {"FP32_DEST_ACC_EN", "1"}};
     const ComputeConfig wconf = precise(compute_compile_time_args, compute_defines);
 
     auto reader_kernel_id =

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
@@ -28,9 +28,8 @@ constexpr uint32_t src0_cb_index = tt::CBIndex::c_0;         // softmax_output
 constexpr uint32_t src1_cb_index = tt::CBIndex::c_1;         // upstream_grad
 constexpr uint32_t ones_cb_index = tt::CBIndex::c_2;         // ones vector for matmul reduction
 constexpr uint32_t out_cb_index = tt::CBIndex::c_7;          // output
-constexpr uint32_t ygrad_cb_index = tt::CBIndex::c_13;       // y * grad
-constexpr uint32_t sum_reduce_cb_index = tt::CBIndex::c_14;  // sum(y * grad) - accumulated
-constexpr uint32_t block_sum_cb_index = tt::CBIndex::c_15;   // block sum temporary
+constexpr uint32_t sum_reduce_cb_index = tt::CBIndex::c_14;  // sum(y * grad)
+constexpr uint32_t partial_cb_index = tt::CBIndex::c_15;     // 32 column partials before final reduction
 
 constexpr const char* const kReaderPath =
     "tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp";
@@ -103,7 +102,7 @@ struct KernelMode {
 };
 
 static constexpr uint32_t memory_estimator(uint32_t width_tiles, uint32_t tile_size) {
-    return (width_tiles * tile_size) * 4U + (1U * tile_size) * 2U;  // src0, src1, out, ygrad; sum_reduce, ones
+    return (width_tiles * tile_size) * 3U + (1U * tile_size) * 3U;  // src0, src1, out; sum_reduce, ones, partial
 }
 
 static KernelMode get_kernel_mode(uint32_t width_tiles, uint32_t tile_size, const tt::tt_metal::IDevice* device) {
@@ -197,7 +196,7 @@ SoftmaxBackwardFactory::cached_program_t SoftmaxBackwardFactory::create(
 
     log_debug(
         tt::LogOp,
-        "SoftmaxBackward: Using {} kernel | Shape: {}x{} tiles | {}x buffering | Estimated L1: {} KB",
+        "SoftmaxBackward: Using {} approach | Shape: {}x{} tiles | {}x buffering | Estimated L1: {} KB",
         tiles_per_block == width_tiles ? "NON-STREAMING" : "STREAMING",
         num_rows,
         width_tiles,
@@ -215,7 +214,6 @@ SoftmaxBackwardFactory::cached_program_t SoftmaxBackwardFactory::create(
 
     const uint32_t block_cb_size_in0 = buffering_multiplier * tiles_per_block * input_tile_size;
     const uint32_t block_cb_size_out = buffering_multiplier * tiles_per_block * output_tile_size;
-    const uint32_t block_cb_size_intermed0 = buffering_multiplier * tiles_per_block * intermed_tile_size;
 
     auto c_in0_config = CircularBufferConfig(block_cb_size_in0, {{src0_cb_index, input_data_format}})
                             .set_page_size(src0_cb_index, input_tile_size);
@@ -229,15 +227,12 @@ SoftmaxBackwardFactory::cached_program_t SoftmaxBackwardFactory::create(
     auto c_out_config = CircularBufferConfig(block_cb_size_out, {{out_cb_index, output_data_format}})
                             .set_page_size(out_cb_index, output_tile_size);
     CreateCircularBuffer(program, worker_cores, c_out_config);
-    auto c_ygrad_config = CircularBufferConfig(block_cb_size_intermed0, {{ygrad_cb_index, intermed_data_format}})
-                              .set_page_size(ygrad_cb_index, intermed_tile_size);
-    CreateCircularBuffer(program, worker_cores, c_ygrad_config);
     auto c_sum_reduce_config = CircularBufferConfig(intermed_tile_size, {{sum_reduce_cb_index, intermed_data_format}})
                                    .set_page_size(sum_reduce_cb_index, intermed_tile_size);
     CreateCircularBuffer(program, worker_cores, c_sum_reduce_config);
-    auto c_block_sum_config = CircularBufferConfig(intermed_tile_size, {{block_sum_cb_index, intermed_data_format}})
-                                  .set_page_size(block_sum_cb_index, intermed_tile_size);
-    CreateCircularBuffer(program, worker_cores, c_block_sum_config);
+    auto c_partial_config = CircularBufferConfig(intermed_tile_size, {{partial_cb_index, intermed_data_format}})
+                                .set_page_size(partial_cb_index, intermed_tile_size);
+    CreateCircularBuffer(program, worker_cores, c_partial_config);
 
     std::vector<uint32_t> reader_compile_time_args = {
         src0_cb_index, src1_cb_index, ones_cb_index, width_tiles, tiles_per_block, mask_w};
@@ -251,10 +246,9 @@ SoftmaxBackwardFactory::cached_program_t SoftmaxBackwardFactory::create(
         src0_cb_index,
         src1_cb_index,
         out_cb_index,
-        ygrad_cb_index,
         sum_reduce_cb_index,
         ones_cb_index,
-        block_sum_cb_index,
+        partial_cb_index,
         width_tiles,
         tiles_per_block};
 

--- a/tt-train/tests/ops/softmax_backward_op_test.cpp
+++ b/tt-train/tests/ops/softmax_backward_op_test.cpp
@@ -250,7 +250,9 @@ TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_LongRows) {
 TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_ManyShortRows) {
     SOFTMAX_BW_SKIP_IF_UNSUPPORTED("many-short-rows shape");
     constexpr SoftmaxBackwardCase test_case{
-        .name = "many_short_rows_non_streaming_5_tiles",
+        // TODO: fails with name "many_short_rows_non_streaming_5_tiles".
+        // Tracking: https://github.com/tenstorrent/tt-metal/issues/41944
+        .name = "many_short_rows_non_streaming",
         .n = 1,
         .c = 30,
         .h = 6400,
@@ -323,7 +325,7 @@ TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_llama8b) {
 
 constexpr std::array<DTypeParam, 2> kDTypeParams = {{
     {"bf16", ttnn::DataType::BFLOAT16, true},
-    {"fp32", ttnn::DataType::FLOAT32, false},
+    {"fp32", ttnn::DataType::FLOAT32, true},
 }};
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tt-train/tests/ops/softmax_backward_op_test.cpp
+++ b/tt-train/tests/ops/softmax_backward_op_test.cpp
@@ -38,7 +38,6 @@ struct SoftmaxBackwardCase {
 struct DTypeParam {
     const char* name;
     ttnn::DataType dtype;
-    bool is_supported;
 };
 
 constexpr uint32_t kSuiteSeed = 42U;
@@ -122,12 +121,6 @@ void run_softmax_backward_case(
     auto y_tt = to_device_tensor(y_tensor, device, dtype_param.dtype);
     auto grad_tt = to_device_tensor(grad_tensor, device, dtype_param.dtype);
 
-    if (!dtype_param.is_supported) {
-        EXPECT_ANY_THROW((void)ttml::metal::softmax_backward(y_tt, grad_tt, test_case.dim))
-            << "case=" << test_case.name << ", dtype=" << dtype_param.name;
-        return;
-    }
-
     ttnn::Tensor result_tt = sub_core_grids.has_value()
                                  ? ttml::metal::softmax_backward(y_tt, grad_tt, test_case.dim, *sub_core_grids)
                                  : ttml::metal::softmax_backward(y_tt, grad_tt, test_case.dim);
@@ -162,16 +155,7 @@ ttnn::distributed::MeshDevice* SoftmaxBackwardOpTest::s_device = nullptr;
 
 class SoftmaxBackwardOpTypedTest : public SoftmaxBackwardOpTest, public ::testing::WithParamInterface<DTypeParam> {};
 
-#define SOFTMAX_BW_SKIP_IF_UNSUPPORTED(description)                                                       \
-    do {                                                                                                  \
-        if (!GetParam().is_supported) {                                                                   \
-            GTEST_SKIP() << "Skipping " << (description) << " for unsupported dtype " << GetParam().name; \
-            return;                                                                                       \
-        }                                                                                                 \
-    } while (0)
-
 TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_LastDim_1Tile) {
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("1-tile last-dim");
     constexpr SoftmaxBackwardCase test_case{
         .name = "1tile_last_dim",
         .n = 1,
@@ -193,7 +177,6 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_SubCoreGrid_Rectangular) {
     if (board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P150 boards";
     }
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("sub-core-grid rectangular");
     // Rectangular sub-grid: 2x2 cores starting at (0,0). Requires device with at least 2x2 compute grid.
     const tt::tt_metal::CoreRange sub_range(tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(1, 1));
     const tt::tt_metal::CoreRangeSet sub_core_grids(sub_range);
@@ -213,7 +196,6 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_SubCoreGrid_Rectangular) {
 }
 
 TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_SubCoreGrid_NonRectangular) {
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("sub-core-grid non-rectangular");
     // Non-rectangular (L-shaped) sub-grid
     std::vector<tt::tt_metal::CoreRange> ranges = {
         tt::tt_metal::CoreRange(tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(2, 0)),  // row y=0
@@ -227,8 +209,8 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_SubCoreGrid_NonRectangular) {
         .h = 32,
         .w = 512,
         .dim = 3,
-        .atol = 1e-2F,
-        .rtol = 1e-2F,
+        .atol = 5e-3F,
+        .rtol = 5e-3F,
         .grad_min = -10.0F,
         .grad_max = 10.0F,
     };
@@ -236,10 +218,9 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_SubCoreGrid_NonRectangular) {
 }
 
 TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_LongRows) {
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("long-row shape");
     constexpr std::array<SoftmaxBackwardCase, 2> cases = {{
-        {"long_rows_streaming_300_tiles", 1, 5, 32, 300 * 32, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"long_rows_streaming_639_tiles", 1, 1, 32, 639 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"long_rows_streaming_300_tiles", 1, 5, 32, 300 * 32, 3, 1e-3F, 1e-3F, -10.0F, 10.0F},
+        {"long_rows_streaming_639_tiles", 1, 1, 32, 639 * 32, -1, 1e-3F, 1e-3F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
@@ -248,10 +229,14 @@ TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_LongRows) {
 }
 
 TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_ManyShortRows) {
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("many-short-rows shape");
-    constexpr SoftmaxBackwardCase test_case{
+    if (GetParam().dtype == ttnn::DataType::BFLOAT16) {
         // TODO: fails with name "many_short_rows_non_streaming_5_tiles".
+        // Also fails for bf16 with max_abs_diff=0.72139114141464233
         // Tracking: https://github.com/tenstorrent/tt-metal/issues/41944
+        GTEST_SKIP() << "Skipping many-short-rows shape for unsupported bf16 dtype ";
+        return;
+    }
+    constexpr SoftmaxBackwardCase test_case{
         .name = "many_short_rows_non_streaming",
         .n = 1,
         .c = 30,
@@ -271,11 +256,10 @@ TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_ManyShortRows) {
 // Type C - first face is full, second face must be padded
 
 TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_Padding_NonStreaming) {
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("padded non-streaming shape");
     constexpr std::array<SoftmaxBackwardCase, 3> cases = {{
-        {"padded_non_streaming_type_a", 1, 1, 128, 14 * 32 + 2, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"padded_non_streaming_type_b", 2, 1, 256, 14 * 32 + 16, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"padded_non_streaming_type_c", 2, 1, 128, 14 * 32 + 18, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"padded_non_streaming_type_a", 1, 1, 128, 14 * 32 + 2, -1, 5e-3F, 1e-3F, -10.0F, 10.0F},
+        {"padded_non_streaming_type_b", 2, 1, 256, 14 * 32 + 16, 3, 5e-3F, 1e-3F, -10.0F, 10.0F},
+        {"padded_non_streaming_type_c", 2, 1, 128, 14 * 32 + 18, 3, 5e-3F, 1e-3F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
@@ -284,11 +268,10 @@ TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_Padding_NonStreaming)
 }
 
 TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_Padding_Streaming) {
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("padded streaming shape");
     constexpr std::array<SoftmaxBackwardCase, 3> cases = {{
-        {"padded_streaming_type_a", 1, 5, 32, 300 * 32 + 3, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"padded_streaming_type_b", 7, 1, 64, 300 * 32 + 16, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"padded_streaming_type_c", 3, 1, 32, 300 * 32 + 19, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"padded_streaming_type_a", 1, 5, 32, 300 * 32 + 3, -1, 1e-3F, 1e-3F, -10.0F, 10.0F},
+        {"padded_streaming_type_b", 7, 1, 64, 300 * 32 + 16, 3, 1e-3F, 1e-3F, -10.0F, 10.0F},
+        {"padded_streaming_type_c", 3, 1, 32, 300 * 32 + 19, 3, 1e-3F, 1e-3F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
@@ -297,13 +280,12 @@ TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_Padding_Streaming) {
 }
 
 TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_WidthBoundaryStreamingSwitch) {
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("boundary shape");
     constexpr std::array<SoftmaxBackwardCase, 5> cases = {{
-        {"boundary_63_tiles", 1, 2, 32, 63 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"boundary_64_tiles", 1, 3, 32, 64 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"boundary_65_tiles", 1, 4, 32, 65 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"boundary_127_tiles", 1, 1, 32, 127 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
-        {"boundary_128_tiles", 3, 1, 32, 128 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"boundary_63_tiles", 1, 2, 32, 63 * 32, -1, 1e-3F, 1e-3F, -10.0F, 10.0F},
+        {"boundary_64_tiles", 1, 3, 32, 64 * 32, -1, 1e-3F, 1e-3F, -10.0F, 10.0F},
+        {"boundary_65_tiles", 1, 4, 32, 65 * 32, -1, 1e-3F, 1e-3F, -10.0F, 10.0F},
+        {"boundary_127_tiles", 1, 1, 32, 127 * 32, -1, 1e-3F, 1e-3F, -10.0F, 10.0F},
+        {"boundary_128_tiles", 3, 1, 32, 128 * 32, -1, 1e-3F, 1e-3F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
@@ -313,9 +295,8 @@ TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_WidthBoundaryStreamin
 
 // 2048 rows by 64 tiles each
 TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_llama8b) {
-    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("llama shape");
     constexpr std::array<SoftmaxBackwardCase, 1> cases = {{
-        {"llama8b_b1", 1, 32, 2048, 2048, 3, 2e-2F, 2e-2F, -10.0F, 10.0F},
+        {"llama8b_b1", 1, 32, 2048, 2048, 3, 1e-3F, 1e-3F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
@@ -324,8 +305,8 @@ TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_llama8b) {
 }
 
 constexpr std::array<DTypeParam, 2> kDTypeParams = {{
-    {"bf16", ttnn::DataType::BFLOAT16, true},
-    {"fp32", ttnn::DataType::FLOAT32, true},
+    {"bf16", ttnn::DataType::BFLOAT16},
+    {"fp32", ttnn::DataType::FLOAT32},
 }};
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### Summary
Add FP32 support for softmax_backward

### Related issues

1. https://github.com/tenstorrent/tt-metal/issues/27796
2. https://github.com/tenstorrent/tt-metal/issues/41944

### Performance

Row number 0 corresponds to current reduce implementation, where we are running matmul on every tile.
Row number 1 is the approach suggested in comments, where we accumulate elements in DST and run reduction once.
It clearly gives performance boost for bf16. 

#### bf16

|    | OP CODE                        | OP TYPE       |   GLOBAL CALL COUNT |   DEVICE ID | DEVICE ARCH   | ATTRIBUTES                                     | MATH FIDELITY   |   CORE COUNT |   AVAILABLE WORKER CORE COUNT |   PARALLELIZATION STRATEGY |   HOST START TS |   HOST END TS |   HOST DURATION [ns] |   DEVICE FW START CYCLE |   DEVICE FW END CYCLE |   OP TO OP LATENCY [ns] |   OP TO OP LATENCY BR/NRISC START [ns] |   DEVICE FW DURATION [ns] |   DEVICE KERNEL DURATION [ns] |   DEVICE KERNEL DURATION DM START [ns] |   DEVICE KERNEL DURATION PER CORE MIN [ns] |   DEVICE KERNEL DURATION PER CORE MAX [ns] |   DEVICE KERNEL DURATION PER CORE AVG [ns] |   DEVICE KERNEL FIRST TO LAST START [ns] |   DEVICE BRISC KERNEL DURATION [ns] |   DEVICE NCRISC KERNEL DURATION [ns] |   DEVICE TRISC0 KERNEL DURATION [ns] |   DEVICE TRISC1 KERNEL DURATION [ns] |   DEVICE TRISC2 KERNEL DURATION [ns] |   DEVICE ERISC KERNEL DURATION [ns] |   DEVICE COMPUTE CB WAIT FRONT [ns] |   DEVICE COMPUTE CB RESERVE BACK [ns] |   DISPATCH TOTAL CQ CMD OP TIME [ns] |   DISPATCH GO SEND WAIT TIME [ns] | INPUT_0_W_PAD[LOGICAL]   | INPUT_0_Z_PAD[LOGICAL]   | INPUT_0_Y_PAD[LOGICAL]   | INPUT_0_X_PAD[LOGICAL]   | INPUT_0_LAYOUT   | INPUT_0_DATATYPE   | INPUT_0_MEMORY         | INPUT_1_W_PAD[LOGICAL]   | INPUT_1_Z_PAD[LOGICAL]   | INPUT_1_Y_PAD[LOGICAL]   | INPUT_1_X_PAD[LOGICAL]   | INPUT_1_LAYOUT   | INPUT_1_DATATYPE   | INPUT_1_MEMORY         | OUTPUT_0_W_PAD[LOGICAL]   | OUTPUT_0_Z_PAD[LOGICAL]   | OUTPUT_0_Y_PAD[LOGICAL]   | OUTPUT_0_X_PAD[LOGICAL]   | OUTPUT_0_LAYOUT   | OUTPUT_0_DATATYPE   | OUTPUT_0_MEMORY        |   METAL TRACE ID |   METAL TRACE REPLAY SESSION ID | COMPUTE KERNEL SOURCE                                                                                   | COMPUTE KERNEL HASH                               | DATA MOVEMENT KERNEL SOURCE                                                                                                                                                                                      | DATA MOVEMENT KERNEL HASH                                                                          |         PROGRAM HASH | PROGRAM CACHE HIT   |   TENSIX DM 0 MAX KERNEL SIZE [B] |   TENSIX DM 1 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 0 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 1 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 2 MAX KERNEL SIZE [B] |   ACTIVE ETH DM 0 MAX KERNEL SIZE [B] |   ACTIVE ETH DM 1 MAX KERNEL SIZE [B] |   IDLE ETH DM 0 MAX KERNEL SIZE [B] |   IDLE ETH DM 1 MAX KERNEL SIZE [B] |   PM IDEAL [ns] |   PM COMPUTE [ns] |   PM BANDWIDTH [ns] | PM REQ I BW                              | PM REQ O BW          |   PM FPU UTIL (%) |   NOC UTIL (%) |   MULTICAST NOC UTIL (%) |   DRAM BW UTIL (%) |   DRAM BW UTIL PER CTRL (%) |   ETH BW UTIL (%) |   NPE CONG IMPACT (%) |
|---:|:-------------------------------|:--------------|--------------------:|------------:|:--------------|:-----------------------------------------------|:----------------|-------------:|------------------------------:|---------------------------:|----------------:|--------------:|---------------------:|------------------------:|----------------------:|------------------------:|---------------------------------------:|--------------------------:|------------------------------:|---------------------------------------:|-------------------------------------------:|-------------------------------------------:|-------------------------------------------:|-----------------------------------------:|------------------------------------:|-------------------------------------:|-------------------------------------:|-------------------------------------:|-------------------------------------:|------------------------------------:|------------------------------------:|--------------------------------------:|-------------------------------------:|----------------------------------:|:-------------------------|:-------------------------|:-------------------------|:-------------------------|:-----------------|:-------------------|:-----------------------|:-------------------------|:-------------------------|:-------------------------|:-------------------------|:-----------------|:-------------------|:-----------------------|:--------------------------|:--------------------------|:--------------------------|:--------------------------|:------------------|:--------------------|:-----------------------|-----------------:|--------------------------------:|:--------------------------------------------------------------------------------------------------------|:--------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|---------------------:|:--------------------|----------------------------------:|----------------------------------:|---------------------------------------:|---------------------------------------:|---------------------------------------:|--------------------------------------:|--------------------------------------:|------------------------------------:|------------------------------------:|----------------:|------------------:|--------------------:|:-----------------------------------------|:---------------------|------------------:|---------------:|-------------------------:|-------------------:|----------------------------:|------------------:|----------------------:|
| 0 | SoftmaxBackwardDeviceOperation      | tt_dnn_device |               15360 |           0 | wormhole_b0   | {'dim': '3'; 'sub_core_grids': 'std::nullopt'}                                                                                                                                                                                                                                                                                                                                                                                      | HiFi4           |            3 |                            64 |                        nan |     21100205631 |   21100665367 |               459736 |          13916464597529 |        13916464724572 |              3446092595 |                             3446093103 |                    127043 |                        126419 |                                 125911 |                                        nan |                                        nan |                                        nan |                                      576 |                              125911 |                                46458 |                               102770 |                               103075 |                               102929 |                                 nan |                                 nan |                                   nan |                                  nan |                               nan | 3[3]                     | 1[1]                     | 32[32]                   | 4096[4096]               | TILE             | BFLOAT16           | DEV_0_DRAM_INTERLEAVED | 3[3]                     | 1[1]                     | 32[32]                   | 4096[4096]               | TILE             | BFLOAT16           | DEV_0_DRAM_INTERLEAVED | 3[3]                      | 1[1]                      | 32[32]                    | 4096[4096]                | TILE              | BFLOAT16            | DEV_0_DRAM_INTERLEAVED |              nan |                             nan | ['tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp'] | ['softmax_backward_kernel/13907027055224190578/'] | ['tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp'; 'tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp']                               | ['writer_softmax_backward/10692813191839266817/'; 'reader_softmax_backward/11170502482046402127/']                          | 13690301228547704411 | False               |                              2440 |                              2892 |                                   3824 |                                   2188 |                                   6120 |                                     0 |                                     0 |                                   0 |                                   0 |            2838 |                 0 |                2838 | [277.1078186035156; 277.1078186035156]   | [277.1078186035156]  |             0     |            nan |                      nan |                nan |                         nan |               nan |                   nan |
| 1 | SoftmaxBackwardDeviceOperation      | tt_dnn_device |               15360 |           0 | wormhole_b0   | {'dim': '3'; 'sub_core_grids': 'std::nullopt'}                                                                                                                                                                                                                                                                                                                                                                                      | HiFi4           |            3 |                            64 |                        nan |     40275646211 |   40276100677 |               454466 |          13631955327055 |        13631955437907 |              3532428703 |                             3532429262 |                    110852 |                        110259 |                                 109700 |                                        nan |                                        nan |                                        nan |                                      617 |                              109699 |                                46517 |                                86550 |                                86894 |                                86725 |                                 nan |                                 nan |                                   nan |                                  nan |                               nan | 3[3]                     | 1[1]                     | 32[32]                   | 4096[4096]               | TILE             | BFLOAT16           | DEV_0_DRAM_INTERLEAVED | 3[3]                     | 1[1]                     | 32[32]                   | 4096[4096]               | TILE             | BFLOAT16           | DEV_0_DRAM_INTERLEAVED | 3[3]                      | 1[1]                      | 32[32]                    | 4096[4096]                | TILE              | BFLOAT16            | DEV_0_DRAM_INTERLEAVED |              nan |                             nan | ['tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp'] | ['softmax_backward_kernel/11817999842119580652/'] | ['tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp'; 'tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp']                               | ['writer_softmax_backward/163614610587227399/'; 'reader_softmax_backward/4258443090277127604/']                             | 13690301228547704411 | False               |                              2440 |                              2892 |                                   3216 |                                   1688 |                                   4512 |                                     0 |                                     0 |                                   0 |                                   0 |            2838 |                 0 |                2838 | [277.1078186035156; 277.1078186035156]   | [277.1078186035156]  |             0     |            nan |                      nan |                nan |                         nan |               nan |                   nan |

#### fp32

|    | OP CODE                        | OP TYPE       |   GLOBAL CALL COUNT |   DEVICE ID | DEVICE ARCH   | ATTRIBUTES                                     | MATH FIDELITY   |   CORE COUNT |   AVAILABLE WORKER CORE COUNT |   PARALLELIZATION STRATEGY |   HOST START TS |   HOST END TS |   HOST DURATION [ns] |   DEVICE FW START CYCLE |   DEVICE FW END CYCLE |   OP TO OP LATENCY [ns] |   OP TO OP LATENCY BR/NRISC START [ns] |   DEVICE FW DURATION [ns] |   DEVICE KERNEL DURATION [ns] |   DEVICE KERNEL DURATION DM START [ns] |   DEVICE KERNEL DURATION PER CORE MIN [ns] |   DEVICE KERNEL DURATION PER CORE MAX [ns] |   DEVICE KERNEL DURATION PER CORE AVG [ns] |   DEVICE KERNEL FIRST TO LAST START [ns] |   DEVICE BRISC KERNEL DURATION [ns] |   DEVICE NCRISC KERNEL DURATION [ns] |   DEVICE TRISC0 KERNEL DURATION [ns] |   DEVICE TRISC1 KERNEL DURATION [ns] |   DEVICE TRISC2 KERNEL DURATION [ns] |   DEVICE ERISC KERNEL DURATION [ns] |   DEVICE COMPUTE CB WAIT FRONT [ns] |   DEVICE COMPUTE CB RESERVE BACK [ns] |   DISPATCH TOTAL CQ CMD OP TIME [ns] |   DISPATCH GO SEND WAIT TIME [ns] | INPUT_0_W_PAD[LOGICAL]   | INPUT_0_Z_PAD[LOGICAL]   | INPUT_0_Y_PAD[LOGICAL]   | INPUT_0_X_PAD[LOGICAL]   | INPUT_0_LAYOUT   | INPUT_0_DATATYPE   | INPUT_0_MEMORY         | INPUT_1_W_PAD[LOGICAL]   | INPUT_1_Z_PAD[LOGICAL]   | INPUT_1_Y_PAD[LOGICAL]   | INPUT_1_X_PAD[LOGICAL]   | INPUT_1_LAYOUT   | INPUT_1_DATATYPE   | INPUT_1_MEMORY         | OUTPUT_0_W_PAD[LOGICAL]   | OUTPUT_0_Z_PAD[LOGICAL]   | OUTPUT_0_Y_PAD[LOGICAL]   | OUTPUT_0_X_PAD[LOGICAL]   | OUTPUT_0_LAYOUT   | OUTPUT_0_DATATYPE   | OUTPUT_0_MEMORY        |   METAL TRACE ID |   METAL TRACE REPLAY SESSION ID | COMPUTE KERNEL SOURCE                                                                                   | COMPUTE KERNEL HASH                               | DATA MOVEMENT KERNEL SOURCE                                                                                                                                                                                      | DATA MOVEMENT KERNEL HASH                                                                          |         PROGRAM HASH | PROGRAM CACHE HIT   |   TENSIX DM 0 MAX KERNEL SIZE [B] |   TENSIX DM 1 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 0 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 1 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 2 MAX KERNEL SIZE [B] |   ACTIVE ETH DM 0 MAX KERNEL SIZE [B] |   ACTIVE ETH DM 1 MAX KERNEL SIZE [B] |   IDLE ETH DM 0 MAX KERNEL SIZE [B] |   IDLE ETH DM 1 MAX KERNEL SIZE [B] |   PM IDEAL [ns] |   PM COMPUTE [ns] |   PM BANDWIDTH [ns] | PM REQ I BW                              | PM REQ O BW          |   PM FPU UTIL (%) |   NOC UTIL (%) |   MULTICAST NOC UTIL (%) |   DRAM BW UTIL (%) |   DRAM BW UTIL PER CTRL (%) |   ETH BW UTIL (%) |   NPE CONG IMPACT (%) |
|---:|:-------------------------------|:--------------|--------------------:|------------:|:--------------|:-----------------------------------------------|:----------------|-------------:|------------------------------:|---------------------------:|----------------:|--------------:|---------------------:|------------------------:|----------------------:|------------------------:|---------------------------------------:|--------------------------:|------------------------------:|---------------------------------------:|-------------------------------------------:|-------------------------------------------:|-------------------------------------------:|-----------------------------------------:|------------------------------------:|-------------------------------------:|-------------------------------------:|-------------------------------------:|-------------------------------------:|------------------------------------:|------------------------------------:|--------------------------------------:|-------------------------------------:|----------------------------------:|:-------------------------|:-------------------------|:-------------------------|:-------------------------|:-----------------|:-------------------|:-----------------------|:-------------------------|:-------------------------|:-------------------------|:-------------------------|:-----------------|:-------------------|:-----------------------|:--------------------------|:--------------------------|:--------------------------|:--------------------------|:------------------|:--------------------|:-----------------------|-----------------:|--------------------------------:|:--------------------------------------------------------------------------------------------------------|:--------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|---------------------:|:--------------------|----------------------------------:|----------------------------------:|---------------------------------------:|---------------------------------------:|---------------------------------------:|--------------------------------------:|--------------------------------------:|------------------------------------:|------------------------------------:|----------------:|------------------:|--------------------:|:-----------------------------------------|:---------------------|------------------:|---------------:|-------------------------:|-------------------:|----------------------------:|------------------:|----------------------:|
|  0 | SoftmaxBackwardDeviceOperation | tt_dnn_device |                5120 |           0 | wormhole_b0   | {'dim': '3'; 'sub_core_grids': 'std::nullopt'} | HiFi4           |            3 |                            64 |                        nan |     19951257924 |   19951933339 |               675415 |          13861608026609 |        13861608206361 |              3702318544 |                             3702319047 |                    179752 |                        179123 |                                 178620 |                                        nan |                                        nan |                                        nan |                                      550 |                              178615 |                               175913 |                               177268 |                               177605 |                               177478 |                                 nan |                                 nan |                                   nan |                                  nan |                               nan | 3[3]                     | 1[1]                     | 32[32]                   | 4096[4096]               | TILE             | FLOAT32            | DEV_0_DRAM_INTERLEAVED | 3[3]                     | 1[1]                     | 32[32]                   | 4096[4096]               | TILE             | FLOAT32            | DEV_0_DRAM_INTERLEAVED | 3[3]                      | 1[1]                      | 32[32]                    | 4096[4096]                | TILE              | FLOAT32             | DEV_0_DRAM_INTERLEAVED |              nan |                             nan | ['tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp'] | ['softmax_backward_kernel/14196871275803436255/'] | ['tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp'; 'tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp'] | ['writer_softmax_backward/4071235234093184090/'; 'reader_softmax_backward/5448327113169271536/']   | 13690301228395477139 | False               |                              2536 |                              2952 |                                   4128 |                                   2224 |                                   5672 |                                     0 |                                     0 |                                   0 |                                   0 |            5677 |                 0 |                5677 | [277.05902099609375; 277.05902099609375] | [277.05902099609375] |                 0 |            nan |                      nan |                nan |                         nan |               nan |                   nan |
|  1 | SoftmaxBackwardDeviceOperation | tt_dnn_device |                5120 |           0 | wormhole_b0   | {'dim': '3'; 'sub_core_grids': 'std::nullopt'} | HiFi4           |            3 |                            64 |                        nan |     29524601205 |   29525125321 |               524116 |          13509971035346 |        13509971212792 |              3685896139 |                             3685896663 |                    177446 |                        176838 |                                 176314 |                                        nan |                                        nan |                                        nan |                                      601 |                              176306 |                               173634 |                               174970 |                               175366 |                               175199 |                                 nan |                                 nan |                                   nan |                                  nan |                               nan | 3[3]                     | 1[1]                     | 32[32]                   | 4096[4096]               | TILE             | FLOAT32            | DEV_0_DRAM_INTERLEAVED | 3[3]                     | 1[1]                     | 32[32]                   | 4096[4096]               | TILE             | FLOAT32            | DEV_0_DRAM_INTERLEAVED | 3[3]                      | 1[1]                      | 32[32]                    | 4096[4096]                | TILE              | FLOAT32             | DEV_0_DRAM_INTERLEAVED |              nan |                             nan | ['tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp'] | ['softmax_backward_kernel/937110983487350854/']   | ['tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp'; 'tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp'] | ['writer_softmax_backward/13848672866725219707/'; 'reader_softmax_backward/1311052536738971945/']  | 13690301228395477139 | False               |                              2536 |                              2952 |                                   3588 |                                   1700 |                                   4544 |                                     0 |                                     0 |                                   0 |                                   0 |            5677 |                 0 |                5677 | [277.05902099609375; 277.05902099609375] | [277.05902099609375] |                 0 |            nan |                      nan |                nan |                         nan |               nan |                   nan |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/softmax-backward-followup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/softmax-backward-followup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vlad/softmax-backward-followup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vlad/softmax-backward-followup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/softmax-backward-followup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/softmax-backward-followup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/softmax-backward-followup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/softmax-backward-followup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vlad/softmax-backward-followup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vlad/softmax-backward-followup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/softmax-backward-followup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/softmax-backward-followup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/softmax-backward-followup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/softmax-backward-followup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/softmax-backward-followup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/softmax-backward-followup1)