### PR TITLE
ttsim: fix GO_MSG race — initialize signal to RUN_MSG_INIT at device open

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -283,10 +283,16 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
         CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(id_, logical_core, core_type);
         auto programmable_core_type = get_programmable_core_type(virtual_core);
         uint64_t go_message_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
-        uint32_t zero = 0;
-        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_addr);
+        // Initialize signal to RUN_MSG_INIT so that wait_for_cores_idle() cannot mistake
+        // an unbooted core (whose L1 is zero-initialized = RUN_MSG_DONE) for an idle core.
+        // BRISC firmware overwrites this with RUN_MSG_DONE once it has fully initialized
+        // and is ready to receive a GO signal.
+        auto init_go_msg = hal.get_dev_msgs_factory(programmable_core_type).create<dev_msgs::go_msg_t>();
+        init_go_msg.view().signal() = dev_msgs::RUN_MSG_INIT;
+        cluster.write_core(init_go_msg.data(), init_go_msg.size(), tt_cxy_pair(id_, virtual_core), go_message_addr);
         cluster.l1_barrier(id_);
         uint64_t go_message_index_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
+        uint32_t zero = 0;
         cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
     };
     std::optional<std::unique_lock<std::mutex>> watcher_lock;

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -265,7 +265,11 @@ bool check_if_riscs_on_specified_core_done(tt::ChipId chip_id, const CoreCoord& 
         tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             core_status.data(), core_status.size(), {static_cast<size_t>(chip_id), core}, go_msg_addr & ~0x3);
         uint8_t run = core_status.view().signal();
-        if (run != run_state && run != tt_metal::dev_msgs::RUN_MSG_DONE) {
+        // RUN_MSG_INIT is valid here: it means the core has been initialized by the host
+        // but BRISC firmware has not yet completed its startup sequence.  Treat it the
+        // same as run_state (i.e. "not done yet") rather than fataling.
+        if (run != run_state && run != tt_metal::dev_msgs::RUN_MSG_DONE &&
+            run != tt_metal::dev_msgs::RUN_MSG_INIT) {
             fprintf(
                 stderr,
                 "Read unexpected run_mailbox value: 0x%x (expected 0x%x or 0x%x)\n",


### PR DESCRIPTION
## Root cause

On ttsim, L1 is zero-initialized. `RUN_MSG_DONE = 0`, so an unbooted core looks identical to an idle core when `wait_for_cores_idle()` polls `signal`. This causes a race:

```
1. Device opens; L1 zero → signal = RUN_MSG_DONE = 0
2. wait_for_cores_idle() reads 0 → falsely declares cores idle (BRISC hasn't booted)
3. LaunchProgram writes signal = RUN_MSG_GO = 0x80
4. BRISC (still booting) executes: go_messages[0].signal = RUN_MSG_DONE  ← OVERWRITES 0x80 with 0
5. BRISC waits for 0x80 but reads 0 → stuck; kernel never executes
6. WaitProgramDone reads 0 → falsely declares done → readback = 0
```

`advance_clock(10)` in ttsim masked this coincidentally — it advanced enough simulation cycles during init that BRISC finished booting before `wait_for_cores_idle` ran. With `advance_clock(1)` (tt-umd PR #2456, which is more accurate), some cores on a 32-chip galaxy don't get enough cycles and the race surfaces.

Failing test: `MeshDeviceFixture.TensixDirectedStreamRegWriteRead` on WH ttsim galaxy (32-chip).

## Fix

- **`device.cpp`**: In `reset_go_message_index` (called at device open for all worker cores), write `RUN_MSG_INIT = 0x40` to the `signal` byte instead of 0. BRISC firmware already overwrites this with `RUN_MSG_DONE` once its startup sequence completes, so `wait_for_cores_idle()` now correctly waits for actual BRISC initialization.

- **`llrt.cpp`**: In `check_if_riscs_on_specified_core_done`, allow `RUN_MSG_INIT` as a valid "not done yet" state instead of hitting `TT_FATAL`.

## Testing

Unblocks tt-umd PR #2456 (`advance_clock(10)` → `advance_clock(1)`). The fix is correct on all platforms — on real hardware BRISC overwrites `RUN_MSG_INIT` immediately on boot, so there is no behavioral change outside of simulators.