### PR TITLE
Fix failures in test_overlapped_tensor_serialization.py

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -65,7 +65,7 @@ def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device, dtype):
     spec1 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=dtype)
     spec2 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
 
-    views = overlap_tensors([[OverlapEntry("t1", t1, spec1), OverlapEntry("t2", t2, spec2)]], device=device)
+    views = overlap_tensors([OverlapEntry("t1", t1, spec1), OverlapEntry("t2", t2, spec2)], device=device)
     assert len(views) == 2
 
     file_name = str(tmp_path / "single_lane.overlappedtensorbin")
@@ -99,7 +99,7 @@ def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device, dtype):
     spec_bf16 = OverlappedTensorSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=dtype)
 
     views = overlap_tensors(
-        [[OverlapEntry("primary", t_primary, spec_primary)], [OverlapEntry("bf16", t_bf16, spec_bf16)]],
+        [OverlapEntry("primary", t_primary, spec_primary), OverlapEntry("bf16", t_bf16, spec_bf16)],
         device=device,
     )
     assert len(views) == 2
@@ -128,7 +128,7 @@ def test_overlapped_tensor_roundtrip_to_device(tmp_path, device, dtype):
     t1 = torch.randn(256, 512, dtype=torch.bfloat16)
     spec1 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
 
-    views = overlap_tensors([[OverlapEntry("t1", t1, spec1)]], device=device)
+    views = overlap_tensors([OverlapEntry("t1", t1, spec1)], device=device)
 
     file_name = str(tmp_path / "to_device.overlappedtensorbin")
     ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
@@ -158,7 +158,7 @@ def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device, dtype):
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     )
 
-    views = overlap_tensors([[OverlapEntry("t1", t1, spec1)]], device=device)
+    views = overlap_tensors([OverlapEntry("t1", t1, spec1)], device=device)
 
     file_name = str(tmp_path / "height_sharded.overlappedtensorbin")
     ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
@@ -193,7 +193,7 @@ def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device, dtype):
     )
 
     views = overlap_tensors(
-        [[OverlapEntry("main", t_main, spec_main)], [OverlapEntry("gamma", t_gamma, spec_gamma)]],
+        [OverlapEntry("main", t_main, spec_main), OverlapEntry("gamma", t_gamma, spec_gamma)],
         device=device,
     )
     assert len(views) == 2
@@ -251,7 +251,7 @@ def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device, dtype):
         tp_dim=(None, 1),
     )
 
-    views = overlap_tensors([[OverlapEntry("t1", t1, spec1), OverlapEntry("t2", t2, spec2)]], device=submesh)
+    views = overlap_tensors([OverlapEntry("t1", t1, spec1), OverlapEntry("t2", t2, spec2)], device=submesh)
     assert len(views) == 2
 
     file_name = str(tmp_path / "tp_4x2.overlappedtensorbin")


### PR DESCRIPTION
overlap_tensors now takes a single flat list[OverlapEntry] instead of a list of lists. test_overlapped_tensor_serialization.py was overlooked in PR 41851.  Update all overlap_tensors(...) call sites in tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py to pass one flat list of entries (e.g. [e1, e2]).

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kwerblinskiTT/fix__test_overlapped_tensor_serialization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kwerblinskiTT/fix__test_overlapped_tensor_serialization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kwerblinskiTT/fix__test_overlapped_tensor_serialization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kwerblinskiTT/fix__test_overlapped_tensor_serialization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kwerblinskiTT/fix__test_overlapped_tensor_serialization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kwerblinskiTT/fix__test_overlapped_tensor_serialization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/fix__test_overlapped_tensor_serialization) |