### PR TITLE
tests: add missing Finish() sync calls to test_noc.cpp

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -254,6 +254,7 @@ TEST_F(MeshDeviceFixture, TensixDirectedStreamRegWriteRead) {
         }
 
         distributed::EnqueueMeshWorkload(cq, workload, true);
+        distributed::Finish(cq);
 
         uint32_t expected_value_to_read = 0x1234;
         for (uint32_t x = 0; x < logical_grid_size.x; x++) {
@@ -362,6 +363,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWrite4BAlignment) {
             {virtual_receiver_core.x, virtual_receiver_core.y, receiver_addr, value_to_write, 1, 0});
 
         distributed::EnqueueMeshWorkload(cq, workload, true);
+        distributed::Finish(cq);
 
         tt_metal::detail::ReadFromDeviceL1(device, receiver_core, receiver_addr, sizeof(uint32_t), readback);
         EXPECT_EQ(readback[0], value_to_write);
@@ -419,6 +421,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDedicatedNoc) {
             {virtual_receiver_core.x, virtual_receiver_core.y, second_receiver_addr, value_to_write + 1, 1, 0});
 
         distributed::EnqueueMeshWorkload(cq, workload, true);
+        distributed::Finish(cq);
 
         tt_metal::detail::ReadFromDeviceL1(device, receiver_core, first_receiver_addr, 32, readback);
         EXPECT_EQ(readback[0], value_to_write);
@@ -467,6 +470,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDedicatedNocMisaligned) {
              sizeof(uint32_t)});
 
         distributed::EnqueueMeshWorkload(cq, workload, true);
+        distributed::Finish(cq);
 
         tt_metal::detail::ReadFromDeviceL1(
             device, receiver_core, base_receiver_addr, num_writes * sizeof(uint32_t), readback);
@@ -545,6 +549,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDynamicNoc) {
              l1_alignment});
 
         distributed::EnqueueMeshWorkload(cq, workload, true);
+        distributed::Finish(cq);
 
         tt_metal::detail::ReadFromDeviceL1(
             device, receiver_core, receiver_addr0, readback.size() * sizeof(uint32_t), readback);
@@ -614,6 +619,7 @@ void run_local_noc_stream_reg_inc(
     tt_metal::detail::WriteToDeviceL1(device, core, unreserved_base_addr, l1_buffer_data, core_type);
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
+    distributed::Finish(cq);
 
     tt_metal::detail::ReadFromDeviceL1(device, core, unreserved_base_addr, sizeof(uint32_t), l1_buffer_data, core_type);
     switch (l1_buffer_data[0]) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39014

### Problem description
`test_noc.cpp` tests were failing on ttsim with `advance_clock(1)` (1 simulated cycle per read) due to missing host/device synchronization. `EnqueueMeshWorkload(cq, workload, true)` with `blocking=true` calls `WaitProgramDone` which polls the GO_MSG, but does not call `l1_barrier()`/`dram_barrier()`. On ttsim the device writes are not guaranteed to be visible to the host without these barriers.

This is the same class of bug fixed in #39017 for other `unit_tests_api` tests.

### What's changed
Add `distributed::Finish(cq)` after each `EnqueueMeshWorkload` call that is followed by `ReadFromDeviceL1` in `test_noc.cpp`. The one call at line 325 (`TensixIncrementStreamRegWrite`) that does not read back L1 is left unchanged.

### Affected tests
- `TensixDirectedStreamRegWriteRead`
- `TensixInlineWrite4BAlignment`
- `TensixInlineWrite4BAlignmentMultipleWrites`
- `TensixInlineWriteDedicatedNocMisaligned`
- `TensixInlineWriteDedicatedNocAligned`
- `TensixStreamRegReadWriteChecks`

### Checklist
- [ ] New/Existing tests provide coverage for changes

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-test-noc-finish-sync) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/fix-test-noc-finish-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-test-noc-finish-sync) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-test-noc-finish-sync) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/fix-test-noc-finish-sync) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/fix-test-noc-finish-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/fix-test-noc-finish-sync) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/fix-test-noc-finish-sync) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-test-noc-finish-sync) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/fix-test-noc-finish-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-test-noc-finish-sync) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-test-noc-finish-sync) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-test-noc-finish-sync) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/fix-test-noc-finish-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-test-noc-finish-sync) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-test-noc-finish-sync) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-test-noc-finish-sync) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/fix-test-noc-finish-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-test-noc-finish-sync) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-test-noc-finish-sync) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-test-noc-finish-sync) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/fix-test-noc-finish-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-test-noc-finish-sync) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-test-noc-finish-sync) |