### PR TITLE
Fix - ttnn.min produces incorrect results for certain tensor shapes and dimensions. Resolves #40854

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -94,3 +94,37 @@ def test_min_row_major(device, input_shape, dim, keepdim):
         frobenius_threshold=1e-09,
         check_ulp=True,
     )
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (32, 32, 32, 32, 32),
+        (3, 6, 40, 64, 32),
+        (3, 6, 40, 63, 20),
+    ],
+)
+def test_min_multi_dim(device, input_shape):
+    """Test from issue #40854: ttnn.min produces incorrect results for certain tensor shapes and dimensions."""
+    dims = (-2, -1)
+    torch.manual_seed(0)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.amin(torch_input_tensor, dim=dims, keepdim=True)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+    output_tensor = ttnn.min(input_tensor, dim=dims, keepdim=True)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -60,13 +60,17 @@ void kernel_main() {
                 reconfig_data_format_srca(cb_input);
                 copy_tile_init(cb_input);
                 negative_tile_init();
+                // Partial chunk (ntiles < row_chunk): the input CB depth matches row_chunk, but only consume ntiles
+                // tiles. Indexed reads plus a bulk pop of ntiles do not advance the CB head during reads, leaving
+                // trailing slots effectively stale; the next pass can index into those offsets and read stale L1 data.
                 for (uint32_t i = 0; i < ntiles; ++i) {
-                    copy_tile(cb_input, i, i);
+                    // Read from index 0 and pop_front(1) per tile to keep the CB head in sync and avoid stale data.
+                    copy_tile(cb_input, 0, i);
+                    cb_input_obj.pop_front(1);
                     negative_tile(i);
                 }
 
                 tile_regs_commit();
-                cb_input_obj.pop_front(chunk_end - wt);
                 cb_ineg_obj.reserve_back(ntiles);
                 tile_regs_wait();
                 pack_reconfig_data_format(cb_ineg);


### PR DESCRIPTION
### Summary

Fixes the Issue:
- #40854

`ttnn.min` produced incorrect results for certain tensor shapes and reduction dimensions due to stale data being read from the circular buffer in the `negate=true` path.

The issue occurred when processing **partial chunks** (`ntiles < row_chunk`). The kernel used index-based reads (`copy_tile(cb_input, i, i)`) followed by a bulk `pop_front(ntiles)`, which caused reads to occur from a **stale CB head pointer**.

This PR fixes the issue by ensuring **sequential CB consumption (read → pop per tile)**, preventing stale tile reads.

### Root Cause

Consider the input tensor shape `(3, 6, 40, 64, 32)` (720 tiles). Work is distributed across cores with `chunk_size = 4`. Some cores process full chunks (4 + 4 + 4), while others process partial chunks (4 + 4 + 3).

#### Problem in Partial Chunk

When `ntiles < row_chunk` (e.g., 3 < 4), the CB is handled incorrectly.

#### Before

| Step           | CB State                            | Operation                         |
| -------------- | ------------------------------------| ----------------------------------|
| Initial        | [T0, T1, T2, T3]                    | CB head at T0                     |
| Read loop      | Reads T0, T1, T2 using index `i`    | Pointer does **not move**         |
| pop_front(3)   | [T3 remains logically]              | Now the pointer is at T3          |
| Next iteration | Reads 3(ntiles) using index again   | Reads T3 and then **stale** data  |

#### After

| Iteration | Action        | CB Head |
| --------- | ------------- | ------- |
| i = 0     | Read T0 → pop | T1      |
| i = 1     | Read T1 → pop | T2      |
| i = 2     | Read T2 → pop | T3      |

- Pointer advances **in sync with reads**
- No stale data access


#### Why This Fix Works

| Old Behavior                | New Behavior                |
| --------------------------- | --------------------------- |
| Index-based reads (`i`)     | Always read from head (`0`) |
| Bulk pop after loop         | Pop per tile                |
| Pointer static during reads | Pointer advances per read   |
| Can read stale tiles        | Always reads fresh tiles    |

---

### Notes for reviewers

Focus on the CB access pattern change in the reduction kernel: 
- Previously, index-based reads (`copy_tile(cb_input, i, i)`) combined with a bulk pop_front(`ntiles`) caused the CB head to remain static during the read loop. This leads to stale data access when `ntiles < row_chunk` (partial chunks), since all reads are performed from a base pointer.

This fix corrects this by fixing the FIFO semantics (read → pop per tile) by always reading from index 0 and calling pop_front(1) per iteration. This ensures the CB head advances in sync with consumption, eliminating stale tile reads.

---

### Validation

- Added a new unit test `test_min_multi_dim` in `tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py`, derived from the repro in #40854
- The test specifically covers multi-dimensional reductions and partial chunk scenarios, which previously triggered stale CB reads
- Verified that all failing cases from the issue now pass with the fix

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-ttnn-min-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-ttnn-min-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-ttnn-min-fix) | [#2705](https://github.com/tenstorrent/tt-metal/actions/runs/24397810885) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-ttnn-min-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-ttnn-min-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-ttnn-min-fix) | [#17457](https://github.com/tenstorrent/tt-metal/actions/runs/24397855802) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-ttnn-min-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-ttnn-min-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-ttnn-min-fix) | [#5185](https://github.com/tenstorrent/tt-metal/actions/runs/24397922273) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-ttnn-min-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-ttnn-min-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-ttnn-min-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-ttnn-min-fix) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-ttnn-min-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-ttnn-min-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-ttnn-min-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-ttnn-min-fix) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-ttnn-min-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-ttnn-min-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-ttnn-min-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-ttnn-min-fix) |