### PR TITLE
Feature: Support DFB configs in trace capture and replay

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -1067,11 +1067,11 @@ DFBConfigReaderProgram create_dfb_config_reader_program(uint32_t entry_size, uin
 
     const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_config_reader.cpp";
 
-    auto producer_kernel = CreateKernel(
-        program, kernel_path, worker, DataMovementConfig{.processor = DataMovementProcessor::RISCV_0});
+    auto producer_kernel =
+        CreateKernel(program, kernel_path, worker, DataMovementConfig{.processor = DataMovementProcessor::RISCV_0});
 
-    auto consumer_kernel = CreateKernel(
-        program, kernel_path, worker, DataMovementConfig{.processor = DataMovementProcessor::RISCV_1});
+    auto consumer_kernel =
+        CreateKernel(program, kernel_path, worker, DataMovementConfig{.processor = DataMovementProcessor::RISCV_1});
 
     experimental::dfb::DataflowBufferConfig dfb_config{
         .entry_size = entry_size,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -24,6 +24,8 @@
 #include "command_queue_fixture.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
+#include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "dispatch_test_utils.hpp"
 #include "env_lib.hpp"
 #include "gtest/gtest.h"
@@ -1044,6 +1046,139 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTraceAndNoT
     for (const distributed::MeshTraceId trace_id : trace_ids) {
         this->device_->release_mesh_trace(trace_id);
     }
+}
+
+// Creates a program whose kernels read DFB config properties from L1 and write
+// them to an output address (passed as an RTA).  No actual DFB data movement
+// happens — the test only checks that the dispatched config values are correct.
+//
+// Returns {program, producer_kernel_handle, consumer_kernel_handle, dfb_id}.
+struct DFBConfigReaderProgram {
+    Program program;
+    KernelHandle producer;
+    KernelHandle consumer;
+    uint32_t dfb_id;
+};
+
+DFBConfigReaderProgram create_dfb_config_reader_program(uint32_t entry_size, uint32_t num_entries) {
+    Program program = CreateProgram();
+    CoreCoord worker = {0, 0};
+    CoreRange core_range({0, 0});
+
+    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_config_reader.cpp";
+
+    auto producer_kernel = CreateKernel(
+        program, kernel_path, worker, DataMovementConfig{.processor = DataMovementProcessor::RISCV_0});
+
+    auto consumer_kernel = CreateKernel(
+        program, kernel_path, worker, DataMovementConfig{.processor = DataMovementProcessor::RISCV_1});
+
+    experimental::dfb::DataflowBufferConfig dfb_config{
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    auto dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range, dfb_config);
+    experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, dfb_id, producer_kernel, consumer_kernel);
+
+    return {std::move(program), producer_kernel, consumer_kernel, dfb_id};
+}
+
+// Enqueues the same DFB program twice inside a single trace with different DFB
+// configs between the two uses.  After replay, reads the config values each
+// execution wrote to L1 and verifies they match the configs that were active at
+// capture time.
+TEST_F(UnitMeshMultiCQSingleDeviceTraceFixture, TensixEnqueueDFBProgramTrace) {
+    if (this->arch_ == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "DFBs not yet supported through Fast Dispatch on Quasar";
+    }
+
+    constexpr uint32_t entry_size_a = 1024;
+    constexpr uint32_t num_entries_a = 16;
+    constexpr uint32_t entry_size_b = 512;
+    constexpr uint32_t num_entries_b = 32;
+    static_assert(entry_size_a * num_entries_a == entry_size_b * num_entries_b, "total DFB size must be equal");
+    constexpr uint32_t dfb_total_size = entry_size_a * num_entries_a;
+
+    CreateDevice(dfb_total_size * 4);
+
+    IDevice* device = this->device_->get_devices()[0];
+    CoreCoord worker = {0, 0};
+
+    // Each execution writes 1 uint32 (entry_size).  Pick addresses after the
+    // DFB's L1 region to avoid overlap.
+    const uint32_t l1_base = static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    const uint32_t output_addr_a = l1_base + dfb_total_size;
+    const uint32_t output_addr_b = output_addr_a + 64;
+
+    // Create the program with config A.
+    auto [program, producer_kernel, consumer_kernel, dfb_id] =
+        create_dfb_config_reader_program(entry_size_a, num_entries_a);
+    auto dfb = program.impl().get_dataflow_buffer(dfb_id);
+
+    // Set RTAs so the first execution writes to output_addr_a.
+    SetRuntimeArgs(program, producer_kernel, worker, {output_addr_a, dfb_id});
+    SetRuntimeArgs(program, consumer_kernel, worker, {output_addr_a, dfb_id});
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range_, std::move(program));
+
+    auto& mesh_command_queue = this->device_->mesh_command_queue(0);
+
+    // Run eager with config A so the program gets compiled and cached.
+    distributed::EnqueueMeshWorkload(mesh_command_queue, workload, true);
+
+    // Verify config A was dispatched correctly in eager mode.
+    {
+        vector<uint32_t> l1_data;
+        detail::ReadFromDeviceL1(device, worker, output_addr_a, sizeof(uint32_t), l1_data);
+        EXPECT_EQ(l1_data[0], entry_size_a) << "eager: entry_size mismatch";
+    }
+
+    // --- Trace capture: enqueue twice with different DFB configs ---
+
+    auto tid = distributed::BeginTraceCapture(this->device_.get(), mesh_command_queue.id());
+
+    // First enqueue: config A, output to output_addr_a.
+    distributed::EnqueueMeshWorkload(mesh_command_queue, workload, false);
+
+    // Modify the DFB config to B between enqueues.
+    dfb->config.entry_size = entry_size_b;
+    dfb->config.num_entries = num_entries_b;
+
+    // Update RTAs so the second execution writes to output_addr_b.
+    auto& program_ref = workload.get_programs().at(device_range_);
+    SetRuntimeArgs(program_ref, producer_kernel, worker, {output_addr_b, dfb_id});
+    SetRuntimeArgs(program_ref, consumer_kernel, worker, {output_addr_b, dfb_id});
+
+    // Second enqueue: config B, output to output_addr_b.
+    distributed::EnqueueMeshWorkload(mesh_command_queue, workload, false);
+
+    this->device_->end_mesh_trace(mesh_command_queue.id(), tid);
+
+    // --- Replay and verify ---
+
+    // Clear L1 output locations before replay.
+    vector<uint32_t> zeros(16, 0);
+    detail::WriteToDeviceL1(device, worker, output_addr_a, zeros);
+    detail::WriteToDeviceL1(device, worker, output_addr_b, zeros);
+
+    this->device_->replay_mesh_trace(mesh_command_queue.id(), tid, true);
+
+    // Read back entry_size written by each execution.
+    vector<uint32_t> result_a, result_b;
+    detail::ReadFromDeviceL1(device, worker, output_addr_a, sizeof(uint32_t), result_a);
+    detail::ReadFromDeviceL1(device, worker, output_addr_b, sizeof(uint32_t), result_b);
+
+    EXPECT_EQ(result_a[0], entry_size_a) << "trace execution 1: entry_size mismatch";
+    EXPECT_EQ(result_b[0], entry_size_b) << "trace execution 2: entry_size mismatch";
+
+    distributed::Finish(mesh_command_queue);
+    this->device_->release_mesh_trace(tid);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_config_reader.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_config_reader.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reads the DFB entry_size and writes it to a specified L1 address so the host
+// can verify the config was dispatched correctly.  No DFB sync operations.
+
+#include "experimental/dataflow_buffer.h"
+
+void kernel_main() {
+    uint32_t output_l1_addr = get_arg_val<uint32_t>(0);
+    uint32_t dfb_id = get_arg_val<uint32_t>(1);
+
+    experimental::DataflowBuffer dfb(dfb_id);
+    volatile uint32_t* output = reinterpret_cast<volatile uint32_t*>(output_l1_addr);
+    output[0] = dfb.get_entry_size();
+}

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2529,6 +2529,22 @@ void update_traced_program_dispatch_commands(
             trace_node.cb_configs_payloads[i].size() * sizeof(uint32_t));
         i++;
     }
+    // Update DFB Configs
+    TT_ASSERT(
+        trace_node.dfb_configs_payloads.size() ==
+        cached_program_command_sequence.dataflow_buffers_on_core_ranges.size());
+    {
+        uint32_t dfb_i = 0;
+        for ([[maybe_unused]] const auto& dfbs_on_core_range :
+             cached_program_command_sequence.dataflow_buffers_on_core_ranges) {
+            uint8_t* dfb_config_payload = cached_program_command_sequence.dfb_configs_payloads[dfb_i];
+            std::memcpy(
+                dfb_config_payload,
+                trace_node.dfb_configs_payloads[dfb_i].data(),
+                trace_node.dfb_configs_payloads[dfb_i].size());
+            dfb_i++;
+        }
+    }
     // Update RTAs.
     TT_ASSERT(cached_program_command_sequence.rta_updates.size() == trace_node.rta_data.size());
     for (size_t i = 0; i < cached_program_command_sequence.rta_updates.size(); i++) {
@@ -2794,13 +2810,36 @@ TraceNode create_trace_node(ProgramImpl& program, IDevice* device, uint32_t num_
         cb_config_payload.resize(first_unused_index);
     }
 
+    std::vector<std::vector<uint8_t>> all_dfb_configs_payloads;
+    if (!hal.has_tile_counter_registers()) {
+        for (const auto& dfbs_on_core_range : cached_program_command_sequence.dataflow_buffers_on_core_ranges) {
+            std::vector<uint8_t> dfb_config_payload(
+                max_cbs * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t), 0);
+            size_t first_unused_byte = 0;
+            for (const auto& dfb : dfbs_on_core_range) {
+                size_t base_index = static_cast<size_t>(dfb->id) * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
+                size_t byte_offset = base_index * sizeof(uint32_t);
+                uint32_t* words = reinterpret_cast<uint32_t*>(dfb_config_payload.data()) + base_index;
+                words[0] = dfb->uniform_alloc_addr();
+                words[1] = dfb->config.entry_size * dfb->config.num_entries;
+                words[2] = dfb->config.num_entries;
+                words[3] = dfb->config.entry_size;
+                first_unused_byte = std::max(
+                    first_unused_byte, byte_offset + UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t));
+            }
+            dfb_config_payload.resize(first_unused_byte);
+            all_dfb_configs_payloads.push_back(std::move(dfb_config_payload));
+        }
+    }
+
     return TraceNode{
         program.shared_from_this(),
         static_cast<uint32_t>(program.get_runtime_id()),
         sub_device_ids[0],
         num_workers,
         std::move(rta_data),
-        std::move(all_cb_configs_payloads)};
+        std::move(all_cb_configs_payloads),
+        std::move(all_dfb_configs_payloads)};
 }
 
 KernelHandle get_device_local_kernel_handle(KernelHandle kernel_handle) {

--- a/tt_metal/impl/trace/trace_node.hpp
+++ b/tt_metal/impl/trace/trace_node.hpp
@@ -40,6 +40,8 @@ struct TraceNode {
     std::vector<std::vector<uint8_t>> rta_data;
     // Matches cb_configs_payloads in the ProgramCommandSequence
     std::vector<std::vector<uint32_t>> cb_configs_payloads;
+    // Matches dfb_configs_payloads in the ProgramCommandSequence
+    std::vector<std::vector<uint8_t>> dfb_configs_payloads;
 
     TraceDispatchMetadata dispatch_metadata;
 };


### PR DESCRIPTION
### Summary

Feature. Adds support for capturing and restoring Dataflow Buffer (DFB) configurations during trace capture and replay, ensuring that DFB state is correctly preserved when programs are replayed from a trace.

**What's changed:**
- `TraceNode` now stores `dfb_configs_payloads` alongside existing RTA and CB config payloads
- `create_trace_node` captures DFB configurations (entry_size, num_entries, address, total size) for Wormhole/Blackhole architectures where DFBs use circular buffer slot formats
- `update_traced_program_dispatch_commands` restores captured DFB configs into the command sequence before replay
- New test `TensixEnqueueDFBProgramTrace` verifies that two enqueues of the same program with different DFB configs inside a trace are correctly captured and replayed, using a custom kernel that reads `DataflowBuffer.get_entry_size()` on-device

### Notes for reviewers

The DFB capture logic mirrors the existing CB config capture pattern but uses `uint8_t` vectors (matching `ProgramCommandSequence::dfb_configs_payloads` type). Only applies to architectures without tile counter registers (Wormhole/Blackhole).

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/dfbtracing2) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/dfbtracing2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/dfbtracing2) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/dfbtracing2) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/dfbtracing2) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/dfbtracing2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/dfbtracing2) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/dfbtracing2) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/dfbtracing2) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/dfbtracing2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/dfbtracing2) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/dfbtracing2) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/dfbtracing2) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/dfbtracing2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/dfbtracing2) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/dfbtracing2) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/dfbtracing2) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/dfbtracing2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/dfbtracing2) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/dfbtracing2) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/dfbtracing2) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/dfbtracing2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/dfbtracing2) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/dfbtracing2) |