### PR TITLE
Add support for DFB local accessor names to Metal 2.0 APIs (host + device)

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -147,6 +147,12 @@ TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
         "has space",      // whitespace
         "1starts_digit",  // leading digit
         "has.dot",        // punctuation
+        "class",          // C++ keyword
+        "namespace",      // C++ keyword
+        "int",            // C++ keyword
+        "_Foo",           // reserved: underscore + uppercase
+        "__foo",          // reserved: leading double underscore
+        "foo__bar",       // reserved: embedded double underscore
     };
 
     for (const auto& bad_name : invalid_names) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -745,9 +745,15 @@ TEST_F(ProgramSpecTestQuasar, DFBNotInAnyWorkerSpecFails) {
 // ============================================================================
 // SECTION 4: Programs Creation Tests
 // ============================================================================
-// These verify that valid configurations succeed.
-// NOTE: Program creation needs full HAL support.
-// TODO: Enable these tests with a Quasar mock device.
+// These verify that valid ProgramSpec configurations produce a Program without throwing.
+// They exercise the full MakeProgramFromSpec pipeline: spec validation, DFB ID assignment,
+// DFBAccessor handle map construction, and kernel object creation.
+//
+// Coverage gap: JIT compilation and device-side execution are not tested here.
+// Mock device isn't really enough to test anything on device side adequately.
+// Execution-level coverage for DFB local accessor bindings will come from:
+//   - DFB integration tests: tests/tt_metal/tt_metal/api/dataflow_buffer/. (TODO)
+//   - Real-hardware tests via the WH/BH Metal 2.0 host API path (when that lands)
 
 TEST_F(ProgramSpecTestQuasar, MinimalValidProgramSpecSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -746,14 +746,10 @@ TEST_F(ProgramSpecTestQuasar, DFBNotInAnyWorkerSpecFails) {
 // SECTION 4: Programs Creation Tests
 // ============================================================================
 // These verify that valid ProgramSpec configurations produce a Program without throwing.
-// They exercise the full MakeProgramFromSpec pipeline: spec validation, DFB ID assignment,
-// DFBAccessor handle map construction, and kernel object creation.
+// They exercise the full MakeProgramFromSpec pipeline, but only on mock device.
 //
-// Coverage gap: JIT compilation and device-side execution are not tested here.
-// Mock device isn't really enough to test anything on device side adequately.
-// Execution-level coverage for DFB local accessor bindings will come from:
-//   - DFB integration tests: tests/tt_metal/tt_metal/api/dataflow_buffer/. (TODO)
-//   - Real-hardware tests via the WH/BH Metal 2.0 host API path (when that lands)
+// Coverage gaps (JIT compilation, device-side execution) are covered by HW tests.
+// (see test_program_spec_hw.cpp)
 
 TEST_F(ProgramSpecTestQuasar, MinimalValidProgramSpecSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -138,6 +138,34 @@ TEST_F(ProgramSpecTestQuasar, DuplicateLocalAccessorNameFails) {
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
+TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
+    NodeCoord node{0, 0};
+
+    const std::vector<std::string> invalid_names = {
+        "",               // empty
+        "has-dash",       // hyphen
+        "has space",      // whitespace
+        "1starts_digit",  // leading digit
+        "has.dot",        // punctuation
+    };
+
+    for (const auto& bad_name : invalid_names) {
+        ProgramSpec spec;
+        spec.program_id = "test_program";
+
+        auto kernel = MakeMinimalDMKernel("kernel", node);
+        auto dfb = MakeMinimalDFB("dfb", node);
+
+        BindDFBToKernel(kernel, "dfb", bad_name, KernelSpec::DFBEndpointType::PRODUCER);
+
+        spec.kernels = {kernel};
+        spec.dataflow_buffers = {dfb};
+        spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"}, {"dfb"})};
+
+        EXPECT_ANY_THROW(MakeProgramFromSpec(spec)) << "Expected rejection for name: '" << bad_name << "'";
+    }
+}
+
 TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
     NodeCoord node{0, 0};
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -107,7 +107,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     consumer.source_type = KernelSpec::SourceType::FILE_PATH;
     consumer.runtime_arguments_schema.num_runtime_args_per_node = {{node, 3}};
 
-    // DFB: both kernels bind it with local accessor name "buf"
+    // DFB: both kernels bind it, with different local accessor names
     auto dfb = MakeMinimalDFB("loopback_dfb", node, entry_size, num_entries);
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     BindDFBToKernel(producer, "loopback_dfb", "my_local_dfb_name", KernelSpec::DFBEndpointType::PRODUCER);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -9,6 +9,8 @@
 // end-to-end on real hardware, with particular focus on DFB local accessor names.
 //
 // Requires: TT_METAL_SLOW_DISPATCH_MODE=1
+//
+// TODO: Switch to using fast dispatch once the MeshWorkload code paths are added.
 
 #include <gtest/gtest.h>
 #include <cstdint>

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Real-hardware tests for Metal 2.0 Host API: ProgramSpec on WH/BH.
+//
+// These tests require a Wormhole B0 or Blackhole device and slow dispatch mode.
+// They prove the ProgramSpec → MakeProgramFromSpec → compile → dispatch → verify pipeline
+// end-to-end on real hardware, with particular focus on DFB local accessor names.
+//
+// Requires: TT_METAL_SLOW_DISPATCH_MODE=1
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
+
+#include "device_fixture.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "test_helpers.hpp"
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+namespace {
+
+using test_helpers::BindDFBToKernel;
+using test_helpers::MakeMinimalDFB;
+using test_helpers::MakeMinimalGen1DMKernel;
+using test_helpers::MakeMinimalWorker;
+
+// ============================================================================
+// Test Fixture
+// ============================================================================
+
+class ProgramSpecHWTest : public tt::tt_metal::MeshDeviceFixture {
+protected:
+    void SetUp() override {
+        MeshDeviceFixture::SetUp();
+        if (this->IsSkipped()) {
+            return;
+        }
+        // These tests target Gen1 (WH/BH) only
+        if (devices_.at(0)->arch() != tt::ARCH::WORMHOLE_B0 && devices_.at(0)->arch() != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
+        }
+    }
+};
+
+// ============================================================================
+// DFB Local Accessor Name Loopback Test
+// ============================================================================
+//
+// Proves that DFB local accessor names work end-to-end on real WH/BH hardware:
+//   1. kernel_bindings_generated.h is emitted correctly (dfb::buf resolves at compile time)
+//   2. The DFBAccessor mechanism works (DFB ID maps to the correct underlying CB)
+//   3. Data flows correctly through the DFB from producer to consumer
+//
+// Pipeline:
+//   Host writes random data → DRAM input buffer (single page = one bank)
+//   Producer DM kernel (BRISC) reads DRAM → DFB (using dfb::buf)
+//   Consumer DM kernel (NCRISC) reads DFB → DRAM (using dfb::buf)
+//   Host reads DRAM output buffer and verifies match
+
+TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+
+    // Test parameters
+    constexpr uint32_t entry_size = 1024;  // bytes per DFB entry
+    constexpr uint32_t num_entries = 4;    // DFB depth (double-buffer + margin)
+    constexpr uint32_t num_transfers = 8;  // total entries to move through the DFB
+    constexpr uint32_t total_bytes = entry_size * num_transfers;
+
+    // Use a single core for simplicity
+    const NodeCoord node{0, 0};
+
+    // -------------------------------------------------------
+    // Create DRAM buffers (single-page so all data is on one bank)
+    // -------------------------------------------------------
+    InterleavedBufferConfig dram_config{
+        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
+    auto input_buffer = CreateBuffer(dram_config);
+    auto output_buffer = CreateBuffer(dram_config);
+
+    // -------------------------------------------------------
+    // Build ProgramSpec
+    // -------------------------------------------------------
+    ProgramSpec spec;
+    spec.program_id = "dfb_accessor_loopback";
+
+    // Producer: BRISC reads from DRAM → DFB
+    auto producer = MakeMinimalGen1DMKernel("producer", node, DataMovementProcessor::RISCV_0);
+    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp";
+    producer.source_type = KernelSpec::SourceType::FILE_PATH;
+    producer.runtime_arguments_schema.num_runtime_args_per_node = {{node, 3}};
+
+    // Consumer: NCRISC reads DFB → DRAM
+    auto consumer = MakeMinimalGen1DMKernel("consumer", node, DataMovementProcessor::RISCV_1);
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
+    consumer.source_type = KernelSpec::SourceType::FILE_PATH;
+    consumer.runtime_arguments_schema.num_runtime_args_per_node = {{node, 3}};
+
+    // DFB: both kernels bind it with local accessor name "buf"
+    auto dfb = MakeMinimalDFB("loopback_dfb", node, entry_size, num_entries);
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    BindDFBToKernel(producer, "loopback_dfb", "my_local_dfb_name", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "loopback_dfb", "a_dfb_named_bob", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.workers =
+        std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"producer", "consumer"}, {"loopback_dfb"})};
+
+    // -------------------------------------------------------
+    // Create Program
+    // -------------------------------------------------------
+    Program program = MakeProgramFromSpec(spec);
+
+    // -------------------------------------------------------
+    // Set runtime args
+    // -------------------------------------------------------
+    ProgramRunParams params;
+    params.kernel_run_params = {
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "producer",
+            .runtime_args =
+                {{node,
+                  {
+                      input_buffer->address(),
+                      0u,  // bank_id (single-page buffer → bank 0)
+                      num_transfers,
+                  }}},
+        },
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "consumer",
+            .runtime_args =
+                {{node,
+                  {
+                      output_buffer->address(),
+                      0u,  // bank_id
+                      num_transfers,
+                  }}},
+        },
+    };
+    SetProgramRunParameters(program, params);
+
+    // -------------------------------------------------------
+    // Fill input buffer with known data
+    // -------------------------------------------------------
+    std::vector<uint32_t> input_data(total_bytes / sizeof(uint32_t));
+    for (size_t i = 0; i < input_data.size(); i++) {
+        input_data[i] = static_cast<uint32_t>(i);
+    }
+    detail::WriteToBuffer(input_buffer, input_data);
+
+    // -------------------------------------------------------
+    // Dispatch
+    // -------------------------------------------------------
+    detail::LaunchProgram(device, program);
+
+    // -------------------------------------------------------
+    // Verify
+    // -------------------------------------------------------
+    std::vector<uint32_t> output_data;
+    detail::ReadFromBuffer(output_buffer, output_data);
+
+    ASSERT_EQ(output_data.size(), input_data.size());
+    EXPECT_EQ(output_data, input_data);
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -23,6 +23,7 @@ set(UNIT_TESTS_API_SOURCES
     dataflow_buffer/test_dataflow_buffer_configs.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
     metal2_host_api/test_program_spec.cpp
+    metal2_host_api/test_program_spec_hw.cpp
     metal2_host_api/test_program_run_params.cpp
     tensor/test_tensor_sharding.cpp
     tensor/test_host_tensor.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel: DFB loopback consumer using DFB local accessor name.
+// Reads data entry-by-entry from a DFB bound via the dfb::a_dfb_named_bob accessor name
+// (from kernel_bindings_generated.h) and writes it to a single-page DRAM buffer.
+//
+// Runtime args:
+//   arg 0: destination DRAM address
+//   arg 1: DRAM bank ID
+//   arg 2: number of entries to transfer
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t bank_id = get_arg_val<uint32_t>(1);
+    uint32_t num_entries = get_arg_val<uint32_t>(2);
+
+    // Construct the DataflowBuffer using the named accessor from kernel_bindings_generated.h
+    experimental::DataflowBuffer buf(dfb::a_dfb_named_bob);
+    uint32_t entry_size = buf.get_entry_size();
+
+    for (uint32_t i = 0; i < num_entries; i++) {
+        buf.wait_front(1);
+        uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
+        noc_async_write(buf.get_read_ptr(), dst_noc_addr, entry_size);
+        noc_async_write_barrier();
+        buf.pop_front(1);
+        dst_addr += entry_size;
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel: DFB loopback producer using DFB local accessor name.
+// Reads data from a single-page DRAM buffer and pushes it entry-by-entry into a DFB
+// bound via the dfb::my_local_dfb_name accessor name (from kernel_bindings_generated.h).
+//
+// Runtime args:
+//   arg 0: source DRAM address
+//   arg 1: DRAM bank ID
+//   arg 2: number of entries to transfer
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t bank_id = get_arg_val<uint32_t>(1);
+    uint32_t num_entries = get_arg_val<uint32_t>(2);
+
+    // Construct the DataflowBuffer using the named accessor from kernel_bindings_generated.h
+    experimental::DataflowBuffer buf(dfb::my_local_dfb_name);
+    uint32_t entry_size = buf.get_entry_size();
+
+    for (uint32_t i = 0; i < num_entries; i++) {
+        buf.reserve_back(1);
+        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
+        noc_async_read(src_noc_addr, buf.get_write_ptr(), entry_size);
+        noc_async_read_barrier();
+        buf.push_back(1);
+        src_addr += entry_size;
+    }
+}

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -33,18 +33,17 @@ namespace experimental {
 //
 // The user's host code declares a local_accessor_name when binding a DFB endpoint to a kernel.
 // The user then uses that local_accessor_name to construct a DataflowBuffer in the kernel code.
-// Usage:
 //
-//   // Host code declares "my_dfb_name" as a the DFB local accessor name for this kernel.
+// Usage example:
+//   // (Host code declares "my_dfb_name" as a the DFB local accessor name for this kernel.)
 //   // In the kernel code:
-//   DataflowBuffer dfb(my_dfb_name);
+//   DataflowBuffer my_dfb(dfb::my_dfb_name);
 //
 // Here my_dfb_name is a constexpr DFBAccessor, auto-included in kernel_bindings_generated.h.
 //
 // Currently, DFBAccessor is backed by a compile-time ID, baked into the kernel binary.
-// If we later decide we need a dynamic mechanism instead, the implementation can switch to an
-// implicit RTA, changing only the generated header and the DFBAccessor struct's internals.
-// (Kernel source code stays unchanged.)
+// If we want to switch to using using an implicit CRTA mechanism, the implementation of
+// DFBAccessor can be transparently modified (kernel-side syntax stays unchanged).
 struct DFBAccessor {
     explicit constexpr DFBAccessor(uint16_t id) noexcept : id(id) {}
     uint16_t id;

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -35,14 +35,14 @@ namespace experimental {
 // The user then uses that local_accessor_name to construct a DataflowBuffer in the kernel code.
 //
 // Usage example:
-//   // (Host code declares "my_dfb_name" as a the DFB local accessor name for this kernel.)
+//   // (Host code declares "my_dfb_name" as the DFB local accessor name for this kernel.)
 //   // In the kernel code:
 //   DataflowBuffer my_dfb(dfb::my_dfb_name);
 //
 // Here my_dfb_name is a constexpr DFBAccessor, auto-included in kernel_bindings_generated.h.
 //
 // Currently, DFBAccessor is backed by a compile-time ID, baked into the kernel binary.
-// If we want to switch to using using an implicit CRTA mechanism, the implementation of
+// If we want to switch to using an implicit CRTA mechanism, the implementation of
 // DFBAccessor can be transparently modified (kernel-side syntax stays unchanged).
 struct DFBAccessor {
     explicit constexpr DFBAccessor(uint16_t id) noexcept : id(id) {}

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -28,6 +28,28 @@
 
 namespace experimental {
 
+// Opaque handle for a DataflowBuffer binding (declared in kernel_bindings_generated.h).
+// The user will never directly interact with this type.
+//
+// The user's host code declares a local_accessor_name when binding a DFB endpoint to a kernel.
+// The user then uses that local_accessor_name to construct a DataflowBuffer in the kernel code.
+// Usage:
+//
+//   // Host code declares "my_dfb_name" as a the DFB local accessor name for this kernel.
+//   // In the kernel code:
+//   DataflowBuffer dfb(my_dfb_name);
+//
+// Here my_dfb_name is a constexpr DFBAccessor, auto-included in kernel_bindings_generated.h.
+//
+// Currently, DFBAccessor is backed by a compile-time ID, baked into the kernel binary.
+// If we later decide we need a dynamic mechanism instead, the implementation can switch to an
+// implicit RTA, changing only the generated header and the DFBAccessor struct's internals.
+// (Kernel source code stays unchanged.)
+struct DFBAccessor {
+    explicit constexpr DFBAccessor(uint16_t id) noexcept : id(id) {}
+    uint16_t id;
+};
+
 class DataflowBuffer {
 public:
 #ifdef ARCH_QUASAR
@@ -36,6 +58,12 @@ public:
     using DFBInterface = LocalCBInterface;
 #endif
 
+    // Preferred constructor for Metal 2.0 / ProgramSpec kernels.
+    // Pass the named binding constant from kernel_bindings_generated.h:
+    //   DataflowBuffer dfb(my_dfb_name);
+    DataflowBuffer(DFBAccessor accessor) : DataflowBuffer(accessor.id) {}
+
+    // Low-level constructor: prefer DFBAccessor overload above for new kernel code.
     DataflowBuffer(uint16_t logical_dfb_id);
 
     uint16_t get_id() const { return logical_dfb_id_; }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -104,13 +104,15 @@ Kernel::Kernel(
     const CoreRangeSet& core_range_set,
     const std::vector<uint32_t>& compile_args,
     const std::map<std::string, std::string>& defines,
-    const std::unordered_map<std::string, uint32_t>& named_compile_args) :
+    const std::unordered_map<std::string, uint32_t>& named_compile_args,
+    const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles) :
     programmable_core_type_(programmable_core_type),
     processor_class_(processor_class),
     kernel_src_(kernel_src),
     core_range_set_(core_range_set),
     compile_time_args_(compile_args),
     named_compile_time_args_(named_compile_args),
+    dataflow_buffer_local_accessor_handles_(dataflow_buffer_local_accessor_handles),
 
     core_with_max_runtime_args_({0, 0}),
     defines_(defines),
@@ -267,6 +269,13 @@ void Kernel::process_compile_time_args(const std::function<void(const std::vecto
 void Kernel::process_named_compile_time_args(
     const std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)> callback) const {
     callback(this->named_compile_time_args());
+}
+
+void Kernel::process_dataflow_buffer_local_accessor_handles(
+    const std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)> callback) const {
+    for (const auto& [accessor_name, logical_dfb_id] : this->dataflow_buffer_local_accessor_handles_) {
+        callback(accessor_name, logical_dfb_id);
+    }
 }
 
 void Kernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -278,10 +278,6 @@ void Kernel::process_dataflow_buffer_local_accessor_handles(
     }
 }
 
-void Kernel::set_dataflow_buffer_local_accessor_handles(const DataflowBufferLocalAccessorHandleMap& handles) {
-    this->dataflow_buffer_local_accessor_handles_ = handles;
-}
-
 void Kernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
     // For FILE_PATH kernels, add the kernel source directory to the include path.
     // This enables relative includes (e.g., #include "foo.inc") to work when the kernel

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -436,6 +436,10 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(it->first);
         hasher.update(static_cast<uint64_t>(it->second));
     }
+    for (const auto& it : sorted_iters(this->dataflow_buffer_local_accessor_handles_)) {
+        hasher.update(it->first);
+        hasher.update(static_cast<uint64_t>(it->second));
+    }
     hasher.update(this->kernel_src_.source_);
     hasher.update(this->compile_time_args_.begin(), this->compile_time_args_.end());
     hasher.update(this->config_hash());

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -278,6 +278,10 @@ void Kernel::process_dataflow_buffer_local_accessor_handles(
     }
 }
 
+void Kernel::set_dataflow_buffer_local_accessor_handles(const DataflowBufferLocalAccessorHandleMap& handles) {
+    this->dataflow_buffer_local_accessor_handles_ = handles;
+}
+
 void Kernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
     // For FILE_PATH kernels, add the kernel source directory to the include path.
     // This enables relative includes (e.g., #include "foo.inc") to work when the kernel

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -5,7 +5,9 @@
 #pragma once
 
 #include <umd/device/types/core_coordinates.hpp>
+#include <cstdint>
 #include <string>
+#include <unordered_map>
 
 #include "api/tt-metalium/kernel_types.hpp"
 #include "api/tt-metalium/runtime_args_data.hpp"
@@ -82,6 +84,10 @@ KernelHandle CreateKernelFromString(
     const std::string& kernel_src_code,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const DramConfig& config);
+
+// Metal 2.0: local DFB accessor names -> logical DFB ids
+using DataflowBufferLocalAccessorHandleMap = std::unordered_map<std::string, uint16_t>;
+
 class Kernel : public JitBuildSettings {
 public:
     using Config = std::variant<
@@ -138,6 +144,8 @@ public:
     void process_compile_time_args(std::function<void(const std::vector<uint32_t>& values)>) const override;
     void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const override;
+    void process_dataflow_buffer_local_accessor_handles(
+        std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const override;
     void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     void validate_runtime_args_size(
@@ -188,7 +196,8 @@ protected:
         const CoreRangeSet& core_range_set,
         const std::vector<uint32_t>& compile_args,
         const std::map<std::string, std::string>& defines,
-        const std::unordered_map<std::string, uint32_t>& named_compile_args);
+        const std::unordered_map<std::string, uint32_t>& named_compile_args,
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {});
 
     HalProgrammableCoreType programmable_core_type_;
     HalProcessorClassType processor_class_;
@@ -199,6 +208,8 @@ protected:
     CoreRangeSet core_range_set_;
     std::vector<uint32_t> compile_time_args_;
     std::unordered_map<std::string, uint32_t> named_compile_time_args_;
+    // Populated only from Kernel ctor; must not be modified afterward (JIT may read concurrently).
+    const DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_{0};
@@ -414,7 +425,8 @@ public:
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const QuasarDataMovementConfig& config,
-        const std::set<DataMovementProcessor>& dm_processors) :
+        const std::set<DataMovementProcessor>& dm_processors,
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {}) :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::DM,
@@ -422,7 +434,8 @@ public:
             cr_set,
             config.compile_args,
             config.defines,
-            config.named_compile_args),
+            config.named_compile_args,
+            dataflow_buffer_local_accessor_handles),
         config_(config),
         dm_processors_(dm_processors.begin(), dm_processors.end()) {
         TT_FATAL(
@@ -470,7 +483,8 @@ public:
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const QuasarComputeConfig& config,
-        const std::set<QuasarComputeProcessor>& compute_processors) :
+        const std::set<QuasarComputeProcessor>& compute_processors,
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {}) :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::COMPUTE,
@@ -478,7 +492,8 @@ public:
             cr_set,
             config.compile_args,
             config.defines,
-            config.named_compile_args),
+            config.named_compile_args,
+            dataflow_buffer_local_accessor_handles),
         config_(config),
         compute_processors_(compute_processors.begin(), compute_processors.end()) {
         TT_FATAL(

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -148,6 +148,10 @@ public:
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const override;
     void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
+    // Metal 2.0: set DFB local accessor handles after construction.
+    // Must be called before JIT compilation.
+    void set_dataflow_buffer_local_accessor_handles(const DataflowBufferLocalAccessorHandleMap& handles);
+
     void validate_runtime_args_size(
         size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) const;
     void set_runtime_args(const CoreCoord& logical_core, stl::Span<const uint32_t> runtime_args);
@@ -208,8 +212,9 @@ protected:
     CoreRangeSet core_range_set_;
     std::vector<uint32_t> compile_time_args_;
     std::unordered_map<std::string, uint32_t> named_compile_time_args_;
-    // Populated only from Kernel ctor; must not be modified afterward (JIT may read concurrently).
-    const DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
+    // Populated at construction time, or via set_dataflow_buffer_local_accessor_handles() (Metal 2.0 path).
+    // Must not be modified after JIT compilation begins (JIT may read concurrently).
+    DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_{0};

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -148,11 +148,6 @@ public:
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const override;
     void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
-    // Metal 2.0: set DFB local accessor handles after construction.
-    // (Setting it up at construction time is better, but it's done this way for WH/BH to keep from leaking
-    // anything about "DFB handles" into the legacy public APIs for kernel creation.)
-    void set_dataflow_buffer_local_accessor_handles(const DataflowBufferLocalAccessorHandleMap& handles);
-
     void validate_runtime_args_size(
         size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) const;
     void set_runtime_args(const CoreCoord& logical_core, stl::Span<const uint32_t> runtime_args);
@@ -213,9 +208,7 @@ protected:
     CoreRangeSet core_range_set_;
     std::vector<uint32_t> compile_time_args_;
     std::unordered_map<std::string, uint32_t> named_compile_time_args_;
-    // Populated at construction time, or via set_dataflow_buffer_local_accessor_handles().
-    // Must not be modified after JIT compilation begins (JIT may read concurrently).
-    DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
+    const DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_{0};
@@ -243,7 +236,11 @@ private:
 
 class DataMovementKernel : public Kernel {
 public:
-    DataMovementKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const DataMovementConfig& config) :
+    DataMovementKernel(
+        const KernelSource& kernel_src,
+        const CoreRangeSet& cr_set,
+        const DataMovementConfig& config,
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {}) :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::DM,
@@ -251,7 +248,8 @@ public:
             cr_set,
             config.compile_args,
             config.defines,
-            config.named_compile_args),
+            config.named_compile_args,
+            dataflow_buffer_local_accessor_handles),
         config_(config) {
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
@@ -361,7 +359,11 @@ private:
 
 class ComputeKernel : public Kernel {
 public:
-    ComputeKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const ComputeConfig& config) :
+    ComputeKernel(
+        const KernelSource& kernel_src,
+        const CoreRangeSet& cr_set,
+        const ComputeConfig& config,
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {}) :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::COMPUTE,
@@ -369,7 +371,8 @@ public:
             cr_set,
             config.compile_args,
             config.defines,
-            config.named_compile_args),
+            config.named_compile_args,
+            dataflow_buffer_local_accessor_handles),
         config_(config) {
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -149,7 +149,8 @@ public:
     void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     // Metal 2.0: set DFB local accessor handles after construction.
-    // Must be called before JIT compilation.
+    // (Setting it up at construction time is better, but it's done this way for WH/BH to keep from leaking
+    // anything about "DFB handles" into the legacy public APIs for kernel creation.)
     void set_dataflow_buffer_local_accessor_handles(const DataflowBufferLocalAccessorHandleMap& handles);
 
     void validate_runtime_args_size(
@@ -212,7 +213,7 @@ protected:
     CoreRangeSet core_range_set_;
     std::vector<uint32_t> compile_time_args_;
     std::unordered_map<std::string, uint32_t> named_compile_time_args_;
-    // Populated at construction time, or via set_dataflow_buffer_local_accessor_handles() (Metal 2.0 path).
+    // Populated at construction time, or via set_dataflow_buffer_local_accessor_handles().
     // Must not be modified after JIT compilation begins (JIT may read concurrently).
     DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -173,9 +173,8 @@ void accumulate_nodes(
     }
 }
 
-// TODO -- figure out if there's a nicer spot for this in program_spec.cpp
-// This is nice, but we don't really do it for CTAs or defines...
-// I guess it's more necessary though?
+// Local accessor names for kernel resource bindings must be valid C++ identifiers
+// They are used verbatim in the generated kernel source code.
 bool IsValidCppIdentifier(std::string_view s) {
     if (s.empty()) {
         return false;
@@ -1068,7 +1067,6 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
 // ============================================================================
 
 // Create map of local accessor name -> logical DFB id
-// TODO: Should probably get rid of the need for uint16_t cast in a future refactor
 tt::tt_metal::DataflowBufferLocalAccessorHandleMap MakeDataflowBufferLocalAccessorHandles(
     const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
     tt::tt_metal::DataflowBufferLocalAccessorHandleMap out;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1411,6 +1411,10 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
                 auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_id);
                 kernel = std::make_shared<ComputeKernel>(kernel_src, node_ranges, config);
             }
+            // Set DFB local accessor handles after construction (gen1 constructors don't take them)
+            if (!dfb_handles.empty()) {
+                kernel->set_dataflow_buffer_local_accessor_handles(dfb_handles);
+            }
         }
 
         // Add the kernel to the ProgramImpl and register the name -> handle mapping

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1375,14 +1375,10 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
         } else {  // gen1
             if (kernel_spec.is_dm_kernel()) {
                 auto config = MakeGen1DataMovementConfig(kernel_spec);
-                kernel = std::make_shared<DataMovementKernel>(kernel_src, node_ranges, config);
+                kernel = std::make_shared<DataMovementKernel>(kernel_src, node_ranges, config, dfb_handles);
             } else {
                 auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_id);
-                kernel = std::make_shared<ComputeKernel>(kernel_src, node_ranges, config);
-            }
-            // Set DFB local accessor handles after construction (gen1 constructors don't take them)
-            if (!dfb_handles.empty()) {
-                kernel->set_dataflow_buffer_local_accessor_handles(dfb_handles);
+                kernel = std::make_shared<ComputeKernel>(kernel_src, node_ranges, config, dfb_handles);
             }
         }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <set>
 #include <string_view>
+#include <unordered_set>
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
@@ -175,10 +176,12 @@ void accumulate_nodes(
 
 // Local accessor names for kernel resource bindings must be valid C++ identifiers
 // They are used verbatim in the generated kernel source code.
+// TODO: Move this to ttsl in a follow up PR
 bool IsValidCppIdentifier(std::string_view s) {
     if (s.empty()) {
         return false;
     }
+    // Reject names with non-identifier characters or an empty/leading-digit form.
     const unsigned char c0 = static_cast<unsigned char>(s[0]);
     if (!((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z') || c0 == '_')) {
         return false;
@@ -189,6 +192,38 @@ bool IsValidCppIdentifier(std::string_view s) {
             return false;
         }
     }
+
+    // Reject reserved identifier patterns per [lex.name]/3.
+    // Names containing "__", or starting with "_" followed by an uppercase letter.
+    if (s.size() >= 2 && s[0] == '_' && s[1] >= 'A' && s[1] <= 'Z') {
+        return false;
+    }
+    if (s.find("__") != std::string_view::npos) {
+        return false;
+    }
+
+    // Reject C++ keywords. Anything in this set would produce uncompilable code
+    // when emitted as a variable identifier in kernel_bindings_generated.h.
+    static const std::unordered_set<std::string_view> kCppKeywords = {
+        "alignas",     "alignof",   "and",        "and_eq",    "asm",      "auto",         "bitand",
+        "bitor",       "bool",      "break",      "case",      "catch",    "char",         "char8_t",
+        "char16_t",    "char32_t",  "class",      "compl",     "concept",  "const",        "consteval",
+        "constexpr",   "constinit", "const_cast", "continue",  "co_await", "co_return",    "co_yield",
+        "decltype",    "default",   "delete",     "do",        "double",   "dynamic_cast", "else",
+        "enum",        "explicit",  "export",     "extern",    "false",    "float",        "for",
+        "friend",      "goto",      "if",         "inline",    "int",      "long",         "mutable",
+        "namespace",   "new",       "noexcept",   "not",       "not_eq",   "nullptr",      "operator",
+        "or",          "or_eq",     "private",    "protected", "public",   "register",     "reinterpret_cast",
+        "requires",    "return",    "short",      "signed",    "sizeof",   "static",       "static_assert",
+        "static_cast", "struct",    "switch",     "template",  "this",     "thread_local", "throw",
+        "true",        "try",       "typedef",    "typeid",    "typename", "union",        "unsigned",
+        "using",       "virtual",   "void",       "volatile",  "wchar_t",  "while",        "xor",
+        "xor_eq",
+    };
+    if (kCppKeywords.contains(s)) {
+        return false;
+    }
+
     return true;
 }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1134,33 +1134,10 @@ KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
 }
 
 // ----------------------------------------------------------------------------
-// InjectDFBAccessorArgs: inject DFB local accessor name -> ID into named_compile_args
-// ----------------------------------------------------------------------------
-//
-// TODO: This is a TEMPORARY solution to pass DFB accessor names to the kernel!
-//       This CTA hack will be deleted in the next PR.
-
-void InjectDFBAccessorArgs(
-    KernelSpec::CompileTimeArgBindings& named_compile_args,
-    const KernelSpec& kernel_spec,
-    const DFBNameToIdMap& dfb_name_to_id) {
-    for (const auto& dfb_binding : kernel_spec.dfb_bindings) {
-        uint32_t dfb_id = dfb_name_to_id.at(dfb_binding.dfb_spec_name);
-        const auto& local_dfb_name = dfb_binding.local_accessor_name;
-        TT_FATAL(
-            !named_compile_args.contains(local_dfb_name),
-            "DFB local accessor name '{}' collides with an existing CTA in kernel '{}'. ",
-            local_dfb_name,
-            kernel_spec.unique_id);
-        named_compile_args[local_dfb_name] = dfb_id;
-    }
-}
-
-// ----------------------------------------------------------------------------
 // MakeGen1DataMovementConfig: Create a DataMovementConfig (WH/BH) from a KernelSpec
 // ----------------------------------------------------------------------------
 
-DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
+DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
     TT_FATAL(kernel_spec.is_dm_kernel(), "Expected a DM kernel");
     const auto& dm_config = std::get<DataMovementConfiguration>(kernel_spec.config_spec);
     const auto& gen1 = dm_config.gen1_data_movement_config.value();
@@ -1173,17 +1150,13 @@ DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec, con
         defines_map[key] = value;
     }
 
-    // Temporary hack: inject DFB local accessors as CTAs
-    auto named_compile_args = kernel_spec.compile_time_arg_bindings;
-    InjectDFBAccessorArgs(named_compile_args, kernel_spec, dfb_name_to_id);
-
     return DataMovementConfig{
         .processor = gen1.processor,
         .noc = gen1.noc,
         .noc_mode = gen1.noc_mode,
         .compile_args = {},  // only named_compile_args is used
         .defines = defines_map,
-        .named_compile_args = named_compile_args,
+        .named_compile_args = kernel_spec.compile_time_arg_bindings,
         .opt_level = kernel_spec.compiler_options.opt_level,
     };
 }
@@ -1210,10 +1183,6 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
         defines_map[key] = value;
     }
 
-    // Temporary hack: inject DFB local accessors as CTAs
-    auto named_compile_args = kernel_spec.compile_time_arg_bindings;
-    InjectDFBAccessorArgs(named_compile_args, kernel_spec, dfb_name_to_id);
-
     return ComputeConfig{
         .math_fidelity = compute_config.math_fidelity,
         .fp32_dest_acc_en = compute_config.fp32_dest_acc_en,
@@ -1223,7 +1192,7 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
         .math_approx_mode = compute_config.math_approx_mode,
         .compile_args = {},  // only named_compile_args is used
         .defines = defines_map,
-        .named_compile_args = named_compile_args,
+        .named_compile_args = kernel_spec.compile_time_arg_bindings,
         .opt_level = kernel_spec.compiler_options.opt_level,
     };
 }
@@ -1405,7 +1374,7 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
             }
         } else {  // gen1
             if (kernel_spec.is_dm_kernel()) {
-                auto config = MakeGen1DataMovementConfig(kernel_spec, dfb_name_to_id);
+                auto config = MakeGen1DataMovementConfig(kernel_spec);
                 kernel = std::make_shared<DataMovementKernel>(kernel_src, node_ranges, config);
             } else {
                 auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_id);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -220,11 +220,9 @@ bool IsValidCppIdentifier(std::string_view s) {
         "using",       "virtual",   "void",       "volatile",  "wchar_t",  "while",        "xor",
         "xor_eq",
     };
-    if (kCppKeywords.contains(s)) {
-        return false;
-    }
 
-    return true;
+    // If we got this far, and the name doesn't match any keywords, it's valid.
+    return !kCppKeywords.contains(s);
 }
 
 // ============================================================================

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -4,7 +4,9 @@
 
 #include <bit>
 #include <functional>
+#include <limits>
 #include <set>
+#include <string_view>
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
@@ -171,6 +173,26 @@ void accumulate_nodes(
     }
 }
 
+// TODO -- figure out if there's a nicer spot for this in program_spec.cpp
+// This is nice, but we don't really do it for CTAs or defines...
+// I guess it's more necessary though?
+bool IsValidCppIdentifier(std::string_view s) {
+    if (s.empty()) {
+        return false;
+    }
+    const unsigned char c0 = static_cast<unsigned char>(s[0]);
+    if (!((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z') || c0 == '_')) {
+        return false;
+    }
+    for (size_t i = 1; i < s.size(); ++i) {
+        const unsigned char c = static_cast<unsigned char>(s[i]);
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_')) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // ============================================================================
 // Step 1: Spec Collection & Validation
 // ============================================================================
@@ -213,6 +235,11 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
             TT_FATAL(
                 inserted,
                 "Kernel '{}' has duplicate local_accessor_name '{}'",
+                kernel.unique_id,
+                dfb_binding.local_accessor_name);
+            TT_FATAL(
+                IsValidCppIdentifier(dfb_binding.local_accessor_name),
+                "Kernel '{}' DFB local_accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 dfb_binding.local_accessor_name);
 
@@ -1040,6 +1067,25 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
 // Step 3: Program Building Helpers
 // ============================================================================
 
+// Create map of local accessor name -> logical DFB id
+// TODO: Should probably get rid of the need for uint16_t cast in a future refactor
+tt::tt_metal::DataflowBufferLocalAccessorHandleMap MakeDataflowBufferLocalAccessorHandles(
+    const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
+    tt::tt_metal::DataflowBufferLocalAccessorHandleMap out;
+    out.reserve(kernel_spec.dfb_bindings.size());
+    for (const auto& dfb_binding : kernel_spec.dfb_bindings) {
+        const uint32_t id = dfb_name_to_id.at(dfb_binding.dfb_spec_name);
+        TT_FATAL(
+            id <= std::numeric_limits<uint16_t>::max(),
+            "Kernel '{}' DFB '{}' logical id {} does not fit uint16_t",
+            kernel_spec.unique_id,
+            dfb_binding.dfb_spec_name,
+            id);
+        out.emplace(dfb_binding.local_accessor_name, static_cast<uint16_t>(id));
+    }
+    return out;
+}
+
 // Create a DataflowBufferConfig from a DataflowBufferSpec and endpoint info.
 experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     const DataflowBufferSpec* dfb_spec,
@@ -1188,8 +1234,7 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
 // MakeQuasarDataMovementConfig: Create a QuasarDataMovementConfig from a KernelSpec
 // ----------------------------------------------------------------------------
 
-experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(
-    const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
+experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(const KernelSpec& kernel_spec) {
     TT_FATAL(kernel_spec.is_dm_kernel(), "Expected a DM kernel");
 
     // Convert defines from vector<pair> to map (yuck)
@@ -1198,15 +1243,11 @@ experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(
         defines_map[key] = value;
     }
 
-    // Temporary hack: inject DFB local accessors as CTAs
-    auto named_compile_args = kernel_spec.compile_time_arg_bindings;
-    InjectDFBAccessorArgs(named_compile_args, kernel_spec, dfb_name_to_id);
-
     return experimental::quasar::QuasarDataMovementConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
         .compile_args = {},  // only named_compile_args is used
         .defines = defines_map,
-        .named_compile_args = named_compile_args,
+        .named_compile_args = kernel_spec.compile_time_arg_bindings,
         .is_legacy_kernel = false,
         .opt_level = kernel_spec.compiler_options.opt_level,
     };
@@ -1241,9 +1282,6 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         defines_map[key] = value;
     }
 
-    auto named_compile_args = kernel_spec.compile_time_arg_bindings;
-    InjectDFBAccessorArgs(named_compile_args, kernel_spec, dfb_name_to_id);
-
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
         .math_fidelity = compute_config.math_fidelity,
@@ -1254,7 +1292,7 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         .math_approx_mode = compute_config.math_approx_mode,
         .compile_args = {},  // Compile args are passed via named_compile_args
         .defines = defines_map,
-        .named_compile_args = named_compile_args,
+        .named_compile_args = kernel_spec.compile_time_arg_bindings,
         .opt_level = kernel_spec.compiler_options.opt_level,
     };
 }
@@ -1347,20 +1385,25 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
         KernelSource kernel_src = MakeKernelSource(kernel_spec);
         NodeRangeSet node_ranges = to_node_range_set(kernel_spec.target_nodes);
 
+        // Make the local accessor name -> DFB ID map for this kernel
+        const tt::tt_metal::DataflowBufferLocalAccessorHandleMap dfb_handles =
+            MakeDataflowBufferLocalAccessorHandles(kernel_spec, dfb_name_to_id);
+
+        // Create the kernel object
         std::shared_ptr<Kernel> kernel;
 
         if (is_gen2_arch()) {
             uint16_t risc_mask = kernel_to_risc_mask.at(&kernel_spec);
             if (kernel_spec.is_dm_kernel()) {
-                auto config = MakeQuasarDataMovementConfig(kernel_spec, dfb_name_to_id);
+                auto config = MakeQuasarDataMovementConfig(kernel_spec);
                 auto processors = GetDMProcessorSet(DMProcessorMask{(uint8_t)(risc_mask & 0xFF)});
                 kernel = std::make_shared<experimental::quasar::QuasarDataMovementKernel>(
-                    kernel_src, node_ranges, config, processors);
+                    kernel_src, node_ranges, config, processors, dfb_handles);
             } else {
                 auto config = MakeQuasarComputeConfig(kernel_spec, dfb_name_to_id);
                 auto processors = GetComputeProcessorSet(ComputeEngineMask{(uint8_t)(risc_mask >> 8)});
                 kernel = std::make_shared<experimental::quasar::QuasarComputeKernel>(
-                    kernel_src, node_ranges, config, processors);
+                    kernel_src, node_ranges, config, processors, dfb_handles);
             }
         } else {  // gen1
             if (kernel_spec.is_dm_kernel()) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -98,10 +98,12 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     if (entries.empty()) {
         content << "// No bindings for this kernel.\n";
     } else {
-        content << "#include \"experimental/dataflow_buffer.h\"\n\n";
+        content << "#include \"experimental/dataflow_buffer.h\"\n\n"
+                   "namespace dfb {\n";
         for (const auto& [name, id] : entries) {
             content << "constexpr experimental::DFBAccessor " << name << "{" << id << "};\n";
         }
+        content << "}  // namespace dfb\n";
     }
     write_file(path, content.str());
 }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <ostream>
 #include <fstream>
+#include <sstream>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -35,7 +36,7 @@
 #include "jit_build_options.hpp"
 #include "jit_build_settings.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include "impl/kernels/kernel.hpp"
+#include "impl/kernels/kernel_source.hpp"
 
 namespace tt::tt_metal {
 enum class UnpackToDestMode : uint8_t;
@@ -59,10 +60,11 @@ string get_kernel_source_to_include(const KernelSource& kernel_src) {
     ttsl::unreachable();
 }
 
-// Generates TRISC prolog: #define + #include for defines_generated.h
+// Generates TRISC prolog: #define + includes for JIT-generated headers and defines_generated.h
 string build_trisc_prolog(const char* trisc_define) {
     ostringstream prolog;
     prolog << "#define " << trisc_define << "\n";
+    prolog << "#include \"kernel_bindings_generated.h\"\n";
     prolog << "#include \"defines_generated.h\"\n";
     return prolog.str();
 }
@@ -80,6 +82,30 @@ void write_file(const string& path, const string& content) {
     }
 }
 
+void write_kernel_bindings_generated_header(const string& out_dir, const JitBuildSettings& settings) {
+    const string path = out_dir + "kernel_bindings_generated.h";
+    vector<pair<string, uint16_t>> entries;
+    settings.process_dataflow_buffer_local_accessor_handles(
+        [&entries](const string& name, uint16_t id) { entries.emplace_back(name, id); });
+    sort(entries.begin(), entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    ostringstream content;
+    content << "// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.\n"
+               "//\n"
+               "// SPDX-License-Identifier: Apache-2.0\n\n"
+               "// AUTO-GENERATED — do not edit.\n\n"
+               "#pragma once\n\n"
+               "#include <cstdint>\n\n";
+    if (entries.empty()) {
+        content << "// No bindings for this kernel.\n";
+    } else {
+        for (const auto& [name, id] : entries) {
+            content << "constexpr uint16_t " << name << " = " << id << ";\n";
+        }
+    }
+    write_file(path, content.str());
+}
+
 }  // namespace
 
 void jit_build_genfiles_kernel_include(
@@ -88,10 +114,12 @@ void jit_build_genfiles_kernel_include(
     log_trace(tt::LogBuildKernels, "Generating defines for BRISC/NCRISC/ERISC user kernel");
 
     string out_dir = env.get_out_kernel_root_path() + settings.get_full_kernel_name() + "/";
+    write_kernel_bindings_generated_header(out_dir, settings);
     string kernel_header = out_dir + "kernel_includes.hpp";
 
     const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src);
-    write_file(kernel_header, kernel_src_to_include);
+    const string kernel_header_content = string("#include \"kernel_bindings_generated.h\"\n") + kernel_src_to_include;
+    write_file(kernel_header, kernel_header_content);
 }
 
 void jit_build_genfiles_triscs_src(
@@ -100,6 +128,7 @@ void jit_build_genfiles_triscs_src(
     log_trace(tt::LogBuildKernels, "Generating defines for TRISCs");
 
     const string out_dir = env.get_out_kernel_root_path() + settings.get_full_kernel_name() + "/";
+    write_kernel_bindings_generated_header(out_dir, settings);
     const string unpack_cpp = out_dir + "chlkc_unpack.cpp";
     const string math_cpp = out_dir + "chlkc_math.cpp";
     const string pack_cpp = out_dir + "chlkc_pack.cpp";

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -94,13 +94,13 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
                "//\n"
                "// SPDX-License-Identifier: Apache-2.0\n\n"
                "// AUTO-GENERATED — do not edit.\n\n"
-               "#pragma once\n\n"
-               "#include <cstdint>\n\n";
+               "#pragma once\n\n";
     if (entries.empty()) {
         content << "// No bindings for this kernel.\n";
     } else {
+        content << "#include \"experimental/dataflow_buffer.h\"\n\n";
         for (const auto& [name, id] : entries) {
-            content << "constexpr uint16_t " << name << " = " << id << ";\n";
+            content << "constexpr experimental::DFBAccessor " << name << "{" << id << "};\n";
         }
     }
     write_file(path, content.str());

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <string_view>
-#include <functional>
 #include <unordered_map>
 
 namespace tt::tt_metal {
@@ -31,6 +31,11 @@ public:
     // Called to process the user named compile time args
     virtual void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const = 0;
+    // DataflowBuffer local accessor name -> logical DFB id (device JIT header generation). Immutable after Kernel
+    // construction; empty when the kernel has no ProgramSpec DFB bindings.
+    virtual void process_dataflow_buffer_local_accessor_handles(
+        std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const {}
+
     // Called to process additional include paths (e.g., kernel source directory for relative includes)
     virtual void process_include_paths(const std::function<void(const std::string& path)>&) const {}
 

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -31,8 +31,8 @@ public:
     // Called to process the user named compile time args
     virtual void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const = 0;
-    // DataflowBuffer local accessor name -> logical DFB id (device JIT header generation). Immutable after Kernel
-    // construction; empty when the kernel has no ProgramSpec DFB bindings.
+    // Called to process the user kernel resource bindings (Metal 2.0 APIs)
+    // (Initially just DFB local accessor bindings, but will be extended.)
     virtual void process_dataflow_buffer_local_accessor_handles(
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const {}
 

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -32,7 +32,7 @@ public:
     virtual void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const = 0;
     // Called to process the user kernel resource bindings (Metal 2.0 APIs)
-    // (Initially just DFB local accessor bindings, but will be extended.)
+    // (Initially just DFB local accessor names, but will be extended and refactored as needed.)
     virtual void process_dataflow_buffer_local_accessor_handles(
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const {}
 


### PR DESCRIPTION
### Ticket
<TODO>

### PR Type
New feature

### Problem description
In "Metal 2.0" host APIs, the user must bind a DFB's endpoints to its producer and consumer kernels. When declaring the DFB-kernel binding, the user declares a "local accessor name" by which the kernel will refer to the DFB. We need to implement that mechanism.

e.g.

```C++
// Host code:
KernelSpec producer{
    .unique_id = "producer",
    .source    = "kernels/my_producer.cpp",
    .target_nodes = NodeCoord{0, 0},
    .dfb_bindings = {
        KernelSpec::DFBBinding{
            .dfb_spec_name       = "pipe",       // identifies the DFB within the ProgramSpec
            .local_accessor_name = "my_out_buf", // name that appears in kernel source
            .endpoint_type       = KernelSpec::DFBEndpointType::PRODUCER,
            .access_pattern      = DFBAccessPattern::STRIDED,
        },
    },
    .config_spec = DataMovementConfiguration{},
};
```
```
// Kernel code (my_producer.cpp)
#include "experimental/dataflow_buffer.h"
void kernel_main() {
    experimental::DataflowBuffer my_dfb(dfb::my_out_buf);

    ...
}
```

### What's changed
 - Modified the kernel build to add a new header file to all generated kernels: `kernel_bindings_generated.h`.   
 - Plumbed the (DFB local accessor name --> DFB ID) map through to the JIT build
 - Added the `DFBAccessor` opaque type to `dataflow_buffer.h`
 - Added a new DFB ctor that takes a `DFBAccessor` argument
 - Updated the kernel cache to understand DFB handles (DFBAccessor is currently baked into the kernel binary, though I expect we'll change that eventually.)
 - Removed the temporary hack that injected DFB IDs into named compile-time args. 
 - Add a (HW) test


### TODOs
 - My test uses slow dispatch. It passes locally, but is default skipped in CI. I'll fix this when I add direct `MeshWorkload` support to Metal 2.0 host APIs. (i.e. within a few days.)
 - `IsValidCppIdentifier` belongs in `ttsl`. I'll move it in a separate PR. (It'll be tricky to get that reviewed; I'm an owner and another is on vacation.)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/dfb_local_accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/dfb_local_accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/dfb_local_accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/dfb_local_accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/dfb_local_accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/dfb_local_accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/dfb_local_accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/dfb_local_accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/dfb_local_accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/dfb_local_accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/dfb_local_accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/dfb_local_accessor)