### PR TITLE
ckernel_sfpu.h: remove topk/typecast/welfords/where (burn-down batch 1)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "llk_math_eltwise_ternary_sfpu_params.h"
+#include "sfpu/ckernel_sfpu_where.h"
 
 namespace ckernel {
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "llk_math_eltwise_ternary_sfpu_params.h"
+#include "sfpu/ckernel_sfpu_where.h"
 
 namespace ckernel {
 

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "ckernel_sfpu.h"
+#include "sfpu/ckernel_sfpu_topk.h"
 #include "ckernel_sfpu_add_top_row.h"
 #include "ckernel_sfpu_binary.h"
 #include "llk_sfpu_types.h"

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_sfpu.h
@@ -52,7 +52,4 @@
 #include "sfpu/ckernel_sfpu_tanh.h"
 #include "sfpu/ckernel_sfpu_tanh_derivative.h"
 #include "sfpu/ckernel_sfpu_threshold.h"
-#include "sfpu/ckernel_sfpu_topk.h"
 #include "sfpu/ckernel_sfpu_trigonometry.h"
-#include "sfpu/ckernel_sfpu_typecast.h"
-#include "sfpu/ckernel_sfpu_where.h"

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
@@ -52,8 +52,4 @@
 #include "sfpu/ckernel_sfpu_tanh.h"
 #include "sfpu/ckernel_sfpu_tanh_derivative.h"
 #include "sfpu/ckernel_sfpu_threshold.h"
-#include "sfpu/ckernel_sfpu_topk.h"
 #include "sfpu/ckernel_sfpu_trigonometry.h"
-#include "sfpu/ckernel_sfpu_typecast.h"
-#include "sfpu/ckernel_sfpu_welfords.h"
-#include "sfpu/ckernel_sfpu_where.h"


### PR DESCRIPTION
## Summary

`ckernel_sfpu.h` is a mega-header that aggregates all 52 SFPU op includes. It is pulled in by `cmath_common.h`, which means every compute kernel parses all SFPU headers even if it uses none of them. This causes measurable JIT compile overhead (~0.2s → 0.12s measured on one kernel).

This is batch 1 of a bottom-up burn-down: remove the last four includes from `ckernel_sfpu.h` and add explicit includes wherever callers were relying on the implicit pull-through.

### Changes

**Removed from `ckernel_sfpu.h` (WH + BH):**
- `ckernel_sfpu_topk.h`
- `ckernel_sfpu_typecast.h`
- `ckernel_sfpu_welfords.h` (WH only — BH never had it)
- `ckernel_sfpu_where.h`

**Added explicit includes:**
- `llk_math_eltwise_ternary_sfpu_where.h` (WH + BH): was calling `_calculate_where_` / `_init_where_` without including the header that defines them — only worked because `ckernel_sfpu.h` pulled it in transitively.

**Audit methodology:** grepped the full tree for every identifier exported by each removed header (`_calculate_topk_`, `_calculate_typecast_`, `_calculate_welfords_`, `_calculate_where_`, etc.) and verified all callers either already have an explicit include or are in files that include the corresponding `llk_*` wrapper which now has the explicit include.

## Test plan
- [ ] Build compute kernels for WH and BH — no compile errors
- [ ] Eltwise where op tests pass on WH/BH
- [ ] Topk, typecast, welfords op tests pass

🤖 BrAIn

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/burn-down-ckernel-sfpu-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/burn-down-ckernel-sfpu-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/burn-down-ckernel-sfpu-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/burn-down-ckernel-sfpu-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/burn-down-ckernel-sfpu-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/burn-down-ckernel-sfpu-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/burn-down-ckernel-sfpu-batch1) |