### PR TITLE
#42004: fix ubsan error in fill for min/max

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -26,6 +26,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_graph_query_op_constraints.cpp
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp
+    test_reduction.cpp
     test_relational_int.cpp
     test_rsub_int.cpp
     test_sub_int.cpp

--- a/tests/ttnn/unit_tests/gtests/test_reduction.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_reduction.cpp
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <array>
+#include <memory>
+#include <optional>
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/shape.hpp>
+#include "ttnn/device.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/creation/creation.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+namespace ttnn::operations::binary::test {
+
+struct SumTensorParameter {
+    int h;
+    int w;
+};
+
+class SumTensorLastDimFixture : public TTNNFixtureWithSuiteDevice<SumTensorLastDimFixture>,
+                                public testing::WithParamInterface<SumTensorParameter> {};
+
+TEST_P(SumTensorLastDimFixture, SumTensorCorrectly) {
+    auto param = GetParam();
+    auto& device = *device_;
+    std::array<uint32_t, 2> dimensions = {param.h, param.w};
+    ttnn::Shape shape(dimensions);
+    std::array<uint32_t, 2> reduced_dimensions = {param.h, 1};
+    ttnn::Shape reduced_shape(reduced_dimensions);
+    constexpr int dim = -1;
+    {
+        const auto input_tensor = ttnn::ones(shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, device);
+        const auto output_tensor = ttnn::sum(input_tensor, dim, true);
+        TT_FATAL(
+            output_tensor.logical_shape() == reduced_shape,
+            "Shapes are not equal output tensor shape {} vs reduced shape {}",
+            output_tensor.logical_shape(),
+            reduced_shape);
+        auto output_vector = output_tensor.to_vector<bfloat16>();
+        float expected = (float)param.w;
+        for (int i = 0; i < param.h; i++) {
+            float value = output_vector[i];
+            TT_FATAL(value == expected, "{} != {} @ {}", value, expected, i);
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SumTensorLastDimTests,
+    SumTensorLastDimFixture,
+    ::testing::Values(SumTensorParameter{3100, 63}, SumTensorParameter{3200, 64}));
+
+class SumTensorFirstDimFixture : public TTNNFixtureWithSuiteDevice<SumTensorFirstDimFixture>,
+                                 public testing::WithParamInterface<SumTensorParameter> {};
+
+TEST_P(SumTensorFirstDimFixture, SumTensorCorrectly) {
+    auto param = GetParam();
+    auto& device = *device_;
+    std::array<uint32_t, 2> dimensions = {param.h, param.w};
+    ttnn::Shape shape(dimensions);
+    std::array<uint32_t, 2> reduced_dimensions = {1, param.w};
+    ttnn::Shape reduced_shape(reduced_dimensions);
+    constexpr int dim = -2;
+    {
+        const auto input_tensor = ttnn::ones(shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, device);
+        const auto output_tensor = ttnn::sum(input_tensor, dim, true);
+        TT_FATAL(
+            output_tensor.logical_shape() == reduced_shape,
+            "Shapes are not equal output tensor shape {} vs reduced shape {}",
+            output_tensor.logical_shape(),
+            reduced_shape);
+        auto output_vector = output_tensor.to_vector<bfloat16>();
+        float expected = (float)param.h;
+        for (int i = 0; i < param.w; i++) {
+            float value = output_vector[i];
+            TT_FATAL(value == expected, "{} != {} @ {}", value, expected, i);
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SumTensorFirstDimTests,
+    SumTensorFirstDimFixture,
+    ::testing::Values(SumTensorParameter{63, 3100}, SumTensorParameter{64, 3200}));
+
+class SumTensorBothDimsFixture : public TTNNFixtureWithSuiteDevice<SumTensorBothDimsFixture>,
+                                 public testing::WithParamInterface<SumTensorParameter> {};
+
+TEST_P(SumTensorBothDimsFixture, SumTensorCorrectly) {
+    auto param = GetParam();
+    auto& device = *device_;
+    std::array<uint32_t, 2> dimensions = {param.h, param.w};
+    ttnn::Shape shape(dimensions);
+    SmallVector<int> dim = {0, 1};
+
+    {
+        const auto input_tensor = ttnn::ones(shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, device);
+        const auto output_tensor = ttnn::sum(input_tensor, dim, false);
+        auto output_vector = output_tensor.to_vector<bfloat16>();
+        float expected = (float)(param.h * param.w);
+        TT_FATAL(
+            output_vector.size() == 1, "Result should only have a single element instead of {}", output_vector.size());
+        float value = output_vector[0];
+        TT_FATAL(value == expected, "{} != {}", value, expected);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SumTensorBothDimsTests,
+    SumTensorBothDimsFixture,
+    ::testing::Values(SumTensorParameter{30, 30}, SumTensorParameter{64, 64}));
+
+struct MinMaxTensorParameter {
+    int h;
+    int w;
+    int offset;
+};
+
+class MinMaxTensorLastDimFixture : public TTNNFixtureWithSuiteDevice<MinMaxTensorLastDimFixture>,
+                                   public testing::WithParamInterface<MinMaxTensorParameter> {};
+
+TEST_P(MinMaxTensorLastDimFixture, MinMaxTensorCorrectly) {
+    auto param = GetParam();
+    auto& device = *device_;
+    std::array<uint32_t, 4> reduced_dimensions = {1, 1, param.h, 1};
+    ttnn::Shape reduced_shape(reduced_dimensions);
+    int dim = -1;
+
+    {
+        const ttnn::Shape tensor_shape{1, 1, param.h, param.w};
+        const MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+        const TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
+        const TensorSpec tensor_spec(tensor_shape, tensor_layout);
+        std::vector<float> host_data(tensor_shape.volume());
+        for (int i = 0; i < param.h; i++) {
+            for (int j = 0; j < param.w; j++) {
+                int index = param.w * i + j;
+                host_data[index] = param.offset + j;
+            }
+        }
+
+        const ttnn::QueueId io_cq = ttnn::QueueId(0);
+        const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
+        const Tensor input_tensor = host_tensor.to_device(&device, mem_cfg, io_cq);
+        const auto output_tensor_max = ttnn::max(input_tensor, dim, true);
+        const auto output_tensor_min = ttnn::min(input_tensor, dim, true);
+        TT_FATAL(
+            output_tensor_max.logical_shape() == reduced_shape,
+            "Shapes are not equal output tensor shape {} vs reduced shape {}",
+            output_tensor_max.logical_shape(),
+            reduced_shape);
+        TT_FATAL(
+            output_tensor_min.logical_shape() == reduced_shape,
+            "Shapes are not equal output tensor shape {} vs reduced shape {}",
+            output_tensor_max.logical_shape(),
+            reduced_shape);
+        auto output_vector_max = output_tensor_max.to_vector<bfloat16>();
+        auto output_vector_min = output_tensor_min.to_vector<bfloat16>();
+        float expected_max = (float)(param.offset + param.w - 1.0);
+        float expected_min = (float)param.offset;
+        for (int i = 0; i < param.h; i++) {
+            float max = output_vector_max[i];
+            float min = output_vector_min[i];
+            TT_FATAL(max == expected_max, "{} != {} @ {}", max, expected_max, i);
+            TT_FATAL(min == expected_min, "{} != {} @ {}", min, expected_min, i);
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MinMaxTensorLastDimTests,
+    MinMaxTensorLastDimFixture,
+    ::testing::Values(
+        MinMaxTensorParameter{3100, 63, 4},
+        MinMaxTensorParameter{3200, 64, 4},
+        MinMaxTensorParameter{3100, 63, -128},
+        MinMaxTensorParameter{3200, 64, -128}));
+
+class MinMaxTensorFirstDimFixture : public TTNNFixtureWithSuiteDevice<MinMaxTensorFirstDimFixture>,
+                                    public testing::WithParamInterface<MinMaxTensorParameter> {};
+
+TEST_P(MinMaxTensorFirstDimFixture, MinMaxTensorCorrectly) {
+    auto param = GetParam();
+    auto& device = *device_;
+    std::array<uint32_t, 4> reduced_dimensions = {1, 1, 1, param.w};
+    ttnn::Shape reduced_shape(reduced_dimensions);
+    int dim = -2;
+    {
+        const ttnn::Shape tensor_shape{1, 1, param.h, param.w};
+        const MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+        const TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
+        const TensorSpec tensor_spec(tensor_shape, tensor_layout);
+        std::vector<float> host_data(tensor_shape.volume());
+        for (int i = 0; i < param.h; i++) {
+            for (int j = 0; j < param.w; j++) {
+                int index = param.w * i + j;
+                host_data[index] = param.offset + i;
+            }
+        }
+
+        const ttnn::QueueId io_cq = ttnn::QueueId(0);
+        const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
+        const Tensor input_tensor = host_tensor.to_device(&device, mem_cfg, io_cq);
+        const auto output_tensor_max = ttnn::max(input_tensor, dim, true);
+        const auto output_tensor_min = ttnn::min(input_tensor, dim, true);
+        TT_FATAL(
+            output_tensor_max.logical_shape() == reduced_shape,
+            "Shapes are not equal output tensor shape {} vs reduced shape {}",
+            output_tensor_max.logical_shape(),
+            reduced_shape);
+        TT_FATAL(
+            output_tensor_min.logical_shape() == reduced_shape,
+            "Shapes are not equal output tensor shape {} vs reduced shape {}",
+            output_tensor_max.logical_shape(),
+            reduced_shape);
+        auto output_vector_max = output_tensor_max.to_vector<bfloat16>();
+        auto output_vector_min = output_tensor_min.to_vector<bfloat16>();
+        for (int i = 0; i < param.w; i++) {
+            float expected_max = (float)(param.offset + param.h - 1.0);
+            float expected_min = (float)param.offset;
+            float max = output_vector_max[i];
+            float min = output_vector_min[i];
+            TT_FATAL(max == expected_max, "{} != {} @ {}", max, expected_max, i);
+            TT_FATAL(min == expected_min, "{} != {} @ {}", min, expected_min, i);
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MinMaxTensorFirstDimTests,
+    MinMaxTensorFirstDimFixture,
+    ::testing::Values(
+        MinMaxTensorParameter{63, 3100, 4},
+        MinMaxTensorParameter{64, 3200, 4},
+        MinMaxTensorParameter{63, 3100, -128},
+        MinMaxTensorParameter{64, 3200, -128}));
+
+class MinMaxTensorBothDimsFixture : public TTNNFixtureWithSuiteDevice<MinMaxTensorBothDimsFixture>,
+                                    public testing::WithParamInterface<MinMaxTensorParameter> {};
+
+TEST_P(MinMaxTensorBothDimsFixture, MinMaxTensorCorrectly) {
+    auto param = GetParam();
+    auto& device = *device_;
+    SmallVector<int> dim = {-2, -1};
+    {
+        const ttnn::Shape tensor_shape{1, 1, param.h, param.w};
+        const MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+        const TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
+        const TensorSpec tensor_spec(tensor_shape, tensor_layout);
+        std::vector<float> host_data(tensor_shape.volume());
+        for (int i = 0; i < param.h; i++) {
+            for (int j = 0; j < param.w; j++) {
+                int index = param.w * i + j;
+                host_data[index] = param.offset + index;
+            }
+        }
+
+        const ttnn::QueueId io_cq = ttnn::QueueId(0);
+        const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
+        const Tensor input_tensor = host_tensor.to_device(&device, mem_cfg, io_cq);
+        const auto output_tensor_max = ttnn::max(input_tensor, dim, true);
+        const auto output_tensor_min = ttnn::min(input_tensor, dim, true);
+        auto output_vector_max = output_tensor_max.to_vector<bfloat16>();
+        auto output_vector_min = output_tensor_min.to_vector<bfloat16>();
+        TT_FATAL(
+            output_vector_max.size() == 1,
+            "Result should only have a single element instead of {}",
+            output_vector_max.size());
+        TT_FATAL(
+            output_vector_min.size() == 1,
+            "Result should only have a single element instead of {}",
+            output_vector_min.size());
+        float expected_max = (float)(param.offset + param.h * param.w - 1.0);
+        float expected_min = (float)param.offset;
+        float max = output_vector_max[0];
+        float min = output_vector_min[0];
+        TT_FATAL(max == expected_max, "{} != {}", max, expected_max);
+        TT_FATAL(min == expected_min, "{} != {}", min, expected_min);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MinMaxTensorBothDimsTests,
+    MinMaxTensorBothDimsFixture,
+    ::testing::Values(MinMaxTensorParameter{64, 64, 1}, MinMaxTensorParameter{30, 30, -1004}));
+
+}  // namespace ttnn::operations::binary::test

--- a/tests/ttnn/unit_tests/gtests/test_reduction.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_reduction.cpp
@@ -169,7 +169,7 @@ TEST_P(MinMaxTensorLastDimFixture, MinMaxTensorCorrectly) {
             reduced_shape);
         auto output_vector_max = output_tensor_max.to_vector<bfloat16>();
         auto output_vector_min = output_tensor_min.to_vector<bfloat16>();
-        float expected_max = (float)(param.offset + param.w - 1.0);
+        float expected_max = (float)(param.offset + param.w - 1);
         float expected_min = (float)param.offset;
         for (int i = 0; i < param.h; i++) {
             float max = output_vector_max[i];
@@ -229,7 +229,7 @@ TEST_P(MinMaxTensorFirstDimFixture, MinMaxTensorCorrectly) {
         auto output_vector_max = output_tensor_max.to_vector<bfloat16>();
         auto output_vector_min = output_tensor_min.to_vector<bfloat16>();
         for (int i = 0; i < param.w; i++) {
-            float expected_max = (float)(param.offset + param.h - 1.0);
+            float expected_max = (float)(param.offset + param.h - 1);
             float expected_min = (float)param.offset;
             float max = output_vector_max[i];
             float min = output_vector_min[i];
@@ -283,7 +283,7 @@ TEST_P(MinMaxTensorBothDimsFixture, MinMaxTensorCorrectly) {
             output_vector_min.size() == 1,
             "Result should only have a single element instead of {}",
             output_vector_min.size());
-        float expected_max = (float)(param.offset + param.h * param.w - 1.0);
+        float expected_max = (float)(param.offset + param.h * param.w - 1);
         float expected_min = (float)param.offset;
         float max = output_vector_max[0];
         float min = output_vector_min[0];

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -697,44 +697,6 @@ def test_mean_2d_tensor_dims(device, h, w, dim, keepdim):
     )
 
 
-@pytest.mark.parametrize("h", [32, 63])
-@pytest.mark.parametrize("w", [32, 63])
-@pytest.mark.parametrize("dim", [-1, -2])
-def test_min_max_non_tile_aligned(device, h, w, dim):
-    """Exercises min/max on non-tile-aligned shapes which trigger fill_pad with -inf/+inf.
-    This hits a UBSan error in fill_pad_program_factory.cpp (issue #42004)."""
-    torch.manual_seed(0)
-
-    torch_input_tensor = torch.randn((1, 1, h, w), dtype=torch.bfloat16)
-    torch_max = torch.max(torch_input_tensor, dim=dim, keepdim=True).values
-    torch_min = torch.min(torch_input_tensor, dim=dim, keepdim=True).values
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-
-    ttnn_max = ttnn.max(input_tensor, dim=dim, keepdim=True)
-    ttnn_min = ttnn.min(input_tensor, dim=dim, keepdim=True)
-
-    ttnn_max = ttnn.to_torch(ttnn.from_device(ttnn_max))
-    ttnn_min = ttnn.to_torch(ttnn.from_device(ttnn_min))
-
-    assert_numeric_metrics(
-        torch_max,
-        ttnn_max,
-        pcc_threshold=0.999,
-        rtol=0.004,
-        atol=0.038,
-        frobenius_threshold=0.004,
-    )
-    assert_numeric_metrics(
-        torch_min,
-        ttnn_min,
-        pcc_threshold=0.999,
-        rtol=0.004,
-        atol=0.038,
-        frobenius_threshold=0.004,
-    )
-
-
 def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
     torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
     batch_size, in_c, in_h, in_w = input_shape

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -697,6 +697,44 @@ def test_mean_2d_tensor_dims(device, h, w, dim, keepdim):
     )
 
 
+@pytest.mark.parametrize("h", [32, 63])
+@pytest.mark.parametrize("w", [32, 63])
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_min_max_non_tile_aligned(device, h, w, dim):
+    """Exercises min/max on non-tile-aligned shapes which trigger fill_pad with -inf/+inf.
+    This hits a UBSan error in fill_pad_program_factory.cpp (issue #42004)."""
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((1, 1, h, w), dtype=torch.bfloat16)
+    torch_max = torch.max(torch_input_tensor, dim=dim, keepdim=True).values
+    torch_min = torch.min(torch_input_tensor, dim=dim, keepdim=True).values
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn_max = ttnn.max(input_tensor, dim=dim, keepdim=True)
+    ttnn_min = ttnn.min(input_tensor, dim=dim, keepdim=True)
+
+    ttnn_max = ttnn.to_torch(ttnn.from_device(ttnn_max))
+    ttnn_min = ttnn.to_torch(ttnn.from_device(ttnn_min))
+
+    assert_numeric_metrics(
+        torch_max,
+        ttnn_max,
+        pcc_threshold=0.999,
+        rtol=0.004,
+        atol=0.038,
+        frobenius_threshold=0.004,
+    )
+    assert_numeric_metrics(
+        torch_min,
+        ttnn_min,
+        pcc_threshold=0.999,
+        rtol=0.004,
+        atol=0.038,
+        frobenius_threshold=0.004,
+    )
+
+
 def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
     torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
     batch_size, in_c, in_h, in_w = input_shape

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -52,13 +52,15 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     const bool src_is_dram = tens_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     // pack bf16 vals
-    uint32_t packed_fill_value = static_cast<std::uint32_t>(fill_value);
+    uint32_t packed_fill_value = 0;
     if (input_tensor.dtype() == DataType::BFLOAT16) {
         packed_fill_value = pack_two_bfloat16_into_uint32({bfloat16(fill_value), bfloat16(fill_value)});
     } else if (input_tensor.dtype() == DataType::UINT16) {
         packed_fill_value = pack_two_uint16_into_uint32({fill_value, fill_value});
     } else if (input_tensor.dtype() == DataType::FLOAT32) {
         packed_fill_value = std::bit_cast<uint32_t>(fill_value);
+    } else {
+        packed_fill_value = static_cast<std::uint32_t>(fill_value);
     }
 
     const uint32_t padded_height = tt::div_up(height, tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #42004

There is a UB bug exposed by running a C++ test with ASan in /work/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp:55:61: 
```
runtime error: -inf is outside the range of representable values of type 'unsigned int'
    #0 0x7fa26468cf34 in ttnn::prim::FillPadProgramFactory::create(ttnn::prim::FillPadParams const&, ttnn::prim::FillPadInputs const&, tt::tt_metal::Tensor&) /work/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp:55:61
```

Instead of setting an initial value without consideration of data types, the initial value needs to be 0.

This is causing merge gate to fail when trying to merge in the test.

Changes:
- add C++ test that runs into this bug
- fix fill pad program factory

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Tested locally that C++ test runs into this failure without program factory changes and passes with them via:
```
./build_metal.sh --build-type ASan --build-tests
./build/test/ttnn/unit_tests_ttnn --gtest_filter="SumTensorLastDimTests/SumTensorLastDimFixture.SumTensorCorrectly/*:SumTensorFirstDimTests/SumTensorFirstDimFixture.SumTensorCorrectly/*:SumTensorBothDimsTests/SumTensorBothDimsFixture.SumTensorCorrectly/*:MinMaxTensorLastDimTests/MinMaxTensorLastDimFixture.MinMaxTensorCorrectly/*:MinMaxTensorFirstDimTests/MinMaxTensorFirstDimFixture.MinMaxTensorCorrectly/*:MinMaxTensorBothDimsTests/MinMaxTensorBothDimsFixture.MinMaxTensorCorrectly/*"
```

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42004_fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-42004_fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42004_fill) | [#2717](https://github.com/tenstorrent/tt-metal/actions/runs/24402550960) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42004_fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-42004_fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42004_fill) | [#17463](https://github.com/tenstorrent/tt-metal/actions/runs/24402559216) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42004_fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-42004_fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42004_fill) | [#5188](https://github.com/tenstorrent/tt-metal/actions/runs/24402577131) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42004_fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-42004_fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42004_fill) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42004_fill) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42004_fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-42004_fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42004_fill) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42004_fill) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42004_fill) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-42004_fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42004_fill) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42004_fill) |