### PR TITLE
Record tt-metal commit in DeepSeek demo artifacts

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 from glob import glob
 from pathlib import Path
 
@@ -86,6 +87,35 @@ def _write_json_output(path: Path, payload: dict, label: str) -> None:
         raise SystemExit(f"Failed to write {label.lower()} '{path}': {e}")
 
 
+def _resolve_tt_metal_commit() -> str:
+    """Resolve the tt-metal commit used for this run."""
+    repo_root = Path(__file__).resolve().parents[4]
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        commit = result.stdout.strip()
+    except Exception:
+        commit = ""
+
+    return commit or "unknown"
+
+
+def _is_primary_artifact_writer() -> bool:
+    for rank_env in ("TT_MESH_HOST_RANK", "OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK"):
+        rank_value = os.getenv(rank_env)
+        if rank_value is None:
+            continue
+        try:
+            return int(rank_value) == 0
+        except ValueError:
+            return False
+    return True
+
+
 def _print_performance_metrics(results: dict) -> None:
     """Print performance metrics from results if available."""
     if "statistics" in results and results["statistics"]:
@@ -102,6 +132,9 @@ def _print_performance_metrics(results: dict) -> None:
         trace_str = f"{trace_metric:.2f}" if trace_metric is not None else "N/A (requires --max-new-tokens >= 128)"
         logger.info(f"Trace execution tokens/sec/user @128th token: {trace_str}")
         logger.info(f"Full demo runtime: {statistics['Full demo runtime']:.2f}s")
+        tt_metal_commit = statistics.get("tt-metal_commit")
+        if tt_metal_commit:
+            logger.info(f"tt-metal commit: {tt_metal_commit}")
 
 
 def _format_model_params_for_reporting(model_params: dict, summarize_sampling: bool = True) -> dict:
@@ -766,6 +799,7 @@ def run_demo(
                 checkpoint_fh.flush()
                 os.fsync(checkpoint_fh.fileno())
 
+            statistics["tt-metal_commit"] = _resolve_tt_metal_commit()
             return {"generations": results, "statistics": statistics, "model_params": model_params}
         finally:
             if checkpoint_fh is not None:
@@ -850,7 +884,7 @@ def main() -> None:
             ),
             random_weights=bool(args.random_weights),
         )
-        if int(os.getenv("TT_MESH_HOST_RANK", "0")) == 0:
+        if _is_primary_artifact_writer():
             _write_json_output(saved_output_path, output_data, "Results")
     else:
         # Print to terminal as before

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -48,6 +48,18 @@ def _assert_no_garbage_tokens(results: dict) -> None:
         pytest.fail("Garbage tokens detected during demo:\n" + "\n".join(failures))
 
 
+def _is_primary_artifact_writer() -> bool:
+    for rank_env in ("TT_MESH_HOST_RANK", "OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK"):
+        rank_value = os.getenv(rank_env)
+        if rank_value is None:
+            continue
+        try:
+            return int(rank_value) == 0
+        except ValueError:
+            return False
+    return True
+
+
 def _assert_perf_targets(results: dict, perf_targets: dict[str, float]) -> None:
     statistics = results.get("statistics", {})
     assert statistics, "Expected demo statistics for performance assertion"
@@ -333,8 +345,8 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
     else:
         assert all(length <= case["max_new_tokens"] for length in generated_lengths)
 
-    # Save results to JSON for artifact upload when requested by the case.
-    if case["artifact_name"] is not None:
+    # Save artifact from host rank 0 only to avoid multi-host write races.
+    if case["artifact_name"] is not None and _is_primary_artifact_writer():
         artifact_dir = Path("generated/artifacts")
         artifact_dir.mkdir(parents=True, exist_ok=True)
         output_file = artifact_dir / f"{case['artifact_name']}.json"

--- a/models/demos/deepseek_v3/demo/test_mtp_demo.py
+++ b/models/demos/deepseek_v3/demo/test_mtp_demo.py
@@ -40,6 +40,18 @@ def _artifact_name_for_current_mesh() -> str | None:
     return None
 
 
+def _is_primary_artifact_writer() -> bool:
+    for rank_env in ("TT_MESH_HOST_RANK", "OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK"):
+        rank_value = os.getenv(rank_env)
+        if rank_value is None:
+            continue
+        try:
+            return int(rank_value) == 0
+        except ValueError:
+            return False
+    return True
+
+
 def _write_demo_artifact(prompts: list[str], results: dict, artifact_name: str) -> None:
     artifact_dir = Path("generated/artifacts")
     artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -108,7 +120,7 @@ def test_mtp_demp_compare_outputs(
     _assert_demo_outputs_match(baseline, mtp)
 
     artifact_name = _artifact_name_for_current_mesh()
-    if artifact_name is not None:
+    if artifact_name is not None and _is_primary_artifact_writer():
         _write_demo_artifact(prompts, mtp, artifact_name)
 
     # Prompt-level acceptance varies across real demo prompts. Keep this smoke test focused on


### PR DESCRIPTION
### Ticket


### Problem description
No tt-metal commit is mentioned when the artifacts are generated, this leads to lack of knowledge of the reproducibility of the outputs.

### What's changed
Always record the runtime tt-metal SHA in demo statistics and restrict artifact writes to the primary MPI rank to avoid multihost overwrite races.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-tt-commit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-tt-commit)
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-e2e-tests.yaml/badge.svg?branch=ds-tt-commit)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-e2e-tests.yaml?query=branch:ds-tt-commit)