### PR TITLE
Restore slow dispatch state after tearing down fast dispatch

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -267,8 +267,6 @@ class CacheWeightProvider:
         t_after_with = time.perf_counter()
         fd_teardown_s = t_after_with - t_before_teardown
 
-        ttnn.enable_asynchronous_slow_dispatch(device)
-
         logger.info(f"CacheWeightProvider MoE layer {layer_id}: setup (cache_config) {setup_s:.3f}s")
         logger.info(f"CacheWeightProvider MoE layer {layer_id}: fast_dispatch initialize {fd_init_s:.3f}s")
         logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_routed_expert_weights {routed_prepare_s:.3f}s")

--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -227,4 +227,30 @@ TEST_F(DispatchContextFixture, SdEnableFdDisableFdThenL1Buffer) {
     }
 }
 
+TEST_F(DispatchContextFixture, AsyncSdStatePreservedAcrossFdTransition) {
+    const auto& rt_options = MetalContext::instance().rtoptions();
+    if (rt_options.get_fast_dispatch()) {
+        GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
+    }
+    const MeshShape system_shape = MetalContext::instance().get_system_mesh().shape();
+    auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (!cluster.is_ubb_galaxy() && cluster.arch() != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP()
+            << "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy and Blackhole clusters.";
+    }
+
+    // Enable async slow dispatch before FD transition
+    experimental::DispatchContext::get().enable_asynchronous_slow_dispatch(mesh_device_.get());
+    EXPECT_TRUE(experimental::DispatchContext::get().is_asynchronous_slow_dispatch_enabled(mesh_device_.get()));
+
+    // SD -> FD -> SD round-trip
+    experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get());
+    experimental::DispatchContext::get().terminate_fast_dispatch(mesh_device_.get());
+
+    // Verify async SD state survived the round-trip
+    EXPECT_TRUE(experimental::DispatchContext::get().is_asynchronous_slow_dispatch_enabled(mesh_device_.get()));
+}
+
 }  // namespace tt::tt_metal::distributed::test

--- a/tests/ttnn/unit_tests/base_functionality/test_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_device.py
@@ -76,3 +76,14 @@ def test_dispatch_context_init_and_terminate(mesh_device, dtype, layout):
         ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device, memory_config=memory_config).cpu()
 
     assert ttnn_tensor.shape == tensor.shape
+
+
+@pytest.mark.requires_fast_runtime_mode_off
+def test_async_sd_state_preserved_across_fd(mesh_device):
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+    assert ttnn.device.is_asynchronous_slow_dispatch_enabled(mesh_device)
+
+    with ttnn.device.setup_fast_dispatch(mesh_device):
+        pass
+
+    assert ttnn.device.is_asynchronous_slow_dispatch_enabled(mesh_device)

--- a/tt_metal/api/tt-metalium/experimental/dispatch_context.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dispatch_context.hpp
@@ -34,16 +34,13 @@ public:
     void terminate_fast_dispatch(distributed::MeshDevice* mesh_device);
     void enable_asynchronous_slow_dispatch(distributed::MeshDevice* mesh_device);
     void disable_asynchronous_slow_dispatch(distributed::MeshDevice* mesh_device);
+    bool is_asynchronous_slow_dispatch_enabled(distributed::MeshDevice* mesh_device) const;
 
-    // Reset DispatchContext state to allow reinitialization
-    void reset() {
-        num_fd_inits_ = 0;
-        fast_dispatch_enabled_ = false;
-    }
+    void reset();
 
 private:
     DispatchContext() = default;
-    ~DispatchContext() = default;
+    ~DispatchContext();
 
     // Custom deleter to allow unique_ptr with private destructor
     struct Deleter {
@@ -53,6 +50,10 @@ private:
 
     bool fast_dispatch_enabled_ = false;
     uint32_t num_fd_inits_ = 0;
+    // SD command queues stashed during an FD session, restored on terminate.
+    // Defined in the .cpp to avoid exposing MeshCommandQueueBase in this header.
+    struct StashedQueues;
+    std::unique_ptr<StashedQueues> stashed_sd_queues_;
     static std::unique_ptr<DispatchContext, Deleter> dispatch_context_ptr_;
 };
 

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -22,8 +22,20 @@
 
 namespace tt::tt_metal::experimental {
 
+struct DispatchContext::StashedQueues {
+    std::vector<std::unique_ptr<distributed::MeshCommandQueueBase>> queues;
+};
+
 // Define the static member with custom deleter
 std::unique_ptr<DispatchContext, DispatchContext::Deleter> DispatchContext::dispatch_context_ptr_ = nullptr;
+
+DispatchContext::~DispatchContext() = default;
+
+void DispatchContext::reset() {
+    num_fd_inits_ = 0;
+    fast_dispatch_enabled_ = false;
+    stashed_sd_queues_.reset();
+}
 
 DispatchContext& DispatchContext::get() {
     if (!dispatch_context_ptr_) {
@@ -68,6 +80,15 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
     device_manager->initialize_dispatch_firmware(/*force_recreate_topology=*/true);
 
     auto& mesh_device_impl = mesh_device->impl();
+
+    // Drain pending SD work and stash the SD queues for restoration on terminate
+    for (auto& cq : mesh_device_impl.mesh_command_queues_) {
+        cq->finish();
+    }
+    stashed_sd_queues_ = std::make_unique<StashedQueues>();
+    for (auto& cq : mesh_device_impl.mesh_command_queues_) {
+        stashed_sd_queues_->queues.push_back(std::move(cq));
+    }
     mesh_device_impl.mesh_command_queues_.clear();
     mesh_device_impl.mesh_command_queues_.reserve(num_hw_cqs);
 
@@ -101,18 +122,18 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     const auto& device_manager = MetalContext::instance(context_id).device_manager();
     const auto& active_devices = device_manager->get_all_active_devices();
 
-    uint8_t num_hw_cqs = active_devices[0]->num_hw_cqs();
     auto& mesh_device_impl = mesh_device->impl();
     mesh_device_impl.mesh_command_queues_.clear();
-    mesh_device_impl.mesh_command_queues_.reserve(num_hw_cqs);
 
-    for (std::size_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-        mesh_device_impl.mesh_command_queues_.push_back(std::make_unique<distributed::SDMeshCommandQueue>(
-            mesh_device,
-            cq_id,
-            std::bind(&distributed::MeshDeviceImpl::lock_api, &mesh_device_impl),
-            mesh_device_impl.active_distributed_context_));
+    // Restore stashed SD queues to preserve pre-FD state (e.g. asynchronous_slow_dispatch_enabled_)
+    TT_FATAL(
+        stashed_sd_queues_ && !stashed_sd_queues_->queues.empty(),
+        "No stashed SD queues to restore; was initialize_fast_dispatch called?");
+    for (auto& cq : stashed_sd_queues_->queues) {
+        mesh_device_impl.mesh_command_queues_.push_back(std::move(cq));
     }
+    stashed_sd_queues_.reset();
+
     for (const auto& dev : active_devices) {
         for (int cq_id = 0; cq_id < dev->num_hw_cqs(); cq_id++) {
             dynamic_cast<tt::tt_metal::Device*>(dev)->command_queues_[cq_id].get()->terminate();
@@ -142,11 +163,16 @@ void DispatchContext::enable_asynchronous_slow_dispatch(distributed::MeshDevice*
 
 void DispatchContext::disable_asynchronous_slow_dispatch(distributed::MeshDevice* mesh_device) {
     TT_FATAL(
-        MetalContext::instance().rtoptions().get_fast_dispatch(),
-        "{} can only be called when Fast Dispatch is enabled.",
+        !MetalContext::instance().rtoptions().get_fast_dispatch(),
+        "{} can only be called when Fast Dispatch is disabled.",
         __func__);
     auto& sd_mesh_cq = dynamic_cast<distributed::SDMeshCommandQueue&>(mesh_device->mesh_command_queue());
     sd_mesh_cq.disable_asynchronous_slow_dispatch();
+}
+
+bool DispatchContext::is_asynchronous_slow_dispatch_enabled(distributed::MeshDevice* mesh_device) const {
+    auto& sd_mesh_cq = dynamic_cast<distributed::SDMeshCommandQueue&>(mesh_device->mesh_command_queue());
+    return sd_mesh_cq.is_asynchronous_slow_dispatch_enabled();
 }
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -67,6 +67,7 @@ public:
 
     void enable_asynchronous_slow_dispatch();
     void disable_asynchronous_slow_dispatch();
+    bool is_asynchronous_slow_dispatch_enabled() const { return asynchronous_slow_dispatch_enabled_; }
 
 private:
     void wait_for_cores_idle();

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -559,6 +559,15 @@ void device_module(nb::module_& m_device) {
         R"doc(
         Experimental: If Slow Dispatch is enabled, this function disables the ability to run multiple non-overlapping programs concurrently on the same device.
         )doc");
+    m_device.def(
+        "is_asynchronous_slow_dispatch_enabled",
+        [](tt::tt_metal::distributed::MeshDevice* device) {
+            return tt::tt_metal::experimental::DispatchContext::get().is_asynchronous_slow_dispatch_enabled(device);
+        },
+        nb::arg("device"),
+        R"doc(
+        Experimental: Returns whether asynchronous slow dispatch is currently enabled on the given device.
+        )doc");
 }
 
 void py_device_module(nb::module_& mod) {

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -23,6 +23,7 @@ get_optimal_dram_bank_to_logical_worker_assignment = (
 )
 enable_asynchronous_slow_dispatch = ttnn._ttnn.device.enable_asynchronous_slow_dispatch
 disable_asynchronous_slow_dispatch = ttnn._ttnn.device.disable_asynchronous_slow_dispatch
+is_asynchronous_slow_dispatch_enabled = ttnn._ttnn.device.is_asynchronous_slow_dispatch_enabled
 
 open_device = ttnn._ttnn.device.open_device
 init_device_compute_kernel_config = ttnn._ttnn.operations.core.init_device_compute_kernel_config


### PR DESCRIPTION
### Summary

This pull request fixes the handling and testing of asynchronous slow dispatch (SD) state across transitions to and from fast dispatch (FD) mode on mesh devices. The change ensure that the asynchronous SD state is preserved when switching between SD and FD, such as whether asynchronous dispatch was enabled or disabled.

Key changes include:

* Added logic to stash and restore SD command queues in `DispatchContext` so that the asynchronous SD state is preserved across FD transitions. This involves saving the SD queues before entering FD and restoring them after exiting FD, instead of recreating them. [[1]](diffhunk://#diff-ce4bc34b606c931900c5535c6fd5ff594c9a4e879bac7fc38fc002763b78ea27R83-R91) [[2]](diffhunk://#diff-ce4bc34b606c931900c5535c6fd5ff594c9a4e879bac7fc38fc002763b78ea27L104-R136) [[3]](diffhunk://#diff-9e9ca79f184395fe77a4a0314c6f3b7757fab8602d608396e095689aab096fcdR53-R56)
* Introduced a new method `is_asynchronous_slow_dispatch_enabled` in `DispatchContext` and `SDMeshCommandQueue` to check if asynchronous SD is currently enabled on a device. [[1]](diffhunk://#diff-9e9ca79f184395fe77a4a0314c6f3b7757fab8602d608396e095689aab096fcdR37-R43) [[2]](diffhunk://#diff-02587f9712697ba8e5788d3a0092494cfe1873cd4f8579006ddc5a1681c36d76R70) [[3]](diffhunk://#diff-60f4c68c4f9196abdb4954a4e51d90f4cc67fd92d4049b1142d4ab3aa4f1f043R562-R570) [[4]](diffhunk://#diff-a653a6fe317c04def911e2ffa88510e3b5d5cde8ac847e39acccb9443037f197R26)
* Improved the `reset` and destructor behavior of `DispatchContext` to clean up internal state correctly. [[1]](diffhunk://#diff-9e9ca79f184395fe77a4a0314c6f3b7757fab8602d608396e095689aab096fcdR37-R43) [[2]](diffhunk://#diff-ce4bc34b606c931900c5535c6fd5ff594c9a4e879bac7fc38fc002763b78ea27R25-R39)

**Testing and Validation:**

* Added new unit and integration tests in both C++ and Python to verify that the asynchronous SD state is preserved after transitioning SD → FD → SD. [[1]](diffhunk://#diff-16b404ad46433db2266ef61fb9c7f92f0eb4115fbc93891d27d6ba97b650371eR230-R255) [[2]](diffhunk://#diff-a9a27841b16026aa6653b7af68aabaca81e727ae03100a2baf5b31232944a8f1R79-R89)

**Other:**

* Fixed a bug in `disable_asynchronous_slow_dispatch` to ensure it can only be called when FD is disabled, not enabled.
* Removed a redundant call to `enable_asynchronous_slow_dispatch` in the MoE layer loader, as this is now handled elsewhere or is unnecessary.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/fast-dispatch-state) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/fast-dispatch-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/fast-dispatch-state) | [#2599](https://github.com/tenstorrent/tt-metal/actions/runs/24344575097) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/fast-dispatch-state) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/fast-dispatch-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/fast-dispatch-state) | [#17404](https://github.com/tenstorrent/tt-metal/actions/runs/24344588796) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/fast-dispatch-state) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/fast-dispatch-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/fast-dispatch-state) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/fast-dispatch-state) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/fast-dispatch-state) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/fast-dispatch-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/fast-dispatch-state) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/fast-dispatch-state) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/fast-dispatch-state) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/fast-dispatch-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/fast-dispatch-state) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/fast-dispatch-state) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/fast-dispatch-state) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/fast-dispatch-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/fast-dispatch-state) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/fast-dispatch-state) |