### PR TITLE
Optimize SiLU SFPU kernel: LUT-based sigmoid for ~35% speedup

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -8,29 +8,66 @@
 
 namespace ckernel::sfpu {
 
-template <bool is_fp32_dest_acc_en, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
+    if constexpr (APPROXIMATION_MODE) {
+        // Fast path: use hardware LUT-based sigmoid approximation.
+        // The LUT coefficients are pre-loaded into L-registers by silu_init.
+        // lut() computes a 3-segment piecewise-linear sigmoid(x)-0.5 in a single
+        // hardware instruction, handling sign internally.
+        sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+        sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+
 #pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat x = sfpi::dst_reg[0];
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat x = sfpi::dst_reg[0];
 
-        // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+            // sigmoid(x) via hardware LUT + 0.5 bias
+            sfpi::vFloat sig = sfpi::lut(x, l0, l1, l2) + 0.5f;
 
-        // Round to bfloat16 if not in fp32 accumulation mode
-        if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            sfpi::vFloat result = x * sig;
+
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
         }
 
-        sfpi::dst_reg[0] = result;
-        sfpi::dst_reg++;
+        sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+        sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+        sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    } else {
+        // Accurate path: sigmoid via exp(-x) + Newton-Raphson reciprocal.
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat x = sfpi::dst_reg[0];
+
+            // silu(x) = x * sigmoid(x)
+            sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+
+            // Round to bfloat16 if not in fp32 accumulation mode
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
+        }
     }
 }
 
 template <bool APPROXIMATION_MODE>
 inline void silu_init() {
-    // calculate_silu uses the non-approx sigmoid path via _sfpu_sigmoid_, so we must use non-approx sigmoid_init
-    sigmoid_init<false>();
+    if constexpr (APPROXIMATION_MODE) {
+        // Load LUT coefficients for sigmoid approximation
+        sigmoid_appx_init();
+    } else {
+        // calculate_silu uses the non-approx sigmoid path via _sfpu_sigmoid_
+        sigmoid_init<false>();
+    }
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_silu_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -8,31 +8,64 @@
 
 namespace ckernel::sfpu {
 
-template <bool is_fp32_dest_acc_en, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
+    if constexpr (APPROXIMATION_MODE) {
+        // Fast path: use hardware LUT-based sigmoid approximation.
+        // The LUT coefficients are pre-loaded into L-registers by silu_init.
+        // lut() computes a 3-segment piecewise-linear sigmoid(x)-0.5 in a single
+        // hardware instruction, handling sign internally.
+        sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+        sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+
 #pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat x = sfpi::dst_reg[0];
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat x = sfpi::dst_reg[0];
 
-        // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+            // sigmoid(x) via hardware LUT + 0.5 bias
+            sfpi::vFloat sig = sfpi::lut(x, l0, l1, l2) + 0.5f;
 
-        // Round to bfloat16 if not in fp32 accumulation mode
-        if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            sfpi::vFloat result = x * sig;
+
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
         }
 
-        sfpi::dst_reg[0] = result;
-        sfpi::dst_reg++;
+        sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+        sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
+        sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    } else {
+        // Accurate path: sigmoid via exp(-x) + Newton-Raphson reciprocal.
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat x = sfpi::dst_reg[0];
+
+            // silu(x) = x * sigmoid(x)
+            sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+
+            // Round to bfloat16 if not in fp32 accumulation mode
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
+        }
     }
 }
 
 template <bool APPROXIMATION_MODE>
 inline void silu_init() {
-    if constexpr (!APPROXIMATION_MODE) {
-        _init_sfpu_reciprocal_<false>();
+    if constexpr (APPROXIMATION_MODE) {
+        // Load LUT coefficients for sigmoid approximation
+        sigmoid_appx_init();
     } else {
-        _init_sfpu_reciprocal_<true>();
+        _init_sfpu_reciprocal_<false>();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_silu_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -822,6 +822,7 @@ std::map<std::string, std::string> get_defines_impl(
 
 bool get_op_approx_mode(UnaryOpType op_type) {
     switch (op_type) {
+        case UnaryOpType::SILU: return true;
         default: return false;
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/unary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/unary_ng_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "unary_ng_device_operation.hpp"
 
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/operations/eltwise/unary_ng/common/unary_ng_op_utils.hpp"
 #include "ttnn/operations/eltwise/unary_ng/common/unary_ng_utils.hpp"
 #include "ttnn/operations/cb_utils.hpp"
@@ -424,7 +425,10 @@ UnaryNgDeviceOperation::ProgramFactory::cached_program_t UnaryNgDeviceOperation:
         unpack_to_dest_mode[tmp0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
 
-    const bool math_approx_mode = false;
+    const bool math_approx_mode = std::all_of(
+        ops_chain.begin(), ops_chain.end(), [](const auto& u) {
+            return ttnn::operations::unary::utils::get_op_approx_mode(u.type());
+        });
     std::map<std::string, std::string> unary_defines = get_block_defines(ops_chain, "0", "0", input.dtype());
     CMAKE_UNIQUE_NAMESPACE::apply_input_dtype_defines(input.dtype(), unary_defines);
     CMAKE_UNIQUE_NAMESPACE::pack_first_op_scalars(


### PR DESCRIPTION
## Summary
- Replace expensive exp(-x) + Newton-Raphson reciprocal sigmoid computation with hardware LUT-based piecewise-linear sigmoid approximation in the SiLU SFPU kernel
- Reduces per-element SFPU instruction count from ~20-30 to ~3 instructions by leveraging the hardware `lut()` instruction
- Enable approximation mode for SiLU via `get_op_approx_mode()` and wire through `unary_ng` dispatch path

## Performance Results (ttperf, wormhole_b0, bfloat16, DRAM)

| Tensor Shape | Baseline (ns) | Optimized (ns) | Improvement |
|---|---|---|---|
| 1,1,32,32 | 3,284 | 2,035 | **38.0%** |
| 1,1,1024,1024 | 39,571 | 25,477 | **35.6%** |
| 1,1,2048,2048 | 128,919 | 93,998 | **27.1%** |

## Changes
- `ckernel_sfpu_silu.h` (wormhole_b0 + blackhole): Add `APPROXIMATION_MODE` template parameter with LUT fast path
- `llk_math_eltwise_unary_sfpu_silu.h` (wormhole_b0 + blackhole): Pass `APPROXIMATE` template arg to `calculate_silu`
- `unary_op_utils.cpp`: Return `true` for `UnaryOpType::SILU` in `get_op_approx_mode()`
- `unary_ng_program_factory.cpp`: Use `get_op_approx_mode()` instead of hardcoded `false`

## Test plan
- [ ] Existing SiLU unit tests pass (accuracy within PCC threshold)
- [ ] ttperf shows consistent improvement across tensor sizes
- [ ] No regression on other unary ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:optimize-silu-lut-sigmoid) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=optimize-silu-lut-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:optimize-silu-lut-sigmoid) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:optimize-silu-lut-sigmoid) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:optimize-silu-lut-sigmoid) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=optimize-silu-lut-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:optimize-silu-lut-sigmoid) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:optimize-silu-lut-sigmoid) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:optimize-silu-lut-sigmoid) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=optimize-silu-lut-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:optimize-silu-lut-sigmoid) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:optimize-silu-lut-sigmoid) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:optimize-silu-lut-sigmoid) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=optimize-silu-lut-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:optimize-silu-lut-sigmoid) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:optimize-silu-lut-sigmoid) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:optimize-silu-lut-sigmoid) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=optimize-silu-lut-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:optimize-silu-lut-sigmoid) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:optimize-silu-lut-sigmoid) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:optimize-silu-lut-sigmoid) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=optimize-silu-lut-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:optimize-silu-lut-sigmoid) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:optimize-silu-lut-sigmoid) |