### PR TITLE
Optimizing phsycial grouping descriptor matching

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
@@ -118,6 +118,13 @@ public:
         const MeshGraphDescriptor& mesh_graph_descriptor,
         const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) const;
 
+    // Lightweight feasibility check: can the flattened mesh's (tray_id, asic_location) requirements
+    // be satisfied by the PSD? Avoids full graph isomorphism — only checks that the PSD has enough
+    // physical ASICs matching each required (tray, location) slot. Used during build_flattened_adjacency_mesh
+    // to quickly prune impossible combinations before the full solver is invoked.
+    static bool can_map_to_psd(
+        const GroupingInfo& grouping_info, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor);
+
     // Find any valid mapping of a grouping to a physical system descriptor
     // Returns unordered_set of ASIC IDs that mark out the grouping in the PSD
     // Returns empty set if no valid mapping exists

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
@@ -118,13 +118,6 @@ public:
         const MeshGraphDescriptor& mesh_graph_descriptor,
         const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) const;
 
-    // Lightweight feasibility check: can the flattened mesh's (tray_id, asic_location) requirements
-    // be satisfied by the PSD? Avoids full graph isomorphism — only checks that the PSD has enough
-    // physical ASICs matching each required (tray, location) slot. Used during build_flattened_adjacency_mesh
-    // to quickly prune impossible combinations before the full solver is invoked.
-    static bool can_map_to_psd(
-        const GroupingInfo& grouping_info, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor);
-
     // Find any valid mapping of a grouping to a physical system descriptor
     // Returns unordered_set of ASIC IDs that mark out the grouping in the PSD
     // Returns empty set if no valid mapping exists
@@ -235,6 +228,11 @@ private:
     // Private helper that takes PSD pointer (used internally by public overloads)
     std::vector<GroupingInfo> build_flattened_adjacency_mesh(
         const GroupingInfo& grouping, const tt::tt_metal::PhysicalSystemDescriptor* physical_system_descriptor) const;
+
+    // Fast feasibility check for (tray_id, asic_location) slot counts vs. the PSD. Used by
+    // build_flattened_adjacency_mesh to prune impossible flattened meshes before graph isomorphism.
+    static bool can_map_to_psd(
+        const GroupingInfo& grouping_info, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor);
 
     // Helper for reading files
     static std::string read_file_to_string(const std::filesystem::path& file_path);

--- a/tt_metal/fabric/physical_grouping_descriptor_graph_building.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_graph_building.cpp
@@ -1050,12 +1050,11 @@ std::vector<GroupingInfo> PhysicalGroupingDescriptor::build_flattened_adjacency_
             rebuild_items_from_flattened_mesh(info, meshe);
             info.adjacency_graph = std::move(meshe.graph);
 
-            // If PSD is provided, validate that the graph can be mapped to it
+            // If PSD is provided, fast feasibility check: verify the PSD has matching
+            // (tray_id, asic_location) slots without doing full graph isomorphism.
             if (physical_system_descriptor != nullptr) {
-                // solve_for_one_grouping_to_psd uses items[node_id] for trait constraints
-                auto mapping_result = find_any_in_psd(info, *physical_system_descriptor);
-                if (mapping_result.empty()) {
-                    continue;  // Skip this combination if it can't be mapped
+                if (!PhysicalGroupingDescriptor::can_map_to_psd(info, *physical_system_descriptor)) {
+                    continue;
                 }
             }
 
@@ -1128,12 +1127,11 @@ std::vector<GroupingInfo> PhysicalGroupingDescriptor::build_flattened_adjacency_
         rebuild_items_from_flattened_mesh(info, joined_mesh);
         info.adjacency_graph = std::move(joined_mesh.graph);
 
-        // If PSD is provided, validate that the top-level joined graph can be mapped to it
+        // If PSD is provided, fast feasibility check: verify the PSD has matching
+        // (tray_id, asic_location) slots without doing full graph isomorphism.
         if (physical_system_descriptor != nullptr) {
-            // solve_for_one_grouping_to_psd uses items[node_id] for trait constraints
-            auto mapping_result = find_any_in_psd(info, *physical_system_descriptor);
-            if (mapping_result.empty()) {
-                return;  // Skip this combination if it can't be mapped
+            if (!PhysicalGroupingDescriptor::can_map_to_psd(info, *physical_system_descriptor)) {
+                return;
             }
         }
 

--- a/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
@@ -1130,7 +1130,7 @@ bool PhysicalGroupingDescriptor::can_map_to_psd(
     const GroupingInfo& grouping_info, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
     // Build a multiset of (tray_id, asic_location) slots available in the PSD.
     std::map<std::pair<uint32_t, uint32_t>, size_t> psd_slot_counts;
-    for (const auto& [asic_id, desc] : physical_system_descriptor.get_asic_descriptors()) {
+    for (const auto& [_, desc] : physical_system_descriptor.get_asic_descriptors()) {
         uint32_t tray = *desc.tray_id;
         uint32_t loc = *desc.asic_location;
         if (tray > 0 && loc <= 8) {

--- a/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
@@ -1128,18 +1128,18 @@ solve_for_many_groupings_to_psd_heterogeneous(
 
 bool PhysicalGroupingDescriptor::can_map_to_psd(
     const GroupingInfo& grouping_info, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
-    // Build a multiset of (tray_id, asic_location) slots available in the PSD.
-    std::map<std::pair<uint32_t, uint32_t>, size_t> psd_slot_counts;
+    using tt::tt_metal::ASICPosition;
+
+    // Build a multiset of ASICPosition slots available in the PSD.
+    std::map<ASICPosition, size_t> psd_slot_counts;
     for (const auto& [_, desc] : physical_system_descriptor.get_asic_descriptors()) {
-        uint32_t tray = *desc.tray_id;
-        uint32_t loc = *desc.asic_location;
-        if (tray > 0 && loc <= 8) {
-            psd_slot_counts[{tray, loc}]++;
+        if (*desc.tray_id > 0 && *desc.asic_location <= 8) {
+            psd_slot_counts[{desc.tray_id, desc.asic_location}]++;
         }
     }
 
-    // Count how many ASICs the grouping needs per (tray, location) slot.
-    std::map<std::pair<uint32_t, uint32_t>, size_t> required_slot_counts;
+    // Count how many ASICs the grouping needs per ASICPosition slot.
+    std::map<ASICPosition, size_t> required_slot_counts;
     for (uint32_t node_id : grouping_info.adjacency_graph.get_nodes()) {
         if (node_id >= grouping_info.items.size()) {
             continue;
@@ -1148,12 +1148,10 @@ bool PhysicalGroupingDescriptor::can_map_to_psd(
         if (item.type != GroupingItemInfo::ItemType::ASIC_LOCATION) {
             continue;
         }
-        uint32_t tray = *item.tray_id;
-        uint32_t loc = *item.asic_location;
-        if (tray == 0 || loc > 8) {
+        if (*item.tray_id == 0 || *item.asic_location > 8) {
             continue;
         }
-        required_slot_counts[{tray, loc}]++;
+        required_slot_counts[{item.tray_id, item.asic_location}]++;
     }
 
     for (const auto& [slot, needed] : required_slot_counts) {

--- a/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
@@ -1126,6 +1126,45 @@ solve_for_many_groupings_to_psd_heterogeneous(
 }
 }  // namespace tt::tt_fabric
 
+bool PhysicalGroupingDescriptor::can_map_to_psd(
+    const GroupingInfo& grouping_info, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
+    // Build a multiset of (tray_id, asic_location) slots available in the PSD.
+    std::map<std::pair<uint32_t, uint32_t>, size_t> psd_slot_counts;
+    for (const auto& [asic_id, desc] : physical_system_descriptor.get_asic_descriptors()) {
+        uint32_t tray = *desc.tray_id;
+        uint32_t loc = *desc.asic_location;
+        if (tray > 0 && loc <= 8) {
+            psd_slot_counts[{tray, loc}]++;
+        }
+    }
+
+    // Count how many ASICs the grouping needs per (tray, location) slot.
+    std::map<std::pair<uint32_t, uint32_t>, size_t> required_slot_counts;
+    for (uint32_t node_id : grouping_info.adjacency_graph.get_nodes()) {
+        if (node_id >= grouping_info.items.size()) {
+            continue;
+        }
+        const GroupingItemInfo& item = grouping_info.items[node_id];
+        if (item.type != GroupingItemInfo::ItemType::ASIC_LOCATION) {
+            continue;
+        }
+        uint32_t tray = *item.tray_id;
+        uint32_t loc = *item.asic_location;
+        if (tray == 0 || loc > 8) {
+            continue;
+        }
+        required_slot_counts[{tray, loc}]++;
+    }
+
+    for (const auto& [slot, needed] : required_slot_counts) {
+        auto it = psd_slot_counts.find(slot);
+        if (it == psd_slot_counts.end() || it->second < needed) {
+            return false;
+        }
+    }
+    return true;
+}
+
 std::unordered_set<tt::tt_metal::AsicID> PhysicalGroupingDescriptor::find_any_in_psd(
     const GroupingInfo& grouping, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) const {
     std::vector<std::string> errors;


### PR DESCRIPTION
# Optimize PGD graph building with fast `can_map_to_psd` feasibility check

## Summary
- Adds a lightweight `can_map_to_psd` static method to `PhysicalGroupingDescriptor` that checks whether a flattened mesh grouping's `(tray_id, asic_location)` requirements can be satisfied by the Physical System Descriptor (PSD), without invoking the full graph isomorphism solver.
- Replaces two `find_any_in_psd` calls inside `build_flattened_adjacency_mesh` with this fast check, pruning impossible combinations early before the expensive solver is invoked later.

## Motivation
During `build_flattened_adjacency_mesh`, many candidate flattened mesh combinations are generated. Previously, each was validated by calling `find_any_in_psd`, which runs a full subgraph isomorphism solve (DFS or SAT). For large topologies (e.g., 3-pod 16x8 configurations), this resulted in the solver being called hundreds of times on combinations that could be trivially rejected by checking whether the PSD even has enough physical ASICs at the required tray/location slots.

## What changed
- **`physical_grouping_descriptor_matching.cpp`**: Added `PhysicalGroupingDescriptor::can_map_to_psd()` — builds a multiset of available `(tray, location)` slots from the PSD, counts the grouping's requirements, and returns `false` if any slot is under-provisioned.
- **`physical_grouping_descriptor_graph_building.cpp`**: Replaced both `find_any_in_psd` calls in `build_flattened_adjacency_mesh` (inner loop at ~line 1053 and outer validation at ~line 1130) with the new `can_map_to_psd` check.
- **`physical_grouping_descriptor.hpp`**: Declared the new static method.

## Performance
`PhysicalGroupingDescriptorSP3Tests` on a 3-pod 16x8 mock cluster (12 MPI ranks):

|  | Before | After |
|--|--------|-------|
| **real** | 39.5s | 6.6s |
| **user** | 7m32s | 59.7s |
| **sys** | 8.3s | 6.3s |

**~6x wall-clock speedup, ~7.5x CPU time reduction.**

`TopologyMapperUtilsTest.BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8*` on same cluster:

|  | Before | After |
|--|--------|-------|
| **real** | 51.2s | 8.0s |
| **user** | 9m52s | 2.1s |
| **sys** | 9.4s | 4.6s |

**~6.4x wall-clock speedup, ~280x CPU time reduction.**

## Test plan
- [x] `PhysicalGroupingDescriptorSP3Tests` — all 10 tests pass (1 skipped as expected)
- [x] No functional changes to final grouping results — `can_map_to_psd` is strictly a necessary-condition filter; the full solver still validates later

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/pgd-opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/pgd-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/pgd-opt) | [#2645](https://github.com/tenstorrent/tt-metal/actions/runs/24362543676) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/pgd-opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/pgd-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/pgd-opt) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/pgd-opt) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/pgd-opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/pgd-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/pgd-opt) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/pgd-opt) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/pgd-opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/pgd-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/pgd-opt) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/pgd-opt) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/pgd-opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/pgd-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/pgd-opt) | [#2885](https://github.com/tenstorrent/tt-metal/actions/runs/24362694021) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/pgd-opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/pgd-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/pgd-opt) | [#2270](https://github.com/tenstorrent/tt-metal/actions/runs/24362701956) |