### PR TITLE
[tt-train] fix deprecated warning

### DIFF
--- a/tt-train/sources/ttml/core/compute_kernel_config.cpp
+++ b/tt-train/sources/ttml/core/compute_kernel_config.cpp
@@ -10,7 +10,7 @@ ttnn::WormholeComputeKernelConfig ComputeKernelConfig::precise() {
     ttnn::WormholeComputeKernelConfig config;
     config.fp32_dest_acc_en = true;
     config.math_approx_mode = false;
-    config.math_fidelity = MathFidelity::HiFi4;
+    config.math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     config.packer_l1_acc = true;
     return config;
 }
@@ -19,7 +19,7 @@ ttnn::WormholeComputeKernelConfig ComputeKernelConfig::softmax() {
     ttnn::WormholeComputeKernelConfig config;
     config.fp32_dest_acc_en = false;
     config.math_approx_mode = false;
-    config.math_fidelity = MathFidelity::HiFi4;
+    config.math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     config.packer_l1_acc = true;
     return config;
 }
@@ -28,7 +28,7 @@ ttnn::WormholeComputeKernelConfig ComputeKernelConfig::matmul() {
     ttnn::WormholeComputeKernelConfig config;
     config.fp32_dest_acc_en = true;
     config.math_approx_mode = false;
-    config.math_fidelity = MathFidelity::HiFi4;
+    config.math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     config.packer_l1_acc = true;
     return config;
 }
@@ -37,7 +37,7 @@ ttnn::WormholeComputeKernelConfig ComputeKernelConfig::fast() {
     ttnn::WormholeComputeKernelConfig config;
     config.fp32_dest_acc_en = false;
     config.math_approx_mode = true;
-    config.math_fidelity = MathFidelity::LoFi;
+    config.math_fidelity = tt::tt_metal::MathFidelity::LoFi;
     config.packer_l1_acc = false;
     return config;
 }

--- a/tt-train/sources/ttml/metal/common/program_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/program_utils.hpp
@@ -83,7 +83,7 @@ inline tt::tt_metal::KernelHandle create_compute_kernel(
         kernel_path,
         core_ranges,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
+            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .math_approx_mode = false,
             .compile_args = compile_time_args,

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_program_factory.cpp
@@ -492,9 +492,9 @@ SDPABackwardKVProgramFactory::cached_program_t SDPABackwardKVProgramFactory::cre
 
     // Set UnpackToDestFp32 only for accumulator buffers (used with SFPU/copy, not FPU matmul)
     auto create_unpack_to_dest_mode = []() {
-        std::vector<UnpackToDestMode> mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-        mode[tt::CBIndex::c_8] = UnpackToDestMode::UnpackToDestFp32;  // kGradValueAccumCbIndex
-        mode[tt::CBIndex::c_9] = UnpackToDestMode::UnpackToDestFp32;  // kGradKeyAccumCbIndex
+        std::vector<tt::tt_metal::UnpackToDestMode> mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+        mode[tt::CBIndex::c_8] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;  // kGradValueAccumCbIndex
+        mode[tt::CBIndex::c_9] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;  // kGradKeyAccumCbIndex
         return mode;
     };
 
@@ -517,7 +517,7 @@ SDPABackwardKVProgramFactory::cached_program_t SDPABackwardKVProgramFactory::cre
             kComputeKernelPath,
             all_cores,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
+                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                 .fp32_dest_acc_en = true,
                 .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                 .math_approx_mode = false,
@@ -541,7 +541,7 @@ SDPABackwardKVProgramFactory::cached_program_t SDPABackwardKVProgramFactory::cre
             kComputeKernelPath,
             core_group_1,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
+                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                 .fp32_dest_acc_en = true,
                 .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                 .math_approx_mode = false,
@@ -566,7 +566,7 @@ SDPABackwardKVProgramFactory::cached_program_t SDPABackwardKVProgramFactory::cre
                 kComputeKernelPath,
                 core_group_2,
                 tt::tt_metal::ComputeConfig{
-                    .math_fidelity = MathFidelity::HiFi4,
+                    .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                     .fp32_dest_acc_en = true,
                     .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                     .math_approx_mode = false,

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_program_factory.cpp
@@ -484,8 +484,8 @@ SDPABackwardQProgramFactory::cached_program_t SDPABackwardQProgramFactory::creat
 
     // Set UnpackToDestFp32 only for accumulator buffers (used with SFPU/copy, not FPU matmul)
     auto create_unpack_to_dest_mode = []() {
-        std::vector<UnpackToDestMode> mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-        mode[tt::CBIndex::c_8] = UnpackToDestMode::UnpackToDestFp32;  // kGradQueryAccumCbIndex
+        std::vector<tt::tt_metal::UnpackToDestMode> mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+        mode[tt::CBIndex::c_8] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;  // kGradQueryAccumCbIndex
         return mode;
     };
 
@@ -507,7 +507,7 @@ SDPABackwardQProgramFactory::cached_program_t SDPABackwardQProgramFactory::creat
             kComputeKernelPath,
             all_cores,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
+                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                 .fp32_dest_acc_en = true,
                 .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                 .math_approx_mode = false,
@@ -529,7 +529,7 @@ SDPABackwardQProgramFactory::cached_program_t SDPABackwardQProgramFactory::creat
             kComputeKernelPath,
             core_group_1,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
+                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                 .fp32_dest_acc_en = true,
                 .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                 .math_approx_mode = false,
@@ -552,7 +552,7 @@ SDPABackwardQProgramFactory::cached_program_t SDPABackwardQProgramFactory::creat
                 kComputeKernelPath,
                 core_group_2,
                 tt::tt_metal::ComputeConfig{
-                    .math_fidelity = MathFidelity::HiFi4,
+                    .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                     .fp32_dest_acc_en = true,
                     .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                     .math_approx_mode = false,

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
@@ -159,7 +159,7 @@ static tt::tt_metal::ComputeConfig precise(
     tt::tt_metal::ComputeConfig config;
     config.fp32_dest_acc_en = true;
     config.math_approx_mode = false;
-    config.math_fidelity = MathFidelity::HiFi4;
+    config.math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     config.compile_args = std::move(compile_time_args);
     config.defines = std::move(defines);
     return config;

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_program_factory.cpp
@@ -352,7 +352,8 @@ AdamWProgramFactory::cached_program_t AdamWProgramFactory::create(
     // -------------------------------------------------------------------------
 
     // FPU is not used at all in the operation
-    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::UnpackToDestFp32);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32);
 
     // Group 1 compile-time arguments
     std::vector<uint32_t> compute_group_1_args = {
@@ -360,7 +361,7 @@ AdamWProgramFactory::cached_program_t AdamWProgramFactory::create(
         block_size};                 // per_core_block_size
 
     tt::tt_metal::ComputeConfig compute_config{
-        .math_fidelity = MathFidelity::HiFi4,
+        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
         .fp32_dest_acc_en = true,
         .unpack_to_dest_mode = unpack_to_dest_mode,
         .math_approx_mode = false,


### PR DESCRIPTION
### Summary
Use `tt::tt_metal::MathFidelity` and `tt::tt_metal::UnpackToDestMode` to fix warnings.

Example:
```bash
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt_metal/api/tt-metalium/base_types.hpp:52:26: note: 'UnpackToDestMode' has been explicitly marked deprecated here
   52 | using UnpackToDestMode [[deprecated("Use tt::tt_metal::UnpackToDestMode")]] = tt::tt_metal::UnpackToDestMode;
      |                          ^
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_program_factory.cpp:510:46: warning: 'MathFidelity' is deprecated: Use tt::tt_metal::MathFidelity [-Wdeprecated-declarations]
  510 |                 .math_fidelity = MathFidelity::HiFi4,
      |                                              ^
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt_metal/api/tt-metalium/base_types.hpp:51:22: note: 'MathFidelity' has been explicitly marked deprecated here
   51 | using MathFidelity [[deprecated("Use tt::tt_metal::MathFidelity")]] = tt::tt_metal::MathFidelity;
      |                      ^
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_program_factory.cpp:532:46: warning: 'MathFidelity' is deprecated: Use tt::tt_metal::MathFidelity [-Wdeprecated-declarations]
  532 |                 .math_fidelity = MathFidelity::HiFi4,
      |                                              ^
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt_metal/api/tt-metalium/base_types.hpp:51:22: note: 'MathFidelity' has been explicitly marked deprecated here
   51 | using MathFidelity [[deprecated("Use tt::tt_metal::MathFidelity")]] = tt::tt_metal::MathFidelity;
      |                      ^
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_program_factory.cpp:555:50: warning: 'MathFidelity' is deprecated: Use tt::tt_metal::MathFidelity [-Wdeprecated-declarations]
  555 |                     .math_fidelity = MathFidelity::HiFi4,
      |                                                  ^
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt_metal/api/tt-metalium/base_types.hpp:51:22: note: 'MathFidelity' has been explicitly marked deprecated here
   51 | using MathFidelity [[deprecated("Use tt::tt_metal::MathFidelity")]] = tt::tt_metal::MathFidelity;
      |                      ^
7 warnings generated.
[3162/3281] Building CXX object tt-train/sources/ttml/CMakeFiles/ttml.dir/metal/optimizers/sgd/device/sgd_program_factory.cpp.o
In file included from /proj_sw/user_dev/vtsilytskyi/tt-metal/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_program_factory.cpp:13:
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt-train/sources/ttml/metal/common/program_utils.hpp:86:42: warning: 'MathFidelity' is deprecated: Use tt::tt_metal::MathFidelity [-Wdeprecated-declarations]
   86 |             .math_fidelity = MathFidelity::HiFi4,
      |                                          ^
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt_metal/api/tt-metalium/base_types.hpp:51:22: note: 'MathFidelity' has been explicitly marked deprecated here
   51 | using MathFidelity [[deprecated("Use tt::tt_metal::MathFidelity")]] = tt::tt_metal::MathFidelity;
      |                      ^
1 warning generated.
```

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/fix-deprecated-warning) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/fix-deprecated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/fix-deprecated-warning) | [#2882](https://github.com/tenstorrent/tt-metal/actions/runs/24472208679) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/fix-deprecated-warning) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/fix-deprecated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/fix-deprecated-warning) | [#17540](https://github.com/tenstorrent/tt-metal/actions/runs/24472223296) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/fix-deprecated-warning) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/fix-deprecated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/fix-deprecated-warning) | [#5247](https://github.com/tenstorrent/tt-metal/actions/runs/24472276671) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/fix-deprecated-warning) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/fix-deprecated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/fix-deprecated-warning) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/fix-deprecated-warning) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/fix-deprecated-warning) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/fix-deprecated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/fix-deprecated-warning) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/fix-deprecated-warning) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/fix-deprecated-warning) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/fix-deprecated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/fix-deprecated-warning) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/fix-deprecated-warning) |