### PR TITLE
Add ND gather reproduction test

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -418,30 +418,26 @@ void kernel_main() {
         get_named_compile_time_arg_val("mcast3_dst_num_pages"),
     };
 
-    // Matmul5 CTArgs
-    using Matmul5CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
-    deepseek_b1_ops::Matmul::ReaderArgs matmul5_args{};
+    // Matmul5 (KNSlicedMatmul) reader args - NCRISC is no-op
+    using Matmul5CTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::ReaderArgs matmul5_args{};
 
-    // Gather3 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
-    // via gather3_sender_idx, avoiding gaps from the non-rectangular o_proj grid)
-    deepseek_b1_ops::Gather::DMArgs gather3_args{
-        .sender =
-            {
-                get_named_compile_time_arg_val("gather3_dest_noc_x"),
-                get_named_compile_time_arg_val("gather3_dest_noc_y"),
-                get_named_compile_time_arg_val("gather3_data_size_bytes"),
-                get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
-                get_named_compile_time_arg_val("gather3_src_cb"),
-                get_named_compile_time_arg_val("gather3_src_num_pages"),
-                get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
-                get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
-                get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
-                get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
-                get_named_compile_time_arg_val("gather3_row_major"),
-                get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 3),  // gather3_receiver_data_addr
-                get_named_compile_time_arg_val("gather3_sender_idx"),
-            },
-        .receiver = {},
+    // GatherReduce3 sender args
+    deepseek_b1_ops::GatherReduce::SenderArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_dest_noc_x"),
+        get_named_compile_time_arg_val("gather3_dest_noc_y"),
+        get_named_compile_time_arg_val("gather3_data_size_bytes"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_addr")),
+        get_named_compile_time_arg_val("gather3_src_cb"),
+        get_named_compile_time_arg_val("gather3_src_num_pages"),
+        get_named_compile_time_arg_val("gather3_grid_start_x"),
+        get_named_compile_time_arg_val("gather3_grid_start_y"),
+        get_named_compile_time_arg_val("gather3_grid_end_x"),
+        get_named_compile_time_arg_val("gather3_grid_end_y"),
+        get_named_compile_time_arg_val("gather3_half_num_cores"),
+        get_named_compile_time_arg_val("gather3_dst_cb_id"),
+        get_named_compile_time_arg_val("gather3_half_size_bytes"),
+        get_named_compile_time_arg_val("gather3_sender_idx"),
     };
 
     // ========================================================================o
@@ -715,11 +711,12 @@ void kernel_main() {
 
     using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
 
-    // Matmul4/2 CTArgs (BRISC is no-op for matmul)
+    // Matmul4 CTArgs (BRISC is no-op for matmul)
     using Matmul4CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
-    using Matmul5CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
     deepseek_b1_ops::Matmul::WriterArgs matmul4_args{};
-    deepseek_b1_ops::Matmul::WriterArgs matmul5_args{};
+    // Matmul5 (KNSlicedMatmul) writer args - BRISC is no-op
+    using Matmul5CTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::WriterArgs matmul5_args{};
 
     // Gather2 receiver args
     deepseek_b1_ops::Gather::DMArgs gather2_args{
@@ -752,18 +749,14 @@ void kernel_main() {
         get_write_ptr(mcast3_dst_cb),  // CB 4 address (now allocated on gather core too)
     };
 
-    // Gather3 receiver args (on sender core 11,9 instead of gather core 12,9)
-    deepseek_b1_ops::Gather::DMArgs gather3_args{
-        .sender = {},
-        .receiver =
-            {
-                get_named_compile_time_arg_val("gather3_noc0_num_senders"),
-                get_named_compile_time_arg_val("gather3_noc1_num_senders"),
-                get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
-                get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-                get_named_compile_time_arg_val("gather3_dst_cb"),
-                get_named_compile_time_arg_val("gather3_dst_num_pages"),
-            },
+    // GatherReduce3 receiver args (on sender core 11,9)
+    deepseek_b1_ops::GatherReduce::ReceiverArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather3_noc1_num_senders"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather3_dst_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_tiles"),
     };
 
     // ========================================================================o
@@ -1111,19 +1104,27 @@ void kernel_main() {
     // Mcast3 CTArgs (no-op)
     deepseek_b1_ops::Mcast::ComputeArgs mcast3_args{};
 
-    // Matmul5 CTArgs
+    // Matmul5 (KNSlicedMatmul) CTArgs + compute args
+    constexpr uint32_t matmul5_k_offset = get_named_compile_time_arg_val("matmul5_k_offset");
+
     using Matmul5CTArgs =
-        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
-    deepseek_b1_ops::Matmul::ComputeArgs matmul5_args{
+        deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
+    deepseek_b1_ops::KNSlicedMatmul::ComputeArgs matmul5_args{
         get_named_compile_time_arg_val("matmul5_in0"),
         get_named_compile_time_arg_val("matmul5_in1"),
         get_named_compile_time_arg_val("matmul5_out"),
-        get_named_compile_time_arg_val("matmul5_k_num_tiles"),
+        matmul5_k_offset,
+        get_named_compile_time_arg_val("matmul5_k_per_core"),
+        get_named_compile_time_arg_val("matmul5_act_total_tiles"),
         get_common_arg_val<uint32_t>(14),  // matmul5_weights_addr
     };
 
-    // Gather3 compute args (no-op)
-    deepseek_b1_ops::Gather::ComputeArgs gather3_args{};
+    // GatherReduce3 compute args
+    deepseek_b1_ops::GatherReduce::ComputeArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_scratch_cb"),
+        get_named_compile_time_arg_val("gather3_out_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_tiles"),
+    };
 
     // CCL Broadcast CTArgs (no-op for TRISC)
     using BcastCTArgs = deepseek_b1_ops::Broadcast::ComputeCTArgs;
@@ -1518,24 +1519,25 @@ void kernel_main() {
         }
 
         // ========================================================================
-        // Matmul5: [1, 8192] x [8192, 64] -> [1, 64] per core (112 active cores)
+        // Matmul5 (KNSlicedMatmul): [1, 8192] x [4096, 32] -> [1, 32] per core (112 active cores)
         // Input: mcast3_dst_cb (CB 4), Weights: matmul5_in1 (CB 5), Output: matmul5_out (CB 6)
-        // Only runs on 112 active cores (is_matmul5_core=true), 18 inactive cores skip
+        // K-split: 2 halves of 56 cores, each core does [1, 4096] @ [4096, 32] -> [1, 32]
         // ========================================================================
         {
             DeviceZoneScopedN("MATMUL5");
-            // pop_in0 = true (mcast3 output consumed), pop_in1 = false (weights persistent)
-            deepseek_b1_ops::Matmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
+            deepseek_b1_ops::KNSlicedMatmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
             matmul5(matmul5_args);
         }
 
         // ========================================================================
-        // Gather3: 112 active matmul5 cores -> sender core (11, 9)
-        // Collects [1, 64] * 112 = [1, 7168]
+        // GatherReduce3: 112 matmul5 cores (2x56 halves) -> sender core (11, 9)
+        // Reduces [1, 32] * 56 from each half -> [1, 1792] per device
         // ========================================================================
         {
             DeviceZoneScopedN("GATHER3");
-            deepseek_b1_ops::Gather::Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, true, true> gather3;
+            deepseek_b1_ops::GatherReduce::
+                Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, Core::is_allreduce_sender_core, true, true>
+                    gather3;
             gather3(gather3_args);
         }
 
@@ -1564,8 +1566,24 @@ void kernel_main() {
         if constexpr (Core::is_allreduce_receiver_core) {
             DeviceZoneScopedN("CCL_RECEIVER");
 #if defined(COMPILE_FOR_NCRISC)
-            // TODO: We're popping the RMSNorm input and then re-pushing it here as the residual
-            // Should avoid this and not pop in RMSNorm
+            // TP4 outer-dim: NOC-copy the correct [1, per_device_out_w] slice of the
+            // input tensor into the residual CB (2 tiles of 32x32) before AllReduce.
+            {
+                constexpr uint32_t residual_offset = get_named_compile_time_arg_val("residual_byte_offset");
+                constexpr uint32_t residual_size = get_named_compile_time_arg_val("residual_copy_size");
+                constexpr uint32_t residual_cb = get_named_compile_time_arg_val("residual_cb_id");
+                constexpr uint32_t residual_num_tiles = get_named_compile_time_arg_val("residual_num_tiles");
+                constexpr uint32_t inp_noc_x = get_named_compile_time_arg_val("input_noc_coord_x");
+                constexpr uint32_t inp_noc_y = get_named_compile_time_arg_val("input_noc_coord_y");
+                uint32_t input_l1_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 4);
+                cb_reserve_back(residual_cb, residual_num_tiles);
+                uint32_t residual_dst = get_write_ptr(residual_cb);
+                uint64_t src_noc_addr = get_noc_addr(inp_noc_x, inp_noc_y, input_l1_addr + residual_offset);
+                noc_async_read(src_noc_addr, residual_dst, residual_size);
+                noc_async_read_barrier();
+                cb_push_back(residual_cb, residual_num_tiles);
+            }
+
             deepseek_b1_ops::AllReduce::Reader<AllReduceReaderCTArgs> ccl_reader;
             ccl_reader(ccl_receiver_args);
 #elif defined(COMPILE_FOR_TRISC)

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -519,6 +519,7 @@ class AttentionBlock:
 
         TILE_1x32 = ttnn.Tile((1, 32))
         tile_1x32_size = TILE_1x32.get_tile_size(data_format)
+        tile_32x32_size = FULL_32x32_TILE.get_tile_size(data_format)
         # Mcast setup: sender core (rmsnorm) -> full mcast grid
         # Only matmul cores (is_matmul_core=true) will actually participate in receive
 
@@ -566,6 +567,13 @@ class AttentionBlock:
         # Row-major (y then x) matches WIDTH_SHARDED shard placement order.
         matmul5_cores = ttnn.corerange_to_cores(matmul5_active_core_grid, row_wise=True)
         gather3_sender_idx_per_core = [(core, idx) for idx, core in enumerate(matmul5_cores)]
+
+        matmul5_half_num_cores = num_matmul5_cores // 2  # 56
+
+        # TP4 outer-dim: each device produces [1, per_device_out_w]
+        num_sp = mesh_shape[0]
+        per_device_out_w = input_shape[1] // num_sp
+        per_device_out_tiles = per_device_out_w // tile_width
 
         # Full grid (union of all cores for semaphore allocation)
         # TODO: Subtract the pipeline core
@@ -690,8 +698,12 @@ class AttentionBlock:
         # ========================================================================
         # Matmul5 parameters: [1, 8192] x [8192, 64] -> [1, 64]
         # ========================================================================
-        matmul5_k_num_tiles = 256  # 8192 / 32 = 256 tiles
-        matmul5_out_w_per_core = 2  # 64 / 32 = 2 tiles per core
+        matmul5_act_total_tiles = 256  # 8192 / 32 = 256 tiles (full activation)
+        matmul5_k_per_core = matmul5_act_total_tiles // 2  # 128 tiles per half
+        matmul5_out_w_per_core = 1  # 32 / 32 = 1 tile per core
+        matmul5_k_offset_per_core = [
+            (core, 0 if idx < matmul5_half_num_cores else matmul5_k_per_core) for idx, core in enumerate(matmul5_cores)
+        ]
 
         # ========================================================================
         # Gather2 parameters: 64 cores -> [1, 8192]
@@ -712,9 +724,10 @@ class AttentionBlock:
         # ========================================================================
         # Gather3 parameters: 112 cores -> [1, 7168]
         # ========================================================================
-        gather3_data_size_bytes = matmul5_out_w_per_core * tile_1x32_size
-        gather3_src_num_pages = matmul5_out_w_per_core  # 2 pages per sender
-        gather3_dst_num_pages = num_tiles  # Same as input tensor
+        gather3_data_size_bytes = matmul5_out_w_per_core * tile_1x32_size  # 1 tile per sender
+        gather3_src_num_pages = matmul5_out_w_per_core  # 1 page per sender
+        gather3_dst_num_tiles = (per_device_out_tiles + 31) // 32  # 2 tiles of 32x32 per half
+        gather3_half_size_bytes = gather3_dst_num_tiles * tile_32x32_size  # padded to 32x32 boundary
         gather3_noc0_num_senders = num_matmul5_cores
         gather3_noc1_num_senders = 0
 
@@ -956,18 +969,19 @@ class AttentionBlock:
         assert (
             post_sdpa_weights2_tensor.get_tile() == matmul_weights_tensor.get_tile()
         ), f"Post SDPA weights2 tensor tile ({post_sdpa_weights2_tensor.get_tile()}) must be equal to matmul weights tensor tile ({matmul_weights_tensor.get_tile()})"
-        matmul5_out_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Matmul5 output (112 active cores)
-        gather3_dst_cb = cb_id_context.get_cb_id(
-            data_format, TD_INTERP
-        )  # Gather3 output = CCL local data (sender core 11,9)
+        matmul5_out_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # KNSlicedMatmul output (112 active cores)
+        gather3_scratch_cb = cb_id_context.get_cb_id(
+            data_format, TD_32x32
+        )  # GatherReduce scratch CB (2 * gather3_dst_num_tiles of 32x32 on receiver)
+        gather3_out_cb = cb_id_context.get_cb_id(
+            data_format, TD_32x32
+        )  # GatherReduce output = CCL local data (sender core 11,9)
         ccl_recv_local_data_cb = cb_id_context.get_cb_id(
-            data_format, TD_INTERP
+            data_format, TD_32x32
         )  # CCL receiver local data (NOC copy on receiver core 12,9)
-        ccl_remote_data_cb = cb_id_context.get_cb_id(data_format, TD_INTERP)  # CCL received remote data (receiver core)
-        ccl_residual_cb = input_cb
-        ccl_output_cb = cb_id_context.get_cb_id(data_format, TD_INTERP)  # CCL output (receiver core)
-
-        attention_block_output_cb = ccl_output_cb  # Attention block output (receiver core)
+        ccl_remote_data_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # CCL received remote data (receiver core)
+        ccl_residual_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # CCL residual (offset slice of input)
+        ccl_output_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # CCL output (receiver core)
 
         # Configure AllReduceConfig in no-ownership mode:
         # All CCL CBs are carved from overlapped memory (sdpa_kv_cache_buffer),
@@ -979,7 +993,7 @@ class AttentionBlock:
             semaphores=ccl_fabric_semaphores + [ccl_local_ready_semaphore],
             cluster_axis=reduce_cluster_axis,
             num_links=num_links_allreduce,
-            local_data_cb_id=gather3_dst_cb,
+            local_data_cb_id=gather3_out_cb,
             recv_local_data_cb_id=ccl_recv_local_data_cb,
             remote_data_cb_id=ccl_remote_data_cb,
             output_cb_id=ccl_output_cb,
@@ -987,6 +1001,8 @@ class AttentionBlock:
             skip_local_push=True,
             skip_ccl=skip_ccl,
             sender_core=ccl_sender_core,
+            num_tiles_override=gather3_dst_num_tiles,
+            page_size_override=tile_32x32_size,
         )
 
         # RMSNorm2 parameters (for 1536 element input using 16x32 tiles)
@@ -1737,24 +1753,28 @@ class AttentionBlock:
             ("mcast3_data_receiver_semaphore", mcast3_data_receiver_semaphore_id),
             ("mcast3_dst_cb", matmul5_in0_cb),
             ("mcast3_dst_num_pages", mcast3_dst_num_pages),
-            # Matmul5
+            # Matmul5 (KNSlicedMatmul)
             ("matmul5_in0", matmul5_in0_cb),
             ("matmul5_in1", matmul5_in1_cb),
             ("matmul5_out", matmul5_out_cb),
-            ("matmul5_k_num_tiles", matmul5_k_num_tiles),
             ("matmul5_out_w_per_core", matmul5_out_w_per_core),
-            # Gather3 sender (destination is now sender core 11,9)
+            ("matmul5_k_per_core", matmul5_k_per_core),
+            ("matmul5_act_total_tiles", matmul5_act_total_tiles),
+            # GatherReduce3 sender (destination is now sender core 11,9)
             ("gather3_dest_noc_x", ccl_sender_noc_core.x),
             ("gather3_dest_noc_y", ccl_sender_noc_core.y),
             ("gather3_data_size_bytes", gather3_data_size_bytes),
-            ("gather3_receiver_semaphore_id", gather3_noc0_receiver_semaphore_id),
+            ("gather3_receiver_semaphore_addr", gather3_noc0_receiver_semaphore_id),
             ("gather3_src_cb", matmul5_out_cb),
             ("gather3_src_num_pages", gather3_src_num_pages),
-            ("gather3_sender_grid_start_x", 0),
-            ("gather3_sender_grid_start_y", 0),
-            ("gather3_sender_grid_end_x", 0),
-            ("gather3_sender_grid_end_y", 0),
-            ("gather3_row_major", 1),
+            # Grid args unused when UsePerCoreSenderIdx=true, but required for struct init
+            ("gather3_grid_start_x", 0),
+            ("gather3_grid_start_y", 0),
+            ("gather3_grid_end_x", 0),
+            ("gather3_grid_end_y", 0),
+            ("gather3_half_num_cores", matmul5_half_num_cores),
+            ("gather3_dst_cb_id", gather3_scratch_cb),
+            ("gather3_half_size_bytes", gather3_half_size_bytes),
         ]
 
         # Append AllReduceConfig NCRISC CT args (writer on sender core + reader on receiver core)
@@ -1815,8 +1835,8 @@ class AttentionBlock:
             ("gather3_noc1_num_senders", gather3_noc1_num_senders),
             ("gather3_noc0_receiver_semaphore_id", gather3_noc0_receiver_semaphore_id),
             ("gather3_noc1_receiver_semaphore_id", gather3_noc1_receiver_semaphore_id),
-            ("gather3_dst_cb", gather3_dst_cb),
-            ("gather3_dst_num_pages", gather3_dst_num_pages),
+            ("gather3_dst_cb", gather3_scratch_cb),
+            ("gather3_dst_num_tiles", gather3_dst_num_tiles),
             ("sdpa_fwd_num_cores", num_sdpa_forwarder_cores),
             ("num_ccl_sender_cores", 1),
             # Input NOC coord
@@ -1871,12 +1891,17 @@ class AttentionBlock:
             ("matmul4_out", matmul4_out_cb),
             ("matmul4_k_num_tiles", matmul4_k_num_tiles),
             ("matmul4_out_w_per_core", matmul4_out_w_per_core),
-            # Matmul5
+            # Matmul5 (KNSlicedMatmul)
             ("matmul5_in0", matmul5_in0_cb),
             ("matmul5_in1", matmul5_in1_cb),
             ("matmul5_out", matmul5_out_cb),
-            ("matmul5_k_num_tiles", matmul5_k_num_tiles),
             ("matmul5_out_w_per_core", matmul5_out_w_per_core),
+            ("matmul5_k_per_core", matmul5_k_per_core),
+            ("matmul5_act_total_tiles", matmul5_act_total_tiles),
+            # GatherReduce3 compute
+            ("gather3_scratch_cb", gather3_scratch_cb),
+            ("gather3_out_cb", gather3_out_cb),
+            ("gather3_dst_num_tiles", gather3_dst_num_tiles),
         ]
 
         # Append AllReduceConfig TRISC CT args (compute on receiver core)
@@ -2715,24 +2740,42 @@ class AttentionBlock:
         matmul5_out_cb_descriptor.format_descriptors = [matmul5_out_cb_format]
         sdpa_kv_cache_running_offset_post_sdpa += matmul5_out_cb_descriptor.total_size
 
-        # CB: Gather3 output = CCL local data (overlapped with sdpa_kv_cache on mcast core)
-        # Owned externally — gather3 writes here, CCL writer reads from it.
-        gather3_dst_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=gather3_dst_cb,
+        # CB: GatherReduce3 scratch (overlapped with sdpa_kv_cache on mcast core)
+        # 2 halves of gather3_dst_num_tiles tiles each (for accumulation before reduction)
+        ccl_cb_total_size = gather3_dst_num_tiles * tile_32x32_size
+        gather3_scratch_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=gather3_scratch_cb,
             data_format=data_format,
-            page_size=tile_size,
-            tile=tile_descriptor,
+            page_size=tile_32x32_size,
+            tile=ttnn.TileDescriptor(FULL_32x32_TILE),
         )
-        gather3_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            gather3_dst_cb,
+        gather3_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            gather3_scratch_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset_mcast_core,
-            total_size=num_tiles * tile_size,
+            total_size=2 * ccl_cb_total_size,
             core_ranges=full_device_grid,
         )
-        gather3_dst_cb_descriptor.format_descriptors = [gather3_dst_cb_format]
-        sdpa_kv_cache_running_offset_mcast_core += gather3_dst_cb_descriptor.total_size
-        gather3_receiver_data_addr = ttnn.get_cb_address(gather3_dst_cb_descriptor)
+        gather3_scratch_cb_descriptor.format_descriptors = [gather3_scratch_cb_format]
+        sdpa_kv_cache_running_offset_mcast_core += gather3_scratch_cb_descriptor.total_size
+
+        # CB: GatherReduce3 output = CCL local data (overlapped with sdpa_kv_cache on mcast core)
+        gather3_out_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=gather3_out_cb,
+            data_format=data_format,
+            page_size=tile_32x32_size,
+            tile=ttnn.TileDescriptor(FULL_32x32_TILE),
+        )
+        gather3_out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            gather3_out_cb,
+            ref_sdpa_kv_cache_buffer,
+            address_offset=sdpa_kv_cache_running_offset_mcast_core,
+            total_size=ccl_cb_total_size,
+            core_ranges=full_device_grid,
+        )
+        gather3_out_cb_descriptor.format_descriptors = [gather3_out_cb_format]
+        sdpa_kv_cache_running_offset_mcast_core += gather3_out_cb_descriptor.total_size
+        gather3_receiver_data_addr = ttnn.get_cb_address(gather3_out_cb_descriptor)
         allreduce_config.set_local_data_addr(gather3_receiver_data_addr)
 
         # CB: CCL recv local data (overlapped with sdpa_kv_cache on mcast core)
@@ -2741,15 +2784,15 @@ class AttentionBlock:
             ccl_recv_local_data_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset_mcast_core,
-            total_size=num_tiles * tile_size,
+            total_size=ccl_cb_total_size,
             core_ranges=full_device_grid,
         )
         ccl_recv_local_data_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
                 buffer_index=ccl_recv_local_data_cb,
                 data_format=data_format,
-                page_size=tile_size,
-                tile=tile_descriptor,
+                page_size=tile_32x32_size,
+                tile=ttnn.TileDescriptor(FULL_32x32_TILE),
             )
         ]
         sdpa_kv_cache_running_offset_mcast_core += ccl_recv_local_data_cb_descriptor.total_size
@@ -2760,28 +2803,52 @@ class AttentionBlock:
             ccl_remote_data_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset_mcast_core,
-            total_size=num_tiles * tile_size,
+            total_size=ccl_cb_total_size,
             core_ranges=full_device_grid,
         )
         ccl_remote_data_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
                 buffer_index=ccl_remote_data_cb,
                 data_format=data_format,
-                page_size=tile_size,
-                tile=tile_descriptor,
+                page_size=tile_32x32_size,
+                tile=ttnn.TileDescriptor(FULL_32x32_TILE),
             )
         ]
         sdpa_kv_cache_running_offset_mcast_core += ccl_remote_data_cb_descriptor.total_size
         ccl_send_addr = ttnn.get_cb_address(ccl_remote_data_cb_descriptor)
         allreduce_config.set_remote_data_addr(ccl_send_addr)
 
-        # CB: CCL output (backed by attention_block_output_tensor)
-        attention_block_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            attention_block_output_cb, ref_attention_block_output_tensor
+        # CB: CCL residual (overlapped with sdpa_kv_cache on mcast core)
+        ccl_residual_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            ccl_residual_cb,
+            ref_sdpa_kv_cache_buffer,
+            address_offset=sdpa_kv_cache_running_offset_mcast_core,
+            total_size=ccl_cb_total_size,
+            core_ranges=full_device_grid,
         )
-        attention_block_output_cb_descriptor.core_ranges = full_device_grid
-        attention_block_output_cb_descriptor.format_descriptors[0].tile = tile_descriptor
-        attention_block_output_cb_descriptor.format_descriptors[0].page_size = cb_page_size
+        ccl_residual_cb_descriptor.format_descriptors = [
+            ttnn.CBFormatDescriptor(
+                buffer_index=ccl_residual_cb,
+                data_format=data_format,
+                page_size=tile_32x32_size,
+                tile=ttnn.TileDescriptor(FULL_32x32_TILE),
+            )
+        ]
+        sdpa_kv_cache_running_offset_mcast_core += ccl_residual_cb_descriptor.total_size
+
+        # CB: CCL output (backed by attention_block_output_tensor for readback)
+        ccl_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            ccl_output_cb, ref_attention_block_output_tensor
+        )
+        ccl_output_cb_descriptor.core_ranges = full_device_grid
+        ccl_output_cb_descriptor.format_descriptors = [
+            ttnn.CBFormatDescriptor(
+                buffer_index=ccl_output_cb,
+                data_format=data_format,
+                page_size=tile_32x32_size,
+                tile=ttnn.TileDescriptor(FULL_32x32_TILE),
+            )
+        ]
 
         post_sdpa_cb_list = [
             matmul4_in0_cb_descriptor,
@@ -2789,10 +2856,12 @@ class AttentionBlock:
             gather2_dst_cb_descriptor,
             matmul5_in0_cb_descriptor,
             matmul5_out_cb_descriptor,
-            gather3_dst_cb_descriptor,
+            gather3_scratch_cb_descriptor,
+            gather3_out_cb_descriptor,
             ccl_recv_local_data_cb_descriptor,
             ccl_remote_data_cb_descriptor,
-            attention_block_output_cb_descriptor,
+            ccl_residual_cb_descriptor,
+            ccl_output_cb_descriptor,
         ]
 
         # In no-ownership mode, get_cb_descriptors() returns [] — all CCL CBs are above.
@@ -3276,6 +3345,11 @@ class AttentionBlock:
                 core_values=gather3_sender_idx_per_core,
                 other_value=0,
             ),
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="matmul5_k_offset",
+                core_values=matmul5_k_offset_per_core,
+                other_value=0,
+            ),
         ]
 
         per_core_ncrisc_args = mla_ncrisc_per_core_args
@@ -3443,6 +3517,16 @@ class AttentionBlock:
                     ("kv_cache_num_sp_devices", mesh_rows),
                 ]
 
+                # TP4 outer-dim residual copy params (receiver core NOC-reads input slice)
+                residual_byte_offset = row * per_device_out_tiles * tile_1x32_size
+                residual_copy_size = per_device_out_tiles * tile_1x32_size
+                residual_copy_named_compile_time_args = [
+                    ("residual_byte_offset", residual_byte_offset),
+                    ("residual_copy_size", residual_copy_size),
+                    ("residual_cb_id", ccl_residual_cb),
+                    ("residual_num_tiles", gather3_dst_num_tiles),
+                ]
+
                 # Assemble full compile-time arg lists from base + per-device parts
                 ncrisc_named_compile_time_args = (
                     bcast_ncrisc_named_compile_time_args
@@ -3450,12 +3534,14 @@ class AttentionBlock:
                     + qrope_ncrisc_addr_args
                     + krope_ncrisc_addr_args
                     + kv_cache_sp_named_compile_time_args
+                    + residual_copy_named_compile_time_args
                 )
                 ncrisc_common_runtime_args = ncrisc_bcast_common_args + [
                     kv_cache_tensor_device.buffer_address(),
                     position_ids_tensor_addr,
                     gather2_receiver_data_addr,
                     gather3_receiver_data_addr,
+                    ref_input_tensor.buffer_address(),  # input tensor L1 addr for residual copy
                 ]
 
                 brisc_named_compile_time_args = (

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
@@ -242,6 +242,8 @@ class AllReduceConfig:
         residual_cb_id=None,
         skip_local_push=False,
         sender_core=None,
+        num_tiles_override=None,
+        page_size_override=None,
     ):
         self.mesh_device = mesh_device
         self.cluster_axis = int(cluster_axis)
@@ -298,9 +300,14 @@ class AllReduceConfig:
         if num_pages % 32 != 0:
             raise ValueError(f"Tile count must be divisible by 32 for 32x32 reinterpretation, got {num_pages}")
 
-        self.total_num_tiles = num_pages // 32
-        self.element_size = 2
-        self.tile_size_bytes = CCL_TILE_H * CCL_TILE_W * self.element_size
+        if num_tiles_override is not None and page_size_override is not None:
+            self.total_num_tiles = int(num_tiles_override)
+            self.element_size = 2
+            self.tile_size_bytes = int(page_size_override)
+        else:
+            self.total_num_tiles = num_pages // 32
+            self.element_size = 2
+            self.tile_size_bytes = CCL_TILE_H * CCL_TILE_W * self.element_size
         self.chunk = resolve_chunk_config(self.total_num_tiles, self.tile_size_bytes, chunk_num_tiles)
 
         self.data_format = metadata_sample.dtype
@@ -798,6 +805,8 @@ class DeepseekMinimalAllReduce:
         skip_local_push=False,
         skip_ccl=False,
         sender_core=None,
+        num_tiles_override=None,
+        page_size_override=None,
     ):
         if skip_ccl:
             return BypassAllReduceConfig(
@@ -833,6 +842,8 @@ class DeepseekMinimalAllReduce:
             residual_cb_id=residual_cb_id,
             skip_local_push=skip_local_push,
             sender_core=sender_core,
+            num_tiles_override=num_tiles_override,
+            page_size_override=page_size_override,
         )
 
     @staticmethod

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
@@ -297,14 +297,14 @@ class AllReduceConfig:
         shard_width = metadata_sample.memory_config().shard_spec.shape[1]
         tiny_tile_w = metadata_sample.tile.tile_shape[1]
         num_pages = shard_width // tiny_tile_w
-        if num_pages % 32 != 0:
-            raise ValueError(f"Tile count must be divisible by 32 for 32x32 reinterpretation, got {num_pages}")
 
         if num_tiles_override is not None and page_size_override is not None:
             self.total_num_tiles = int(num_tiles_override)
             self.element_size = 2
             self.tile_size_bytes = int(page_size_override)
         else:
+            if num_pages % 32 != 0:
+                raise ValueError(f"Tile count must be divisible by 32 for 32x32 reinterpretation, got {num_pages}")
             self.total_num_tiles = num_pages // 32
             self.element_size = 2
             self.tile_size_bytes = CCL_TILE_H * CCL_TILE_W * self.element_size

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_kernel.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Standalone kernel replicating the gather portion of GatherReduce
+// (no TRISC reduction) for ND issue reproduction.
+//
+// 96 sender cores (12x8) each write 64B to a single receiver core
+// using the same half-based offset and NOC API sequence as GatherReduce.
+//
+// Sender (NCRISC): computes half-based offset, NOC writes 64B to receiver, sem inc
+// Receiver (BRISC): waits on semaphore for all senders
+// TRISC: no-op
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+#include "api/dataflow/dataflow_api.h"
+#endif
+
+constexpr bool is_sender_core = get_named_compile_time_arg_val("is_sender_core") == 1;
+constexpr bool is_receiver_core = get_named_compile_time_arg_val("is_receiver_core") == 1;
+
+void kernel_main() {
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (is_sender_core) {
+        // Compile-time args (same names as GatherReduce in attention block)
+        constexpr uint32_t src_cb = get_named_compile_time_arg_val("src_cb");
+        constexpr uint32_t src_num_pages = get_named_compile_time_arg_val("src_num_pages");
+        constexpr uint32_t dest_noc_x = get_named_compile_time_arg_val("dest_noc_x");
+        constexpr uint32_t dest_noc_y = get_named_compile_time_arg_val("dest_noc_y");
+        constexpr uint32_t data_size_bytes = get_named_compile_time_arg_val("data_size_bytes");
+        constexpr uint32_t grid_start_x = get_named_compile_time_arg_val("grid_start_x");
+        constexpr uint32_t grid_start_y = get_named_compile_time_arg_val("grid_start_y");
+        constexpr uint32_t grid_end_x = get_named_compile_time_arg_val("grid_end_x");
+        constexpr uint32_t grid_end_y = get_named_compile_time_arg_val("grid_end_y");
+        constexpr uint32_t half_num_cores = get_named_compile_time_arg_val("half_num_cores");
+        constexpr uint32_t half_size_bytes = get_named_compile_time_arg_val("half_size_bytes");
+
+        // Semaphore address (resolved from semaphore ID)
+        uint32_t receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("receiver_semaphore_id"));
+
+        // Runtime arg: receiver's output buffer L1 address
+        uint32_t receiver_data_addr = get_common_arg_val<uint32_t>(0);
+
+        // Setup sharded input buffer (makes data available for cb_wait_front)
+        unified_kernels::setup_sharded_buffer(src_cb, src_num_pages);
+
+        // Compute half-based offset (identical to GatherReduce)
+        const auto half_info = unified_kernels::get_split_half_core_info<true>(
+            grid_start_x, grid_start_y, grid_end_x, grid_end_y, half_num_cores);
+        uint32_t dst_offset = (half_info.is_half0 ? 0 : half_size_bytes) + half_info.half_local_idx * data_size_bytes;
+
+        // Build NOC addresses
+        const uint64_t dst_noc_coord = get_noc_addr(dest_noc_x, dest_noc_y, 0);
+        uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(receiver_data_addr + dst_offset);
+        uint64_t dst_sem_noc_addr = dst_noc_coord | (uint64_t)receiver_semaphore_addr;
+
+        // Wait for source CB data
+        cb_wait_front(src_cb, src_num_pages);
+        uint32_t src_addr = get_read_ptr(src_cb);
+
+        // NOC write sequence (identical to GatherReduce)
+        noc_async_write_one_packet<true, true>(src_addr, dst_data_noc_addr, data_size_bytes);
+        // BH does not support posted atomics due to a bug
+        noc_semaphore_inc(dst_sem_noc_addr, 1);
+        noc_async_posted_writes_flushed();
+
+        cb_pop_front(src_cb, src_num_pages);
+        noc_async_atomic_barrier();
+    }
+#elif defined(COMPILE_FOR_BRISC)
+    if constexpr (is_receiver_core) {
+        constexpr uint32_t noc0_num_senders = get_named_compile_time_arg_val("noc0_num_senders");
+        uint32_t noc0_receiver_semaphore_addr =
+            get_semaphore(get_named_compile_time_arg_val("noc0_receiver_semaphore_id"));
+
+        volatile tt_l1_ptr uint32_t* sem_ptr = (volatile tt_l1_ptr uint32_t*)noc0_receiver_semaphore_addr;
+
+        // Wait for all senders to complete their NOC writes
+        noc_semaphore_wait(sem_ptr, noc0_num_senders);
+        noc_semaphore_set(sem_ptr, 0);
+    }
+#elif defined(COMPILE_FOR_TRISC)
+    // No-op: gather only, no reduction
+#endif
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
@@ -1,16 +1,18 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Standalone kernel replicating the gather + reduce portion of GatherReduce
-// for ND issue reproduction.
+// Standalone kernel replicating GatherReduce3 from bliu/deepseek attention block.
 //
-// 96 sender cores (12x8) each write 64B to a single receiver core's scratch CB
-// using the same half-based offset and NOC API sequence as GatherReduce.
-// TRISC on the receiver core reduces the two halves: out[i] = half0[i] + half1[i]
+// 112 sender cores (o_proj grid: 12x8 + 8x2) each write 64B to a single
+// receiver core (11,9) scratch CB using UsePerCoreSenderIdx mode with
+// noc_async_write + noc_async_write_barrier (matching production exactly).
+// TRISC on the receiver reduces the two halves: out[i] = half0[i] + half1[i]
+// using 32x32 tiles (2 tiles per half, ceil(56/32) = 2).
 //
-// Sender (NCRISC): computes half-based offset, NOC writes 64B to receiver scratch CB, sem inc
+// Sender (NCRISC): uses per-core sender_idx to compute half-based offset,
+//                   noc_async_write + noc_async_write_barrier, sem inc
 // Receiver (BRISC): cb_reserve_back on scratch, waits on semaphore, cb_push_back
-// TRISC (receiver only): add_half_tiles reduction
+// TRISC (receiver only): add_half_tiles reduction (32x32 tiles)
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
@@ -35,25 +37,22 @@ void kernel_main() {
         constexpr uint32_t dest_noc_x = get_named_compile_time_arg_val("dest_noc_x");
         constexpr uint32_t dest_noc_y = get_named_compile_time_arg_val("dest_noc_y");
         constexpr uint32_t data_size_bytes = get_named_compile_time_arg_val("data_size_bytes");
-        constexpr uint32_t grid_start_x = get_named_compile_time_arg_val("grid_start_x");
-        constexpr uint32_t grid_start_y = get_named_compile_time_arg_val("grid_start_y");
-        constexpr uint32_t grid_end_x = get_named_compile_time_arg_val("grid_end_x");
-        constexpr uint32_t grid_end_y = get_named_compile_time_arg_val("grid_end_y");
         constexpr uint32_t half_num_cores = get_named_compile_time_arg_val("half_num_cores");
         constexpr uint32_t half_size_bytes = get_named_compile_time_arg_val("half_size_bytes");
         constexpr uint32_t scratch_cb = get_named_compile_time_arg_val("scratch_cb");
+        constexpr uint32_t sender_idx = get_named_compile_time_arg_val("sender_idx");
 
         uint32_t receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("receiver_semaphore_id"));
 
         // Setup sharded input buffer
         unified_kernels::setup_sharded_buffer(src_cb, src_num_pages);
 
-        // Compute half-based offset (identical to GatherReduce)
-        const auto half_info = unified_kernels::get_split_half_core_info<true>(
-            grid_start_x, grid_start_y, grid_end_x, grid_end_y, half_num_cores);
-        uint32_t dst_offset = (half_info.is_half0 ? 0 : half_size_bytes) + half_info.half_local_idx * data_size_bytes;
+        // Compute half-based offset using per-core sender index (UsePerCoreSenderIdx mode)
+        constexpr bool is_half0 = sender_idx < half_num_cores;
+        constexpr uint32_t half_local_idx = is_half0 ? sender_idx : (sender_idx - half_num_cores);
+        uint32_t dst_offset = (is_half0 ? 0 : half_size_bytes) + half_local_idx * data_size_bytes;
 
-        // Get scratch CB base address (same L1 addr on all cores)
+        // Get scratch CB base address
         uint32_t dst_base_addr = get_write_ptr(scratch_cb);
 
         // Build NOC addresses
@@ -65,11 +64,10 @@ void kernel_main() {
         cb_wait_front(src_cb, src_num_pages);
         uint32_t src_addr = get_read_ptr(src_cb);
 
-        // NOC write sequence (identical to GatherReduce)
-        noc_async_write_one_packet<true, true>(src_addr, dst_data_noc_addr, data_size_bytes);
-        // BH does not support posted atomics due to a bug
+        // NOC write sequence (matching bliu/deepseek: non-posted write + barrier)
+        noc_async_write(src_addr, dst_data_noc_addr, data_size_bytes);
+        noc_async_write_barrier();
         noc_semaphore_inc(dst_sem_noc_addr, 1);
-        noc_async_posted_writes_flushed();
 
         cb_pop_front(src_cb, src_num_pages);
         noc_async_atomic_barrier();
@@ -100,20 +98,10 @@ void kernel_main() {
         constexpr uint32_t out_cb = get_named_compile_time_arg_val("out_cb");
         constexpr uint32_t num_tiles = get_named_compile_time_arg_val("num_tiles");
 
-        // WORKAROUND: Reset out_cb pack state on TRISC2 — firmware may not
-        // fully reinitialize LocalCBInterface between generic_op executions.
-#if defined(UCK_CHLKC_PACK)
-        {
-            LocalCBInterface& oi = get_local_cb_interface(out_cb);
-            oi.fifo_wr_ptr = oi.fifo_limit - oi.fifo_size;
-            oi.fifo_wr_tile_ptr = 0;
-            oi.fifo_num_pages = num_tiles;
-            oi.tiles_acked_received_init = 0;
-        }
-#endif
+        // Full HW init required for standalone kernel (production gets this from earlier micro-ops)
+        binary_op_init_common(scratch_cb, scratch_cb, out_cb);
 
-        // Reduce: out[i] = scratch[i] + scratch[i + num_tiles] for i in [0, num_tiles)
-        // Identical to GatherReduce::add_half_tiles
+        // Match production add_half_tiles exactly
         reconfig_data_format<false, true>(scratch_cb, scratch_cb);
         pack_reconfig_data_format<true>(out_cb);
         add_tiles_init(scratch_cb, scratch_cb);
@@ -130,14 +118,10 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_tiles; i++) {
             pack_tile(i, out_cb);
         }
-        cb_push_back(out_cb, num_tiles);
         tile_regs_release();
+        cb_push_back(out_cb, num_tiles);
 
         cb_pop_front(scratch_cb, 2 * num_tiles);
-
-        // Consume output CB to reset tiles_acked (no downstream consumer in this test)
-        cb_wait_front(out_cb, num_tiles);
-        cb_pop_front(out_cb, num_tiles);
     }
 #endif
 }

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
@@ -100,6 +100,33 @@ void kernel_main() {
         constexpr uint32_t out_cb = get_named_compile_time_arg_val("out_cb");
         constexpr uint32_t num_tiles = get_named_compile_time_arg_val("num_tiles");
 
+        // WORKAROUND: Full CB state reset — firmware may not reinitialize
+        // all LocalCBInterface fields between generic_op program executions.
+        // Mirrors what setup_local_cb_read_write_interfaces does at program load.
+#if defined(UCK_CHLKC_UNPACK)
+        // TRISC0 (unpack) owns fifo_rd_ptr for both scratch_cb and out_cb
+        {
+            LocalCBInterface& si = get_local_cb_interface(scratch_cb);
+            si.fifo_rd_ptr = si.fifo_limit - si.fifo_size;
+            si.tiles_acked_received_init = 0;
+        }
+        {
+            LocalCBInterface& oi = get_local_cb_interface(out_cb);
+            oi.fifo_rd_ptr = oi.fifo_limit - oi.fifo_size;
+            oi.tiles_acked_received_init = 0;
+        }
+#endif
+#if defined(UCK_CHLKC_PACK)
+        // TRISC2 (pack) owns fifo_wr_ptr for out_cb
+        {
+            LocalCBInterface& oi = get_local_cb_interface(out_cb);
+            oi.fifo_wr_ptr = oi.fifo_limit - oi.fifo_size;
+            oi.fifo_wr_tile_ptr = 0;
+            oi.fifo_num_pages = num_tiles;
+            oi.tiles_acked_received_init = 0;
+        }
+#endif
+
         // Reduce: out[i] = scratch[i] + scratch[i + num_tiles] for i in [0, num_tiles)
         // Identical to GatherReduce::add_half_tiles
         reconfig_data_format<false, true>(scratch_cb, scratch_cb);

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Standalone kernel replicating the gather + reduce portion of GatherReduce
+// for ND issue reproduction.
+//
+// 96 sender cores (12x8) each write 64B to a single receiver core's scratch CB
+// using the same half-based offset and NOC API sequence as GatherReduce.
+// TRISC on the receiver core reduces the two halves: out[i] = half0[i] + half1[i]
+//
+// Sender (NCRISC): computes half-based offset, NOC writes 64B to receiver scratch CB, sem inc
+// Receiver (BRISC): cb_reserve_back on scratch, waits on semaphore, cb_push_back
+// TRISC (receiver only): add_half_tiles reduction
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+#include "api/dataflow/dataflow_api.h"
+#endif
+
+#if defined(COMPILE_FOR_TRISC)
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#endif
+
+constexpr bool is_sender_core = get_named_compile_time_arg_val("is_sender_core") == 1;
+constexpr bool is_receiver_core = get_named_compile_time_arg_val("is_receiver_core") == 1;
+
+void kernel_main() {
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (is_sender_core) {
+        constexpr uint32_t src_cb = get_named_compile_time_arg_val("src_cb");
+        constexpr uint32_t src_num_pages = get_named_compile_time_arg_val("src_num_pages");
+        constexpr uint32_t dest_noc_x = get_named_compile_time_arg_val("dest_noc_x");
+        constexpr uint32_t dest_noc_y = get_named_compile_time_arg_val("dest_noc_y");
+        constexpr uint32_t data_size_bytes = get_named_compile_time_arg_val("data_size_bytes");
+        constexpr uint32_t grid_start_x = get_named_compile_time_arg_val("grid_start_x");
+        constexpr uint32_t grid_start_y = get_named_compile_time_arg_val("grid_start_y");
+        constexpr uint32_t grid_end_x = get_named_compile_time_arg_val("grid_end_x");
+        constexpr uint32_t grid_end_y = get_named_compile_time_arg_val("grid_end_y");
+        constexpr uint32_t half_num_cores = get_named_compile_time_arg_val("half_num_cores");
+        constexpr uint32_t half_size_bytes = get_named_compile_time_arg_val("half_size_bytes");
+        constexpr uint32_t scratch_cb = get_named_compile_time_arg_val("scratch_cb");
+
+        uint32_t receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("receiver_semaphore_id"));
+
+        // Setup sharded input buffer
+        unified_kernels::setup_sharded_buffer(src_cb, src_num_pages);
+
+        // Compute half-based offset (identical to GatherReduce)
+        const auto half_info = unified_kernels::get_split_half_core_info<true>(
+            grid_start_x, grid_start_y, grid_end_x, grid_end_y, half_num_cores);
+        uint32_t dst_offset = (half_info.is_half0 ? 0 : half_size_bytes) + half_info.half_local_idx * data_size_bytes;
+
+        // Get scratch CB base address (same L1 addr on all cores)
+        uint32_t dst_base_addr = get_write_ptr(scratch_cb);
+
+        // Build NOC addresses
+        const uint64_t dst_noc_coord = get_noc_addr(dest_noc_x, dest_noc_y, 0);
+        uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(dst_base_addr + dst_offset);
+        uint64_t dst_sem_noc_addr = dst_noc_coord | (uint64_t)receiver_semaphore_addr;
+
+        // Wait for source CB data
+        cb_wait_front(src_cb, src_num_pages);
+        uint32_t src_addr = get_read_ptr(src_cb);
+
+        // NOC write sequence (identical to GatherReduce)
+        noc_async_write_one_packet<true, true>(src_addr, dst_data_noc_addr, data_size_bytes);
+        // BH does not support posted atomics due to a bug
+        noc_semaphore_inc(dst_sem_noc_addr, 1);
+        noc_async_posted_writes_flushed();
+
+        cb_pop_front(src_cb, src_num_pages);
+        noc_async_atomic_barrier();
+    }
+#elif defined(COMPILE_FOR_BRISC)
+    if constexpr (is_receiver_core) {
+        constexpr uint32_t noc0_num_senders = get_named_compile_time_arg_val("noc0_num_senders");
+        constexpr uint32_t scratch_cb = get_named_compile_time_arg_val("scratch_cb");
+        constexpr uint32_t num_tiles = get_named_compile_time_arg_val("num_tiles");
+        uint32_t noc0_receiver_semaphore_addr =
+            get_semaphore(get_named_compile_time_arg_val("noc0_receiver_semaphore_id"));
+
+        volatile tt_l1_ptr uint32_t* sem_ptr = (volatile tt_l1_ptr uint32_t*)noc0_receiver_semaphore_addr;
+
+        // Reserve space in scratch CB for both halves (2 * num_tiles)
+        cb_reserve_back(scratch_cb, 2 * num_tiles);
+
+        // Wait for all senders to complete their NOC writes
+        noc_semaphore_wait(sem_ptr, noc0_num_senders);
+        noc_semaphore_set(sem_ptr, 0);
+
+        // Push data to make it available for TRISC
+        cb_push_back(scratch_cb, 2 * num_tiles);
+    }
+#elif defined(COMPILE_FOR_TRISC)
+    if constexpr (is_receiver_core) {
+        constexpr uint32_t scratch_cb = get_named_compile_time_arg_val("scratch_cb");
+        constexpr uint32_t out_cb = get_named_compile_time_arg_val("out_cb");
+        constexpr uint32_t num_tiles = get_named_compile_time_arg_val("num_tiles");
+
+        // Reduce: out[i] = scratch[i] + scratch[i + num_tiles] for i in [0, num_tiles)
+        // Identical to GatherReduce::add_half_tiles
+        reconfig_data_format<false, true>(scratch_cb, scratch_cb);
+        pack_reconfig_data_format<true>(out_cb);
+        add_tiles_init(scratch_cb, scratch_cb);
+
+        cb_wait_front(scratch_cb, 2 * num_tiles);
+        cb_reserve_back(out_cb, num_tiles);
+
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < num_tiles; i++) {
+            add_tiles(scratch_cb, scratch_cb, i, num_tiles + i, i);
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles; i++) {
+            pack_tile(i, out_cb);
+        }
+        cb_push_back(out_cb, num_tiles);
+        tile_regs_release();
+
+        cb_pop_front(scratch_cb, 2 * num_tiles);
+    }
+#endif
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
@@ -122,6 +122,10 @@ void kernel_main() {
         tile_regs_release();
 
         cb_pop_front(scratch_cb, 2 * num_tiles);
+
+        // Consume output CB to reset tiles_acked (no downstream consumer in this test)
+        cb_wait_front(out_cb, num_tiles);
+        cb_pop_front(out_cb, num_tiles);
     }
 #endif
 }

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp
@@ -100,24 +100,9 @@ void kernel_main() {
         constexpr uint32_t out_cb = get_named_compile_time_arg_val("out_cb");
         constexpr uint32_t num_tiles = get_named_compile_time_arg_val("num_tiles");
 
-        // WORKAROUND: Full CB state reset — firmware may not reinitialize
-        // all LocalCBInterface fields between generic_op program executions.
-        // Mirrors what setup_local_cb_read_write_interfaces does at program load.
-#if defined(UCK_CHLKC_UNPACK)
-        // TRISC0 (unpack) owns fifo_rd_ptr for both scratch_cb and out_cb
-        {
-            LocalCBInterface& si = get_local_cb_interface(scratch_cb);
-            si.fifo_rd_ptr = si.fifo_limit - si.fifo_size;
-            si.tiles_acked_received_init = 0;
-        }
-        {
-            LocalCBInterface& oi = get_local_cb_interface(out_cb);
-            oi.fifo_rd_ptr = oi.fifo_limit - oi.fifo_size;
-            oi.tiles_acked_received_init = 0;
-        }
-#endif
+        // WORKAROUND: Reset out_cb pack state on TRISC2 — firmware may not
+        // fully reinitialize LocalCBInterface between generic_op executions.
 #if defined(UCK_CHLKC_PACK)
-        // TRISC2 (pack) owns fifo_wr_ptr for out_cb
         {
             LocalCBInterface& oi = get_local_cb_interface(out_cb);
             oi.fifo_wr_ptr = oi.fifo_limit - oi.fifo_size;

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -637,13 +637,16 @@ def test_attention_block(
 
     # Per-core dimensions
     n1_per_core = post_sdpa_intermediate // num_matmul1_cores  # 8192 / 64 = 128
-    n2_per_core = output_size // num_matmul2_cores  # 7168 / 112 = 64
+    per_device_out_w = output_size // mesh_rows  # 7168 / 4 = 1792
+    n2_per_core = per_device_out_w // (num_matmul2_cores // 2)  # 1792 / 56 = 32
 
     logger.info(f"Testing post_sdpa fused op with SDPA reduce-to-all phase:")
     logger.info(f"  SDPA: [{SDPA_L_HEIGHT}, {SDPA_L_WIDTH}] L tensor, [{SDPA_L_HEIGHT}, {SDPA_MS_WIDTH}] MS tensor")
     logger.info(f"  Matmul1: [{M}, {K1}] x [{K1}, {post_sdpa_intermediate}] on {num_matmul1_cores} cores")
-    logger.info(f"  Matmul2: [{M}, {K2}] x [{K2}, {output_size}] on {num_matmul2_cores} active cores")
-    logger.info(f"  TP All-Reduce: [{M}, {output_size}] across {num_devices} devices")
+    logger.info(
+        f"  Matmul2 (KNSliced): [{M}, {K2}] x [{K2//2}, {n2_per_core}] per core, {num_matmul2_cores} cores (2x{num_matmul2_cores//2} halves)"
+    )
+    logger.info(f"  TP All-Reduce: [{M}, {per_device_out_w}] per device across {num_devices} devices")
 
     gather_core = ttnn.CoreCoord(12, 9)
     gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
@@ -725,9 +728,9 @@ def test_attention_block(
     # Create CCL tensors
     # ========================================================================
     # Final output: receiver core (12,9) — all-reduce output + residual add
-    output_shard_spec = ttnn.ShardSpec(gather_core_grid, (M, output_size), ttnn.ShardOrientation.ROW_MAJOR)
+    output_shard_spec = ttnn.ShardSpec(gather_core_grid, (M, per_device_out_w), ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
-    mesh_output_torch = torch.cat([torch.zeros((M, output_size), dtype=torch.bfloat16)] * num_devices, dim=0)
+    mesh_output_torch = torch.cat([torch.zeros((M, per_device_out_w), dtype=torch.bfloat16)] * num_devices, dim=0)
     ttnn_attention_block_output = ttnn.from_torch(
         mesh_output_torch,
         device=submesh,
@@ -1104,17 +1107,26 @@ def test_attention_block(
 
     # ========================================================================
     # Validate attention block output (full pipeline: SDPA -> kv_b2 -> o_proj -> all-reduce + residual)
+    # Without AllGather, each device has [1, per_device_out_w] = [1, 1792] (its row's slice)
+    # Column partners (same row) should have identical output. Different rows have different slices.
     # ========================================================================
-    ref_device_idx = 0
-    ref_device_output = output_torch[ref_device_idx : ref_device_idx + 1, :]
+    slot_size = per_device_out_w  # 1792
     for device_idx in range(mesh_rows * mesh_cols):
-        received = output_torch[device_idx : device_idx + 1, :]
-        if device_idx != ref_device_idx:
-            dev_eq = torch.equal(received, ref_device_output)
-            assert dev_eq, f"Device {device_idx} output mismatch"
+        sp_group = device_idx // mesh_cols  # which row = which slice
+        tp_group = device_idx % mesh_cols
 
-        passing, pcc = comp_pcc(torch_output_expected, received, 0.997)
-        max_diff = torch.max(torch.abs(torch_output_expected - received)).item()
+        received = output_torch[device_idx : device_idx + 1, :]
+        expected_slice = torch_output_expected[:, sp_group * slot_size : (sp_group + 1) * slot_size]
+
+        # Column partners should be identical
+        col_partner_idx = sp_group * mesh_cols  # first device in this row
+        if device_idx != col_partner_idx:
+            partner_output = output_torch[col_partner_idx : col_partner_idx + 1, :]
+            dev_eq = torch.equal(received, partner_output)
+            assert dev_eq, f"Device {device_idx} output differs from column partner {col_partner_idx}"
+
+        passing, pcc = comp_pcc(expected_slice, received, 0.997)
+        max_diff = torch.max(torch.abs(expected_slice - received)).item()
         logger.info(f"Device {device_idx} Attention Block Output PCC: {pcc} Max Diff: {max_diff}")
         assert passing, f"Device {device_idx} Attention Block Output PCC check failed: {pcc}"
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ND Gather Reproduction Test
+
+Replicates the gather portion of GatherReduce after matmul5 in the attention block:
+  - 96 sender cores (12x8 grid) each write 64B (1x32 bf16 tile) to a single receiver core
+  - Half-based offset: cores 0-47 write to half0, cores 48-95 write to half1
+  - NOC API: noc_async_write_one_packet + noc_semaphore_inc + noc_async_posted_writes_flushed
+  - No TRISC reduction
+
+Run multiple iterations to detect non-deterministic (ND) PCC corruption.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+
+# =============================================================================
+# Constants matching GatherReduce3 in the attention block
+# =============================================================================
+
+SENDER_GRID_START = (0, 0)
+SENDER_GRID_END = (11, 7)
+NUM_SENDER_COLS = SENDER_GRID_END[0] - SENDER_GRID_START[0] + 1  # 12
+NUM_SENDER_ROWS = SENDER_GRID_END[1] - SENDER_GRID_START[1] + 1  # 8
+NUM_SENDERS = NUM_SENDER_COLS * NUM_SENDER_ROWS  # 96
+HALF_NUM_CORES = NUM_SENDERS // 2  # 48
+WIDTH_PER_CORE = 32  # 1x32 tile
+TILE = ttnn.Tile([1, 32])
+DATA_SIZE_BYTES = 64  # 1x32 bf16 tile = 32 * 2 bytes
+HALF_SIZE_BYTES = HALF_NUM_CORES * DATA_SIZE_BYTES  # 48 * 64 = 3072
+TOTAL_WIDTH = NUM_SENDERS * WIDTH_PER_CORE  # 96 * 32 = 3072 elements
+
+RECEIVER_CORE = ttnn.CoreCoord(12, 9)  # rmsnorm core in attention block
+
+KERNEL_PATH = "models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_kernel.cpp"
+
+SEMAPHORE_ID = 0
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def create_sharded_input(device, torch_input, sender_grid, shard_shape):
+    """Create WIDTH_SHARDED input tensor on the sender grid."""
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({sender_grid}),
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+    return ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=TILE,
+    )
+
+
+def create_output_tensor(device, output_shape, receiver_core):
+    """Create HEIGHT_SHARDED output tensor on the receiver core."""
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(receiver_core, receiver_core)}),
+        output_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    torch_output = torch.zeros(output_shape, dtype=torch.bfloat16)
+    return ttnn.from_torch(
+        torch_output,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=TILE,
+    )
+
+
+def build_program(device, input_tensor, output_tensor, sender_grid, receiver_core):
+    """Build the gather program descriptor (identical NOC pattern to GatherReduce)."""
+    receiver_noc_core = device.worker_core_from_logical_core(receiver_core)
+    receiver_data_addr = output_tensor.buffer_address()
+
+    sender_core_range = ttnn.CoreRangeSet({sender_grid})
+    receiver_core_range = ttnn.CoreRangeSet({ttnn.CoreRange(receiver_core, receiver_core)})
+    all_cores = sender_core_range.merge(receiver_core_range)
+
+    # --- Semaphore ---
+    semaphore = ttnn.SemaphoreDescriptor(
+        id=SEMAPHORE_ID,
+        core_ranges=all_cores,
+        initial_value=0,
+    )
+
+    # --- Sender kernel (NCRISC) on 12x8 grid ---
+    sender_named_args = [
+        ("is_sender_core", 1),
+        ("is_receiver_core", 0),
+        ("src_cb", 0),
+        ("src_num_pages", 1),
+        ("dest_noc_x", receiver_noc_core.x),
+        ("dest_noc_y", receiver_noc_core.y),
+        ("data_size_bytes", DATA_SIZE_BYTES),
+        ("receiver_semaphore_id", SEMAPHORE_ID),
+        ("grid_start_x", sender_grid.start.x),
+        ("grid_start_y", sender_grid.start.y),
+        ("grid_end_x", sender_grid.end.x),
+        ("grid_end_y", sender_grid.end.y),
+        ("half_num_cores", HALF_NUM_CORES),
+        ("half_size_bytes", HALF_SIZE_BYTES),
+    ]
+
+    sender_kernel = ttnn.KernelDescriptor(
+        kernel_source=KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=sender_core_range,
+        named_compile_time_args=sender_named_args,
+        common_runtime_args=[receiver_data_addr],
+        config=ttnn.DataMovementConfigDescriptor(
+            processor=ttnn.DataMovementProcessor.RISCV_1,
+            noc=ttnn.NOC.NOC_0,
+        ),
+    )
+
+    # --- Receiver kernel (BRISC) on receiver core ---
+    receiver_named_args = [
+        ("is_sender_core", 0),
+        ("is_receiver_core", 1),
+        ("noc0_num_senders", NUM_SENDERS),
+        ("noc0_receiver_semaphore_id", SEMAPHORE_ID),
+    ]
+
+    receiver_kernel = ttnn.KernelDescriptor(
+        kernel_source=KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=receiver_core_range,
+        named_compile_time_args=receiver_named_args,
+        config=ttnn.DataMovementConfigDescriptor(
+            processor=ttnn.DataMovementProcessor.RISCV_0,
+            noc=ttnn.NOC.NOC_1,
+        ),
+    )
+
+    # --- Compute kernels (no-op) ---
+    sender_compute = ttnn.KernelDescriptor(
+        kernel_source=KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=sender_core_range,
+        named_compile_time_args=[("is_sender_core", 1), ("is_receiver_core", 0)],
+        config=ttnn.ComputeConfigDescriptor(),
+    )
+
+    receiver_compute = ttnn.KernelDescriptor(
+        kernel_source=KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=receiver_core_range,
+        named_compile_time_args=[("is_sender_core", 0), ("is_receiver_core", 1)],
+        config=ttnn.ComputeConfigDescriptor(),
+    )
+
+    # --- CBs ---
+    src_cb = ttnn.cb_descriptor_from_sharded_tensor(0, input_tensor)
+
+    return ttnn.ProgramDescriptor(
+        kernels=[sender_kernel, receiver_kernel, sender_compute, receiver_compute],
+        cbs=[src_cb],
+        semaphores=[semaphore],
+    )
+
+
+# =============================================================================
+# Test
+# =============================================================================
+
+
+@pytest.mark.requires_grid_size((13, 10))
+@pytest.mark.parametrize("num_iterations", [20])
+def test_nd_gather(device, check_requires_grid_size, num_iterations):
+    """
+    Run the gather pattern from GatherReduce (96 senders -> 1 receiver, 64B each)
+    multiple times and check for ND PCC corruption.
+    """
+    sender_grid = ttnn.CoreRange(
+        ttnn.CoreCoord(*SENDER_GRID_START),
+        ttnn.CoreCoord(*SENDER_GRID_END),
+    )
+
+    shard_shape = (1, WIDTH_PER_CORE)
+    output_shape = (1, TOTAL_WIDTH)
+
+    logger.info(f"Testing ND gather: {NUM_SENDERS} senders (12x8) -> receiver ({RECEIVER_CORE.x},{RECEIVER_CORE.y})")
+    logger.info(f"  data_size_bytes={DATA_SIZE_BYTES}, half_num_cores={HALF_NUM_CORES}, iterations={num_iterations}")
+
+    all_pass = True
+    pcc_values = []
+
+    for i in range(num_iterations):
+        torch.manual_seed(i)
+        torch_input = torch.randn(output_shape, dtype=torch.bfloat16)
+
+        ttnn_input = create_sharded_input(device, torch_input, sender_grid, shard_shape)
+        ttnn_output = create_output_tensor(device, output_shape, RECEIVER_CORE)
+
+        program = build_program(device, ttnn_input, ttnn_output, sender_grid, RECEIVER_CORE)
+        result = ttnn.generic_op([ttnn_input, ttnn_output], program)
+
+        result_torch = ttnn.to_torch(result)
+        passing, pcc_msg = comp_pcc(torch_input, result_torch, 0.9999)
+        pcc_values.append(float(pcc_msg.split("=")[-1].strip()))
+
+        status = "PASS" if passing else "FAIL"
+        logger.info(f"  [{i+1:>2}/{num_iterations}] {status} {pcc_msg}")
+
+        if not passing:
+            all_pass = False
+
+        ttnn_input.deallocate()
+        ttnn_output.deallocate()
+
+    # Summary
+    logger.info(f"Results: {sum(1 for p in pcc_values if p >= 0.9999)}/{num_iterations} passed (PCC >= 0.9999)")
+    logger.info(f"  min PCC = {min(pcc_values):.6f}, max PCC = {max(pcc_values):.6f}")
+
+    assert all_pass, f"ND gather failed on {sum(1 for p in pcc_values if p < 0.9999)}/{num_iterations} iterations"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
@@ -351,12 +351,18 @@ def build_gather_reduce_program(device, input_tensor, anchor_tensor, output_tens
     )
 
     # --- Compute kernels ---
-    # Sender compute (no-op)
+    # Sender compute (no-op, but must pass TRISC args for constexpr resolution)
     sender_compute = ttnn.KernelDescriptor(
         kernel_source=GATHER_REDUCE_KERNEL_PATH,
         source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
         core_ranges=sender_core_range,
-        named_compile_time_args=[("is_sender_core", 1), ("is_receiver_core", 0)],
+        named_compile_time_args=[
+            ("is_sender_core", 1),
+            ("is_receiver_core", 0),
+            ("scratch_cb", scratch_cb_id),
+            ("out_cb", out_cb_id),
+            ("num_tiles", NUM_REDUCE_TILES),
+        ],
         config=ttnn.ComputeConfigDescriptor(),
     )
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
@@ -467,6 +467,14 @@ def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
 
         result_torch = ttnn.to_torch(result)
 
+        # Debug: print shape and first values on first 3 iterations
+        if i < 3:
+            logger.info(f"  [{i+1:>2}] result shape={result_torch.shape}, dtype={result_torch.dtype}")
+            logger.info(f"  [{i+1:>2}] result[:5]={result_torch.flatten()[:5].tolist()}")
+            logger.info(
+                f"  [{i+1:>2}] result nonzero count={result_torch.count_nonzero().item()}/{result_torch.numel()}"
+            )
+
         if reference_output is None:
             reference_output = result_torch.clone()
             # Sanity: output should not be all zeros

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
@@ -2,16 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-ND Gather Reproduction Test
+ND GatherReduce3 Reproduction Test
 
-Replicates the gather portion of GatherReduce after matmul5 in the attention block:
-  - 96 sender cores (12x8 grid) each write 64B (1x32 bf16 tile) to a single receiver core
-  - Half-based offset: cores 0-47 write to half0, cores 48-95 write to half1
-  - NOC API: noc_async_write_one_packet + noc_semaphore_inc + noc_async_posted_writes_flushed
-  - No TRISC reduction
+Replicates GatherReduce3 after matmul5 in the bliu/deepseek attention block:
+  - 112 sender cores (o_proj grid: 12x8 + 8x2) each write 64B (1x32 bf16 tile)
+  - UsePerCoreSenderIdx mode: per-core contiguous index 0..111
+  - Half-based offset: cores 0-55 write to half0, cores 56-111 write to half1
+  - NOC API: noc_async_write + noc_async_write_barrier + noc_semaphore_inc
+  - TRISC reduces using 32x32 tiles: out[i] = half0[i] + half1[i]
+  - Receiver core (11, 9) = CCL sender core
 
 Run multiple iterations to detect non-deterministic (ND) PCC corruption.
 """
+
+import sys
 
 import pytest
 import torch
@@ -21,30 +25,31 @@ import ttnn
 from models.common.utility_functions import comp_pcc
 
 # =============================================================================
-# Constants matching GatherReduce3 in the attention block
+# Constants matching GatherReduce3 on bliu/deepseek
 # =============================================================================
 
-SENDER_GRID_START = (0, 0)
-SENDER_GRID_END = (11, 7)
-NUM_SENDER_COLS = SENDER_GRID_END[0] - SENDER_GRID_START[0] + 1  # 12
-NUM_SENDER_ROWS = SENDER_GRID_END[1] - SENDER_GRID_START[1] + 1  # 8
-NUM_SENDERS = NUM_SENDER_COLS * NUM_SENDER_ROWS  # 96
-HALF_NUM_CORES = NUM_SENDERS // 2  # 48
-WIDTH_PER_CORE = 32  # 1x32 tile
+# Non-rectangular sender grid: o_proj cores = 12x8 + 8x2 = 112 cores
+SENDER_RANGE1_START = (0, 0)
+SENDER_RANGE1_END = (11, 7)  # 12 cols x 8 rows = 96 cores
+SENDER_RANGE2_START = (0, 8)
+SENDER_RANGE2_END = (7, 9)  # 8 cols x 2 rows = 16 cores
+NUM_SENDERS = 112
+HALF_NUM_CORES = 56
+
+RECEIVER_CORE = ttnn.CoreCoord(11, 9)  # CCL sender core in bliu/deepseek
+
+WIDTH_PER_CORE = 32  # 1x32 tile per sender
 TILE_1X32 = ttnn.Tile([1, 32])
-DATA_SIZE_BYTES = 64  # 1x32 bf16 tile = 32 * 2 bytes
-HALF_SIZE_BYTES = HALF_NUM_CORES * DATA_SIZE_BYTES  # 48 * 64 = 3072
-TOTAL_WIDTH = NUM_SENDERS * WIDTH_PER_CORE  # 96 * 32 = 3072 elements
+DATA_SIZE_BYTES = 64  # 1x32 bf16 = 32 * 2
+TOTAL_WIDTH = NUM_SENDERS * WIDTH_PER_CORE  # 3584
 
-# Gather+Reduce constants (16x32 tiles for TRISC reduction)
-NUM_REDUCE_TILES = 3  # 3 tiles of 16x32 per half
-TILE_16X32 = ttnn.Tile([16, 32])
-TILE_16X32_SIZE = 1024  # 16 * 32 * 2 bytes (bf16)
-SCRATCH_SIZE_BYTES = 2 * NUM_REDUCE_TILES * TILE_16X32_SIZE  # 6144 bytes
+# Reduction uses 32x32 tiles: ceil(56 senders / 32 rows per tile) = 2 tiles per half
+TILE_32X32 = ttnn.Tile([32, 32])
+TILE_32X32_SIZE = 2048  # 32 * 32 * 2 bytes (bf16)
+NUM_REDUCE_TILES = 2  # 2 tiles of 32x32 per half
+HALF_SIZE_BYTES = NUM_REDUCE_TILES * TILE_32X32_SIZE  # 4096
+SCRATCH_SIZE_BYTES = 2 * HALF_SIZE_BYTES  # 8192
 
-RECEIVER_CORE = ttnn.CoreCoord(12, 9)  # rmsnorm core in attention block
-
-GATHER_KERNEL_PATH = "models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_kernel.cpp"
 GATHER_REDUCE_KERNEL_PATH = "models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp"
 
 SEMAPHORE_ID = 0
@@ -55,13 +60,17 @@ SEMAPHORE_ID = 0
 # =============================================================================
 
 
-def create_sharded_input(device, torch_input, sender_grid, shard_shape):
-    """Create WIDTH_SHARDED input tensor on the sender grid."""
-    shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({sender_grid}),
-        shard_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
+def get_sender_core_range_set():
+    """Build the non-rectangular sender CoreRangeSet matching o_proj grid."""
+    range1 = ttnn.CoreRange(ttnn.CoreCoord(*SENDER_RANGE1_START), ttnn.CoreCoord(*SENDER_RANGE1_END))
+    range2 = ttnn.CoreRange(ttnn.CoreCoord(*SENDER_RANGE2_START), ttnn.CoreCoord(*SENDER_RANGE2_END))
+    return ttnn.CoreRangeSet({range1, range2})
+
+
+def create_sharded_input(device, torch_input, sender_core_range_set):
+    """Create WIDTH_SHARDED input on the non-rectangular sender grid."""
+    shard_shape = (1, WIDTH_PER_CORE)
+    shard_spec = ttnn.ShardSpec(sender_core_range_set, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
     return ttnn.from_torch(
         torch_input,
@@ -73,196 +82,28 @@ def create_sharded_input(device, torch_input, sender_grid, shard_shape):
     )
 
 
-def create_output_tensor(device, output_shape, receiver_core):
-    """Create HEIGHT_SHARDED output tensor on the receiver core."""
-    shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({ttnn.CoreRange(receiver_core, receiver_core)}),
-        output_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
+def create_scratch_anchor(device, full_grid_set, num_grid_cores):
+    """Create HEIGHT_SHARDED anchor tensor on full grid for scratch CB address allocation.
+    Uses 32x32 tiles to match production GatherReduce3 scratch format."""
+    # 4 tiles of 32x32 per shard = (128, 32)
+    shard_h = 2 * NUM_REDUCE_TILES * 32  # 4 * 32 = 128
+    shard_w = 32
+    shard_spec = ttnn.ShardSpec(full_grid_set, (shard_h, shard_w), ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-    torch_output = torch.zeros(output_shape, dtype=torch.bfloat16)
     return ttnn.from_torch(
-        torch_output,
+        torch.zeros([num_grid_cores * shard_h, shard_w], dtype=torch.bfloat16),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=mem_config,
-        tile=TILE_1X32,
+        tile=TILE_32X32,
     )
 
 
-def build_program(device, input_tensor, output_tensor, sender_grid, receiver_core):
-    """Build the gather program descriptor (identical NOC pattern to GatherReduce)."""
-    receiver_noc_core = device.worker_core_from_logical_core(receiver_core)
-    receiver_data_addr = output_tensor.buffer_address()
-
-    sender_core_range = ttnn.CoreRangeSet({sender_grid})
+def create_output_tensor(device, receiver_core):
+    """Create HEIGHT_SHARDED output tensor on receiver core for reduce result (2 tiles of 32x32)."""
     receiver_core_range = ttnn.CoreRangeSet({ttnn.CoreRange(receiver_core, receiver_core)})
-    all_cores = sender_core_range.merge(receiver_core_range)
-
-    # --- Semaphore ---
-    semaphore = ttnn.SemaphoreDescriptor(
-        id=SEMAPHORE_ID,
-        core_ranges=all_cores,
-        initial_value=0,
-    )
-
-    # --- Sender kernel (NCRISC) on 12x8 grid ---
-    sender_named_args = [
-        ("is_sender_core", 1),
-        ("is_receiver_core", 0),
-        ("src_cb", 0),
-        ("src_num_pages", 1),
-        ("dest_noc_x", receiver_noc_core.x),
-        ("dest_noc_y", receiver_noc_core.y),
-        ("data_size_bytes", DATA_SIZE_BYTES),
-        ("receiver_semaphore_id", SEMAPHORE_ID),
-        ("grid_start_x", sender_grid.start.x),
-        ("grid_start_y", sender_grid.start.y),
-        ("grid_end_x", sender_grid.end.x),
-        ("grid_end_y", sender_grid.end.y),
-        ("half_num_cores", HALF_NUM_CORES),
-        ("half_size_bytes", HALF_SIZE_BYTES),
-    ]
-
-    sender_kernel = ttnn.KernelDescriptor(
-        kernel_source=GATHER_KERNEL_PATH,
-        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-        core_ranges=sender_core_range,
-        named_compile_time_args=sender_named_args,
-        common_runtime_args=[receiver_data_addr],
-        config=ttnn.DataMovementConfigDescriptor(
-            processor=ttnn.DataMovementProcessor.RISCV_1,
-            noc=ttnn.NOC.NOC_0,
-        ),
-    )
-
-    # --- Receiver kernel (BRISC) on receiver core ---
-    receiver_named_args = [
-        ("is_sender_core", 0),
-        ("is_receiver_core", 1),
-        ("noc0_num_senders", NUM_SENDERS),
-        ("noc0_receiver_semaphore_id", SEMAPHORE_ID),
-    ]
-
-    receiver_kernel = ttnn.KernelDescriptor(
-        kernel_source=GATHER_KERNEL_PATH,
-        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-        core_ranges=receiver_core_range,
-        named_compile_time_args=receiver_named_args,
-        config=ttnn.DataMovementConfigDescriptor(
-            processor=ttnn.DataMovementProcessor.RISCV_0,
-            noc=ttnn.NOC.NOC_1,
-        ),
-    )
-
-    # --- Compute kernels (no-op) ---
-    sender_compute = ttnn.KernelDescriptor(
-        kernel_source=GATHER_KERNEL_PATH,
-        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-        core_ranges=sender_core_range,
-        named_compile_time_args=[("is_sender_core", 1), ("is_receiver_core", 0)],
-        config=ttnn.ComputeConfigDescriptor(),
-    )
-
-    receiver_compute = ttnn.KernelDescriptor(
-        kernel_source=GATHER_KERNEL_PATH,
-        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-        core_ranges=receiver_core_range,
-        named_compile_time_args=[("is_sender_core", 0), ("is_receiver_core", 1)],
-        config=ttnn.ComputeConfigDescriptor(),
-    )
-
-    # --- CBs ---
-    src_cb = ttnn.cb_descriptor_from_sharded_tensor(0, input_tensor)
-
-    return ttnn.ProgramDescriptor(
-        kernels=[sender_kernel, receiver_kernel, sender_compute, receiver_compute],
-        cbs=[src_cb],
-        semaphores=[semaphore],
-    )
-
-
-# =============================================================================
-# Test
-# =============================================================================
-
-
-@pytest.mark.requires_grid_size((13, 10))
-@pytest.mark.parametrize("num_iterations", [20])
-def test_nd_gather(device, check_requires_grid_size, num_iterations):
-    """
-    Run the gather pattern from GatherReduce (96 senders -> 1 receiver, 64B each)
-    multiple times and check for ND PCC corruption.
-    """
-    sender_grid = ttnn.CoreRange(
-        ttnn.CoreCoord(*SENDER_GRID_START),
-        ttnn.CoreCoord(*SENDER_GRID_END),
-    )
-
-    shard_shape = (1, WIDTH_PER_CORE)
-    output_shape = (1, TOTAL_WIDTH)
-
-    logger.info(f"Testing ND gather: {NUM_SENDERS} senders (12x8) -> receiver ({RECEIVER_CORE.x},{RECEIVER_CORE.y})")
-    logger.info(f"  data_size_bytes={DATA_SIZE_BYTES}, half_num_cores={HALF_NUM_CORES}, iterations={num_iterations}")
-
-    all_pass = True
-    pcc_values = []
-
-    for i in range(num_iterations):
-        torch.manual_seed(i)
-        torch_input = torch.randn(output_shape, dtype=torch.bfloat16)
-
-        ttnn_input = create_sharded_input(device, torch_input, sender_grid, shard_shape)
-        ttnn_output = create_output_tensor(device, output_shape, RECEIVER_CORE)
-
-        program = build_program(device, ttnn_input, ttnn_output, sender_grid, RECEIVER_CORE)
-        result = ttnn.generic_op([ttnn_input, ttnn_output], program)
-
-        result_torch = ttnn.to_torch(result)
-        passing, pcc_val = comp_pcc(torch_input, result_torch, 0.9999)
-        pcc_values.append(float(pcc_val))
-
-        status = "PASS" if passing else "FAIL"
-        logger.info(f"  [{i+1:>2}/{num_iterations}] {status} PCC={pcc_val:.6f}")
-
-        if not passing:
-            all_pass = False
-
-        ttnn_input.deallocate()
-        ttnn_output.deallocate()
-
-    # Summary
-    logger.info(f"Results: {sum(1 for p in pcc_values if p >= 0.9999)}/{num_iterations} passed (PCC >= 0.9999)")
-    logger.info(f"  min PCC = {min(pcc_values):.6f}, max PCC = {max(pcc_values):.6f}")
-
-    assert all_pass, f"ND gather failed on {sum(1 for p in pcc_values if p < 0.9999)}/{num_iterations} iterations"
-
-
-# =============================================================================
-# Gather + Reduce Test
-# =============================================================================
-
-
-def create_scratch_anchor(device, full_grid_set, num_grid_cores):
-    """Create HEIGHT_SHARDED anchor tensor on full grid for scratch CB address allocation."""
-    scratch_shard_u32 = SCRATCH_SIZE_BYTES // 4  # 6144 / 4 = 1536 uint32 elements
-    shard_spec = ttnn.ShardSpec(full_grid_set, (1, scratch_shard_u32), ttnn.ShardOrientation.ROW_MAJOR)
-    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-    return ttnn.from_torch(
-        torch.zeros([num_grid_cores, scratch_shard_u32], dtype=torch.uint32),
-        dtype=ttnn.uint32,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device,
-        memory_config=mem_config,
-    )
-
-
-def create_reduce_output_tensor(device, receiver_core):
-    """Create HEIGHT_SHARDED output tensor on receiver core for reduce result (3 tiles of 16x32)."""
-    receiver_core_range = ttnn.CoreRangeSet({ttnn.CoreRange(receiver_core, receiver_core)})
-    output_shape = (NUM_REDUCE_TILES * 16, 32)  # (48, 32) = 3 tiles of 16x32
+    output_shape = (NUM_REDUCE_TILES * 32, 32)  # (64, 32) = 2 tiles of 32x32
     shard_spec = ttnn.ShardSpec(receiver_core_range, output_shape, ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
     return ttnn.from_torch(
@@ -271,120 +112,96 @@ def create_reduce_output_tensor(device, receiver_core):
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=mem_config,
-        tile=TILE_16X32,
+        tile=TILE_32X32,
     )
 
 
-def build_gather_reduce_program(device, input_tensor, anchor_tensor, output_tensor, sender_grid, receiver_core):
-    """Build the gather+reduce program (identical NOC pattern + TRISC reduction as GatherReduce)."""
-    receiver_noc_core = device.worker_core_from_logical_core(receiver_core)
+def build_program(device, input_tensor, anchor_tensor, output_tensor, sender_core_range_set, receiver_core):
+    """Build the GatherReduce3 program using UnifiedKernelDescriptor (matches bliu/deepseek production)."""
+    from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+        PerCoreCompileTimeDescriptor,
+        UnifiedCompileTimeCoreDescriptor,
+        UnifiedKernelDescriptor,
+    )
 
-    sender_core_range = ttnn.CoreRangeSet({sender_grid})
+    receiver_noc_core = device.worker_core_from_logical_core(receiver_core)
     receiver_core_range = ttnn.CoreRangeSet({ttnn.CoreRange(receiver_core, receiver_core)})
-    all_cores = sender_core_range.merge(receiver_core_range)
+    all_cores = sender_core_range_set.merge(receiver_core_range)
 
     # Bounding box grid for scratch CB (must cover all sender + receiver cores)
     full_grid = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(12, 9))
     full_grid_set = ttnn.CoreRangeSet({full_grid})
 
-    # CB indices
     src_cb_id = 0
     scratch_cb_id = 1
     out_cb_id = 2
 
     # --- Semaphore ---
-    semaphore = ttnn.SemaphoreDescriptor(
-        id=SEMAPHORE_ID,
+    semaphore = ttnn.SemaphoreDescriptor(id=SEMAPHORE_ID, core_ranges=all_cores, initial_value=0)
+
+    # --- Per-core sender_idx (UsePerCoreSenderIdx mode) ---
+    sender_cores = ttnn.corerange_to_cores(sender_core_range_set, row_wise=True)
+    sender_idx_core_values = [(core, idx) for idx, core in enumerate(sender_cores)]
+
+    # --- Unified kernel ---
+    unified_kernel = UnifiedKernelDescriptor(
+        kernel_source=GATHER_REDUCE_KERNEL_PATH,
         core_ranges=all_cores,
-        initial_value=0,
-    )
-
-    # --- Sender kernel (NCRISC) on 12x8 grid ---
-    sender_named_args = [
-        ("is_sender_core", 1),
-        ("is_receiver_core", 0),
-        ("src_cb", src_cb_id),
-        ("src_num_pages", 1),
-        ("dest_noc_x", receiver_noc_core.x),
-        ("dest_noc_y", receiver_noc_core.y),
-        ("data_size_bytes", DATA_SIZE_BYTES),
-        ("receiver_semaphore_id", SEMAPHORE_ID),
-        ("grid_start_x", sender_grid.start.x),
-        ("grid_start_y", sender_grid.start.y),
-        ("grid_end_x", sender_grid.end.x),
-        ("grid_end_y", sender_grid.end.y),
-        ("half_num_cores", HALF_NUM_CORES),
-        ("half_size_bytes", HALF_SIZE_BYTES),
-        ("scratch_cb", scratch_cb_id),
-    ]
-
-    sender_kernel = ttnn.KernelDescriptor(
-        kernel_source=GATHER_REDUCE_KERNEL_PATH,
-        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-        core_ranges=sender_core_range,
-        named_compile_time_args=sender_named_args,
-        config=ttnn.DataMovementConfigDescriptor(
-            processor=ttnn.DataMovementProcessor.RISCV_1,
-            noc=ttnn.NOC.NOC_0,
-        ),
-    )
-
-    # --- Receiver kernel (BRISC) on receiver core ---
-    receiver_named_args = [
-        ("is_sender_core", 0),
-        ("is_receiver_core", 1),
-        ("noc0_num_senders", NUM_SENDERS),
-        ("noc0_receiver_semaphore_id", SEMAPHORE_ID),
-        ("scratch_cb", scratch_cb_id),
-        ("num_tiles", NUM_REDUCE_TILES),
-    ]
-
-    receiver_kernel = ttnn.KernelDescriptor(
-        kernel_source=GATHER_REDUCE_KERNEL_PATH,
-        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-        core_ranges=receiver_core_range,
-        named_compile_time_args=receiver_named_args,
-        config=ttnn.DataMovementConfigDescriptor(
-            processor=ttnn.DataMovementProcessor.RISCV_0,
-            noc=ttnn.NOC.NOC_1,
-        ),
-    )
-
-    # --- Compute kernels ---
-    # Sender compute (no-op, but must pass TRISC args for constexpr resolution)
-    sender_compute = ttnn.KernelDescriptor(
-        kernel_source=GATHER_REDUCE_KERNEL_PATH,
-        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-        core_ranges=sender_core_range,
-        named_compile_time_args=[
-            ("is_sender_core", 1),
-            ("is_receiver_core", 0),
+        ncrisc_named_compile_time_args=[
+            ("src_cb", src_cb_id),
+            ("src_num_pages", 1),
+            ("dest_noc_x", receiver_noc_core.x),
+            ("dest_noc_y", receiver_noc_core.y),
+            ("data_size_bytes", DATA_SIZE_BYTES),
+            ("receiver_semaphore_id", SEMAPHORE_ID),
+            ("half_num_cores", HALF_NUM_CORES),
+            ("half_size_bytes", HALF_SIZE_BYTES),
+            ("scratch_cb", scratch_cb_id),
+        ],
+        brisc_named_compile_time_args=[
+            ("noc0_num_senders", NUM_SENDERS),
+            ("noc0_receiver_semaphore_id", SEMAPHORE_ID),
+            ("scratch_cb", scratch_cb_id),
+            ("num_tiles", NUM_REDUCE_TILES),
+        ],
+        trisc_named_compile_time_args=[
             ("scratch_cb", scratch_cb_id),
             ("out_cb", out_cb_id),
             ("num_tiles", NUM_REDUCE_TILES),
         ],
-        config=ttnn.ComputeConfigDescriptor(),
+        trisc_compute_config=ttnn.ComputeConfigDescriptor(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            dst_full_sync_en=False,
+        ),
+        unified_compile_time_core_descriptors=[
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_sender_core",
+                core_range=sender_core_range_set,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_receiver_core",
+                core_range=receiver_core_range,
+                value=1,
+                other_value=0,
+            ),
+        ],
+        per_core_compile_time_descriptors=[
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="sender_idx",
+                core_values=sender_idx_core_values,
+                other_value=0,
+            ),
+        ],
     )
 
-    # Receiver compute (TRISC add_half_tiles)
-    receiver_compute_args = [
-        ("is_sender_core", 0),
-        ("is_receiver_core", 1),
-        ("scratch_cb", scratch_cb_id),
-        ("out_cb", out_cb_id),
-        ("num_tiles", NUM_REDUCE_TILES),
-    ]
-
-    receiver_compute = ttnn.KernelDescriptor(
-        kernel_source=GATHER_REDUCE_KERNEL_PATH,
-        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-        core_ranges=receiver_core_range,
-        named_compile_time_args=receiver_compute_args,
-        config=ttnn.ComputeConfigDescriptor(),
-    )
+    kernel_result = unified_kernel.get_kernel_descriptors()
 
     # --- CBs ---
-    # CB0: src input (from sharded input tensor, on sender cores only)
+    # CB0: src input (from sharded input tensor, on sender cores)
     src_cb = ttnn.cb_descriptor_from_sharded_tensor(src_cb_id, input_tensor)
 
     # CB1: scratch (from anchor tensor, on ALL cores so get_write_ptr returns same addr)
@@ -398,8 +215,8 @@ def build_gather_reduce_program(device, input_tensor, anchor_tensor, output_tens
         ttnn.CBFormatDescriptor(
             buffer_index=scratch_cb_id,
             data_format=ttnn.bfloat16,
-            page_size=TILE_16X32_SIZE,
-            tile=ttnn.TileDescriptor(TILE_16X32),
+            page_size=TILE_32X32_SIZE,
+            tile=ttnn.TileDescriptor(TILE_32X32),
         )
     ]
 
@@ -409,44 +226,48 @@ def build_gather_reduce_program(device, input_tensor, anchor_tensor, output_tens
         ttnn.CBFormatDescriptor(
             buffer_index=out_cb_id,
             data_format=ttnn.bfloat16,
-            page_size=TILE_16X32_SIZE,
-            tile=ttnn.TileDescriptor(TILE_16X32),
+            page_size=TILE_32X32_SIZE,
+            tile=ttnn.TileDescriptor(TILE_32X32),
         )
     ]
 
     return ttnn.ProgramDescriptor(
-        kernels=[sender_kernel, receiver_kernel, sender_compute, receiver_compute],
+        kernels=kernel_result.kernels,
         cbs=[src_cb, scratch_cb, out_cb],
         semaphores=[semaphore],
     )
 
 
+# =============================================================================
+# Test
+# =============================================================================
+
+
 @pytest.mark.requires_grid_size((13, 10))
-@pytest.mark.parametrize("num_iterations", [5])
+@pytest.mark.parametrize("num_iterations", [50])
 def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
     """
-    Run the gather+reduce pattern from GatherReduce (96 senders -> 1 receiver, 64B each,
-    then TRISC add_half_tiles reduction) multiple times and check for ND PCC corruption.
+    Run the GatherReduce3 pattern (112 senders -> receiver (11,9), 64B each,
+    then TRISC add_half_tiles reduction with 32x32 tiles) multiple times
+    and check for ND PCC corruption.
+
+    Matches bliu/deepseek production: non-rectangular o_proj grid,
+    UsePerCoreSenderIdx, noc_async_write + barrier.
 
     Uses same input every iteration. If output varies across iterations, that's ND.
     """
-    sender_grid = ttnn.CoreRange(
-        ttnn.CoreCoord(*SENDER_GRID_START),
-        ttnn.CoreCoord(*SENDER_GRID_END),
-    )
+    sender_core_range_set = get_sender_core_range_set()
 
     # Bounding box grid for anchor tensor
     full_grid = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(12, 9))
     full_grid_set = ttnn.CoreRangeSet({full_grid})
     num_grid_cores = 13 * 10  # 130
 
-    shard_shape = (1, WIDTH_PER_CORE)
-
     logger.info(
-        f"Testing ND gather+reduce: {NUM_SENDERS} senders (12x8) -> receiver ({RECEIVER_CORE.x},{RECEIVER_CORE.y})"
+        f"Testing GatherReduce3: {NUM_SENDERS} senders (12x8+8x2) -> receiver ({RECEIVER_CORE.x},{RECEIVER_CORE.y})"
     )
     logger.info(f"  data_size_bytes={DATA_SIZE_BYTES}, half_num_cores={HALF_NUM_CORES}")
-    logger.info(f"  reduce: {NUM_REDUCE_TILES} tiles of 16x32, scratch={SCRATCH_SIZE_BYTES}B")
+    logger.info(f"  reduce: {NUM_REDUCE_TILES} tiles of 32x32, scratch={SCRATCH_SIZE_BYTES}B")
     logger.info(f"  iterations={num_iterations} (same input each time, checking output consistency)")
 
     # Fixed input for all iterations
@@ -455,8 +276,8 @@ def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
 
     # Allocate tensors ONCE — reuse across all iterations to keep L1 addresses stable
     anchor = create_scratch_anchor(device, full_grid_set, num_grid_cores)
-    ttnn_input = create_sharded_input(device, torch_input, sender_grid, shard_shape)
-    ttnn_output = create_reduce_output_tensor(device, RECEIVER_CORE)
+    ttnn_input = create_sharded_input(device, torch_input, sender_core_range_set)
+    ttnn_output = create_output_tensor(device, RECEIVER_CORE)
     logger.info(
         f"  L1 addrs: anchor=0x{anchor.buffer_address():x}, "
         f"input=0x{ttnn_input.buffer_address():x}, output=0x{ttnn_output.buffer_address():x}"
@@ -467,26 +288,25 @@ def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
     pcc_values = []
 
     for i in range(num_iterations):
-        program = build_gather_reduce_program(device, ttnn_input, anchor, ttnn_output, sender_grid, RECEIVER_CORE)
+        logger.info(f"  [{i+1:>2}] Building program...")
+        program = build_program(device, ttnn_input, anchor, ttnn_output, sender_core_range_set, RECEIVER_CORE)
+        logger.info(f"  [{i+1:>2}] Program built. Launching generic_op...")
+        sys.stdout.flush()
+        sys.stderr.flush()
         result = ttnn.generic_op([ttnn_input, anchor, ttnn_output], program)
+        logger.info(f"  [{i+1:>2}] generic_op completed. Reading output...")
+        sys.stdout.flush()
+        sys.stderr.flush()
 
         result_torch = ttnn.to_torch(ttnn_output)
+        logger.info(f"  [{i+1:>2}] output read OK, shape={result_torch.shape}")
 
-        # Diagnostic: check if scratch CB (anchor) has data on receiver core
-        # Receiver core (12,9) is shard index 129 (last) in the full grid
-        anchor_torch = ttnn.to_torch(anchor)
-        receiver_scratch = anchor_torch[129]  # uint32 data
-
-        # Debug: print shape and first values on first 5 iterations
-        if i < 5:
+        if i < 3:
             logger.info(f"  [{i+1:>2}] output[:5]={result_torch.flatten()[:5].tolist()}")
             logger.info(f"  [{i+1:>2}] output nonzero={result_torch.count_nonzero().item()}/{result_torch.numel()}")
-            scratch_nonzero = (receiver_scratch != 0).sum().item()
-            logger.info(f"  [{i+1:>2}] scratch(receiver) nonzero={scratch_nonzero}/{receiver_scratch.numel()}")
 
         if reference_output is None:
             reference_output = result_torch.clone()
-            # Sanity: output should not be all zeros
             is_nonzero = result_torch.abs().sum().item() > 0
             logger.info(f"  [{i+1:>2}/{num_iterations}] Reference run (non-zero={is_nonzero})")
             if not is_nonzero:
@@ -513,4 +333,4 @@ def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
 
     assert (
         all_pass
-    ), f"ND gather+reduce failed: {sum(1 for p in pcc_values if p < 0.9999)}/{len(pcc_values)} iterations differ from reference"
+    ), f"ND GatherReduce3 failed: {sum(1 for p in pcc_values if p < 0.9999)}/{len(pcc_values)} iterations differ from reference"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
@@ -214,11 +214,11 @@ def test_nd_gather(device, check_requires_grid_size, num_iterations):
         result = ttnn.generic_op([ttnn_input, ttnn_output], program)
 
         result_torch = ttnn.to_torch(result)
-        passing, pcc_msg = comp_pcc(torch_input, result_torch, 0.9999)
-        pcc_values.append(float(pcc_msg.split("=")[-1].strip()))
+        passing, pcc_val = comp_pcc(torch_input, result_torch, 0.9999)
+        pcc_values.append(float(pcc_val))
 
         status = "PASS" if passing else "FAIL"
-        logger.info(f"  [{i+1:>2}/{num_iterations}] {status} {pcc_msg}")
+        logger.info(f"  [{i+1:>2}/{num_iterations}] {status} PCC={pcc_val:.6f}")
 
         if not passing:
             all_pass = False

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
@@ -422,7 +422,7 @@ def build_gather_reduce_program(device, input_tensor, anchor_tensor, output_tens
 
 
 @pytest.mark.requires_grid_size((13, 10))
-@pytest.mark.parametrize("num_iterations", [20])
+@pytest.mark.parametrize("num_iterations", [5])
 def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
     """
     Run the gather+reduce pattern from GatherReduce (96 senders -> 1 receiver, 64B each,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
@@ -453,27 +453,36 @@ def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
     torch.manual_seed(42)
     torch_input = torch.randn(1, TOTAL_WIDTH, dtype=torch.bfloat16)
 
+    # Allocate tensors ONCE — reuse across all iterations to keep L1 addresses stable
+    anchor = create_scratch_anchor(device, full_grid_set, num_grid_cores)
+    ttnn_input = create_sharded_input(device, torch_input, sender_grid, shard_shape)
+    ttnn_output = create_reduce_output_tensor(device, RECEIVER_CORE)
+    logger.info(
+        f"  L1 addrs: anchor=0x{anchor.buffer_address():x}, "
+        f"input=0x{ttnn_input.buffer_address():x}, output=0x{ttnn_output.buffer_address():x}"
+    )
+
     reference_output = None
     all_pass = True
     pcc_values = []
 
     for i in range(num_iterations):
-        ttnn_input = create_sharded_input(device, torch_input, sender_grid, shard_shape)
-        anchor = create_scratch_anchor(device, full_grid_set, num_grid_cores)
-        ttnn_output = create_reduce_output_tensor(device, RECEIVER_CORE)
-
         program = build_gather_reduce_program(device, ttnn_input, anchor, ttnn_output, sender_grid, RECEIVER_CORE)
         result = ttnn.generic_op([ttnn_input, anchor, ttnn_output], program)
 
-        result_torch = ttnn.to_torch(result)
+        result_torch = ttnn.to_torch(ttnn_output)
 
-        # Debug: print shape and first values on first 3 iterations
-        if i < 3:
-            logger.info(f"  [{i+1:>2}] result shape={result_torch.shape}, dtype={result_torch.dtype}")
-            logger.info(f"  [{i+1:>2}] result[:5]={result_torch.flatten()[:5].tolist()}")
-            logger.info(
-                f"  [{i+1:>2}] result nonzero count={result_torch.count_nonzero().item()}/{result_torch.numel()}"
-            )
+        # Diagnostic: check if scratch CB (anchor) has data on receiver core
+        # Receiver core (12,9) is shard index 129 (last) in the full grid
+        anchor_torch = ttnn.to_torch(anchor)
+        receiver_scratch = anchor_torch[129]  # uint32 data
+
+        # Debug: print shape and first values on first 5 iterations
+        if i < 5:
+            logger.info(f"  [{i+1:>2}] output[:5]={result_torch.flatten()[:5].tolist()}")
+            logger.info(f"  [{i+1:>2}] output nonzero={result_torch.count_nonzero().item()}/{result_torch.numel()}")
+            scratch_nonzero = (receiver_scratch != 0).sum().item()
+            logger.info(f"  [{i+1:>2}] scratch(receiver) nonzero={scratch_nonzero}/{receiver_scratch.numel()}")
 
         if reference_output is None:
             reference_output = result_torch.clone()
@@ -490,9 +499,9 @@ def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
             if not passing:
                 all_pass = False
 
-        ttnn_input.deallocate()
-        anchor.deallocate()
-        ttnn_output.deallocate()
+    anchor.deallocate()
+    ttnn_input.deallocate()
+    ttnn_output.deallocate()
 
     # Summary
     if pcc_values:

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_nd_gather.py
@@ -31,14 +31,21 @@ NUM_SENDER_ROWS = SENDER_GRID_END[1] - SENDER_GRID_START[1] + 1  # 8
 NUM_SENDERS = NUM_SENDER_COLS * NUM_SENDER_ROWS  # 96
 HALF_NUM_CORES = NUM_SENDERS // 2  # 48
 WIDTH_PER_CORE = 32  # 1x32 tile
-TILE = ttnn.Tile([1, 32])
+TILE_1X32 = ttnn.Tile([1, 32])
 DATA_SIZE_BYTES = 64  # 1x32 bf16 tile = 32 * 2 bytes
 HALF_SIZE_BYTES = HALF_NUM_CORES * DATA_SIZE_BYTES  # 48 * 64 = 3072
 TOTAL_WIDTH = NUM_SENDERS * WIDTH_PER_CORE  # 96 * 32 = 3072 elements
 
+# Gather+Reduce constants (16x32 tiles for TRISC reduction)
+NUM_REDUCE_TILES = 3  # 3 tiles of 16x32 per half
+TILE_16X32 = ttnn.Tile([16, 32])
+TILE_16X32_SIZE = 1024  # 16 * 32 * 2 bytes (bf16)
+SCRATCH_SIZE_BYTES = 2 * NUM_REDUCE_TILES * TILE_16X32_SIZE  # 6144 bytes
+
 RECEIVER_CORE = ttnn.CoreCoord(12, 9)  # rmsnorm core in attention block
 
-KERNEL_PATH = "models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_kernel.cpp"
+GATHER_KERNEL_PATH = "models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_kernel.cpp"
+GATHER_REDUCE_KERNEL_PATH = "models/demos/deepseek_v3_b1/tests/unit_tests/kernels/test_nd_gather_reduce_kernel.cpp"
 
 SEMAPHORE_ID = 0
 
@@ -62,7 +69,7 @@ def create_sharded_input(device, torch_input, sender_grid, shard_shape):
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=mem_config,
-        tile=TILE,
+        tile=TILE_1X32,
     )
 
 
@@ -81,7 +88,7 @@ def create_output_tensor(device, output_shape, receiver_core):
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=mem_config,
-        tile=TILE,
+        tile=TILE_1X32,
     )
 
 
@@ -120,7 +127,7 @@ def build_program(device, input_tensor, output_tensor, sender_grid, receiver_cor
     ]
 
     sender_kernel = ttnn.KernelDescriptor(
-        kernel_source=KERNEL_PATH,
+        kernel_source=GATHER_KERNEL_PATH,
         source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
         core_ranges=sender_core_range,
         named_compile_time_args=sender_named_args,
@@ -140,7 +147,7 @@ def build_program(device, input_tensor, output_tensor, sender_grid, receiver_cor
     ]
 
     receiver_kernel = ttnn.KernelDescriptor(
-        kernel_source=KERNEL_PATH,
+        kernel_source=GATHER_KERNEL_PATH,
         source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
         core_ranges=receiver_core_range,
         named_compile_time_args=receiver_named_args,
@@ -152,7 +159,7 @@ def build_program(device, input_tensor, output_tensor, sender_grid, receiver_cor
 
     # --- Compute kernels (no-op) ---
     sender_compute = ttnn.KernelDescriptor(
-        kernel_source=KERNEL_PATH,
+        kernel_source=GATHER_KERNEL_PATH,
         source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
         core_ranges=sender_core_range,
         named_compile_time_args=[("is_sender_core", 1), ("is_receiver_core", 0)],
@@ -160,7 +167,7 @@ def build_program(device, input_tensor, output_tensor, sender_grid, receiver_cor
     )
 
     receiver_compute = ttnn.KernelDescriptor(
-        kernel_source=KERNEL_PATH,
+        kernel_source=GATHER_KERNEL_PATH,
         source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
         core_ranges=receiver_core_range,
         named_compile_time_args=[("is_sender_core", 0), ("is_receiver_core", 1)],
@@ -231,3 +238,256 @@ def test_nd_gather(device, check_requires_grid_size, num_iterations):
     logger.info(f"  min PCC = {min(pcc_values):.6f}, max PCC = {max(pcc_values):.6f}")
 
     assert all_pass, f"ND gather failed on {sum(1 for p in pcc_values if p < 0.9999)}/{num_iterations} iterations"
+
+
+# =============================================================================
+# Gather + Reduce Test
+# =============================================================================
+
+
+def create_scratch_anchor(device, full_grid_set, num_grid_cores):
+    """Create HEIGHT_SHARDED anchor tensor on full grid for scratch CB address allocation."""
+    scratch_shard_u32 = SCRATCH_SIZE_BYTES // 4  # 6144 / 4 = 1536 uint32 elements
+    shard_spec = ttnn.ShardSpec(full_grid_set, (1, scratch_shard_u32), ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    return ttnn.from_torch(
+        torch.zeros([num_grid_cores, scratch_shard_u32], dtype=torch.uint32),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+    )
+
+
+def create_reduce_output_tensor(device, receiver_core):
+    """Create HEIGHT_SHARDED output tensor on receiver core for reduce result (3 tiles of 16x32)."""
+    receiver_core_range = ttnn.CoreRangeSet({ttnn.CoreRange(receiver_core, receiver_core)})
+    output_shape = (NUM_REDUCE_TILES * 16, 32)  # (48, 32) = 3 tiles of 16x32
+    shard_spec = ttnn.ShardSpec(receiver_core_range, output_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    return ttnn.from_torch(
+        torch.zeros(output_shape, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=TILE_16X32,
+    )
+
+
+def build_gather_reduce_program(device, input_tensor, anchor_tensor, output_tensor, sender_grid, receiver_core):
+    """Build the gather+reduce program (identical NOC pattern + TRISC reduction as GatherReduce)."""
+    receiver_noc_core = device.worker_core_from_logical_core(receiver_core)
+
+    sender_core_range = ttnn.CoreRangeSet({sender_grid})
+    receiver_core_range = ttnn.CoreRangeSet({ttnn.CoreRange(receiver_core, receiver_core)})
+    all_cores = sender_core_range.merge(receiver_core_range)
+
+    # Bounding box grid for scratch CB (must cover all sender + receiver cores)
+    full_grid = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(12, 9))
+    full_grid_set = ttnn.CoreRangeSet({full_grid})
+
+    # CB indices
+    src_cb_id = 0
+    scratch_cb_id = 1
+    out_cb_id = 2
+
+    # --- Semaphore ---
+    semaphore = ttnn.SemaphoreDescriptor(
+        id=SEMAPHORE_ID,
+        core_ranges=all_cores,
+        initial_value=0,
+    )
+
+    # --- Sender kernel (NCRISC) on 12x8 grid ---
+    sender_named_args = [
+        ("is_sender_core", 1),
+        ("is_receiver_core", 0),
+        ("src_cb", src_cb_id),
+        ("src_num_pages", 1),
+        ("dest_noc_x", receiver_noc_core.x),
+        ("dest_noc_y", receiver_noc_core.y),
+        ("data_size_bytes", DATA_SIZE_BYTES),
+        ("receiver_semaphore_id", SEMAPHORE_ID),
+        ("grid_start_x", sender_grid.start.x),
+        ("grid_start_y", sender_grid.start.y),
+        ("grid_end_x", sender_grid.end.x),
+        ("grid_end_y", sender_grid.end.y),
+        ("half_num_cores", HALF_NUM_CORES),
+        ("half_size_bytes", HALF_SIZE_BYTES),
+        ("scratch_cb", scratch_cb_id),
+    ]
+
+    sender_kernel = ttnn.KernelDescriptor(
+        kernel_source=GATHER_REDUCE_KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=sender_core_range,
+        named_compile_time_args=sender_named_args,
+        config=ttnn.DataMovementConfigDescriptor(
+            processor=ttnn.DataMovementProcessor.RISCV_1,
+            noc=ttnn.NOC.NOC_0,
+        ),
+    )
+
+    # --- Receiver kernel (BRISC) on receiver core ---
+    receiver_named_args = [
+        ("is_sender_core", 0),
+        ("is_receiver_core", 1),
+        ("noc0_num_senders", NUM_SENDERS),
+        ("noc0_receiver_semaphore_id", SEMAPHORE_ID),
+        ("scratch_cb", scratch_cb_id),
+        ("num_tiles", NUM_REDUCE_TILES),
+    ]
+
+    receiver_kernel = ttnn.KernelDescriptor(
+        kernel_source=GATHER_REDUCE_KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=receiver_core_range,
+        named_compile_time_args=receiver_named_args,
+        config=ttnn.DataMovementConfigDescriptor(
+            processor=ttnn.DataMovementProcessor.RISCV_0,
+            noc=ttnn.NOC.NOC_1,
+        ),
+    )
+
+    # --- Compute kernels ---
+    # Sender compute (no-op)
+    sender_compute = ttnn.KernelDescriptor(
+        kernel_source=GATHER_REDUCE_KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=sender_core_range,
+        named_compile_time_args=[("is_sender_core", 1), ("is_receiver_core", 0)],
+        config=ttnn.ComputeConfigDescriptor(),
+    )
+
+    # Receiver compute (TRISC add_half_tiles)
+    receiver_compute_args = [
+        ("is_sender_core", 0),
+        ("is_receiver_core", 1),
+        ("scratch_cb", scratch_cb_id),
+        ("out_cb", out_cb_id),
+        ("num_tiles", NUM_REDUCE_TILES),
+    ]
+
+    receiver_compute = ttnn.KernelDescriptor(
+        kernel_source=GATHER_REDUCE_KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=receiver_core_range,
+        named_compile_time_args=receiver_compute_args,
+        config=ttnn.ComputeConfigDescriptor(),
+    )
+
+    # --- CBs ---
+    # CB0: src input (from sharded input tensor, on sender cores only)
+    src_cb = ttnn.cb_descriptor_from_sharded_tensor(src_cb_id, input_tensor)
+
+    # CB1: scratch (from anchor tensor, on ALL cores so get_write_ptr returns same addr)
+    scratch_cb = ttnn.cb_descriptor_from_sharded_tensor(
+        scratch_cb_id,
+        anchor_tensor,
+        total_size=SCRATCH_SIZE_BYTES,
+        core_ranges=full_grid_set,
+    )
+    scratch_cb.format_descriptors = [
+        ttnn.CBFormatDescriptor(
+            buffer_index=scratch_cb_id,
+            data_format=ttnn.bfloat16,
+            page_size=TILE_16X32_SIZE,
+            tile=ttnn.TileDescriptor(TILE_16X32),
+        )
+    ]
+
+    # CB2: output (from output tensor, on receiver core only)
+    out_cb = ttnn.cb_descriptor_from_sharded_tensor(out_cb_id, output_tensor)
+    out_cb.format_descriptors = [
+        ttnn.CBFormatDescriptor(
+            buffer_index=out_cb_id,
+            data_format=ttnn.bfloat16,
+            page_size=TILE_16X32_SIZE,
+            tile=ttnn.TileDescriptor(TILE_16X32),
+        )
+    ]
+
+    return ttnn.ProgramDescriptor(
+        kernels=[sender_kernel, receiver_kernel, sender_compute, receiver_compute],
+        cbs=[src_cb, scratch_cb, out_cb],
+        semaphores=[semaphore],
+    )
+
+
+@pytest.mark.requires_grid_size((13, 10))
+@pytest.mark.parametrize("num_iterations", [20])
+def test_nd_gather_reduce(device, check_requires_grid_size, num_iterations):
+    """
+    Run the gather+reduce pattern from GatherReduce (96 senders -> 1 receiver, 64B each,
+    then TRISC add_half_tiles reduction) multiple times and check for ND PCC corruption.
+
+    Uses same input every iteration. If output varies across iterations, that's ND.
+    """
+    sender_grid = ttnn.CoreRange(
+        ttnn.CoreCoord(*SENDER_GRID_START),
+        ttnn.CoreCoord(*SENDER_GRID_END),
+    )
+
+    # Bounding box grid for anchor tensor
+    full_grid = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(12, 9))
+    full_grid_set = ttnn.CoreRangeSet({full_grid})
+    num_grid_cores = 13 * 10  # 130
+
+    shard_shape = (1, WIDTH_PER_CORE)
+
+    logger.info(
+        f"Testing ND gather+reduce: {NUM_SENDERS} senders (12x8) -> receiver ({RECEIVER_CORE.x},{RECEIVER_CORE.y})"
+    )
+    logger.info(f"  data_size_bytes={DATA_SIZE_BYTES}, half_num_cores={HALF_NUM_CORES}")
+    logger.info(f"  reduce: {NUM_REDUCE_TILES} tiles of 16x32, scratch={SCRATCH_SIZE_BYTES}B")
+    logger.info(f"  iterations={num_iterations} (same input each time, checking output consistency)")
+
+    # Fixed input for all iterations
+    torch.manual_seed(42)
+    torch_input = torch.randn(1, TOTAL_WIDTH, dtype=torch.bfloat16)
+
+    reference_output = None
+    all_pass = True
+    pcc_values = []
+
+    for i in range(num_iterations):
+        ttnn_input = create_sharded_input(device, torch_input, sender_grid, shard_shape)
+        anchor = create_scratch_anchor(device, full_grid_set, num_grid_cores)
+        ttnn_output = create_reduce_output_tensor(device, RECEIVER_CORE)
+
+        program = build_gather_reduce_program(device, ttnn_input, anchor, ttnn_output, sender_grid, RECEIVER_CORE)
+        result = ttnn.generic_op([ttnn_input, anchor, ttnn_output], program)
+
+        result_torch = ttnn.to_torch(result)
+
+        if reference_output is None:
+            reference_output = result_torch.clone()
+            # Sanity: output should not be all zeros
+            is_nonzero = result_torch.abs().sum().item() > 0
+            logger.info(f"  [{i+1:>2}/{num_iterations}] Reference run (non-zero={is_nonzero})")
+            if not is_nonzero:
+                logger.warning("  Reference output is all zeros!")
+        else:
+            passing, pcc_val = comp_pcc(reference_output, result_torch, 0.9999)
+            pcc_values.append(float(pcc_val))
+            status = "PASS" if passing else "FAIL"
+            logger.info(f"  [{i+1:>2}/{num_iterations}] {status} PCC={pcc_val:.6f} (vs reference)")
+            if not passing:
+                all_pass = False
+
+        ttnn_input.deallocate()
+        anchor.deallocate()
+        ttnn_output.deallocate()
+
+    # Summary
+    if pcc_values:
+        num_pass = sum(1 for p in pcc_values if p >= 0.9999)
+        logger.info(f"Results: {num_pass}/{len(pcc_values)} passed (PCC >= 0.9999 vs reference)")
+        logger.info(f"  min PCC = {min(pcc_values):.6f}, max PCC = {max(pcc_values):.6f}")
+    else:
+        logger.info("Only 1 iteration run, no cross-iteration comparison")
+
+    assert (
+        all_pass
+    ), f"ND gather+reduce failed: {sum(1 for p in pcc_values if p < 0.9999)}/{len(pcc_values)} iterations differ from reference"

--- a/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
@@ -72,6 +72,8 @@ struct GatherReduce {
         uint32_t gather_reduce_half_num_cores;
         uint32_t dst_cb_id;
         uint32_t half_size_bytes;
+        uint32_t sender_idx =
+            0;  // explicit per-core index; 0 means compute from grid (only valid for rectangular grids)
     };
 
     struct ComputeArgs {
@@ -101,8 +103,8 @@ struct GatherReduce {
         for (uint32_t i = 0; i < num_tiles; i++) {
             pack_tile(i, out_cb);
         }
-        cb_push_back(out_cb, num_tiles);
         tile_regs_release();
+        cb_push_back(out_cb, num_tiles);
 
         cb_pop_front(in_cb, 2 * num_tiles);
     }
@@ -116,7 +118,7 @@ struct GatherReduce {
     // IsReduceCore: compile-time flag for reduce cores
     // pop_src: whether to pop the source CB after sending
     // ========================================================================
-    template <bool IsSenderCore, bool IsReceiverCore, bool IsReduceCore, bool pop_src>
+    template <bool IsSenderCore, bool IsReceiverCore, bool IsReduceCore, bool pop_src, bool UsePerCoreSenderIdx = false>
     class Op {
     public:
         void operator()(const RTArgs& args) { impl(args); }
@@ -128,12 +130,19 @@ struct GatherReduce {
             // NCRISC (Sender) - DataMovementProcessor.RISCV_1
             // ================================================================
             if constexpr (IsSenderCore) {
-                const auto half_info = unified_kernels::get_split_half_core_info<true>(
-                    args.gather_reduce_grid_start_x,
-                    args.gather_reduce_grid_start_y,
-                    args.gather_reduce_grid_end_x,
-                    args.gather_reduce_grid_end_y,
-                    args.gather_reduce_half_num_cores);
+                unified_kernels::SplitHalfCoreInfo half_info;
+                if constexpr (UsePerCoreSenderIdx) {
+                    const bool is_half0 = args.sender_idx < args.gather_reduce_half_num_cores;
+                    half_info = {
+                        is_half0, is_half0 ? args.sender_idx : (args.sender_idx - args.gather_reduce_half_num_cores)};
+                } else {
+                    half_info = unified_kernels::get_split_half_core_info<true>(
+                        args.gather_reduce_grid_start_x,
+                        args.gather_reduce_grid_start_y,
+                        args.gather_reduce_grid_end_x,
+                        args.gather_reduce_grid_end_y,
+                        args.gather_reduce_half_num_cores);
+                }
                 uint32_t dst_base_addr = get_write_ptr(args.dst_cb_id);
                 uint32_t dst_offset =
                     (half_info.is_half0 ? 0 : args.half_size_bytes) + half_info.half_local_idx * args.data_size_bytes;
@@ -148,10 +157,13 @@ struct GatherReduce {
                 // Get source address from CB
                 uint32_t src_addr = get_read_ptr(args.src_cb);
 
-                noc_async_write_one_packet<true, true>(src_addr, dst_data_noc_addr, args.data_size_bytes);
-                // BH does not support posted atomics due to a bug
+                // Non-posted write with barrier: guarantees data is at destination
+                // L1 before the semaphore increment fires. Posted writes are
+                // insufficient because the atomic semaphore increment can overtake
+                // the data on the NOC, causing the receiver to read stale memory.
+                noc_async_write(src_addr, dst_data_noc_addr, args.data_size_bytes);
+                noc_async_write_barrier();
                 noc_semaphore_inc(dst_sem_noc_addr, 1);
-                noc_async_posted_writes_flushed();
 
                 // Pop the source CB after sending
                 if constexpr (pop_src) {


### PR DESCRIPTION
Standalone test replicating the gather portion of GatherReduce after matmul5 in the attention block. 96 sender cores (12x8) each write 64B to a single receiver core using the same half-based offset and NOC API sequence. No TRISC reduction. Runs 20 iterations to detect ND PCC corruption.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-nd-gather-repro) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=worktree-nd-gather-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-nd-gather-repro) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-nd-gather-repro) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:worktree-nd-gather-repro) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=worktree-nd-gather-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:worktree-nd-gather-repro) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:worktree-nd-gather-repro) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-nd-gather-repro) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=worktree-nd-gather-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-nd-gather-repro) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-nd-gather-repro) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-nd-gather-repro) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=worktree-nd-gather-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-nd-gather-repro) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-nd-gather-repro) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-nd-gather-repro) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=worktree-nd-gather-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-nd-gather-repro) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-nd-gather-repro) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-nd-gather-repro) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=worktree-nd-gather-repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-nd-gather-repro) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-nd-gather-repro) |