### PR TITLE
[skip ci] ci: Route eltwise L2 nightly tests to CIv2 N300 runner

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -675,7 +675,7 @@ jobs:
     name: ttnn nightly eltwise tests group ${{ matrix.group }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
+        (contains('P150b, N300', inputs.runner-label) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     steps:

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -675,7 +675,7 @@ jobs:
     name: ttnn nightly eltwise tests group ${{ matrix.group }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (contains('P150b, N300', inputs.runner-label) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
+        (contains('P150b, N150, N300', inputs.runner-label) && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     steps:


### PR DESCRIPTION
## Summary
- Route eltwise L2 nightly tests to `tt-ubuntu-2204-N300-stable` (CIv2) instead of label-based `["N300", "in-service", "cloud-virtual-machine"]` runner selection
- Matches the pattern already used by SDPA tests for CIv2 N300

## Test plan
- [x] Trigger L2 nightly with `additional_test_categories: eltwise` on `wormhole_b0` and verify eltwise jobs run on CIv2 N300 runner
- [x] Confirm other jobs are unaffected

## CI Run
- https://github.com/tenstorrent/tt-metal/actions/runs/24352526393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/eltwise-civ2-n300)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/eltwise-civ2-n300)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/eltwise-civ2-n300)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [#5155](https://github.com/tenstorrent/tt-metal/actions/runs/24353393942) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/eltwise-civ2-n300)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/eltwise-civ2-n300)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/eltwise-civ2-n300)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/eltwise-civ2-n300) |