### PR TITLE
tt_symbiote: add Gemma4 31B TTNN modules with TRACED mode support

### DIFF
--- a/models/experimental/tt_symbiote/core/module.py
+++ b/models/experimental/tt_symbiote/core/module.py
@@ -219,6 +219,20 @@ class TTNNModule:
         """Forward pass - must be implemented by subclasses."""
         raise NotImplementedError("Forward method must be implemented by subclasses.")
 
+    def pre_trace_execute(self, func_args, func_kwargs):
+        """Hook called before ttnn.execute_trace during trace replay.
+
+        Override to copy trace-sensitive inputs to module-owned persistent
+        buffers (avoiding TTNN trace allocator buffer aliasing).
+        """
+
+    def post_trace_execute(self, func_args, func_kwargs, result):
+        """Hook called after ttnn.execute_trace during trace replay.
+
+        Override to perform post-processing on trace outputs or update
+        module state based on the replayed result.
+        """
+
     def named_modules(self, memo=None, prefix="", remove_duplicate=True):
         """Iterator over all modules in the network, yielding both the name of the module as well as the module itself."""
         if memo is None:

--- a/models/experimental/tt_symbiote/core/run_config.py
+++ b/models/experimental/tt_symbiote/core/run_config.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type
 
 import torch
-from models.experimental.tt_symbiote.core.utils import tree_map
+from models.experimental.tt_symbiote.core.utils import tree_map, flat_map_bypass
 from tracy import signpost
 
 import ttnn
@@ -283,6 +283,9 @@ class DispatchManager:
         assert isinstance(file_name, str), "file_name must be a string"
         assert file_name.endswith(".csv"), "file_name must end with .csv"
         df = DispatchManager.get_timing_entries_stats()
+        if df.empty:
+            print(f"[WARN] No timing entries recorded. Skipping save to {file_name}")
+            return
         df.to_csv(file_name, index=True)
         pivot_table = df.pivot_table(
             index=["func_name", "module_name"], columns="backend", values="duration", aggfunc="sum", fill_value=0
@@ -596,10 +599,11 @@ class NormalRun:
             transform = fast_unwrap_to_device(self.device)
         else:
             transform = compose_transforms(wrap_to_torch_ttnn_tensor, to_ttnn_wrap, set_device_wrap(self.device))
-        func_args = tree_map(transform, args)
+        _map = flat_map_bypass if bypass else tree_map
+        func_args = _map(transform, args)
         # TODO: fix kwds not being passed correctly
         other_kwargs = {k: v for k, v in kwds.items() if "past_key_value" not in k}
-        func_kwargs = tree_map(transform, other_kwargs)
+        func_kwargs = _map(transform, other_kwargs)
         func_kwargs.update({k: v for k, v in kwds.items() if "past_key_value" in k})
         begin = time.time()
         self.preprocess_weights()
@@ -943,6 +947,8 @@ class TracedRun(LightweightRun):
     _input_memory_config: Any = None
     _trace_cache: Dict[Tuple, TraceEntry] = {}
     _warmup_keys: Set[Tuple] = set()  # keys that have completed warm-up (run 1)
+    _base_pre_trace_execute: Any = None
+    _base_post_trace_execute: Any = None
 
     @classmethod
     def configure(
@@ -952,11 +958,15 @@ class TracedRun(LightweightRun):
         input_memory_config=None,
     ) -> None:
         """Configure traced run mode."""
+        from models.experimental.tt_symbiote.core.module import TTNNModule
+
         cls._device = device
         cls._cq_id = cq_id
         cls._input_memory_config = input_memory_config or ttnn.DRAM_MEMORY_CONFIG
         cls._trace_cache = {}
         cls._warmup_keys = set()
+        cls._base_pre_trace_execute = TTNNModule.pre_trace_execute
+        cls._base_post_trace_execute = TTNNModule.post_trace_execute
 
     @classmethod
     def cache_size(cls) -> int:
@@ -1050,7 +1060,7 @@ class TracedRun(LightweightRun):
         trace_inputs = []
         trace_func_args = []
 
-        for arg in func_args:
+        for arg_idx, arg in enumerate(func_args):
             if isinstance(arg, ttnn.Tensor):
                 host_tensor = arg.cpu() if arg.storage_type() != ttnn.StorageType.HOST else arg
                 trace_input = ttnn.to_device(host_tensor, device, memory_config=mem_config)
@@ -1126,6 +1136,7 @@ class TracedRun(LightweightRun):
         # before starting trace capture. Without this, in-flight CCL ops can
         # cause "Writes/Reads are not supported during trace capture" errors.
         ttnn.synchronize_device(device)
+
         # Capture — the output from THIS forward is the trace_output whose
         # device buffer will be rewritten by every subsequent execute_trace.
         trace_id = ttnn.begin_trace_capture(device, cq_id=cq_id)
@@ -1147,16 +1158,16 @@ class TracedRun(LightweightRun):
     @staticmethod
     def module_run(self, *args, **kwds):
         assert self.device is not None, "Device must be set for TTNN module execution."
-        begin_full = time.time()
         # Transform inputs
         bypass = getattr(self, "_bypass_tensor_wrapping", False)
         if bypass:
             transform = fast_unwrap_to_device(self.device)
         else:
             transform = compose_transforms(wrap_to_torch_ttnn_tensor, to_ttnn_wrap, set_device_wrap(self.device))
-        func_args = tree_map(transform, args)
+        _map = flat_map_bypass if bypass else tree_map
+        func_args = _map(transform, args)
         other_kwargs = {k: v for k, v in kwds.items() if "past_key_value" not in k}
-        func_kwargs = tree_map(transform, other_kwargs)
+        func_kwargs = _map(transform, other_kwargs)
         func_kwargs.update({k: v for k, v in kwds.items() if "past_key_value" in k})
 
         begin = time.time()
@@ -1210,8 +1221,12 @@ class TracedRun(LightweightRun):
             print(f"{self.__class__.__name__}: {self.module_name} on device {self.device} [TRACED]")
             TracedRun._copy_inputs_to_trace_buffer(func_args, entry.trace_inputs)
             TracedRun._copy_kwargs_to_trace_buffer(func_kwargs, entry.trace_kwargs)
+            if type(self).pre_trace_execute is not TracedRun._base_pre_trace_execute:
+                self.pre_trace_execute(func_args, func_kwargs)
             ttnn.execute_trace(entry.device, entry.trace_id, cq_id=TracedRun._cq_id, blocking=False)
             result = entry.trace_output
+            if type(self).post_trace_execute is not TracedRun._base_post_trace_execute:
+                self.post_trace_execute(func_args, func_kwargs, result)
         elif cache_key in TracedRun._warmup_keys:
             # === RUN 2: CAPTURE (system already warmed up for this key) ===
             _TRACE_RUNNING = True
@@ -1234,10 +1249,6 @@ class TracedRun(LightweightRun):
         end = time.time()
         DispatchManager.record_timing("TTNN", self.module_name, self.__class__.__name__ + "_forward", {}, end - begin)
         DispatchManager.set_current_module_name(None)
-        end_full = time.time()
-        DispatchManager.record_timing(
-            "TorchModules", self.module_name, self.__class__.__name__, {}, end_full - begin_full
-        )
         if bypass:
             return result
         return post_process_ttnn_module_output(self, result)

--- a/models/experimental/tt_symbiote/core/utils.py
+++ b/models/experimental/tt_symbiote/core/utils.py
@@ -126,6 +126,21 @@ def ensure_tile_layout(tensor: ttnn.Tensor) -> ttnn.Tensor:
     return tensor
 
 
+def flat_map_bypass(func, data):
+    """Fast single-level map for bypass path. No recursion, no ABC imports.
+
+    Only handles flat dicts, tuples, and lists — does NOT recurse into nested
+    structures. Safe for decoder layer args/kwargs which are always flat.
+    """
+    if isinstance(data, dict):
+        return {k: func(v) for k, v in data.items()}
+    elif isinstance(data, tuple):
+        return tuple(func(x) for x in data)
+    elif isinstance(data, list):
+        return [func(x) for x in data]
+    return func(data)
+
+
 def optimized_tree_map_with_only_dict_list(*args, **kwargs):
     # don't use pytorch
     from collections.abc import Mapping, Sequence

--- a/models/experimental/tt_symbiote/models/bailing_moe_v2.py
+++ b/models/experimental/tt_symbiote/models/bailing_moe_v2.py
@@ -140,7 +140,7 @@ class TTNNBailingMoeV2Model(TTNNModule):
         layers = self.layers[: -self.num_nextn_predict_layers] if self.num_nextn_predict_layers > 0 else self.layers
         mtp_layers = self.layers[-self.num_nextn_predict_layers :] if self.num_nextn_predict_layers > 0 else None
 
-        for decoder_layer in layers:
+        for layer_idx, decoder_layer in enumerate(layers):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
@@ -168,6 +168,15 @@ class TTNNBailingMoeV2Model(TTNNModule):
                     position_embeddings=position_embeddings,
                 )
             hidden_states = layer_outputs[0]
+
+            # Update KV cache Python-side counters OUTSIDE the trace boundary.
+            # During trace replay, execute_trace only replays device ops;
+            # _seq_lengths increments inside paged_update_on_device / paged_fill_on_device
+            # do NOT execute. By updating here, the counters advance correctly
+            # in all phases (warmup, capture, replay).
+            if past_key_values is not None and hasattr(past_key_values, "update_seq_length"):
+                seq_len = inputs_embeds.shape[1]  # prefill: SEQ_LEN, decode: 1
+                past_key_values.update_seq_length(layer_idx=layer_idx, seq_len=seq_len)
 
             if use_cache:
                 next_decoder_cache = layer_outputs[2 if output_attentions else 1]

--- a/models/experimental/tt_symbiote/models/gemma4_text.py
+++ b/models/experimental/tt_symbiote/models/gemma4_text.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""TTNN Gemma4 Text Model implementation.
+
+Replaces Gemma4TextModel to:
+- Handle input_ids → embedding on device (trace-safe)
+- Iterate decoder layers without ModuleList slicing
+  (HF's self.layers[:N] reconstructs a ModuleList, failing for TTNNModule)
+- Keep rotary embeddings and causal masks on host (unchanged)
+"""
+
+from typing import Optional
+
+import torch
+import ttnn
+from transformers.modeling_outputs import BaseModelOutputWithPast
+
+from models.experimental.tt_symbiote.core.module import TTNNModule
+from models.experimental.tt_symbiote.core.tensor import TorchTTNNTensor
+
+
+class TTNNGemma4TextModel(TTNNModule):
+    """Replaces Gemma4TextModel (the language_model inside Gemma4Model).
+
+    Follows the same pattern as TTNNBailingMoeV2Model: stores a reference to
+    the original HF model, overrides ``call`` to run the forward pass with
+    TTNN-replaced children, and handles the embedding input conversion that
+    would otherwise break trace capture.
+    """
+
+    @staticmethod
+    def from_torch(model):
+        new_model = TTNNGemma4TextModel()
+        new_model.model = model
+        new_model._decode_cache_position = None
+
+        # Bypass tensor wrapping/unwrapping for decoder layers.
+        # These sit under the HF Gemma4TextModel (nn.Module), so
+        # set_device() would give them _bypass_tensor_wrapping=False.
+        # Bypassing is safe: no PyTorch ops touch hidden_states between
+        # layer calls, and each layer's forward already works with raw
+        # ttnn.Tensor objects.
+        for layer in model.layers:
+            if isinstance(layer, TTNNModule):
+                layer._bypass_tensor_wrapping = True
+        model.norm._bypass_tensor_wrapping = True
+        return new_model
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def __getattr__(self, name):
+        """Delegate attribute access to the wrapped HF model for HF compatibility.
+
+        HF code may access config, embed_tokens.weight, etc. on the language_model.
+        """
+        # Check own __dict__ first (set by TTNNModule.__init__ and from_torch)
+        try:
+            return self.__dict__[name]
+        except KeyError:
+            pass
+        # Delegate to the wrapped HF model
+        return getattr(self.__dict__["model"], name)
+
+    def call(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values=None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        per_layer_inputs: Optional[torch.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        **kwargs,
+    ):
+        ttnn_object = self
+        self = self.model
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if input_ids is not None:
+            # Convert input_ids to UINT32 on device for TTNN embedding lookup.
+            # This is the host→device transfer that prevents embed_tokens from
+            # being @trace_enabled. By doing it here in the model wrapper
+            # (outside any trace boundary) we keep the decoder layer traces clean.
+            input_ids_tt = ttnn.from_torch(
+                input_ids.cpu().to(torch.int32),
+                device=ttnn_object.device,
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_object.device),
+            )
+            inputs_embeds = self.embed_tokens(input_ids_tt)
+
+        if use_cache and past_key_values is None:
+            from transformers import DynamicCache
+
+            past_key_values = DynamicCache(config=self.config)
+
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            position_ids = torch.arange(inputs_embeds.shape[1], device="cpu") + past_seen_tokens
+            position_ids = position_ids.unsqueeze(0)
+
+        # Build causal mask mapping (full_attention + sliding_attention)
+        if not isinstance(attention_mask, dict):
+            from transformers.models.gemma4.modeling_gemma4 import (
+                create_causal_mask,
+                create_sliding_window_causal_mask,
+            )
+
+            mask_kwargs = {
+                "config": self.config,
+                "inputs_embeds": inputs_embeds,
+                "attention_mask": attention_mask,
+                "past_key_values": past_key_values,
+                "position_ids": position_ids,
+            }
+            causal_mask_mapping = {
+                "full_attention": create_causal_mask(**mask_kwargs),
+                "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+            }
+        else:
+            causal_mask_mapping = attention_mask
+
+        # Pre-convert causal masks to ttnn.Tensor for bypass-enabled decoder layers.
+        # With _bypass_tensor_wrapping=True, fast_unwrap_to_device passes torch.Tensor
+        # unchanged, but TTNNSDPAAttention needs ttnn.Tensor for on-device SDPA.
+        mesh_mapper = (
+            ttnn.ReplicateTensorToMesh(ttnn_object.device) if ttnn_object.device.get_num_devices() > 1 else None
+        )
+        for mask_key, mask_val in causal_mask_mapping.items():
+            if isinstance(mask_val, torch.Tensor):
+                causal_mask_mapping[mask_key] = ttnn.from_torch(
+                    mask_val,
+                    device=ttnn_object.device,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                    mesh_mapper=mesh_mapper,
+                )
+
+        hidden_states = inputs_embeds
+
+        # Pre-convert cache_position to an on-device TTNN tensor (trace-safe).
+        # This runs OUTSIDE any trace boundary, so ttnn.from_torch is allowed.
+        #
+        # IMPORTANT: For decode (single-token steps), we use a PERSISTENT device
+        # buffer allocated once and updated in-place via ttnn.copy(). This prevents
+        # the trace allocator from aliasing the buffer's device address with trace
+        # intermediates. Without this, layer 0's trace replay can overwrite the
+        # cache_position buffer, corrupting it for layers 1-59.
+        # See PLAN_gemma4_traced_mode_root_cause.md for full analysis.
+        cache_position = kwargs.get("cache_position")
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], dtype=torch.int32
+            )
+        if not isinstance(cache_position, ttnn.Tensor):
+            cp = cache_position
+            if hasattr(cp, "cpu"):
+                cp = cp.cpu()
+            if isinstance(cp, torch.Tensor):
+                cp = cp.to(torch.int32)
+            else:
+                cp = torch.tensor(cp, dtype=torch.int32)
+            mesh_mapper = (
+                ttnn.ReplicateTensorToMesh(ttnn_object.device) if ttnn_object.device.get_num_devices() > 1 else None
+            )
+            is_decode = inputs_embeds.shape[1] == 1
+            if is_decode and ttnn_object._decode_cache_position is not None:
+                # Subsequent decode steps: copy new value into persistent buffer.
+                cp_temp = ttnn.from_torch(
+                    cp,
+                    device=ttnn_object.device,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=mesh_mapper,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+                ttnn.copy(cp_temp, ttnn_object._decode_cache_position)
+                cache_position = ttnn_object._decode_cache_position
+            else:
+                cache_position = ttnn.from_torch(
+                    cp,
+                    device=ttnn_object.device,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=mesh_mapper,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+                if is_decode:
+                    # First decode step: save as persistent buffer.
+                    # This allocation happens BEFORE trace capture, so the
+                    # trace allocator knows this address is in use.
+                    ttnn_object._decode_cache_position = cache_position
+        kwargs["cache_position"] = cache_position
+
+        # Skip HF CPU rotary — TTNN attention uses BailingRotarySetup on-device (see rope.py).
+        # TTNNGemma4DecoderLayer always passes position_embeddings=None to attention anyway.
+        position_embeddings = {layer_type: None for layer_type in self.unique_layer_types}
+
+        # Iterate decoder layers directly — no slicing avoids ModuleList
+        # reconstruction (HF's [:N] creates a new ModuleList that rejects TTNNModule).
+        num_layers = self.config.num_hidden_layers
+        for i, decoder_layer in enumerate(self.layers):
+            if i >= num_layers:
+                break
+
+            per_layer_input = per_layer_inputs[:, :, i, :] if per_layer_inputs is not None else None
+
+            hidden_states = decoder_layer(
+                hidden_states,
+                per_layer_input,
+                position_embeddings=position_embeddings[self.config.layer_types[i]],
+                attention_mask=causal_mask_mapping[self.config.layer_types[i]],
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=TorchTTNNTensor(hidden_states),
+            past_key_values=past_key_values,
+        )

--- a/models/experimental/tt_symbiote/modules/attention.py
+++ b/models/experimental/tt_symbiote/modules/attention.py
@@ -98,6 +98,7 @@ class TTNNPagedAttentionKVCache(Cache):
         self._device = device
         self._seq_lengths: list[int] = [0] * num_layers
         self._seen_tokens = 0
+        self._external_seq_tracking = False
 
         page_table = torch.arange(config.max_num_blocks, dtype=torch.int32)
         self.page_table = page_table.reshape(config.batch_size, config.blocks_per_sequence)
@@ -173,9 +174,14 @@ class TTNNPagedAttentionKVCache(Cache):
         ttnn.experimental.paged_fill_cache(k_cache, key_states, page_table, batch_idx=batch_idx)
         ttnn.experimental.paged_fill_cache(v_cache, value_states, page_table, batch_idx=batch_idx)
 
-        self._seq_lengths[layer_idx] += seq_len
-        if layer_idx == 0:
-            self._seen_tokens += seq_len
+        # When external seq tracking is enabled (via update_seq_length()),
+        # the caller is responsible for updating counters outside the trace
+        # boundary. Otherwise, update counters here for backward compatibility
+        # with callers that do not use update_seq_length().
+        if not self._external_seq_tracking:
+            self._seq_lengths[layer_idx] += seq_len
+            if layer_idx == 0:
+                self._seen_tokens += seq_len
 
     def paged_update_on_device(
         self,
@@ -204,7 +210,28 @@ class TTNNPagedAttentionKVCache(Cache):
             page_table=page_table,
         )
 
-        seq_len = key_states.shape[0]
+        # When external seq tracking is enabled (via update_seq_length()),
+        # the caller is responsible for updating counters outside the trace
+        # boundary. Otherwise, update counters here for backward compatibility.
+        if not self._external_seq_tracking:
+            seq_len = key_states.shape[0]
+            self._seq_lengths[layer_idx] += seq_len
+            if layer_idx == 0:
+                self._seen_tokens += seq_len
+
+    def update_seq_length(self, layer_idx: int, seq_len: int = 1) -> None:
+        """Increment Python-side sequence counters for a layer.
+
+        This MUST be called outside the trace boundary (i.e. from the model's
+        layer loop) so that the counters advance correctly during trace replay,
+        warmup, and capture phases alike.
+
+        Calling this method enables external sequence tracking, which disables
+        the automatic counter increments inside paged_fill_on_device() and
+        paged_update_on_device() to prevent double-counting.
+        """
+        if not self._external_seq_tracking:
+            self._external_seq_tracking = True
         self._seq_lengths[layer_idx] += seq_len
         if layer_idx == 0:
             self._seen_tokens += seq_len
@@ -217,13 +244,28 @@ class TTNNPagedAttentionKVCache(Cache):
         scale: float = 1.0,
         program_config=None,
         compute_kernel_config=None,
+        sliding_window: int | None = None,
     ) -> ttnn.Tensor:
+        """Paged SDPA decode with optional sliding window.
+
+        Args:
+            sliding_window: If set, restricts attention to the most recent
+                sliding_window KV positions. Currently plumbed through but
+                NOT enforced -- the paged_scaled_dot_product_attention_decode
+                kernel in tt-metal 0.62.2 does not support sliding_window_size
+                natively, and dynamic attn_mask construction is incompatible
+                with trace capture. See Phase 2 plan for enforcement strategy.
+        """
         if not self._is_on_device:
             raise RuntimeError("KV cache not on device. Call to_device(device).")
 
         k_cache = self._tt_key_cache[layer_idx]
         v_cache = self._tt_value_cache[layer_idx]
         page_table = self._tt_page_table
+
+        # TODO(Phase 2): Enforce sliding window via circular-buffer-as-pages
+        # strategy. For now, sliding_window is accepted but not enforced.
+        # This is correct for sequences shorter than the window size.
 
         return ttnn.transformer.paged_scaled_dot_product_attention_decode(
             query,

--- a/models/experimental/tt_symbiote/modules/gemma4_attention.py
+++ b/models/experimental/tt_symbiote/modules/gemma4_attention.py
@@ -1,0 +1,1186 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gemma4 Attention implementations for TTNN.
+
+This module provides TTNN-accelerated attention mechanisms specific to Gemma4:
+- TTNNGemma4Attention: Unified attention class for both sliding and global layers
+- TTNNGemma4PagedAttentionKVCache: Dual paged KV cache routing sliding/global layers
+
+Gemma4 attention has two variants:
+- Sliding layers: 32 Q heads, 16 KV heads, head_dim=256, separate K/V projections
+- Global layers: 32 Q heads, 4 KV heads, head_dim=512, K=V sharing (v_proj is None)
+
+Both variants use per-head Q/K/V RMSNorm (no 1/sqrt(d) scaling) and RoPE.
+"""
+
+from typing import Optional
+
+import torch
+
+import ttnn
+from models.experimental.tt_symbiote.core.module import TTNNModule
+from models.experimental.tt_symbiote.core.tensor import TorchTTNNTensor
+from models.experimental.tt_symbiote.modules.attention import (
+    TTNNPagedAttentionKVCache,
+    PagedAttentionConfig,
+    TTNNSDPAAttention,
+)
+from models.experimental.tt_symbiote.modules.linear import (
+    TTNNLinear,
+    TTNNLinearIReplicatedWColSharded,
+    TTNNLinearIColShardedWAllReduced,
+)
+from models.experimental.tt_symbiote.modules.normalization import TTNNLocalRMSNorm
+from models.experimental.tt_symbiote.modules.rope import (
+    BailingRotarySetup,
+)
+from models.experimental.tt_symbiote.core.run_config import trace_enabled
+
+try:
+    from transformers.cache_utils import Cache
+except ImportError:
+    Cache = object
+
+
+def _reverse_permute_weight(tensor: torch.Tensor, n_heads: int, head_dim: int) -> torch.Tensor:
+    """Permute Q/K weight from HF split-half to Meta interleaved layout.
+
+    Full rotary: standard permutation matching tt-transformers reverse_permute.
+    Reorders from [first_half, second_half] to interleaved [x0, x_{d/2}, x1, x_{d/2+1}, ...].
+    """
+    dim1, dim2 = tensor.shape
+    return tensor.view(n_heads, 2, dim1 // n_heads // 2, dim2).transpose(1, 2).reshape(dim1, dim2)
+
+
+def _reverse_permute_norm_weight(weight: torch.Tensor, head_dim: int) -> torch.Tensor:
+    """Permute per-head norm weight from split-half to interleaved layout.
+
+    When Q/K projection weights are permuted via _reverse_permute_weight, the
+    per-head norm weights (q_norm, k_norm) must be permuted identically so that
+    the element-wise scaling aligns with the reordered head dimensions.
+
+    Transforms [w0, w1, ..., w_{d/2-1}, w_{d/2}, ...] to [w0, w_{d/2}, w1, w_{d/2+1}, ...].
+    """
+    return weight.view(2, head_dim // 2).T.reshape(-1)
+
+
+def _deinterleave_heads(tensor, head_dim):
+    """Convert from interleaved [a0,b0,a1,b1,...] to split-half [a0,a1,...,b0,b1,...] format.
+
+    Applied per-head on the last dimension. Used to un-permute V states that
+    inherited the k_proj weight permutation in K=V sharing layers.
+    """
+    shape = list(tensor.shape)
+    new_shape = shape[:-1] + [head_dim // 2, 2]
+    tensor = ttnn.reshape(tensor, new_shape)
+    ndim = len(new_shape)
+    perm = list(range(ndim - 2)) + [ndim - 1, ndim - 2]
+    tensor = ttnn.permute(tensor, perm)
+    tensor = ttnn.reshape(tensor, shape)
+    return tensor
+
+
+@trace_enabled
+class TTNNGemma4Attention(TTNNModule):
+    """TTNN-accelerated Attention for Gemma4.
+
+    Handles BOTH sliding and global attention layers. The from_torch method
+    inspects hf_attn.is_sliding to determine the variant.
+
+    Sliding layers:
+    - 32 Q heads, 16 KV heads, head_dim=256
+    - Separate q_proj, k_proj, v_proj
+    - Q-norm, K-norm, V-norm (per-head RMSNorm)
+
+    Global layers:
+    - 32 Q heads, 4 KV heads, head_dim=512
+    - q_proj and k_proj only; v_proj is None (K=V sharing)
+    - After k_proj, the shared output gets k_norm -> K and v_norm -> V
+
+    Both use scaling=1.0 (norms replace 1/sqrt(d) scaling) and full RoPE.
+    """
+
+    # Class-level cache for BailingRotarySetup instances, shared across layers
+    # with the same (device_id, head_dim, rope_theta) to avoid OOM from
+    # per-layer cos/sin cache allocation (~16-32MB each × 60 layers = ~1.1GB).
+    _shared_rotary_setups = {}
+
+    def __init__(self):
+        super().__init__()
+        self.num_attention_heads = None
+        self.num_key_value_heads = None
+        self.num_key_value_groups = None
+        self.head_dim = None
+        self.hidden_size = None
+        self.scaling = None
+        self.is_causal = True
+        self.is_sliding = None
+        self.layer_idx = None
+        self.sliding_window = None
+
+        self.q_proj = None
+        self.k_proj = None
+        self.v_proj = None  # None for global layers (K=V sharing)
+        self.o_proj = None
+        self.q_norm = None
+        self.k_norm = None
+        self.v_norm = None
+        self.rope = None
+        self.sdpa = None
+        self.core_grid = None
+
+    @classmethod
+    def from_torch(cls, hf_attn, distributed: bool = True):
+        """Create TTNNGemma4Attention from HuggingFace Gemma4TextAttention.
+
+        Args:
+            hf_attn: HuggingFace Gemma4TextAttention module
+            distributed: Whether to use distributed linear layers (default True for T3K)
+
+        Returns:
+            TTNNGemma4Attention instance
+        """
+        new_attn = cls()
+        new_attn._fallback_torch_layer = hf_attn
+
+        # Extract configuration
+        config = hf_attn.config
+        new_attn.is_sliding = hf_attn.is_sliding
+        new_attn.layer_idx = hf_attn.layer_idx
+        new_attn.num_attention_heads = config.num_attention_heads  # 32
+        # num_key_value_heads is a local variable in HF's __init__, not stored as self attr.
+        # Replicate the HF logic: use num_global_key_value_heads for global (k=v) layers,
+        # otherwise use config.num_key_value_heads.
+        use_alternative_attention = getattr(config, "attention_k_eq_v", False) and not new_attn.is_sliding
+        num_kv_heads = config.num_global_key_value_heads if use_alternative_attention else config.num_key_value_heads
+        new_attn.num_key_value_heads = num_kv_heads
+        new_attn.num_key_value_groups = new_attn.num_attention_heads // new_attn.num_key_value_heads
+        new_attn.head_dim = hf_attn.head_dim  # 256 sliding, 512 global
+        new_attn.hidden_size = config.hidden_size
+
+        # Gemma4 uses per-head norms instead of 1/sqrt(d) scaling.
+        # Read scaling from the HF module if available, otherwise default to 1.0.
+        new_attn.scaling = getattr(hf_attn, "scaling", 1.0)
+
+        # Store sliding window size for decode mask construction.
+        # Sliding layers enforce a window; global layers use None (full context).
+        new_attn.sliding_window = getattr(hf_attn, "sliding_window", None)
+
+        # Choose linear layer class for output projection
+        LinearClsOut = TTNNLinearIReplicatedWColSharded if distributed else TTNNLinear
+
+        # Permute Q/K weights from HF split-half to Meta interleaved layout
+        # before creating TTNN linear layers. This is required for
+        # ttnn.experimental.rotary_embedding_llama which expects interleaved
+        # cos/sin pairs [c0, c0, c1, c1, ...].
+        q_weight = _reverse_permute_weight(
+            hf_attn.q_proj.weight.data.clone(), new_attn.num_attention_heads, new_attn.head_dim
+        )
+        k_weight = _reverse_permute_weight(
+            hf_attn.k_proj.weight.data.clone(), new_attn.num_key_value_heads, new_attn.head_dim
+        )
+
+        # Permute per-head Q/K norm weights to match the interleaved layout.
+        # The norm weight is [head_dim] and applied element-wise after projection,
+        # so it must follow the same split-half -> interleaved reordering.
+        if hasattr(hf_attn.q_norm, "weight") and hf_attn.q_norm.weight is not None:
+            hf_attn.q_norm.weight.data = _reverse_permute_norm_weight(hf_attn.q_norm.weight.data, new_attn.head_dim)
+        if hasattr(hf_attn.k_norm, "weight") and hf_attn.k_norm.weight is not None:
+            hf_attn.k_norm.weight.data = _reverse_permute_norm_weight(hf_attn.k_norm.weight.data, new_attn.head_dim)
+
+        # Fused QKV projection: concatenate Q, K, V weights into single matmul.
+        # Sliding layers: Q + K + V; Global layers: Q + K only (K=V sharing).
+        # Uses TTNNLinearIColShardedWAllReduced: input col-sharded -> matmul -> all_reduce
+        # replaces 3 separate matmuls + 4 all_gather CCL ops with 1 matmul + 2 CCL ops.
+        q_size = new_attn.num_attention_heads * new_attn.head_dim
+        kv_size = new_attn.num_key_value_heads * new_attn.head_dim
+
+        has_v_proj = hf_attn.v_proj is not None
+        new_attn._has_v_proj = has_v_proj
+
+        if has_v_proj:
+            v_weight = hf_attn.v_proj.weight.data.clone()
+            fused_weight = torch.cat([q_weight, k_weight, v_weight], dim=0)
+        else:
+            fused_weight = torch.cat([q_weight, k_weight], dim=0)
+
+        fused_linear = torch.nn.Linear(new_attn.hidden_size, fused_weight.shape[0], bias=False)
+        fused_linear.weight.data = fused_weight
+        new_attn.qkv_proj = TTNNLinearIColShardedWAllReduced.from_torch(fused_linear)
+        new_attn._q_size = q_size
+        new_attn._kv_size = kv_size
+
+        # Keep individual proj references as None (fused into qkv_proj)
+        new_attn.q_proj = None
+        new_attn.k_proj = None
+        new_attn.v_proj = None
+
+        # O projection: row-parallel with reduce_scatter
+        new_attn.o_proj = LinearClsOut.from_torch(hf_attn.o_proj)
+
+        # Per-head Q/K/V norms (Gemma4RMSNorm instances, weights already permuted above)
+        new_attn.q_norm = TTNNLocalRMSNorm.from_torch(hf_attn.q_norm)
+        new_attn.k_norm = TTNNLocalRMSNorm.from_torch(hf_attn.k_norm)
+        if hasattr(hf_attn, "v_norm") and hf_attn.v_norm is not None:
+            # Gemma4RMSNorm(with_scale=False) doesn't store dim; stash it for _infer_dim
+            if not hasattr(hf_attn.v_norm, "weight") or hf_attn.v_norm.weight is None:
+                hf_attn.v_norm._norm_dim = new_attn.head_dim
+            new_attn.v_norm = TTNNLocalRMSNorm.from_torch(hf_attn.v_norm)
+        else:
+            new_attn.v_norm = None
+
+        # RoPE is handled by BailingRotarySetup (initialized in move_weights_to_device_impl)
+
+        # SDPA for attention computation
+        new_attn.sdpa = TTNNSDPAAttention()
+
+        # Default core grid (will be updated in move_weights_to_device_impl)
+        new_attn.core_grid = ttnn.CoreGrid(y=8, x=8)
+
+        return new_attn
+
+    def move_weights_to_device_impl(self):
+        """Initialize SDPA config and move weights to device."""
+        super().move_weights_to_device_impl()
+
+        # Query grid dynamically from device
+        grid = self.device.compute_with_storage_grid_size()
+        self.core_grid = ttnn.CoreGrid(y=grid.y, x=grid.x)
+
+        if self.sdpa.program_config is None:
+            # Configure SDPA for the appropriate head_dim
+            # Use smaller chunk sizes for larger head_dim to avoid L1 pressure
+            chunk_size = 64 if self.head_dim >= 512 else 128
+            self.sdpa.program_config = ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=(self.core_grid.x, self.core_grid.y),
+                q_chunk_size=chunk_size,
+                k_chunk_size=chunk_size,
+                exp_approx_mode=False,
+            )
+            self.sdpa.compute_kernel_config = ttnn.init_device_compute_kernel_config(
+                self.device.arch(),
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+                packer_l1_acc=False,
+            )
+
+        # Pre-allocate replicated decode cur_pos buffer for trace safety.
+        if self.device.get_num_devices() > 1:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self.device)
+            self._decode_cur_pos = ttnn.from_torch(
+                torch.zeros(1, dtype=torch.int32),
+                device=self.device,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=mesh_mapper,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+        # Initialize BailingRotarySetup for on-device RoPE (trace-safe).
+        # Pre-computes cos/sin caches and transformation matrices on device,
+        # avoiding frozen position_embeddings during trace replay.
+        # SHARED across layers with the same config to avoid OOM — only 2 unique
+        # configs exist (sliding head_dim=256, global head_dim=512).
+        config = self._fallback_torch_layer.config
+        layer_type = "sliding_attention" if self.is_sliding else "full_attention"
+        rope_params = config.rope_parameters[layer_type]
+        rope_theta = rope_params["rope_theta"]  # 10_000 sliding, 1_000_000 global
+        partial_rotary_factor = rope_params.get("partial_rotary_factor", 1.0)  # 1.0 sliding, 0.25 global
+        setup_key = (id(self.device), self.head_dim, rope_theta, partial_rotary_factor)
+        if setup_key not in TTNNGemma4Attention._shared_rotary_setups:
+            # Gemma4 follows the HuggingFace Gemma3 convention: inv_freq is
+            # computed over the full head_dim and only the first rotary_dim
+            # frequencies are used.  This differs from the standard Phi/Ling
+            # convention where inv_freq is computed over rotary_dim only.
+            TTNNGemma4Attention._shared_rotary_setups[setup_key] = BailingRotarySetup(
+                device=self.device,
+                head_dim=self.head_dim,
+                max_seq_len=min(getattr(config, "max_position_embeddings", 8192), 2048),
+                rope_theta=rope_theta,
+                partial_rotary_factor=partial_rotary_factor,
+                use_head_dim_for_freq=True,
+            )
+        self._rotary_setup = TTNNGemma4Attention._shared_rotary_setups[setup_key]
+        self._rotary_dim = self._rotary_setup.rotary_dim  # 256 sliding, 128 global
+
+    @property
+    def _is_distributed(self):
+        return (
+            self.device_state is not None
+            and hasattr(self.device_state, "ccl_manager")
+            and self.device_state.ccl_manager is not None
+        )
+
+    def _maybe_all_gather(self, tensor):
+        """All-gather tensor across mesh devices if in distributed mode.
+
+        Uses Ring topology for trace compatibility — Linear topology may
+        allocate dynamic intermediate buffers that are not pinned by trace
+        capture, causing address aliasing on replay.
+        """
+        if not self._is_distributed:
+            return tensor
+        gathered = ttnn.all_gather(
+            tensor,
+            dim=-1,
+            num_links=1,
+            cluster_axis=1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Ring,
+        )
+        return gathered
+
+    def _is_tensor_replicated(self, tensor) -> bool:
+        """Check if tensor is replicated across devices (vs sharded)."""
+        if tensor is None:
+            return True
+
+        if hasattr(tensor, "ttnn_distributed_tensor_config"):
+            config = tensor.ttnn_distributed_tensor_config
+            if config is not None:
+                mapper = config.mesh_mapper
+                if mapper is not None:
+                    mapper_type = type(mapper).__name__
+                    if "Replicate" in mapper_type:
+                        return True
+                    if "Shard" in mapper_type:
+                        return False
+                return False
+
+        physical_shape = None
+        if hasattr(tensor, "ttnn_tensor") and tensor.ttnn_tensor is not None:
+            physical_shape = tuple(int(i) for i in tensor.ttnn_tensor.shape)
+        elif isinstance(tensor, ttnn.Tensor):
+            physical_shape = tuple(int(i) for i in tensor.shape)
+        elif hasattr(tensor, "shape") and tensor.shape is not None:
+            physical_shape = tuple(tensor.shape)
+
+        if physical_shape is not None and len(physical_shape) >= 1 and self.device is not None:
+            num_devices = self.device.get_num_devices() if hasattr(self.device, "get_num_devices") else 1
+            if num_devices > 1:
+                last_dim = physical_shape[-1]
+                if last_dim == self.hidden_size:
+                    return True
+                elif last_dim == self.hidden_size / num_devices:
+                    return False
+
+        return False
+
+    def _repeat_kv(self, hidden_states: ttnn.Tensor, n_rep: int) -> ttnn.Tensor:
+        """Repeat KV heads to match Q heads for GQA.
+
+        Uses repeat_interleave for correct GQA head ordering.
+        """
+        if n_rep == 1:
+            return hidden_states
+        return ttnn.repeat_interleave(hidden_states, n_rep, dim=1)
+
+    def _to_replicated(self, tensor: ttnn.Tensor) -> ttnn.Tensor:
+        """Convert a multi-device tensor to an explicitly replicated tensor.
+
+        After all-gather the data is identical on every device but the mesh
+        topology metadata differs from ReplicateTensorToMesh. Paged-attention
+        kernels require the replicated topology, so we round-trip through the
+        host for decode tokens (tiny tensors, negligible overhead).
+        """
+        if self.device.get_num_devices() <= 1:
+            return tensor
+        t = tensor
+        if isinstance(t, TorchTTNNTensor):
+            t = t.to_ttnn if hasattr(t, "to_ttnn") else t
+        orig_shape = list(t.shape)
+        mesh_composer = ttnn.ConcatMeshToTensor(self.device, dim=0)
+        t_torch = ttnn.to_torch(t, mesh_composer=mesh_composer)
+        t_torch = t_torch[: orig_shape[0]]
+        return ttnn.from_torch(
+            t_torch,
+            device=self.device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+            dtype=t.dtype,
+            layout=t.layout,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _apply_per_head_norm(self, states, norm_module, batch_size, seq_length, num_heads, head_dim):
+        """Apply per-head RMSNorm by flattening to [batch*seq*heads, head_dim].
+
+        Args:
+            states: Tensor of shape [batch, seq, num_heads, head_dim]
+            norm_module: TTNNLocalRMSNorm instance
+            batch_size: Batch size
+            seq_length: Sequence length
+            num_heads: Number of heads
+            head_dim: Head dimension
+
+        Returns:
+            Normalized tensor of shape [batch, seq, num_heads, head_dim]
+        """
+        orig_shape = states.shape
+        # Flatten to 2D for rms_norm: [batch * seq * num_heads, head_dim]
+        states = ttnn.reshape(states, (batch_size * seq_length * num_heads, head_dim))
+        states = norm_module(states)
+        states = ttnn.reshape(states, orig_shape)
+        return states
+
+    def _project_qkv(self, hidden_states, batch_size, seq_length, apply_rope=False, for_decode=False):
+        """Project hidden states to Q, K, V via fused QKV matmul and apply per-head norms.
+
+        Uses a single fused QKV projection (TTNNLinearIColShardedWAllReduced)
+        instead of 3 separate projections + all_gathers. Input arrives col-sharded
+        from the norm; the fused linear does matmul + reduce_scatter + all_gather
+        in 1 matmul + 2 CCL ops (vs 3 matmuls + 4 CCL ops before).
+
+        For decode (S=1, for_decode=True), uses an optimized reshape path that
+        goes directly from [B, 1, proj_size] to [num_heads, head_dim] for norm,
+        skipping the intermediate [B, S, H, D] reshape. This saves 2 reshape ops
+        per projection (6 total for Q/K/V).
+
+        Args:
+            hidden_states: Input tensor [batch, seq_len, hidden_size]
+            batch_size: Batch dimension
+            seq_length: Sequence length
+            apply_rope: Unused, kept for signature compatibility (always False)
+            for_decode: If True, skip the permute to [B,H,S,D] and return
+                [B,S,H,D] directly (avoids 3 trace ops when S=1).
+
+        Returns:
+            Tuple of (query_states, key_states, value_states) in
+            [batch, num_heads, seq_len, head_dim] layout (or [B,S,H,D] if for_decode).
+        """
+        if hidden_states.layout != ttnn.TILE_LAYOUT:
+            hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        # Fused QKV: single matmul + all_reduce produces replicated output
+        qkv_states = self.qkv_proj(hidden_states)
+
+        # Slice into Q, K, V components
+        q_size = self._q_size
+        kv_size = self._kv_size
+        query_states = ttnn.slice(qkv_states, [0, 0, 0], [batch_size, seq_length, q_size])
+        key_states = ttnn.slice(qkv_states, [0, 0, q_size], [batch_size, seq_length, q_size + kv_size])
+        if self._has_v_proj:
+            value_states = ttnn.slice(
+                qkv_states, [0, 0, q_size + kv_size], [batch_size, seq_length, q_size + 2 * kv_size]
+            )
+        else:
+            # Global layers (K=V sharing): clone K output for V path
+            value_states = ttnn.clone(key_states, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.deallocate(qkv_states)
+
+        if for_decode and seq_length == 1:
+            # Optimized decode path: skip intermediate [B,S,H,D] reshape.
+            # Go directly from [B, 1, proj_size] to [num_heads, head_dim] for norm,
+            # then reshape to [B, 1, H, D]. Saves 2 reshapes per projection.
+            query_states = ttnn.reshape(query_states, (self.num_attention_heads, self.head_dim))
+            key_states = ttnn.reshape(key_states, (self.num_key_value_heads, self.head_dim))
+            value_states = ttnn.reshape(value_states, (self.num_key_value_heads, self.head_dim))
+
+            if not self._has_v_proj:
+                value_states = _deinterleave_heads(value_states, self.head_dim)
+
+            query_states = self.q_norm(query_states)
+            key_states = self.k_norm(key_states)
+            if self.v_norm is not None:
+                value_states = self.v_norm(value_states)
+
+            query_states = ttnn.reshape(query_states, (batch_size, seq_length, self.num_attention_heads, self.head_dim))
+            key_states = ttnn.reshape(key_states, (batch_size, seq_length, self.num_key_value_heads, self.head_dim))
+            value_states = ttnn.reshape(value_states, (batch_size, seq_length, self.num_key_value_heads, self.head_dim))
+        else:
+            # Prefill path: standard reshape chain
+            query_states = ttnn.reshape(query_states, (batch_size, seq_length, self.num_attention_heads, self.head_dim))
+            key_states = ttnn.reshape(key_states, (batch_size, seq_length, self.num_key_value_heads, self.head_dim))
+            value_states = ttnn.reshape(value_states, (batch_size, seq_length, self.num_key_value_heads, self.head_dim))
+
+            if not self._has_v_proj:
+                value_states = _deinterleave_heads(value_states, self.head_dim)
+
+            query_states = self._apply_per_head_norm(
+                query_states,
+                self.q_norm,
+                batch_size,
+                seq_length,
+                self.num_attention_heads,
+                self.head_dim,
+            )
+            key_states = self._apply_per_head_norm(
+                key_states,
+                self.k_norm,
+                batch_size,
+                seq_length,
+                self.num_key_value_heads,
+                self.head_dim,
+            )
+            if self.v_norm is not None:
+                value_states = self._apply_per_head_norm(
+                    value_states,
+                    self.v_norm,
+                    batch_size,
+                    seq_length,
+                    self.num_key_value_heads,
+                    self.head_dim,
+                )
+
+            # Permute to [batch, num_heads, seq_len, head_dim] for prefill attention
+            query_states = ttnn.permute(query_states, (0, 2, 1, 3))
+            key_states = ttnn.permute(key_states, (0, 2, 1, 3))
+            value_states = ttnn.permute(value_states, (0, 2, 1, 3))
+
+        return query_states, key_states, value_states
+
+    def _apply_rotary_embedding_llama(
+        self, query_states, key_states, cos, sin, trans_mat, is_decode_mode, batch_size=None
+    ):
+        """Apply rotary_embedding_llama with partial-RoPE optimization.
+
+        The TTNN rotary_embedding_llama kernel requires head_dim <= 256.
+        Three paths:
+        1. head_dim <= 256: Direct single kernel call (sliding layers).
+        2. head_dim > 256 AND rotary_dim <= 256: Partial RoPE — slice only the
+           rotary dims (128 for Gemma 4 global), apply one kernel call, concat
+           with untouched pass-through dims. 1.57x decode speedup.
+        3. head_dim > 256 AND rotary_dim > 256: Chunked fallback — split into
+           256-dim chunks and apply RoPE to each (future-proofing).
+
+        In decode mode, the kernel requires HEIGHT_SHARDED inputs, so tensors
+        are sharded before RoPE and un-sharded after.
+        """
+        max_rope_dim = 256
+
+        # --- Path 1: head_dim fits kernel limit (sliding layers, head_dim=256) ---
+        if self.head_dim <= max_rope_dim:
+            query_states = ttnn.experimental.rotary_embedding_llama(
+                query_states, cos, sin, trans_mat, is_decode_mode=is_decode_mode
+            )
+            key_states = ttnn.experimental.rotary_embedding_llama(
+                key_states, cos, sin, trans_mat, is_decode_mode=is_decode_mode
+            )
+            return query_states, key_states
+
+        # --- Path 2: Partial RoPE (global layers, rotary_dim=128 <= 256) ---
+        rotary_dim = self._rotary_dim
+        if rotary_dim <= max_rope_dim:
+            # Slice rotary portion and pass-through portion
+            q_rot = query_states[:, :, :, :rotary_dim]
+            q_pass = query_states[:, :, :, rotary_dim:]
+            k_rot = key_states[:, :, :, :rotary_dim]
+            k_pass = key_states[:, :, :, rotary_dim:]
+
+            # Slice cos/sin to actual rotary dims only
+            cos_rot = cos[:, :, :, :rotary_dim]
+            sin_rot = sin[:, :, :, :rotary_dim]
+
+            # For decode mode, shard rotary-dim tensors to L1 (kernel requirement)
+            if is_decode_mode and batch_size is not None:
+                batch_grid = ttnn.num_cores_to_corerangeset(
+                    batch_size, self.device.compute_with_storage_grid_size(), True
+                )
+                shard_mem = ttnn.create_sharded_memory_config(
+                    shape=(ttnn.TILE_SIZE, rotary_dim),
+                    core_grid=batch_grid,
+                    strategy=ttnn.ShardStrategy.HEIGHT,
+                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                    use_height_and_width_as_shard_shape=True,
+                )
+                q_rot = ttnn.to_memory_config(q_rot, shard_mem)
+                k_rot = ttnn.to_memory_config(k_rot, shard_mem)
+                cos_rot = ttnn.to_memory_config(cos_rot, shard_mem)
+                sin_rot = ttnn.to_memory_config(sin_rot, shard_mem)
+
+            # Single RoPE kernel call per Q/K (128 dims fits kernel limit)
+            q_rot = ttnn.experimental.rotary_embedding_llama(
+                q_rot, cos_rot, sin_rot, trans_mat, is_decode_mode=is_decode_mode
+            )
+            k_rot = ttnn.experimental.rotary_embedding_llama(
+                k_rot, cos_rot, sin_rot, trans_mat, is_decode_mode=is_decode_mode
+            )
+
+            # Unshard back to DRAM after RoPE
+            if is_decode_mode and batch_size is not None:
+                q_rot = ttnn.to_memory_config(q_rot, ttnn.DRAM_MEMORY_CONFIG)
+                k_rot = ttnn.to_memory_config(k_rot, ttnn.DRAM_MEMORY_CONFIG)
+
+            # Concat rotated portion with untouched pass-through
+            query_states = ttnn.concat([q_rot, q_pass], dim=-1)
+            key_states = ttnn.concat([k_rot, k_pass], dim=-1)
+            return query_states, key_states
+
+        # --- Path 3: Chunked fallback for rotary_dim > 256 (future-proofing) ---
+        num_chunks = (self.head_dim + max_rope_dim - 1) // max_rope_dim
+        q_chunks = []
+        k_chunks = []
+
+        shard_mem = None
+        if is_decode_mode and batch_size is not None:
+            batch_grid = ttnn.num_cores_to_corerangeset(batch_size, self.device.compute_with_storage_grid_size(), True)
+            shard_mem = ttnn.create_sharded_memory_config(
+                shape=(ttnn.TILE_SIZE, max_rope_dim),
+                core_grid=batch_grid,
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+
+        for i in range(num_chunks):
+            start = i * max_rope_dim
+            end = min((i + 1) * max_rope_dim, self.head_dim)
+            q_chunk = query_states[:, :, :, start:end]
+            k_chunk = key_states[:, :, :, start:end]
+            cos_chunk = cos[:, :, :, start:end]
+            sin_chunk = sin[:, :, :, start:end]
+
+            if shard_mem is not None:
+                q_chunk = ttnn.to_memory_config(q_chunk, shard_mem)
+                k_chunk = ttnn.to_memory_config(k_chunk, shard_mem)
+                cos_chunk = ttnn.to_memory_config(cos_chunk, shard_mem)
+                sin_chunk = ttnn.to_memory_config(sin_chunk, shard_mem)
+
+            q_chunk = ttnn.experimental.rotary_embedding_llama(
+                q_chunk, cos_chunk, sin_chunk, trans_mat, is_decode_mode=is_decode_mode
+            )
+            k_chunk = ttnn.experimental.rotary_embedding_llama(
+                k_chunk, cos_chunk, sin_chunk, trans_mat, is_decode_mode=is_decode_mode
+            )
+
+            if shard_mem is not None:
+                q_chunk = ttnn.to_memory_config(q_chunk, ttnn.DRAM_MEMORY_CONFIG)
+                k_chunk = ttnn.to_memory_config(k_chunk, ttnn.DRAM_MEMORY_CONFIG)
+
+            q_chunks.append(q_chunk)
+            k_chunks.append(k_chunk)
+
+        query_states = ttnn.concat(q_chunks, dim=-1)
+        key_states = ttnn.concat(k_chunks, dim=-1)
+        return query_states, key_states
+
+    def _forward_prefill(
+        self,
+        hidden_states: ttnn.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[ttnn.Tensor],
+        past_key_values,
+        cache_position: Optional[torch.LongTensor],
+    ) -> tuple[ttnn.Tensor, Optional[torch.Tensor]]:
+        """Prefill path for attention computation."""
+        batch_size, seq_length = hidden_states.shape[0], hidden_states.shape[1]
+
+        # Project Q/K/V with per-head norms (no RoPE yet)
+        query_states, key_states, value_states = self._project_qkv(hidden_states, batch_size, seq_length)
+
+        # Apply on-device RoPE via BailingRotarySetup (trace-safe)
+        seq_len = query_states.shape[2]
+        cos, sin = self._rotary_setup.get_cos_sin_for_prefill(seq_len)
+        trans_mat = self._rotary_setup.get_trans_mat(is_decode=False)
+
+        if isinstance(query_states, ttnn.Tensor) and query_states.dtype != ttnn.bfloat16:
+            query_states = ttnn.typecast(query_states, ttnn.bfloat16)
+        if isinstance(key_states, ttnn.Tensor) and key_states.dtype != ttnn.bfloat16:
+            key_states = ttnn.typecast(key_states, ttnn.bfloat16)
+
+        query_states, key_states = self._apply_rotary_embedding_llama(
+            query_states, key_states, cos, sin, trans_mat, is_decode_mode=False
+        )
+
+        # Expand KV to match Q heads (GQA)
+        key_states = self._repeat_kv(key_states, self.num_key_value_groups)
+        value_states = self._repeat_kv(value_states, self.num_key_value_groups)
+
+        use_paged = isinstance(past_key_values, TTNNGemma4PagedAttentionKVCache) or isinstance(
+            past_key_values, TTNNPagedAttentionKVCache
+        )
+
+        if past_key_values is not None:
+            cache_layer_idx = self.layer_idx
+
+            if use_paged:
+                # Get unexpanded KV for cache storage
+                kv_key = key_states[:, :: self.num_key_value_groups, :, :]
+                kv_value = value_states[:, :: self.num_key_value_groups, :, :]
+
+                past_key_values.paged_fill_on_device(
+                    kv_key,
+                    kv_value,
+                    layer_idx=cache_layer_idx,
+                    batch_idx=0,
+                )
+            else:
+                # Standard cache path (non-paged)
+                cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+                kv_key = key_states[:, :: self.num_key_value_groups, :, :]
+                kv_value = value_states[:, :: self.num_key_value_groups, :, :]
+
+                torch_tensors = [TorchTTNNTensor(kv_key), TorchTTNNTensor(kv_value)]
+                orig_shapes = [kv_key.shape, kv_value.shape]
+
+                torch_tensors = [
+                    torch_tensor.to_torch[: orig_shape[0], : orig_shape[1], : orig_shape[2], : orig_shape[3]]
+                    for orig_shape, torch_tensor in zip(orig_shapes, torch_tensors)
+                ]
+
+                cached_key, cached_value = past_key_values.update(
+                    *torch_tensors,
+                    self.layer_idx,
+                    cache_kwargs,
+                )
+                cached_key, cached_value = [TorchTTNNTensor(cached_key), TorchTTNNTensor(cached_value)]
+                cached_key = ttnn.to_device(cached_key.to_ttnn, self.device)
+                cached_value = ttnn.to_device(cached_value.to_ttnn, self.device)
+                cached_key = self._maybe_all_gather(cached_key)
+                cached_value = self._maybe_all_gather(cached_value)
+
+                key_states = self._repeat_kv(cached_key, self.num_key_value_groups)
+                value_states = self._repeat_kv(cached_value, self.num_key_value_groups)
+
+        # Compute attention
+        attn_output = self.sdpa(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0,
+            scaling=self.scaling,
+            is_causal=self.is_causal,
+            transpose_output=True,
+        )
+
+        # Reshape output: [batch, seq_len, num_heads, head_dim] -> [batch, seq_len, hidden_dim]
+        attn_shape = list(attn_output.shape)
+        attn_batch = attn_shape[0]
+        attn_seq = attn_shape[1]
+        attn_output = ttnn.reshape(attn_output, (attn_batch, attn_seq, self.num_attention_heads * self.head_dim))
+
+        # Output projection
+        attn_output = self.o_proj(attn_output)
+
+        return attn_output, None
+
+    def _get_cur_pos_device_tensor(self, cache_position, past_key_values, layer_idx, batch_size):
+        """Extract cur_pos as an on-device int32 tensor.
+
+        Like Ling's pattern: the model wrapper (TTNNGemma4TextModel.call)
+        always provides cache_position as an on-device ttnn.Tensor(int32).
+        TracedRun manages the trace buffer; we only copy into
+        _decode_cur_pos for a stable address on multi-device.
+        """
+        cp = cache_position
+        if isinstance(cp, TorchTTNNTensor):
+            cp = cp.ttnn_tensor
+
+        # Flatten and slice to batch_size
+        if len(cp.shape) > 1:
+            total_elems = 1
+            for d in cp.shape:
+                total_elems *= d
+            cp = ttnn.reshape(cp, (total_elems,))
+        if cp.shape[0] > batch_size:
+            cp = ttnn.slice(cp, [0], [batch_size])
+
+        # On multi-device, copy into pre-allocated buffer for trace-stable address
+        if self._decode_cur_pos is not None:
+            ttnn.copy(cp, self._decode_cur_pos)
+            return self._decode_cur_pos
+        return cp
+
+    def _forward_decode_paged(
+        self,
+        hidden_states: ttnn.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[ttnn.Tensor],
+        past_key_values,
+        cache_position: Optional[torch.LongTensor],
+    ) -> tuple[ttnn.Tensor, Optional[torch.Tensor]]:
+        """Decode path using paged attention with on-device KV cache.
+
+        TTNN paged kernels require tensors in [1, batch, heads, head_dim]
+        layout (S B H D) whereas _project_qkv returns the standard
+        [batch, heads, seq, head_dim] (B H S D).
+        """
+        batch_size, seq_length = hidden_states.shape[0], hidden_states.shape[1]
+
+        layer_idx = self.layer_idx
+
+        # Always resolve position from cache_position kwarg. This ensures
+        # _decode_cur_pos is updated during ALL phases (warmup, capture, replay).
+        # During replay, pre_trace_execute pre-copies the correct value
+        # to the trace kwarg buffer before execute_trace, so the baked-in copy
+        # (from kwarg buffer to _decode_cur_pos) uses the correct position.
+        cur_pos_tt = self._get_cur_pos_device_tensor(cache_position, past_key_values, layer_idx, batch_size)
+
+        # Project Q/K/V with per-head norms (no RoPE yet).
+        # for_decode=True skips the [B,H,S,D] permute — returns [B,S,H,D].
+        query_states, key_states, value_states = self._project_qkv(
+            hidden_states, batch_size, seq_length, for_decode=True
+        )
+
+        # Reshape Q/K/V from [B, S, H, D] to [1, B, H, D] for decode RoPE.
+        # With for_decode=True and S=1: [1,1,H,D] -> [1,1,H,D] (same values, no permute needed).
+        query_states = ttnn.reshape(query_states, (1, batch_size, self.num_attention_heads, self.head_dim))
+        key_states = ttnn.reshape(key_states, (1, batch_size, self.num_key_value_heads, self.head_dim))
+        value_states = ttnn.reshape(value_states, (1, batch_size, self.num_key_value_heads, self.head_dim))
+
+        # Typecast to bfloat16 for rotary_embedding_llama
+        if isinstance(query_states, ttnn.Tensor) and query_states.dtype != ttnn.bfloat16:
+            query_states = ttnn.typecast(query_states, ttnn.bfloat16)
+        if isinstance(key_states, ttnn.Tensor) and key_states.dtype != ttnn.bfloat16:
+            key_states = ttnn.typecast(key_states, ttnn.bfloat16)
+
+        # On-device RoPE for decode (trace-safe) via BailingRotarySetup
+        cos_ttnn, sin_ttnn = self._rotary_setup.get_cos_sin_for_decode(cur_pos_tt)
+
+        if self.head_dim <= 256:
+            # Standard sharded decode RoPE path (head_dim fits kernel limit)
+            batch_grid = ttnn.num_cores_to_corerangeset(batch_size, self.device.compute_with_storage_grid_size(), True)
+
+            rope_shard_mem = ttnn.create_sharded_memory_config(
+                shape=(ttnn.TILE_SIZE, self.head_dim),
+                core_grid=batch_grid,
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            cos_ttnn = ttnn.to_memory_config(cos_ttnn, rope_shard_mem)
+            sin_ttnn = ttnn.to_memory_config(sin_ttnn, rope_shard_mem)
+
+            q_shard_mem = ttnn.create_sharded_memory_config(
+                shape=(ttnn.TILE_SIZE, self.head_dim),
+                core_grid=batch_grid,
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            query_states = ttnn.to_memory_config(query_states, q_shard_mem)
+
+            k_shard_mem = ttnn.create_sharded_memory_config(
+                shape=(ttnn.TILE_SIZE, key_states.shape[-1]),
+                core_grid=batch_grid,
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            key_states = ttnn.to_memory_config(key_states, k_shard_mem)
+
+            trans_mat = self._rotary_setup.get_trans_mat_decode_sharded(batch_size)
+
+            query_states = ttnn.experimental.rotary_embedding_llama(
+                query_states, cos_ttnn, sin_ttnn, trans_mat, is_decode_mode=True
+            )
+            key_states = ttnn.experimental.rotary_embedding_llama(
+                key_states, cos_ttnn, sin_ttnn, trans_mat, is_decode_mode=True
+            )
+        else:
+            # Split decode RoPE for head_dim > 256 (kernel limit workaround).
+            # Global layers (head_dim=512): split into 256-dim chunks, apply
+            # RoPE to each, concat back. Skip sharding for simplicity — only
+            # 10 out of 60 layers use this path.
+            trans_mat = self._rotary_setup.get_trans_mat_decode_sharded(batch_size)
+            query_states, key_states = self._apply_rotary_embedding_llama(
+                query_states, key_states, cos_ttnn, sin_ttnn, trans_mat, is_decode_mode=True, batch_size=batch_size
+            )
+
+        # query_states/key_states are now in [1, B, H, D] — the S B H D layout
+        # that paged kernels expect. After RoPE they stay in their current
+        # memory config (HEIGHT_SHARDED L1 for head_dim<=256 path, DRAM for
+        # the split path). No copy-to-replicated needed — the all_gather in
+        # _project_qkv already produced full tensors on each device.
+        query_states_paged = query_states
+        kv_key = key_states
+        kv_value = value_states
+
+        # Typecast value_states to bfloat16 if needed (for paged cache)
+        if isinstance(kv_value, ttnn.Tensor) and kv_value.dtype != ttnn.bfloat16:
+            kv_value = ttnn.typecast(kv_value, ttnn.bfloat16)
+
+        tile_size = 32
+        shard_h = ((self.num_key_value_heads + tile_size - 1) // tile_size) * tile_size
+
+        core_grid = ttnn.CoreGrid(y=1, x=batch_size)
+        shard_cfg = ttnn.create_sharded_memory_config(
+            shape=(shard_h, self.head_dim),
+            core_grid=core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        kv_key = ttnn.to_memory_config(kv_key, shard_cfg)
+        kv_value = ttnn.to_memory_config(kv_value, shard_cfg)
+
+        # Update the on-device paged KV cache
+        past_key_values.paged_update_on_device(
+            kv_key,
+            kv_value,
+            layer_idx=layer_idx,
+            current_pos=cur_pos_tt,
+        )
+        ttnn.deallocate(kv_key)
+        ttnn.deallocate(kv_value)
+
+        # Paged SDPA decode
+        attn_output = past_key_values.paged_sdpa_decode(
+            query_states_paged,
+            layer_idx,
+            current_pos=cur_pos_tt,
+            scale=self.scaling,
+            program_config=self.sdpa.program_config,
+            compute_kernel_config=self.sdpa.compute_kernel_config,
+            sliding_window=self.sliding_window,
+        )
+        # attn_output: [1, B, H, head_dim]
+
+        # HEIGHT_SHARDED for nlp_concat_heads_decode
+        sdpa_output_memcfg = ttnn.create_sharded_memory_config(
+            shape=(32, self.head_dim),
+            core_grid=ttnn.CoreGrid(y=1, x=batch_size),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        attn_output = ttnn.to_memory_config(attn_output, sdpa_output_memcfg)
+
+        attn_output = ttnn.experimental.nlp_concat_heads_decode(
+            attn_output,
+            num_heads=self.num_attention_heads,
+        )
+
+        # Output projection runs on width-sharded tensor before slice
+        attn_output = self.o_proj(attn_output)
+
+        if batch_size < 32:
+            attn_output = ttnn.slice(attn_output, [0, 0, 0, 0], [1, 1, batch_size, attn_output.shape[-1]])
+
+        attn_output = ttnn.reshape(attn_output, (batch_size, seq_length, -1))
+
+        return attn_output, None
+
+    def forward(
+        self,
+        hidden_states: ttnn.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[ttnn.Tensor] = None,
+        past_key_values=None,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> tuple[ttnn.Tensor, Optional[torch.Tensor]]:
+        """Forward pass through Gemma4 attention.
+
+        Args:
+            hidden_states: Input tensor [batch, seq_len, hidden_size]
+            position_embeddings: Tuple of (cos, sin) for RoPE
+            attention_mask: Optional attention mask
+            past_key_values: Optional KV cache (TTNNGemma4PagedAttentionKVCache or DynamicCache)
+            cache_position: Optional cache position tensor
+            position_ids: Optional position IDs (unused, for API compatibility)
+            **kwargs: Additional arguments for forward compatibility
+
+        Returns:
+            Tuple of (attention_output, None)
+        """
+        seq_length = hidden_states.shape[1]
+
+        use_paged = isinstance(past_key_values, TTNNGemma4PagedAttentionKVCache) or isinstance(
+            past_key_values, TTNNPagedAttentionKVCache
+        )
+
+        if use_paged and seq_length == 1:
+            ttnn_output, _ = self._forward_decode_paged(
+                hidden_states,
+                position_embeddings,
+                attention_mask,
+                past_key_values,
+                cache_position,
+            )
+        else:
+            ttnn_output, _ = self._forward_prefill(
+                hidden_states,
+                position_embeddings,
+                attention_mask,
+                past_key_values,
+                cache_position,
+            )
+
+        return ttnn_output, None
+
+
+class TTNNGemma4PagedAttentionKVCache(Cache):
+    """Dual paged KV cache for Gemma4 that routes sliding/global layers to separate caches.
+
+    Gemma4 has two types of attention layers with different KV configurations:
+    - Sliding layers: 16 KV heads, head_dim=256, with sliding window
+    - Global layers: 4 KV heads, head_dim=512, full context
+
+    This class wraps two TTNNPagedAttentionKVCache instances and routes
+    operations to the correct cache based on layer_idx.
+    """
+
+    def __init__(self, text_config, global_layer_indices, device=None):
+        """Initialize dual paged KV cache.
+
+        Args:
+            text_config: Gemma4TextConfig with model dimensions
+            global_layer_indices: Set or list of layer indices that use global attention
+            device: TTNN device or mesh device
+        """
+        try:
+            super().__init__(layers=[])
+        except Exception:
+            super().__init__()
+
+        self.text_config = text_config
+        self.global_layer_indices = set(global_layer_indices)
+
+        # Build layer routing: layer_idx -> ('sliding'|'global', cache_layer_idx)
+        self._routing = {}
+        sliding_idx = 0
+        global_idx = 0
+        for layer_idx in range(text_config.num_hidden_layers):
+            if layer_idx in self.global_layer_indices:
+                self._routing[layer_idx] = ("global", global_idx)
+                global_idx += 1
+            else:
+                self._routing[layer_idx] = ("sliding", sliding_idx)
+                sliding_idx += 1
+
+        num_sliding = text_config.num_hidden_layers - len(self.global_layer_indices)
+        num_global = len(self.global_layer_indices)
+
+        # Sliding: only needs ceil(window/block_size) blocks per sequence.
+        # window=1024, block_size=64 -> 16 blocks. Use 32 for headroom.
+        sliding_config = PagedAttentionConfig(block_size=64, max_num_blocks=32)
+        # Global: needs ceil(max_seq_len/block_size) blocks. For typical
+        # inference (prompt + 128-256 new tokens), 64 blocks = 4096 tokens.
+        global_config = PagedAttentionConfig(block_size=64, max_num_blocks=64)
+
+        # Sliding cache: more KV heads, smaller head_dim
+        self.sliding_cache = TTNNPagedAttentionKVCache(
+            num_layers=num_sliding,
+            num_kv_heads=text_config.num_key_value_heads,  # 16
+            head_dim=text_config.head_dim,  # 256
+            config=sliding_config,
+        )
+
+        # Global cache: fewer KV heads, larger head_dim
+        # Use global-specific config attributes if available, otherwise derive from config
+        global_num_kv_heads = getattr(
+            text_config,
+            "num_global_key_value_heads",
+            getattr(text_config, "global_num_key_value_heads", 4),
+        )
+        global_head_dim = getattr(
+            text_config,
+            "global_head_dim",
+            getattr(text_config, "head_dim_global", 512),
+        )
+
+        self.global_cache = TTNNPagedAttentionKVCache(
+            num_layers=num_global,
+            num_kv_heads=global_num_kv_heads,  # 4
+            head_dim=global_head_dim,  # 512
+            config=global_config,
+        )
+
+        self._device = device
+
+    def _get_cache_and_idx(self, layer_idx: int):
+        """Route layer_idx to the correct sub-cache and cache-local index.
+
+        Returns:
+            Tuple of (cache_instance, cache_local_layer_idx)
+        """
+        cache_type, cache_idx = self._routing[layer_idx]
+        if cache_type == "global":
+            return self.global_cache, cache_idx
+        else:
+            return self.sliding_cache, cache_idx
+
+    def to_device(self, device) -> "TTNNGemma4PagedAttentionKVCache":
+        """Move both sub-caches to device."""
+        self._device = device
+        self.sliding_cache.to_device(device)
+        self.global_cache.to_device(device)
+        return self
+
+    def paged_fill_on_device(
+        self,
+        key_states: ttnn.Tensor,
+        value_states: ttnn.Tensor,
+        layer_idx: int,
+        batch_idx: int = 0,
+    ):
+        """Fill KV cache for a layer, routing to the correct sub-cache."""
+        cache, cache_idx = self._get_cache_and_idx(layer_idx)
+        cache.paged_fill_on_device(key_states, value_states, cache_idx, batch_idx)
+
+    def paged_update_on_device(
+        self,
+        key_states: ttnn.Tensor,
+        value_states: ttnn.Tensor,
+        layer_idx: int,
+        current_pos: ttnn.Tensor,
+    ):
+        """Update KV cache for a layer, routing to the correct sub-cache."""
+        cache, cache_idx = self._get_cache_and_idx(layer_idx)
+        cache.paged_update_on_device(key_states, value_states, cache_idx, current_pos)
+
+    def update_seq_length(self, layer_idx: int, seq_len: int = 1) -> None:
+        """Increment Python-side sequence counters, routing to the correct sub-cache."""
+        cache, cache_idx = self._get_cache_and_idx(layer_idx)
+        cache.update_seq_length(cache_idx, seq_len)
+
+    def paged_sdpa_decode(
+        self,
+        query: ttnn.Tensor,
+        layer_idx: int,
+        current_pos: ttnn.Tensor,
+        scale: float = 1.0,
+        program_config=None,
+        compute_kernel_config=None,
+        sliding_window: int | None = None,
+    ) -> ttnn.Tensor:
+        """Decode using paged KV cache, routing to the correct sub-cache."""
+        cache, cache_idx = self._get_cache_and_idx(layer_idx)
+        return cache.paged_sdpa_decode(
+            query,
+            cache_idx,
+            current_pos,
+            scale,
+            program_config,
+            compute_kernel_config,
+            sliding_window=sliding_window,
+        )
+
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+        cache_kwargs: Optional[dict] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Update CPU-side KV cache (DynamicCache compatibility)."""
+        cache, cache_idx = self._get_cache_and_idx(layer_idx)
+        return cache.update(key_states, value_states, cache_idx, cache_kwargs)
+
+    def get_seq_length(self, layer_idx: int = 0) -> int:
+        """Get sequence length for a layer, routing to the correct sub-cache."""
+        if layer_idx in self._routing:
+            cache, cache_idx = self._get_cache_and_idx(layer_idx)
+            return cache.get_seq_length(cache_idx)
+        # Default: return sliding cache layer 0
+        return self.sliding_cache.get_seq_length(0)
+
+    def get_max_cache_shape(self) -> Optional[int]:
+        """Return the max cache shape (minimum of both sub-caches)."""
+        sliding_max = self.sliding_cache.get_max_cache_shape()
+        global_max = self.global_cache.get_max_cache_shape()
+        if sliding_max is None:
+            return global_max
+        if global_max is None:
+            return sliding_max
+        return min(sliding_max, global_max)
+
+    def reset(self) -> None:
+        """Reset both sub-caches for a new generation turn."""
+        self.sliding_cache.reset()
+        self.global_cache.reset()

--- a/models/experimental/tt_symbiote/modules/gemma4_mlp.py
+++ b/models/experimental/tt_symbiote/modules/gemma4_mlp.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gemma 4 Text MLP implementation for TTNN."""
+
+import torch
+import ttnn
+from models.experimental.tt_symbiote.core.module import TTNNModule
+from models.experimental.tt_symbiote.modules.linear import (
+    TTNNLinearIColShardedWAllReduced,
+    TTNNLinearIReplicatedWColSharded,
+)
+
+
+class TTNNGemma4TextMLP(TTNNModule):
+    """TTNN implementation of the Gemma 4 31B-it dense MLP.
+
+    Architecture (fused gate-up):
+        gate_up = fused_gate_up_proj(x)       # [B, S, 5376] -> [B, S, 43008]
+        gate = gate_up[:, :, :21504]           # slice
+        up = gate_up[:, :, 21504:]             # slice
+        output = down_proj(gelu(gate) * up)    # [B, S, 21504] -> [B, S, 5376]
+    """
+
+    @classmethod
+    def from_torch(cls, torch_mlp):
+        """Create a TTNNGemma4TextMLP from a PyTorch Gemma4TextMLP layer."""
+        tt_module = cls()
+        tt_module._fallback_torch_layer = torch_mlp
+
+        # Store intermediate_size for slice boundary in forward()
+        tt_module.intermediate_size = torch_mlp.gate_proj.out_features  # 21504
+
+        # Fused gate-up projection: concatenate gate_proj and up_proj weights
+        # into a single [2*intermediate_size, hidden_size] weight matrix.
+        # Single matmul + all_reduce replaces two separate matmul + all_reduce chains.
+        gate_weight = torch_mlp.gate_proj.weight.data.clone()  # [21504, 5376]
+        up_weight = torch_mlp.up_proj.weight.data.clone()  # [21504, 5376]
+        fused_weight = torch.cat([gate_weight, up_weight], dim=0)  # [43008, 5376]
+
+        fused_linear = torch.nn.Linear(
+            torch_mlp.gate_proj.in_features,  # 5376
+            2 * tt_module.intermediate_size,  # 43008
+            bias=False,
+        )
+        fused_linear.weight.data = fused_weight
+
+        tt_module.fused_gate_up_proj = TTNNLinearIColShardedWAllReduced.from_torch(fused_linear)
+
+        # Keep individual proj references as None (fused into fused_gate_up_proj)
+        tt_module.gate_proj = None
+        tt_module.up_proj = None
+
+        # Down projection unchanged
+        tt_module.down_proj = TTNNLinearIReplicatedWColSharded.from_torch(torch_mlp.down_proj)
+
+        return tt_module
+
+    def forward(self, hidden_states: ttnn.Tensor) -> ttnn.Tensor:
+        if hidden_states.layout != ttnn.TILE_LAYOUT:
+            hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        if hidden_states.dtype != ttnn.bfloat16:
+            hidden_states = ttnn.typecast(hidden_states, ttnn.bfloat16)
+
+        batch_size = hidden_states.shape[0]
+        seq_len = hidden_states.shape[1]
+
+        # Fused gate + up projection (single matmul + all_reduce)
+        gate_up = self.fused_gate_up_proj(hidden_states)
+
+        # Slice into gate and up halves
+        gate = ttnn.slice(gate_up, [0, 0, 0], [batch_size, seq_len, self.intermediate_size])
+        up = ttnn.slice(gate_up, [0, 0, self.intermediate_size], [batch_size, seq_len, 2 * self.intermediate_size])
+        ttnn.deallocate(gate_up)
+
+        # GeLU activation on gate path
+        gate = ttnn.gelu(gate, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        # Element-wise multiply gate and up
+        gate_up_mul = ttnn.multiply(gate, up)
+        ttnn.deallocate(gate)
+        ttnn.deallocate(up)
+
+        # Down projection
+        output = self.down_proj(gate_up_mul)
+        ttnn.deallocate(gate_up_mul)
+
+        return output

--- a/models/experimental/tt_symbiote/modules/gemma4_modules.py
+++ b/models/experimental/tt_symbiote/modules/gemma4_modules.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gemma 4 specific module implementations for TTNN.
+
+Provides TTNN-accelerated versions of Gemma 4 architectural components:
+- TTNNGemma4ScaledEmbedding: Scaled word embedding (multiplies by sqrt(hidden_size))
+- TTNNGemma4DecoderLayer: Decoder layer wrapper for on-device residual adds and tracing
+"""
+
+import math
+
+import torch
+import ttnn
+from models.experimental.tt_symbiote.core.module import TTNNModule
+from models.experimental.tt_symbiote.core.run_config import trace_enabled
+from models.experimental.tt_symbiote.modules.embedding import TTNNEmbedding
+from models.experimental.tt_symbiote.modules.gemma4_attention import TTNNGemma4Attention
+from models.experimental.tt_symbiote.modules.gemma4_mlp import TTNNGemma4TextMLP
+from models.experimental.tt_symbiote.modules.normalization import TTNNDistributedRMSNorm
+
+
+class TTNNGemma4ScaledEmbedding(TTNNModule):
+    """TTNN-accelerated scaled word embedding for Gemma 4 models.
+
+    Wraps TTNNEmbedding and multiplies the output by sqrt(hidden_size),
+    replicating the behaviour of Gemma4TextScaledWordEmbedding.
+
+    NOT trace-enabled: forward() converts torch input_ids via ttnn.from_torch
+    which allocates new device memory (forbidden during trace capture).
+    """
+
+    @classmethod
+    def from_torch(cls, embedding):
+        """Create from a Gemma4TextScaledWordEmbedding instance.
+
+        Args:
+            embedding: HF Gemma4TextScaledWordEmbedding with an ``embed_scale``
+                attribute and an underlying ``nn.Embedding`` weight.
+        """
+        new_layer = cls()
+        new_layer._fallback_torch_layer = embedding
+        new_layer.embedder = TTNNEmbedding.from_torch(embedding)
+        new_layer.embed_scale = float(getattr(embedding, "embed_scale", math.sqrt(embedding.embedding_dim)))
+        return new_layer
+
+    def forward(self, tt_indices):
+        # Ensure indices are UINT32 for the TTNN embedding op.
+        # The framework may pass torch.Tensor or TTNN Tensor (INT32).
+        # TTNN typecast requires last dim % 32 == 0, so we convert via host if needed.
+        if isinstance(tt_indices, torch.Tensor):
+            tt_indices = ttnn.from_torch(
+                tt_indices.to(torch.int32),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+            )
+            tt_indices = ttnn.to_device(tt_indices, self.device)
+        elif isinstance(tt_indices, ttnn.Tensor) and tt_indices.dtype != ttnn.uint32:
+            # Roundtrip through host to cast INT32 -> UINT32 without padding constraints
+            torch_indices = ttnn.to_torch(tt_indices, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
+            # Take first device shard (all shards are identical for replicated input)
+            if torch_indices.shape[0] > tt_indices.shape[0]:
+                torch_indices = torch_indices[: tt_indices.shape[0]]
+            tt_indices = ttnn.from_torch(
+                torch_indices.to(torch.int32),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+            )
+            tt_indices = ttnn.to_device(tt_indices, self.device)
+        out = self.embedder(tt_indices)
+        out = ttnn.multiply(out, self.embed_scale)
+        return out
+
+
+@trace_enabled
+class TTNNGemma4DecoderLayer(TTNNModule):
+    """Replaces Gemma4TextDecoderLayer to keep residual adds on-device.
+
+    Eliminates host round-trips by using ttnn.add for residual connections.
+    This is the primary trace boundary for Gemma4 — @trace_enabled captures
+    the full op sequence (norms + attention + FFN) in a single trace.
+
+    HF Gemma4TextDecoderLayer forward flow (31B, no MoE):
+        input_layernorm -> self_attn -> post_attention_layernorm -> residual_add
+        pre_feedforward_layernorm -> mlp -> post_feedforward_layernorm -> residual_add
+        layer_scalar multiplication
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.input_layernorm = None
+        self.post_attention_layernorm = None
+        self.pre_feedforward_layernorm = None
+        self.post_feedforward_layernorm = None
+        self.self_attn = None
+        self.mlp = None
+        self.layer_scalar = 1.0
+
+    @classmethod
+    def from_torch(cls, torch_layer):
+        """Create from Gemma4TextDecoderLayer."""
+        new_layer = cls()
+        new_layer._fallback_torch_layer = torch_layer
+
+        new_layer.input_layernorm = TTNNDistributedRMSNorm.from_torch(torch_layer.input_layernorm)
+        new_layer.post_attention_layernorm = TTNNDistributedRMSNorm.from_torch(torch_layer.post_attention_layernorm)
+        new_layer.pre_feedforward_layernorm = TTNNDistributedRMSNorm.from_torch(torch_layer.pre_feedforward_layernorm)
+        new_layer.post_feedforward_layernorm = TTNNDistributedRMSNorm.from_torch(torch_layer.post_feedforward_layernorm)
+        new_layer.self_attn = TTNNGemma4Attention.from_torch(torch_layer.self_attn)
+        new_layer.mlp = TTNNGemma4TextMLP.from_torch(torch_layer.mlp)
+
+        # layer_scalar is a learnable scalar (nn.Parameter) initialised to 1.0
+        scalar = getattr(torch_layer, "layer_scalar", None)
+        if scalar is not None:
+            new_layer.layer_scalar = float(scalar.item() if hasattr(scalar, "item") else scalar)
+
+        return new_layer
+
+    def pre_trace_execute(self, func_args, func_kwargs):
+        """Copy cache_position to a module-owned persistent buffer before trace replay.
+
+        Avoids TTNN trace allocator buffer aliasing: the trace kwarg buffer for
+        cache_position can be overwritten by another layer's trace intermediates.
+        Copying to _decode_cur_pos here (outside the trace) ensures the value
+        survives any intermediate overwrites during trace replay.
+        """
+        cache_position = func_kwargs.get("cache_position")
+        if cache_position is None:
+            return
+        attn = self.self_attn
+        if not hasattr(attn, "_decode_cur_pos") or attn._decode_cur_pos is None:
+            return
+        from models.experimental.tt_symbiote.core.tensor import TorchTTNNTensor
+
+        cp = cache_position
+        if isinstance(cp, TorchTTNNTensor):
+            cp = cp.ttnn_tensor
+        # Only copy during decode (shape [1]). Prefill (shape [N]) doesn't need
+        # this fix — buffer aliasing only affects decode trace replays.
+        if cp.shape != attn._decode_cur_pos.shape:
+            return
+        ttnn.copy(cp, attn._decode_cur_pos)
+
+    def post_trace_execute(self, func_args, func_kwargs, result):
+        """Update KV cache sequence counters after trace replay.
+
+        During replay, paged_fill/update_on_device Python-side counter
+        increments do not execute (baked into device trace). This hook
+        ensures counters advance on every replay iteration.
+        """
+        past_key_values = func_kwargs.get("past_key_values")
+        if past_key_values is None or not hasattr(past_key_values, "update_seq_length"):
+            return
+        hidden_states = func_args[0]
+        seq_len = hidden_states.shape[-2]
+        layer_idx = self.self_attn.layer_idx
+        past_key_values.update_seq_length(layer_idx=layer_idx, seq_len=seq_len)
+
+    def forward(
+        self,
+        hidden_states,
+        per_layer_input=None,
+        position_embeddings=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        **kwargs,
+    ):
+        hs = hidden_states
+
+        # Ensure TILE layout and bfloat16 for TTNN ops
+        if hs.layout != ttnn.TILE_LAYOUT:
+            hs = ttnn.to_layout(hs, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        if hs.dtype != ttnn.bfloat16:
+            hs = ttnn.typecast(hs, ttnn.bfloat16)
+
+        # ----- Attention block -----
+        residual = hs
+
+        hs = self.input_layernorm(hs)
+
+        # Pass cache_position as explicit kwarg so TracedRun can
+        # pre-allocate a device buffer for it (matches Ling pattern).
+        seq_len = hs.shape[-2]
+        is_decode = seq_len == 1
+        attn_out, _ = self.self_attn(
+            hidden_states=hs,
+            position_embeddings=None,
+            attention_mask=None if is_decode else attention_mask,
+            past_key_values=past_key_values,
+            cache_position=kwargs.get("cache_position"),
+        )
+
+        attn_out = self.post_attention_layernorm(attn_out)
+
+        # Residual add ON DEVICE
+        hs = ttnn.add(residual, attn_out)
+        ttnn.deallocate(attn_out)
+        # NOTE: Do NOT deallocate residual here — it is the pre-allocated trace
+        # input buffer.  ttnn.deallocate inside a traced forward would be
+        # replayed by execute_trace, freeing the buffer that
+        # _copy_inputs_to_trace_buffer needs on the next replay iteration.
+
+        # ----- FFN block -----
+        residual = hs
+
+        hs = self.pre_feedforward_layernorm(hs)
+        mlp_out = self.mlp(hs)
+        mlp_out = self.post_feedforward_layernorm(mlp_out)
+
+        # Residual add ON DEVICE
+        hs = ttnn.add(residual, mlp_out)
+        ttnn.deallocate(mlp_out)
+        ttnn.deallocate(residual)
+
+        # Layer scalar (1.0 in 31B — effectively a no-op)
+        if self.layer_scalar != 1.0:
+            hs = ttnn.multiply(hs, self.layer_scalar)
+
+        # HF Gemma4TextDecoderLayer returns a plain tensor (not a tuple).
+        return hs

--- a/models/experimental/tt_symbiote/modules/normalization.py
+++ b/models/experimental/tt_symbiote/modules/normalization.py
@@ -70,7 +70,7 @@ class TTNNRMSNorm(TTNNModule):
     @classmethod
     def from_torch(cls, rms_norm: DeepseekV2RMSNorm):
         """Create from PyTorch RMSNorm."""
-        if rms_norm.weight is None:
+        if not hasattr(rms_norm, "weight") or rms_norm.weight is None:
             print(f"Warning: RMSNorm layer {rms_norm} has no weight. Using standard RMSNorm.")
             return rms_norm
         new_layer_norm = cls()
@@ -97,6 +97,74 @@ class TTNNRMSNorm(TTNNModule):
 
 
 @trace_enabled
+class TTNNLocalRMSNorm(TTNNModule):
+    """
+    Local (per-device) RMSNorm for per-head norms (Q-norm, K-norm, V-norm) in Gemma4 attention.
+
+    Unlike TTNNDistributedRMSNorm, this operates on local tensors per device and does NOT
+    perform any cross-device reduction. Supports Gemma4RMSNorm which uses `eps` instead of
+    `variance_epsilon` and may have `with_scale=False` (no learnable weight).
+    """
+
+    @classmethod
+    def from_torch(cls, rms_norm):
+        """Create from PyTorch RMSNorm (supports Gemma4RMSNorm with optional scale)."""
+        # Gemma4RMSNorm may have with_scale=False, meaning weight is None
+        has_scale = getattr(rms_norm, "with_scale", True)
+        if has_scale and rms_norm.weight is None:
+            print(f"Warning: RMSNorm layer {rms_norm} has no weight. Using standard RMSNorm.")
+            return rms_norm
+        new_layer_norm = cls()
+        new_layer_norm._fallback_torch_layer = rms_norm
+        return new_layer_norm
+
+    def preprocess_weights_impl(self):
+        """Preprocess RMSNorm weights for TTNN."""
+        # Gemma4RMSNorm uses `eps` instead of `variance_epsilon`
+        self.eps = getattr(self.torch_layer, "eps", getattr(self.torch_layer, "variance_epsilon", 1e-6))
+
+        has_scale = getattr(self.torch_layer, "with_scale", True)
+        if has_scale and hasattr(self.torch_layer, "weight") and self.torch_layer.weight is not None:
+            weight = self.torch_layer.weight
+        else:
+            # Create dummy all-ones weight for Gemma4RMSNorm with with_scale=False
+            dim = self._infer_dim()
+            weight = torch.ones(dim)
+
+        # Shape [1, dim] for broadcasting over 4D inputs [batch, heads, seq, head_dim]
+        self.tt_weight = ttnn.from_torch(weight.unsqueeze(0), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    def _infer_dim(self):
+        """Infer the normalization dimension from the torch layer."""
+        if hasattr(self.torch_layer, "weight") and self.torch_layer.weight is not None:
+            return self.torch_layer.weight.shape[0]
+        # Fallback: check for normalized_shape or similar attributes
+        if hasattr(self.torch_layer, "normalized_shape"):
+            return self.torch_layer.normalized_shape
+        if hasattr(self.torch_layer, "dim"):
+            return self.torch_layer.dim
+        # Stashed by attention module for Gemma4RMSNorm(with_scale=False)
+        if hasattr(self.torch_layer, "_norm_dim"):
+            return self.torch_layer._norm_dim
+        raise ValueError("Cannot infer normalization dimension from torch layer with no weight")
+
+    def move_weights_to_device_impl(self):
+        """Move weights to TTNN device with replication across mesh."""
+        self.tt_weight = ttnn.to_device(
+            self.tt_weight,
+            self.device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        """Forward pass through local RMSNorm. Input is 4D [batch, heads, seq, head_dim]."""
+        if x.layout != ttnn.TILE_LAYOUT:
+            x = ttnn.to_layout(x, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        x = ttnn.rms_norm(x, weight=self.tt_weight, epsilon=self.eps)
+        return x
+
+
+@trace_enabled
 class TTNNDistributedRMSNorm(TTNNModule):
     """
     Distributed RMSNorm implementation that performs the reduction across devices in the forward pass.
@@ -106,7 +174,7 @@ class TTNNDistributedRMSNorm(TTNNModule):
     @classmethod
     def from_torch(cls, rms_norm: "RMSNorm"):
         """Create from PyTorch RMSNorm."""
-        if rms_norm.weight is None:
+        if not hasattr(rms_norm, "weight") or rms_norm.weight is None:
             print(f"Warning: RMSNorm layer {rms_norm} has no weight. Using standard RMSNorm.")
             return rms_norm
         new_layer_norm = cls()
@@ -116,8 +184,13 @@ class TTNNDistributedRMSNorm(TTNNModule):
     def move_weights_to_device_impl(self):
         """Move weights to TTNN device."""
         dim = self.torch_layer.weight.shape[0]
+        # Pad to nearest multiple of 32 for TILE compatibility
+        padded_dim = ((dim + 31) // 32) * 32
+        weight = self.torch_layer.weight
+        if padded_dim != dim:
+            weight = torch.nn.functional.pad(weight, (0, padded_dim - dim), value=1.0)
         self.weight_distributed = ttnn.as_tensor(
-            self.torch_layer.weight.unsqueeze(0).view(1, 1, dim).reshape([1, 1, dim // 32, 32]).to(torch.bfloat16),
+            weight.unsqueeze(0).view(1, 1, padded_dim).reshape([1, 1, padded_dim // 32, 32]).to(torch.bfloat16),
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=(ttnn.ShardTensor2dMesh(self.device, dims=(None, 2), mesh_shape=list(self.device.shape))),
         )
@@ -128,20 +201,24 @@ class TTNNDistributedRMSNorm(TTNNModule):
         original_shape = inp.shape
         if len(original_shape) == 3:
             inp = ttnn.unsqueeze(inp, 1)  # Add batch dimension for RMSNorm
+        if inp.layout != ttnn.TILE_LAYOUT:
+            inp = ttnn.to_layout(inp, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         # Run distributed rmsnorm part 1
         tt_stats = ttnn.rms_norm_pre_all_gather(inp, dtype=ttnn.bfloat16)
-        # AllGather stats
+        # AllGather stats — use Ring topology for trace compatibility.
+        # Linear topology may allocate dynamic intermediates not pinned by trace.
         tt_stats = ttnn.all_gather(
             tt_stats,
             dim=-1,
             num_links=1,
-            topology=ttnn.Topology.Linear,
+            topology=ttnn.Topology.Ring,
         )
         # Run distributed rmsnorm part 2
+        eps = getattr(self.torch_layer, "variance_epsilon", getattr(self.torch_layer, "eps", 1e-6))
         tt_out = ttnn.rms_norm_post_all_gather(
             inp,
             tt_stats,
-            epsilon=self.torch_layer.variance_epsilon,
+            epsilon=eps,
             weight=self.weight_distributed,
         )
         tt_stats.deallocate(True)

--- a/models/experimental/tt_symbiote/modules/qwen_attention.py
+++ b/models/experimental/tt_symbiote/modules/qwen_attention.py
@@ -142,6 +142,17 @@ class TTNNQwenPagedAttentionKVCache(TTNNPagedAttentionKVCache):
         cache_idx = self._get_cache_idx(layer_idx)
         super().paged_update_on_device(key_states, value_states, cache_idx, current_pos)
 
+    def update_seq_length(self, layer_idx: int, seq_len: int = 1) -> None:
+        """Increment Python-side sequence counters, mapping layer_idx to cache_idx.
+
+        Silently skips layers not in the cache mapping (e.g. linear attention
+        layers in Qwen3.5 hybrid attention).
+        """
+        if self._layer_to_cache_idx is not None and layer_idx not in self._layer_to_cache_idx:
+            return  # This layer doesn't use paged KV cache
+        cache_idx = self._get_cache_idx(layer_idx)
+        super().update_seq_length(cache_idx, seq_len)
+
     def paged_sdpa_decode(
         self,
         query: ttnn.Tensor,
@@ -773,7 +784,8 @@ class TTNNQwen3FullAttention(TTNNModule):
         kv_value = ttnn.to_memory_config(kv_value, shard_cfg)
 
         # --- update the on-device paged KV cache ---
-        # paged_update_on_device handles _seq_lengths and _seen_tokens updates internally
+        # NOTE: _seq_lengths / _seen_tokens are updated by the caller via
+        # update_seq_length() outside the trace boundary.
         past_key_values.paged_update_on_device(
             kv_key,
             kv_value,

--- a/models/experimental/tt_symbiote/modules/rope.py
+++ b/models/experimental/tt_symbiote/modules/rope.py
@@ -279,10 +279,26 @@ def _compute_cos_sin_cache(
     max_seq_len: int,
     rope_theta: float,
     partial_rotary_factor: float = 1.0,
+    use_head_dim_for_freq: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Compute cos/sin cache in Meta interleaved format, identity-padded for partial rotary."""
+    """Compute cos/sin cache in Meta interleaved format, identity-padded for partial rotary.
+
+    Args:
+        head_dim: Full head dimension.
+        max_seq_len: Maximum sequence length.
+        rope_theta: RoPE base frequency.
+        partial_rotary_factor: Fraction of head_dim to apply rotary to.
+        use_head_dim_for_freq: If True, use head_dim as the denominator in the
+            inv_freq formula (matching HuggingFace Gemma3/4 convention where
+            inv_freq is computed over the full head_dim and only a prefix is
+            used). If False (default), use rotary_dim as the denominator
+            (matching the standard RoPE / HuggingFace Phi convention where
+            inv_freq is computed over only the rotary dimensions).
+            When partial_rotary_factor == 1.0, both choices are equivalent.
+    """
     rotary_dim = int(head_dim * partial_rotary_factor)
-    inv_freq = 1.0 / (rope_theta ** (torch.arange(0, rotary_dim, 2).float() / rotary_dim))
+    freq_dim = head_dim if use_head_dim_for_freq else rotary_dim
+    inv_freq = 1.0 / (rope_theta ** (torch.arange(0, rotary_dim, 2).float() / freq_dim))
     t = torch.arange(max_seq_len, dtype=inv_freq.dtype)
     freqs = torch.outer(t, inv_freq)
 
@@ -321,8 +337,13 @@ class BailingRotarySetup:
         rope_theta: float,
         partial_rotary_factor: float = 1.0,
         datatype: ttnn.DataType = ttnn.bfloat16,
+        use_head_dim_for_freq: bool = False,
     ) -> None:
-        """Initialize with pre-computed cos/sin cache and transformation matrices."""
+        """Initialize with pre-computed cos/sin cache and transformation matrices.
+
+        Args:
+            use_head_dim_for_freq: See _compute_cos_sin_cache docstring.
+        """
         self.device = device
         self.head_dim = head_dim
         self.rotary_dim = int(head_dim * partial_rotary_factor)
@@ -338,6 +359,7 @@ class BailingRotarySetup:
             max_seq_len=max_seq_len,
             rope_theta=rope_theta,
             partial_rotary_factor=partial_rotary_factor,
+            use_head_dim_for_freq=use_head_dim_for_freq,
         )
 
         mesh_mapper = ttnn.ReplicateTensorToMesh(device) if self.is_mesh_device else None
@@ -390,6 +412,23 @@ class BailingRotarySetup:
         )
         self._trans_mat_decode_torch = trans_mat_decode_torch.to(torch.bfloat16)
         self._trans_mat_decode_sharded_cache = {}
+
+        # Pre-allocate typecast padding buffer for trace-safe decode path.
+        # batch_size=1 during decode -> pad_amount = 31 (32 - 1 % 32).
+        pad_amount = 32 - 1  # = 31
+        pad_torch = torch.zeros(pad_amount, dtype=torch.int32)
+        self._typecast_pad_buffer = ttnn.from_torch(
+            pad_torch,
+            device=device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+        # Pre-populate sharded trans_mat for decode (batch_size=1) to avoid
+        # lazy ttnn.from_torch during trace capture.
+        self.get_trans_mat_decode_sharded(1)
 
         trans_mat_prefill_torch = _get_rotation_transformation_mat(ttnn.TILE_SIZE)
         self.trans_mat_prefill = ttnn.from_torch(

--- a/models/experimental/tt_symbiote/tests/test_gemma4.py
+++ b/models/experimental/tt_symbiote/tests/test_gemma4.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test for Gemma4 31B model with TTNN backend.
+
+Gemma4 31B is a dense multimodal model with:
+- 60 heterogeneous decoder layers (50 sliding-window + 10 global attention)
+- Sliding attention: 32Q/16KV heads, head_dim=256, window=1024
+- Global attention: 32Q/4KV heads, head_dim=512, K=V sharing, partial RoPE
+- GeGLU FFN (intermediate_size=21504)
+- V-norm (RMSNorm without learnable scale) on all layers
+- Logit soft-capping (30.0)
+"""
+
+import os
+
+import pytest
+import torch
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import ttnn
+from models.experimental.tt_symbiote.core.run_config import DispatchManager
+from models.experimental.tt_symbiote.utils.device_management import set_device
+from models.experimental.tt_symbiote.utils.module_replacement import register_module_replacement_dict
+import transformers
+from models.experimental.tt_symbiote.core.run_config import TracedRun
+from models.experimental.tt_symbiote.modules.linear import (
+    TTNNLinearIColShardedWRowSharded,
+)
+
+assert transformers.__version__.startswith(
+    "5."
+), "This test requires transformers version 5.0.0.dev0. Try: `pip install git+https://github.com/huggingface/transformers.git`"
+
+
+MESH_DEVICE_MAP = {
+    "N150": (1, 1),
+    "N300": (1, 2),
+    "N150x4": (1, 4),
+    "T3K": (1, 8),
+    "TG": (8, 4),
+    "P150": (1, 1),
+    "P300": (1, 2),
+    "P150x4": (1, 4),
+    "P150x8": (1, 8),
+    "BHGLX": (8, 4),
+}
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"trace_region_size": 200000000, "num_command_queues": 1, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [MESH_DEVICE_MAP.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))],
+    indirect=True,
+)
+@pytest.mark.parametrize("max_new_tokens", [128], ids=["128tok"])
+def test_gemma4(mesh_device, max_new_tokens):
+    """Test Gemma4 31B model with TTNN acceleration.
+
+    Gemma4 31B is a dense model with 60 heterogeneous decoder layers:
+    - 50 sliding-window attention layers (16 KV heads, head_dim=256, window=1024)
+    - 10 global attention layers (4 KV heads, head_dim=512, K=V sharing, partial RoPE)
+    - GeGLU FFN on all layers
+    - Layer pattern: 5 sliding then 1 global, repeated 10 times
+    """
+
+    model_name = "google/gemma-4-31B"
+    print(f"Loading model {model_name}...")
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    # NOTE: Gemma4 is multimodal (Gemma4ForConditionalGeneration). If AutoModelForCausalLM
+    # fails because the model is registered as a conditional-generation model, use instead:
+    #   from transformers import AutoModelForImageTextToText, AutoProcessor
+    #   model = AutoModelForImageTextToText.from_pretrained(model_name, ...)
+    #   processor = AutoProcessor.from_pretrained(model_name, ...)
+    # and construct text-only inputs via processor(text=..., return_tensors="pt").
+    model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True, torch_dtype=torch.bfloat16)
+
+    # Phase 2: TTNN module replacements (follows Ling 3-pass pattern)
+    from models.experimental.tt_symbiote.modules.gemma4_attention import (
+        TTNNGemma4PagedAttentionKVCache,
+    )
+    from models.experimental.tt_symbiote.modules.gemma4_modules import (
+        TTNNGemma4ScaledEmbedding,
+        TTNNGemma4DecoderLayer,
+    )
+    from models.experimental.tt_symbiote.modules.normalization import TTNNDistributedRMSNorm
+    from models.experimental.tt_symbiote.models.gemma4_text import TTNNGemma4TextModel
+
+    # Get HF classes from the loaded model
+    # Gemma4 is multimodal: model.model is Gemma4Model (wrapper), text model is at language_model
+    text_model = model.model.language_model
+    decoder_class = text_model.layers[0].__class__  # Gemma4TextDecoderLayer
+    norm_class = text_model.layers[0].input_layernorm.__class__  # Gemma4RMSNorm
+    embed_class = text_model.embed_tokens.__class__  # Gemma4TextScaledWordEmbedding
+    text_model_class = text_model.__class__  # Gemma4TextModel
+
+    print(f"Decoder class: {decoder_class.__name__}")
+    print(f"Norm class: {norm_class.__name__}")
+    print(f"Embed class: {embed_class.__name__}")
+
+    # Gemma4 tokenizer does not have a chat_template set, so we manually
+    # construct the prompt using Gemma4's turn tokens: <|turn> and <turn|>
+    # The tokenizer auto-prepends <bos>, so we don't include it in the string.
+    prompt = "<|turn>user\nWhat is your favorite condiment?<turn|>\n<|turn>model\n"
+    # Use first parameter's device (model.device may not exist for multi-modal models)
+    model_device = next(model.parameters()).device
+    inputs = tokenizer(prompt, return_tensors="pt").to(model_device)
+
+    # Some tokenizers produce token_type_ids that the model does not expect
+    if "token_type_ids" in inputs:
+        del inputs["token_type_ids"]
+
+    # Three-pass replacement matching Ling pattern.
+    # Gemma4RMSNorm is shared between language_model and vision_tower, but
+    # vision tower norms have incompatible dims for 8-device sharding.
+    # Exclude all vision_tower and embed_vision modules from replacement.
+    exclude_vision = {name for name, _ in model.named_modules() if "vision_tower" in name or "embed_vision" in name}
+
+    # Pass 1: decoder layers, final norm, embedding
+    nn_to_ttnn = {
+        decoder_class: TTNNGemma4DecoderLayer,
+        norm_class: TTNNDistributedRMSNorm,
+        embed_class: TTNNGemma4ScaledEmbedding,
+    }
+    modules = register_module_replacement_dict(model, nn_to_ttnn, model_config=None, exclude_replacement=exclude_vision)
+
+    nn_to_ttnn2 = {
+        torch.nn.Linear: TTNNLinearIColShardedWRowSharded,
+    }
+    modules.update(register_module_replacement_dict(model, nn_to_ttnn2, model_config=None))
+
+    # Pass 3: model wrapper — replaces Gemma4TextModel with TTNNGemma4TextModel
+    # which handles input_ids→embedding conversion (trace-safe) and iterates
+    # layers without ModuleList slicing.
+    nn_to_ttnn_model = {
+        text_model_class: TTNNGemma4TextModel,
+    }
+    modules.update(register_module_replacement_dict(model, nn_to_ttnn_model, model_config=None))
+
+    # Pass 3: lm_head — replace the CPU nn.Linear (5120 -> 262144) with TTNN.
+    # Done as a direct replacement since nn.Linear is too broad for the dict pattern.
+
+    set_device(model, mesh_device)
+
+    print(f"Preprocessing {len(modules)} TTNN modules weights...")
+    for k, v in tqdm(modules.items()):
+        v.preprocess_weights()
+        v.move_weights_to_device()
+
+    # Create paged KV cache for Gemma4 (dual cache: sliding + global)
+    text_config = model.config.text_config
+    global_indices = {i for i, lt in enumerate(text_config.layer_types) if lt == "full_attention"}
+    kv_cache = TTNNGemma4PagedAttentionKVCache(
+        text_config=text_config,
+        global_layer_indices=global_indices,
+        device=mesh_device,
+    )
+    kv_cache.to_device(mesh_device)
+
+    print("Running inference...")
+    model.eval()
+    torch.set_grad_enabled(False)
+
+    # HF generate() accesses self.device (a read-only property from ModuleUtilsMixin).
+    # After TTNN replacement, the property may fail if no torch parameters remain reachable
+    # in the default iteration order. Override with a concrete property.
+    try:
+        _ = model.device
+    except (AttributeError, StopIteration):
+        pass
+    # Force-set device via class override to ensure HF generate() can resolve it.
+    type(model).device = property(lambda self: model_device)
+
+    # Warmup run
+    outputs = model.generate(**inputs, max_new_tokens=2, past_key_values=kv_cache, use_cache=True)
+    kv_cache.reset()
+
+    # Warmup run with traceing enabled
+    outputs = model.generate(**inputs, max_new_tokens=4, past_key_values=kv_cache, use_cache=True)
+    kv_cache.reset()
+
+    # Actual traced run
+    DispatchManager.clear_timings()
+    outputs = model.generate(**inputs, max_new_tokens=max_new_tokens, past_key_values=kv_cache, use_cache=True)
+    ttnn.synchronize_device(mesh_device)
+
+    generated_text = tokenizer.decode(outputs[0][inputs["input_ids"].shape[-1] :])
+    print(f"Gemma4 OUTPUT: {generated_text}")
+
+    assert len(generated_text.strip()) > 0, "Generated output should not be empty"
+
+    DispatchManager.save_stats_to_file("gemma4_timing_stats.csv")
+    TracedRun.release_all()

--- a/models/experimental/tt_symbiote/utils/device_management.py
+++ b/models/experimental/tt_symbiote/utils/device_management.py
@@ -104,7 +104,8 @@ def set_device(obj, device, device_init=DeviceInit, **kwargs):
                         _set_device_recursive(v, parent_is_ttnn=isinstance(current_obj, TTNNModule))
         elif isinstance(current_obj, TTNNModule):
             # Set bypass based on parent type: TTNN children of TTNN modules bypass wrapping
-            current_obj._bypass_tensor_wrapping = parent_is_ttnn
+            if not getattr(current_obj, "_bypass_tensor_wrapping", False):
+                current_obj._bypass_tensor_wrapping = parent_is_ttnn
             _initialize_module_on_device(current_obj, device, device_init)
             if hasattr(current_obj, "call"):
                 if not hasattr(current_obj.call, "_is_timed"):


### PR DESCRIPTION
Add TTNN-accelerated modules for Gemma4 31B:
- TTNNGemma4Attention: unified sliding/global attention with per-head norms, K=V sharing for global layers, and paged attention decode path
- TTNNGemma4PagedAttentionKVCache: dual paged KV cache routing sliding/global layers to separate caches with different head dims
- TTNNGemma4FFN: GeGLU feed-forward with gate/up/down projections
- TTNNGemma4DecoderLayer: decoder layer wrapper keeping residual adds on-device
- TTNNGemma4ScaledEmbedding: scaled word embedding (sqrt(hidden_size))
- TTNNLocalRMSNorm: per-device RMSNorm for per-head norms (no cross-device reduction)

All modules decorated with @trace_enabled for TT_SYMBIOTE_RUN_MODE=TRACED. Pre-allocated decode buffers in attention for trace-safe tensor reuse.



tt_symbiote: match Ling pattern for Gemma4 module replacement

Switch from manual _modules dict assignment to register_module_replacement_dict on the top-level model, matching the Ling test pattern. Decoder class is now in nn_to_ttnn dict. Vision tower modules excluded via exclude_replacement set since Gemma4RMSNorm is shared between language_model and vision_tower with incompatible dimensions.



full graceful run

checking in changes. Trace works with correct output

adding untracked file

added perf changes

tt_symbiote: removed position embeddings hash map from text model. Made all modules traceable.

tt_symbiote: removed tensor wrapping from gemma

tt_symbiote: fixed var error

tt_symbiote: reverted embed tokens from wrapping opt

tt_symbiote: added optimized tree map for bypassed modules

tt_symbiote: optmized tree map

checking in further optimizations

tt_symbiote: add fused gate-up MLP module for Gemma 4

Adds TTNNGemma4TextMLP which fuses gate_proj and up_proj into a single matmul, reducing decode latency by ~0.6ms per layer (36ms total).



tt_symbiote: remove debug monkey-patch from trace capture

Removes TRACE-WRITE-DETECT instrumentation that logged traceback on every from_torch/to_device call during trace capture. Development-only debugging code not suitable for shared branches.



tt_symbiote: remove dead TTNNGemma4FFN class from gemma4_modules

TTNNGemma4FFN was superseded by TTNNGemma4TextMLP (from gemma4_mlp.py), which the decoder layer already uses. Remove the unused class and its now-orphaned imports (TTNNLinearIReplicatedWColSharded, TTNNLinearIColShardedWRowSharded, run_on_devices, DeviceArch).



tt_symbiote: restore backward-compatible KV cache counters and fix RoPE inv_freq for merge safety

Restore internal counter increments in paged_fill_on_device/paged_update_on_device behind an _external_seq_tracking flag so Ling (bailing) models that don't call update_seq_length() continue to work. Make RoPE inv_freq denominator configurable (rotary_dim default for Ling, head_dim opt-in for Gemma4) so partial_rotary_factor models use the correct convention.



tt_symbiote: add pre/post_trace_execute hooks to TTNNModule

Replace the ad-hoc hasattr/update_trace_stable_buffers pattern with generic pre_trace_execute and post_trace_execute hooks on TTNNModule. Move KV cache update_seq_length from the Gemma4 model loop into post_trace_execute on the decoder layer, so counters advance correctly during trace replay without model-level bookkeeping.



tt_symbiote: skip trace hooks for modules that don't override them

Guard pre/post_trace_execute calls with a type check so modules that inherit the base no-op don't pay for a method call + frame setup on every trace replay. Also remove gemma4_decoder_layer.py which was added but not referenced by any production code.



tt_symbiote: cache TTNNModule hook references in TracedRun.configure

Move the lazy import of TTNNModule from the per-replay hot path into configure(), caching the base class method references as class attrs. The replay path now does pointer comparisons against the cached refs with zero import overhead.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
