### PR TITLE
#41922: Use regular C++ API & syntax for calling _{trunc,floor,ceil}_body_ [BUG FIX]

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
@@ -46,14 +46,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_fmod_(sfpi::vFloat in0, sfpi::vFloat in1) 
     // Compute a/b = a * (1/b)
     sfpi::vFloat div_result = a * recip;
 
-    // Compute trunc(a/b)
-    // Input in LReg0, output in LReg1. LReg2/LReg3 are clobbered by _trunc_body_(),
-    // so we must read them to inform the SFPI register allocator they are not immediately available.
-    sfpi::l_reg[sfpi::LRegs::LReg0] = div_result;
-    _trunc_body_();
-    sfpi::vFloat trunc_div = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vFloat tmp2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vFloat tmp3 = sfpi::l_reg[sfpi::LRegs::LReg3];
+    sfpi::vFloat trunc_div = _trunc_body_(div_result);
 
     // Compute fmod = a - trunc(a/b) * b
     sfpi::vFloat result = a - trunc_div * b;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -119,13 +119,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat 
     sfpi::vFloat div_result = a * _sfpu_reciprocal_<2>(b);
 
     // Compute floor(a/b)
-    // Input in LReg0, output in LReg1. LReg2/LReg3 are clobbered by _floor_body_(),
-    // so we must read them to inform the SFPI register allocator they are not immediately available.
-    sfpi::l_reg[sfpi::LRegs::LReg0] = div_result;
-    _floor_body_();
-    sfpi::vFloat floor_div = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vFloat _lreg2_clobbered_ = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vFloat _lreg3_clobbered_ = sfpi::l_reg[sfpi::LRegs::LReg3];
+    sfpi::vFloat floor_div = _floor_body_(div_result);
 
     // Compute remainder = a - floor(a/b) * b
     sfpi::vFloat result = a - floor_div * b;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -30,21 +30,9 @@ inline void calculate_rdiv(const uint value) {
         sfpi::vFloat result = recip * val;
 
         if constexpr (rounding_mode == RoundingMode::Trunc) {
-            // Use hand-optimised "trunc" implementation.
-            // Input is in L0.  Output is in L1, and L2/L3 get clobbered.
-            sfpi::l_reg[sfpi::LRegs::LReg0] = result;
-            _trunc_body_();
-            result = sfpi::l_reg[sfpi::LRegs::LReg1];
-            sfpi::vFloat tmp2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-            sfpi::vFloat tmp3 = sfpi::l_reg[sfpi::LRegs::LReg3];
+            result = _trunc_body_(result);
         } else if constexpr (rounding_mode == RoundingMode::Floor) {
-            // Use hand-optimised "floor" implementation.
-            // Input is in L0.  Output is in L1, and L2/L3 get clobbered.
-            sfpi::l_reg[sfpi::LRegs::LReg0] = result;
-            _floor_body_();
-            result = sfpi::l_reg[sfpi::LRegs::LReg1];
-            sfpi::vFloat tmp2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-            sfpi::vFloat tmp3 = sfpi::l_reg[sfpi::LRegs::LReg3];
+            result = _floor_body_(result);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
@@ -52,14 +52,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_fmod_(sfpi::vFloat in0, sfpi::vFloat in1) 
     // Compute a/b = a * (1/b)
     sfpi::vFloat div_result = a * recip;
 
-    // Compute trunc(a/b)
-    // Input in LReg0, output in LReg1. LReg2/LReg3 are clobbered by _trunc_body_(),
-    // so we must read them to inform the SFPI register allocator they are not immediately available.
-    sfpi::l_reg[sfpi::LRegs::LReg0] = div_result;
-    _trunc_body_();
-    sfpi::vFloat trunc_div = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vFloat tmp2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vFloat tmp3 = sfpi::l_reg[sfpi::LRegs::LReg3];
+    sfpi::vFloat trunc_div = _trunc_body_(div_result);
 
     // Compute fmod = a - trunc(a/b) * b
     sfpi::vFloat result = a - trunc_div * b;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -171,13 +171,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat 
     sfpi::vFloat div_result = a * _sfpu_reciprocal_<2>(b);
 
     // Compute floor(a/b)
-    // Input in LReg0, output in LReg1. LReg2/LReg3 are clobbered by _floor_body_(),
-    // so we must read them to inform the SFPI register allocator they are not immediately available.
-    sfpi::l_reg[sfpi::LRegs::LReg0] = div_result;
-    _floor_body_();
-    sfpi::vFloat floor_div = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vFloat _lreg2_clobbered_ = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vFloat _lreg3_clobbered_ = sfpi::l_reg[sfpi::LRegs::LReg3];
+    sfpi::vFloat floor_div = _floor_body_(div_result);
 
     // Compute remainder = a - floor(a/b) * b
     sfpi::vFloat result = a - floor_div * b;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -30,21 +30,9 @@ inline void calculate_rdiv(const uint value) {
         sfpi::vFloat result = recip * val;
 
         if constexpr (rounding_mode == RoundingMode::Trunc) {
-            // Use hand-optimised "trunc" implementation.
-            // Input is in L0.  Output is in L1, and L2/L3 get clobbered.
-            sfpi::l_reg[sfpi::LRegs::LReg0] = result;
-            _trunc_body_();
-            result = sfpi::l_reg[sfpi::LRegs::LReg1];
-            sfpi::vFloat tmp2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-            sfpi::vFloat tmp3 = sfpi::l_reg[sfpi::LRegs::LReg3];
+            result = _trunc_body_(result);
         } else if constexpr (rounding_mode == RoundingMode::Floor) {
-            // Use hand-optimised "floor" implementation.
-            // Input is in L0.  Output is in L1, and L2/L3 get clobbered.
-            sfpi::l_reg[sfpi::LRegs::LReg0] = result;
-            _floor_body_();
-            result = sfpi::l_reg[sfpi::LRegs::LReg1];
-            sfpi::vFloat tmp2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-            sfpi::vFloat tmp3 = sfpi::l_reg[sfpi::LRegs::LReg3];
+            result = _floor_body_(result);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -18,9 +18,14 @@ namespace ckernel
 namespace sfpu
 {
 
-// computes L1=trunc(L0).
-inline void _trunc_body_()
+// #41922: CONSTRUCTION ZONE
+// Implemented:Standard calling API, old bodies
+// ToDo: use sfpi API
+
+// compute truncate to zero
+sfpi_inline sfpi::vFloat _trunc_body_(sfpi::vFloat val)
 {
+    sfpi::l_reg[sfpi::LRegs::LReg0] = val;
     // set L3=23.  TODO: this could be stored in a constant register, but use by rdiv prevents this for now.
     TTI_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_SHORT, 23);
     // mask = 0x8000_0000
@@ -37,26 +42,36 @@ inline void _trunc_body_()
     TTI_SFPENCC(0, 0, 0, 0);
     // apply mask
     TTI_SFPAND(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
+
+    // Make sure compiler avoids these two regs here, ugh.
+    sfpi::vFloat tmp2 __attribute__((unused)) = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vFloat tmp3 __attribute__((unused)) = sfpi::l_reg[sfpi::LRegs::LReg3];
+
+    return sfpi::l_reg[sfpi::LRegs::LReg1];
 }
 
-// computes L1=floor(L0).
-inline void _floor_body_()
+// compute floor
+sfpi_inline sfpi::vFloat _floor_body_(sfpi::vFloat val)
 {
-    _trunc_body_();
+    sfpi::l_reg[sfpi::LRegs::LReg1] = _trunc_body_(val);
     // if v>u, set v=v-1.
     TTI_SFPGT(0, p_sfpu::LREG0, p_sfpu::LREG1, 1); // SFPGT_MOD1_SET_CC
     TTI_SFPMAD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LCONST_neg1, p_sfpu::LREG1, 0);
     TTI_SFPENCC(0, 0, 0, 0);
+
+    return sfpi::l_reg[sfpi::LRegs::LReg1];
 }
 
-// computes L1=ceil(L0).
-inline void _ceil_body_()
+// computes ceil
+sfpi_inline sfpi::vFloat _ceil_body_(sfpi::vFloat val)
 {
-    _trunc_body_();
+    sfpi::l_reg[sfpi::LRegs::LReg1] = _trunc_body_(val);
     // if v<u, set v=v+1.
     TTI_SFPGT(0, p_sfpu::LREG1, p_sfpu::LREG0, 1); // SFPGT_MOD1_SET_CC
     TTI_SFPMAD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG1, 0);
     TTI_SFPENCC(0, 0, 0, 0);
+
+    return sfpi::l_reg[sfpi::LRegs::LReg1];
 }
 
 inline constexpr std::array<float, 84> PRECOMPUTED_POW10_TABLE = {
@@ -68,48 +83,48 @@ inline constexpr std::array<float, 84> PRECOMPUTED_POW10_TABLE = {
 };
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_floor_()
+sfpi_inline void _calculate_floor_()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
-        _floor_body_();
+        sfpi::l_reg[sfpi::LRegs::LReg1] = _floor_body_(sfpi::l_reg[sfpi::LRegs::LReg0]);
         TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_ceil_()
+sfpi_inline void _calculate_ceil_()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
-        _ceil_body_();
+        sfpi::l_reg[sfpi::LRegs::LReg1] = _ceil_body_(sfpi::l_reg[sfpi::LRegs::LReg0]);
         TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_trunc_()
+sfpi_inline void _calculate_trunc_()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
-        _trunc_body_();
+        sfpi::l_reg[sfpi::LRegs::LReg1] = _trunc_body_(sfpi::l_reg[sfpi::LRegs::LReg0]);
         TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_frac_()
+sfpi_inline void _calculate_frac_()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
-        _trunc_body_();
+        sfpi::l_reg[sfpi::LRegs::LReg1] = _trunc_body_(sfpi::l_reg[sfpi::LRegs::LReg0]);
         // frac(x) = x - trunc(x)
         TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LCONST_neg1, p_sfpu::LREG0, p_sfpu::LREG1, 0);
         TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
@@ -117,7 +132,7 @@ inline void _calculate_frac_()
     }
 }
 
-inline sfpi::vFloat _round_even_(sfpi::vFloat v)
+sfpi_inline sfpi::vFloat _round_even_(sfpi::vFloat v)
 {
     // Create a temporary copy tmp = abs(v).
     sfpi::vFloat tmp = sfpi::setsgn(v, 0);
@@ -169,7 +184,7 @@ void _calculate_round_(const int decimals)
 
 // Performs stochastic rounding of values in DST from fp32 to fp16b format.
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_stochastic_round_()
+sfpi_inline void _calculate_stochastic_round_()
 {
 #pragma GCC unroll ITERATIONS
     for (int d = 0; d < ITERATIONS; d++)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -18,9 +18,14 @@ namespace ckernel
 namespace sfpu
 {
 
-// computes L1=trunc(L0).
-inline void _trunc_body_()
+// #41922: CONSTRUCTION ZONE
+// Implemented:Standard calling API, old bodies
+// ToDo: use sfpi API
+
+// compute truncate to zero
+sfpi_inline sfpi::vFloat _trunc_body_(sfpi::vFloat val)
 {
+    sfpi::l_reg[sfpi::LRegs::LReg0] = val;
     // set L3=23.  TODO: this could be stored in a constant register, but use by rdiv prevents this for now.
     TTI_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_SHORT, 23);
     // mask = 0x8000_0000
@@ -37,12 +42,18 @@ inline void _trunc_body_()
     TTI_SFPENCC(0, 0, 0, 0);
     // apply mask
     TTI_SFPAND(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
+
+    // Make sure compiler avoids these two regs here, ugh.
+    sfpi::vFloat tmp2 __attribute__((unused)) = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vFloat tmp3 __attribute__((unused)) = sfpi::l_reg[sfpi::LRegs::LReg3];
+
+    return sfpi::l_reg[sfpi::LRegs::LReg1];
 }
 
-// computes L1=floor(L0).
-inline void _floor_body_()
+// computes floor
+sfpi_inline sfpi::vFloat _floor_body_(sfpi::vFloat val)
 {
-    _trunc_body_();
+    sfpi::l_reg[sfpi::LRegs::LReg1] = _trunc_body_(val);
     // if v>u, set v=v-1; this only happens for negative values.
     // on Wormhole, we don't have SFPGT, so use u<0 and (v-u)<0 instead.
     // First, ensure u<0.
@@ -51,12 +62,14 @@ inline void _floor_body_()
     TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
     TTI_SFPMAD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LCONST_neg1, p_sfpu::LREG1, 0);
     TTI_SFPENCC(0, 0, 0, 0);
+
+    return sfpi::l_reg[sfpi::LRegs::LReg1];
 }
 
-// computes L1=ceil(L0).
-inline void _ceil_body_()
+// computes ceil
+sfpi_inline sfpi::vFloat _ceil_body_(sfpi::vFloat val)
 {
-    _trunc_body_();
+    sfpi::l_reg[sfpi::LRegs::LReg1] = _trunc_body_(val);
     // if v<u, set v=v+1.
     // on Wormhole, we don't have SFPGT, so use u>=0 and (v-u)<0 instead.
     // First, ensure u>=0.
@@ -65,6 +78,8 @@ inline void _ceil_body_()
     TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
     TTI_SFPMAD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG1, 0);
     TTI_SFPENCC(0, 0, 0, 0);
+
+    return sfpi::l_reg[sfpi::LRegs::LReg1];
 }
 
 inline constexpr std::array<float, 84> PRECOMPUTED_POW10_TABLE = {
@@ -76,48 +91,48 @@ inline constexpr std::array<float, 84> PRECOMPUTED_POW10_TABLE = {
 };
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_floor_()
+sfpi_inline void _calculate_floor_()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
-        _floor_body_();
+        sfpi::l_reg[sfpi::LRegs::LReg1] = _floor_body_(sfpi::l_reg[sfpi::LRegs::LReg0]);
         TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_ceil_()
+sfpi_inline void _calculate_ceil_()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
-        _ceil_body_();
+        sfpi::l_reg[sfpi::LRegs::LReg1] = _ceil_body_(sfpi::l_reg[sfpi::LRegs::LReg0]);
         TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_trunc_()
+sfpi_inline void _calculate_trunc_()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
-        _trunc_body_();
+        sfpi::l_reg[sfpi::LRegs::LReg1] = _trunc_body_(sfpi::l_reg[sfpi::LRegs::LReg0]);
         TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_frac_()
+sfpi_inline void _calculate_frac_()
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
-        _trunc_body_();
+        sfpi::l_reg[sfpi::LRegs::LReg1] = _trunc_body_(sfpi::l_reg[sfpi::LRegs::LReg0]);
         // frac(x) = x - trunc(x)
         TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LCONST_neg1, p_sfpu::LREG0, p_sfpu::LREG1, 0);
         TTI_SFPNOP;
@@ -126,7 +141,7 @@ inline void _calculate_frac_()
     }
 }
 
-inline sfpi::vFloat _round_even_(sfpi::vFloat v)
+sfpi_inline sfpi::vFloat _round_even_(sfpi::vFloat v)
 {
     // Create a temporary copy tmp = abs(v).
     sfpi::vFloat tmp = sfpi::setsgn(v, 0);
@@ -178,7 +193,7 @@ void _calculate_round_(const int decimals)
 
 // Performs stochastic rounding of values in DST from fp32 to fp16b format.
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void _calculate_stochastic_round_()
+sfpi_inline void _calculate_stochastic_round_()
 {
 #pragma GCC unroll ITERATIONS
     for (int d = 0; d < ITERATIONS; d++)


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/41922


### Summary

Implements regular C syntax for passing args and returning results to hand coded routines.  This ends up being the same generated code btw.

Next stage will be converting the bodies to using SFPI itself.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/lreg-41922) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/lreg-41922)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/lreg-41922) | [#2653](https://github.com/tenstorrent/tt-metal/actions/runs/24365441526) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/lreg-41922) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/lreg-41922)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/lreg-41922) | [#17430](https://github.com/tenstorrent/tt-metal/actions/runs/24365458687) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/lreg-41922) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/lreg-41922)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/lreg-41922) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/lreg-41922) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/lreg-41922) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/lreg-41922)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/lreg-41922) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/lreg-41922) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/lreg-41922) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/lreg-41922)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/lreg-41922) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/lreg-41922) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/lreg-41922) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/lreg-41922)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/lreg-41922) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/lreg-41922) |