### PR TITLE
Fill DeepSeekV3 B1 KV cache on device

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -371,6 +371,8 @@ models/datasets/llm_dataset_utils.py @skhorasganiTT @uaydonat @tenstorrent/codeo
 models/demos @uaydonat @yieldthought @cglagovichTT @tenstorrent/codeowner-bypass
 models/demos/deepseek_v3 @uaydonat @yieldthought @kpaigwar @pprajapatiTT @esmalTT @johanna-rock-tt @yalrawwashTT @tenstorrent/codeowner-bypass
 models/demos/deepseek_v3_b1 @tt-aho @TT-BrianLiu @sjameelTT @nardoTT @tt-asaigal @tenstorrent/codeowner-bypass
+models/demos/deepseek_v3_b1/demo @esmalTT @tt-aho @TT-BrianLiu @sjameelTT @nardoTT @tt-asaigal @tenstorrent/codeowner-bypass
+models/demos/deepseek_v3_b1/weights @esmalTT @tt-aho @TT-BrianLiu @sjameelTT @nardoTT @tt-asaigal @tenstorrent/codeowner-bypass
 models/demos/deepseek_v3_d_p @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
 models/demos/gpt_oss @uaydonat @mtairum @sraizada-tt @handrewsTT @tenstorrent/codeowner-bypass
 models/**/bert*/ @TT-BrianLiu @uaydonat @tenstorrent/codeowner-bypass

--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -24,6 +24,7 @@ from models.demos.deepseek_v3_b1.demo.stage import (
 from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBlock
 from models.demos.deepseek_v3_b1.fused_ops.decoder_block.op import DecoderBlock
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
+from models.demos.deepseek_v3_b1.micro_ops.dram_zero_fill.op import DRAMZeroFill
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
 from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
@@ -398,14 +399,24 @@ def create_decoder_block_tensors(
     torch_kv_cache[:, :, :position_id, :] = torch.randn(1, 1, position_id, kvpe_dim, dtype=torch.bfloat16)
     torch_kv_cache_shuffled = deinterleave_kv_cache(torch_kv_cache, dcs, num_sp)
     kv_cache_2d_mesh_mapper = ttnn.ShardTensor2dMesh(submesh, mesh_shape=(mesh_rows, mesh_cols), dims=(2, None))
-    ttnn_kv_cache = ttnn.from_torch(
-        torch_kv_cache_shuffled,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=kv_mem,
-        mesh_mapper=kv_cache_2d_mesh_mapper,
-    )
+    if position_id == 0:
+        # Fast path for empty-context decode: allocate directly in DRAM and zero on device.
+        ttnn_kv_cache = DRAMZeroFill.allocate_kv_cache_on_device(
+            submesh,
+            num_users=torch_kv_cache.shape[0],
+            max_seq_len=max_seq_len,
+            kvpe_dim=kvpe_dim,
+            dtype=ttnn.bfloat8_b,
+        )
+    else:
+        ttnn_kv_cache = ttnn.from_torch(
+            torch_kv_cache_shuffled,
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=kv_mem,
+            mesh_mapper=kv_cache_2d_mesh_mapper,
+        )
 
     # ── KV cache clone for standalone AttentionBlock.op sanity check ──
     ttnn_kv_cache_attn_ref = None

--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -400,13 +400,13 @@ def create_decoder_block_tensors(
     torch_kv_cache_shuffled = deinterleave_kv_cache(torch_kv_cache, dcs, num_sp)
     kv_cache_2d_mesh_mapper = ttnn.ShardTensor2dMesh(submesh, mesh_shape=(mesh_rows, mesh_cols), dims=(2, None))
     if position_id == 0:
-        # Fast path for empty-context decode: allocate directly in DRAM and zero on device.
         ttnn_kv_cache = DRAMZeroFill.allocate_kv_cache_on_device(
             submesh,
             num_users=torch_kv_cache.shape[0],
             max_seq_len=max_seq_len,
             kvpe_dim=kvpe_dim,
             dtype=ttnn.bfloat8_b,
+            mesh_shape=(mesh_rows, mesh_cols),
         )
     else:
         ttnn_kv_cache = ttnn.from_torch(
@@ -421,14 +421,24 @@ def create_decoder_block_tensors(
     # ── KV cache clone for standalone AttentionBlock.op sanity check ──
     ttnn_kv_cache_attn_ref = None
     if validate_debug_tensors:
-        ttnn_kv_cache_attn_ref = ttnn.from_torch(
-            torch_kv_cache_shuffled,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            device=submesh,
-            memory_config=kv_mem,
-            mesh_mapper=kv_cache_2d_mesh_mapper,
-        )
+        if position_id == 0:
+            ttnn_kv_cache_attn_ref = DRAMZeroFill.allocate_kv_cache_on_device(
+                submesh,
+                num_users=torch_kv_cache.shape[0],
+                max_seq_len=max_seq_len,
+                kvpe_dim=kvpe_dim,
+                dtype=ttnn.bfloat8_b,
+                mesh_shape=(mesh_rows, mesh_cols),
+            )
+        else:
+            ttnn_kv_cache_attn_ref = ttnn.from_torch(
+                torch_kv_cache_shuffled,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                device=submesh,
+                memory_config=kv_mem,
+                mesh_mapper=kv_cache_2d_mesh_mapper,
+            )
 
     # ── SDPA output tensor ──
     s1_cores, _ = FlashMLADecode.ProgramConfig.grid.BLOCKS[0]

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/kernels/dram_zero_fill_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/kernels/dram_zero_fill_kernel.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// DRAM Zero Fill kernel: writes zero tiles to all pages of a DRAM tensor.
+//
+// NCRISC: Each core zeroes one L1 tile, then writes it to its assigned
+//         range of DRAM pages via noc_async_write_page + TensorAccessor.
+// BRISC:  No-op.
+// TRISC:  No-op.
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+
+void kernel_main() {
+#if defined(COMPILE_FOR_NCRISC)
+    constexpr uint32_t output_cb = get_named_compile_time_arg_val("output_cb");
+    constexpr uint32_t total_pages = get_named_compile_time_arg_val("total_pages");
+    constexpr uint32_t pages_per_core = get_named_compile_time_arg_val("pages_per_core");
+    constexpr uint32_t page_size = get_named_compile_time_arg_val("page_size");
+    constexpr uint32_t grid_start_x = get_named_compile_time_arg_val("grid_start_x");
+    constexpr uint32_t grid_start_y = get_named_compile_time_arg_val("grid_start_y");
+    constexpr uint32_t grid_end_x = get_named_compile_time_arg_val("grid_end_x");
+    constexpr uint32_t grid_end_y = get_named_compile_time_arg_val("grid_end_y");
+
+    uint32_t core_id = unified_kernels::linear_id_in_grid<true>(grid_start_x, grid_start_y, grid_end_x, grid_end_y);
+
+    uint32_t buffer_addr = get_common_arg_val<uint32_t>(0);
+    constexpr auto ta_args = TensorAccessorArgs<0>();
+    auto accessor = TensorAccessor(ta_args, buffer_addr, page_size);
+
+    cb_reserve_back(output_cb, 1);
+    uint32_t l1_addr = get_write_ptr(output_cb);
+
+    // Zero the L1 scratch tile
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(l1_addr);
+    for (uint32_t i = 0; i < page_size / sizeof(uint32_t); i++) {
+        ptr[i] = 0;
+    }
+
+    uint32_t start_page = core_id * pages_per_core;
+    uint32_t end_page = start_page + pages_per_core;
+    if (end_page > total_pages) {
+        end_page = total_pages;
+    }
+
+    for (uint32_t page_id = start_page; page_id < end_page; page_id++) {
+        noc_async_write_page(page_id, accessor, l1_addr);
+    }
+    noc_async_write_barrier();
+#endif
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
@@ -44,6 +44,7 @@ class DRAMZeroFill:
         max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
         kvpe_dim: int = DEFAULT_KVPE_DIM,
         dtype: ttnn.DataType = ttnn.bfloat8_b,
+        mesh_shape: tuple[int, int] | None = None,
     ) -> ttnn.Tensor:
         """
         Allocate a zero-filled KV cache tensor in DRAM with the standard
@@ -58,13 +59,21 @@ class DRAMZeroFill:
             max_seq_len: Total (global) sequence length across all mesh rows.
             kvpe_dim: Combined KNOPE + KROPE feature dimension.
             dtype: Data type for the cache (default bfloat8_b).
+            mesh_shape: (rows, cols) mesh shape for the tensor topology.
+                Dim 2 is sharded across rows, replicated across cols
+                (matching ShardTensor2dMesh dims=(2, None)).
+                Defaults to ``(device.shape[0], device.shape[1])``.
 
         Returns:
             A zero-filled DRAM tensor of per-device shape
             ``[num_users, 1, max_seq_len // mesh_rows, kvpe_dim]``.
         """
         mesh_rows = device.shape[0]
+        mesh_cols = device.shape[1]
         per_device_seq = max_seq_len // mesh_rows
+
+        if mesh_shape is None:
+            mesh_shape = (mesh_rows, mesh_cols)
 
         program_config = FlashMLADecode.ProgramConfig(k_chunk_size=DEFAULT_K_CHUNK_SIZE, exp_approx_mode=False)
         kv_nd_shard_spec = ttnn.NdShardSpec(
@@ -78,6 +87,17 @@ class DRAMZeroFill:
         shape = ttnn.Shape([num_users, 1, per_device_seq, kvpe_dim])
         tensor = ttnn.allocate_tensor_on_device(shape, dtype, ttnn.TILE_LAYOUT, device, kv_mem)
         DRAMZeroFill.op(tensor)
+
+        # Set the correct topology so downstream ops see this tensor as TP=2, SP=4
+        # which is what ShardTensor2dMesh() would produce
+        dist_shape = ttnn.MeshShape(mesh_shape[0], mesh_shape[1])
+        placements = [ttnn.PlacementShard(2), ttnn.PlacementReplicate()]
+        coords = [
+            ttnn.MeshCoordinate([coord[i] for i in range(coord.dims())])
+            for coord in ttnn.MeshCoordinateRange(dist_shape)
+        ]
+        tensor.update_tensor_topology(ttnn.TensorTopology(dist_shape, placements, coords))
+
         return tensor
 
     @staticmethod

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DRAM Zero Fill micro op.
+
+Writes zeros to all pages of a DRAM tensor using a kernel on the 12x10 compute
+grid.  Each core zeroes a single L1 tile and then writes it to its assigned
+slice of DRAM pages via noc_async_write_page + TensorAccessor.
+
+This replaces the host-side ttnn.from_torch / ttnn.zeros pattern for
+zero-initialization, avoiding the host-to-device transfer entirely.
+"""
+
+import math
+
+import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import UnifiedKernelDescriptor
+
+KERNEL_PATH = "models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/kernels/dram_zero_fill_kernel.cpp"
+
+GRID_X = 12
+GRID_Y = 10
+NUM_CORES = GRID_X * GRID_Y  # 120
+
+OUTPUT_CB = 0
+TILE_32x32 = ttnn.Tile((32, 32))
+
+DEFAULT_KVPE_DIM = 576
+DEFAULT_MAX_SEQ_LEN = 1024 * 32
+DEFAULT_K_CHUNK_SIZE = 128
+
+
+class DRAMZeroFill:
+    """Zero-fill a pre-allocated DRAM tensor using a device kernel."""
+
+    @staticmethod
+    def allocate_kv_cache_on_device(
+        device: ttnn.MeshDevice,
+        *,
+        num_users: int = 1,
+        max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
+        kvpe_dim: int = DEFAULT_KVPE_DIM,
+        dtype: ttnn.DataType = ttnn.bfloat8_b,
+    ) -> ttnn.Tensor:
+        """
+        Allocate a zero-filled KV cache tensor in DRAM with the standard
+        NdShardSpec layout used by FlashMLADecode.
+
+        The sequence dimension is sharded across mesh rows, so each device
+        receives ``max_seq_len // mesh_rows`` elements along dim 2.
+
+        Args:
+            device: Single device or MeshDevice to allocate on.
+            num_users: Batch / user count (first dimension).
+            max_seq_len: Total (global) sequence length across all mesh rows.
+            kvpe_dim: Combined KNOPE + KROPE feature dimension.
+            dtype: Data type for the cache (default bfloat8_b).
+
+        Returns:
+            A zero-filled DRAM tensor of per-device shape
+            ``[num_users, 1, max_seq_len // mesh_rows, kvpe_dim]``.
+        """
+        mesh_rows = device.shape[0]
+        per_device_seq = max_seq_len // mesh_rows
+
+        program_config = FlashMLADecode.ProgramConfig(k_chunk_size=DEFAULT_K_CHUNK_SIZE, exp_approx_mode=False)
+        kv_nd_shard_spec = ttnn.NdShardSpec(
+            shard_shape=[1, 1, program_config.k_chunk_size, kvpe_dim],
+            grid=program_config.grid.optimal_dram_grid(),
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+        )
+        kv_mem = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=kv_nd_shard_spec)
+
+        shape = ttnn.Shape([num_users, 1, per_device_seq, kvpe_dim])
+        tensor = ttnn.allocate_tensor_on_device(shape, dtype, ttnn.TILE_LAYOUT, device, kv_mem)
+        DRAMZeroFill.op(tensor)
+        return tensor
+
+    @staticmethod
+    def op(output_tensor: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        Write zeros to every page of *output_tensor* on device.
+
+        Args:
+            output_tensor: A DRAM tensor previously allocated with
+                ``ttnn.allocate_tensor_on_device`` (any NdShardSpec config).
+
+        Returns:
+            The same tensor, now filled with zeros.
+        """
+        page_size = TILE_32x32.get_tile_size(output_tensor.dtype)
+
+        shape = output_tensor.shape
+        tile_rows = shape[-2] // 32
+        tile_cols = shape[-1] // 32
+        batch_tiles = 1
+        for d in range(len(shape) - 2):
+            batch_tiles *= shape[d]
+        total_pages = batch_tiles * tile_rows * tile_cols
+        pages_per_core = math.ceil(total_pages / NUM_CORES)
+
+        core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(GRID_X - 1, GRID_Y - 1))])
+
+        tensor_accessor_args = ttnn.TensorAccessorArgs(output_tensor)
+        ncrisc_compile_time_args = tensor_accessor_args.get_compile_time_args()
+
+        ncrisc_named = [
+            ("output_cb", OUTPUT_CB),
+            ("total_pages", total_pages),
+            ("pages_per_core", pages_per_core),
+            ("page_size", page_size),
+            ("grid_start_x", 0),
+            ("grid_start_y", 0),
+            ("grid_end_x", GRID_X - 1),
+            ("grid_end_y", GRID_Y - 1),
+        ]
+
+        cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=OUTPUT_CB,
+            data_format=output_tensor.dtype,
+            page_size=page_size,
+            tile=ttnn.TileDescriptor(TILE_32x32),
+        )
+        cb_descriptor = ttnn.CBDescriptor(
+            total_size=page_size,
+            core_ranges=core_grid,
+            format_descriptors=[cb_format],
+        )
+
+        ncrisc_common_runtime_args = [output_tensor.buffer_address()]
+
+        kernel_desc = UnifiedKernelDescriptor(
+            kernel_source=KERNEL_PATH,
+            core_ranges=core_grid,
+            ncrisc_compile_time_args=ncrisc_compile_time_args,
+            ncrisc_named_compile_time_args=ncrisc_named,
+            ncrisc_common_runtime_args=ncrisc_common_runtime_args,
+        )
+
+        kernel_result = kernel_desc.get_kernel_descriptors()
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=kernel_result.kernels,
+            cbs=[cb_descriptor],
+        )
+
+        return ttnn.generic_op([output_tensor, output_tensor], program_descriptor)

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
@@ -70,12 +70,23 @@ class DRAMZeroFill:
         """
         mesh_rows = device.shape[0]
         mesh_cols = device.shape[1]
+        if max_seq_len % mesh_rows != 0:
+            raise ValueError(
+                "max_seq_len must be divisible by mesh_rows for KV cache allocation: "
+                f"got max_seq_len={max_seq_len}, mesh_rows={mesh_rows}"
+            )
         per_device_seq = max_seq_len // mesh_rows
 
         if mesh_shape is None:
             mesh_shape = (mesh_rows, mesh_cols)
 
         program_config = FlashMLADecode.ProgramConfig(k_chunk_size=DEFAULT_K_CHUNK_SIZE, exp_approx_mode=False)
+        if per_device_seq % program_config.k_chunk_size != 0:
+            raise ValueError(
+                "Per-device sequence length must be divisible by k_chunk_size for KV cache allocation: "
+                f"got per_device_seq={per_device_seq}, k_chunk_size={program_config.k_chunk_size}, "
+                f"max_seq_len={max_seq_len}, mesh_rows={mesh_rows}"
+            )
         kv_nd_shard_spec = ttnn.NdShardSpec(
             shard_shape=[1, 1, program_config.k_chunk_size, kvpe_dim],
             grid=program_config.grid.optimal_dram_grid(),
@@ -114,7 +125,19 @@ class DRAMZeroFill:
         """
         page_size = TILE_32x32.get_tile_size(output_tensor.dtype)
 
+        device_grid = output_tensor.device().compute_with_storage_grid_size()
+        if device_grid.x < GRID_X or device_grid.y < GRID_Y:
+            raise ValueError(
+                "DRAMZeroFill requires at least a 12x10 compute grid: "
+                f"required=({GRID_X}, {GRID_Y}), actual=({device_grid.x}, {device_grid.y})"
+            )
+
         shape = output_tensor.shape
+        if shape[-2] % 32 != 0 or shape[-1] % 32 != 0:
+            raise ValueError(
+                "DRAMZeroFill requires the last two tensor dimensions to be multiples of 32: "
+                f"got shape={list(shape)}, shape[-2]={shape[-2]}, shape[-1]={shape[-1]}"
+            )
         tile_rows = shape[-2] // 32
         tile_cols = shape[-1] // 32
         batch_tiles = 1

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 import ttnn
+from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.micro_ops.dram_zero_fill.op import DRAMZeroFill
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 
@@ -59,6 +60,9 @@ def _build_reference_kv_tensor(submesh, num_users, max_seq_len):
 @pytest.mark.requires_grid_size((12, 10))
 def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> None:
     """Zero-fill a KV-cache-shaped DRAM tensor and verify all zeros."""
+    if is_slow_dispatch() and (num_users > 1 or max_seq_len > 1024 * 32):
+        pytest.skip("Host readback (ttnn.to_torch) for this shape is too slow in slow dispatch mode")
+
     if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < 8:
         pytest.skip("Test requires 8 devices (4x2 mesh)")
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit test for the DRAMZeroFill micro op.
+
+Allocates a DRAM tensor with the exact KV cache NdShardSpec configuration,
+runs the zero-fill kernel, reads the result back to host, and verifies that
+every element is zero.
+"""
+
+import time
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.dram_zero_fill.op import DRAMZeroFill
+
+KVPE_DIM = 576
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+@pytest.mark.parametrize("max_seq_len", [1024 * 32, 1024 * 64, 1024 * 128])
+@pytest.mark.parametrize("num_users", [1, 32, 64])
+@pytest.mark.requires_grid_size((12, 10))
+def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> None:
+    """Zero-fill a KV-cache-shaped DRAM tensor and verify all zeros."""
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < 8:
+        pytest.skip("Test requires 8 devices (4x2 mesh)")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+
+    # Poison DRAM with random data so that a no-op kernel can't pass by luck.
+    mesh_rows = submesh.shape[0]
+    per_device_seq = max_seq_len // mesh_rows
+    poison = ttnn.from_torch(
+        torch.randn(num_users, 1, per_device_seq, KVPE_DIM),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
+    )
+    ttnn.deallocate(poison, force=True)
+
+    # Warmup (includes kernel compilation)
+    t0 = time.perf_counter()
+    warmup_tensor = DRAMZeroFill.allocate_kv_cache_on_device(
+        submesh, num_users=num_users, max_seq_len=max_seq_len, kvpe_dim=KVPE_DIM
+    )
+    ttnn.synchronize_device(submesh)
+    warmup_ms = (time.perf_counter() - t0) * 1000.0
+    ttnn.deallocate(warmup_tensor, force=True)
+
+    # Real run (cached kernel)
+    t0 = time.perf_counter()
+    output_tensor = DRAMZeroFill.allocate_kv_cache_on_device(
+        submesh, num_users=num_users, max_seq_len=max_seq_len, kvpe_dim=KVPE_DIM
+    )
+    ttnn.synchronize_device(submesh)
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+    print(
+        f"\nDRAMZeroFill  num_users={num_users}  max_seq_len={max_seq_len}  shape={list(output_tensor.shape)}"
+        f"  warmup={warmup_ms:.2f} ms  run={elapsed_ms:.2f} ms"
+    )
+
+    result = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+    expected = torch.zeros_like(result)
+    assert torch.equal(result, expected), (
+        f"Non-zero values found: max abs = {result.abs().max().item()}, "
+        f"non-zero count = {result.count_nonzero().item()} / {result.numel()}"
+    )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
@@ -6,7 +6,8 @@
 
 Allocates a DRAM tensor with the exact KV cache NdShardSpec configuration,
 runs the zero-fill kernel, reads the result back to host, and verifies that
-every element is zero.
+every element is zero and that the tensor topology matches the reference
+produced by ShardTensor2dMesh.
 """
 
 import time
@@ -16,8 +17,36 @@ import torch
 
 import ttnn
 from models.demos.deepseek_v3_b1.micro_ops.dram_zero_fill.op import DRAMZeroFill
+from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 
 KVPE_DIM = 576
+
+
+def _build_reference_kv_tensor(submesh, num_users, max_seq_len):
+    """Create a KV cache via the original from_torch + ShardTensor2dMesh path."""
+    mesh_rows = submesh.shape[0]
+    mesh_cols = submesh.shape[1]
+    per_device_seq = max_seq_len // mesh_rows
+
+    program_config = FlashMLADecode.ProgramConfig(k_chunk_size=128, exp_approx_mode=False)
+    kv_nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, program_config.k_chunk_size, KVPE_DIM],
+        grid=program_config.grid.optimal_dram_grid(),
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    kv_mem = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=kv_nd_shard_spec)
+    kv_cache_2d_mesh_mapper = ttnn.ShardTensor2dMesh(submesh, mesh_shape=(mesh_rows, mesh_cols), dims=(2, None))
+
+    torch_kv = torch.zeros((num_users, 1, max_seq_len, KVPE_DIM), dtype=torch.bfloat16)
+    return ttnn.from_torch(
+        torch_kv,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=kv_mem,
+        mesh_mapper=kv_cache_2d_mesh_mapper,
+    )
 
 
 @pytest.mark.parametrize(
@@ -34,9 +63,10 @@ def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> 
         pytest.skip("Test requires 8 devices (4x2 mesh)")
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    mesh_rows = submesh.shape[0]
+    mesh_cols = submesh.shape[1]
 
     # Poison DRAM with random data so that a no-op kernel can't pass by luck.
-    mesh_rows = submesh.shape[0]
     per_device_seq = max_seq_len // mesh_rows
     poison = ttnn.from_torch(
         torch.randn(num_users, 1, per_device_seq, KVPE_DIM),
@@ -50,7 +80,11 @@ def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> 
     # Warmup (includes kernel compilation)
     t0 = time.perf_counter()
     warmup_tensor = DRAMZeroFill.allocate_kv_cache_on_device(
-        submesh, num_users=num_users, max_seq_len=max_seq_len, kvpe_dim=KVPE_DIM
+        submesh,
+        num_users=num_users,
+        max_seq_len=max_seq_len,
+        kvpe_dim=KVPE_DIM,
+        mesh_shape=(mesh_rows, mesh_cols),
     )
     ttnn.synchronize_device(submesh)
     warmup_ms = (time.perf_counter() - t0) * 1000.0
@@ -59,7 +93,11 @@ def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> 
     # Real run (cached kernel)
     t0 = time.perf_counter()
     output_tensor = DRAMZeroFill.allocate_kv_cache_on_device(
-        submesh, num_users=num_users, max_seq_len=max_seq_len, kvpe_dim=KVPE_DIM
+        submesh,
+        num_users=num_users,
+        max_seq_len=max_seq_len,
+        kvpe_dim=KVPE_DIM,
+        mesh_shape=(mesh_rows, mesh_cols),
     )
     ttnn.synchronize_device(submesh)
     elapsed_ms = (time.perf_counter() - t0) * 1000.0
@@ -69,9 +107,34 @@ def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> 
         f"  warmup={warmup_ms:.2f} ms  run={elapsed_ms:.2f} ms"
     )
 
+    # Verify data is all zeros
     result = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
     expected = torch.zeros_like(result)
     assert torch.equal(result, expected), (
         f"Non-zero values found: max abs = {result.abs().max().item()}, "
         f"non-zero count = {result.count_nonzero().item()} / {result.numel()}"
     )
+
+    # Verify topology matches reference from_torch + ShardTensor2dMesh path
+    ref_tensor = _build_reference_kv_tensor(submesh, num_users, max_seq_len)
+
+    ref_topo = ref_tensor.tensor_topology()
+    out_topo = output_tensor.tensor_topology()
+
+    assert (
+        out_topo.distribution_shape() == ref_topo.distribution_shape()
+    ), f"distribution_shape mismatch: {out_topo.distribution_shape()} != {ref_topo.distribution_shape()}"
+    out_placements = [str(p) for p in out_topo.placements()]
+    ref_placements = [str(p) for p in ref_topo.placements()]
+    assert out_placements == ref_placements, f"placements mismatch: {out_placements} != {ref_placements}"
+
+    out_coords = [str(c) for c in out_topo.mesh_coords()]
+    ref_coords = [str(c) for c in ref_topo.mesh_coords()]
+    assert out_coords == ref_coords, f"mesh_coords mismatch: {out_coords} != {ref_coords}"
+
+    # Verify memory config matches
+    assert (
+        output_tensor.memory_config() == ref_tensor.memory_config()
+    ), f"memory_config mismatch:\n  got:  {output_tensor.memory_config()}\n  want: {ref_tensor.memory_config()}"
+
+    ttnn.deallocate(ref_tensor, force=True)

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -24,8 +24,6 @@
 #include <taskflow/taskflow.hpp>
 #include <cstdlib>
 #include <cstring>
-#include <cstdio>
-#include <string_view>
 #include <thread>
 
 namespace tt::tt_metal::detail {

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -24,6 +24,8 @@
 #include <taskflow/taskflow.hpp>
 #include <cstdlib>
 #include <cstring>
+#include <cstdio>
+#include <string_view>
 #include <thread>
 
 namespace tt::tt_metal::detail {

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1496,6 +1496,17 @@ void pytensor_module(nb::module_& mod) {
 
                     topology = tt_tensor.tensor_topology()
             )doc")
+        .def(
+            "update_tensor_topology",
+            [](Tensor& self, const tt::tt_metal::TensorTopology& topology) { self.update_tensor_topology(topology); },
+            nb::arg("topology"),
+            R"doc(
+                Update the topology of the tensor.
+
+                .. code-block:: python
+
+                    tt_tensor.update_tensor_topology(new_topology)
+            )doc")
         .def_prop_rw(
             "tensor_id",
             [](const Tensor& self) { return self.tensor_id; },


### PR DESCRIPTION
### Summary

- https://github.com/tenstorrent/tt-blaze/issues/249

This PR introduces a device-side zero-fill micro-op for DRAM tensors, `DRAMZeroFill`, and integrates it with the decoder stage for KV cache initialization. This replaces previous host zero-initialization which was slow for multi-user usecases. 

Previously, KV cache initialization for 64 users took 15 seconds. This change reduces the end-to-end initialization time to <1 ms when using fast-dispatch and around 30 ms when using slow-dispatch

### What's Changed?

* Added the `DRAMZeroFill` micro-op (`op.py`, `dram_zero_fill_kernel.cpp`) to allocate and zero-initialize DRAM tensors directly on device, avoiding host-to-device transfers and matching the expected mesh topology for downstream operations. [[1]](diffhunk://#diff-47487a519e57d70f597b20096f585f0542aa114a0bbdb46d644ba2b342e14fcdR1-R170) [[2]](diffhunk://#diff-5c44308f7db05da8dbba119709a4a45a0707cf67a6d50d293c56a63dc82c8a91R1-R51)
* Integrated `DRAMZeroFill.allocate_kv_cache_on_device` into the decoder stage (`decoder_stage.py`) for cases where the KV cache is being initialized at `position_id == 0` [[1]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011R27) [[2]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011R402-R411) [[3]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011R424-R433)
* Added a unit test (`test_dram_zero_fill.py`) that verifies the zero-fill operation, tensor topology, and memory configuration against the previous reference implementation.
* Exposed a new `update_tensor_topology` method in the Python API for tensors, enabling downstream code to adjust tensor topology metadata as needed.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/kv-cache-zero-fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/kv-cache-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/kv-cache-zero-fill) | [#2711](https://github.com/tenstorrent/tt-metal/actions/runs/24401445087) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/kv-cache-zero-fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/kv-cache-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/kv-cache-zero-fill) | [#17465](https://github.com/tenstorrent/tt-metal/actions/runs/24403125173) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/kv-cache-zero-fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/kv-cache-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/kv-cache-zero-fill) | [#5187](https://github.com/tenstorrent/tt-metal/actions/runs/24401459359) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/kv-cache-zero-fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/kv-cache-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/kv-cache-zero-fill) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/kv-cache-zero-fill) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/kv-cache-zero-fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/kv-cache-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/kv-cache-zero-fill) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/kv-cache-zero-fill) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/kv-cache-zero-fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/kv-cache-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/kv-cache-zero-fill) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/kv-cache-zero-fill) |