### PR TITLE
feat(fabric): add FabricBuilder plugin factory registration

### DIFF
--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -280,10 +280,20 @@ void FabricBuilder::create_kernels() {
 }
 
 // ============ Plugin Factory Registration ============
+//
+// Thread safety: registration must happen before any fabric init call.
+// This is a program-startup operation, not a concurrent runtime operation.
+// No mutex is needed because the ordering contract is: register once during
+// setup, then fabric init reads it. Concurrent registration is a programming error.
 
 static FabricBuilderFactory g_fabric_builder_factory = nullptr;
 
-void register_fabric_builder_factory(FabricBuilderFactory factory) { g_fabric_builder_factory = std::move(factory); }
+void register_fabric_builder_factory(FabricBuilderFactory factory) {
+    TT_FATAL(
+        !g_fabric_builder_factory || !factory,
+        "FabricBuilder factory already registered. Call with nullptr to clear before re-registering.");
+    g_fabric_builder_factory = std::move(factory);
+}
 
 const FabricBuilderFactory& get_fabric_builder_factory() { return g_fabric_builder_factory; }
 

--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -279,4 +279,12 @@ void FabricBuilder::create_kernels() {
     }
 }
 
+// ============ Plugin Factory Registration ============
+
+static FabricBuilderFactory g_fabric_builder_factory = nullptr;
+
+void register_fabric_builder_factory(FabricBuilderFactory factory) { g_fabric_builder_factory = std::move(factory); }
+
+const FabricBuilderFactory& get_fabric_builder_factory() { return g_fabric_builder_factory; }
+
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -35,6 +35,13 @@ class FabricBuilderContext;
  *      discover_channels() -> create_routers() -> connect_routers() ->
  *      compile_ancillary_kernels() -> create_kernels()
  *   3. FabricBuilder is destroyed, router builders are destroyed
+ *
+ * ABI note: This class has virtual methods (added for plugin subclassing support).
+ * This means it carries a vptr and its layout differs from a non-virtual version.
+ * FabricBuilder is only constructed via fabric_init.cpp (never embedded in other
+ * structs or passed across shared library boundaries by value), so the ABI impact
+ * is limited to callers that previously constructed FabricBuilder directly. The
+ * register_fabric_builder_factory() API is the intended extension point.
  */
 class FabricBuilder {
 public:
@@ -154,14 +161,25 @@ protected:
  * out-of-tree builder implementations without compile-time coupling.
  *
  * The factory receives the same arguments as the FabricBuilder constructor and must
- * return a fully-functional FabricBuilder (or subclass) that implements all build phases:
- * discover_channels, create_routers, connect_routers, compile_ancillary_kernels, create_kernels.
+ * return a non-null, fully-functional FabricBuilder (or subclass) that implements all
+ * build phases: discover_channels, create_routers, connect_routers,
+ * compile_ancillary_kernels, create_kernels.
+ *
+ * Thread safety: Registration must happen before any call to
+ * create_and_compile_tt_fabric_program(). This is a program-startup operation.
+ * Concurrent registration or registration during fabric init is a programming error.
+ * Double-registration without clearing (nullptr) first will assert.
+ *
+ * Note: This header is currently internal (not in the public api/ install set).
+ * Out-of-tree consumers must include it from the tt-metal source tree. A public
+ * forwarding header under api/tt-metalium/experimental/fabric/ may be added in the
+ * future if this API stabilizes.
  *
  * Usage:
  *   // In plugin initialization (before fabric init):
  *   tt::tt_fabric::register_fabric_builder_factory(
- *       [](IDevice* device, Program& program, FabricContext& ctx)
- *           -> std::unique_ptr<FabricBuilder> {
+ *       [](tt::tt_metal::IDevice* device, tt::tt_metal::Program& program,
+ *          tt::tt_fabric::FabricContext& ctx) -> std::unique_ptr<tt::tt_fabric::FabricBuilder> {
  *           return std::make_unique<MyCustomFabricBuilder>(device, program, ctx);
  *       });
  */
@@ -171,6 +189,8 @@ using FabricBuilderFactory = std::function<std::unique_ptr<FabricBuilder>(
 /**
  * Register a custom FabricBuilder factory. When set, fabric initialization will use this
  * factory instead of constructing the default FabricBuilder. Pass nullptr to clear.
+ * Asserts if a factory is already registered (clear first with nullptr before re-registering).
+ * Must be called before any fabric init. The factory must return a non-null pointer.
  */
 void register_fabric_builder_factory(FabricBuilderFactory factory);
 

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <unordered_map>
@@ -38,32 +39,34 @@ class FabricBuilderContext;
 class FabricBuilder {
 public:
     FabricBuilder(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program, FabricContext& fabric_context);
+    virtual ~FabricBuilder() = default;
 
     /**
      * Discover active ethernet channels and neighbors for this device.
      * Must be called before create_routers().
      */
-    void discover_channels();
+    virtual void discover_channels();
 
     /**
      * Create all router builders for this device.
+     * Override to dispatch to custom FabricRouterBuilder subclasses.
      */
-    void create_routers();
+    virtual void create_routers();
 
     /**
      * Connect routers using topology-appropriate connections.
      */
-    void connect_routers();
+    virtual void connect_routers();
 
     /**
      * Compile ancillary kernels (e.g., tensix mux) for each router.
      */
-    void compile_ancillary_kernels();
+    virtual void compile_ancillary_kernels();
 
     /**
      * Create the main ERISC router kernels.
      */
-    void create_kernels();
+    virtual void create_kernels();
 
     /**
      * Check if any routers were created.
@@ -75,7 +78,7 @@ public:
      */
     size_t get_num_routers() const { return routers_.size(); }
 
-private:
+protected:
     /**
      * RouterConnectionPair - Internal struct for router connection info
      */
@@ -140,5 +143,40 @@ private:
     // Master router channel (first in map)
     chan_id_t master_router_chan_ = 0;
 };
+
+// ============ Plugin Factory Registration ============
+
+/**
+ * Factory function type for creating custom FabricBuilder implementations.
+ *
+ * External code (e.g., custom fabric builder plugins) can register a factory function
+ * that will be called instead of constructing the default FabricBuilder. This enables
+ * out-of-tree builder implementations without compile-time coupling.
+ *
+ * The factory receives the same arguments as the FabricBuilder constructor and must
+ * return a fully-functional FabricBuilder (or subclass) that implements all build phases:
+ * discover_channels, create_routers, connect_routers, compile_ancillary_kernels, create_kernels.
+ *
+ * Usage:
+ *   // In plugin initialization (before fabric init):
+ *   tt::tt_fabric::register_fabric_builder_factory(
+ *       [](IDevice* device, Program& program, FabricContext& ctx)
+ *           -> std::unique_ptr<FabricBuilder> {
+ *           return std::make_unique<MyCustomFabricBuilder>(device, program, ctx);
+ *       });
+ */
+using FabricBuilderFactory = std::function<std::unique_ptr<FabricBuilder>(
+    tt::tt_metal::IDevice*, tt::tt_metal::Program&, FabricContext&)>;
+
+/**
+ * Register a custom FabricBuilder factory. When set, fabric initialization will use this
+ * factory instead of constructing the default FabricBuilder. Pass nullptr to clear.
+ */
+void register_fabric_builder_factory(FabricBuilderFactory factory);
+
+/**
+ * Returns the currently registered factory, or nullptr if none is registered.
+ */
+const FabricBuilderFactory& get_fabric_builder_factory();
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -26,8 +26,12 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto& fabric_context = control_plane.get_fabric_context();
 
-    // Use FabricBuilder to coordinate the build phases
-    FabricBuilder builder(device, *fabric_program_ptr, fabric_context);
+    // Use FabricBuilder to coordinate the build phases.
+    // If a custom factory is registered, use it; otherwise construct the default.
+    const auto& factory = get_fabric_builder_factory();
+    auto builder_ptr = factory ? factory(device, *fabric_program_ptr, fabric_context)
+                               : std::make_unique<FabricBuilder>(device, *fabric_program_ptr, fabric_context);
+    auto& builder = *builder_ptr;
 
     // Execute build phases
     builder.discover_channels();

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -31,6 +31,7 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     const auto& factory = get_fabric_builder_factory();
     auto builder_ptr = factory ? factory(device, *fabric_program_ptr, fabric_context)
                                : std::make_unique<FabricBuilder>(device, *fabric_program_ptr, fabric_context);
+    TT_FATAL(builder_ptr != nullptr, "FabricBuilder factory returned nullptr");
     auto& builder = *builder_ptr;
 
     // Execute build phases


### PR DESCRIPTION
## Summary

- Make `FabricBuilder` methods virtual and members protected for subclassing
- Add `register_fabric_builder_factory()` / `get_fabric_builder_factory()` API
- `fabric_init.cpp` dispatches to registered factory when present, falls back to default

This enables out-of-tree `FabricBuilder` implementations without compile-time coupling. External code registers a factory function before fabric init; tt-metal calls it instead of constructing the default `FabricBuilder`. No new dependencies, no `dlopen`, no `#ifdef`.

**Changes:**
- `fabric_builder.hpp`: virtual methods, protected members, virtual destructor, factory type + registration API
- `fabric_builder.cpp`: factory storage (static global) and accessor functions
- `fabric_init.cpp`: 3-line change to check factory before default construction

## Test plan

- [ ] CI build passes (no functional change when no factory is registered — identical codepath)
- [ ] Verify default fabric init is unchanged (factory is nullptr by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/fabric-plugins) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/fabric-plugins)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/fabric-plugins) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/fabric-plugins) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/fabric-plugins) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/fabric-plugins)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/fabric-plugins) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/fabric-plugins) |
| [tm-fabric-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/fabric-plugins) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/fabric-plugins)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/fabric-plugins) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/fabric-plugins) |
