### PR TITLE
Shuffle moe op order/riscs to enable prefetching down proj weights

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -117,10 +117,14 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ReaderArgs rmsnorm_args{};
 
     // Mcast receiver args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_dst_cb"),
+                get_named_compile_time_arg_val("mcast_dst_num_pages"),
+            },
     };
 
     // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
@@ -156,10 +160,14 @@ void kernel_main() {
 
     // Mcast2 receiver args (for matmul2 cores to receive matmul2 input from input core)
     // Uses same semaphore as first mcast
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("matmul2_in0"),
-        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("matmul2_in0"),
+                get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+            },
     };
 
     // Matmul3 reader args (NCRISC is no-op)
@@ -412,10 +420,14 @@ void kernel_main() {
     };
 
     // Mcast3 receiver args
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast3_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast3_dst_cb"),
-        get_named_compile_time_arg_val("mcast3_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast3_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast3_dst_cb"),
+                get_named_compile_time_arg_val("mcast3_dst_num_pages"),
+            },
     };
 
     // Matmul5 CTArgs
@@ -591,18 +603,22 @@ void kernel_main() {
     constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
 
     // Mcast sender args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        get_read_ptr(mcast_src_cb),
-        get_write_ptr(mcast_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                get_read_ptr(mcast_src_cb),
+                get_write_ptr(mcast_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Matmul CTArgs type alias (BRISC uses WriterCTArgs)
@@ -642,18 +658,22 @@ void kernel_main() {
     // Uses same grid and semaphores as first mcast
     // Reads from rmsnorm2_output_cb, writes to matmul2_in0 with loopback
     constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("rmsnorm2_output_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
-        mcast2_src_cb,  // Wait for rmsnorm2_output_cb
-        get_named_compile_time_arg_val("mcast2_src_num_pages"),
-        get_read_ptr(mcast2_src_cb),  // Read from rmsnorm2_output_cb
-        get_write_ptr(matmul2_in0),   // Write to matmul2_in0 (loopback)
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+                mcast2_src_cb,  // Wait for rmsnorm2_output_cb
+                get_named_compile_time_arg_val("mcast2_src_num_pages"),
+                get_read_ptr(mcast2_src_cb),  // Read from rmsnorm2_output_cb
+                get_write_ptr(matmul2_in0),   // Write to matmul2_in0 (loopback)
+            },
+        .receiver = {},
     };
 
     // Matmul writer args (BRISC is no-op)
@@ -738,18 +758,22 @@ void kernel_main() {
     // Mcast3 sender args
     constexpr uint32_t mcast3_src_cb = get_named_compile_time_arg_val("mcast3_src_cb");
     constexpr uint32_t mcast3_dst_cb = get_named_compile_time_arg_val("mcast3_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast3_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast3_data_size_bytes"),
-        mcast3_src_cb,
-        get_named_compile_time_arg_val("mcast3_src_num_pages"),
-        get_read_ptr(mcast3_src_cb),
-        get_write_ptr(mcast3_dst_cb),  // CB 4 address (now allocated on gather core too)
+    deepseek_b1_ops::Mcast::DMArgs mcast3_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+                get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast3_data_size_bytes"),
+                mcast3_src_cb,
+                get_named_compile_time_arg_val("mcast3_src_num_pages"),
+                get_read_ptr(mcast3_src_cb),
+                get_write_ptr(mcast3_dst_cb),  // CB 4 address (now allocated on gather core too)
+            },
+        .receiver = {},
     };
 
     // Gather3 receiver args (on sender core 11,9 instead of gather core 12,9)

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -156,11 +156,13 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ReaderArgs rmsnorm_args{};
 
     // Mcast receiver args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
-    };
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver = {
+            get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+            get_named_compile_time_arg_val("mcast_dst_cb"),
+            get_named_compile_time_arg_val("mcast_dst_num_pages"),
+        }};
 
     // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
     using MatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
@@ -195,11 +197,13 @@ void kernel_main() {
 
     // Mcast2 receiver args (for matmul2 cores to receive matmul2 input from input core)
     // Uses same semaphore as first mcast
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("matmul2_in0"),
-        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
-    };
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender = {},
+        .receiver = {
+            get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
+            get_named_compile_time_arg_val("matmul2_in0"),
+            get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+        }};
 
     // Matmul3 reader args (NCRISC is no-op)
     deepseek_b1_ops::Matmul::ReaderArgs matmul3_args{};
@@ -451,11 +455,13 @@ void kernel_main() {
     };
 
     // Mcast3 receiver args
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast3_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast3_dst_cb"),
-        get_named_compile_time_arg_val("mcast3_dst_num_pages"),
-    };
+    deepseek_b1_ops::Mcast::DMArgs mcast3_args{
+        .sender = {},
+        .receiver = {
+            get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
+            get_named_compile_time_arg_val("mcast3_dst_cb"),
+            get_named_compile_time_arg_val("mcast3_dst_num_pages"),
+        }};
 
     // Matmul5 CTArgs
     using Matmul5CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
@@ -630,19 +636,22 @@ void kernel_main() {
     constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
 
     // Mcast sender args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        get_read_ptr(mcast_src_cb),
-        get_write_ptr(mcast_dst_cb),
-    };
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                get_read_ptr(mcast_src_cb),
+                get_write_ptr(mcast_dst_cb),
+            },
+        .receiver = {}};
 
     // Matmul CTArgs type alias (BRISC uses WriterCTArgs)
     using MatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
@@ -681,19 +690,22 @@ void kernel_main() {
     // Uses same grid and semaphores as first mcast
     // Reads from rmsnorm2_output_cb, writes to matmul2_in0 with loopback
     constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("rmsnorm2_output_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
-        mcast2_src_cb,  // Wait for rmsnorm2_output_cb
-        get_named_compile_time_arg_val("mcast2_src_num_pages"),
-        get_read_ptr(mcast2_src_cb),  // Read from rmsnorm2_output_cb
-        get_write_ptr(matmul2_in0),   // Write to matmul2_in0 (loopback)
-    };
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+                mcast2_src_cb,  // Wait for rmsnorm2_output_cb
+                get_named_compile_time_arg_val("mcast2_src_num_pages"),
+                get_read_ptr(mcast2_src_cb),  // Read from rmsnorm2_output_cb
+                get_write_ptr(matmul2_in0),   // Write to matmul2_in0 (loopback)
+            },
+        .receiver = {}};
 
     // Matmul writer args (BRISC is no-op)
     using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
@@ -777,19 +789,22 @@ void kernel_main() {
     // Mcast3 sender args
     constexpr uint32_t mcast3_src_cb = get_named_compile_time_arg_val("mcast3_src_cb");
     constexpr uint32_t mcast3_dst_cb = get_named_compile_time_arg_val("mcast3_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast3_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast3_data_size_bytes"),
-        mcast3_src_cb,
-        get_named_compile_time_arg_val("mcast3_src_num_pages"),
-        get_read_ptr(mcast3_src_cb),
-        get_write_ptr(mcast3_dst_cb),  // CB 4 address (now allocated on gather core too)
-    };
+    deepseek_b1_ops::Mcast::DMArgs mcast3_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+                get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast3_data_size_bytes"),
+                mcast3_src_cb,
+                get_named_compile_time_arg_val("mcast3_src_num_pages"),
+                get_read_ptr(mcast3_src_cb),
+                get_write_ptr(mcast3_dst_cb),  // CB 4 address (now allocated on gather core too)
+            },
+        .receiver = {}};
 
     // Gather3 receiver args
     deepseek_b1_ops::Gather::DMArgs gather3_args{
@@ -1217,11 +1232,13 @@ void kernel_main() {
         struct Routed {
             // Mcast (receiver)
             using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-            deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("moe_mcast_dst_cb"),
-                get_named_compile_time_arg_val("moe_mcast_dst_num_pages"),
-            };
+            deepseek_b1_ops::Mcast::DMArgs mcast_args{
+                .sender = {},
+                .receiver = {
+                    get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("moe_mcast_dst_cb"),
+                    get_named_compile_time_arg_val("moe_mcast_dst_num_pages"),
+                }};
 
 #ifdef ENABLE_ROUTING
             // Gate Matmul (reader — no-op)
@@ -1241,19 +1258,11 @@ void kernel_main() {
             // Gate (reader — no-op)
             using GateCTArgs = deepseek_b1_ops::DeepseekMoeGate::ReaderCTArgs;
 
-            // Index Mcast (receiver)
-            deepseek_b1_ops::Mcast::ReceiverArgs index_mcast_args{
-                get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("gate_proj_cb_index"),
-                get_named_compile_time_arg_val("index_mcast_num_pages"),
-            };
+            // Index Mcast (no-op on NCRISC — receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs index_mcast_args{.sender = {}, .receiver = {}};
 
-            // Expert Scale Mcast (receiver)
-            deepseek_b1_ops::Mcast::ReceiverArgs expert_scale_mcast_args{
-                get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("mul_cb_scalar_src"),
-                get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
-            };
+            // Expert Scale Mcast (no-op on NCRISC — receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs expert_scale_mcast_args{.sender = {}, .receiver = {}};
 #endif  // ENABLE_ROUTING
 
             // gate_proj DRAM Streaming Matmul (reader)
@@ -1307,12 +1316,8 @@ void kernel_main() {
                 get_named_compile_time_arg_val("down_proj_gather_dst_num_pages"),
             };
 
-            // down_proj Mcast (receiver)
-            deepseek_b1_ops::Mcast::ReceiverArgs down_proj_mcast_args{
-                get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("down_proj_mcast_dst_cb"),
-                get_named_compile_time_arg_val("down_proj_mcast_dst_num_pages"),
-            };
+            // down_proj Mcast (no-op on NCRISC — receiver moved to BRISC)
+            deepseek_b1_ops::Mcast::DMArgs down_proj_mcast_args{.sender = {}, .receiver = {}};
 
             // down_proj DRAM Streaming Matmul (reader)
             using DownProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::ReaderCTArgs<
@@ -1338,11 +1343,13 @@ void kernel_main() {
 
             // Residual Mcast — receiver (input from sender → residual CB)
             using ResidualMcastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-            deepseek_b1_ops::Mcast::ReceiverArgs residual_mcast_args{
-                get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_residual_cb"),
-                get_named_compile_time_arg_val("shared_residual_num_pages"),
-            };
+            deepseek_b1_ops::Mcast::DMArgs residual_mcast_args{
+                .sender = {},
+                .receiver = {
+                    get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("shared_residual_cb"),
+                    get_named_compile_time_arg_val("shared_residual_num_pages"),
+                }};
 
             // RMSNorm (reader — no-op)
             using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -1397,11 +1404,13 @@ void kernel_main() {
 
             // Down Mcast — receiver (gated reduce output → all 130 cores)
             using DownMcastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-            deepseek_b1_ops::Mcast::ReceiverArgs down_mcast_args{
-                get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_down_mcast_dst_cb"),
-                get_named_compile_time_arg_val("shared_down_mcast_dst_num_pages"),
-            };
+            deepseek_b1_ops::Mcast::DMArgs down_mcast_args{
+                .sender = {},
+                .receiver = {
+                    get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("shared_down_mcast_dst_cb"),
+                    get_named_compile_time_arg_val("shared_down_mcast_dst_num_pages"),
+                }};
 
             // Down Proj Matmul — reader (no-op for NCRISC)
             using DownMatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
@@ -1421,13 +1430,9 @@ void kernel_main() {
                 get_named_compile_time_arg_val("shared_og_dst_num_pages"),
             };
 
-            // Output Mcast — receiver (DRAM cores receive into add_cb_in1)
+            // Output Mcast — no-op on NCRISC (receiver moved to BRISC)
             using OutputMcastCTArgs = Routed::McastCTArgs;
-            deepseek_b1_ops::Mcast::ReceiverArgs output_mcast_args{
-                get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("add_cb_in1"),
-                get_named_compile_time_arg_val("shared_output_mcast_dst_num_pages"),
-            };
+            deepseek_b1_ops::Mcast::DMArgs output_mcast_args{.sender = {}, .receiver = {}};
         } shared;
     } moe;
 
@@ -1440,19 +1445,22 @@ void kernel_main() {
                 get_named_compile_time_arg_val("moe_mcast_num_cores"),
                 get_named_compile_time_arg_val("moe_mcast_is_part_of_receiver_grid"),
                 Core::is_sender_core && Core::is_mcast_grid_core>;
-            deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
-                get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("moe_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("moe_mcast_src_cb"),
-                get_named_compile_time_arg_val("moe_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("moe_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("moe_mcast_dst_cb")),
-            };
+            deepseek_b1_ops::Mcast::DMArgs mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                        get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("moe_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("moe_mcast_src_cb"),
+                        get_named_compile_time_arg_val("moe_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("moe_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("moe_mcast_dst_cb")),
+                    },
+                .receiver = {}};
 
 #ifdef ENABLE_ROUTING
             // Gate Matmul (writer — no-op)
@@ -1481,35 +1489,49 @@ void kernel_main() {
                 get_named_compile_time_arg_val("gate_output_cb"),
                 get_named_compile_time_arg_val("gate_output_indices_cb")>;
 
-            // Index Mcast (sender)
-            deepseek_b1_ops::Mcast::SenderArgs index_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
-                get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("index_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("gate_output_indices_cb"),
-                get_named_compile_time_arg_val("index_mcast_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("gate_output_indices_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("gate_proj_cb_index")),
-            };
+            // Index Mcast (sender + receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs index_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                        get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("index_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("gate_output_indices_cb"),
+                        get_named_compile_time_arg_val("index_mcast_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("gate_output_indices_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("gate_proj_cb_index")),
+                    },
+                .receiver = {
+                    get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("gate_proj_cb_index"),
+                    get_named_compile_time_arg_val("index_mcast_num_pages"),
+                }};
 
-            // Expert Scale Mcast (sender)
-            deepseek_b1_ops::Mcast::SenderArgs expert_scale_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
-                get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("expert_scale_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("gate_output_cb"),
-                get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("gate_output_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("mul_cb_scalar_src")),
-            };
+            // Expert Scale Mcast (sender + receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs expert_scale_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                        get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("expert_scale_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("gate_output_cb"),
+                        get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("gate_output_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("mul_cb_scalar_src")),
+                    },
+                .receiver = {
+                    get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("mul_cb_scalar_src"),
+                    get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
+                }};
 #endif  // ENABLE_ROUTING
 
             // DRAM Streaming Matmul (writer — no-op for BRISC)
@@ -1543,20 +1565,27 @@ void kernel_main() {
                 get_named_compile_time_arg_val("down_proj_gather_sender_idx"),
             };
 
-            // down_proj Mcast (sender)
-            deepseek_b1_ops::Mcast::SenderArgs down_proj_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
-                get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("down_proj_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("down_proj_mcast_src_cb"),
-                get_named_compile_time_arg_val("down_proj_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("down_proj_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("down_proj_mcast_dst_cb")),
-            };
+            // down_proj Mcast (sender + receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs down_proj_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                        get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("down_proj_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("down_proj_mcast_src_cb"),
+                        get_named_compile_time_arg_val("down_proj_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("down_proj_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("down_proj_mcast_dst_cb")),
+                    },
+                .receiver = {
+                    get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("down_proj_mcast_dst_cb"),
+                    get_named_compile_time_arg_val("down_proj_mcast_dst_num_pages"),
+                }};
 
             // down_proj DRAM Matmul (writer — no-op for BRISC)
             using DownProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::WriterCTArgs;
@@ -1566,19 +1595,22 @@ void kernel_main() {
 
             // Residual Mcast — sender (input from sender → residual CB, pop_src=false)
             using ResidualMcastCTArgs = McastCTArgs;
-            deepseek_b1_ops::Mcast::SenderArgs residual_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
-                get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_residual_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("shared_residual_mcast_src_cb"),
-                get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("shared_residual_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("shared_residual_mcast_dst_cb")),
-            };
+            deepseek_b1_ops::Mcast::DMArgs residual_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                        get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_residual_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("shared_residual_mcast_src_cb"),
+                        get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("shared_residual_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("shared_residual_mcast_dst_cb")),
+                    },
+                .receiver = {}};
 
             // RMSNorm (writer — no-op)
             using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
@@ -1657,19 +1689,22 @@ void kernel_main() {
 
             // Down Mcast — sender (reuse Routed::McastCTArgs: same grid, same persistent sender)
             using DownMcastCTArgs = Routed::McastCTArgs;
-            deepseek_b1_ops::Mcast::SenderArgs down_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
-                get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_down_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("shared_down_mcast_src_cb"),
-                get_named_compile_time_arg_val("shared_down_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("shared_down_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("shared_down_mcast_dst_cb")),
-            };
+            deepseek_b1_ops::Mcast::DMArgs down_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                        get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_down_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("shared_down_mcast_src_cb"),
+                        get_named_compile_time_arg_val("shared_down_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("shared_down_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("shared_down_mcast_dst_cb")),
+                    },
+                .receiver = {}};
 
             // Down Proj Matmul — writer (no-op for BRISC)
             using DownMatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
@@ -1696,21 +1731,28 @@ void kernel_main() {
                 get_named_compile_time_arg_val("shared_residual_add_core_idx"),  // reuse matmul core index
             };
 
-            // Output Mcast — sender (sender core → 130 cores)
+            // Output Mcast — sender + receiver on BRISC (sender core → 130 cores)
             using OutputMcastCTArgs = Routed::McastCTArgs;
-            deepseek_b1_ops::Mcast::SenderArgs output_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
-                get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_output_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("shared_output_mcast_src_cb"),
-                get_named_compile_time_arg_val("shared_output_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("shared_output_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("add_cb_in1")),
-            };
+            deepseek_b1_ops::Mcast::DMArgs output_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                        get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_output_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("shared_output_mcast_src_cb"),
+                        get_named_compile_time_arg_val("shared_output_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("shared_output_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("add_cb_in1")),
+                    },
+                .receiver = {
+                    get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("add_cb_in1"),
+                    get_named_compile_time_arg_val("shared_output_mcast_dst_num_pages"),
+                }};
         } shared;
     } moe;
 
@@ -2462,13 +2504,6 @@ void kernel_main() {
             deepseek_b1_ops::Matmul::Op<Moe::Routed::GateMMCTArgs, Core::Routed::is_gate_mm_core, false, false> gate_mm;
             gate_mm(moe.routed.gate_mm_args);
         }
-
-        // 3. Gather: Collect matmul outputs from compute cores to sender core
-        {
-            DeviceZoneScopedN("GATHER");
-            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_mm_core, Core::is_sender_core, true> gather;
-            gather(moe.routed.gather_args);
-        }
 #endif  // ENABLE_ROUTING
 
         // 3a. Shared Expert: Gate/Up KN-sliced matmul on 128 compute cores
@@ -2485,7 +2520,26 @@ void kernel_main() {
             shared_gu_matmul(moe.shared.gu_matmul_args);
         }
 
+        // 5c. Shared Expert: Gate Gather (A) — 64 gate cores send to sender core
+        //     Uses MoeGather (sender=BRISC) to avoid NOC contention with DRAM matmul (NCRISC)
+        {
+            DeviceZoneScopedN("SHARED_GATE_GATHER");
+            deepseek_b1_ops::MoeGather::Op<
+                Core::Shared::is_gate_compute_core,
+                Core::Shared::is_gated_reduce_core,
+                true,  // pop_src
+                true>  // UsePerCoreSenderIdx
+                shared_gate_gather;
+            shared_gate_gather(moe.shared.ag_args);
+        }
+
 #ifdef ENABLE_ROUTING
+        // 3. Gather: Collect matmul outputs from compute cores to sender core
+        {
+            DeviceZoneScopedN("GATHER");
+            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_mm_core, Core::is_sender_core, true> gather;
+            gather(moe.routed.gather_args);
+        }
         // 4. Gate: Top-K expert selection (on sender core only)
         {
             DeviceZoneScopedN("GATE");
@@ -2501,9 +2555,10 @@ void kernel_main() {
             deepseek_b1_ops::Mcast::Op<
                 Moe::Routed::McastCTArgs,
                 Core::is_sender_core,
-                Core::is_mcast_grid_core,
                 Core::Routed::is_gate_proj_core,
-                true>
+                Core::Routed::is_gate_proj_core,
+                true,
+                /*ReceiverOnBrisc=*/true>
                 index_mcast;
             index_mcast(moe.routed.index_mcast_args);
         }
@@ -2514,26 +2569,14 @@ void kernel_main() {
             deepseek_b1_ops::Mcast::Op<
                 Moe::Routed::McastCTArgs,
                 Core::is_sender_core,
-                Core::is_mcast_grid_core,
                 Core::Routed::is_gate_proj_core,
-                true>  // pop_src
+                Core::Routed::is_gate_proj_core,
+                true,
+                /*ReceiverOnBrisc=*/true>
                 expert_scale_mcast;
             expert_scale_mcast(moe.routed.expert_scale_mcast_args);
         }
 #endif  // ENABLE_ROUTING
-
-        // 5c. Shared Expert: Gate Gather (A) — 64 gate cores send to sender core
-        //     Uses MoeGather (sender=BRISC) to avoid NOC contention with DRAM matmul (NCRISC)
-        {
-            DeviceZoneScopedN("SHARED_GATE_GATHER");
-            deepseek_b1_ops::MoeGather::Op<
-                Core::Shared::is_gate_compute_core,
-                Core::Shared::is_gated_reduce_core,
-                true,  // pop_src
-                true>  // UsePerCoreSenderIdx
-                shared_gate_gather;
-            shared_gate_gather(moe.shared.ag_args);
-        }
 
         // 5d. Shared Expert: Up Gather (B) — 64 up cores send to sender core
         {
@@ -2571,7 +2614,7 @@ void kernel_main() {
             DeviceZoneScopedN("UP_PROJ");
             constexpr uint32_t cb_in1_addr = get_named_compile_time_arg_val("gate_proj_in1_buf_addr");
             deepseek_b1_ops::DRAMStreamingMatmul::
-                Op<Moe::Routed::UpProjCTArgs, Core::Routed::is_gate_proj_core, true, true, cb_in1_addr, false, true>
+                Op<Moe::Routed::UpProjCTArgs, Core::Routed::is_gate_proj_core, true, true, cb_in1_addr>
                     up_proj;
             up_proj();
         }
@@ -2583,57 +2626,21 @@ void kernel_main() {
             mul_op();
         }
 
-        // 9. down_proj Gather: Gather fused output from gate_proj cores to sender core
-        {
-            DeviceZoneScopedN("DOWN_PROJ_GATHER");
-            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_proj_core, Core::is_sender_core, true, true>
-                down_proj_gather;
-            down_proj_gather(moe.routed.down_proj_gather_args);
-        }
-
-        // 10. down_proj Mcast: Broadcast gathered fused output to gate_proj cores
-        {
-            DeviceZoneScopedN("DOWN_PROJ_MCAST");
-            deepseek_b1_ops::Mcast::Op<
-                Moe::Routed::McastCTArgs,
-                Core::is_sender_core,
-                Core::is_mcast_grid_core,
-                Core::Routed::is_gate_proj_core,
-                true>  // pop_src
-                down_proj_mcast;
-            down_proj_mcast(moe.routed.down_proj_mcast_args);
-        }
-
-        // 11. down_proj: DRAM Streaming Matmul (PopIndex=true: last consumer of expert index CB)
-        {
-            DeviceZoneScopedN("DOWN_PROJ");
-            constexpr uint32_t down_proj_cb_in1_addr = get_named_compile_time_arg_val("down_proj_in1_buf_addr");
-            deepseek_b1_ops::DRAMStreamingMatmul::Op<
-                Moe::Routed::DownProjCTArgs,
-                Core::Routed::is_gate_proj_core,
-                true,
-                true,
-                down_proj_cb_in1_addr,
-                true>
-                down_proj;
-            down_proj();
-        }
-
-        // 11b. Shared: Down Mcast — broadcast gated reduce output [1, K_down] to all 130 cores
+        // 9. Shared: Down Mcast — broadcast gated reduce output [1, K_down] to all 130 cores
         //      Source is mcast_src_cb (CB 31) filled by gated reduce, pop_src=true
         {
             DeviceZoneScopedN("SHARED_DOWN_MCAST");
             deepseek_b1_ops::Mcast::Op<
                 Moe::Shared::DownMcastCTArgs,
                 Core::is_sender_core,
-                Core::is_mcast_grid_core,
+                Core::Shared::is_mcast_receiver_core,
                 Core::Shared::is_mcast_receiver_core,
                 true>
                 shared_down_mcast;
             shared_down_mcast(moe.shared.down_mcast_args);
         }
 
-        // 11c. Shared: Down Proj Matmul — SRAM matmul [1, K_down] x [K_down, N_per_core] on 112 cores
+        // 9b. Shared: Down Proj Matmul — SRAM matmul [1, K_down] x [K_down, N_per_core] on 112 cores
         {
             DeviceZoneScopedN("SHARED_DOWN_MATMUL");
             deepseek_b1_ops::Matmul::Op<
@@ -2645,7 +2652,7 @@ void kernel_main() {
             shared_down_matmul(moe.shared.down_matmul_args);
         }
 
-        // 11d. Shared: Residual Add — matmul_out + shard(residual) on 112 cores
+        // 9c. Shared: Residual Add — matmul_out + shard(residual) on 112 cores
         //      When multi-device reduce is enabled, only the ROOT1 device performs
         //      the actual add so the residual is counted exactly once after the
         //      cross-device sum.  Non-root devices pass matmul output through.
@@ -2664,7 +2671,7 @@ void kernel_main() {
             shared_residual_add(moe.shared.residual_add_args);
         }
 
-        // 11e. Shared: Output Gather — 112 matmul cores → sender core
+        // 9d. Shared: Output Gather — 112 matmul cores → sender core
         {
             DeviceZoneScopedN("SHARED_OUTPUT_GATHER");
             deepseek_b1_ops::MoeGather::Op<
@@ -2676,20 +2683,58 @@ void kernel_main() {
             shared_output_gather(moe.shared.og_args);
         }
 
-        // 11f. Shared: Output Mcast — sender core → 130 cores (DRAM cores receive into add_cb_in1)
+        // 9e. Shared: Output Mcast — sender core → 130 cores (DRAM cores receive into add_cb_in1)
         {
             DeviceZoneScopedN("SHARED_OUTPUT_MCAST");
             deepseek_b1_ops::Mcast::Op<
                 Moe::Shared::OutputMcastCTArgs,
                 Core::is_sender_core,             // IsSenderCore
-                Core::is_mcast_grid_core,         // IsMcastGridCore (all 130 cores for semaphore ack)
+                Core::Routed::is_gate_proj_core,  // IsMcastGridCore (8 DRAM cores)
                 Core::Routed::is_gate_proj_core,  // IsReceiverCore (8 DRAM cores receive into add_cb_in1)
-                /*pop_src=*/true>
+                /*pop_src=*/true,
+                /*ReceiverOnBrisc=*/true>
                 shared_output_mcast;
             shared_output_mcast(moe.shared.output_mcast_args);
         }
 
-        // 12. Eltwise Add: down_proj + shared_expert_output
+        // 10. down_proj Gather: Gather fused output from gate_proj cores to sender core
+        {
+            DeviceZoneScopedN("DOWN_PROJ_GATHER");
+            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_proj_core, Core::is_sender_core, true, true>
+                down_proj_gather;
+            down_proj_gather(moe.routed.down_proj_gather_args);
+        }
+
+        // 11. down_proj Mcast: Broadcast gathered fused output to gate_proj cores
+        {
+            DeviceZoneScopedN("DOWN_PROJ_MCAST");
+            deepseek_b1_ops::Mcast::Op<
+                Moe::Routed::McastCTArgs,
+                Core::is_sender_core,
+                Core::Routed::is_gate_proj_core,
+                Core::Routed::is_gate_proj_core,
+                true,
+                /*ReceiverOnBrisc=*/true>
+                down_proj_mcast;
+            down_proj_mcast(moe.routed.down_proj_mcast_args);
+        }
+
+        // 12. down_proj: DRAM Streaming Matmul (PopIndex=true: last consumer of expert index CB)
+        {
+            DeviceZoneScopedN("DOWN_PROJ");
+            constexpr uint32_t down_proj_cb_in1_addr = get_named_compile_time_arg_val("down_proj_in1_buf_addr");
+            deepseek_b1_ops::DRAMStreamingMatmul::Op<
+                Moe::Routed::DownProjCTArgs,
+                Core::Routed::is_gate_proj_core,
+                true,
+                true,
+                down_proj_cb_in1_addr,
+                true>
+                down_proj;
+            down_proj();
+        }
+
+        // 13. Eltwise Add: down_proj + shared_expert_output
         {
             DeviceZoneScopedN("ELTWISE_ADD");
             constexpr bool add_pop_output =

--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
@@ -52,18 +52,26 @@ void kernel_main() {
 #if defined(COMPILE_FOR_NCRISC)
     // Mcast1 receiver args
     using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_dst_cb"),
+                get_named_compile_time_arg_val("mcast_dst_num_pages"),
+            },
     };
 
     // Mcast2 receiver args
     using Mcast2CTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast2_dst_cb"),
-        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast2_dst_cb"),
+                get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+            },
     };
 
     // Matmul CTArgs (NCRISC is no-op for matmul compute)
@@ -105,18 +113,22 @@ void kernel_main() {
 
     constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
     constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        get_read_ptr(mcast_src_cb),
-        get_write_ptr(mcast_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                get_read_ptr(mcast_src_cb),
+                get_write_ptr(mcast_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Mcast2 sender args (same grid, different semaphores and CBs)
@@ -124,18 +136,22 @@ void kernel_main() {
 
     constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
     constexpr uint32_t mcast2_dst_cb = get_named_compile_time_arg_val("mcast2_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
-        mcast2_src_cb,
-        get_named_compile_time_arg_val("mcast2_src_num_pages"),
-        get_read_ptr(mcast2_src_cb),
-        get_write_ptr(mcast2_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+                mcast2_src_cb,
+                get_named_compile_time_arg_val("mcast2_src_num_pages"),
+                get_read_ptr(mcast2_src_cb),
+                get_write_ptr(mcast2_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Matmul CTArgs (BRISC is no-op for matmul)

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
@@ -106,18 +106,26 @@ void kernel_main() {
 
     // Mcast1 receiver args
     using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_dst_cb"),
+                get_named_compile_time_arg_val("mcast_dst_num_pages"),
+            },
     };
 
     // Mcast2 receiver args
     using Mcast2CTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast2_dst_cb"),
-        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast2_dst_cb"),
+                get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+            },
     };
 
     // Matmul CTArgs (NCRISC is no-op for matmul compute)
@@ -189,18 +197,22 @@ void kernel_main() {
 
     constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
     constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        get_read_ptr(mcast_src_cb),
-        get_write_ptr(mcast_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                get_read_ptr(mcast_src_cb),
+                get_write_ptr(mcast_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Mcast2 sender args (same grid, different semaphores and CBs)
@@ -208,18 +220,22 @@ void kernel_main() {
 
     constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
     constexpr uint32_t mcast2_dst_cb = get_named_compile_time_arg_val("mcast2_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
-        mcast2_src_cb,
-        get_named_compile_time_arg_val("mcast2_src_num_pages"),
-        get_read_ptr(mcast2_src_cb),
-        get_write_ptr(mcast2_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+                mcast2_src_cb,
+                get_named_compile_time_arg_val("mcast2_src_num_pages"),
+                get_read_ptr(mcast2_src_cb),
+                get_write_ptr(mcast2_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Matmul CTArgs (BRISC is no-op for matmul)

--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
@@ -129,10 +129,14 @@ void kernel_main() {
     }
 
     using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_dst_cb"),
+                get_named_compile_time_arg_val("mcast_dst_num_pages"),
+            },
     };
 
     // Matmul reader args (NCRISC is a no-op for matmul; compute runs on TRISC)
@@ -228,18 +232,22 @@ void kernel_main() {
 
     constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
     constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        Core::is_input_core ? get_read_ptr(mcast_src_cb) : 0,
-        get_write_ptr(mcast_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                Core::is_input_core ? get_read_ptr(mcast_src_cb) : 0,
+                get_write_ptr(mcast_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Matmul writer args (BRISC is a no-op for matmul; compute runs on TRISC)

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -109,11 +109,13 @@ void kernel_main() {
         struct Routed {
             // Mcast (receiver)
             using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-            deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("moe_mcast_dst_cb"),
-                get_named_compile_time_arg_val("moe_mcast_dst_num_pages"),
-            };
+            deepseek_b1_ops::Mcast::DMArgs mcast_args{
+                .sender = {},
+                .receiver = {
+                    get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("moe_mcast_dst_cb"),
+                    get_named_compile_time_arg_val("moe_mcast_dst_num_pages"),
+                }};
 
 #ifdef ENABLE_ROUTING
             // Gate Matmul (reader — no-op)
@@ -133,19 +135,11 @@ void kernel_main() {
             // Gate (reader — no-op)
             using GateCTArgs = deepseek_b1_ops::DeepseekMoeGate::ReaderCTArgs;
 
-            // Index Mcast (receiver)
-            deepseek_b1_ops::Mcast::ReceiverArgs index_mcast_args{
-                get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("gate_proj_cb_index"),
-                get_named_compile_time_arg_val("index_mcast_num_pages"),
-            };
+            // Index Mcast (no-op on NCRISC — receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs index_mcast_args{.sender = {}, .receiver = {}};
 
-            // Expert Scale Mcast (receiver)
-            deepseek_b1_ops::Mcast::ReceiverArgs expert_scale_mcast_args{
-                get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("mul_cb_scalar_src"),
-                get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
-            };
+            // Expert Scale Mcast (no-op on NCRISC — receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs expert_scale_mcast_args{.sender = {}, .receiver = {}};
 #endif  // ENABLE_ROUTING
 
             // gate_proj DRAM Streaming Matmul (reader)
@@ -199,12 +193,8 @@ void kernel_main() {
                 get_named_compile_time_arg_val("down_proj_gather_dst_num_pages"),
             };
 
-            // down_proj Mcast (receiver)
-            deepseek_b1_ops::Mcast::ReceiverArgs down_proj_mcast_args{
-                get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("down_proj_mcast_dst_cb"),
-                get_named_compile_time_arg_val("down_proj_mcast_dst_num_pages"),
-            };
+            // down_proj Mcast (no-op on NCRISC — receiver moved to BRISC)
+            deepseek_b1_ops::Mcast::DMArgs down_proj_mcast_args{.sender = {}, .receiver = {}};
 
             // down_proj DRAM Streaming Matmul (reader)
             using DownProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::ReaderCTArgs<
@@ -230,11 +220,13 @@ void kernel_main() {
 
             // Residual Mcast — receiver (input from sender → residual CB)
             using ResidualMcastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-            deepseek_b1_ops::Mcast::ReceiverArgs residual_mcast_args{
-                get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_residual_cb"),
-                get_named_compile_time_arg_val("shared_residual_num_pages"),
-            };
+            deepseek_b1_ops::Mcast::DMArgs residual_mcast_args{
+                .sender = {},
+                .receiver = {
+                    get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("shared_residual_cb"),
+                    get_named_compile_time_arg_val("shared_residual_num_pages"),
+                }};
 
             // RMSNorm (reader — no-op)
             using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -289,11 +281,13 @@ void kernel_main() {
 
             // Down Mcast — receiver (gated reduce output → all 130 cores)
             using DownMcastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-            deepseek_b1_ops::Mcast::ReceiverArgs down_mcast_args{
-                get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_down_mcast_dst_cb"),
-                get_named_compile_time_arg_val("shared_down_mcast_dst_num_pages"),
-            };
+            deepseek_b1_ops::Mcast::DMArgs down_mcast_args{
+                .sender = {},
+                .receiver = {
+                    get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("shared_down_mcast_dst_cb"),
+                    get_named_compile_time_arg_val("shared_down_mcast_dst_num_pages"),
+                }};
 
             // Down Proj Matmul — reader (no-op for NCRISC)
             using DownMatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
@@ -313,13 +307,9 @@ void kernel_main() {
                 get_named_compile_time_arg_val("shared_og_dst_num_pages"),
             };
 
-            // Output Mcast — receiver (DRAM cores receive into add_cb_in1)
+            // Output Mcast — no-op on NCRISC (receiver moved to BRISC)
             using OutputMcastCTArgs = Routed::McastCTArgs;
-            deepseek_b1_ops::Mcast::ReceiverArgs output_mcast_args{
-                get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("add_cb_in1"),
-                get_named_compile_time_arg_val("shared_output_mcast_dst_num_pages"),
-            };
+            deepseek_b1_ops::Mcast::DMArgs output_mcast_args{.sender = {}, .receiver = {}};
         } shared;
     } moe;
 
@@ -375,19 +365,22 @@ void kernel_main() {
                 get_named_compile_time_arg_val("moe_mcast_num_cores"),
                 get_named_compile_time_arg_val("moe_mcast_is_part_of_receiver_grid"),
                 Core::is_sender_core && Core::is_mcast_grid_core>;
-            deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("moe_mcast_data_sender_semaphore_addr"),
-                get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("moe_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("moe_mcast_src_cb"),
-                get_named_compile_time_arg_val("moe_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("moe_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("moe_mcast_dst_cb")),
-            };
+            deepseek_b1_ops::Mcast::DMArgs mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("moe_mcast_data_sender_semaphore_addr"),
+                        get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("moe_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("moe_mcast_src_cb"),
+                        get_named_compile_time_arg_val("moe_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("moe_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("moe_mcast_dst_cb")),
+                    },
+                .receiver = {}};
 
 #ifdef ENABLE_ROUTING
             // Gate Matmul (writer — no-op)
@@ -416,35 +409,49 @@ void kernel_main() {
                 get_named_compile_time_arg_val("gate_output_cb"),
                 get_named_compile_time_arg_val("gate_output_indices_cb")>;
 
-            // Index Mcast (sender)
-            deepseek_b1_ops::Mcast::SenderArgs index_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("index_mcast_sender_semaphore_addr"),
-                get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("index_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("gate_output_indices_cb"),
-                get_named_compile_time_arg_val("index_mcast_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("gate_output_indices_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("gate_proj_cb_index")),
-            };
+            // Index Mcast (sender + receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs index_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("index_mcast_sender_semaphore_addr"),
+                        get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("index_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("gate_output_indices_cb"),
+                        get_named_compile_time_arg_val("index_mcast_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("gate_output_indices_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("gate_proj_cb_index")),
+                    },
+                .receiver = {
+                    get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("gate_proj_cb_index"),
+                    get_named_compile_time_arg_val("index_mcast_num_pages"),
+                }};
 
-            // Expert Scale Mcast (sender)
-            deepseek_b1_ops::Mcast::SenderArgs expert_scale_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("expert_scale_mcast_sender_semaphore_addr"),
-                get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("expert_scale_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("gate_output_cb"),
-                get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("gate_output_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("mul_cb_scalar_src")),
-            };
+            // Expert Scale Mcast (sender + receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs expert_scale_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("expert_scale_mcast_sender_semaphore_addr"),
+                        get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("expert_scale_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("gate_output_cb"),
+                        get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("gate_output_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("mul_cb_scalar_src")),
+                    },
+                .receiver = {
+                    get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("mul_cb_scalar_src"),
+                    get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
+                }};
 #endif  // ENABLE_ROUTING
 
             // DRAM Streaming Matmul (writer — no-op for BRISC)
@@ -478,20 +485,27 @@ void kernel_main() {
                 get_named_compile_time_arg_val("down_proj_gather_sender_idx"),
             };
 
-            // down_proj Mcast (sender)
-            deepseek_b1_ops::Mcast::SenderArgs down_proj_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("down_proj_mcast_sender_semaphore_addr"),
-                get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("down_proj_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("down_proj_mcast_src_cb"),
-                get_named_compile_time_arg_val("down_proj_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("down_proj_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("down_proj_mcast_dst_cb")),
-            };
+            // down_proj Mcast (sender + receiver on BRISC)
+            deepseek_b1_ops::Mcast::DMArgs down_proj_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("down_proj_mcast_sender_semaphore_addr"),
+                        get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("down_proj_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("down_proj_mcast_src_cb"),
+                        get_named_compile_time_arg_val("down_proj_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("down_proj_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("down_proj_mcast_dst_cb")),
+                    },
+                .receiver = {
+                    get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("down_proj_mcast_dst_cb"),
+                    get_named_compile_time_arg_val("down_proj_mcast_dst_num_pages"),
+                }};
 
             // down_proj DRAM Matmul (writer — no-op for BRISC)
             using DownProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::WriterCTArgs;
@@ -501,19 +515,22 @@ void kernel_main() {
 
             // Residual Mcast — sender (input from sender → residual CB, pop_src=false)
             using ResidualMcastCTArgs = McastCTArgs;
-            deepseek_b1_ops::Mcast::SenderArgs residual_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("shared_residual_mcast_data_sender_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_residual_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("shared_residual_mcast_src_cb"),
-                get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("shared_residual_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("shared_residual_mcast_dst_cb")),
-            };
+            deepseek_b1_ops::Mcast::DMArgs residual_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("shared_residual_mcast_data_sender_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_residual_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("shared_residual_mcast_src_cb"),
+                        get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("shared_residual_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("shared_residual_mcast_dst_cb")),
+                    },
+                .receiver = {}};
 
             // RMSNorm (writer — no-op)
             using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
@@ -592,19 +609,22 @@ void kernel_main() {
 
             // Down Mcast — sender (reuse Routed::McastCTArgs: same grid, same persistent sender)
             using DownMcastCTArgs = Routed::McastCTArgs;
-            deepseek_b1_ops::Mcast::SenderArgs down_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("shared_down_mcast_data_sender_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_down_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("shared_down_mcast_src_cb"),
-                get_named_compile_time_arg_val("shared_down_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("shared_down_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("shared_down_mcast_dst_cb")),
-            };
+            deepseek_b1_ops::Mcast::DMArgs down_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("shared_down_mcast_data_sender_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_down_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("shared_down_mcast_src_cb"),
+                        get_named_compile_time_arg_val("shared_down_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("shared_down_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("shared_down_mcast_dst_cb")),
+                    },
+                .receiver = {}};
 
             // Down Proj Matmul — writer (no-op for BRISC)
             using DownMatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
@@ -631,21 +651,28 @@ void kernel_main() {
                 get_named_compile_time_arg_val("shared_residual_add_core_idx"),  // reuse matmul core index
             };
 
-            // Output Mcast — sender (sender core → 130 cores)
+            // Output Mcast — sender + receiver on BRISC (sender core → 130 cores)
             using OutputMcastCTArgs = Routed::McastCTArgs;
-            deepseek_b1_ops::Mcast::SenderArgs output_mcast_args{
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("shared_output_mcast_data_sender_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("shared_output_mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("shared_output_mcast_src_cb"),
-                get_named_compile_time_arg_val("shared_output_mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("shared_output_mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("add_cb_in1")),
-            };
+            deepseek_b1_ops::Mcast::DMArgs output_mcast_args{
+                .sender =
+                    {
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                        get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                        get_named_compile_time_arg_val("shared_output_mcast_data_sender_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
+                        get_named_compile_time_arg_val("shared_output_mcast_data_size_bytes"),
+                        get_named_compile_time_arg_val("shared_output_mcast_src_cb"),
+                        get_named_compile_time_arg_val("shared_output_mcast_src_num_pages"),
+                        get_read_ptr(get_named_compile_time_arg_val("shared_output_mcast_src_cb")),
+                        get_write_ptr(get_named_compile_time_arg_val("add_cb_in1")),
+                    },
+                .receiver = {
+                    get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
+                    get_named_compile_time_arg_val("add_cb_in1"),
+                    get_named_compile_time_arg_val("shared_output_mcast_dst_num_pages"),
+                }};
         } shared;
     } moe;
 
@@ -1051,15 +1078,7 @@ void kernel_main() {
             gate_mm(moe.routed.gate_mm_args);
         }
 
-        // 3. Gather: Collect matmul outputs from compute cores to sender core
-        {
-            DeviceZoneScopedN("GATHER");
-            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_mm_core, Core::is_sender_core, true> gather;
-            gather(moe.routed.gather_args);
-        }
-#endif  // ENABLE_ROUTING
-
-        // 3a. Shared Expert: Gate/Up KN-sliced matmul on 128 compute cores
+        // 3. Shared Expert: Gate/Up KN-sliced matmul on 128 compute cores
         //     CB 1 (act) is shared: on gate_proj cores it is also consumed by gate_proj (step 6)
         //     and up_proj (step 7, which pops it). So we only pop here on non-gate_proj cores.
         {
@@ -1073,7 +1092,27 @@ void kernel_main() {
             shared_gu_matmul(moe.shared.gu_matmul_args);
         }
 
+        // 3b. Shared Expert: Gate Gather (A) — 64 gate cores send to sender core
+        //     Uses MoeGather (sender=BRISC) to avoid NOC contention with DRAM matmul (NCRISC)
+        {
+            DeviceZoneScopedN("SHARED_GATE_GATHER");
+            deepseek_b1_ops::MoeGather::Op<
+                Core::Shared::is_gate_compute_core,
+                Core::Shared::is_gated_reduce_core,
+                true,  // pop_src
+                true>  // UsePerCoreSenderIdx
+                shared_gate_gather;
+            shared_gate_gather(moe.shared.ag_args);
+        }
+
 #ifdef ENABLE_ROUTING
+        // 3c. Gather: Collect matmul outputs from compute cores to sender core
+        {
+            DeviceZoneScopedN("GATHER");
+            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_mm_core, Core::is_sender_core, true> gather;
+            gather(moe.routed.gather_args);
+        }
+
         // 4. Gate: Top-K expert selection (on sender core only)
         {
             DeviceZoneScopedN("GATE");
@@ -1091,7 +1130,8 @@ void kernel_main() {
                 Core::is_sender_core,
                 Core::is_mcast_grid_core,
                 Core::Routed::is_gate_proj_core,
-                true>
+                true,
+                /*ReceiverOnBrisc=*/true>
                 index_mcast;
             index_mcast(moe.routed.index_mcast_args);
         }
@@ -1104,24 +1144,12 @@ void kernel_main() {
                 Core::is_sender_core,
                 Core::is_mcast_grid_core,
                 Core::Routed::is_gate_proj_core,
-                true>  // pop_src
+                true,
+                /*ReceiverOnBrisc=*/true>
                 expert_scale_mcast;
             expert_scale_mcast(moe.routed.expert_scale_mcast_args);
         }
 #endif  // ENABLE_ROUTING
-
-        // 5c. Shared Expert: Gate Gather (A) — 64 gate cores send to sender core
-        //     Uses MoeGather (sender=BRISC) to avoid NOC contention with DRAM matmul (NCRISC)
-        {
-            DeviceZoneScopedN("SHARED_GATE_GATHER");
-            deepseek_b1_ops::MoeGather::Op<
-                Core::Shared::is_gate_compute_core,
-                Core::Shared::is_gated_reduce_core,
-                true,  // pop_src
-                true>  // UsePerCoreSenderIdx
-                shared_gate_gather;
-            shared_gate_gather(moe.shared.ag_args);
-        }
 
         // 5d. Shared Expert: Up Gather (B) — 64 up cores send to sender core
         {
@@ -1159,7 +1187,7 @@ void kernel_main() {
             DeviceZoneScopedN("UP_PROJ");
             constexpr uint32_t cb_in1_addr = get_named_compile_time_arg_val("gate_proj_in1_buf_addr");
             deepseek_b1_ops::DRAMStreamingMatmul::
-                Op<Moe::Routed::UpProjCTArgs, Core::Routed::is_gate_proj_core, true, true, cb_in1_addr, false, true>
+                Op<Moe::Routed::UpProjCTArgs, Core::Routed::is_gate_proj_core, true, true, cb_in1_addr>
                     up_proj;
             up_proj();
         }
@@ -1171,43 +1199,7 @@ void kernel_main() {
             mul_op();
         }
 
-        // 9. down_proj Gather: Gather fused output from gate_proj cores to sender core
-        {
-            DeviceZoneScopedN("DOWN_PROJ_GATHER");
-            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_proj_core, Core::is_sender_core, true, true>
-                down_proj_gather;
-            down_proj_gather(moe.routed.down_proj_gather_args);
-        }
-
-        // 10. down_proj Mcast: Broadcast gathered fused output to gate_proj cores
-        {
-            DeviceZoneScopedN("DOWN_PROJ_MCAST");
-            deepseek_b1_ops::Mcast::Op<
-                Moe::Routed::McastCTArgs,
-                Core::is_sender_core,
-                Core::is_mcast_grid_core,
-                Core::Routed::is_gate_proj_core,
-                true>  // pop_src
-                down_proj_mcast;
-            down_proj_mcast(moe.routed.down_proj_mcast_args);
-        }
-
-        // 11. down_proj: DRAM Streaming Matmul (PopIndex=true: last consumer of expert index CB)
-        {
-            DeviceZoneScopedN("DOWN_PROJ");
-            constexpr uint32_t down_proj_cb_in1_addr = get_named_compile_time_arg_val("down_proj_in1_buf_addr");
-            deepseek_b1_ops::DRAMStreamingMatmul::Op<
-                Moe::Routed::DownProjCTArgs,
-                Core::Routed::is_gate_proj_core,
-                true,
-                true,
-                down_proj_cb_in1_addr,
-                true>
-                down_proj;
-            down_proj();
-        }
-
-        // 11b. Shared: Down Mcast — broadcast gated reduce output [1, K_down] to all 130 cores
+        // 9. Shared: Down Mcast — broadcast gated reduce output [1, K_down] to all 130 cores
         //      Source is mcast_src_cb (CB 31) filled by gated reduce, pop_src=true
         {
             DeviceZoneScopedN("SHARED_DOWN_MCAST");
@@ -1221,7 +1213,7 @@ void kernel_main() {
             shared_down_mcast(moe.shared.down_mcast_args);
         }
 
-        // 11c. Shared: Down Proj Matmul — SRAM matmul [1, K_down] x [K_down, N_per_core] on 112 cores
+        // 9b. Shared: Down Proj Matmul — SRAM matmul [1, K_down] x [K_down, N_per_core] on 112 cores
         {
             DeviceZoneScopedN("SHARED_DOWN_MATMUL");
             deepseek_b1_ops::Matmul::Op<
@@ -1233,7 +1225,7 @@ void kernel_main() {
             shared_down_matmul(moe.shared.down_matmul_args);
         }
 
-        // 11d. Shared: Residual Add — matmul_out + shard(residual) on 112 cores
+        // 9c. Shared: Residual Add — matmul_out + shard(residual) on 112 cores
         //      When multi-device reduce is enabled, only the ROOT1 device performs
         //      the actual add so the residual is counted exactly once after the
         //      cross-device sum.  Non-root devices pass matmul output through.
@@ -1252,7 +1244,7 @@ void kernel_main() {
             shared_residual_add(moe.shared.residual_add_args);
         }
 
-        // 11e. Shared: Output Gather — 112 matmul cores → sender core
+        // 9d. Shared: Output Gather — 112 matmul cores → sender core
         {
             DeviceZoneScopedN("SHARED_OUTPUT_GATHER");
             deepseek_b1_ops::MoeGather::Op<
@@ -1264,7 +1256,7 @@ void kernel_main() {
             shared_output_gather(moe.shared.og_args);
         }
 
-        // 11f. Shared: Output Mcast — sender core → 130 cores (DRAM cores receive into add_cb_in1)
+        // 9e. Shared: Output Mcast — sender core → 130 cores (DRAM cores receive into add_cb_in1)
         {
             DeviceZoneScopedN("SHARED_OUTPUT_MCAST");
             deepseek_b1_ops::Mcast::Op<
@@ -1272,12 +1264,50 @@ void kernel_main() {
                 Core::is_sender_core,             // IsSenderCore
                 Core::is_mcast_grid_core,         // IsMcastGridCore (all 130 cores for semaphore ack)
                 Core::Routed::is_gate_proj_core,  // IsReceiverCore (8 DRAM cores receive into add_cb_in1)
-                /*pop_src=*/true>
+                /*pop_src=*/true,
+                /*ReceiverOnBrisc=*/true>
                 shared_output_mcast;
             shared_output_mcast(moe.shared.output_mcast_args);
         }
 
-        // 12. Eltwise Add: down_proj + shared_expert_output
+        // 10. down_proj Gather: Gather fused output from gate_proj cores to sender core
+        {
+            DeviceZoneScopedN("DOWN_PROJ_GATHER");
+            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_proj_core, Core::is_sender_core, true, true>
+                down_proj_gather;
+            down_proj_gather(moe.routed.down_proj_gather_args);
+        }
+
+        // 11. down_proj Mcast: Broadcast gathered fused output to gate_proj cores
+        {
+            DeviceZoneScopedN("DOWN_PROJ_MCAST");
+            deepseek_b1_ops::Mcast::Op<
+                Moe::Routed::McastCTArgs,
+                Core::is_sender_core,
+                Core::is_mcast_grid_core,
+                Core::Routed::is_gate_proj_core,
+                true,
+                /*ReceiverOnBrisc=*/true>
+                down_proj_mcast;
+            down_proj_mcast(moe.routed.down_proj_mcast_args);
+        }
+
+        // 12. down_proj: DRAM Streaming Matmul (PopIndex=true: last consumer of expert index CB)
+        {
+            DeviceZoneScopedN("DOWN_PROJ");
+            constexpr uint32_t down_proj_cb_in1_addr = get_named_compile_time_arg_val("down_proj_in1_buf_addr");
+            deepseek_b1_ops::DRAMStreamingMatmul::Op<
+                Moe::Routed::DownProjCTArgs,
+                Core::Routed::is_gate_proj_core,
+                true,
+                true,
+                down_proj_cb_in1_addr,
+                true>
+                down_proj;
+            down_proj();
+        }
+
+        // 13. Eltwise Add: down_proj + shared_expert_output
         {
             DeviceZoneScopedN("ELTWISE_ADD");
             constexpr bool add_pop_output =

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -1547,14 +1547,7 @@ class MoeRoutedExpertOp:
             ("gate_input_cb", ctx.gate_params["input_cb"] if ctx.enable_routing else 0),
             ("gate_bias_cb", ctx.gate_params["bias_cb"] if ctx.enable_routing else 0),
             ("gate_input_indices_cb", ctx.gate_params["indices_cb"] if ctx.enable_routing else 0),
-            # Index mcast receiver (routing only)
-            ("index_mcast_receiver_semaphore_addr", ctx.index_mcast_receiver_semaphore_addr),
             ("gate_proj_cb_index", ctx.gate_proj_cb_index),
-            ("index_mcast_num_pages", ctx.index_mcast_num_pages),
-            # Expert scale mcast receiver (routing only)
-            ("expert_scale_mcast_receiver_semaphore_addr", ctx.expert_scale_mcast_receiver_semaphore_addr),
-            ("mul_cb_scalar_src", ctx.mul_cb_scalar_src),
-            ("expert_scale_mcast_num_pages", ctx.expert_scale_mcast_num_pages),
             # Mul reader (setup mul_in1 buffer)
             ("mul_cb_in1", ctx.mul_cb_in1),
             ("mul_num_tiles", ctx.mul_num_tiles),
@@ -1571,10 +1564,6 @@ class MoeRoutedExpertOp:
             ),
             ("down_proj_gather_dst_cb", ctx.down_proj_gather_params["dst_cb"]),
             ("down_proj_gather_dst_num_pages", ctx.down_proj_gather_params["dst_num_pages"]),
-            # down_proj mcast receiver
-            ("down_proj_mcast_receiver_semaphore_addr", ctx.down_proj_mcast_params["receiver_semaphore_addr"]),
-            ("down_proj_mcast_dst_cb", ctx.down_proj_mcast_params["dst_cb"]),
-            ("down_proj_mcast_dst_num_pages", ctx.down_proj_mcast_params["dst_num_pages"]),
             # Eltwise add
             ("add_cb_in0", ctx.add_cb_in0),
             ("add_cb_in1", ctx.add_cb_in1),
@@ -1716,6 +1705,8 @@ class MoeRoutedExpertOp:
             ("down_proj_mcast_src_cb", ctx.down_proj_mcast_params["src_cb"]),
             ("down_proj_mcast_dst_cb", ctx.down_proj_mcast_params["dst_cb"]),
             ("down_proj_mcast_src_num_pages", ctx.down_proj_mcast_params["src_num_pages"]),
+            # down_proj mcast receiver
+            ("down_proj_mcast_dst_num_pages", ctx.down_proj_mcast_params["dst_num_pages"]),
             # CB reset addresses for DRAM matmul working buffers
             ("gate_proj_in1_buf_addr", ctx.gate_proj_params["in1_buf_addr"]),
             ("down_proj_in1_buf_addr", ctx.down_proj_params["in1_buf_addr"]),
@@ -2622,9 +2613,6 @@ class MoeSharedExpertOp:
             ("shared_og_noc1_receiver_semaphore_addr", shared_ctx.output_gather_params["noc1_receiver_semaphore_addr"]),
             ("shared_og_dst_cb", shared_ctx.output_gather_params["dst_cb"]),
             ("shared_og_dst_num_pages", shared_ctx.output_gather_params["dst_num_pages"]),
-            # Output mcast receiver (DRAM cores receive into add_cb_in1) — separate semaphore
-            ("shared_output_mcast_data_receiver_semaphore_addr", shared_ctx.output_mcast_receiver_semaphore_addr),
-            ("shared_output_mcast_dst_num_pages", shared_ctx.output_mcast_params["dst_num_pages"]),
         ]
         brisc_args = [
             # Gate gather (A) sender (MoeGather: sender on BRISC)
@@ -2664,6 +2652,8 @@ class MoeSharedExpertOp:
             ("shared_output_mcast_data_size_bytes", shared_ctx.output_mcast_params["data_size_bytes"]),
             ("shared_output_mcast_src_cb", shared_ctx.output_gather_params["dst_cb"]),  # read from output gather dst
             ("shared_output_mcast_src_num_pages", shared_ctx.output_mcast_params["src_num_pages"]),
+            # Output mcast receiver
+            ("shared_output_mcast_dst_num_pages", shared_ctx.output_mcast_params["dst_num_pages"]),
         ]
         trisc_args = [
             # Gate/Up matmul

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
@@ -60,11 +60,13 @@ void kernel_main() {
     // Mcast (receiver)
     // ------------------------------------------------------------------------
     using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
-    };
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver = {
+            get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+            get_named_compile_time_arg_val("mcast_dst_cb"),
+            get_named_compile_time_arg_val("mcast_dst_num_pages"),
+        }};
 
     // ------------------------------------------------------------------------
     // Matmul (reader)
@@ -101,22 +103,14 @@ void kernel_main() {
     using GateCTArgs = deepseek_b1_ops::DeepseekMoeGate::ReaderCTArgs;
 
     // ------------------------------------------------------------------------
-    // Index Mcast (receiver) - receives expert indices
+    // Index Mcast (no-op on NCRISC — receiver on BRISC)
     // ------------------------------------------------------------------------
-    deepseek_b1_ops::Mcast::ReceiverArgs index_mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("index_mcast_receiver_semaphore")),
-        get_named_compile_time_arg_val("gate_proj_cb_index"),
-        get_named_compile_time_arg_val("index_mcast_num_pages"),
-    };
+    deepseek_b1_ops::Mcast::DMArgs index_mcast_args{.sender = {}, .receiver = {}};
 
     // ------------------------------------------------------------------------
-    // Expert Scale Mcast (receiver) - receives expert scale for scalar multiply
+    // Expert Scale Mcast (no-op on NCRISC — receiver on BRISC)
     // ------------------------------------------------------------------------
-    deepseek_b1_ops::Mcast::ReceiverArgs expert_scale_mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore")),
-        get_named_compile_time_arg_val("mul_cb_scalar_src"),
-        get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
-    };
+    deepseek_b1_ops::Mcast::DMArgs expert_scale_mcast_args{.sender = {}, .receiver = {}};
 
     // ------------------------------------------------------------------------
     // DRAM Streaming Matmul (reader - DRAM streaming uses NOC_0)
@@ -190,13 +184,9 @@ void kernel_main() {
     };
 
     // ------------------------------------------------------------------------
-    // down_proj_mcast (receiver) - receives broadcasted fused output
+    // down_proj_mcast (no-op on NCRISC — receiver moved to BRISC)
     // ------------------------------------------------------------------------
-    deepseek_b1_ops::Mcast::ReceiverArgs down_proj_mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore")),
-        get_named_compile_time_arg_val("down_proj_mcast_dst_cb"),
-        get_named_compile_time_arg_val("down_proj_mcast_dst_num_pages"),
-    };
+    deepseek_b1_ops::Mcast::DMArgs down_proj_mcast_args{.sender = {}, .receiver = {}};
 
     // ------------------------------------------------------------------------
     // down_proj DRAM Matmul (reader - DRAM streaming uses NOC_0)
@@ -294,19 +284,22 @@ void kernel_main() {
 
     constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
     constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        get_read_ptr(mcast_src_cb),
-        get_write_ptr(mcast_dst_cb),
-    };
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                get_read_ptr(mcast_src_cb),
+                get_write_ptr(mcast_dst_cb),
+            },
+        .receiver = {}};
 
     // ------------------------------------------------------------------------
     // Matmul (writer)
@@ -342,38 +335,52 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     constexpr uint32_t index_mcast_src_cb = get_named_compile_time_arg_val("gate_output_indices_cb");
     constexpr uint32_t index_mcast_dst_cb = get_named_compile_time_arg_val("gate_proj_cb_index");
-    deepseek_b1_ops::Mcast::SenderArgs index_mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("index_mcast_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("index_mcast_receiver_semaphore")),
-        get_named_compile_time_arg_val("index_mcast_data_size_bytes"),
-        index_mcast_src_cb,
-        get_named_compile_time_arg_val("index_mcast_num_pages"),
-        get_read_ptr(index_mcast_src_cb),
-        get_write_ptr(index_mcast_dst_cb),
-    };
+    deepseek_b1_ops::Mcast::DMArgs index_mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("index_mcast_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("index_mcast_receiver_semaphore")),
+                get_named_compile_time_arg_val("index_mcast_data_size_bytes"),
+                index_mcast_src_cb,
+                get_named_compile_time_arg_val("index_mcast_num_pages"),
+                get_read_ptr(index_mcast_src_cb),
+                get_write_ptr(index_mcast_dst_cb),
+            },
+        .receiver = {
+            get_semaphore(get_named_compile_time_arg_val("index_mcast_receiver_semaphore")),
+            get_named_compile_time_arg_val("gate_proj_cb_index"),
+            get_named_compile_time_arg_val("index_mcast_num_pages"),
+        }};
 
     // ------------------------------------------------------------------------
     // Expert Scale Mcast (sender) - broadcasts expert scale for scalar multiply
     // ------------------------------------------------------------------------
     constexpr uint32_t expert_scale_mcast_src_cb = get_named_compile_time_arg_val("gate_output_cb");
     constexpr uint32_t expert_scale_mcast_dst_cb = get_named_compile_time_arg_val("mul_cb_scalar_src");
-    deepseek_b1_ops::Mcast::SenderArgs expert_scale_mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("expert_scale_mcast_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore")),
-        get_named_compile_time_arg_val("expert_scale_mcast_data_size_bytes"),
-        expert_scale_mcast_src_cb,
-        get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
-        get_read_ptr(expert_scale_mcast_src_cb),
-        get_write_ptr(expert_scale_mcast_dst_cb),
-    };
+    deepseek_b1_ops::Mcast::DMArgs expert_scale_mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("expert_scale_mcast_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore")),
+                get_named_compile_time_arg_val("expert_scale_mcast_data_size_bytes"),
+                expert_scale_mcast_src_cb,
+                get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
+                get_read_ptr(expert_scale_mcast_src_cb),
+                get_write_ptr(expert_scale_mcast_dst_cb),
+            },
+        .receiver = {
+            get_semaphore(get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore")),
+            get_named_compile_time_arg_val("mul_cb_scalar_src"),
+            get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
+        }};
 
     // DRAM Streaming Matmul (no-op for BRISC, handled by NCRISC)
     using GateProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::WriterCTArgs;
@@ -410,19 +417,26 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     constexpr uint32_t down_proj_mcast_src_cb = get_named_compile_time_arg_val("down_proj_mcast_src_cb");
     constexpr uint32_t down_proj_mcast_dst_cb = get_named_compile_time_arg_val("down_proj_mcast_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs down_proj_mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("down_proj_mcast_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore")),
-        get_named_compile_time_arg_val("down_proj_mcast_data_size_bytes"),
-        down_proj_mcast_src_cb,
-        get_named_compile_time_arg_val("down_proj_mcast_src_num_pages"),
-        get_read_ptr(down_proj_mcast_src_cb),
-        get_write_ptr(down_proj_mcast_dst_cb),
-    };
+    deepseek_b1_ops::Mcast::DMArgs down_proj_mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("down_proj_mcast_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore")),
+                get_named_compile_time_arg_val("down_proj_mcast_data_size_bytes"),
+                down_proj_mcast_src_cb,
+                get_named_compile_time_arg_val("down_proj_mcast_src_num_pages"),
+                get_read_ptr(down_proj_mcast_src_cb),
+                get_write_ptr(down_proj_mcast_dst_cb),
+            },
+        .receiver = {
+            get_semaphore(get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore")),
+            get_named_compile_time_arg_val("down_proj_mcast_dst_cb"),
+            get_named_compile_time_arg_val("down_proj_mcast_dst_num_pages"),
+        }};
 
     // down_proj DRAM Matmul (no-op for BRISC, handled by NCRISC)
     using DownProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::WriterCTArgs;
@@ -674,7 +688,15 @@ void kernel_main() {
     // ========================================================================
     {
         DeviceZoneScopedN("MCAST_INDEX");
-        mcast(index_mcast_args);
+        deepseek_b1_ops::Mcast::Op<
+            McastCTArgs,
+            Core::is_sender_core,
+            Core::is_mcast_grid_core,
+            Core::is_gate_proj_core,
+            true,
+            /*ReceiverOnBrisc=*/true>
+            index_mcast;
+        index_mcast(index_mcast_args);
     }
 
     // ========================================================================
@@ -686,8 +708,9 @@ void kernel_main() {
             McastCTArgs,
             Core::is_sender_core,
             Core::is_mcast_grid_core,
-            Core::is_gate_proj_core,  // Only gate_proj cores receive expert scale
-            true>                     // pop_src
+            Core::is_gate_proj_core,
+            true,
+            /*ReceiverOnBrisc=*/true>
             expert_scale_mcast;
         expert_scale_mcast(expert_scale_mcast_args);
     }
@@ -709,8 +732,7 @@ void kernel_main() {
     // ========================================================================
     {
         DeviceZoneScopedN("UP_PROJ");
-        deepseek_b1_ops::DRAMStreamingMatmul::Op<UpProjCTArgs, Core::is_gate_proj_core, true, false, 0, false, true>
-            up_proj;
+        deepseek_b1_ops::DRAMStreamingMatmul::Op<UpProjCTArgs, Core::is_gate_proj_core, true, false> up_proj;
         up_proj();
     }
 
@@ -747,7 +769,8 @@ void kernel_main() {
             Core::is_sender_core,
             Core::is_mcast_grid_core,
             Core::is_gate_proj_core,  // Same receivers as input mcast for down_proj
-            true>                     // pop_src
+            true,
+            /*ReceiverOnBrisc=*/true>
             down_proj_mcast;
         down_proj_mcast(down_proj_mcast_args);
     }

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -1363,14 +1363,7 @@ class MoeRoutedExpert:
                 ("gate_input_cb", gate_params["input_cb"]),
                 ("gate_bias_cb", gate_params["bias_cb"]),
                 ("gate_input_indices_cb", gate_params["indices_cb"]),
-                # Index mcast receiver args (compute cores)
-                ("index_mcast_receiver_semaphore", index_mcast_receiver_semaphore_id),
                 ("gate_proj_cb_index", gate_proj_cb_index),
-                ("index_mcast_num_pages", index_mcast_num_pages),
-                # Expert scale mcast receiver args (compute cores)
-                ("expert_scale_mcast_receiver_semaphore", expert_scale_mcast_receiver_semaphore_id),
-                ("mul_cb_scalar_src", mul_cb_scalar_src),
-                ("expert_scale_mcast_num_pages", expert_scale_mcast_num_pages),
                 # Mul reader args (setup mul_in1 buffer)
                 ("mul_cb_in1", mul_cb_in1),
                 ("mul_num_tiles", mul_num_tiles),
@@ -1387,10 +1380,6 @@ class MoeRoutedExpert:
                 ("down_proj_gather_sender_grid_end_y", down_proj_gather_params["sender_grid_end_y"]),
                 ("down_proj_gather_row_major", down_proj_gather_params["row_major"]),
                 ("down_proj_gather_receiver_data_addr", down_proj_gather_params["receiver_data_addr"]),
-                # down_proj_mcast receiver args (compute cores)
-                ("down_proj_mcast_receiver_semaphore", down_proj_mcast_params["receiver_semaphore_id"]),
-                ("down_proj_mcast_dst_cb", down_proj_mcast_params["dst_cb"]),
-                ("down_proj_mcast_dst_num_pages", down_proj_mcast_params["dst_num_pages"]),
                 # Eltwise add args (CB indices and wait tiles for setup_sharded_buffer)
                 ("add_cb_in0", add_cb_in0),
                 ("add_cb_in1", add_cb_in1),
@@ -1501,6 +1490,8 @@ class MoeRoutedExpert:
                 ("down_proj_mcast_src_cb", down_proj_mcast_params["src_cb"]),
                 ("down_proj_mcast_dst_cb", down_proj_mcast_params["dst_cb"]),
                 ("down_proj_mcast_src_num_pages", down_proj_mcast_params["src_num_pages"]),
+                # down_proj_mcast receiver args
+                ("down_proj_mcast_dst_num_pages", down_proj_mcast_params["dst_num_pages"]),
                 # ReduceToOne writer args
                 ("reduce_local_cb", reduce_local_cb),
                 ("reduce_scratch_cb", reduce_scratch_cb),

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -120,10 +120,14 @@ void kernel_main() {
 
     // Mcast3 receiver args
     using Mcast3CTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast3_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast3_dst_cb"),
-        get_named_compile_time_arg_val("mcast3_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast3_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast3_dst_cb"),
+                get_named_compile_time_arg_val("mcast3_dst_num_pages"),
+            },
     };
 
     // Matmul5 CTArgs
@@ -212,18 +216,22 @@ void kernel_main() {
 
     constexpr uint32_t mcast3_src_cb = get_named_compile_time_arg_val("mcast3_src_cb");
     constexpr uint32_t mcast3_dst_cb = get_named_compile_time_arg_val("mcast3_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast3_args{
-        get_named_compile_time_arg_val("mcast3_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast3_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast3_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast3_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast3_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast3_data_size_bytes"),
-        mcast3_src_cb,
-        get_named_compile_time_arg_val("mcast3_src_num_pages"),
-        get_read_ptr(mcast3_src_cb),
-        get_write_ptr(mcast3_dst_cb),  // CB 4 address (now allocated on gather core too)
+    deepseek_b1_ops::Mcast::DMArgs mcast3_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast3_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast3_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast3_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast3_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast3_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast3_data_size_bytes"),
+                mcast3_src_cb,
+                get_named_compile_time_arg_val("mcast3_src_num_pages"),
+                get_read_ptr(mcast3_src_cb),
+                get_write_ptr(mcast3_dst_cb),  // CB 4 address (now allocated on gather core too)
+            },
+        .receiver = {},
     };
 
     // Gather3 receiver args

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -123,10 +123,14 @@ if constexpr (!Core::skip_ccl) {
     deepseek_b1_ops::RMSNorm::ReaderArgs rmsnorm_args{};
 
     // Mcast receiver args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_dst_cb"),
+                get_named_compile_time_arg_val("mcast_dst_num_pages"),
+            },
     };
 
     // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
@@ -162,10 +166,14 @@ if constexpr (!Core::skip_ccl) {
 
     // Mcast2 receiver args (for matmul2 cores to receive matmul2 input from input core)
     // Uses same semaphore as first mcast
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("matmul2_in0"),
-        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("matmul2_in0"),
+                get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+            },
     };
 
     // Matmul3 reader args (NCRISC is no-op)
@@ -426,18 +434,22 @@ if constexpr (!Core::skip_ccl) {
     constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
 
     // Mcast sender args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        get_read_ptr(mcast_src_cb),
-        get_write_ptr(mcast_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                get_read_ptr(mcast_src_cb),
+                get_write_ptr(mcast_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Matmul CTArgs type alias (BRISC uses WriterCTArgs)
@@ -477,18 +489,22 @@ if constexpr (!Core::skip_ccl) {
     // Uses same grid and semaphores as first mcast
     // Reads from rmsnorm2_output_cb, writes to matmul2_in0 with loopback
     constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("rmsnorm2_output_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
-        mcast2_src_cb,  // Wait for rmsnorm2_output_cb
-        get_named_compile_time_arg_val("mcast2_src_num_pages"),
-        get_read_ptr(mcast2_src_cb),  // Read from rmsnorm2_output_cb
-        get_write_ptr(matmul2_in0),   // Write to matmul2_in0 (loopback)
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+                mcast2_src_cb,  // Wait for rmsnorm2_output_cb
+                get_named_compile_time_arg_val("mcast2_src_num_pages"),
+                get_read_ptr(mcast2_src_cb),  // Read from rmsnorm2_output_cb
+                get_write_ptr(matmul2_in0),   // Write to matmul2_in0 (loopback)
+            },
+        .receiver = {},
     };
 
     // Matmul writer args (BRISC is no-op)

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
@@ -78,10 +78,14 @@ void kernel_main() {
 #if defined(COMPILE_FOR_NCRISC)
     // Activation mcast receiver args
     using ActMcastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs act_mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("act_mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("act_mcast_dst_cb"),
-        get_named_compile_time_arg_val("act_mcast_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs act_mcast_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("act_mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("act_mcast_dst_cb"),
+                get_named_compile_time_arg_val("act_mcast_dst_num_pages"),
+            },
     };
 
     // Gated reduce reader args (NCRISC no-op)
@@ -132,17 +136,25 @@ void kernel_main() {
 
     // Mcast1 receiver args (down proj activation)
     using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_dst_cb"),
+                get_named_compile_time_arg_val("mcast_dst_num_pages"),
+            },
     };
 
     // Mcast2 receiver args (residual, shares init/teardown with mcast1)
-    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast2_dst_cb"),
-        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast2_dst_cb"),
+                get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+            },
     };
 
     // Gate/Up sliced matmul reader args (NCRISC no-op)
@@ -186,18 +198,22 @@ void kernel_main() {
 
     constexpr uint32_t act_mcast_src_cb = get_named_compile_time_arg_val("act_mcast_src_cb");
     constexpr uint32_t act_mcast_dst_cb = get_named_compile_time_arg_val("act_mcast_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs act_mcast_args{
-        get_named_compile_time_arg_val("act_mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("act_mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("act_mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("act_mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("act_mcast_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("act_mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("act_mcast_data_size_bytes"),
-        act_mcast_src_cb,
-        get_named_compile_time_arg_val("act_mcast_src_num_pages"),
-        get_read_ptr(act_mcast_src_cb),
-        get_write_ptr(act_mcast_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs act_mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("act_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("act_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("act_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("act_mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("act_mcast_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("act_mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("act_mcast_data_size_bytes"),
+                act_mcast_src_cb,
+                get_named_compile_time_arg_val("act_mcast_src_num_pages"),
+                get_read_ptr(act_mcast_src_cb),
+                get_write_ptr(act_mcast_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Gated reduce writer args (BRISC no-op)
@@ -240,35 +256,43 @@ void kernel_main() {
 
     constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
     constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        get_read_ptr(mcast_src_cb),
-        get_write_ptr(mcast_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                get_read_ptr(mcast_src_cb),
+                get_write_ptr(mcast_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Mcast2 sender args (residual, shares init/teardown with mcast1)
     constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
     constexpr uint32_t mcast2_dst_cb = get_named_compile_time_arg_val("mcast2_dst_cb");
-    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
-        mcast2_src_cb,
-        get_named_compile_time_arg_val("mcast2_src_num_pages"),
-        get_read_ptr(mcast2_src_cb),
-        get_write_ptr(mcast2_dst_cb),
+    deepseek_b1_ops::Mcast::DMArgs mcast2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast2_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+                mcast2_src_cb,
+                get_named_compile_time_arg_val("mcast2_src_num_pages"),
+                get_read_ptr(mcast2_src_cb),
+                get_write_ptr(mcast2_dst_cb),
+            },
+        .receiver = {},
     };
 
     // Gate/Up sliced matmul writer args (BRISC no-op)

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -420,10 +420,10 @@ inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
 
     // Move and reverse the other column of 8 values
     // Disable index tracking while we shift values
-    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     // There is a hardware bug that affects operations on LREG4-7 while this is enabled
     TTI_SFPCONFIG(0, 0xF, 1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -420,10 +420,10 @@ inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
 
     // Move and reverse the other column of 8 values
     // Disable index tracking while we shift values
-    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
-    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     // There is a hardware bug that affects operations on LREG4-7 while this is enabled
     TTI_SFPCONFIG(0, 0xF, 1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
 

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_kernel.cpp
@@ -39,7 +39,8 @@ void kernel_main() {
 #elif defined(COMPILE_FOR_BRISC)
     using MoeGateCTArgs = deepseek_b1_ops::DeepseekMoeGate::WriterCTArgs<
         get_named_compile_time_arg_val("moe_gate_output_cb"),
-        get_named_compile_time_arg_val("moe_gate_output_indices_cb")>;
+        get_named_compile_time_arg_val("moe_gate_output_indices_cb"),
+        true>;
 
 #elif defined(COMPILE_FOR_TRISC)
     using MoeGateCTArgs = deepseek_b1_ops::DeepseekMoeGate::ComputeCTArgs<

--- a/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
@@ -38,10 +38,14 @@ void kernel_main() {
     }
 
     // Mcast receiver args (from compile-time args, passed to op as runtime args)
-    Mcast::ReceiverArgs mcast_args{
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_dst_cb"),
-        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    Mcast::DMArgs mcast_args{
+        .sender = {},
+        .receiver =
+            {
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_dst_cb"),
+                get_named_compile_time_arg_val("mcast_dst_num_pages"),
+            },
     };
 
 // ============================================================================
@@ -61,18 +65,22 @@ void kernel_main() {
     uint32_t mcast_receiver_data_addr = get_common_arg_val<uint32_t>(0);
 
     // Mcast sender args (from compile-time args, passed to op as runtime args)
-    Mcast::SenderArgs mcast_args{
-        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
-        get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
-        get_named_compile_time_arg_val("mcast_data_size_bytes"),
-        mcast_src_cb,
-        get_named_compile_time_arg_val("mcast_src_num_pages"),
-        get_read_ptr(mcast_src_cb),
-        mcast_receiver_data_addr,
+    Mcast::DMArgs mcast_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_sender_semaphore")),
+                get_semaphore(get_named_compile_time_arg_val("mcast_data_receiver_semaphore")),
+                get_named_compile_time_arg_val("mcast_data_size_bytes"),
+                mcast_src_cb,
+                get_named_compile_time_arg_val("mcast_src_num_pages"),
+                get_read_ptr(mcast_src_cb),
+                mcast_receiver_data_addr,
+            },
+        .receiver = {},
     };
 
 // ============================================================================

--- a/models/demos/deepseek_v3_b1/unified_kernels/deepseek_moe_gate.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/deepseek_moe_gate.hpp
@@ -47,10 +47,11 @@ struct DeepseekMoeGate {
     struct ReaderCTArgs {};
 
     // Writer CTArgs (BRISC)
-    template <uint32_t output_cb_, uint32_t output_indices_cb_>
+    template <uint32_t output_cb_, uint32_t output_indices_cb_, bool wait_for_output_ = false>
     struct WriterCTArgs {
         static constexpr uint32_t output_cb = output_cb_;
         static constexpr uint32_t output_indices_cb = output_indices_cb_;
+        static constexpr bool wait_for_output = wait_for_output_;
     };
 
     // Compute CTArgs (TRISC)
@@ -98,8 +99,10 @@ struct DeepseekMoeGate {
             // ================================================================
             // BRISC: Wait for compute to finish
             // ================================================================
-            cb_wait_front(CTArgs::output_indices_cb, 1);
-            cb_wait_front(CTArgs::output_cb, 1);
+            if constexpr (CTArgs::wait_for_output) {
+                cb_wait_front(CTArgs::output_indices_cb, 1);
+                cb_wait_front(CTArgs::output_cb, 1);
+            }
 
 #elif defined(COMPILE_FOR_TRISC)
             // ================================================================

--- a/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
@@ -188,19 +188,21 @@ FORCE_INLINE void teardown_persistent_mcast_sender(uint32_t data_sender_semaphor
     riscv_wait(10000);  // This is just to guarantee safety due to posted mcast hw bug
 }
 
-#endif  // defined(COMPILE_FOR_BRISC)
+#endif  // defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC)
 
 // ============================================================================
 // Mcast micro-op
 //
 // Multicasts data from a single sender core to multiple receiver cores.
-// Sender runs on BRISC, Receiver runs on NCRISC.
+// Default: Sender on BRISC, Receiver on NCRISC.
+// ReceiverOnBrisc mode: Both sender and receiver on BRISC, NCRISC is no-op.
+//   Use when NCRISC is needed for other work (e.g. down_proj_mcast).
 //
 // CB States:
-//   BRISC (Sender):
+//   Sender (BRISC):
 //     - Waits: src_cb (src_num_pages)
 //     - Pops: src_cb (src_num_pages) if pop_src=true
-//   NCRISC (Receiver):
+//   Receiver (NCRISC, or BRISC when ReceiverOnBrisc=true):
 //     - Reserves: dst_cb (dst_num_pages)
 //     - Pushes: dst_cb (dst_num_pages)
 //   TRISC: No-op
@@ -209,15 +211,14 @@ FORCE_INLINE void teardown_persistent_mcast_sender(uint32_t data_sender_semaphor
 //   Sender: Assumes sender_semaphore contains VALID (set during init)
 //   Receiver: Waits for receiver_semaphore == VALID, then resets to INVALID
 //
-// Note: Sender assumes that receiver's dst_cb is ready to receive at the beginning of NCRISC execution.
+// Note: Sender assumes that receiver's dst_cb is ready to receive at the beginning of execution.
 // ============================================================================
 struct Mcast {
     // ========================================================================
-    // Compile-time args structs - different per RISC
-    // Only what MUST be compile-time (used as template parameters)
+    // Compile-time args structs
     // ========================================================================
 
-    // Sender CTArgs (BRISC): mcast_num_cores, is_part_of_receiver_grid
+    // Sender CTArgs: mcast_num_cores, is_part_of_receiver_grid
     // If sender is part of receiver grid, it needs loopback to receive its own mcast
     template <uint32_t McastNumCores, bool IsPartOfReceiverGrid, bool Loopback>
     struct SenderCTArgs {
@@ -226,17 +227,13 @@ struct Mcast {
         static constexpr bool loopback = Loopback;
     };
 
-    // Receiver CTArgs (NCRISC): none needed
     struct ReceiverCTArgs {};
-
-    // Compute CTArgs (TRISC): none needed
     struct ComputeCTArgs {};
 
     // ========================================================================
-    // Runtime args structs - different layout per RISC
+    // Runtime args structs
     // ========================================================================
 
-    // Sender args (BRISC): all runtime parameters
     struct SenderArgs {
         uint32_t dest_noc_start_x;
         uint32_t dest_noc_start_y;
@@ -251,66 +248,72 @@ struct Mcast {
         uint32_t mcast_receiver_data_addr;
     };
 
-    // Receiver args (NCRISC): all runtime parameters
     struct ReceiverArgs {
         uint32_t data_receiver_semaphore_addr;
         uint32_t dst_cb;
         uint32_t dst_num_pages;
     };
 
-    // Compute args (TRISC) - not used for mcast (dataflow only)
+    // Unified dataflow args: both BRISC and NCRISC get the full set so the
+    // sender/receiver impl can be placed on either RISC without restructuring.
+    struct DMArgs {
+        SenderArgs sender;
+        ReceiverArgs receiver;
+    };
+
     struct ComputeArgs {};
 
-    // Note: For mcast, BRISC=Sender, NCRISC=Receiver
-    using RTArgs = unified_kernels::SelectByRISCV<ReceiverArgs, SenderArgs, ComputeArgs>;
+    using RTArgs = unified_kernels::SelectByRISCV<DMArgs, DMArgs, ComputeArgs>;
 
     // ========================================================================
     // Op - the actual operation
     //
     // CTArgsT: compile-time args (mcast_num_cores, loopback, is_part_of_receiver_grid)
     // IsSenderCore: compile-time flag to distinguish sender vs receiver cores
+    // IsMcastGridCore: compile-time flag for cores in the mcast destination grid
     // IsReceiverCore: compile-time flag for receiver cores
     // pop_src: whether to pop the source CB after sending
+    // ReceiverOnBrisc: when true, receiver logic runs on BRISC instead of NCRISC.
+    //   BRISC does send-then-receive; NCRISC is no-op.
     //
     // Usage:
     //   Op op;
     //   op.init(args);      // Initialize persistent mcast sender (call once)
     //   op(args);           // Send data (can be called multiple times)
     //   op.teardown(args);  // Teardown persistent mcast sender (call once)
-    //
-    // Or use the legacy all-in-one call:
-    //   op.init_send_teardown(args);  // Does init + send + teardown
     // ========================================================================
-    template <typename CTArgsT, bool IsSenderCore, bool IsMcastGridCore, bool IsReceiverCore, bool pop_src>
+    template <
+        typename CTArgsT,
+        bool IsSenderCore,
+        bool IsMcastGridCore,
+        bool IsReceiverCore,
+        bool pop_src,
+        bool ReceiverOnBrisc = false>
     class Op {
     public:
         // ====================================================================
         // init - Initialize persistent mcast sender (BRISC only)
-        // Must be called before operator() on sender core
-        // No-op for NCRISC/TRISC
         // ====================================================================
         template <bool init_noc = true>
         void init([[maybe_unused]] const RTArgs& args) {
 #if defined(COMPILE_FOR_BRISC)
             if constexpr (IsSenderCore) {
-                // Compute multicast NOC address and store for later use
                 uint64_t mcast_flag_noc_addr = get_noc_multicast_addr<noc_index>(
-                    args.dest_noc_start_x,
-                    args.dest_noc_start_y,
-                    args.dest_noc_end_x,
-                    args.dest_noc_end_y,
-                    (uint64_t)(args.data_receiver_semaphore_addr));
+                    args.sender.dest_noc_start_x,
+                    args.sender.dest_noc_start_y,
+                    args.sender.dest_noc_end_x,
+                    args.sender.dest_noc_end_y,
+                    (uint64_t)(args.sender.data_receiver_semaphore_addr));
                 volatile tt_l1_ptr uint32_t* data_sender_semaphore_addr_ptr =
-                    (volatile tt_l1_ptr uint32_t*)args.data_sender_semaphore_addr;
+                    (volatile tt_l1_ptr uint32_t*)args.sender.data_sender_semaphore_addr;
                 if constexpr (init_noc) {
                     noc_semaphore_set(data_sender_semaphore_addr_ptr, INVALID);
-                    // Initialize persistent mcast sender
                     init_persistent_mcast_sender<
                         CTArgsT::mcast_num_cores,
                         CTArgsT::loopback,
                         CTArgsT::is_part_of_receiver_grid,
                         linked,
-                        posted>(mcast_flag_noc_addr, args.data_sender_semaphore_addr);
+                        posted>(mcast_flag_noc_addr, args.sender.data_sender_semaphore_addr);
                     noc_async_posted_writes_flushed();
                 }
                 noc_semaphore_set(data_sender_semaphore_addr_ptr, VALID);
@@ -319,82 +322,89 @@ struct Mcast {
         }
 
         // ====================================================================
-        // operator() - Send data via mcast (BRISC sender) / Full receive logic (NCRISC receiver)
-        // For BRISC: Must call init() first, waits for src CB, sends data
-        // For NCRISC: Reserve CB, wait for semaphore, push CB (complete receive)
+        // operator() - Send data (BRISC sender) and/or receive data (receiver)
         // ====================================================================
         void operator()(const RTArgs& args) { impl(args); }
 
         // ====================================================================
         // teardown - Teardown persistent mcast sender (BRISC only)
-        // Must be called after all operator() calls on sender core
-        // No-op for NCRISC/TRISC
         // ====================================================================
         void teardown([[maybe_unused]] const RTArgs& args) {
 #if defined(COMPILE_FOR_BRISC)
             if constexpr (IsSenderCore) {
-                // Teardown persistent mcast sender
                 teardown_persistent_mcast_sender<
                     CTArgsT::mcast_num_cores,
                     CTArgsT::loopback,
-                    CTArgsT::is_part_of_receiver_grid>(args.data_sender_semaphore_addr);
+                    CTArgsT::is_part_of_receiver_grid>(args.sender.data_sender_semaphore_addr);
             }
 #endif
         }
 
     private:
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+        static void sender_impl(const SenderArgs& s) {
+            cb_wait_front(s.src_cb, s.src_num_pages);
+
+            mcast_send_with_state<
+                CTArgsT::mcast_num_cores,
+                CTArgsT::loopback,
+                CTArgsT::is_part_of_receiver_grid,
+                linked,
+                posted,
+                true,
+                true,
+                write_cmd_buf>(s.input_data_addr, s.mcast_receiver_data_addr, s.data_size_bytes);
+            mcast_send_with_state<
+                CTArgsT::mcast_num_cores,
+                CTArgsT::loopback,
+                CTArgsT::is_part_of_receiver_grid,
+                linked,
+                posted,
+                true,
+                mcast_is_shared_write_cmd_buf,
+                write_reg_cmd_buf>(s.data_sender_semaphore_addr, s.data_receiver_semaphore_addr, 4);
+
+            noc_async_posted_writes_flushed();
+
+            if constexpr (pop_src) {
+                cb_pop_front(s.src_cb, s.src_num_pages);
+            }
+        }
+
+        static void receiver_impl(const ReceiverArgs& r) {
+            volatile tt_l1_ptr uint32_t* data_receiver_semaphore_addr_ptr =
+                (volatile tt_l1_ptr uint32_t*)(r.data_receiver_semaphore_addr);
+            cb_reserve_back(r.dst_cb, r.dst_num_pages);
+            noc_semaphore_wait(data_receiver_semaphore_addr_ptr, VALID);
+            noc_semaphore_set(data_receiver_semaphore_addr_ptr, INVALID);
+            cb_push_back(r.dst_cb, r.dst_num_pages);
+        }
+
+        static void mcast_grid_impl(const ReceiverArgs& r) {
+            volatile tt_l1_ptr uint32_t* data_receiver_semaphore_addr_ptr =
+                (volatile tt_l1_ptr uint32_t*)(r.data_receiver_semaphore_addr);
+            noc_semaphore_wait(data_receiver_semaphore_addr_ptr, VALID);
+            noc_semaphore_set(data_receiver_semaphore_addr_ptr, INVALID);
+        }
+#endif
+
         void impl([[maybe_unused]] const RTArgs& args) {
 #if defined(COMPILE_FOR_BRISC)
+            // BRISC: Sender always, Receiver when ReceiverOnBrisc=true
             if constexpr (IsSenderCore) {
-                // Wait for source CB data to be ready
-                cb_wait_front(args.src_cb, args.src_num_pages);
-
-                // Send data with state
-                mcast_send_with_state<
-                    CTArgsT::mcast_num_cores,
-                    CTArgsT::loopback,
-                    CTArgsT::is_part_of_receiver_grid,
-                    linked,
-                    posted,
-                    true,
-                    true,
-                    write_cmd_buf>(args.input_data_addr, args.mcast_receiver_data_addr, args.data_size_bytes);
-                mcast_send_with_state<
-                    CTArgsT::mcast_num_cores,
-                    CTArgsT::loopback,
-                    CTArgsT::is_part_of_receiver_grid,
-                    linked,
-                    posted,
-                    true,
-                    mcast_is_shared_write_cmd_buf,
-                    write_reg_cmd_buf>(args.data_sender_semaphore_addr, args.data_receiver_semaphore_addr, 4);
-
-                noc_async_posted_writes_flushed();
-
-                // Pop the source CB after sending
-                if constexpr (pop_src) {
-                    cb_pop_front(args.src_cb, args.src_num_pages);
-                }
+                sender_impl(args.sender);
+            }
+            if constexpr (ReceiverOnBrisc && IsReceiverCore) {
+                receiver_impl(args.receiver);
+            } else if constexpr (ReceiverOnBrisc && IsMcastGridCore) {
+                mcast_grid_impl(args.receiver);
             }
 #elif defined(COMPILE_FOR_NCRISC)
-            // ================================================================
-            // NCRISC - Receiver cores: reserve, wait, push (all in operator)
-            // ================================================================
-            if constexpr (IsReceiverCore) {
-                volatile tt_l1_ptr uint32_t* data_receiver_semaphore_addr_ptr =
-                    (volatile tt_l1_ptr uint32_t*)(args.data_receiver_semaphore_addr);
-                // Reserve space in destination CB before mcast writes to it
-                cb_reserve_back(args.dst_cb, args.dst_num_pages);
-                noc_semaphore_wait(data_receiver_semaphore_addr_ptr, VALID);
-                noc_semaphore_set(data_receiver_semaphore_addr_ptr, INVALID);
-
-                // Push to destination CB after data arrived
-                cb_push_back(args.dst_cb, args.dst_num_pages);
-            } else if constexpr (IsMcastGridCore) {
-                volatile tt_l1_ptr uint32_t* data_receiver_semaphore_addr_ptr =
-                    (volatile tt_l1_ptr uint32_t*)(args.data_receiver_semaphore_addr);
-                noc_semaphore_wait(data_receiver_semaphore_addr_ptr, VALID);
-                noc_semaphore_set(data_receiver_semaphore_addr_ptr, INVALID);
+            // NCRISC: Receiver when ReceiverOnBrisc=false, no-op otherwise
+            if constexpr (!ReceiverOnBrisc && IsReceiverCore) {
+                receiver_impl(args.receiver);
+            } else if constexpr (!ReceiverOnBrisc && IsMcastGridCore) {
+                mcast_grid_impl(args.receiver);
             }
 #endif
         }


### PR DESCRIPTION
### Summary
Down proj weight reading was getting serialized waiting for down proj activations, as both the mcast wait and weight reading were on ncrisc.

- Added support for mcast wait to be on brisc
- Removed up proj ncrisc wait for output
- Moved expert index, expert scale, shared output, and down proj mcast to receive on brisc
- Reordered some shared expert ops so that it's not unnecessarily stalled by routed expert ops

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/shuffle) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/shuffle)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/shuffle) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/shuffle) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/shuffle) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/shuffle)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/shuffle) | [#17469](https://github.com/tenstorrent/tt-metal/actions/runs/24403713905) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/shuffle) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/shuffle)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/shuffle) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/shuffle) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/shuffle) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/shuffle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/shuffle) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/shuffle) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/shuffle) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/shuffle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/shuffle) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/shuffle) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/shuffle) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/shuffle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/shuffle) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/shuffle) |