### PR TITLE
[skip ci] Re-add test_suite_bh_pcie_didt_tests to blackhole loudbox and qbge upstream tests

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -292,6 +292,7 @@ test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_loudbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
+test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_p300"]="
@@ -303,6 +304,7 @@ test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_qb_ge"]="
 test_suite_bh_multi_pcie_metal_unit_tests
+test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["wh_6u"]="


### PR DESCRIPTION

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes https://github.com/tenstorrent/metal-internal-workflows/issues/825
Underlying issue fixed with fw ver 19.8.0 flashed on all LB and QB2 systems in CI.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Tests were removed originally in https://github.com/tenstorrent/tt-metal/pull/36596 and https://github.com/tenstorrent/tt-metal/pull/36519
This reverts the two changes.

- [x] Upstream tests: https://github.com/tenstorrent/tt-metal/actions/runs/24352522150 (WH-6u failure is on main)