### PR TITLE
ci: restore functionality of tt-llk CI in tt-metal

### DIFF
--- a/.github/actions/find-changed-files/action.yml
+++ b/.github/actions/find-changed-files/action.yml
@@ -32,8 +32,12 @@ outputs:
     value: ${{ steps.find-changed-files.outputs.models-changed }}
   build-workflows-changed:
     value: ${{ steps.find-changed-files.outputs.build-workflows-changed }}
-  llk-engine-changed:
-    value: ${{ steps.find-changed-files.outputs.llk-engine-changed }}
+  llk-wormhole-changed:
+    value: ${{ steps.find-changed-files.outputs.llk-wormhole-changed }}
+  llk-blackhole-changed:
+    value: ${{ steps.find-changed-files.outputs.llk-blackhole-changed }}
+  llk-common-changed:
+    value: ${{ steps.find-changed-files.outputs.llk-common-changed }}
   llk-quasar-changed:
     value: ${{ steps.find-changed-files.outputs.llk-quasar-changed }}
   llk-tests-changed:

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -23,7 +23,9 @@ DOCS_CHANGED=false
 MODEL_CHARTS_CHANGED=false
 MODELS_CHANGED=false
 BUILD_WORKFLOWS_CHANGED=false
-LLK_ENGINE_CHANGED=false
+LLK_WORMHOLE_CHANGED=false
+LLK_BLACKHOLE_CHANGED=false
+LLK_COMMON_CHANGED=false
 LLK_QUASAR_CHANGED=false
 LLK_TESTS_CHANGED=false
 LLK_PERF_CHANGED=false
@@ -55,10 +57,16 @@ while IFS= read -r FILE; do
         tt_metal/tt-llk/.github/**|tt_metal/tt-llk/tests/requirements.txt)
             LLK_CI_CHANGED=true
             ;;
-        tt_metal/tt-llk/tt_llk_wormhole_b0/**|tt_metal/tt-llk/tt_llk_blackhole/**|tt_metal/tt-llk/common/**)
-            LLK_ENGINE_CHANGED=true
+        tt_metal/tt-llk/tt_llk_wormhole_b0/**)
+            LLK_WORMHOLE_CHANGED=true
             ;;
-        tt_metal/tt-llk/tt_llk_quasar/**)
+        tt_metal/tt-llk/tt_llk_blackhole/**)
+            LLK_BLACKHOLE_CHANGED=true
+            ;;
+        tt_metal/tt-llk/common/**)
+            LLK_COMMON_CHANGED=true
+            ;;
+        tt_metal/tt-llk/tt_llk_quasar/**|tt_metal/tt-llk/tests/sources/quasar/**|tt_metal/tt-llk/tests/python_tests/quasar/**)
             LLK_QUASAR_CHANGED=true
             ;;
         tt_metal/tt-llk/tests/**/perf/**|tt_metal/tt-llk/tests/**/*perf*)
@@ -145,7 +153,7 @@ if [[ "$SUBMODULE_CHANGED" = true ]]; then
 fi
 
 # LLK engine changes imply Metalium may be affected (LLK is compiled into device kernels)
-if [[ "$LLK_ENGINE_CHANGED" = true ]]; then
+if [[ "$LLK_WORMHOLE_CHANGED" = true || "$LLK_BLACKHOLE_CHANGED" = true || "$LLK_COMMON_CHANGED" = true ]]; then
     TTMETALIUM_CHANGED=true
     ANY_CODE_CHANGED=true
 fi
@@ -173,7 +181,9 @@ declare -A changes=(
     [model-charts-changed]=$MODEL_CHARTS_CHANGED
     [models-changed]=$MODELS_CHANGED
     [build-workflows-changed]=$BUILD_WORKFLOWS_CHANGED
-    [llk-engine-changed]=$LLK_ENGINE_CHANGED
+    [llk-wormhole-changed]=$LLK_WORMHOLE_CHANGED
+    [llk-blackhole-changed]=$LLK_BLACKHOLE_CHANGED
+    [llk-common-changed]=$LLK_COMMON_CHANGED
     [llk-quasar-changed]=$LLK_QUASAR_CHANGED
     [llk-tests-changed]=$LLK_TESTS_CHANGED
     [llk-perf-changed]=$LLK_PERF_CHANGED

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -71,7 +71,6 @@ while IFS= read -r FILE; do
             ;;
         tt_metal/tt-llk/tests/**/perf/**|tt_metal/tt-llk/tests/**/*perf*)
             LLK_PERF_CHANGED=true
-            LLK_TESTS_CHANGED=true
             ;;
         tt_metal/tt-llk/tests/**)
             LLK_TESTS_CHANGED=true

--- a/.github/workflows/llk-nightly.yaml
+++ b/.github/workflows/llk-nightly.yaml
@@ -35,7 +35,6 @@ jobs:
       random_order: false
       timeout_minutes: 360
       coverage: true
-      use_durations: false
 
   nightly-test-blackhole:
     name: "🕳️ Nightly Tests (Blackhole)"
@@ -50,7 +49,6 @@ jobs:
       random_order: false
       timeout_minutes: 360
       coverage: true
-      use_durations: false
 
   nightly-summary:
     name: "📊 Nightly Summary"

--- a/.github/workflows/llk-run-perf-tests.yaml
+++ b/.github/workflows/llk-run-perf-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     if: |
       contains(fromJSON('["workflow_dispatch","workflow_call","schedule"]'), github.event_name) ||
       (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.labels.*.name, 'performance-tests'))
+       contains(github.event.pull_request.labels.*.name, 'llk:performance-tests'))
     outputs:
       wormhole: ${{ steps.set.outputs.wormhole }}
       blackhole: ${{ steps.set.outputs.blackhole }}
@@ -114,7 +114,7 @@ jobs:
       always() && (
       contains(fromJSON('["workflow_dispatch","workflow_call","schedule"]'), github.event_name) ||
       (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.labels.*.name, 'performance-tests'))
+       contains(github.event.pull_request.labels.*.name, 'llk:performance-tests'))
       )
     needs:
       - build-images

--- a/.github/workflows/llk-run-perf-tests.yaml
+++ b/.github/workflows/llk-run-perf-tests.yaml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       wormhole: ${{ steps.set.outputs.wormhole }}
       blackhole: ${{ steps.set.outputs.blackhole }}
+      common: ${{ steps.set.outputs.common }}
       performance: ${{ steps.set.outputs.performance }}
     steps:
       - name: Checkout code
@@ -41,12 +42,14 @@ jobs:
         with:
           filters: |
               wormhole:
-                - 'tt_llk_wormhole_b0/**'
+                - 'tt_metal/tt-llk/tt_llk_wormhole_b0/**'
               blackhole:
-                - 'tt_llk_blackhole/**'
+                - 'tt_metal/tt-llk/tt_llk_blackhole/**'
+              common:
+                - 'tt_metal/tt-llk/common/**'
               performance:
-                - '**/*perf**'
-                - '**/*profiler**'
+                - 'tt_metal/tt-llk/**/*perf**'
+                - 'tt_metal/tt-llk/**/*profiler**'
 
       - name: Resolve test triggers (nightly vs changes)
         id: set
@@ -54,10 +57,12 @@ jobs:
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "wormhole=true" >> $GITHUB_OUTPUT
             echo "blackhole=true" >> $GITHUB_OUTPUT
+            echo "common=true" >> $GITHUB_OUTPUT
             echo "performance=true" >> $GITHUB_OUTPUT
           else
             echo "wormhole=${{ steps.filter.outputs.wormhole }}" >> $GITHUB_OUTPUT
             echo "blackhole=${{ steps.filter.outputs.blackhole }}" >> $GITHUB_OUTPUT
+            echo "common=${{ steps.filter.outputs.common }}" >> $GITHUB_OUTPUT
             echo "performance=${{ steps.filter.outputs.performance }}" >> $GITHUB_OUTPUT
           fi
 
@@ -72,6 +77,7 @@ jobs:
     uses: ./.github/workflows/llk-setup-and-test.yaml
     needs: [build-images, detect-changes]
     if: ${{ needs.detect-changes.outputs.wormhole == 'true' ||
+            needs.detect-changes.outputs.common == 'true' ||
             needs.detect-changes.outputs.performance == 'true' ||
             github.event_name == 'workflow_dispatch' ||
             github.event_name == 'workflow_call' }}
@@ -89,6 +95,7 @@ jobs:
     uses: ./.github/workflows/llk-setup-and-test.yaml
     needs: [build-images, detect-changes]
     if: ${{ needs.detect-changes.outputs.blackhole == 'true' ||
+            needs.detect-changes.outputs.common == 'true' ||
             needs.detect-changes.outputs.performance == 'true' ||
             github.event_name == 'workflow_dispatch' ||
             github.event_name == 'workflow_call' }}

--- a/.github/workflows/llk-setup-and-test.yaml
+++ b/.github/workflows/llk-setup-and-test.yaml
@@ -35,11 +35,6 @@ on:
         required: false
         default: false
         type: boolean
-      use_durations:
-        description: "Use previously collected test durations for balanced splitting"
-        required: false
-        default: false
-        type: boolean
       compile_time_args:
         description: "Convert every runtime argument into compile time argument and compile all variants like that"
         required: false
@@ -127,14 +122,6 @@ jobs:
           SPEED_OF_LIGHT_FLAG=""
           if [[ "${{ inputs.compile_time_args }}" == "true" ]]; then
             SPEED_OF_LIGHT_FLAG="--speed-of-light"
-          fi
-
-          DURATIONS_FLAG=""
-          if [[ "${{ inputs.use_durations }}" == "true" ]] && [[ -f ".test_durations" ]]; then
-            DURATIONS_FLAG="--durations-path=.test_durations"
-            echo "Using duration-based test splitting from .test_durations"
-          else
-            echo "Duration file not found or not enabled, using default splitting"
           fi
 
           echo "Compiling artefacts"

--- a/.github/workflows/llk-setup-and-test.yaml
+++ b/.github/workflows/llk-setup-and-test.yaml
@@ -100,22 +100,6 @@ jobs:
           ./setup_testing_env.sh
           cd ..
 
-      # Step 2.5: Download test duration data for balanced splitting
-      # Downloads the latest available artifact from main branch only
-      - name: Download test duration data
-        if: ${{ inputs.use_durations }}
-        uses: dawidd6/action-download-artifact@v12
-        continue-on-error: true
-        with:
-          workflow: llk-collect-test-durations.yaml
-          workflow_conclusion: success
-          branch: main
-          name: test-durations-${{ contains(inputs.runs_on, 'n150') && 'wormhole' || 'blackhole' }}
-          path: ${{ env.LLK_PATH }}/tests/python_tests/
-          if_no_artifact_found: warn
-          search_artifacts: true
-          check_artifacts: true
-
       # Step 3: Run the tests
       - name: Run tests
         shell: bash

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -554,7 +554,8 @@ jobs:
         github.event.action != 'destroyed' &&
         (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
         (github.ref_name == 'main' ||
-         needs.find-changed-files.outputs.llk-quasar-changed == 'true')
+         needs.find-changed-files.outputs.llk-quasar-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
     uses: ./.github/workflows/llk-build-quasar.yaml
     secrets: inherit

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -144,7 +144,9 @@ jobs:
       tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
       tt-train-changed: ${{ steps.find-changes.outputs.tt-train-changed }}
       model-charts-changed: ${{ steps.find-changes.outputs.model-charts-changed }}
-      llk-engine-changed: ${{ steps.find-changes.outputs.llk-engine-changed }}
+      llk-wormhole-changed: ${{ steps.find-changes.outputs.llk-wormhole-changed }}
+      llk-blackhole-changed: ${{ steps.find-changes.outputs.llk-blackhole-changed }}
+      llk-common-changed: ${{ steps.find-changes.outputs.llk-common-changed }}
       llk-quasar-changed: ${{ steps.find-changes.outputs.llk-quasar-changed }}
       llk-tests-changed: ${{ steps.find-changes.outputs.llk-tests-changed }}
       llk-perf-changed: ${{ steps.find-changes.outputs.llk-perf-changed }}
@@ -436,16 +438,83 @@ jobs:
         # Without this, fixes.yml paths don't match the PR diff and comments are silently dropped.
         repo_path_prefix: /__w
 
-  # LLK Functional Unit Tests on Wormhole (PR gate - runs when LLK engine, tests, or perf code changed)
+  # LLK PR Labeling — auto-apply labels based on which LLK directories changed
+  llk-label-pr:
+    needs: find-changed-files
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (needs.find-changed-files.outputs.llk-wormhole-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-blackhole-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-common-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-tests-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-ci-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-perf-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-quasar-changed == 'true')
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync LLK labels based on changes
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const expectedLabels = new Set();
+            if ("${{ needs.find-changed-files.outputs.llk-wormhole-changed }}" === "true") expectedLabels.add("llk:wormhole");
+            if ("${{ needs.find-changed-files.outputs.llk-blackhole-changed }}" === "true") expectedLabels.add("llk:blackhole");
+            if ("${{ needs.find-changed-files.outputs.llk-common-changed }}" === "true") expectedLabels.add("llk:common");
+            if ("${{ needs.find-changed-files.outputs.llk-tests-changed }}" === "true") expectedLabels.add("llk:test-infra");
+            if ("${{ needs.find-changed-files.outputs.llk-ci-changed }}" === "true") expectedLabels.add("llk:ci");
+            if ("${{ needs.find-changed-files.outputs.llk-perf-changed }}" === "true") expectedLabels.add("llk:performance");
+            if ("${{ needs.find-changed-files.outputs.llk-quasar-changed }}" === "true") expectedLabels.add("llk:quasar");
+
+            const managedLabels = new Set(["llk:wormhole", "llk:blackhole", "llk:common",
+                                           "llk:ci", "llk:test-infra",
+                                           "llk:performance", "llk:quasar"]);
+
+            const {data: currentLabels} = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const currentLabelSet = new Set(currentLabels.map(label => label.name));
+
+            const labelsToAdd = [...expectedLabels].filter(label => !currentLabelSet.has(label));
+            const labelsToRemove = [...currentLabelSet]
+              .filter(label => managedLabels.has(label) && !expectedLabels.has(label));
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labelsToAdd
+              });
+            }
+
+            if (labelsToRemove.length > 0) {
+              await Promise.all(labelsToRemove.map(label =>
+                github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label
+                })
+              ));
+            }
+
+  # LLK Functional Unit Tests on Wormhole (PR gate - runs on wormhole/common/test/ci changes)
   llk-test-wormhole:
     needs: [ build-docker-images, find-changed-files ]
     if: ${{
         github.event.action != 'destroyed' &&
         (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
         (github.ref_name == 'main' ||
-         needs.find-changed-files.outputs.llk-engine-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-wormhole-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-common-changed == 'true' ||
          needs.find-changed-files.outputs.llk-tests-changed == 'true' ||
-         needs.find-changed-files.outputs.llk-perf-changed == 'true')
+         needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
     uses: ./.github/workflows/llk-setup-and-test.yaml
     secrets: inherit
@@ -456,16 +525,17 @@ jobs:
       pytest_markers: "not perf and not nightly and not quasar"
       use_durations: false
 
-  # LLK Functional Unit Tests on Blackhole (PR gate - runs when LLK engine, tests, or perf code changed)
+  # LLK Functional Unit Tests on Blackhole (PR gate - runs on blackhole/common/test/ci changes)
   llk-test-blackhole:
     needs: [ build-docker-images, find-changed-files ]
     if: ${{
         github.event.action != 'destroyed' &&
         (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
         (github.ref_name == 'main' ||
-         needs.find-changed-files.outputs.llk-engine-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-blackhole-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-common-changed == 'true' ||
          needs.find-changed-files.outputs.llk-tests-changed == 'true' ||
-         needs.find-changed-files.outputs.llk-perf-changed == 'true')
+         needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
     uses: ./.github/workflows/llk-setup-and-test.yaml
     secrets: inherit

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -555,6 +555,8 @@ jobs:
         (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
         (github.ref_name == 'main' ||
          needs.find-changed-files.outputs.llk-quasar-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-common-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-tests-changed == 'true' ||
          needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
     uses: ./.github/workflows/llk-build-quasar.yaml

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -441,6 +441,9 @@ jobs:
   # LLK PR Labeling — auto-apply labels based on which LLK directories changed
   llk-label-pr:
     needs: find-changed-files
+    permissions:
+      issues: write
+      pull-requests: write
     if: >-
       ${{
         github.event_name == 'pull_request' &&
@@ -523,7 +526,6 @@ jobs:
       runs_on: tt-ubuntu-2204-n150-stable
       test_splits: 2
       pytest_markers: "not perf and not nightly and not quasar"
-      use_durations: false
 
   # LLK Functional Unit Tests on Blackhole (PR gate - runs on blackhole/common/test/ci changes)
   llk-test-blackhole:
@@ -544,7 +546,6 @@ jobs:
       runs_on: tt-ubuntu-2204-p150b-stable
       test_splits: 2
       pytest_markers: "not perf and not nightly and not quasar"
-      use_durations: false
 
   # LLK Quasar Build Check (compile-only, no hardware needed)
   llk-build-quasar:


### PR DESCRIPTION
## Summary

This PR restores LLK CI functionality that was lost when `tt-llk` was merged into `tt-metal`. The old standalone `on-pr.yml` had granular change detection, automatic PR labeling, and proper test gating. This PR brings all of that back, adapted to the monorepo structure.

### Changes

**Granular change detection** (`find-changed-files.sh`, `action.yml`)
- Split the monolithic `llk-engine-changed` flag into three separate flags: `llk-wormhole-changed`, `llk-blackhole-changed`, and `llk-common-changed`. This allows wormhole-only changes to skip blackhole tests and vice versa, matching the old repo behavior.
- Added quasar test paths (`tests/sources/quasar/**`, `tests/python_tests/quasar/**`) to the `llk-quasar-changed` flag. Previously these were incorrectly caught by the generic `llk-tests-changed` pattern.

**Automatic PR labeling** (`pr-gate.yaml`)
- Added an `llk-label-pr` job that auto-applies and removes labels based on which LLK directories changed: `llk:wormhole`, `llk:blackhole`, `llk:common`, `llk:test-infra`, `llk:ci`, `llk:performance`, `llk:quasar`.
- Only runs on PRs that touch LLK files (not every PR in the repo).

**Correct test gating** (`pr-gate.yaml`)
- Wormhole functional tests now trigger on `llk-wormhole-changed || llk-common-changed || llk-tests-changed || llk-ci-changed` (not on blackhole or quasar or perf changes).
- Blackhole functional tests now trigger on `llk-blackhole-changed || llk-common-changed || llk-tests-changed || llk-ci-changed` (not on wormhole or quasar or perf changes).
- Quasar functional tests now trigger on `llk-quasar-changed || llk-common-changed || llk-tests-changed || llk-ci-changed` (not on blackhole or wormhole or perf changes).
- Removed `llk-perf-changed` from functional test triggers. Perf changes should only run the separate perf test workflow, matching the old `on-pr.yml` behavior.

**Fix perf test paths** (`llk-run-perf-tests.yaml`)
- Fixed `dorny/paths-filter` patterns that still used old standalone repo paths (`tt_llk_wormhole_b0/**`) instead of monorepo paths (`tt_metal/tt-llk/tt_llk_wormhole_b0/**`). These patterns were never matching.
- Added `common` directory tracking, so that common changes now trigger functional and perf tests on both archs.
- Scoped the `performance` glob to `tt_metal/tt-llk/**` to avoid matching unrelated perf files across the monorepo.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/sort-out-llk-ci) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/sort-out-llk-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/sort-out-llk-ci) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/sort-out-llk-ci) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/sort-out-llk-ci) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=filip/sort-out-llk-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/sort-out-llk-ci) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/sort-out-llk-ci) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/sort-out-llk-ci) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/sort-out-llk-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/sort-out-llk-ci) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/sort-out-llk-ci) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/sort-out-llk-ci) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/sort-out-llk-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/sort-out-llk-ci) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/sort-out-llk-ci) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/sort-out-llk-ci) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/sort-out-llk-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/sort-out-llk-ci) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/sort-out-llk-ci) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/sort-out-llk-ci) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/sort-out-llk-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/sort-out-llk-ci) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/sort-out-llk-ci) |