### PR TITLE
High Batch Deepseek generalized automated testing script for CI + local machines

### DIFF
--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -38,6 +38,15 @@ on:
         required: false
         default: false
         type: boolean
+      demo_upr_mode:
+        description: 'UPR variant for demo and stress tests'
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - 32
+          - 8
       recalculate_weights_cache:
         description: 'Recalculate weights cache in a new directory'
         required: false
@@ -181,7 +190,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
 
       - name: Run quad DeepSeek V3 unit tests
         if: ${{ matrix.setup == 'quad' && inputs.deepseekv3_unit_tests }}
@@ -205,7 +214,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
 
       # ── DeepSeek V3 module tests ────────────────────────────────────────
       - name: Run dual DeepSeek V3 module tests
@@ -230,7 +239,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
 
       - name: Run quad DeepSeek V3 module tests
         if: ${{ matrix.setup == 'quad' && inputs.deepseekv3_module_tests }}
@@ -254,7 +263,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
 
       # ── Teacher forced accuracy tests ───────────────────────────────────
       - name: Run dual teacher forced accuracy test
@@ -279,7 +288,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_teacher_forced
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_teacher_forced
 
       - name: Upload dual teacher forced accuracy artifacts
         if: ${{ always() && matrix.setup == 'dual' && (inputs.teacher_forced || github.event_name == 'schedule') }}
@@ -313,7 +322,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
 
       - name: Upload quad teacher forced accuracy artifacts
         if: ${{ always() && matrix.setup == 'quad' && inputs.teacher_forced }}
@@ -348,7 +357,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
 
       - name: Upload dual demo output artifacts
         if: ${{ always() && matrix.setup == 'dual' && (inputs.demo || github.event_name == 'schedule') }}
@@ -357,7 +366,7 @@ jobs:
           name: dual-demo-output-${{ github.run_id }}
           path: |
             generated/artifacts/dual_demo_output.log
-            generated/artifacts/dual_demo_full_results.json
+            generated/artifacts/dual_demo_full_results*.json
           if-no-files-found: warn
 
       - name: Run dual MTP demo parity smoke test
@@ -382,7 +391,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_mtp
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_mtp
 
       - name: Upload dual MTP demo output artifacts
         if: ${{ always() && matrix.setup == 'dual' && (inputs.demo || github.event_name == 'schedule') }}
@@ -416,7 +425,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
 
       - name: Upload quad demo output artifacts
         if: ${{ always() && matrix.setup == 'quad' && inputs.demo }}
@@ -425,7 +434,7 @@ jobs:
           name: quad-demo-output-${{ github.run_id }}
           path: |
             generated/artifacts/quad_demo_output.log
-            generated/artifacts/quad_demo_full_results.json
+            generated/artifacts/quad_demo_full_results*.json
           if-no-files-found: warn
 
       - name: Run quad MTP demo parity smoke test
@@ -450,7 +459,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
 
       - name: Upload quad MTP demo output artifacts
         if: ${{ always() && matrix.setup == 'quad' && inputs.demo }}
@@ -485,7 +494,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
 
       - name: Upload dual demo stress output artifacts
         if: ${{ always() && matrix.setup == 'dual' && (inputs.demo_stress || github.event_name == 'schedule') }}
@@ -494,7 +503,7 @@ jobs:
           name: dual-demo-stress-output-${{ github.run_id }}
           path: |
             generated/artifacts/dual_demo_stress_output.log
-            generated/artifacts/dual_demo_stress_results.json
+            generated/artifacts/dual_demo_stress_results*.json
           if-no-files-found: warn
 
       - name: Run quad demo stress test (56 prompts, 20 batches)
@@ -519,7 +528,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress
+            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
 
       - name: Upload quad demo stress output artifacts
         if: ${{ always() && matrix.setup == 'quad' && inputs.demo_stress }}
@@ -528,5 +537,5 @@ jobs:
           name: quad-demo-stress-output-${{ github.run_id }}
           path: |
             generated/artifacts/quad_demo_stress_output.log
-            generated/artifacts/quad_demo_stress_results.json
+            generated/artifacts/quad_demo_stress_results*.json
           if-no-files-found: warn

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -190,7 +190,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
 
       - name: Run quad DeepSeek V3 unit tests
         if: ${{ matrix.setup == 'quad' && inputs.deepseekv3_unit_tests }}
@@ -214,7 +214,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
 
       # ── DeepSeek V3 module tests ────────────────────────────────────────
       - name: Run dual DeepSeek V3 module tests
@@ -239,7 +239,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
 
       - name: Run quad DeepSeek V3 module tests
         if: ${{ matrix.setup == 'quad' && inputs.deepseekv3_module_tests }}
@@ -263,7 +263,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
 
       # ── Teacher forced accuracy tests ───────────────────────────────────
       - name: Run dual teacher forced accuracy test
@@ -288,7 +288,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_teacher_forced
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_teacher_forced
 
       - name: Upload dual teacher forced accuracy artifacts
         if: ${{ always() && matrix.setup == 'dual' && (inputs.teacher_forced || github.event_name == 'schedule') }}
@@ -322,7 +322,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
 
       - name: Upload quad teacher forced accuracy artifacts
         if: ${{ always() && matrix.setup == 'quad' && inputs.teacher_forced }}
@@ -357,7 +357,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
 
       - name: Upload dual demo output artifacts
         if: ${{ always() && matrix.setup == 'dual' && (inputs.demo || github.event_name == 'schedule') }}
@@ -391,7 +391,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_mtp
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_mtp
 
       - name: Upload dual MTP demo output artifacts
         if: ${{ always() && matrix.setup == 'dual' && (inputs.demo || github.event_name == 'schedule') }}
@@ -425,7 +425,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
 
       - name: Upload quad demo output artifacts
         if: ${{ always() && matrix.setup == 'quad' && inputs.demo }}
@@ -459,7 +459,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
 
       - name: Upload quad MTP demo output artifacts
         if: ${{ always() && matrix.setup == 'quad' && inputs.demo }}
@@ -494,7 +494,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
 
       - name: Upload dual demo stress output artifacts
         if: ${{ always() && matrix.setup == 'dual' && (inputs.demo_stress || github.event_name == 'schedule') }}
@@ -528,7 +528,7 @@ jobs:
           install_wheel: true
           run_args: |
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress "${{ github.event_name == 'schedule' && 'all' || inputs.demo_upr_mode || 'all' }}"
 
       - name: Upload quad demo stress output artifacts
         if: ${{ always() && matrix.setup == 'quad' && inputs.demo_stress }}

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -4,30 +4,26 @@ set -eo pipefail
 # Default ARCH_NAME for local runs when not set by CI.
 export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
 
-# Prefer `tt-run` on PATH (from pip/editable install). Otherwise run `ttrun.py` directly so
-# multihost scripts work when console scripts are not installed (avoids importing `ttnn` package
-# root, which is unnecessary for the launcher).
-_tt_run() {
+# Prefer tt-run on PATH; otherwise run ttrun.py directly.
+tt_run() {
     if command -v tt-run >/dev/null 2>&1; then
         command tt-run "$@"
         return
     fi
     if [[ -z "${TT_METAL_HOME:-}" ]]; then
-        echo "_tt_run: tt-run not on PATH and TT_METAL_HOME is unset; cannot locate ttrun.py" >&2
+        echo "tt_run: tt-run not on PATH and TT_METAL_HOME is unset; cannot locate ttrun.py" >&2
         return 1
     fi
-    local _ttrun_py="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
-    if [[ ! -f "${_ttrun_py}" ]]; then
-        echo "_tt_run: expected launcher at ${_ttrun_py} (missing); install ttnn or set TT_METAL_HOME" >&2
+    local ttrun_py="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
+    if [[ ! -f "${ttrun_py}" ]]; then
+        echo "tt_run: expected launcher at ${ttrun_py} (missing); install ttnn or set TT_METAL_HOME" >&2
         return 1
     fi
-    "${PYTHON:-python3}" "${_ttrun_py}" "$@"
+    "${PYTHON:-python3}" "${ttrun_py}" "$@"
 }
 
-# MPI/OpenFabrics TCP binding: CI / many Galaxy boxes use "cnx1". If it is missing, pick the
-# first non-virtual interface in operstate up (skips lo, docker, tailscale, …) so local clusters
-# like UF-* hosts get a valid btl_tcp_if_include without manual export.
-_default_mpi_tcp_interface() {
+# Pick cnx1 when present, else first up non-virtual NIC.
+default_mpi_tcp_interface() {
     if [[ -d /sys/class/net/cnx1 ]]; then
         echo "cnx1"
         return 0
@@ -47,11 +43,11 @@ _default_mpi_tcp_interface() {
     echo "cnx1"
 }
 
-_export_tcp_interface_for_multihost() {
-    export TCP_INTERFACE="${TCP_INTERFACE:-$(_default_mpi_tcp_interface)}"
+export_tcp_interface_for_multihost() {
+    export TCP_INTERFACE="${TCP_INTERFACE:-$(default_mpi_tcp_interface)}"
 }
 
-_extract_hosts_from_hostfile() {
+extract_hosts_from_hostfile() {
     local host_count="$1"
     local hostfile="${2:-/etc/mpirun/hostfile}"
 
@@ -65,10 +61,10 @@ _extract_hosts_from_hostfile() {
 run_quad_galaxy_unit_tests() {
   fail=0
 
-  _export_tcp_interface_for_multihost
+  export_tcp_interface_for_multihost
   local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile"
   local tcp_interface="${TCP_INTERFACE}"
-  local hosts="$(_extract_hosts_from_hostfile 4)"
+  local hosts="$(extract_hosts_from_hostfile 4)"
   local rank_binding_yaml="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
   local tt_mpi_args="--host $hosts --map-by rankfile:file=/etc/mpirun/rankfile --bind-to none --output-filename logs/mpi_job"
   local mpi_host="--host $hosts"
@@ -83,12 +79,12 @@ run_quad_galaxy_unit_tests() {
 
   mpirun-ulfm $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation --send-traffic --cabling-descriptor-path ${descriptor_path}/cabling_descriptor.textproto --deployment-descriptor-path ${descriptor_path}/deployment_descriptor.textproto ; fail+=$?
 
-  _tt_run --tcp-interface "$tcp_interface" --rank-binding "$rank_binding_yaml" --mpi-args "$tt_mpi_args" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
+  tt_run --tcp-interface "$tcp_interface" --rank-binding "$rank_binding_yaml" --mpi-args "$tt_mpi_args" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
 
   # TODO: Currently failing on 1D/2D tests
-  #_tt_run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
+  #tt_run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
 
-  _tt_run --tcp-interface "$tcp_interface" --rank-binding "$rank_binding_yaml" --mpi-args "$tt_mpi_args" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
+  tt_run --tcp-interface "$tcp_interface" --rank-binding "$rank_binding_yaml" --mpi-args "$tt_mpi_args" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -99,7 +95,7 @@ run_quad_galaxy_unit_tests() {
 # Environment setup helpers
 ###############################################################################
 
-_resolve_deepseekv3_cache() {
+resolve_deepseekv3_cache() {
     local ci_cache="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"
     if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
         local resolved
@@ -116,7 +112,7 @@ _resolve_deepseekv3_cache() {
     fi
 }
 
-_resolve_deepseekv3_model() {
+resolve_deepseekv3_model() {
     local default_model="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
     local model_path="${DEEPSEEK_V3_HF_MODEL_OVERRIDE:-${DEEPSEEK_V3_HF_MODEL:-${default_model}}}"
 
@@ -133,10 +129,10 @@ _resolve_deepseekv3_model() {
 setup_dual_galaxy_env() {
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
     export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto"
-    export HOSTS="$(_extract_hosts_from_hostfile 2)"
+    export HOSTS="$(extract_hosts_from_hostfile 2)"
     export RANKFILE=/etc/mpirun/rankfile
     export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
-    _export_tcp_interface_for_multihost
+    export_tcp_interface_for_multihost
     mkdir -p logs
     mkdir -p generated/artifacts
 
@@ -157,8 +153,8 @@ setup_dual_galaxy_env() {
         exit 1
     fi
 
-    _resolve_deepseekv3_model
-    _resolve_deepseekv3_cache
+    resolve_deepseekv3_model
+    resolve_deepseekv3_cache
     export MESH_DEVICE="DUAL"
     export USE_TORUS_MODE=0
     echo "Dual Galaxy: USE_TORUS_MODE=0 (torus/ring mode disabled)."
@@ -167,10 +163,10 @@ setup_dual_galaxy_env() {
 setup_quad_galaxy_env() {
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
     export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_torus_xy_graph_descriptor.textproto"
-    export HOSTS="$(_extract_hosts_from_hostfile 4)"
+    export HOSTS="$(extract_hosts_from_hostfile 4)"
     export RANKFILE=/etc/mpirun/rankfile
     export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
-    _export_tcp_interface_for_multihost
+    export_tcp_interface_for_multihost
     mkdir -p logs
     mkdir -p generated/artifacts
 
@@ -191,17 +187,14 @@ setup_quad_galaxy_env() {
     echo "Using MPI TCP interface (tt-run / Open MPI): ${TCP_INTERFACE}"
     echo "Using quad Galaxy rankfile: ${RANKFILE}"
 
-    _resolve_deepseekv3_model
-    _resolve_deepseekv3_cache
+    resolve_deepseekv3_model
+    resolve_deepseekv3_cache
     export MESH_DEVICE="QUAD"
 
-    # DeepSeek V3 currently interprets any set USE_TORUS_MODE as torus/ring.
-    # This script uses USE_TORUS_MODE=0 as an explicit OFF sentinel; _run_deepseekv3_tt
-    # unsets it for child test processes so OFF works while still overriding ambient env.
-    # Default is ON; set DS_QUAD_USE_TORUS_MODE=0 or pass --no-torus to disable.
-    local _ds_quad_torus="${DS_QUAD_USE_TORUS_MODE:-1}"
-    _ds_quad_torus="${_ds_quad_torus,,}"
-    case "${_ds_quad_torus}" in
+    # DS_QUAD_USE_TORUS_MODE defaults to 1; set 0 or --no-torus to disable torus mode.
+    local ds_quad_torus="${DS_QUAD_USE_TORUS_MODE:-1}"
+    ds_quad_torus="${ds_quad_torus,,}"
+    case "${ds_quad_torus}" in
         ""|1|true|yes|on)
             export USE_TORUS_MODE=1
             echo "Quad Galaxy: USE_TORUS_MODE=1 (DeepSeek V3 torus/ring mode enabled)."
@@ -229,7 +222,7 @@ _demo_timeout() {
     fi
 }
 
-_resolve_upr_mode() {
+resolve_upr_mode() {
     local upr_mode="${DEEPSEEK_DEMO_UPR_MODE:-all}"
     upr_mode="${upr_mode,,}"
     case "${upr_mode}" in
@@ -250,11 +243,11 @@ _resolve_upr_mode() {
     esac
 }
 
-_demo_case_selector() {
+demo_case_selector() {
     local setup_name="$1"
     local profile_name="$2"
     local upr_mode
-    upr_mode="$(_resolve_upr_mode)"
+    upr_mode="$(resolve_upr_mode)"
 
     case "${upr_mode}" in
         both)
@@ -271,21 +264,20 @@ _demo_case_selector() {
 
 # Helper: run a test command via tt-run using the current environment
 _run_deepseekv3_tt() {
-    # DeepSeek uses presence-only checks on USE_TORUS_MODE today.
-    # Treat "0" as explicit OFF by unsetting for the launched process.
+    # USE_TORUS_MODE=0 means OFF, so unset it for the launched process.
     if [[ "${USE_TORUS_MODE:-}" == "0" ]]; then
         if [[ -n "${MPI_ARGS:-}" ]]; then
-            ( unset USE_TORUS_MODE; _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@" )
+            ( unset USE_TORUS_MODE; tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@" )
         else
-            ( unset USE_TORUS_MODE; _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" "$@" )
+            ( unset USE_TORUS_MODE; tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" "$@" )
         fi
         return
     fi
 
     if [[ -n "${MPI_ARGS:-}" ]]; then
-        _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@"
+        tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@"
     else
-        _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" "$@"
+        tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" "$@"
     fi
 }
 
@@ -391,7 +383,7 @@ run_dual_demo_test() {
     setup_dual_galaxy_env
     local timeout=$(_demo_timeout 2400)
     local selector
-    selector="$(_demo_case_selector "dual" "full")"
+    selector="$(demo_case_selector "dual" "full")"
 
     _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '$selector' 2>&1 | tee generated/artifacts/dual_demo_output.log"
 }
@@ -408,7 +400,7 @@ run_quad_demo_test() {
     setup_quad_galaxy_env
     local timeout=$(_demo_timeout 3600)
     local selector
-    selector="$(_demo_case_selector "quad" "full")"
+    selector="$(demo_case_selector "quad" "full")"
 
     _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '$selector' 2>&1 | tee generated/artifacts/quad_demo_output.log"
 }
@@ -428,7 +420,7 @@ run_dual_demo_stress_test() {
     setup_dual_galaxy_env
     local timeout=$(_demo_timeout 5400)
     local selector
-    selector="$(_demo_case_selector "dual" "stress")"
+    selector="$(demo_case_selector "dual" "stress")"
 
     _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '$selector' 2>&1 | tee generated/artifacts/dual_demo_stress_output.log"
 }
@@ -437,7 +429,7 @@ run_quad_demo_stress_test() {
     setup_quad_galaxy_env
     local timeout=$(_demo_timeout 5400)
     local selector
-    selector="$(_demo_case_selector "quad" "stress")"
+    selector="$(demo_case_selector "quad" "stress")"
 
     _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '$selector' 2>&1 | tee generated/artifacts/quad_demo_stress_output.log"
 }
@@ -492,26 +484,11 @@ run_quad_galaxy_tests() {
 }
 
 ###############################################################################
-# Environment - prepare a runnable multihost test environment
-#
-# Goal: make local runs work out of the box while keeping CI compatibility.
-# CI sets most of these variables externally; local runs can rely on this
-# script to fill in missing defaults.
-#
-# Optional overrides:
-#   MULTIHOST_SKIP_SHARED_VENV=1     - skip setup_shared_venv.sh activation
-#   MULTIHOST_SOURCE_VENV=/path      - source venv for setup_shared_venv.sh
-#   MULTIHOST_MATCH_CI_HOME=1        - export HOME=\$TT_METAL_HOME (CI parity)
-#   MULTIHOST_FORCE_PYTHONHOME=0     - disable PYTHONHOME override for ranks
-#   DS_QUAD_USE_TORUS_MODE=0         - quad DeepSeek runs: set USE_TORUS_MODE=0 (debug /
-#                                    linear fabric). Default is 1. Also:
-#                                    pass --no-torus on the command line.
+# Environment setup for local and CI-compatible multihost runs.
 ###############################################################################
 
-_set_multihost_pythonhome_if_needed() {
-    # Some physical hosts cannot resolve the base interpreter from copied venv metadata
-    # (for example when pyvenv.cfg points to a host-local uv install path). Explicitly
-    # setting PYTHONHOME to the shared venv keeps Python startup deterministic on all ranks.
+set_multihost_pythonhome_if_needed() {
+    # Force PYTHONHOME when copied venv metadata points to host-local interpreters.
     if [[ "${MULTIHOST_FORCE_PYTHONHOME:-1}" == "0" ]]; then
         return 0
     fi
@@ -532,7 +509,7 @@ _set_multihost_pythonhome_if_needed() {
     fi
 }
 
-_init_multihost_test_env() {
+init_multihost_test_env() {
     export TT_METAL_HOME="$(cd -- "${TT_METAL_HOME}" && pwd -P)"
     cd "${TT_METAL_HOME}"
 
@@ -541,34 +518,34 @@ _init_multihost_test_env() {
     export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
     export LOGURU_LEVEL="${LOGURU_LEVEL:-INFO}"
 
-    local _reports="${TT_METAL_HOME}/generated/test_reports"
-    export GTEST_OUTPUT="${GTEST_OUTPUT:-xml:${_reports}/}"
-    mkdir -p "${_reports}"
+    local reports_dir="${TT_METAL_HOME}/generated/test_reports"
+    export GTEST_OUTPUT="${GTEST_OUTPUT:-xml:${reports_dir}/}"
+    mkdir -p "${reports_dir}"
 
     if [[ "${MULTIHOST_MATCH_CI_HOME:-}" == "1" ]]; then
         export HOME="${TT_METAL_HOME}"
     fi
 
     if [[ "${MULTIHOST_SKIP_SHARED_VENV:-0}" == "1" ]]; then
-        _set_multihost_pythonhome_if_needed
+        set_multihost_pythonhome_if_needed
         return 0
     fi
 
-    local _setup_venv="${TT_METAL_HOME}/tests/scripts/multihost/setup_shared_venv.sh"
-    local _py_env="${TT_METAL_HOME}/python_env"
-    local _src_venv="${MULTIHOST_SOURCE_VENV:-/opt/venv}"
-    if [[ ! -x "${_setup_venv}" ]]; then
-        echo "Warning: ${_setup_venv} is missing; skipping shared venv activation." >&2
-        _set_multihost_pythonhome_if_needed
+    local setup_venv_script="${TT_METAL_HOME}/tests/scripts/multihost/setup_shared_venv.sh"
+    local py_env_dir="${TT_METAL_HOME}/python_env"
+    local source_venv="${MULTIHOST_SOURCE_VENV:-/opt/venv}"
+    if [[ ! -x "${setup_venv_script}" ]]; then
+        echo "Warning: ${setup_venv_script} is missing; skipping shared venv activation." >&2
+        set_multihost_pythonhome_if_needed
         return 0
     fi
-    if [[ -d "${_py_env}" ]] || [[ -d "${_src_venv}" ]]; then
-        eval "$("${_setup_venv}" --activate "${_src_venv}" "${_py_env}")"
+    if [[ -d "${py_env_dir}" ]] || [[ -d "${source_venv}" ]]; then
+        eval "$("${setup_venv_script}" --activate "${source_venv}" "${py_env_dir}")"
     else
-        echo "Warning: neither ${_py_env} nor ${_src_venv} exists; skipping setup_shared_venv.sh. Use a venv with ttnn installed or set MULTIHOST_SOURCE_VENV." >&2
+        echo "Warning: neither ${py_env_dir} nor ${source_venv} exists; skipping setup_shared_venv.sh. Use a venv with ttnn installed or set MULTIHOST_SOURCE_VENV." >&2
     fi
 
-    _set_multihost_pythonhome_if_needed
+    set_multihost_pythonhome_if_needed
 }
 
 ###############################################################################
@@ -587,16 +564,9 @@ main() {
         echo "TT_METAL_HOME not set; defaulting to current directory: ${TT_METAL_HOME}"
     fi
 
-    _init_multihost_test_env
+    init_multihost_test_env
 
-    # Support running specific test function via argument.
-    # Positional compatibility:
-    #   $1 test function (default: all)
-    #   $2 UPR mode (all|32|8), optional when it is not an option flag
-    # Optional local-testing flags:
-    #   --no-torus                       - quad DeepSeek: set USE_TORUS_MODE=0 (see DS_QUAD_USE_TORUS_MODE)
-    #   --model-path <path>
-    #   --cache-path <path>
+    # Args: [test_function] [upr_mode] plus --no-torus/--model-path/--cache-path.
     local test_function="all"
     if [[ $# -gt 0 ]]; then
         test_function="$1"
@@ -610,8 +580,8 @@ main() {
     fi
     if [[ -n "${upr_mode_arg}" ]]; then
         export DEEPSEEK_DEMO_UPR_MODE="${upr_mode_arg}"
-        _resolve_upr_mode >/dev/null
-        echo "Using demo UPR mode: $(_resolve_upr_mode)"
+        resolve_upr_mode >/dev/null
+        echo "Using demo UPR mode: $(resolve_upr_mode)"
     fi
 
     while [[ $# -gt 0 ]]; do

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -160,6 +160,8 @@ setup_dual_galaxy_env() {
     _resolve_deepseekv3_model
     _resolve_deepseekv3_cache
     export MESH_DEVICE="DUAL"
+    export USE_TORUS_MODE=0
+    echo "Dual Galaxy: USE_TORUS_MODE=0 (torus/ring mode disabled)."
 }
 
 setup_quad_galaxy_env() {
@@ -193,8 +195,10 @@ setup_quad_galaxy_env() {
     _resolve_deepseekv3_cache
     export MESH_DEVICE="QUAD"
 
-    # DeepSeek V3 reads USE_TORUS_MODE: any set value enables ring/torus; unset => linear.
-    # Default is ON; set DS_QUAD_USE_TORUS_MODE=0 or pass --no-torus to disable for debugging.
+    # DeepSeek V3 currently interprets any set USE_TORUS_MODE as torus/ring.
+    # This script uses USE_TORUS_MODE=0 as an explicit OFF sentinel; _run_deepseekv3_tt
+    # unsets it for child test processes so OFF works while still overriding ambient env.
+    # Default is ON; set DS_QUAD_USE_TORUS_MODE=0 or pass --no-torus to disable.
     local _ds_quad_torus="${DS_QUAD_USE_TORUS_MODE:-1}"
     _ds_quad_torus="${_ds_quad_torus,,}"
     case "${_ds_quad_torus}" in
@@ -203,8 +207,8 @@ setup_quad_galaxy_env() {
             echo "Quad Galaxy: USE_TORUS_MODE=1 (DeepSeek V3 torus/ring mode enabled)."
             ;;
         0|false|no|off)
-            unset USE_TORUS_MODE
-            echo "Quad Galaxy: USE_TORUS_MODE unset (DeepSeek V3 torus/ring mode disabled)."
+            export USE_TORUS_MODE=0
+            echo "Quad Galaxy: USE_TORUS_MODE=0 (DeepSeek V3 torus/ring mode disabled)."
             ;;
         *)
             echo "Error: unsupported DS_QUAD_USE_TORUS_MODE='${DS_QUAD_USE_TORUS_MODE:-}' (use 1|0|true|false|yes|no|on|off)." >&2
@@ -267,6 +271,17 @@ _demo_case_selector() {
 
 # Helper: run a test command via tt-run using the current environment
 _run_deepseekv3_tt() {
+    # DeepSeek uses presence-only checks on USE_TORUS_MODE today.
+    # Treat "0" as explicit OFF by unsetting for the launched process.
+    if [[ "${USE_TORUS_MODE:-}" == "0" ]]; then
+        if [[ -n "${MPI_ARGS:-}" ]]; then
+            ( unset USE_TORUS_MODE; _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@" )
+        else
+            ( unset USE_TORUS_MODE; _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" "$@" )
+        fi
+        return
+    fi
+
     if [[ -n "${MPI_ARGS:-}" ]]; then
         _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@"
     else
@@ -488,8 +503,8 @@ run_quad_galaxy_tests() {
 #   MULTIHOST_SOURCE_VENV=/path      - source venv for setup_shared_venv.sh
 #   MULTIHOST_MATCH_CI_HOME=1        - export HOME=\$TT_METAL_HOME (CI parity)
 #   MULTIHOST_FORCE_PYTHONHOME=0     - disable PYTHONHOME override for ranks
-#   DS_QUAD_USE_TORUS_MODE=0         - quad DeepSeek runs: do not set USE_TORUS_MODE (debug /
-#                                    linear fabric). Default is 1 (same as unset). Also:
+#   DS_QUAD_USE_TORUS_MODE=0         - quad DeepSeek runs: set USE_TORUS_MODE=0 (debug /
+#                                    linear fabric). Default is 1. Also:
 #                                    pass --no-torus on the command line.
 ###############################################################################
 
@@ -579,7 +594,7 @@ main() {
     #   $1 test function (default: all)
     #   $2 UPR mode (all|32|8), optional when it is not an option flag
     # Optional local-testing flags:
-    #   --no-torus                       - quad DeepSeek: unset USE_TORUS_MODE (see DS_QUAD_USE_TORUS_MODE)
+    #   --no-torus                       - quad DeepSeek: set USE_TORUS_MODE=0 (see DS_QUAD_USE_TORUS_MODE)
     #   --model-path <path>
     #   --cache-path <path>
     local test_function="all"

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -4,6 +4,53 @@ set -eo pipefail
 # Default ARCH_NAME for local runs when not set by CI.
 export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
 
+# Prefer `tt-run` on PATH (from pip/editable install). Otherwise run `ttrun.py` directly so
+# multihost scripts work when console scripts are not installed (avoids importing `ttnn` package
+# root, which is unnecessary for the launcher).
+_tt_run() {
+    if command -v tt-run >/dev/null 2>&1; then
+        command tt-run "$@"
+        return
+    fi
+    if [[ -z "${TT_METAL_HOME:-}" ]]; then
+        echo "_tt_run: tt-run not on PATH and TT_METAL_HOME is unset; cannot locate ttrun.py" >&2
+        return 1
+    fi
+    local _ttrun_py="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
+    if [[ ! -f "${_ttrun_py}" ]]; then
+        echo "_tt_run: expected launcher at ${_ttrun_py} (missing); install ttnn or set TT_METAL_HOME" >&2
+        return 1
+    fi
+    "${PYTHON:-python3}" "${_ttrun_py}" "$@"
+}
+
+# MPI/OpenFabrics TCP binding: CI / many Galaxy boxes use "cnx1". If it is missing, pick the
+# first non-virtual interface in operstate up (skips lo, docker, tailscale, …) so local clusters
+# like UF-* hosts get a valid btl_tcp_if_include without manual export.
+_default_mpi_tcp_interface() {
+    if [[ -d /sys/class/net/cnx1 ]]; then
+        echo "cnx1"
+        return 0
+    fi
+    local n state
+    for n in /sys/class/net/*; do
+        n="${n##*/}"
+        case "${n}" in
+            lo | docker* | br-* | veth* | tailscale*) continue ;;
+        esac
+        state="$(cat "/sys/class/net/${n}/operstate" 2>/dev/null || true)"
+        if [[ "${state}" == "up" ]]; then
+            echo "${n}"
+            return 0
+        fi
+    done
+    echo "cnx1"
+}
+
+_export_tcp_interface_for_multihost() {
+    export TCP_INTERFACE="${TCP_INTERFACE:-$(_default_mpi_tcp_interface)}"
+}
+
 ###############################################################################
 # Infrastructure unit tests (quad galaxy only)
 ###############################################################################
@@ -11,11 +58,12 @@ export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
 run_quad_galaxy_unit_tests() {
   fail=0
 
+  _export_tcp_interface_for_multihost
   local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile"
-  local tcp_interface="cnx1"
+  local tcp_interface="${TCP_INTERFACE}"
   local hosts="g05glx04,g05glx03,g05glx02,g05glx01"
   local mpi_host="--host $hosts"
-  local mpirun_args_base="$mpi_args_base --mca btl self,tcp --mca btl_tcp_if_include cnx1 --tag-output"
+  local mpirun_args_base="$mpi_args_base --mca btl self,tcp --mca btl_tcp_if_include ${tcp_interface} --tag-output"
   local mpirun_args="$mpi_host $mpirun_args_base"
 
   local mesh_graph="tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_torus_xy_graph_descriptor.textproto"
@@ -26,12 +74,12 @@ run_quad_galaxy_unit_tests() {
 
   mpirun-ulfm $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation --send-traffic --cabling-descriptor-path ${descriptor_path}/cabling_descriptor.textproto --deployment-descriptor-path ${descriptor_path}/deployment_descriptor.textproto ; fail+=$?
 
-  tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
+  _tt_run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
 
   # TODO: Currently failing on 1D/2D tests
-  #tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
+  #_tt_run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
 
-  tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
+  _tt_run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -59,6 +107,20 @@ _resolve_deepseekv3_cache() {
     fi
 }
 
+_resolve_deepseekv3_model() {
+    local default_model="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
+    local model_path="${DEEPSEEK_V3_HF_MODEL_OVERRIDE:-${DEEPSEEK_V3_HF_MODEL:-${default_model}}}"
+
+    if [[ ! -d "${model_path}" ]]; then
+        echo "Error: DeepSeek V3 model directory does not exist: ${model_path}" >&2
+        echo "For local testing, pass --model-path <path> (or set DEEPSEEK_V3_HF_MODEL_OVERRIDE)." >&2
+        exit 1
+    fi
+
+    export DEEPSEEK_V3_HF_MODEL="${model_path}"
+    echo "Using DeepSeek V3 model: ${DEEPSEEK_V3_HF_MODEL}"
+}
+
 setup_dual_galaxy_env() {
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
     export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto"
@@ -66,11 +128,12 @@ setup_dual_galaxy_env() {
     export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 2 | paste -sd,)"
     export RANKFILE=/etc/mpirun/rankfile
     export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
-    export TCP_INTERFACE="cnx1"
+    _export_tcp_interface_for_multihost
     mkdir -p logs
     mkdir -p generated/artifacts
 
     echo "Using dual Galaxy hosts: ${HOSTS}"
+    echo "Using MPI TCP interface (tt-run / Open MPI): ${TCP_INTERFACE}"
     echo "Using dual Galaxy rankfile: ${RANKFILE}"
 
     if ! test -f "$RANKFILE"; then
@@ -86,7 +149,7 @@ setup_dual_galaxy_env() {
         exit 1
     fi
 
-    export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
+    _resolve_deepseekv3_model
     _resolve_deepseekv3_cache
     export MESH_DEVICE="DUAL"
 }
@@ -97,7 +160,7 @@ setup_quad_galaxy_env() {
     # heuristic to extract only 4 first hosts from the hostfile
     export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 4 | paste -sd,)"
     export RANKFILE=/etc/mpirun/rankfile
-    export TCP_INTERFACE="cnx1"
+    _export_tcp_interface_for_multihost
     mkdir -p logs
     mkdir -p generated/artifacts
 
@@ -114,7 +177,10 @@ setup_quad_galaxy_env() {
         exit 1
     fi
 
-    export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
+    echo "Using quad Galaxy hosts: ${HOSTS}"
+    echo "Using MPI TCP interface (tt-run / Open MPI): ${TCP_INTERFACE}"
+
+    _resolve_deepseekv3_model
     _resolve_deepseekv3_cache
     export MESH_DEVICE="QUAD"
     export USE_TORUS_MODE=1
@@ -174,7 +240,7 @@ _demo_case_selector() {
 
 # Helper: run a test command via tt-run using the current environment
 _run_deepseekv3_tt() {
-    tt-run --tcp-interface $TCP_INTERFACE --mesh-graph-descriptor "$MESH_GRAPH_DESCRIPTOR" --hosts "$HOSTS" "$@"
+    _tt_run --tcp-interface $TCP_INTERFACE --mesh-graph-descriptor "$MESH_GRAPH_DESCRIPTOR" --hosts "$HOSTS" "$@"
 }
 
 ###############################################################################
@@ -380,6 +446,83 @@ run_quad_galaxy_tests() {
 }
 
 ###############################################################################
+# Environment - prepare a runnable multihost test environment
+#
+# Goal: make local runs work out of the box while keeping CI compatibility.
+# CI sets most of these variables externally; local runs can rely on this
+# script to fill in missing defaults.
+#
+# Optional overrides:
+#   MULTIHOST_SKIP_SHARED_VENV=1     - skip setup_shared_venv.sh activation
+#   MULTIHOST_SOURCE_VENV=/path      - source venv for setup_shared_venv.sh
+#   MULTIHOST_MATCH_CI_HOME=1        - export HOME=\$TT_METAL_HOME (CI parity)
+#   MULTIHOST_FORCE_PYTHONHOME=0     - disable PYTHONHOME override for ranks
+###############################################################################
+
+_set_multihost_pythonhome_if_needed() {
+    # Some physical hosts cannot resolve the base interpreter from copied venv metadata
+    # (for example when pyvenv.cfg points to a host-local uv install path). Explicitly
+    # setting PYTHONHOME to the shared venv keeps Python startup deterministic on all ranks.
+    if [[ "${MULTIHOST_FORCE_PYTHONHOME:-1}" == "0" ]]; then
+        return 0
+    fi
+
+    local pyhome="${TT_METAL_HOME}/python_env"
+    local -a encodings_candidates=()
+    shopt -s nullglob
+    encodings_candidates=("${pyhome}"/lib/python*/encodings/__init__.py)
+    shopt -u nullglob
+
+    if [[ ${#encodings_candidates[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    if [[ "${PYTHONHOME:-}" != "${pyhome}" ]]; then
+        export PYTHONHOME="${pyhome}"
+        echo "Using PYTHONHOME override for multihost ranks: ${PYTHONHOME}"
+    fi
+}
+
+_init_multihost_test_env() {
+    export TT_METAL_HOME="$(cd -- "${TT_METAL_HOME}" && pwd -P)"
+    cd "${TT_METAL_HOME}"
+
+    export PYTHONPATH="${TT_METAL_HOME}${PYTHONPATH:+:${PYTHONPATH}}"
+    export LD_LIBRARY_PATH="${TT_METAL_HOME}/build/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
+    export LOGURU_LEVEL="${LOGURU_LEVEL:-INFO}"
+
+    local _reports="${TT_METAL_HOME}/generated/test_reports"
+    export GTEST_OUTPUT="${GTEST_OUTPUT:-xml:${_reports}/}"
+    mkdir -p "${_reports}"
+
+    if [[ "${MULTIHOST_MATCH_CI_HOME:-}" == "1" ]]; then
+        export HOME="${TT_METAL_HOME}"
+    fi
+
+    if [[ "${MULTIHOST_SKIP_SHARED_VENV:-0}" == "1" ]]; then
+        _set_multihost_pythonhome_if_needed
+        return 0
+    fi
+
+    local _setup_venv="${TT_METAL_HOME}/tests/scripts/multihost/setup_shared_venv.sh"
+    local _py_env="${TT_METAL_HOME}/python_env"
+    local _src_venv="${MULTIHOST_SOURCE_VENV:-/opt/venv}"
+    if [[ ! -x "${_setup_venv}" ]]; then
+        echo "Warning: ${_setup_venv} is missing; skipping shared venv activation." >&2
+        _set_multihost_pythonhome_if_needed
+        return 0
+    fi
+    if [[ -d "${_py_env}" ]] || [[ -d "${_src_venv}" ]]; then
+        eval "$("${_setup_venv}" --activate "${_src_venv}" "${_py_env}")"
+    else
+        echo "Warning: neither ${_py_env} nor ${_src_venv} exists; skipping setup_shared_venv.sh. Use a venv with ttnn installed or set MULTIHOST_SOURCE_VENV." >&2
+    fi
+
+    _set_multihost_pythonhome_if_needed
+}
+
+###############################################################################
 # Main dispatcher
 ###############################################################################
 
@@ -395,17 +538,63 @@ main() {
         exit 1
     fi
 
-    # Run tests
-    cd $TT_METAL_HOME
-    export PYTHONPATH=$TT_METAL_HOME
+    _init_multihost_test_env
 
-    # Support running specific test function via argument
-    local test_function="${1:-all}"
-    local upr_mode_arg="${2:-}"
+    # Support running specific test function via argument.
+    # Positional compatibility:
+    #   $1 test function (default: all)
+    #   $2 UPR mode (all|32|8), optional when it is not an option flag
+    # Optional local-testing flags:
+    #   --model-path <path>
+    #   --cache-path <path>
+    local test_function="all"
+    if [[ $# -gt 0 ]]; then
+        test_function="$1"
+        shift
+    fi
+
+    local upr_mode_arg=""
+    if [[ $# -gt 0 && "${1}" != --* ]]; then
+        upr_mode_arg="$1"
+        shift
+    fi
     if [[ -n "${upr_mode_arg}" ]]; then
         export DEEPSEEK_DEMO_UPR_MODE="${upr_mode_arg}"
         _resolve_upr_mode >/dev/null
         echo "Using demo UPR mode: $(_resolve_upr_mode)"
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --model-path)
+                if [[ $# -lt 2 ]]; then
+                    echo "Error: --model-path requires a value." >&2
+                    exit 1
+                fi
+                export DEEPSEEK_V3_HF_MODEL_OVERRIDE="$2"
+                shift 2
+                ;;
+            --cache-path)
+                if [[ $# -lt 2 ]]; then
+                    echo "Error: --cache-path requires a value." >&2
+                    exit 1
+                fi
+                export DEEPSEEK_V3_CACHE_OVERRIDE="$2"
+                shift 2
+                ;;
+            *)
+                echo "Unknown argument: $1" >&2
+                echo "Usage: $0 [test_function] [upr_mode] [--model-path <path>] [--cache-path <path>]" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [[ -n "${DEEPSEEK_V3_HF_MODEL_OVERRIDE:-}" ]]; then
+        echo "Using local DeepSeek model override: ${DEEPSEEK_V3_HF_MODEL_OVERRIDE}"
+    fi
+    if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
+        echo "Using local DeepSeek cache override: ${DEEPSEEK_V3_CACHE_OVERRIDE}"
     fi
 
     case "$test_function" in
@@ -464,6 +653,8 @@ main() {
             echo "Unknown test function: $test_function" 1>&2
             echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all_needed_local_tests, all" 1>&2
             echo "Optional second argument: UPR mode (all|32|8)" 1>&2
+            echo "Optional flags for local testing: --model-path <path> --cache-path <path>" 1>&2
+            echo "Example: $0 quad_demo 32 --model-path /data/deepseek/DeepSeek-R1-0528-dequantized --cache-path /data/deepseek/DeepSeek-R1-0528-Cache/CI" 1>&2
             exit 1
             ;;
     esac

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -1,11 +1,60 @@
 #!/bin/bash
 set -eo pipefail
 
-# Exit immediately if ARCH_NAME is not set or empty
-if [ -z "${ARCH_NAME}" ]; then
-  echo "Error: ARCH_NAME is not set. Exiting." >&2
-  exit 1
-fi
+# Default ARCH_NAME for local runs when not pre-set by CI.
+export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
+
+readonly DEFAULT_DUAL_HOSTS_CSV="g02glx01,g02glx02"
+readonly DEFAULT_QUAD_HOSTS_CSV="g05glx04,g05glx03,g05glx02,g05glx01"
+readonly DEFAULT_SOURCE_RANKFILE="${MPI_SOURCE_RANKFILE:-/etc/mpirun/rankfile}"
+readonly DEFAULT_TCP_INTERFACE="${TT_RUN_TCP_INTERFACE:-ens5f0np0}"
+TMP_RANKFILES=()
+
+usage() {
+  cat <<'EOF'
+Usage:
+  run_quad_galaxy_tests.sh <test_function> [upr_mode]
+
+Notes:
+  Run from the tt-metal repository root, or set TT_METAL_HOME to the repo root.
+  ARCH_NAME defaults to wormhole_b0 when unset (this script exports it).
+
+Arguments:
+  test_function  One of:
+                 unit_tests
+                 dual_deepseekv3_unit_tests
+                 quad_deepseekv3_unit_tests
+                 dual_deepseekv3_module_tests
+                 quad_deepseekv3_module_tests
+                 dual_teacher_forced
+                 quad_teacher_forced
+                 dual_demo
+                 quad_demo
+                 dual_demo_mtp
+                 quad_demo_mtp
+                 dual_demo_stress
+                 quad_demo_stress
+                 dual_deepseekv3_integration_tests
+                 quad_deepseekv3_integration_tests
+                 all_needed_local_tests
+                 all
+  upr_mode       Optional demo UPR mode: all | 32 | 8 (default: all).
+                 Ignored for all_needed_local_tests (demos always run 8 and 32 UPR).
+
+Examples:
+  bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh unit_tests
+  QUAD_MPI_HOSTS="h1,h2,h3,h4" bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress 32
+  bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh all_needed_local_tests
+EOF
+}
+
+cleanup_temp_rankfiles() {
+  local rankfile_path
+  for rankfile_path in "${TMP_RANKFILES[@]}"; do
+    rm -f "${rankfile_path}"
+  done
+}
+trap cleanup_temp_rankfiles EXIT
 
 ###############################################################################
 # Infrastructure unit tests (quad galaxy only)
@@ -14,14 +63,16 @@ fi
 run_quad_galaxy_unit_tests() {
   fail=0
 
+  # tt-run --tcp-interface handles tcp and tag flags
   local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile"
   local tcp_interface="cnx1"
-  local hosts="g05glx04,g05glx03,g05glx02,g05glx01"
-  local mpi_host="--host $hosts"
+  local mpi_host="--host g05glx04,g05glx03,g05glx02,g05glx01"
+  local mpi_args="$mpi_host $mpi_args_base"
+
   local mpirun_args_base="$mpi_args_base --mca btl self,tcp --mca btl_tcp_if_include cnx1 --tag-output"
   local mpirun_args="$mpi_host $mpirun_args_base"
 
-  local mesh_graph="tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_torus_xy_graph_descriptor.textproto"
+  local rank_binding="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
   local descriptor_path="${DESCRIPTOR_PATH:-/etc/mpirun}"
 
   # TODO: Currently failing
@@ -29,12 +80,12 @@ run_quad_galaxy_unit_tests() {
 
   mpirun-ulfm $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation --send-traffic --cabling-descriptor-path ${descriptor_path}/cabling_descriptor.textproto --deployment-descriptor-path ${descriptor_path}/deployment_descriptor.textproto ; fail+=$?
 
-  tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
+  tt-run --tcp-interface $tcp_interface --rank-binding "$rank_binding" --mpi-args "$mpi_args" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
 
   # TODO: Currently failing on 1D/2D tests
-  #tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
+  #tt-run --tcp-interface $tcp_interface --rank-binding "$rank_binding" --mpi-args "$mpi_args" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
 
-  tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
+  tt-run --tcp-interface $tcp_interface --rank-binding "$rank_binding" --mpi-args "$mpi_args" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -42,102 +93,222 @@ run_quad_galaxy_unit_tests() {
 }
 
 ###############################################################################
-# Environment setup helpers
+# Environment setup helpers (DeepSeek multihost: rankfile + hosts)
 ###############################################################################
 
 _resolve_deepseekv3_cache() {
-    local ci_cache="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"
-    if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
-        local resolved
-        resolved=$(realpath -m "${DEEPSEEK_V3_CACHE_OVERRIDE}")
-        local ci_resolved
-        ci_resolved=$(realpath -m "${ci_cache}")
-        if [[ "${resolved}" == "${ci_resolved}" || "${resolved}" == "${ci_resolved}/"* ]]; then
-            echo "Error: DEEPSEEK_V3_CACHE_OVERRIDE must not point to or inside the production CI cache (${ci_cache})." >&2
-            exit 1
-        fi
-        export DEEPSEEK_V3_CACHE="${DEEPSEEK_V3_CACHE_OVERRIDE}"
-    else
-        export DEEPSEEK_V3_CACHE="${ci_cache}"
+  local ci_cache="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"
+  if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
+    local resolved
+    resolved="$(realpath -m "${DEEPSEEK_V3_CACHE_OVERRIDE}")"
+    local ci_resolved
+    ci_resolved="$(realpath -m "${ci_cache}")"
+    if [[ "${resolved}" == "${ci_resolved}" || "${resolved}" == "${ci_resolved}/"* ]]; then
+      echo "Error: DEEPSEEK_V3_CACHE_OVERRIDE must not point to or inside the production CI cache (${ci_cache})." >&2
+      exit 1
     fi
+    export DEEPSEEK_V3_CACHE="${DEEPSEEK_V3_CACHE_OVERRIDE}"
+  else
+    export DEEPSEEK_V3_CACHE="${ci_cache}"
+  fi
 }
 
-setup_dual_galaxy_env() {
-    export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
-    export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto"
-    # heuristic to extract only 2 first hosts from the hostfile
-    export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 2 | paste -sd,)"
-    export RANKFILE=/etc/mpirun/rankfile
-    export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
-    export TCP_INTERFACE="cnx1"
-    mkdir -p logs
-    mkdir -p generated/artifacts
+_extract_hosts_csv_from_rankfile() {
+  local rankfile="$1"
+  local expected_count="$2"
 
-    echo "Using dual Galaxy hosts: ${HOSTS}"
-    echo "Using dual Galaxy rankfile: ${RANKFILE}"
+  if [[ ! -f "${rankfile}" ]]; then
+    return 1
+  fi
 
-    if ! test -f "$RANKFILE"; then
-        echo "File '$RANKFILE' does not exist."
-        exit 1
+  local -a rank_hosts=()
+  local line
+  while IFS= read -r line; do
+    if [[ "${line}" =~ ^[[:space:]]*rank[[:space:]]+[0-9]+=([^[:space:]]+) ]]; then
+      rank_hosts+=("${BASH_REMATCH[1]}")
     fi
-    if ! test -f "$RANK_BINDING_YAML"; then
-        echo "File '$RANK_BINDING_YAML' does not exist."
-        exit 1
-    fi
-    if ! test -f "$MESH_GRAPH_DESCRIPTOR"; then
-        echo "File '$MESH_GRAPH_DESCRIPTOR' does not exist."
-        exit 1
-    fi
+  done < "${rankfile}"
 
-    export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
-    _resolve_deepseekv3_cache
-    export MESH_DEVICE="DUAL"
+  if [[ ${#rank_hosts[@]} -lt ${expected_count} ]]; then
+    return 1
+  fi
+
+  local -a selected_hosts=("${rank_hosts[@]:0:${expected_count}}")
+  local hosts_csv
+  hosts_csv="$(IFS=','; echo "${selected_hosts[*]}")"
+  echo "${hosts_csv}"
 }
 
-setup_quad_galaxy_env() {
-    export RANK_BINDING_YAML="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
-    export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_torus_xy_graph_descriptor.textproto"
-    # heuristic to extract only 4 first hosts from the hostfile
-    export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 4 | paste -sd,)"
-    export RANKFILE=/etc/mpirun/rankfile
-    export TCP_INTERFACE="cnx1"
-    mkdir -p logs
-    mkdir -p generated/artifacts
+_build_rankfile_from_hosts_csv() {
+  local hosts_csv="$1"
+  local expected_count="$2"
+  local rankfile_path="$3"
+  local hosts_error_hint="$4"
 
-    if ! test -f "$RANKFILE"; then
-        echo "File '$RANKFILE' does not exist."
-        exit 1
-    fi
-    if ! test -f "$RANK_BINDING_YAML"; then
-        echo "File '$RANK_BINDING_YAML' does not exist."
-        exit 1
-    fi
-    if ! test -f "$MESH_GRAPH_DESCRIPTOR"; then
-        echo "File '$MESH_GRAPH_DESCRIPTOR' does not exist."
-        exit 1
-    fi
+  local -a hosts=()
+  IFS=',' read -r -a hosts <<< "${hosts_csv}"
+  if [[ ${#hosts[@]} -ne ${expected_count} ]]; then
+    echo "${hosts_error_hint} must contain exactly ${expected_count} comma-separated hosts." >&2
+    exit 1
+  fi
 
-    export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
-    _resolve_deepseekv3_cache
-    export MESH_DEVICE="QUAD"
-    export USE_TORUS_MODE=1
+  : > "${rankfile_path}"
+  echo "# mpirun rankfile" >> "${rankfile_path}"
+  local rank_idx
+  for rank_idx in "${!hosts[@]}"; do
+    echo "rank ${rank_idx}=${hosts[$rank_idx]} slot=0:*" >> "${rankfile_path}"
+  done
+}
+
+_resolve_dual_hosts_csv() {
+  if [[ -n "${DUAL_MPI_HOSTS:-}" ]]; then
+    echo "${DUAL_MPI_HOSTS}"
+    return
+  fi
+
+  if [[ -n "${MPI_HOSTS:-}" ]]; then
+    echo "${MPI_HOSTS}"
+    return
+  fi
+
+  local source_rankfile="${DUAL_SOURCE_RANKFILE:-${DEFAULT_SOURCE_RANKFILE}}"
+  local hosts_from_rankfile
+  if hosts_from_rankfile="$(_extract_hosts_csv_from_rankfile "${source_rankfile}" 2)"; then
+    echo "${hosts_from_rankfile}"
+    return
+  fi
+
+  echo "${DEFAULT_DUAL_HOSTS_CSV}"
+}
+
+_resolve_quad_hosts_csv() {
+  if [[ -n "${QUAD_MPI_HOSTS:-}" ]]; then
+    echo "${QUAD_MPI_HOSTS}"
+    return
+  fi
+
+  local source_rankfile="${QUAD_SOURCE_RANKFILE:-${DEFAULT_SOURCE_RANKFILE}}"
+  local hosts_from_rankfile
+  if hosts_from_rankfile="$(_extract_hosts_csv_from_rankfile "${source_rankfile}" 4)"; then
+    echo "${hosts_from_rankfile}"
+    return
+  fi
+
+  echo "${DEFAULT_QUAD_HOSTS_CSV}"
+}
+
+_resolve_upr_mode() {
+  local upr_mode="${DEEPSEEK_DEMO_UPR_MODE:-all}"
+  upr_mode="${upr_mode,,}"
+  case "${upr_mode}" in
+    ""|all|both)
+      echo "both"
+      ;;
+    32|32upr|upr32)
+      echo "32"
+      ;;
+    8|8upr|upr8)
+      echo "8"
+      ;;
+    *)
+      echo "Unsupported DEEPSEEK_DEMO_UPR_MODE='${DEEPSEEK_DEMO_UPR_MODE:-}'." >&2
+      echo "Supported values: all|both|32|8" >&2
+      exit 1
+      ;;
+  esac
+}
+
+_demo_case_selector() {
+  local setup_name="$1"
+  local profile_name="$2"
+  local upr_mode
+  upr_mode="$(_resolve_upr_mode)"
+
+  case "${upr_mode}" in
+    both)
+      echo "${setup_name}_${profile_name}_demo_32upr or ${setup_name}_${profile_name}_demo_8upr"
+      ;;
+    32)
+      echo "${setup_name}_${profile_name}_demo_32upr"
+      ;;
+    8)
+      echo "${setup_name}_${profile_name}_demo_8upr"
+      ;;
+  esac
 }
 
 # Compute pytest --timeout value.
 # When DEEPSEEK_V3_CACHE_OVERRIDE is set (cache recalculation), add 6 hours.
 _demo_timeout() {
-    local base_timeout=$1
-    local cache_extra=21600  # 6 hours
-    if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
-        echo $(( base_timeout + cache_extra ))
-    else
-        echo "$base_timeout"
-    fi
+  local base_timeout="$1"
+  local cache_extra=21600  # 6 hours
+  if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
+    echo $((base_timeout + cache_extra))
+  else
+    echo "${base_timeout}"
+  fi
 }
 
-# Helper: run a test command via tt-run using the current environment
+setup_dual_galaxy_env() {
+  export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
+  export HOSTS="$(_resolve_dual_hosts_csv)"
+  export RANKFILE="$(mktemp "${TMPDIR:-/tmp}/rankfile_dual_deepseek_ci.XXXXXX")"
+  TMP_RANKFILES+=("${RANKFILE}")
+  _build_rankfile_from_hosts_csv "${HOSTS}" 2 "${RANKFILE}" "DUAL_MPI_HOSTS (or MPI_HOSTS)"
+  export MPI_ARGS="--host ${HOSTS} --map-by rankfile:file=${RANKFILE} --bind-to none --output-filename logs/mpi_job"
+  export TCP_INTERFACE="${TT_RUN_TCP_INTERFACE:-${DEFAULT_TCP_INTERFACE}}"
+  export DUAL_MPI_HOSTS="${HOSTS}"
+  mkdir -p logs
+  mkdir -p generated/artifacts
+
+  echo "Using dual Galaxy hosts: ${HOSTS}"
+  echo "Using dual Galaxy rankfile: ${RANKFILE}"
+
+  if ! test -f "${RANK_BINDING_YAML}"; then
+    echo "File '${RANK_BINDING_YAML}' does not exist." >&2
+    exit 1
+  fi
+
+  export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
+  _resolve_deepseekv3_cache
+  export MESH_DEVICE="DUAL"
+  unset USE_TORUS_MODE
+}
+
+setup_quad_galaxy_env() {
+  export RANK_BINDING_YAML="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
+  export HOSTS="$(_resolve_quad_hosts_csv)"
+  export RANKFILE="$(mktemp "${TMPDIR:-/tmp}/rankfile_quad_deepseek_ci.XXXXXX")"
+  TMP_RANKFILES+=("${RANKFILE}")
+  _build_rankfile_from_hosts_csv "${HOSTS}" 4 "${RANKFILE}" "QUAD_MPI_HOSTS"
+  export MPI_ARGS="--host ${HOSTS} --map-by rankfile:file=${RANKFILE} --bind-to none --output-filename logs/mpi_job"
+  export TCP_INTERFACE="${TT_RUN_TCP_INTERFACE:-${DEFAULT_TCP_INTERFACE}}"
+  export QUAD_MPI_HOSTS="${HOSTS}"
+  mkdir -p logs
+  mkdir -p generated/artifacts
+
+  if ! test -f "${RANK_BINDING_YAML}"; then
+    echo "File '${RANK_BINDING_YAML}' does not exist." >&2
+    exit 1
+  fi
+
+  export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
+  _resolve_deepseekv3_cache
+  export MESH_DEVICE="QUAD"
+  export USE_TORUS_MODE=1
+}
+
 _run_deepseekv3_tt() {
-    tt-run --tcp-interface $TCP_INTERFACE --mesh-graph-descriptor "$MESH_GRAPH_DESCRIPTOR" --hosts "$HOSTS" "$@"
+  local mpi_args="${MPI_ARGS} -x DEEPSEEK_V3_HF_MODEL -x DEEPSEEK_V3_CACHE -x MESH_DEVICE"
+  if [[ -n "${USE_TORUS_MODE:-}" ]]; then
+    mpi_args="${mpi_args} -x USE_TORUS_MODE"
+  fi
+
+  tt-run \
+    --tcp-interface "${TCP_INTERFACE}" \
+    --rank-binding "${RANK_BINDING_YAML}" \
+    --mpi-args "${mpi_args}" \
+    "$@"
 }
 
 ###############################################################################
@@ -145,25 +316,25 @@ _run_deepseekv3_tt() {
 ###############################################################################
 
 run_dual_deepseekv3_unit_tests() {
-    fail=0
-    setup_dual_galaxy_env
+  fail=0
+  setup_dual_galaxy_env
 
-    _run_deepseekv3_tt pytest -svvv models/demos/deepseek_v3/tests/unit ; fail+=$?
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv models/demos/deepseek_v3/tests/unit 2>&1 | tee generated/artifacts/dual_deepseekv3_unit_output.log" ; fail+=$?
 
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_quad_deepseekv3_unit_tests() {
-    fail=0
-    setup_quad_galaxy_env
+  fail=0
+  setup_quad_galaxy_env
 
-    _run_deepseekv3_tt pytest -svvv models/demos/deepseek_v3/tests/unit ; fail+=$?
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv models/demos/deepseek_v3/tests/unit 2>&1 | tee generated/artifacts/quad_deepseekv3_unit_output.log" ; fail+=$?
 
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 ###############################################################################
@@ -171,25 +342,25 @@ run_quad_deepseekv3_unit_tests() {
 ###############################################################################
 
 run_dual_deepseekv3_module_tests() {
-    fail=0
-    setup_dual_galaxy_env
+  fail=0
+  setup_dual_galaxy_env
 
-    _run_deepseekv3_tt pytest -svvv models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests ; fail+=$?
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests 2>&1 | tee generated/artifacts/dual_deepseekv3_module_output.log" ; fail+=$?
 
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_quad_deepseekv3_module_tests() {
-    fail=0
-    setup_quad_galaxy_env
+  fail=0
+  setup_quad_galaxy_env
 
-    _run_deepseekv3_tt pytest -svvv models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests ; fail+=$?
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests 2>&1 | tee generated/artifacts/quad_deepseekv3_module_output.log" ; fail+=$?
 
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 ###############################################################################
@@ -197,41 +368,39 @@ run_quad_deepseekv3_module_tests() {
 ###############################################################################
 
 run_dual_teacher_forced_test() {
-    fail=0
-    setup_dual_galaxy_env
-    local timeout=$(_demo_timeout 3600)
+  fail=0
+  setup_dual_galaxy_env
+  local timeout=$(_demo_timeout 3600)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/dual_teacher_forced_output.log" ; fail+=$?
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/dual_teacher_forced_output.log" ; fail+=$?
 
-    # Extract accuracy metrics from logs and save to artifact file
-    if [[ -f generated/artifacts/dual_teacher_forced_output.log ]]; then
-        echo "Extracting accuracy metrics from test output..."
-        grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/dual_teacher_forced_output.log > generated/artifacts/dual_teacher_forced_accuracy.txt || true
-        echo "Accuracy metrics saved to generated/artifacts/dual_teacher_forced_accuracy.txt"
-    fi
+  if [[ -f generated/artifacts/dual_teacher_forced_output.log ]]; then
+    echo "Extracting accuracy metrics from test output..."
+    grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/dual_teacher_forced_output.log > generated/artifacts/dual_teacher_forced_accuracy.txt || true
+    echo "Accuracy metrics saved to generated/artifacts/dual_teacher_forced_accuracy.txt"
+  fi
 
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_quad_teacher_forced_test() {
-    fail=0
-    setup_quad_galaxy_env
-    local timeout=$(_demo_timeout 3600)
+  fail=0
+  setup_quad_galaxy_env
+  local timeout=$(_demo_timeout 3600)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/quad_teacher_forced_output.log" ; fail+=$?
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/quad_teacher_forced_output.log" ; fail+=$?
 
-    # Extract accuracy metrics from logs and save to artifact file
-    if [[ -f generated/artifacts/quad_teacher_forced_output.log ]]; then
-        echo "Extracting accuracy metrics from test output..."
-        grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/quad_teacher_forced_output.log > generated/artifacts/quad_teacher_forced_accuracy.txt || true
-        echo "Accuracy metrics saved to generated/artifacts/quad_teacher_forced_accuracy.txt"
-    fi
+  if [[ -f generated/artifacts/quad_teacher_forced_output.log ]]; then
+    echo "Extracting accuracy metrics from test output..."
+    grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/quad_teacher_forced_output.log > generated/artifacts/quad_teacher_forced_accuracy.txt || true
+    echo "Accuracy metrics saved to generated/artifacts/quad_teacher_forced_accuracy.txt"
+  fi
 
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 ###############################################################################
@@ -239,32 +408,55 @@ run_quad_teacher_forced_test() {
 ###############################################################################
 
 run_dual_demo_test() {
-    setup_dual_galaxy_env
-    local timeout=$(_demo_timeout 2400)
+  fail=0
+  setup_dual_galaxy_env
+  local timeout=$(_demo_timeout 2400)
+  local selector
+  selector="$(_demo_case_selector "dual" "full")"
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[dual_full_demo]' 2>&1 | tee generated/artifacts/dual_demo_output.log"
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '${selector}' 2>&1 | tee generated/artifacts/dual_demo_output.log" ; fail+=$?
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_dual_demo_mtp_test() {
-    setup_dual_galaxy_env
-    local timeout=$(_demo_timeout 2400)
+  fail=0
+  setup_dual_galaxy_env
+  local timeout=$(_demo_timeout 2400)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log"
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log" ; fail+=$?
 
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_quad_demo_test() {
-    setup_quad_galaxy_env
-    local timeout=$(_demo_timeout 3600)
+  fail=0
+  setup_quad_galaxy_env
+  local timeout=$(_demo_timeout 3600)
+  local selector
+  selector="$(_demo_case_selector "quad" "full")"
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[quad_full_demo]' 2>&1 | tee generated/artifacts/quad_demo_output.log"
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '${selector}' 2>&1 | tee generated/artifacts/quad_demo_output.log" ; fail+=$?
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_quad_demo_mtp_test() {
-    setup_quad_galaxy_env
-    local timeout=$(_demo_timeout 3600)
+  fail=0
+  setup_quad_galaxy_env
+  local timeout=$(_demo_timeout 3600)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log"
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log" ; fail+=$?
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 ###############################################################################
@@ -272,48 +464,75 @@ run_quad_demo_mtp_test() {
 ###############################################################################
 
 run_dual_demo_stress_test() {
-    setup_dual_galaxy_env
-    local timeout=$(_demo_timeout 5400)
+  fail=0
+  setup_dual_galaxy_env
+  local timeout=$(_demo_timeout 5400)
+  local selector
+  selector="$(_demo_case_selector "dual" "stress")"
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[dual_stress_demo]' 2>&1 | tee generated/artifacts/dual_demo_stress_output.log"
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '${selector}' 2>&1 | tee generated/artifacts/dual_demo_stress_output.log" ; fail+=$?
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_quad_demo_stress_test() {
-    setup_quad_galaxy_env
-    local timeout=$(_demo_timeout 5400)
+  fail=0
+  setup_quad_galaxy_env
+  local timeout=$(_demo_timeout 5400)
+  local selector
+  selector="$(_demo_case_selector "quad" "stress")"
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[quad_stress_demo]' 2>&1 | tee generated/artifacts/quad_demo_stress_output.log"
+  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '${selector}' 2>&1 | tee generated/artifacts/quad_demo_stress_output.log" ; fail+=$?
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 ###############################################################################
 # Composite runners
 ###############################################################################
 
-# All dual galaxy deepseek v3 integration tests
+run_all_needed_local_tests() {
+  local _saved_upr="${DEEPSEEK_DEMO_UPR_MODE:-}"
+  export DEEPSEEK_DEMO_UPR_MODE=all
+  run_dual_teacher_forced_test
+  run_dual_demo_test
+  run_dual_demo_stress_test
+  run_quad_teacher_forced_test
+  run_quad_demo_test
+  run_quad_demo_stress_test
+  if [[ -n "${_saved_upr}" ]]; then
+    export DEEPSEEK_DEMO_UPR_MODE="${_saved_upr}"
+  else
+    unset DEEPSEEK_DEMO_UPR_MODE
+  fi
+}
+
 run_dual_deepseekv3_integration_tests() {
-    run_dual_deepseekv3_module_tests
-    run_dual_teacher_forced_test
-    run_dual_demo_test
-    run_dual_demo_mtp_test
-    run_dual_demo_stress_test
+  run_dual_deepseekv3_module_tests
+  run_dual_teacher_forced_test
+  run_dual_demo_test
+  run_dual_demo_mtp_test
+  run_dual_demo_stress_test
 }
 
-# All quad galaxy deepseek v3 integration tests
 run_quad_deepseekv3_integration_tests() {
-    run_quad_deepseekv3_module_tests
-    run_quad_teacher_forced_test
-    run_quad_demo_test
-    run_quad_demo_mtp_test
-    run_quad_demo_stress_test
+  run_quad_deepseekv3_module_tests
+  run_quad_teacher_forced_test
+  run_quad_demo_test
+  run_quad_demo_mtp_test
+  run_quad_demo_stress_test
 }
 
-# Run everything
 run_quad_galaxy_tests() {
-    run_quad_galaxy_unit_tests
-    run_dual_deepseekv3_unit_tests
-    run_quad_deepseekv3_unit_tests
-    run_dual_deepseekv3_integration_tests
-    run_quad_deepseekv3_integration_tests
+  run_quad_galaxy_unit_tests
+  run_dual_deepseekv3_unit_tests
+  run_quad_deepseekv3_unit_tests
+  run_dual_deepseekv3_integration_tests
+  run_quad_deepseekv3_integration_tests
 }
 
 ###############################################################################
@@ -321,84 +540,93 @@ run_quad_galaxy_tests() {
 ###############################################################################
 
 main() {
-    # For CI pipeline - source func commands but don't execute tests if not invoked directly
-    if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
-        echo "Script is being sourced, not executing main function"
-        return 0
+  if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Script is being sourced, not executing main function"
+    return 0
+  fi
+
+  if [[ -z "${TT_METAL_HOME:-}" ]]; then
+    local repo_root
+    repo_root="$(pwd)"
+    if [[ ! -f "${repo_root}/tests/scripts/multihost/run_quad_galaxy_tests.sh" ]]; then
+      echo "Run this script from the tt-metal repository root or set TT_METAL_HOME." >&2
+      exit 1
     fi
+    export TT_METAL_HOME="${repo_root}"
+  fi
 
-    if [[ -z "$TT_METAL_HOME" ]]; then
-        echo "Must provide TT_METAL_HOME in environment" 1>&2
-        exit 1
-    fi
+  cd "$TT_METAL_HOME"
+  export PYTHONPATH="$TT_METAL_HOME"
 
-    if [[ -z "$ARCH_NAME" ]]; then
-        echo "Must provide ARCH_NAME in environment" 1>&2
-        exit 1
-    fi
+  local test_function="${1:-all}"
+  local upr_mode_arg="${2:-}"
+  if [[ -n "${upr_mode_arg}" && "${test_function}" != "all_needed_local_tests" ]]; then
+    export DEEPSEEK_DEMO_UPR_MODE="${upr_mode_arg}"
+    _resolve_upr_mode >/dev/null
+    echo "Using demo UPR mode: $(_resolve_upr_mode)"
+  fi
 
-    # Run tests
-    cd $TT_METAL_HOME
-    export PYTHONPATH=$TT_METAL_HOME
-
-    # Support running specific test function via argument
-    local test_function="${1:-all}"
-
-    case "$test_function" in
-        "unit_tests")
-            run_quad_galaxy_unit_tests
-            ;;
-        "dual_deepseekv3_unit_tests")
-            run_dual_deepseekv3_unit_tests
-            ;;
-        "quad_deepseekv3_unit_tests")
-            run_quad_deepseekv3_unit_tests
-            ;;
-        "dual_deepseekv3_module_tests")
-            run_dual_deepseekv3_module_tests
-            ;;
-        "quad_deepseekv3_module_tests")
-            run_quad_deepseekv3_module_tests
-            ;;
-        "dual_teacher_forced")
-            run_dual_teacher_forced_test
-            ;;
-        "quad_teacher_forced")
-            run_quad_teacher_forced_test
-            ;;
-        "dual_demo")
-            run_dual_demo_test
-            ;;
-        "dual_demo_mtp")
-            run_dual_demo_mtp_test
-            ;;
-        "quad_demo")
-            run_quad_demo_test
-            ;;
-        "quad_demo_mtp")
-            run_quad_demo_mtp_test
-            ;;
-        "dual_demo_stress")
-            run_dual_demo_stress_test
-            ;;
-        "quad_demo_stress")
-            run_quad_demo_stress_test
-            ;;
-        "dual_deepseekv3_integration_tests")
-            run_dual_deepseekv3_integration_tests
-            ;;
-        "quad_deepseekv3_integration_tests")
-            run_quad_deepseekv3_integration_tests
-            ;;
-        "all")
-            run_quad_galaxy_tests
-            ;;
-        *)
-            echo "Unknown test function: $test_function" 1>&2
-            echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all" 1>&2
-            exit 1
-            ;;
-    esac
+  case "$test_function" in
+    "unit_tests")
+      run_quad_galaxy_unit_tests
+      ;;
+    "dual_deepseekv3_unit_tests")
+      run_dual_deepseekv3_unit_tests
+      ;;
+    "quad_deepseekv3_unit_tests")
+      run_quad_deepseekv3_unit_tests
+      ;;
+    "dual_deepseekv3_module_tests")
+      run_dual_deepseekv3_module_tests
+      ;;
+    "quad_deepseekv3_module_tests")
+      run_quad_deepseekv3_module_tests
+      ;;
+    "dual_teacher_forced")
+      run_dual_teacher_forced_test
+      ;;
+    "quad_teacher_forced")
+      run_quad_teacher_forced_test
+      ;;
+    "dual_demo")
+      run_dual_demo_test
+      ;;
+    "dual_demo_mtp")
+      run_dual_demo_mtp_test
+      ;;
+    "quad_demo")
+      run_quad_demo_test
+      ;;
+    "quad_demo_mtp")
+      run_quad_demo_mtp_test
+      ;;
+    "dual_demo_stress")
+      run_dual_demo_stress_test
+      ;;
+    "quad_demo_stress")
+      run_quad_demo_stress_test
+      ;;
+    "dual_deepseekv3_integration_tests")
+      run_dual_deepseekv3_integration_tests
+      ;;
+    "quad_deepseekv3_integration_tests")
+      run_quad_deepseekv3_integration_tests
+      ;;
+    "all_needed_local_tests")
+      run_all_needed_local_tests
+      ;;
+    "all")
+      run_quad_galaxy_tests
+      ;;
+    "-h"|"--help")
+      usage
+      ;;
+    *)
+      echo "Unknown test function: $test_function" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
 }
 
 main "$@"

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -1,60 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
-# Default ARCH_NAME for local runs when not pre-set by CI.
-export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
-
-readonly DEFAULT_DUAL_HOSTS_CSV="g02glx01,g02glx02"
-readonly DEFAULT_QUAD_HOSTS_CSV="g05glx04,g05glx03,g05glx02,g05glx01"
-readonly DEFAULT_SOURCE_RANKFILE="${MPI_SOURCE_RANKFILE:-/etc/mpirun/rankfile}"
-readonly DEFAULT_TCP_INTERFACE="${TT_RUN_TCP_INTERFACE:-ens5f0np0}"
-TMP_RANKFILES=()
-
-usage() {
-  cat <<'EOF'
-Usage:
-  run_quad_galaxy_tests.sh <test_function> [upr_mode]
-
-Notes:
-  Run from the tt-metal repository root, or set TT_METAL_HOME to the repo root.
-  ARCH_NAME defaults to wormhole_b0 when unset (this script exports it).
-
-Arguments:
-  test_function  One of:
-                 unit_tests
-                 dual_deepseekv3_unit_tests
-                 quad_deepseekv3_unit_tests
-                 dual_deepseekv3_module_tests
-                 quad_deepseekv3_module_tests
-                 dual_teacher_forced
-                 quad_teacher_forced
-                 dual_demo
-                 quad_demo
-                 dual_demo_mtp
-                 quad_demo_mtp
-                 dual_demo_stress
-                 quad_demo_stress
-                 dual_deepseekv3_integration_tests
-                 quad_deepseekv3_integration_tests
-                 all_needed_local_tests
-                 all
-  upr_mode       Optional demo UPR mode: all | 32 | 8 (default: all).
-                 Ignored for all_needed_local_tests (demos always run 8 and 32 UPR).
-
-Examples:
-  bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh unit_tests
-  QUAD_MPI_HOSTS="h1,h2,h3,h4" bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress 32
-  bash ./tests/scripts/multihost/run_quad_galaxy_tests.sh all_needed_local_tests
-EOF
-}
-
-cleanup_temp_rankfiles() {
-  local rankfile_path
-  for rankfile_path in "${TMP_RANKFILES[@]}"; do
-    rm -f "${rankfile_path}"
-  done
-}
-trap cleanup_temp_rankfiles EXIT
+# Exit immediately if ARCH_NAME is not set or empty
+if [ -z "${ARCH_NAME}" ]; then
+  echo "Error: ARCH_NAME is not set. Exiting." >&2
+  exit 1
+fi
 
 ###############################################################################
 # Infrastructure unit tests (quad galaxy only)
@@ -63,16 +14,14 @@ trap cleanup_temp_rankfiles EXIT
 run_quad_galaxy_unit_tests() {
   fail=0
 
-  # tt-run --tcp-interface handles tcp and tag flags
   local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile"
   local tcp_interface="cnx1"
-  local mpi_host="--host g05glx04,g05glx03,g05glx02,g05glx01"
-  local mpi_args="$mpi_host $mpi_args_base"
-
+  local hosts="g05glx04,g05glx03,g05glx02,g05glx01"
+  local mpi_host="--host $hosts"
   local mpirun_args_base="$mpi_args_base --mca btl self,tcp --mca btl_tcp_if_include cnx1 --tag-output"
   local mpirun_args="$mpi_host $mpirun_args_base"
 
-  local rank_binding="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
+  local mesh_graph="tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_torus_xy_graph_descriptor.textproto"
   local descriptor_path="${DESCRIPTOR_PATH:-/etc/mpirun}"
 
   # TODO: Currently failing
@@ -80,12 +29,12 @@ run_quad_galaxy_unit_tests() {
 
   mpirun-ulfm $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation --send-traffic --cabling-descriptor-path ${descriptor_path}/cabling_descriptor.textproto --deployment-descriptor-path ${descriptor_path}/deployment_descriptor.textproto ; fail+=$?
 
-  tt-run --tcp-interface $tcp_interface --rank-binding "$rank_binding" --mpi-args "$mpi_args" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
+  tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
 
   # TODO: Currently failing on 1D/2D tests
-  #tt-run --tcp-interface $tcp_interface --rank-binding "$rank_binding" --mpi-args "$mpi_args" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
+  #tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
 
-  tt-run --tcp-interface $tcp_interface --rank-binding "$rank_binding" --mpi-args "$mpi_args" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
+  tt-run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -93,222 +42,142 @@ run_quad_galaxy_unit_tests() {
 }
 
 ###############################################################################
-# Environment setup helpers (DeepSeek multihost: rankfile + hosts)
+# Environment setup helpers
 ###############################################################################
 
 _resolve_deepseekv3_cache() {
-  local ci_cache="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"
-  if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
-    local resolved
-    resolved="$(realpath -m "${DEEPSEEK_V3_CACHE_OVERRIDE}")"
-    local ci_resolved
-    ci_resolved="$(realpath -m "${ci_cache}")"
-    if [[ "${resolved}" == "${ci_resolved}" || "${resolved}" == "${ci_resolved}/"* ]]; then
-      echo "Error: DEEPSEEK_V3_CACHE_OVERRIDE must not point to or inside the production CI cache (${ci_cache})." >&2
-      exit 1
+    local ci_cache="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"
+    if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
+        local resolved
+        resolved=$(realpath -m "${DEEPSEEK_V3_CACHE_OVERRIDE}")
+        local ci_resolved
+        ci_resolved=$(realpath -m "${ci_cache}")
+        if [[ "${resolved}" == "${ci_resolved}" || "${resolved}" == "${ci_resolved}/"* ]]; then
+            echo "Error: DEEPSEEK_V3_CACHE_OVERRIDE must not point to or inside the production CI cache (${ci_cache})." >&2
+            exit 1
+        fi
+        export DEEPSEEK_V3_CACHE="${DEEPSEEK_V3_CACHE_OVERRIDE}"
+    else
+        export DEEPSEEK_V3_CACHE="${ci_cache}"
     fi
-    export DEEPSEEK_V3_CACHE="${DEEPSEEK_V3_CACHE_OVERRIDE}"
-  else
-    export DEEPSEEK_V3_CACHE="${ci_cache}"
-  fi
 }
 
-_extract_hosts_csv_from_rankfile() {
-  local rankfile="$1"
-  local expected_count="$2"
+setup_dual_galaxy_env() {
+    export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
+    export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto"
+    # heuristic to extract only 2 first hosts from the hostfile
+    export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 2 | paste -sd,)"
+    export RANKFILE=/etc/mpirun/rankfile
+    export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
+    export TCP_INTERFACE="cnx1"
+    mkdir -p logs
+    mkdir -p generated/artifacts
 
-  if [[ ! -f "${rankfile}" ]]; then
-    return 1
-  fi
+    echo "Using dual Galaxy hosts: ${HOSTS}"
+    echo "Using dual Galaxy rankfile: ${RANKFILE}"
 
-  local -a rank_hosts=()
-  local line
-  while IFS= read -r line; do
-    if [[ "${line}" =~ ^[[:space:]]*rank[[:space:]]+[0-9]+=([^[:space:]]+) ]]; then
-      rank_hosts+=("${BASH_REMATCH[1]}")
+    if ! test -f "$RANKFILE"; then
+        echo "File '$RANKFILE' does not exist."
+        exit 1
     fi
-  done < "${rankfile}"
+    if ! test -f "$RANK_BINDING_YAML"; then
+        echo "File '$RANK_BINDING_YAML' does not exist."
+        exit 1
+    fi
+    if ! test -f "$MESH_GRAPH_DESCRIPTOR"; then
+        echo "File '$MESH_GRAPH_DESCRIPTOR' does not exist."
+        exit 1
+    fi
 
-  if [[ ${#rank_hosts[@]} -lt ${expected_count} ]]; then
-    return 1
-  fi
-
-  local -a selected_hosts=("${rank_hosts[@]:0:${expected_count}}")
-  local hosts_csv
-  hosts_csv="$(IFS=','; echo "${selected_hosts[*]}")"
-  echo "${hosts_csv}"
+    export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
+    _resolve_deepseekv3_cache
+    export MESH_DEVICE="DUAL"
 }
 
-_build_rankfile_from_hosts_csv() {
-  local hosts_csv="$1"
-  local expected_count="$2"
-  local rankfile_path="$3"
-  local hosts_error_hint="$4"
+setup_quad_galaxy_env() {
+    export RANK_BINDING_YAML="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
+    export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_torus_xy_graph_descriptor.textproto"
+    # heuristic to extract only 4 first hosts from the hostfile
+    export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 4 | paste -sd,)"
+    export RANKFILE=/etc/mpirun/rankfile
+    export TCP_INTERFACE="cnx1"
+    mkdir -p logs
+    mkdir -p generated/artifacts
 
-  local -a hosts=()
-  IFS=',' read -r -a hosts <<< "${hosts_csv}"
-  if [[ ${#hosts[@]} -ne ${expected_count} ]]; then
-    echo "${hosts_error_hint} must contain exactly ${expected_count} comma-separated hosts." >&2
-    exit 1
-  fi
+    if ! test -f "$RANKFILE"; then
+        echo "File '$RANKFILE' does not exist."
+        exit 1
+    fi
+    if ! test -f "$RANK_BINDING_YAML"; then
+        echo "File '$RANK_BINDING_YAML' does not exist."
+        exit 1
+    fi
+    if ! test -f "$MESH_GRAPH_DESCRIPTOR"; then
+        echo "File '$MESH_GRAPH_DESCRIPTOR' does not exist."
+        exit 1
+    fi
 
-  : > "${rankfile_path}"
-  echo "# mpirun rankfile" >> "${rankfile_path}"
-  local rank_idx
-  for rank_idx in "${!hosts[@]}"; do
-    echo "rank ${rank_idx}=${hosts[$rank_idx]} slot=0:*" >> "${rankfile_path}"
-  done
-}
-
-_resolve_dual_hosts_csv() {
-  if [[ -n "${DUAL_MPI_HOSTS:-}" ]]; then
-    echo "${DUAL_MPI_HOSTS}"
-    return
-  fi
-
-  if [[ -n "${MPI_HOSTS:-}" ]]; then
-    echo "${MPI_HOSTS}"
-    return
-  fi
-
-  local source_rankfile="${DUAL_SOURCE_RANKFILE:-${DEFAULT_SOURCE_RANKFILE}}"
-  local hosts_from_rankfile
-  if hosts_from_rankfile="$(_extract_hosts_csv_from_rankfile "${source_rankfile}" 2)"; then
-    echo "${hosts_from_rankfile}"
-    return
-  fi
-
-  echo "${DEFAULT_DUAL_HOSTS_CSV}"
-}
-
-_resolve_quad_hosts_csv() {
-  if [[ -n "${QUAD_MPI_HOSTS:-}" ]]; then
-    echo "${QUAD_MPI_HOSTS}"
-    return
-  fi
-
-  local source_rankfile="${QUAD_SOURCE_RANKFILE:-${DEFAULT_SOURCE_RANKFILE}}"
-  local hosts_from_rankfile
-  if hosts_from_rankfile="$(_extract_hosts_csv_from_rankfile "${source_rankfile}" 4)"; then
-    echo "${hosts_from_rankfile}"
-    return
-  fi
-
-  echo "${DEFAULT_QUAD_HOSTS_CSV}"
-}
-
-_resolve_upr_mode() {
-  local upr_mode="${DEEPSEEK_DEMO_UPR_MODE:-all}"
-  upr_mode="${upr_mode,,}"
-  case "${upr_mode}" in
-    ""|all|both)
-      echo "both"
-      ;;
-    32|32upr|upr32)
-      echo "32"
-      ;;
-    8|8upr|upr8)
-      echo "8"
-      ;;
-    *)
-      echo "Unsupported DEEPSEEK_DEMO_UPR_MODE='${DEEPSEEK_DEMO_UPR_MODE:-}'." >&2
-      echo "Supported values: all|both|32|8" >&2
-      exit 1
-      ;;
-  esac
-}
-
-_demo_case_selector() {
-  local setup_name="$1"
-  local profile_name="$2"
-  local upr_mode
-  upr_mode="$(_resolve_upr_mode)"
-
-  case "${upr_mode}" in
-    both)
-      echo "${setup_name}_${profile_name}_demo_32upr or ${setup_name}_${profile_name}_demo_8upr"
-      ;;
-    32)
-      echo "${setup_name}_${profile_name}_demo_32upr"
-      ;;
-    8)
-      echo "${setup_name}_${profile_name}_demo_8upr"
-      ;;
-  esac
+    export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
+    _resolve_deepseekv3_cache
+    export MESH_DEVICE="QUAD"
+    export USE_TORUS_MODE=1
 }
 
 # Compute pytest --timeout value.
 # When DEEPSEEK_V3_CACHE_OVERRIDE is set (cache recalculation), add 6 hours.
 _demo_timeout() {
-  local base_timeout="$1"
-  local cache_extra=21600  # 6 hours
-  if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
-    echo $((base_timeout + cache_extra))
-  else
-    echo "${base_timeout}"
-  fi
+    local base_timeout=$1
+    local cache_extra=21600  # 6 hours
+    if [[ -n "${DEEPSEEK_V3_CACHE_OVERRIDE:-}" ]]; then
+        echo $(( base_timeout + cache_extra ))
+    else
+        echo "$base_timeout"
+    fi
 }
 
-setup_dual_galaxy_env() {
-  export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
-  export HOSTS="$(_resolve_dual_hosts_csv)"
-  export RANKFILE="$(mktemp "${TMPDIR:-/tmp}/rankfile_dual_deepseek_ci.XXXXXX")"
-  TMP_RANKFILES+=("${RANKFILE}")
-  _build_rankfile_from_hosts_csv "${HOSTS}" 2 "${RANKFILE}" "DUAL_MPI_HOSTS (or MPI_HOSTS)"
-  export MPI_ARGS="--host ${HOSTS} --map-by rankfile:file=${RANKFILE} --bind-to none --output-filename logs/mpi_job"
-  export TCP_INTERFACE="${TT_RUN_TCP_INTERFACE:-${DEFAULT_TCP_INTERFACE}}"
-  export DUAL_MPI_HOSTS="${HOSTS}"
-  mkdir -p logs
-  mkdir -p generated/artifacts
-
-  echo "Using dual Galaxy hosts: ${HOSTS}"
-  echo "Using dual Galaxy rankfile: ${RANKFILE}"
-
-  if ! test -f "${RANK_BINDING_YAML}"; then
-    echo "File '${RANK_BINDING_YAML}' does not exist." >&2
-    exit 1
-  fi
-
-  export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
-  _resolve_deepseekv3_cache
-  export MESH_DEVICE="DUAL"
-  unset USE_TORUS_MODE
+_resolve_upr_mode() {
+    local upr_mode="${DEEPSEEK_DEMO_UPR_MODE:-all}"
+    upr_mode="${upr_mode,,}"
+    case "${upr_mode}" in
+        ""|all|both)
+            echo "both"
+            ;;
+        32|32upr|upr32)
+            echo "32"
+            ;;
+        8|8upr|upr8)
+            echo "8"
+            ;;
+        *)
+            echo "Unsupported DEEPSEEK_DEMO_UPR_MODE='${DEEPSEEK_DEMO_UPR_MODE:-}'." >&2
+            echo "Supported values: all|both|32|8" >&2
+            exit 1
+            ;;
+    esac
 }
 
-setup_quad_galaxy_env() {
-  export RANK_BINDING_YAML="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
-  export HOSTS="$(_resolve_quad_hosts_csv)"
-  export RANKFILE="$(mktemp "${TMPDIR:-/tmp}/rankfile_quad_deepseek_ci.XXXXXX")"
-  TMP_RANKFILES+=("${RANKFILE}")
-  _build_rankfile_from_hosts_csv "${HOSTS}" 4 "${RANKFILE}" "QUAD_MPI_HOSTS"
-  export MPI_ARGS="--host ${HOSTS} --map-by rankfile:file=${RANKFILE} --bind-to none --output-filename logs/mpi_job"
-  export TCP_INTERFACE="${TT_RUN_TCP_INTERFACE:-${DEFAULT_TCP_INTERFACE}}"
-  export QUAD_MPI_HOSTS="${HOSTS}"
-  mkdir -p logs
-  mkdir -p generated/artifacts
+_demo_case_selector() {
+    local setup_name="$1"
+    local profile_name="$2"
+    local upr_mode
+    upr_mode="$(_resolve_upr_mode)"
 
-  if ! test -f "${RANK_BINDING_YAML}"; then
-    echo "File '${RANK_BINDING_YAML}' does not exist." >&2
-    exit 1
-  fi
-
-  export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
-  _resolve_deepseekv3_cache
-  export MESH_DEVICE="QUAD"
-  export USE_TORUS_MODE=1
+    case "${upr_mode}" in
+        both)
+            echo "${setup_name}_${profile_name}_demo_32upr or ${setup_name}_${profile_name}_demo_8upr"
+            ;;
+        32)
+            echo "${setup_name}_${profile_name}_demo_32upr"
+            ;;
+        8)
+            echo "${setup_name}_${profile_name}_demo_8upr"
+            ;;
+    esac
 }
 
+# Helper: run a test command via tt-run using the current environment
 _run_deepseekv3_tt() {
-  local mpi_args="${MPI_ARGS} -x DEEPSEEK_V3_HF_MODEL -x DEEPSEEK_V3_CACHE -x MESH_DEVICE"
-  if [[ -n "${USE_TORUS_MODE:-}" ]]; then
-    mpi_args="${mpi_args} -x USE_TORUS_MODE"
-  fi
-
-  tt-run \
-    --tcp-interface "${TCP_INTERFACE}" \
-    --rank-binding "${RANK_BINDING_YAML}" \
-    --mpi-args "${mpi_args}" \
-    "$@"
+    tt-run --tcp-interface $TCP_INTERFACE --mesh-graph-descriptor "$MESH_GRAPH_DESCRIPTOR" --hosts "$HOSTS" "$@"
 }
 
 ###############################################################################
@@ -316,25 +185,25 @@ _run_deepseekv3_tt() {
 ###############################################################################
 
 run_dual_deepseekv3_unit_tests() {
-  fail=0
-  setup_dual_galaxy_env
+    fail=0
+    setup_dual_galaxy_env
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv models/demos/deepseek_v3/tests/unit 2>&1 | tee generated/artifacts/dual_deepseekv3_unit_output.log" ; fail+=$?
+    _run_deepseekv3_tt pytest -svvv models/demos/deepseek_v3/tests/unit ; fail+=$?
 
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 run_quad_deepseekv3_unit_tests() {
-  fail=0
-  setup_quad_galaxy_env
+    fail=0
+    setup_quad_galaxy_env
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv models/demos/deepseek_v3/tests/unit 2>&1 | tee generated/artifacts/quad_deepseekv3_unit_output.log" ; fail+=$?
+    _run_deepseekv3_tt pytest -svvv models/demos/deepseek_v3/tests/unit ; fail+=$?
 
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 ###############################################################################
@@ -342,25 +211,25 @@ run_quad_deepseekv3_unit_tests() {
 ###############################################################################
 
 run_dual_deepseekv3_module_tests() {
-  fail=0
-  setup_dual_galaxy_env
+    fail=0
+    setup_dual_galaxy_env
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests 2>&1 | tee generated/artifacts/dual_deepseekv3_module_output.log" ; fail+=$?
+    _run_deepseekv3_tt pytest -svvv models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests ; fail+=$?
 
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 run_quad_deepseekv3_module_tests() {
-  fail=0
-  setup_quad_galaxy_env
+    fail=0
+    setup_quad_galaxy_env
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests 2>&1 | tee generated/artifacts/quad_deepseekv3_module_output.log" ; fail+=$?
+    _run_deepseekv3_tt pytest -svvv models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests ; fail+=$?
 
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 ###############################################################################
@@ -368,39 +237,41 @@ run_quad_deepseekv3_module_tests() {
 ###############################################################################
 
 run_dual_teacher_forced_test() {
-  fail=0
-  setup_dual_galaxy_env
-  local timeout=$(_demo_timeout 3600)
+    fail=0
+    setup_dual_galaxy_env
+    local timeout=$(_demo_timeout 3600)
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/dual_teacher_forced_output.log" ; fail+=$?
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/dual_teacher_forced_output.log" ; fail+=$?
 
-  if [[ -f generated/artifacts/dual_teacher_forced_output.log ]]; then
-    echo "Extracting accuracy metrics from test output..."
-    grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/dual_teacher_forced_output.log > generated/artifacts/dual_teacher_forced_accuracy.txt || true
-    echo "Accuracy metrics saved to generated/artifacts/dual_teacher_forced_accuracy.txt"
-  fi
+    # Extract accuracy metrics from logs and save to artifact file
+    if [[ -f generated/artifacts/dual_teacher_forced_output.log ]]; then
+        echo "Extracting accuracy metrics from test output..."
+        grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/dual_teacher_forced_output.log > generated/artifacts/dual_teacher_forced_accuracy.txt || true
+        echo "Accuracy metrics saved to generated/artifacts/dual_teacher_forced_accuracy.txt"
+    fi
 
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 run_quad_teacher_forced_test() {
-  fail=0
-  setup_quad_galaxy_env
-  local timeout=$(_demo_timeout 3600)
+    fail=0
+    setup_quad_galaxy_env
+    local timeout=$(_demo_timeout 3600)
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/quad_teacher_forced_output.log" ; fail+=$?
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/quad_teacher_forced_output.log" ; fail+=$?
 
-  if [[ -f generated/artifacts/quad_teacher_forced_output.log ]]; then
-    echo "Extracting accuracy metrics from test output..."
-    grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/quad_teacher_forced_output.log > generated/artifacts/quad_teacher_forced_accuracy.txt || true
-    echo "Accuracy metrics saved to generated/artifacts/quad_teacher_forced_accuracy.txt"
-  fi
+    # Extract accuracy metrics from logs and save to artifact file
+    if [[ -f generated/artifacts/quad_teacher_forced_output.log ]]; then
+        echo "Extracting accuracy metrics from test output..."
+        grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/quad_teacher_forced_output.log > generated/artifacts/quad_teacher_forced_accuracy.txt || true
+        echo "Accuracy metrics saved to generated/artifacts/quad_teacher_forced_accuracy.txt"
+    fi
 
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 ###############################################################################
@@ -408,55 +279,36 @@ run_quad_teacher_forced_test() {
 ###############################################################################
 
 run_dual_demo_test() {
-  fail=0
-  setup_dual_galaxy_env
-  local timeout=$(_demo_timeout 2400)
-  local selector
-  selector="$(_demo_case_selector "dual" "full")"
+    setup_dual_galaxy_env
+    local timeout=$(_demo_timeout 2400)
+    local selector
+    selector="$(_demo_case_selector "dual" "full")"
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '${selector}' 2>&1 | tee generated/artifacts/dual_demo_output.log" ; fail+=$?
-
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '$selector' 2>&1 | tee generated/artifacts/dual_demo_output.log"
 }
 
 run_dual_demo_mtp_test() {
-  fail=0
-  setup_dual_galaxy_env
-  local timeout=$(_demo_timeout 2400)
+    setup_dual_galaxy_env
+    local timeout=$(_demo_timeout 2400)
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log" ; fail+=$?
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log"
 
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
 }
 
 run_quad_demo_test() {
-  fail=0
-  setup_quad_galaxy_env
-  local timeout=$(_demo_timeout 3600)
-  local selector
-  selector="$(_demo_case_selector "quad" "full")"
+    setup_quad_galaxy_env
+    local timeout=$(_demo_timeout 3600)
+    local selector
+    selector="$(_demo_case_selector "quad" "full")"
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '${selector}' 2>&1 | tee generated/artifacts/quad_demo_output.log" ; fail+=$?
-
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '$selector' 2>&1 | tee generated/artifacts/quad_demo_output.log"
 }
 
 run_quad_demo_mtp_test() {
-  fail=0
-  setup_quad_galaxy_env
-  local timeout=$(_demo_timeout 3600)
+    setup_quad_galaxy_env
+    local timeout=$(_demo_timeout 3600)
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log" ; fail+=$?
-
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log"
 }
 
 ###############################################################################
@@ -464,75 +316,52 @@ run_quad_demo_mtp_test() {
 ###############################################################################
 
 run_dual_demo_stress_test() {
-  fail=0
-  setup_dual_galaxy_env
-  local timeout=$(_demo_timeout 5400)
-  local selector
-  selector="$(_demo_case_selector "dual" "stress")"
+    setup_dual_galaxy_env
+    local timeout=$(_demo_timeout 5400)
+    local selector
+    selector="$(_demo_case_selector "dual" "stress")"
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '${selector}' 2>&1 | tee generated/artifacts/dual_demo_stress_output.log" ; fail+=$?
-
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '$selector' 2>&1 | tee generated/artifacts/dual_demo_stress_output.log"
 }
 
 run_quad_demo_stress_test() {
-  fail=0
-  setup_quad_galaxy_env
-  local timeout=$(_demo_timeout 5400)
-  local selector
-  selector="$(_demo_case_selector "quad" "stress")"
+    setup_quad_galaxy_env
+    local timeout=$(_demo_timeout 5400)
+    local selector
+    selector="$(_demo_case_selector "quad" "stress")"
 
-  _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '${selector}' 2>&1 | tee generated/artifacts/quad_demo_stress_output.log" ; fail+=$?
-
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo.py -k '$selector' 2>&1 | tee generated/artifacts/quad_demo_stress_output.log"
 }
 
 ###############################################################################
 # Composite runners
 ###############################################################################
 
-run_all_needed_local_tests() {
-  local _saved_upr="${DEEPSEEK_DEMO_UPR_MODE:-}"
-  export DEEPSEEK_DEMO_UPR_MODE=all
-  run_dual_teacher_forced_test
-  run_dual_demo_test
-  run_dual_demo_stress_test
-  run_quad_teacher_forced_test
-  run_quad_demo_test
-  run_quad_demo_stress_test
-  if [[ -n "${_saved_upr}" ]]; then
-    export DEEPSEEK_DEMO_UPR_MODE="${_saved_upr}"
-  else
-    unset DEEPSEEK_DEMO_UPR_MODE
-  fi
-}
-
+# All dual galaxy deepseek v3 integration tests
 run_dual_deepseekv3_integration_tests() {
-  run_dual_deepseekv3_module_tests
-  run_dual_teacher_forced_test
-  run_dual_demo_test
-  run_dual_demo_mtp_test
-  run_dual_demo_stress_test
+    run_dual_deepseekv3_module_tests
+    run_dual_teacher_forced_test
+    run_dual_demo_test
+    run_dual_demo_mtp_test
+    run_dual_demo_stress_test
 }
 
+# All quad galaxy deepseek v3 integration tests
 run_quad_deepseekv3_integration_tests() {
-  run_quad_deepseekv3_module_tests
-  run_quad_teacher_forced_test
-  run_quad_demo_test
-  run_quad_demo_mtp_test
-  run_quad_demo_stress_test
+    run_quad_deepseekv3_module_tests
+    run_quad_teacher_forced_test
+    run_quad_demo_test
+    run_quad_demo_mtp_test
+    run_quad_demo_stress_test
 }
 
+# Run everything
 run_quad_galaxy_tests() {
-  run_quad_galaxy_unit_tests
-  run_dual_deepseekv3_unit_tests
-  run_quad_deepseekv3_unit_tests
-  run_dual_deepseekv3_integration_tests
-  run_quad_deepseekv3_integration_tests
+    run_quad_galaxy_unit_tests
+    run_dual_deepseekv3_unit_tests
+    run_quad_deepseekv3_unit_tests
+    run_dual_deepseekv3_integration_tests
+    run_quad_deepseekv3_integration_tests
 }
 
 ###############################################################################
@@ -540,93 +369,91 @@ run_quad_galaxy_tests() {
 ###############################################################################
 
 main() {
-  if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
-    echo "Script is being sourced, not executing main function"
-    return 0
-  fi
-
-  if [[ -z "${TT_METAL_HOME:-}" ]]; then
-    local repo_root
-    repo_root="$(pwd)"
-    if [[ ! -f "${repo_root}/tests/scripts/multihost/run_quad_galaxy_tests.sh" ]]; then
-      echo "Run this script from the tt-metal repository root or set TT_METAL_HOME." >&2
-      exit 1
+    # For CI pipeline - source func commands but don't execute tests if not invoked directly
+    if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+        echo "Script is being sourced, not executing main function"
+        return 0
     fi
-    export TT_METAL_HOME="${repo_root}"
-  fi
 
-  cd "$TT_METAL_HOME"
-  export PYTHONPATH="$TT_METAL_HOME"
+    if [[ -z "$TT_METAL_HOME" ]]; then
+        echo "Must provide TT_METAL_HOME in environment" 1>&2
+        exit 1
+    fi
 
-  local test_function="${1:-all}"
-  local upr_mode_arg="${2:-}"
-  if [[ -n "${upr_mode_arg}" && "${test_function}" != "all_needed_local_tests" ]]; then
-    export DEEPSEEK_DEMO_UPR_MODE="${upr_mode_arg}"
-    _resolve_upr_mode >/dev/null
-    echo "Using demo UPR mode: $(_resolve_upr_mode)"
-  fi
+    if [[ -z "$ARCH_NAME" ]]; then
+        echo "Must provide ARCH_NAME in environment" 1>&2
+        exit 1
+    fi
 
-  case "$test_function" in
-    "unit_tests")
-      run_quad_galaxy_unit_tests
-      ;;
-    "dual_deepseekv3_unit_tests")
-      run_dual_deepseekv3_unit_tests
-      ;;
-    "quad_deepseekv3_unit_tests")
-      run_quad_deepseekv3_unit_tests
-      ;;
-    "dual_deepseekv3_module_tests")
-      run_dual_deepseekv3_module_tests
-      ;;
-    "quad_deepseekv3_module_tests")
-      run_quad_deepseekv3_module_tests
-      ;;
-    "dual_teacher_forced")
-      run_dual_teacher_forced_test
-      ;;
-    "quad_teacher_forced")
-      run_quad_teacher_forced_test
-      ;;
-    "dual_demo")
-      run_dual_demo_test
-      ;;
-    "dual_demo_mtp")
-      run_dual_demo_mtp_test
-      ;;
-    "quad_demo")
-      run_quad_demo_test
-      ;;
-    "quad_demo_mtp")
-      run_quad_demo_mtp_test
-      ;;
-    "dual_demo_stress")
-      run_dual_demo_stress_test
-      ;;
-    "quad_demo_stress")
-      run_quad_demo_stress_test
-      ;;
-    "dual_deepseekv3_integration_tests")
-      run_dual_deepseekv3_integration_tests
-      ;;
-    "quad_deepseekv3_integration_tests")
-      run_quad_deepseekv3_integration_tests
-      ;;
-    "all_needed_local_tests")
-      run_all_needed_local_tests
-      ;;
-    "all")
-      run_quad_galaxy_tests
-      ;;
-    "-h"|"--help")
-      usage
-      ;;
-    *)
-      echo "Unknown test function: $test_function" >&2
-      usage >&2
-      exit 1
-      ;;
-  esac
+    # Run tests
+    cd $TT_METAL_HOME
+    export PYTHONPATH=$TT_METAL_HOME
+
+    # Support running specific test function via argument
+    local test_function="${1:-all}"
+    local upr_mode_arg="${2:-}"
+    if [[ -n "${upr_mode_arg}" ]]; then
+        export DEEPSEEK_DEMO_UPR_MODE="${upr_mode_arg}"
+        _resolve_upr_mode >/dev/null
+        echo "Using demo UPR mode: $(_resolve_upr_mode)"
+    fi
+
+    case "$test_function" in
+        "unit_tests")
+            run_quad_galaxy_unit_tests
+            ;;
+        "dual_deepseekv3_unit_tests")
+            run_dual_deepseekv3_unit_tests
+            ;;
+        "quad_deepseekv3_unit_tests")
+            run_quad_deepseekv3_unit_tests
+            ;;
+        "dual_deepseekv3_module_tests")
+            run_dual_deepseekv3_module_tests
+            ;;
+        "quad_deepseekv3_module_tests")
+            run_quad_deepseekv3_module_tests
+            ;;
+        "dual_teacher_forced")
+            run_dual_teacher_forced_test
+            ;;
+        "quad_teacher_forced")
+            run_quad_teacher_forced_test
+            ;;
+        "dual_demo")
+            run_dual_demo_test
+            ;;
+        "dual_demo_mtp")
+            run_dual_demo_mtp_test
+            ;;
+        "quad_demo")
+            run_quad_demo_test
+            ;;
+        "quad_demo_mtp")
+            run_quad_demo_mtp_test
+            ;;
+        "dual_demo_stress")
+            run_dual_demo_stress_test
+            ;;
+        "quad_demo_stress")
+            run_quad_demo_stress_test
+            ;;
+        "dual_deepseekv3_integration_tests")
+            run_dual_deepseekv3_integration_tests
+            ;;
+        "quad_deepseekv3_integration_tests")
+            run_quad_deepseekv3_integration_tests
+            ;;
+        "all")
+            run_quad_galaxy_tests
+            ;;
+        *)
+            echo "Unknown test function: $test_function" 1>&2
+            echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all" 1>&2
+            echo "Optional second argument: UPR mode (all|32|8)" 1>&2
+            exit 1
+            ;;
+    esac
 }
 
 main "$@"

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -192,7 +192,25 @@ setup_quad_galaxy_env() {
     _resolve_deepseekv3_model
     _resolve_deepseekv3_cache
     export MESH_DEVICE="QUAD"
-    export USE_TORUS_MODE=1
+
+    # DeepSeek V3 reads USE_TORUS_MODE: any set value enables ring/torus; unset => linear.
+    # Default is ON; set DS_QUAD_USE_TORUS_MODE=0 or pass --no-torus to disable for debugging.
+    local _ds_quad_torus="${DS_QUAD_USE_TORUS_MODE:-1}"
+    _ds_quad_torus="${_ds_quad_torus,,}"
+    case "${_ds_quad_torus}" in
+        ""|1|true|yes|on)
+            export USE_TORUS_MODE=1
+            echo "Quad Galaxy: USE_TORUS_MODE=1 (DeepSeek V3 torus/ring mode enabled)."
+            ;;
+        0|false|no|off)
+            unset USE_TORUS_MODE
+            echo "Quad Galaxy: USE_TORUS_MODE unset (DeepSeek V3 torus/ring mode disabled)."
+            ;;
+        *)
+            echo "Error: unsupported DS_QUAD_USE_TORUS_MODE='${DS_QUAD_USE_TORUS_MODE:-}' (use 1|0|true|false|yes|no|on|off)." >&2
+            exit 1
+            ;;
+    esac
 }
 
 # Compute pytest --timeout value.
@@ -470,6 +488,9 @@ run_quad_galaxy_tests() {
 #   MULTIHOST_SOURCE_VENV=/path      - source venv for setup_shared_venv.sh
 #   MULTIHOST_MATCH_CI_HOME=1        - export HOME=\$TT_METAL_HOME (CI parity)
 #   MULTIHOST_FORCE_PYTHONHOME=0     - disable PYTHONHOME override for ranks
+#   DS_QUAD_USE_TORUS_MODE=0         - quad DeepSeek runs: do not set USE_TORUS_MODE (debug /
+#                                    linear fabric). Default is 1 (same as unset). Also:
+#                                    pass --no-torus on the command line.
 ###############################################################################
 
 _set_multihost_pythonhome_if_needed() {
@@ -558,6 +579,7 @@ main() {
     #   $1 test function (default: all)
     #   $2 UPR mode (all|32|8), optional when it is not an option flag
     # Optional local-testing flags:
+    #   --no-torus                       - quad DeepSeek: unset USE_TORUS_MODE (see DS_QUAD_USE_TORUS_MODE)
     #   --model-path <path>
     #   --cache-path <path>
     local test_function="all"
@@ -579,6 +601,10 @@ main() {
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --no-torus)
+                export DS_QUAD_USE_TORUS_MODE=0
+                shift
+                ;;
             --model-path)
                 if [[ $# -lt 2 ]]; then
                     echo "Error: --model-path requires a value." >&2
@@ -597,7 +623,7 @@ main() {
                 ;;
             *)
                 echo "Unknown argument: $1" >&2
-                echo "Usage: $0 [test_function] [upr_mode] [--model-path <path>] [--cache-path <path>]" >&2
+                echo "Usage: $0 [test_function] [upr_mode] [--no-torus] [--model-path <path>] [--cache-path <path>]" >&2
                 exit 1
                 ;;
         esac
@@ -666,8 +692,8 @@ main() {
             echo "Unknown test function: $test_function" 1>&2
             echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all_needed_local_tests, all" 1>&2
             echo "Optional second argument: UPR mode (all|32|8)" 1>&2
-            echo "Optional flags for local testing: --model-path <path> --cache-path <path>" 1>&2
-            echo "Example: $0 quad_demo 32 --model-path /data/deepseek/DeepSeek-R1-0528-dequantized --cache-path /data/deepseek/DeepSeek-R1-0528-Cache/CI" 1>&2
+            echo "Optional flags: --no-torus  --model-path <path>  --cache-path <path>" 1>&2
+            echo "Example: $0 quad_demo 32 --no-torus --model-path /data/deepseek/DeepSeek-R1-0528-dequantized --cache-path /data/deepseek/DeepSeek-R1-0528-Cache/CI" 1>&2
             exit 1
             ;;
     esac

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -51,6 +51,13 @@ _export_tcp_interface_for_multihost() {
     export TCP_INTERFACE="${TCP_INTERFACE:-$(_default_mpi_tcp_interface)}"
 }
 
+_extract_hosts_from_hostfile() {
+    local host_count="$1"
+    local hostfile="${2:-/etc/mpirun/hostfile}"
+
+    awk '!/^#/ && NF {print $1}' "$hostfile" | head -n "$host_count" | paste -sd,
+}
+
 ###############################################################################
 # Infrastructure unit tests (quad galaxy only)
 ###############################################################################
@@ -61,7 +68,9 @@ run_quad_galaxy_unit_tests() {
   _export_tcp_interface_for_multihost
   local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile"
   local tcp_interface="${TCP_INTERFACE}"
-  local hosts="g05glx04,g05glx03,g05glx02,g05glx01"
+  local hosts="$(_extract_hosts_from_hostfile 4)"
+  local rank_binding_yaml="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
+  local tt_mpi_args="--host $hosts --map-by rankfile:file=/etc/mpirun/rankfile --bind-to none --output-filename logs/mpi_job"
   local mpi_host="--host $hosts"
   local mpirun_args_base="$mpi_args_base --mca btl self,tcp --mca btl_tcp_if_include ${tcp_interface} --tag-output"
   local mpirun_args="$mpi_host $mpirun_args_base"
@@ -74,12 +83,12 @@ run_quad_galaxy_unit_tests() {
 
   mpirun-ulfm $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation --send-traffic --cabling-descriptor-path ${descriptor_path}/cabling_descriptor.textproto --deployment-descriptor-path ${descriptor_path}/deployment_descriptor.textproto ; fail+=$?
 
-  _tt_run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
+  _tt_run --tcp-interface "$tcp_interface" --rank-binding "$rank_binding_yaml" --mpi-args "$tt_mpi_args" pytest -svv "tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace" ; fail+=$?
 
   # TODO: Currently failing on 1D/2D tests
   #_tt_run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
 
-  _tt_run --tcp-interface $tcp_interface --mesh-graph-descriptor "$mesh_graph" --hosts "$hosts" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
+  _tt_run --tcp-interface "$tcp_interface" --rank-binding "$rank_binding_yaml" --mpi-args "$tt_mpi_args" pytest -svv tests/nightly/tg/ccl/ -k "quad_host_mesh" ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -124,8 +133,7 @@ _resolve_deepseekv3_model() {
 setup_dual_galaxy_env() {
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
     export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto"
-    # heuristic to extract only 2 first hosts from the hostfile
-    export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 2 | paste -sd,)"
+    export HOSTS="$(_extract_hosts_from_hostfile 2)"
     export RANKFILE=/etc/mpirun/rankfile
     export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
     _export_tcp_interface_for_multihost
@@ -157,9 +165,9 @@ setup_dual_galaxy_env() {
 setup_quad_galaxy_env() {
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
     export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_torus_xy_graph_descriptor.textproto"
-    # heuristic to extract only 4 first hosts from the hostfile
-    export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 4 | paste -sd,)"
+    export HOSTS="$(_extract_hosts_from_hostfile 4)"
     export RANKFILE=/etc/mpirun/rankfile
+    export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
     _export_tcp_interface_for_multihost
     mkdir -p logs
     mkdir -p generated/artifacts
@@ -179,6 +187,7 @@ setup_quad_galaxy_env() {
 
     echo "Using quad Galaxy hosts: ${HOSTS}"
     echo "Using MPI TCP interface (tt-run / Open MPI): ${TCP_INTERFACE}"
+    echo "Using quad Galaxy rankfile: ${RANKFILE}"
 
     _resolve_deepseekv3_model
     _resolve_deepseekv3_cache
@@ -240,7 +249,11 @@ _demo_case_selector() {
 
 # Helper: run a test command via tt-run using the current environment
 _run_deepseekv3_tt() {
-    _tt_run --tcp-interface $TCP_INTERFACE --mesh-graph-descriptor "$MESH_GRAPH_DESCRIPTOR" --hosts "$HOSTS" "$@"
+    if [[ -n "${MPI_ARGS:-}" ]]; then
+        _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@"
+    else
+        _tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" "$@"
+    fi
 }
 
 ###############################################################################

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -117,9 +117,9 @@ resolve_deepseekv3_model() {
     local model_path="${DEEPSEEK_V3_HF_MODEL_OVERRIDE:-${DEEPSEEK_V3_HF_MODEL:-${default_model}}}"
 
     if [[ ! -d "${model_path}" ]]; then
-        echo "Error: DeepSeek V3 model directory does not exist: ${model_path}" >&2
-        echo "For local testing, pass --model-path <path> (or set DEEPSEEK_V3_HF_MODEL_OVERRIDE)." >&2
-        exit 1
+        echo "Warning: DeepSeek V3 model directory not visible from orchestrator: ${model_path}" >&2
+        echo "  This is expected in CI Docker containers; model must exist on Galaxy hosts." >&2
+        echo "  For local testing, pass --model-path <path> (or set DEEPSEEK_V3_HF_MODEL_OVERRIDE)." >&2
     fi
 
     export DEEPSEEK_V3_HF_MODEL="${model_path}"

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -546,9 +546,9 @@ main() {
         return 0
     fi
 
-    if [[ -z "$TT_METAL_HOME" ]]; then
-        echo "Must provide TT_METAL_HOME in environment" 1>&2
-        exit 1
+    if [[ -z "${TT_METAL_HOME:-}" ]]; then
+        export TT_METAL_HOME="$(pwd -P)"
+        echo "TT_METAL_HOME not set; defaulting to current directory: ${TT_METAL_HOME}"
     fi
 
     _init_multihost_test_env

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -262,23 +262,55 @@ demo_case_selector() {
     esac
 }
 
-# Helper: run a test command via tt-run using the current environment
-_run_deepseekv3_tt() {
-    # USE_TORUS_MODE=0 means OFF, so unset it for the launched process.
-    if [[ "${USE_TORUS_MODE:-}" == "0" ]]; then
-        if [[ -n "${MPI_ARGS:-}" ]]; then
-            ( unset USE_TORUS_MODE; tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@" )
-        else
-            ( unset USE_TORUS_MODE; tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" "$@" )
-        fi
-        return
+teacher_forced_pytest_args() {
+    local test_node="models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy"
+    local upr_mode
+    upr_mode="$(resolve_upr_mode)"
+
+    if [[ "${upr_mode}" == "both" ]]; then
+        echo "${test_node}"
+        return 0
     fi
 
+    # Parametrize values from test_demo_teacher_forced.py:
+    #   max_users_per_row: [8, 32]  ids=["8", "32"]
+    #   max_new_tokens:    [128, 2048, 8192]  ids=["128", "2048", "8192"]
+    #   reference_file:    [REFERENCE_FILE]
+    # Node ID format: test_demo_teacher_forcing_accuracy[{upr}-{tokens}-reference_file0]
+    local token_count
+    for token_count in 128 2048 8192; do
+        echo "${test_node}[${upr_mode}-${token_count}-reference_file0]"
+    done
+}
+
+# Helper: run a test command via tt-run using the current environment
+_run_deepseekv3_tt() {
+    local -a tt_run_args=(--tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML")
     if [[ -n "${MPI_ARGS:-}" ]]; then
-        tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" --mpi-args "$MPI_ARGS" "$@"
-    else
-        tt_run --tcp-interface "$TCP_INTERFACE" --rank-binding "$RANK_BINDING_YAML" "$@"
+        tt_run_args+=(--mpi-args "$MPI_ARGS")
     fi
+
+    local runtime_root="${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME:-$(pwd -P)}}"
+    local torus_mode="${USE_TORUS_MODE-__UNSET__}"
+
+    tt_run "${tt_run_args[@]}" env \
+        _DS_MESH_DEVICE="${MESH_DEVICE:-}" \
+        _DS_USE_TORUS_MODE="${torus_mode}" \
+        _DS_RUNTIME_ROOT="${runtime_root}" \
+        bash -c '
+            if [[ -n "${_DS_MESH_DEVICE}" ]]; then
+                export MESH_DEVICE="${_DS_MESH_DEVICE}"
+            fi
+            if [[ "${_DS_USE_TORUS_MODE}" == "0" || "${_DS_USE_TORUS_MODE}" == "__UNSET__" ]]; then
+                unset USE_TORUS_MODE
+            elif [[ -n "${_DS_USE_TORUS_MODE}" ]]; then
+                export USE_TORUS_MODE="${_DS_USE_TORUS_MODE}"
+            fi
+            if [[ -n "${_DS_RUNTIME_ROOT}" ]]; then
+                export TT_METAL_RUNTIME_ROOT="${_DS_RUNTIME_ROOT}"
+            fi
+            exec "$@"
+        ' _ "$@"
 }
 
 ###############################################################################
@@ -341,8 +373,10 @@ run_dual_teacher_forced_test() {
     fail=0
     setup_dual_galaxy_env
     local timeout=$(_demo_timeout 3600)
+    local tf_args
+    tf_args="$(teacher_forced_pytest_args | paste -sd' ')"
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/dual_teacher_forced_output.log" ; fail+=$?
+    _run_deepseekv3_tt bash -c "set -f -o pipefail; pytest -svvv --timeout=$timeout ${tf_args} 2>&1 | tee generated/artifacts/dual_teacher_forced_output.log" ; fail+=$?
 
     # Extract accuracy metrics from logs and save to artifact file
     if [[ -f generated/artifacts/dual_teacher_forced_output.log ]]; then
@@ -360,8 +394,10 @@ run_quad_teacher_forced_test() {
     fail=0
     setup_quad_galaxy_env
     local timeout=$(_demo_timeout 3600)
+    local tf_args
+    tf_args="$(teacher_forced_pytest_args | paste -sd' ')"
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/quad_teacher_forced_output.log" ; fail+=$?
+    _run_deepseekv3_tt bash -c "set -f -o pipefail; pytest -svvv --timeout=$timeout ${tf_args} 2>&1 | tee generated/artifacts/quad_teacher_forced_output.log" ; fail+=$?
 
     # Extract accuracy metrics from logs and save to artifact file
     if [[ -f generated/artifacts/quad_teacher_forced_output.log ]]; then

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
-# Exit immediately if ARCH_NAME is not set or empty
-if [ -z "${ARCH_NAME}" ]; then
-  echo "Error: ARCH_NAME is not set. Exiting." >&2
-  exit 1
-fi
+# Default ARCH_NAME for local runs when not set by CI.
+export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
 
 ###############################################################################
 # Infrastructure unit tests (quad galaxy only)
@@ -355,6 +352,24 @@ run_quad_deepseekv3_integration_tests() {
     run_quad_demo_stress_test
 }
 
+run_all_needed_local_tests() {
+    local saved_upr_mode="${DEEPSEEK_DEMO_UPR_MODE:-}"
+    export DEEPSEEK_DEMO_UPR_MODE="all"
+
+    run_dual_teacher_forced_test
+    run_dual_demo_test
+    run_dual_demo_stress_test
+    run_quad_teacher_forced_test
+    run_quad_demo_test
+    run_quad_demo_stress_test
+
+    if [[ -n "${saved_upr_mode}" ]]; then
+        export DEEPSEEK_DEMO_UPR_MODE="${saved_upr_mode}"
+    else
+        unset DEEPSEEK_DEMO_UPR_MODE
+    fi
+}
+
 # Run everything
 run_quad_galaxy_tests() {
     run_quad_galaxy_unit_tests
@@ -377,11 +392,6 @@ main() {
 
     if [[ -z "$TT_METAL_HOME" ]]; then
         echo "Must provide TT_METAL_HOME in environment" 1>&2
-        exit 1
-    fi
-
-    if [[ -z "$ARCH_NAME" ]]; then
-        echo "Must provide ARCH_NAME in environment" 1>&2
         exit 1
     fi
 
@@ -444,12 +454,15 @@ main() {
         "quad_deepseekv3_integration_tests")
             run_quad_deepseekv3_integration_tests
             ;;
+        "all_needed_local_tests")
+            run_all_needed_local_tests
+            ;;
         "all")
             run_quad_galaxy_tests
             ;;
         *)
             echo "Unknown test function: $test_function" 1>&2
-            echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all" 1>&2
+            echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all_needed_local_tests, all" 1>&2
             echo "Optional second argument: UPR mode (all|32|8)" 1>&2
             exit 1
             ;;


### PR DESCRIPTION
### Summary
Resolves https://github.com/tenstorrent/tt-metal/issues/41974. Changed the bash script to be generalizable to any machine (it should work for local + CI machines). It also allows choosing 8 upr / 32upr, and updates the YAML file to reflect this.

You now do NOT need to specify hosts, it is automatically determined with a heuristic, making this generalizable to all local and CI machines without needing to manually specify hosts.

NOTE: you still do need to specify model weights path & cache path because that differs from cluster to cluster. 

Sample command:
`tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo 32 --model-path /data/deepseek/DeepSeek-R1-0528-dequantized --cache-path /data/deepseek/DeepSeek-R1-0528-Cache/`

To run all tests for `ds-rc1`, sample command:
`tests/scripts/multihost/run_quad_galaxy_tests.sh all_needed_local_tests --model-path /data/deepseek/DeepSeek-R1-0528-dequantized --cache-path /data/deepseek/DeepSeek-R1-0528-Cache/`

### Notes for reviewers
CI dual galaxy appears to not be passing health tests...

https://github.com/tenstorrent/tt-metal/actions/runs/24686789772

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-automated-testing-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-automated-testing-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ds-automated-testing-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ds-automated-testing-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ds-automated-testing-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ds-automated-testing-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ds-automated-testing-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ds-automated-testing-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ds-automated-testing-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ds-automated-testing-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ds-automated-testing-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ds-automated-testing-script)