### PR TITLE
Fix DeepSeek MLA decode broadcast all-gather subdevice config

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1110,6 +1110,7 @@ class MLA1D(AbstractModule):
             cluster_axis=1,
             dim=2,
             memory_config=ttnn.L1_MEMORY_CONFIG,
+            subdevice_id=ttnn.SubDeviceId(0),
             use_broadcast=True,
         )
 


### PR DESCRIPTION
## Summary
- set `subdevice_id=ttnn.SubDeviceId(0)` on DeepSeek MLA decode `wo_ag_decode`
- fix the current-`main` broadcast `all_gather_async` assert hit in DeepSeek decode on Galaxy TG

## Validation
- isolated clean-`main` repro for `wo_ag_decode` broadcast all-gather now succeeds with config-driven `subdevice_id`
- `models/demos/deepseek_v3/tests/test_model.py::test_mode_decode_forward_pass_batch_8_users_per_row` advances past the original subdevice assert on current `main`

Fixes #42044

[![Galaxy DeepSeek module CI](https://img.shields.io/badge/Galaxy%20DeepSeek%20module-run%2024401399636%20in%20progress-blue)](https://github.com/tenstorrent/tt-metal/actions/runs/24401399636)
