### PR TITLE
[quasar]: Bug fix! Restore the num_tiles multiplier in llk_pop_tiles and llk_push_tiles …

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
@@ -37,7 +37,7 @@ inline void llk_push_tiles(const std::int32_t dfb_id, const std::int32_t num_til
     const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
 
     local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx +=
-        local_dfb_interface.stride_size_tiles;
+        num_tiles * local_dfb_interface.stride_size_tiles;
     local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr += num_words;
     local_dfb_interface.wr_entry_ptr = 0;
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -39,7 +39,7 @@ inline void llk_pop_tiles(const std::int32_t dfb_id, const std::int32_t num_tile
     const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
 
     local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx +=
-        local_dfb_interface.stride_size_tiles;
+        num_tiles * local_dfb_interface.stride_size_tiles;
     local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr += num_words;
     if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr >=
         local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Missing num_tiles multiplier in DFB entry index advancement (introduced in #41506)

#41506 ("Fixes for multithreaded matmul") moved rd_entry_idx / wr_entry_idx from the top-level LocalDFBInterface into per-TC DFBTCSlot. During that refactor, the num_tiles multiplier was dropped in both llk_pop_tiles (llk_io_unpack.h) and llk_push_tiles (llk_io_pack.h):
```
// Before #41506 
local_dfb_interface.rd_entry_idx += (num_tiles * local_dfb_interface.stride_size_tiles);

// After #41506: num_tiles multiplier missing
local_dfb_interface.tc_slots[tc_idx].rd_entry_idx += local_dfb_interface.stride_size_tiles;
```
This means rd_entry_idx / wr_entry_idx advance by 1 instead of num_tiles per pop/push call. Any kernel that pops or pushes more than 1 tile at a time will read/write from the wrong DFB offset on subsequent operations.

The bug was not caught because the BMM test that accompanied the change only ever calls pop_front(1) / push_back(1), where num_tiles * stride == stride.

Quasar pack untilize tests (*QuasarComputePackUntilize*) pop and push multiple tiles at a time, directly exercising the fix

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skotarac/bug_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skotarac/bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skotarac/bug_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skotarac/bug_fix) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skotarac/bug_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skotarac/bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skotarac/bug_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skotarac/bug_fix) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skotarac/bug_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skotarac/bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skotarac/bug_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skotarac/bug_fix) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skotarac/bug_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skotarac/bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skotarac/bug_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skotarac/bug_fix) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skotarac/bug_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skotarac/bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skotarac/bug_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skotarac/bug_fix) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skotarac/bug_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skotarac/bug_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skotarac/bug_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skotarac/bug_fix) |