### PR TITLE
Fix sweep validation: matrix JSON, step summary, and mesh shape sub-grouping

### DIFF
--- a/.github/workflows/ttnn-model-trace-sweep-validation-impl.yaml
+++ b/.github/workflows/ttnn-model-trace-sweep-validation-impl.yaml
@@ -288,7 +288,8 @@ jobs:
               --manifest-path "$MANIFEST_PATH" \
               --master-json-path "$MASTER_JSON_PATH" \
               --vectors-root "$VECTORS_ROOT" \
-              --scope-target "$SCOPE_TARGET"
+              --scope-target "$SCOPE_TARGET" \
+              --write-to-file
           )
           echo "matrix=$matrix_json" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ttnn-model-trace-sweep-validation-impl.yaml
+++ b/.github/workflows/ttnn-model-trace-sweep-validation-impl.yaml
@@ -319,6 +319,7 @@ jobs:
         GITHUB_ACTIONS: true
         TT_SMI_RESET_COMMAND: ${{ matrix.tt_smi_cmd }}
         TRACY_NO_INVARIANT_CHECK: 1
+        MESH_DEVICE_SHAPE: ${{ matrix.mesh_device_shape }}
         LEAD_MODELS_RUN: ${{ matrix.validation_scope == 'lead_models' && '1' || '0' }}
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
@@ -453,7 +454,14 @@ jobs:
         if: always()
         run: |
           if [[ -f validation_summary.md ]]; then
-            cat validation_summary.md >> "$GITHUB_STEP_SUMMARY"
+            # Guard against exceeding the 1MB GitHub step summary limit
+            file_size=$(stat -c%s validation_summary.md 2>/dev/null || echo 0)
+            if (( file_size > 900000 )); then
+              head -c 890000 validation_summary.md >> "$GITHUB_STEP_SUMMARY"
+              echo -e "\n\n---\n⚠️ Report truncated (${file_size} bytes exceeded 1MB step summary limit)." >> "$GITHUB_STEP_SUMMARY"
+            else
+              cat validation_summary.md >> "$GITHUB_STEP_SUMMARY"
+            fi
           else
             cat <<'EOF' > validation_summary.md
           # Sweep Validation Summary

--- a/tests/sweep_framework/framework/compute_validation_sweep_matrix.py
+++ b/tests/sweep_framework/framework/compute_validation_sweep_matrix.py
@@ -25,6 +25,7 @@ from constants import format_hardware_suffix, parse_hardware_suffix, strip_group
 from matrix_runner_config import (
     GENERATION_MANIFEST_FILENAME,
     get_lead_models_test_group_name_for_hardware_group,
+    get_mesh_device_shape_for_hardware_group,
     get_runner_config,
     get_test_group_name_for_hardware_group,
 )
@@ -164,6 +165,8 @@ def compute_validation_matrix(
         total_batches = len(runner_batches)
         trace_id_list = sorted(trace_ids_by_hardware.get(hardware_group, []))
 
+        mesh_device_shape = get_mesh_device_shape_for_hardware_group(hardware_group)
+
         for index, batch in enumerate(runner_batches, start=1):
             include.append(
                 {
@@ -177,6 +180,7 @@ def compute_validation_matrix(
                     "vectors_artifact_name": f"sweeps-vectors-{validation_scope}",
                     "trace_ids": trace_id_list,
                     "hardware_group": hardware_label,
+                    "mesh_device_shape": mesh_device_shape,
                 }
             )
 

--- a/tests/sweep_framework/framework/compute_validation_sweep_matrix.py
+++ b/tests/sweep_framework/framework/compute_validation_sweep_matrix.py
@@ -150,6 +150,11 @@ def compute_validation_matrix(
     if unmatched_modules:
         grouped_items.append((None, unmatched_modules))
 
+    # Read mesh shapes per hardware group from the generation manifest.
+    # This enables sub-grouping: each hw group spawns one CI job per mesh shape,
+    # so MESH_DEVICE_SHAPE is set correctly and vectors are filtered at runtime.
+    manifest_mesh_shapes = generation_manifest.get("mesh_shapes_by_hardware_group", {})
+
     for hardware_group, grouped_modules in grouped_items:
         base_modules = sorted({strip_grouping_suffix(module) for module in grouped_modules})
         if not base_modules:
@@ -161,28 +166,37 @@ def compute_validation_matrix(
         else:
             test_group_name = get_test_group_name_for_hardware_group(hardware_group)
         runner_config = get_runner_config(test_group_name)
-        runner_batches = chunk_modules(base_modules, batch_size)
-        total_batches = len(runner_batches)
         trace_id_list = sorted(trace_ids_by_hardware.get(hardware_group, []))
 
-        mesh_device_shape = get_mesh_device_shape_for_hardware_group(hardware_group)
+        # Determine mesh shapes for this hardware group.
+        # Use manifest data if available (dynamic, from actual vector data),
+        # otherwise fall back to the static hardware-based mapping.
+        mesh_shapes = manifest_mesh_shapes.get(hardware_label, [])
+        if not mesh_shapes:
+            fallback = get_mesh_device_shape_for_hardware_group(hardware_group)
+            mesh_shapes = [fallback] if fallback else [""]
 
-        for index, batch in enumerate(runner_batches, start=1):
-            include.append(
-                {
-                    **runner_config,
-                    "batch_display": f"{validation_scope}:{hardware_label}:{batch}",
-                    "batch_ordinal": f"{index}/{total_batches}",
-                    "batch_index": index,
-                    "module_selector": batch,
-                    "suite_name": "model_traced",
-                    "validation_scope": validation_scope,
-                    "vectors_artifact_name": f"sweeps-vectors-{validation_scope}",
-                    "trace_ids": trace_id_list,
-                    "hardware_group": hardware_label,
-                    "mesh_device_shape": mesh_device_shape,
-                }
-            )
+        for mesh_shape in sorted(mesh_shapes):
+            mesh_label = f"mesh_{mesh_shape}" if mesh_shape else "default"
+            runner_batches = chunk_modules(base_modules, batch_size)
+            total_batches = len(runner_batches)
+
+            for index, batch in enumerate(runner_batches, start=1):
+                include.append(
+                    {
+                        **runner_config,
+                        "batch_display": f"{validation_scope}:{hardware_label}:{mesh_label}:{batch}",
+                        "batch_ordinal": f"{index}/{total_batches}",
+                        "batch_index": index,
+                        "module_selector": batch,
+                        "suite_name": "model_traced",
+                        "validation_scope": validation_scope,
+                        "vectors_artifact_name": f"sweeps-vectors-{validation_scope}",
+                        "trace_ids": trace_id_list,
+                        "hardware_group": hardware_label,
+                        "mesh_device_shape": mesh_shape,
+                    }
+                )
 
     return {"include": include}
 

--- a/tests/sweep_framework/framework/matrix_runner_config.py
+++ b/tests/sweep_framework/framework/matrix_runner_config.py
@@ -266,6 +266,30 @@ def get_matrix_output_key_for_test_group(test_group_name):
     return profile["matrix_output_key"]
 
 
+def get_mesh_device_shape_for_hardware_group(hardware_group) -> str:
+    """Return the primary mesh device shape string for a hardware group.
+
+    This is the "natural" mesh shape that the hardware physically provides,
+    used to set ``MESH_DEVICE_SHAPE`` so that the sweep framework filters
+    vectors to those matching the actual device topology.
+    """
+    if hardware_group is None:
+        return "1x1"
+
+    _board_type, device_series, card_count = hardware_group
+
+    if device_series == "tt_galaxy_wh":
+        return "4x8"
+    if device_series == "n300" and card_count == 4:
+        return "2x4"
+    if device_series == "n300" and card_count == 1:
+        return "1x2"
+    if device_series == "p150b":
+        return "1x1"
+    # n150 or unknown single-chip
+    return "1x1"
+
+
 def get_test_group_name_for_hardware_group(hardware_group):
     """Map a parsed hardware tuple to the logical test group used in CI."""
     if hardware_group is None:

--- a/tests/sweep_framework/framework/vector_source.py
+++ b/tests/sweep_framework/framework/vector_source.py
@@ -580,8 +580,11 @@ class VectorExportSource(VectorSource):
                                     machine_mismatch_count += 1
                                     continue
 
-                            # Apply mesh filtering when manifest grouping mode says ownership is by mesh.
-                            if filter_policy["enforce_mesh_capability"] and (
+                            # Apply mesh filtering when manifest grouping mode says ownership is by mesh,
+                            # OR when MESH_DEVICE_SHAPE is explicitly set (e.g. hw-grouped validation
+                            # jobs that need to filter vectors to the matching mesh topology).
+                            mesh_env_override = bool(os.environ.get("MESH_DEVICE_SHAPE", "").strip())
+                            if (filter_policy["enforce_mesh_capability"] or mesh_env_override) and (
                                 allowed_mesh_shapes or strict_ci_mesh_ownership
                             ):
                                 # If mesh shape is missing in JSON, do not filter out.

--- a/tests/sweep_framework/framework/vector_source.py
+++ b/tests/sweep_framework/framework/vector_source.py
@@ -488,17 +488,21 @@ class VectorExportSource(VectorSource):
                 f"card_count={current_machine_info.get('card_count', 'unknown')}"
             )
 
+        mesh_env_override = bool(os.environ.get("MESH_DEVICE_SHAPE", "").strip())
         allowed_mesh_shapes = set()
-        if filter_policy["enforce_mesh_capability"]:
+        if filter_policy["enforce_mesh_capability"] or mesh_env_override:
             allowed_mesh_shapes = self._resolve_allowed_mesh_shapes(capability_profile, current_machine_info)
             if allowed_mesh_shapes:
                 mesh_labels = sorted(f"{rows}x{cols}" for rows, cols in allowed_mesh_shapes)
-                mode_label = "CI ownership" if explicit_test_group_name else "local hardware capability"
+                mode_label = (
+                    "MESH_DEVICE_SHAPE env override" if mesh_env_override
+                    else ("CI ownership" if explicit_test_group_name else "local hardware capability")
+                )
                 logger.info(
-                    f"Manifest-selected mesh filtering enabled for module '{module_name}' via {mode_label}: "
+                    f"Mesh filtering enabled for module '{module_name}' via {mode_label}: "
                     f"{mesh_labels}"
                 )
-            else:
+            elif not mesh_env_override:
                 logger.warning(
                     f"Manifest grouping mode is 'mesh' for module '{module_name}', but no mesh capability was "
                     "derived. Set TEST_GROUP_NAME for strict CI ownership or MESH_DEVICE_SHAPE for a manual override."
@@ -580,13 +584,10 @@ class VectorExportSource(VectorSource):
                                     machine_mismatch_count += 1
                                     continue
 
-                            # Apply mesh filtering when manifest grouping mode says ownership is by mesh,
-                            # OR when MESH_DEVICE_SHAPE is explicitly set (e.g. hw-grouped validation
-                            # jobs that need to filter vectors to the matching mesh topology).
-                            mesh_env_override = bool(os.environ.get("MESH_DEVICE_SHAPE", "").strip())
-                            if (filter_policy["enforce_mesh_capability"] or mesh_env_override) and (
-                                allowed_mesh_shapes or strict_ci_mesh_ownership
-                            ):
+                            # Apply mesh filtering when we have allowed shapes to filter against.
+                            # allowed_mesh_shapes is populated when enforce_mesh_capability is True
+                            # OR when MESH_DEVICE_SHAPE env var is set (hw-grouped validation jobs).
+                            if allowed_mesh_shapes:
                                 # If mesh shape is missing in JSON, do not filter out.
                                 # Otherwise, accept when ANY traced entry matches an allowed mesh.
                                 traced_mesh_entries = []

--- a/tests/sweep_framework/sweeps_parameter_generator.py
+++ b/tests/sweep_framework/sweeps_parameter_generator.py
@@ -31,6 +31,9 @@ DO_RANDOMIZE = False
 VECTOR_GROUPING_MODE = "mesh"
 GENERATION_MANIFEST_FILENAME = "generation_manifest.json"
 GENERATED_VECTOR_FILES = set()
+# Track mesh shapes discovered per hardware group during vector export.
+# Populated by export_suite_vectors_json(), consumed by write_generation_manifest().
+MESH_SHAPES_BY_HARDWARE_GROUP: dict[str, set[str]] = defaultdict(set)
 
 
 def get_mesh_shape_from_vector(vector):
@@ -388,6 +391,10 @@ def write_generation_manifest(module_name, model_traced, suite_name, vector_file
         "model_traced": model_traced,
         "suite_name": suite_name,
         "vector_files": sorted(vector_files),
+        "mesh_shapes_by_hardware_group": {
+            hw_label: sorted(mesh_shapes)
+            for hw_label, mesh_shapes in sorted(MESH_SHAPES_BY_HARDWARE_GROUP.items())
+        },
     }
 
     try:
@@ -491,6 +498,14 @@ def export_suite_vectors_json(module_name, suite_name, vectors):
         # base module name and let any compatible runner pick up the file.
         grouped_module_name = module_name if group_key is None else f"{module_name}{format_group_suffix(group_key)}"
         GENERATED_VECTOR_FILES.add(f"{grouped_module_name}.json")
+
+        # Track mesh shapes per hardware group for downstream matrix splitting.
+        if VECTOR_GROUPING_MODE == "hw" and group_key is not None:
+            hw_label = f"{group_key[0]}_{group_key[1]}_{group_key[2]}c"
+            for vector in grouped_subset:
+                mesh_shape = get_mesh_shape_from_vector(vector)
+                if mesh_shape is not None:
+                    MESH_SHAPES_BY_HARDWARE_GROUP[hw_label].add(f"{mesh_shape[0]}x{mesh_shape[1]}")
 
         # Export vectors WITHOUT modifying sweep_name.
         # Routing info is already present in traced_machine_info; sweep_name stays
@@ -789,5 +804,6 @@ if __name__ == "__main__":
         logger.info(f"Master trace override: {resolved}")
 
     GENERATED_VECTOR_FILES.clear()
+    MESH_SHAPES_BY_HARDWARE_GROUP.clear()
     generate_tests(args.module_name, args.skip_modules, args.model_traced, args.suite_name)
     write_generation_manifest(args.module_name, args.model_traced, args.suite_name, GENERATED_VECTOR_FILES)

--- a/tests/sweep_framework/validate_sweep_trace.py
+++ b/tests/sweep_framework/validate_sweep_trace.py
@@ -402,19 +402,35 @@ def render_report(report: ValidationReport) -> str:
             lines.append(f"| `{cat}` | {cat_counts[cat]} | {DIFF_CATEGORIES.get(cat, cat)} |")
         lines.append("")
 
-    # Detailed diffs
+    # Detailed diffs (truncated to avoid exceeding GitHub step summary 1MB limit)
     if report.diffed:
+        max_detailed_entries = 20
+        shown = report.diffed[:max_detailed_entries]
+        remaining = len(report.diffed) - max_detailed_entries
+
         lines.append("## Detailed diffs")
         lines.append("")
-        for r in report.diffed:
+        if remaining > 0:
+            lines.append(
+                f"> Showing first {max_detailed_entries} of {len(report.diffed)} diffed configs. "
+                f"{remaining} additional entries omitted to stay within GitHub step summary size limits."
+            )
+            lines.append("")
+
+        for r in shown:
             lines.append(f"### `{r.op_name}` config_hash `{r.config_hash[:16]}...`")
             lines.append(f"master config_id={r.master_config_id}, sweep config_id={r.sweep_config_id}")
             lines.append("")
             lines.append("| Path | Category | Master | Sweep |")
             lines.append("|------|----------|--------|-------|")
-            for d in r.diffs:
+            max_diffs_per_entry = 10
+            for d in r.diffs[:max_diffs_per_entry]:
                 lines.append(
                     f"| `{d.path}` | `{d.category}` | {_trunc(d.master_value, 40)} | {_trunc(d.sweep_value, 40)} |"
+                )
+            if len(r.diffs) > max_diffs_per_entry:
+                lines.append(
+                    f"| ... | | {len(r.diffs) - max_diffs_per_entry} more diffs omitted | |"
                 )
             lines.append("")
 


### PR DESCRIPTION
## Summary
- Fix --write-to-file flag missing from compute_validation_sweep_matrix.py invocation
- Fix step summary exceeding GitHub 1MB limit by truncating detailed diffs
- Add dynamic mesh shape sub-grouping within hardware groups for proper exact match rates

## Problem
1. Matrix JSON not written: jq failed because --write-to-file was not passed
2. Step summary too large: Detailed diffs section generated 3.8MB reports
3. Low exact match rate (161/7586 = 2.1%): Nearly all diffs were tensor_placement mismatches because MESH_DEVICE_SHAPE was never set

## Solution: Hierarchical hw → mesh grouping
Generator tracks mesh shapes per hardware group in generation_manifest.json. Matrix builder emits separate CI jobs per (hardware, mesh_shape) pair. Each job sets MESH_DEVICE_SHAPE in the container env, and vector_source.py honors this even in hw-grouped mode.

## Changes
- Workflow: Added --write-to-file, MESH_DEVICE_SHAPE env var, step summary size guard
- validate_sweep_trace.py: Truncate detailed diffs (max 20 entries x 10 diffs)
- sweeps_parameter_generator.py: Track mesh shapes per hw group, write to manifest
- compute_validation_sweep_matrix.py: Read mesh shapes from manifest, emit per-(hw, mesh) jobs
- matrix_runner_config.py: Static fallback mesh mapping when manifest unavailable
- vector_source.py: Honor MESH_DEVICE_SHAPE in hw-grouped mode

## Test plan
- [x] Run 24392774859: Verified --write-to-file fix (all 24 sweep jobs ran)
- [ ] Run 24403956542: Validating mesh sub-grouping + step summary truncation

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-sweep-validation-matrix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/fix-sweep-validation-matrix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-sweep-validation-matrix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-sweep-validation-matrix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-sweep-validation-matrix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-sweep-validation-matrix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-sweep-validation-matrix) |