### PR TITLE
Move profiler per-device program ID encoding from dispatch to read time

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -316,20 +316,9 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         auto& trace_node = trace_nodes_.back();
         bool use_prefetcher_cache = mesh_workload.impl().max_program_kernels_sizeB_ <= this->prefetcher_cache_sizeB_;
         for (auto& [device_range, program] : mesh_workload.get_programs()) {
-#if defined(TRACY_ENABLE)
-            // With tracy enabled, each device has a different program runtime ID in the launch message, so we need to
-            // handle each device separately rather than grouping them.
-            for (const auto& coord : device_range) {
-                trace_node.trace_nodes.push_back(std::pair<MeshCoordinateRange, TraceNode>(
-                    coord,
-                    program_dispatch::create_trace_node(
-                        program.impl(), mesh_device_, num_workers, use_prefetcher_cache)));
-            }
-#else
             trace_node.trace_nodes.push_back(std::pair<MeshCoordinateRange, TraceNode>(
                 device_range,
                 program_dispatch::create_trace_node(program.impl(), mesh_device_, num_workers, use_prefetcher_cache)));
-#endif
         }
         trace_node.multicast_go_signals = mcast_go_signals;
         trace_node.unicast_go_signals = unicast_go_signals;
@@ -416,8 +405,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             program_cmd_seq,
             dispatch_metadata.stall_first,
             dispatch_metadata.stall_before_program,
-            chip_ids_in_workload,
-            program.get_runtime_id());
+            chip_ids_in_workload);
     }
     // Send go signals to devices not running a program to ensure consistent global state
     this->write_go_signal_to_unused_sub_grids(
@@ -979,15 +967,13 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     ProgramCommandSequence& program_cmd_seq,
     bool stall_first,
     bool stall_before_program,
-    std::unordered_set<uint32_t>& chip_ids_in_workload,
-    uint32_t program_runtime_id) {
+    std::unordered_set<uint32_t>& chip_ids_in_workload) {
     auto dispatch_core_config = MetalContext::instance(mesh_device_->impl().get_context_id())
                                     .get_dispatch_core_manager()
                                     .get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
-        this->update_launch_messages_for_device_profiler(program_cmd_seq, program_runtime_id, device);
         program_dispatch::write_program_command_sequence(
             program_cmd_seq, device->sysmem_manager(), id_, dispatch_core_type, stall_first, stall_before_program);
         chip_ids_in_workload.insert(device->id());
@@ -1350,15 +1336,6 @@ void FDMeshCommandQueue::record_end() {
                 sub_device_id,
                 ProgramBinaryStatus::Committed,
                 std::pair<bool, int>(mesh_node.unicast_go_signals, num_virtual_eth_cores));
-#if defined(TRACY_ENABLE)
-            for (auto& [is_multicast, original_launch_msg, launch_msg] :
-                 cached_program_command_sequence.launch_messages) {
-                auto* device = mesh_device_->get_device(range.start_coord());
-                TT_ASSERT(range.start_coord() == range.end_coord());
-                launch_msg.kernel_config().host_assigned_id() =
-                    tt_metal::detail::EncodePerDeviceProgramID(node.program_runtime_id, device->id());
-            }
-#endif
 
             // Issue dispatch commands for this program
             program_dispatch::write_program_command_sequence(
@@ -1435,18 +1412,6 @@ void FDMeshCommandQueue::record_end() {
 SystemMemoryManager& FDMeshCommandQueue::reference_sysmem_manager() {
     auto local_devices = mesh_device_->get_devices();
     return local_devices.at(0)->sysmem_manager();
-}
-
-void FDMeshCommandQueue::update_launch_messages_for_device_profiler(
-    ProgramCommandSequence& program_cmd_seq, uint32_t program_runtime_id, IDevice* device) {
-    if (tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
-            .rtoptions()
-            .get_profiler_enabled()) {
-        for (auto& [is_multicast, original_launch_msg, launch_msg] : program_cmd_seq.launch_messages) {
-            launch_msg.kernel_config().host_assigned_id() =
-                tt_metal::detail::EncodePerDeviceProgramID(program_runtime_id, device->id());
-        }
-    }
 }
 
 std::pair<bool, size_t> FDMeshCommandQueue::query_prefetcher_cache(uint64_t workload_id, uint32_t lengthB) {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -313,20 +313,9 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         auto& trace_node = trace_nodes_.back();
         bool use_prefetcher_cache = mesh_workload.impl().max_program_kernels_sizeB_ <= this->prefetcher_cache_sizeB_;
         for (auto& [device_range, program] : mesh_workload.get_programs()) {
-#if defined(TRACY_ENABLE)
-            // With tracy enabled, each device has a different program runtime ID in the launch message, so we need to
-            // handle each device separately rather than grouping them.
-            for (const auto& coord : device_range) {
-                trace_node.trace_nodes.push_back(std::pair<MeshCoordinateRange, TraceNode>(
-                    coord,
-                    program_dispatch::create_trace_node(
-                        program.impl(), mesh_device_, num_workers, use_prefetcher_cache)));
-            }
-#else
             trace_node.trace_nodes.push_back(std::pair<MeshCoordinateRange, TraceNode>(
                 device_range,
                 program_dispatch::create_trace_node(program.impl(), mesh_device_, num_workers, use_prefetcher_cache)));
-#endif
         }
         trace_node.multicast_go_signals = mcast_go_signals;
         trace_node.unicast_go_signals = unicast_go_signals;
@@ -413,8 +402,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             program_cmd_seq,
             dispatch_metadata.stall_first,
             dispatch_metadata.stall_before_program,
-            chip_ids_in_workload,
-            program.get_runtime_id());
+            chip_ids_in_workload);
     }
     // Send go signals to devices not running a program to ensure consistent global state
     this->write_go_signal_to_unused_sub_grids(
@@ -969,15 +957,13 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     ProgramCommandSequence& program_cmd_seq,
     bool stall_first,
     bool stall_before_program,
-    std::unordered_set<uint32_t>& chip_ids_in_workload,
-    uint32_t program_runtime_id) {
+    std::unordered_set<uint32_t>& chip_ids_in_workload) {
     auto dispatch_core_config = MetalContext::instance(mesh_device_->impl().get_context_id())
                                     .get_dispatch_core_manager()
                                     .get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
-        this->update_launch_messages_for_device_profiler(program_cmd_seq, program_runtime_id, device);
         program_dispatch::write_program_command_sequence(
             program_cmd_seq, device->sysmem_manager(), id_, dispatch_core_type, stall_first, stall_before_program);
         chip_ids_in_workload.insert(device->id());
@@ -1334,15 +1320,6 @@ void FDMeshCommandQueue::record_end() {
                 sub_device_id,
                 ProgramBinaryStatus::Committed,
                 std::pair<bool, int>(mesh_node.unicast_go_signals, num_virtual_eth_cores));
-#if defined(TRACY_ENABLE)
-            for (auto& [is_multicast, original_launch_msg, launch_msg] :
-                 cached_program_command_sequence.launch_messages) {
-                auto* device = mesh_device_->get_device(range.start_coord());
-                TT_ASSERT(range.start_coord() == range.end_coord());
-                launch_msg.kernel_config().host_assigned_id() =
-                    tt_metal::detail::EncodePerDeviceProgramID(node.program_runtime_id, device->id());
-            }
-#endif
 
             // Issue dispatch commands for this program
             program_dispatch::write_program_command_sequence(
@@ -1419,18 +1396,6 @@ void FDMeshCommandQueue::record_end() {
 SystemMemoryManager& FDMeshCommandQueue::reference_sysmem_manager() {
     auto local_devices = mesh_device_->get_devices();
     return local_devices.at(0)->sysmem_manager();
-}
-
-void FDMeshCommandQueue::update_launch_messages_for_device_profiler(
-    ProgramCommandSequence& program_cmd_seq, uint32_t program_runtime_id, IDevice* device) {
-    if (tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
-            .rtoptions()
-            .get_profiler_enabled()) {
-        for (auto& [is_multicast, original_launch_msg, launch_msg] : program_cmd_seq.launch_messages) {
-            launch_msg.kernel_config().host_assigned_id() =
-                tt_metal::detail::EncodePerDeviceProgramID(program_runtime_id, device->id());
-        }
-    }
 }
 
 std::pair<bool, size_t> FDMeshCommandQueue::query_prefetcher_cache(uint64_t workload_id, uint32_t lengthB) {

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -62,8 +62,7 @@ private:
         ProgramCommandSequence& program_cmd_seq,
         bool stall_first,
         bool stall_before_program,
-        std::unordered_set<uint32_t>& chip_ids_in_workload,
-        uint32_t program_runtime_id);
+        std::unordered_set<uint32_t>& chip_ids_in_workload);
     // For a given MeshWorkload, a subgrid is unused if no programs are run on it.  Go signals
     // must be sent to this subgrid, to ensure consistent global state across the Virtual Mesh.
     // This function generates and writes dispatch commands forwarding go signals to these subgrids.
@@ -74,13 +73,6 @@ private:
         bool mcast_go_signals,
         bool unicast_go_signals,
         const program_dispatch::ProgramDispatchMetadata& dispatch_md);
-    // When the device profiler is not enabled, launch messages are identical across all physical devices running the
-    // same program, to reduce state managed on host. When the profiler is enabled, the host_assigned_id field in the
-    // launch message must be unique across physical devices to accurately capture program execution time on host and
-    // device. This API is responsible for updating the launch message before writing it to each device (see
-    // tt_metal/api/tt-metalium/dev_msgs.h for a description of how the host_assigned_id field is generated).
-    void update_launch_messages_for_device_profiler(
-        ProgramCommandSequence& program_cmd_seq, uint32_t program_runtime_id, IDevice* device);
     // Clear the num_workers_completed counter on the dispatcher cores corresponding to this CQ.
     void clear_expected_num_workers_completed();
     // Access a reference system memory manager, which acts as a global host side state manager for

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -158,10 +158,7 @@ struct kernel_config_msg_t {
     volatile uint8_t brisc_noc_mode;
     volatile uint8_t min_remote_cb_start_index;
     volatile uint8_t exit_erisc_kernel;
-    // 32 bit program/launch_msg_id used by the performance profiler
-    // [9:0]: physical device id
-    // [30:10]: program id
-    // [31:31]: 0 (specifies that this id corresponds to a program running on device)
+    // 32 bit program/launch_msg_id used by the performance profiler.
     volatile uint32_t host_assigned_id;
     // bit i set => processor i enabled
     volatile uint32_t enables;

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1595,6 +1595,9 @@ void DeviceProfiler::readRiscProfilerResults(
                         deviceTraceCounterRead = (data_buffer.at(index) >> 11) & 0xFFFF;
                     }
                     runHostCounterRead = data_buffer.at(index + 1);
+                    if (runHostCounterRead != 0) {
+                        runHostCounterRead = detail::EncodePerDeviceProgramID(runHostCounterRead, device_id);
+                    }
 
                     const uint32_t base_program_id =
                         detail::DecodePerDeviceProgramID(runHostCounterRead).base_program_id;

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1563,6 +1563,9 @@ void DeviceProfiler::readRiscProfilerResults(
                         deviceTraceCounterRead = (data_buffer.at(index) >> 11) & 0xFFFF;
                     }
                     runHostCounterRead = data_buffer.at(index + 1);
+                    if (runHostCounterRead != 0) {
+                        runHostCounterRead = detail::EncodePerDeviceProgramID(runHostCounterRead, device_id);
+                    }
 
                     const uint32_t base_program_id =
                         detail::DecodePerDeviceProgramID(runHostCounterRead).base_program_id;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -482,12 +482,10 @@ void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
         HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(programmable_core_type_index);
         for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
             auto* kg = program.impl().kernels_on_core(logical_core, programmable_core_type_index);
-            auto runtime_id = program.get_runtime_id();
 
             // Use a thread-local copy of launch_msg to avoid racing on the shared KernelGroup state
             dev_msgs::launch_msg_t local_launch_msg = kg->launch_msg;
-            local_launch_msg.view().kernel_config().host_assigned_id() =
-                runtime_id == 0 ? 0 : detail::EncodePerDeviceProgramID(runtime_id, device_id);
+            local_launch_msg.view().kernel_config().host_assigned_id() = program.get_runtime_id();
 
             auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
             tt::llrt::write_launch_msg_to_core(
@@ -877,9 +875,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
 
             for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
                 auto* kg = program.impl().kernels_on_core(logical_core, programmable_core_type_index);
-                auto runtime_id = program.get_runtime_id();
-                kg->launch_msg.view().kernel_config().host_assigned_id() =
-                    runtime_id == 0 ? 0 : detail::EncodePerDeviceProgramID(runtime_id, device->id());
+                kg->launch_msg.view().kernel_config().host_assigned_id() = program.get_runtime_id();
 
                 auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
                 not_done_cores.insert(physical_core);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -489,12 +489,10 @@ void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
         HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(programmable_core_type_index);
         for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
             auto* kg = program.impl().kernels_on_core(logical_core, programmable_core_type_index);
-            auto runtime_id = program.get_runtime_id();
 
             // Use a thread-local copy of launch_msg to avoid racing on the shared KernelGroup state
             dev_msgs::launch_msg_t local_launch_msg = kg->launch_msg;
-            local_launch_msg.view().kernel_config().host_assigned_id() =
-                runtime_id == 0 ? 0 : detail::EncodePerDeviceProgramID(runtime_id, device_id);
+            local_launch_msg.view().kernel_config().host_assigned_id() = program.get_runtime_id();
 
             auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
             tt::llrt::write_launch_msg_to_core(


### PR DESCRIPTION
**Cleanup.**

### Summary
Move the per-device program ID encoding (combining `program_runtime_id` with `device_id`) from the dispatch path to the profiler read path (`readRiscProfilerResults`). Previously, each device needed a unique launch message when the profiler or Tracy was enabled, which prevented grouping devices running the same program. Now the raw `runtime_id` is written to all devices uniformly, and the device-specific encoding is applied when profiler results are read back.

### Notes for reviewers
The encoding in `profiler.cpp` is gated on `runHostCounterRead != 0` to preserve the zero-means-unused convention.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/tracemeshduplicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/tracemeshduplicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/tracemeshduplicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/tracemeshduplicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/tracemeshduplicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/tracemeshduplicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/tracemeshduplicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/tracemeshduplicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/tracemeshduplicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/tracemeshduplicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/tracemeshduplicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/tracemeshduplicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/tracemeshduplicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/tracemeshduplicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/tracemeshduplicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/tracemeshduplicate)