### PR TITLE
Disable adding 8 NOPs after ebreak for LW and LLK asserts

### DIFF
--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -90,10 +90,11 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
 
 #if defined(LIGHTWEIGHT_KERNEL_ASSERTS)
 
-#define ASSERT(condition, ...) \
-    do {                       \
-        if (!(condition))      \
-            while (true);      \
+#define ASSERT(condition, ...)      \
+    do {                            \
+        if (!(condition)) {         \
+            asm volatile("ebreak"); \
+        }                           \
     } while (0)
 
 #define ASSERT_ENABLED 1

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -260,7 +260,7 @@ void JitBuildEnv::init(
 
     if (!rtoptions.get_watcher_enabled() && !rtoptions.get_lightweight_kernel_asserts() &&
         rtoptions.get_llk_asserts()) {
-        this->defines_ += "-DENV_LLK_INFRA ";
+        this->defines_ += "-DENABLE_LLK_ASSERT_ONLY ";
     }
 
     if (rtoptions.get_disable_sfploadmacro()) {

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -12,6 +12,7 @@
 #include <umd/device/utils/semver.hpp>
 
 #include "blackhole/bh_hal.hpp"
+#include "rtoptions.hpp"
 #include "dev_mem_map.h"
 #include "eth_fw_api.h"
 #include "hal_types.hpp"
@@ -209,6 +210,12 @@ public:
         if (params.core_type == HalProgrammableCoreType::ACTIVE_ETH && params.processor_id == 0 &&
             enable_2_erisc_mode_) {
             cflags += "-Werror=stack-usage=1912 ";
+        }
+        // We need to disable -mtt-fix-whbhebreak for asserts using ebreak.
+        // After asserts, we don't want to continue code execution, so we don't need 8 nops after ebreak (as it will
+        // unnecessarily grow code size).
+        if (params.rtoptions.get_lightweight_kernel_asserts() || params.rtoptions.get_llk_asserts()) {
+            cflags += "-mno-tt-fix-whbhebreak ";
         }
         return cflags;
     }

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -181,6 +181,12 @@ public:
             params.core_type == HalProgrammableCoreType::IDLE_ETH) {
             cflags += "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
         }
+        // We need to disable -mtt-fix-whbhebreak for asserts using ebreak.
+        // After asserts, we don't want to continue code execution, so we don't need 8 nops after ebreak (as it will
+        // unnecessarily grow code size).
+        if (params.rtoptions.get_lightweight_kernel_asserts() || params.rtoptions.get_llk_asserts()) {
+            cflags += "-mno-tt-fix-whbhebreak ";
+        }
         return cflags;
     }
 

--- a/tt_metal/tt-llk/common/llk_assert.h
+++ b/tt_metal/tt-llk/common/llk_assert.h
@@ -6,7 +6,7 @@
 
 #ifdef ENABLE_LLK_ASSERT
 
-#ifdef ENV_LLK_INFRA
+#if defined(ENV_LLK_INFRA) || defined(ENABLE_LLK_ASSERT_ONLY)
 
 #define UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
 
@@ -26,7 +26,7 @@
 
 #define LLK_ASSERT(condition, message) ASSERT(condition)
 
-#endif // ENV_LLK_INFRA
+#endif // defined(ENV_LLK_INFRA) || defined(ENABLE_LLK_ASSERT_ONLY)
 
 #else
 

--- a/tt_metal/tt-llk/setup_clangd.sh
+++ b/tt_metal/tt-llk/setup_clangd.sh
@@ -115,7 +115,6 @@ validate_sfpi_installation() {
 # Function to generate compile flags
 generate_compile_flags() {
     echo "Generating compile_flags.txt for $CHIP_ARCH architecture..."
-    # -mno-tt-fix-whbhebreak: LLK_ASSERT uses ebreak; match Hal tensix cflags (no 8 NOPs after ebreak).
 
     cat > "$ROOT_DIR/compile_flags.txt" <<EOF
 -DENV_LLK_INFRA
@@ -132,7 +131,6 @@ generate_compile_flags() {
 -DLLK_TRISC_PACK
 
 -DENABLE_LLK_ASSERT
--mno-tt-fix-whbhebreak
 
 -isystem
 $ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv-tt-elf/15.1.0/include/

--- a/tt_metal/tt-llk/setup_clangd.sh
+++ b/tt_metal/tt-llk/setup_clangd.sh
@@ -115,6 +115,7 @@ validate_sfpi_installation() {
 # Function to generate compile flags
 generate_compile_flags() {
     echo "Generating compile_flags.txt for $CHIP_ARCH architecture..."
+    # -mno-tt-fix-whbhebreak: LLK_ASSERT uses ebreak; match Hal tensix cflags (no 8 NOPs after ebreak).
 
     cat > "$ROOT_DIR/compile_flags.txt" <<EOF
 -DENV_LLK_INFRA
@@ -131,6 +132,7 @@ generate_compile_flags() {
 -DLLK_TRISC_PACK
 
 -DENABLE_LLK_ASSERT
+-mno-tt-fix-whbhebreak
 
 -isystem
 $ROOT_DIR/tests/sfpi/compiler/lib/gcc/riscv-tt-elf/15.1.0/include/

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -352,9 +352,18 @@ class TestConfig:
             )
 
         TestConfig.OPTIONS_LINK = "-Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -nostartfiles -Wl,--trace"
+        # LLK_ASSERT uses ebreak under ENV_LLK_INFRA (see common/llk_assert.h). Match Hal tensix cflags
+        # (wh_hal.cpp / bh_hal.cpp): -mno-tt-fix-whbhebreak avoids 8 NOPs after ebreak.
+        no_wh_ebreak_fixup = (
+            "-mno-tt-fix-whbhebreak "
+            if TestConfig.CHIP_ARCH
+            in (ChipArchitecture.WORMHOLE, ChipArchitecture.BLACKHOLE)
+            else ""
+        )
         TestConfig.INITIAL_OPTIONS_COMPILE = (
             "-nostdlib -fno-use-cxa-atexit -Werror -Wall -fno-asynchronous-unwind-tables -fno-exceptions -fno-rtti -Wunused-parameter "
             "-Wfloat-equal -Wpointer-arith -Wnull-dereference -Wredundant-decls -Wuninitialized -Wmaybe-uninitialized "
+            f"{no_wh_ebreak_fixup}"
             f"-DTENSIX_FIRMWARE -DENV_LLK_INFRA -DENABLE_LLK_ASSERT {TestConfig.ARCH_DEFINE} "
             f"{'-DSPEED_OF_LIGHT' if TestConfig.SPEED_OF_LIGHT else ''}"
         )


### PR DESCRIPTION
### Summary

Closes #42042

When Lightweight Kernel Asserts or LLK Asserts are enabled, the `-mtt-fix-whbhebreak` compiler flag causes 8 NOP instructions to be inserted after every `ebreak`. This is a hardware errata workaround ensuring safe pipeline drain before resuming execution after `ebreak`. However, assert-triggered `ebreak`s are terminal — the core halts and never resumes — making these NOPs unreachable dead code that unnecessarily inflates kernel binary size.

This PR passes `-mno-tt-fix-whbhebreak` to the compiler conditionally when either `TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS=1` or `TT_METAL_LLK_ASSERTS=1` is set. The workaround remains active in production builds.

### Notes for reviewers

- The change is in `common_flags()` for both `wh_hal.cpp` (Wormhole) and `bh_hal.cpp` (Blackhole).
- The flag is gated behind `params.rtoptions.get_lightweight_kernel_asserts() || params.rtoptions.get_llk_asserts()`, so production builds are unaffected.
- `rtoptions.hpp` is included in `bh_hal.cpp` to access these getters (it was already transitively available in `wh_hal.cpp`).
- This is safe because LW asserts compile to `while(true);` and LLK asserts compile to `asm volatile("ebreak")` — in both cases execution never continues past the assertion point.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/disable_ebreak_fix_for_lw_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/disable_ebreak_fix_for_lw_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/disable_ebreak_fix_for_lw_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/disable_ebreak_fix_for_lw_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/disable_ebreak_fix_for_lw_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/disable_ebreak_fix_for_lw_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/disable_ebreak_fix_for_lw_llk_asserts) |