### PR TITLE
Defer SDPA accumulator writes to reduce critical-path DRAM stalls

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -538,6 +538,31 @@ void kernel_main() {
                     stats_tile_bytes);
             };
 
+            // Flush deferred save — drains cb_out/cb_max_out/cb_sum_out to DRAM.
+            auto flush_deferred = [&]() {
+                constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
+                save_accumulators_with_trid(
+                    deferred_qi.is_joint_q ? joint_out_generator : out_generator,
+                    stats_writer,
+                    stats_tile_logical,
+                    deferred_nb,
+                    deferred_nq,
+                    Sq_chunk_t,
+                    deferred_qi.out_slice,
+                    all_tiles_valid,
+                    deferred_qi.stats_seq_start_tile,
+                    deferred_qi.stats_seq_end_tile,
+                    sum_offset,
+                    cb_out,
+                    cb_max_out,
+                    cb_sum_out,
+                    tile_bytes,
+                    stats_tile_bytes,
+                    out_subblock_h,
+                    deferred_trid);
+                deferred_pending = false;
+            };
+
             for (uint32_t q_index = 0; q_index + global_q_start < global_q_end; ++q_index) {
                 uint32_t global_q_chunk = remap_q_index(global_q_start + q_index, num_q_chunks, use_zigzag_balancing);
 
@@ -554,32 +579,7 @@ void kernel_main() {
                     complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
                 }
 
-                // Flush deferred save helper — drains cb_out/cb_max_out/cb_sum_out to DRAM.
-                auto flush_deferred = [&]() {
-                    constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
-                    save_accumulators_with_trid(
-                        deferred_qi.is_joint_q ? joint_out_generator : out_generator,
-                        stats_writer,
-                        stats_tile_logical,
-                        deferred_nb,
-                        deferred_nq,
-                        Sq_chunk_t,
-                        deferred_qi.out_slice,
-                        all_tiles_valid,
-                        deferred_qi.stats_seq_start_tile,
-                        deferred_qi.stats_seq_end_tile,
-                        sum_offset,
-                        cb_out,
-                        cb_max_out,
-                        cb_sum_out,
-                        tile_bytes,
-                        stats_tile_bytes,
-                        out_subblock_h,
-                        deferred_trid);
-                    deferred_pending = false;
-                };
-
-                // Early flush (flush_before_prefetch): drain staging CBs before prefetch.
+                // 2. Early flush (flush_before_prefetch): drain staging CBs before prefetch.
                 // - total_valid_kv <= 1: compute's sole K chunk triggers save_to_staging on
                 //   K0, reserving staging CBs immediately — deadlock if they're still full.
                 // - q_per_core == 2: next Q == last Q whose deferred data isn't in DRAM yet,
@@ -592,7 +592,7 @@ void kernel_main() {
                     flush_deferred();
                 }
 
-                // 3. Prefetch next Q chunk for the upcoming ring iteration.
+                // 3. Prefetch next Q chunk's accumulators from DRAM.
                 // Intra-ring: issue reads for Q[q+1] during Q[q]'s K-loop.
                 // Only barrier when next Q's TRID hasn't been cleared yet this ring iter:
                 //   Q[0]: wB(TRID_INNER) — clears all prev-ring inner saves
@@ -608,14 +608,13 @@ void kernel_main() {
                         prefetch_q(global_q_chunk + 1);
                     }
                 }
-
-                // Cross-ring prefetch: Q[N-1] → Q[0] of next ring iter.
+                // Cross-ring: Q[N-1] → Q[0] of next ring iter.
                 if (!single_q_chunk && !is_last_ring_iter && (global_q_chunk + 1 >= global_q_end)) {
                     noc_async_write_barrier_with_trid(TRID_FIRST);
                     prefetch_q(global_q_start);
                 }
 
-                // Late flush (>= 2 valid K chunks, q_per_core >= 3): flush during K-loop
+                // 4. Late flush (>= 2 valid K chunks, q_per_core >= 3): flush during K-loop
                 // window after prefetch, spreading DRAM writes to reduce bank contention.
                 if (deferred_pending) {
                     flush_deferred();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -418,10 +418,13 @@ void kernel_main() {
 
     // Deferred save: stash params for save_accumulators_with_trid and call it
     // during the next Q chunk's K-loop window to avoid DRAM bank contention.
-    bool deferred_pending = false;
-    uint32_t deferred_trid;
-    uint32_t deferred_nb, deferred_nq;
-    QChunkInfo deferred_qi;
+    struct DeferredWriteContext {
+        bool pending = false;
+        uint32_t trid = 0;
+        uint32_t nb = 0;
+        uint32_t nq = 0;
+        QChunkInfo qi = {};
+    } deferred = {};
 
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
@@ -438,19 +441,11 @@ void kernel_main() {
             continue;
         }
 
-        // Count valid (non-skipped) K chunks for this ring iteration — same skip logic as
-        // compute (skip local K chunks whose global start tile >= logical_nt).
         // When total_valid_kv == 1, compute's sole K chunk triggers save_to_staging on K0,
         // reserving staging CBs immediately. The deferred flush must happen before any
         // prefetch that blocks on cb_prev_out, or the writer and compute deadlock.
-        uint32_t total_valid_kv = 0;
-        for (uint32_t k = 0; k < num_kv_chunks; ++k) {
-            const bool is_joint = k >= num_local_k_chunks;
-            if (!is_joint && (ring_iter_kv_start_tile + k * Sk_chunk_t >= logical_nt)) {
-                continue;
-            }
-            total_valid_kv++;
-        }
+        const uint32_t total_valid_kv =
+            count_valid_kv_chunks(num_kv_chunks, num_local_k_chunks, ring_iter_kv_start_tile, Sk_chunk_t, logical_nt);
         const bool single_valid_kv_chunk = (total_valid_kv <= 1);
 
         /**
@@ -503,66 +498,6 @@ void kernel_main() {
             const uint32_t last_q_index = q_per_core - 1;
             const bool flush_before_prefetch = single_valid_kv_chunk || q_per_core == 2;
 
-            auto q_trid = [last_q_index](uint32_t q_idx) -> uint32_t {
-                if (q_idx == 0) {
-                    return TRID_FIRST;
-                }
-                if (q_idx == last_q_index) {
-                    return TRID_LAST;
-                }
-                return TRID_INNER;
-            };
-
-            // Issue restore reads for a Q chunk by its global index.
-            auto prefetch_q = [&](uint32_t gq) {
-                const uint32_t nb_pf = gq / (NH * num_q_chunks);
-                const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
-                const uint32_t qc_pf = gq % num_q_chunks;
-                const auto qi_pf =
-                    get_q_chunk_info(qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                issue_restore_reads(
-                    qi_pf.is_joint_q ? joint_out_generator : out_generator,
-                    stats_writer,
-                    stats_tile_logical,
-                    nb_pf,
-                    nq_pf,
-                    Sq_chunk_t,
-                    qi_pf.out_slice,
-                    qi_pf.stats_seq_start_tile,
-                    qi_pf.stats_seq_end_tile,
-                    sum_offset,
-                    cb_prev_out,
-                    cb_max_in,
-                    cb_sum_in,
-                    tile_bytes,
-                    stats_tile_bytes);
-            };
-
-            // Flush deferred save — drains cb_out/cb_max_out/cb_sum_out to DRAM.
-            auto flush_deferred = [&]() {
-                constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
-                save_accumulators_with_trid(
-                    deferred_qi.is_joint_q ? joint_out_generator : out_generator,
-                    stats_writer,
-                    stats_tile_logical,
-                    deferred_nb,
-                    deferred_nq,
-                    Sq_chunk_t,
-                    deferred_qi.out_slice,
-                    all_tiles_valid,
-                    deferred_qi.stats_seq_start_tile,
-                    deferred_qi.stats_seq_end_tile,
-                    sum_offset,
-                    cb_out,
-                    cb_max_out,
-                    cb_sum_out,
-                    tile_bytes,
-                    stats_tile_bytes,
-                    out_subblock_h,
-                    deferred_trid);
-                deferred_pending = false;
-            };
-
             for (uint32_t q_index = 0; q_index + global_q_start < global_q_end; ++q_index) {
                 uint32_t global_q_chunk = remap_q_index(global_q_start + q_index, num_q_chunks, use_zigzag_balancing);
 
@@ -588,8 +523,28 @@ void kernel_main() {
                 // With >= 2 valid K chunks and q_per_core >= 3, K0 uses ping-pong accumulators
                 // (not staging CBs), so the writer prefetches first and flushes later during
                 // the K-loop window — spreading DRAM writes to reduce bank contention.
-                if (deferred_pending && flush_before_prefetch) {
-                    flush_deferred();
+                if (deferred.pending && flush_before_prefetch) {
+                    constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
+                    save_accumulators_with_trid(
+                        deferred.qi.is_joint_q ? joint_out_generator : out_generator,
+                        stats_writer,
+                        stats_tile_logical,
+                        deferred.nb,
+                        deferred.nq,
+                        Sq_chunk_t,
+                        deferred.qi.out_slice,
+                        all_tiles_valid,
+                        deferred.qi.stats_seq_start_tile,
+                        deferred.qi.stats_seq_end_tile,
+                        sum_offset,
+                        cb_out,
+                        cb_max_out,
+                        cb_sum_out,
+                        tile_bytes,
+                        stats_tile_bytes,
+                        out_subblock_h,
+                        deferred.trid);
+                    deferred.pending = false;
                 }
 
                 // 3. Prefetch next Q chunk's accumulators from DRAM.
@@ -601,23 +556,86 @@ void kernel_main() {
                 if (!single_q_chunk && ring_iter > 0) {
                     const uint32_t next_q_index = q_index + 1;
                     if (next_q_index < q_per_core) {
-                        const uint32_t next_trid = q_trid(next_q_index);
+                        const uint32_t next_trid =
+                            next_q_index == 0 ? TRID_FIRST : (next_q_index == last_q_index ? TRID_LAST : TRID_INNER);
                         if (next_trid != TRID_INNER || next_q_index == 1) {
                             noc_async_write_barrier_with_trid(next_trid);
                         }
-                        prefetch_q(global_q_chunk + 1);
+                        const uint32_t gq = global_q_chunk + 1;
+                        const uint32_t nb_pf = gq / (NH * num_q_chunks);
+                        const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
+                        const uint32_t qc_pf = gq % num_q_chunks;
+                        const auto qi_pf = get_q_chunk_info(
+                            qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                        issue_restore_reads(
+                            qi_pf.is_joint_q ? joint_out_generator : out_generator,
+                            stats_writer,
+                            stats_tile_logical,
+                            nb_pf,
+                            nq_pf,
+                            Sq_chunk_t,
+                            qi_pf.out_slice,
+                            qi_pf.stats_seq_start_tile,
+                            qi_pf.stats_seq_end_tile,
+                            sum_offset,
+                            cb_prev_out,
+                            cb_max_in,
+                            cb_sum_in,
+                            tile_bytes,
+                            stats_tile_bytes);
                     }
                 }
                 // Cross-ring: Q[N-1] → Q[0] of next ring iter.
                 if (!single_q_chunk && !is_last_ring_iter && (global_q_chunk + 1 >= global_q_end)) {
                     noc_async_write_barrier_with_trid(TRID_FIRST);
-                    prefetch_q(global_q_start);
+                    const uint32_t gq = global_q_start;
+                    const uint32_t nb_pf = gq / (NH * num_q_chunks);
+                    const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
+                    const uint32_t qc_pf = gq % num_q_chunks;
+                    const auto qi_pf = get_q_chunk_info(
+                        qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                    issue_restore_reads(
+                        qi_pf.is_joint_q ? joint_out_generator : out_generator,
+                        stats_writer,
+                        stats_tile_logical,
+                        nb_pf,
+                        nq_pf,
+                        Sq_chunk_t,
+                        qi_pf.out_slice,
+                        qi_pf.stats_seq_start_tile,
+                        qi_pf.stats_seq_end_tile,
+                        sum_offset,
+                        cb_prev_out,
+                        cb_max_in,
+                        cb_sum_in,
+                        tile_bytes,
+                        stats_tile_bytes);
                 }
 
                 // 4. Late flush (>= 2 valid K chunks, q_per_core >= 3): flush during K-loop
                 // window after prefetch, spreading DRAM writes to reduce bank contention.
-                if (deferred_pending) {
-                    flush_deferred();
+                if (deferred.pending) {
+                    constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
+                    save_accumulators_with_trid(
+                        deferred.qi.is_joint_q ? joint_out_generator : out_generator,
+                        stats_writer,
+                        stats_tile_logical,
+                        deferred.nb,
+                        deferred.nq,
+                        Sq_chunk_t,
+                        deferred.qi.out_slice,
+                        all_tiles_valid,
+                        deferred.qi.stats_seq_start_tile,
+                        deferred.qi.stats_seq_end_tile,
+                        sum_offset,
+                        cb_out,
+                        cb_max_out,
+                        cb_sum_out,
+                        tile_bytes,
+                        stats_tile_bytes,
+                        out_subblock_h,
+                        deferred.trid);
+                    deferred.pending = false;
                 }
 
                 // === Compute runs K-loop for this Q chunk ===
@@ -638,11 +656,11 @@ void kernel_main() {
                         out_subblock_h);
                     noc_async_write_barrier();
                 } else if (!single_q_chunk) {
-                    deferred_pending = true;
-                    deferred_trid = q_trid(q_index);
-                    deferred_nb = nb;
-                    deferred_nq = nq;
-                    deferred_qi = qi;
+                    deferred.pending = true;
+                    deferred.trid = q_index == 0 ? TRID_FIRST : (q_index == last_q_index ? TRID_LAST : TRID_INNER);
+                    deferred.nb = nb;
+                    deferred.nq = nq;
+                    deferred.qi = qi;
                 }
             }
         } else {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -415,6 +415,14 @@ void kernel_main() {
 
     uint32_t ring_index = fused_op_receiver.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
+
+    // Deferred save: stash params for save_accumulators_with_trid and call it
+    // during the next Q chunk's K-loop window to avoid DRAM bank contention.
+    bool deferred_pending = false;
+    uint32_t deferred_trid;
+    uint32_t deferred_nb, deferred_nq;
+    QChunkInfo deferred_qi;
+
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -572,6 +580,31 @@ void kernel_main() {
                         stats_tile_bytes);
                 }
 
+                // Flush deferred save from previous Q during K-loop window.
+                if (deferred_pending) {
+                    constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
+                    save_accumulators_with_trid(
+                        deferred_qi.is_joint_q ? joint_out_generator : out_generator,
+                        stats_writer,
+                        stats_tile_logical,
+                        deferred_nb,
+                        deferred_nq,
+                        Sq_chunk_t,
+                        deferred_qi.out_slice,
+                        all_tiles_valid,
+                        deferred_qi.stats_seq_start_tile,
+                        deferred_qi.stats_seq_end_tile,
+                        sum_offset,
+                        cb_out,
+                        cb_max_out,
+                        cb_sum_out,
+                        tile_bytes,
+                        stats_tile_bytes,
+                        out_subblock_h,
+                        deferred_trid);
+                    deferred_pending = false;
+                }
+
                 // === Compute runs K-loop for this Q chunk ===
 
                 // Wait for compute to signal last K-chunk start (multi-Q only).
@@ -590,32 +623,13 @@ void kernel_main() {
                         out_subblock_h);
                     noc_async_write_barrier();
                 } else if (!single_q_chunk) {
-                    // Accumulators are raw compute state — all tiles are valid (including padded rows),
-                    // so bypass maybe_write_tile's padding skip (same convention as restore reads).
-                    constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
-                    save_accumulators_with_trid(
-                        qi.is_joint_q ? joint_out_generator : out_generator,
-                        stats_writer,
-                        stats_tile_logical,
-                        nb,
-                        nq,
-                        Sq_chunk_t,
-                        qi.out_slice,
-                        all_tiles_valid,
-                        qi.stats_seq_start_tile,
-                        qi.stats_seq_end_tile,
-                        sum_offset,
-                        cb_out,
-                        cb_max_out,
-                        cb_sum_out,
-                        tile_bytes,
-                        stats_tile_bytes,
-                        out_subblock_h,
-                        q_trid(q_index));
+                    deferred_pending = true;
+                    deferred_trid = q_trid(q_index);
+                    deferred_nb = nb;
+                    deferred_nq = nq;
+                    deferred_qi = qi;
                 }
             }
-            // No global write_barrier — per-trid barriers in the Q loop
-            // ensure each save has landed before its data is read back.
         } else {
             for (uint32_t q_iter = 0; q_iter + global_q_start < global_q_end; ++q_iter) {
                 uint32_t global_q_chunk = remap_q_index(global_q_start + q_iter, num_q_chunks, use_zigzag_balancing);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -438,6 +438,21 @@ void kernel_main() {
             continue;
         }
 
+        // Count valid (non-skipped) K chunks for this ring iteration — same skip logic as
+        // compute (skip local K chunks whose global start tile >= logical_nt).
+        // When total_valid_kv == 1, compute's sole K chunk triggers save_to_staging on K0,
+        // reserving staging CBs immediately. The deferred flush must happen before any
+        // prefetch that blocks on cb_prev_out, or the writer and compute deadlock.
+        uint32_t total_valid_kv = 0;
+        for (uint32_t k = 0; k < num_kv_chunks; ++k) {
+            const bool is_joint = k >= num_local_k_chunks;
+            if (!is_joint && (ring_iter_kv_start_tile + k * Sk_chunk_t >= logical_nt)) {
+                continue;
+            }
+            total_valid_kv++;
+        }
+        const bool single_valid_kv_chunk = (total_valid_kv <= 1);
+
         /**
         We have 3 possible masks
         - global N mask
@@ -486,6 +501,7 @@ void kernel_main() {
 
             const uint32_t q_per_core = global_q_end - global_q_start;
             const uint32_t last_q_index = q_per_core - 1;
+            const bool flush_before_prefetch = single_valid_kv_chunk || q_per_core == 2;
 
             auto q_trid = [last_q_index](uint32_t q_idx) -> uint32_t {
                 if (q_idx == 0) {
@@ -533,40 +549,13 @@ void kernel_main() {
                     get_q_chunk_info(q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
                 const uint32_t end_seq_tile = get_end_seq_tile(qi, ring_id, Lt, local_padded_Nt);
 
-                // 1. Complete restore + intra-ring prefetch (ring_iter > 0 only)
+                // 1. Complete restore (ring_iter > 0 only)
                 if (!single_q_chunk && ring_iter > 0) {
                     complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
-
-                    // Intra-ring prefetch: issue reads for Q[q+1] during Q[q]'s K-loop.
-                    // Skipped for q_per_core == 2: Q[1] == Q[last] whose deferred save
-                    // hasn't been flushed yet — late-prefetched after the flush instead.
-                    //
-                    // Only barrier when next Q's TRID hasn't been cleared yet this ring iter:
-                    //   Q[0]: wB(TRID_INNER) — clears all prev-ring inner saves
-                    //   Q[N-2]: wB(TRID_LAST) — clears prev-ring Q[N-1] save
-                    //   Q[1..N-3]: skip — TRID_INNER already cleared at Q[0]
-                    // Without this, Q[j+1]'s wB(TRID_INNER) would stall on Q[j]'s
-                    // current-ring save (near-zero flight time) for q_per_core >= 5.
-                    const uint32_t next_q_index = q_index + 1;
-                    if (next_q_index < q_per_core && q_per_core > 2) {
-                        const uint32_t next_trid = q_trid(next_q_index);
-                        if (next_trid != TRID_INNER || next_q_index == 1) {
-                            noc_async_write_barrier_with_trid(next_trid);
-                        }
-                        prefetch_q(global_q_chunk + 1);
-                    }
                 }
 
-                // 2. Cross-ring prefetch: Q[N-1] → Q[0] of next ring iter.
-                // Skipped for q_per_core == 2: Q[0]'s deferred save hasn't been flushed
-                // yet — late-prefetched after the flush instead (same as intra-ring above).
-                if (!single_q_chunk && !is_last_ring_iter && (global_q_chunk + 1 >= global_q_end) && q_per_core > 2) {
-                    noc_async_write_barrier_with_trid(TRID_FIRST);
-                    prefetch_q(global_q_start);
-                }
-
-                // Flush deferred save from previous Q during K-loop window.
-                if (deferred_pending) {
+                // Flush deferred save helper — drains cb_out/cb_max_out/cb_sum_out to DRAM.
+                auto flush_deferred = [&]() {
                     constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
                     save_accumulators_with_trid(
                         deferred_qi.is_joint_q ? joint_out_generator : out_generator,
@@ -588,19 +577,48 @@ void kernel_main() {
                         out_subblock_h,
                         deferred_trid);
                     deferred_pending = false;
+                };
 
-                    // q_per_core == 2: both prefetches above were skipped because the
-                    // deferred Q's data wasn't in DRAM yet. Now that the flush has
-                    // written it, barrier and issue the late prefetch reads.
-                    if (q_per_core == 2) {
-                        if (q_index == 0 && ring_iter > 0) {
-                            noc_async_write_barrier_with_trid(deferred_trid);
-                            prefetch_q(global_q_chunk + 1);
-                        } else if (q_index == last_q_index && !is_last_ring_iter) {
-                            noc_async_write_barrier_with_trid(deferred_trid);
-                            prefetch_q(global_q_start);
+                // Early flush (flush_before_prefetch): drain staging CBs before prefetch.
+                // - total_valid_kv <= 1: compute's sole K chunk triggers save_to_staging on
+                //   K0, reserving staging CBs immediately — deadlock if they're still full.
+                // - q_per_core == 2: next Q == last Q whose deferred data isn't in DRAM yet,
+                //   so prefetch would read stale data without flushing first.
+                //
+                // With >= 2 valid K chunks and q_per_core >= 3, K0 uses ping-pong accumulators
+                // (not staging CBs), so the writer prefetches first and flushes later during
+                // the K-loop window — spreading DRAM writes to reduce bank contention.
+                if (deferred_pending && flush_before_prefetch) {
+                    flush_deferred();
+                }
+
+                // 3. Prefetch next Q chunk for the upcoming ring iteration.
+                // Intra-ring: issue reads for Q[q+1] during Q[q]'s K-loop.
+                // Only barrier when next Q's TRID hasn't been cleared yet this ring iter:
+                //   Q[0]: wB(TRID_INNER) — clears all prev-ring inner saves
+                //   Q[N-2]: wB(TRID_LAST) — clears prev-ring Q[N-1] save
+                //   Q[1..N-3]: skip — TRID_INNER already cleared at Q[0]
+                if (!single_q_chunk && ring_iter > 0) {
+                    const uint32_t next_q_index = q_index + 1;
+                    if (next_q_index < q_per_core) {
+                        const uint32_t next_trid = q_trid(next_q_index);
+                        if (next_trid != TRID_INNER || next_q_index == 1) {
+                            noc_async_write_barrier_with_trid(next_trid);
                         }
+                        prefetch_q(global_q_chunk + 1);
                     }
+                }
+
+                // Cross-ring prefetch: Q[N-1] → Q[0] of next ring iter.
+                if (!single_q_chunk && !is_last_ring_iter && (global_q_chunk + 1 >= global_q_end)) {
+                    noc_async_write_barrier_with_trid(TRID_FIRST);
+                    prefetch_q(global_q_start);
+                }
+
+                // Late flush (>= 2 valid K chunks, q_per_core >= 3): flush during K-loop
+                // window after prefetch, spreading DRAM writes to reduce bank contention.
+                if (deferred_pending) {
+                    flush_deferred();
                 }
 
                 // === Compute runs K-loop for this Q chunk ===

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -497,6 +497,31 @@ void kernel_main() {
                 return TRID_INNER;
             };
 
+            // Issue restore reads for a Q chunk by its global index.
+            auto prefetch_q = [&](uint32_t gq) {
+                const uint32_t nb_pf = gq / (NH * num_q_chunks);
+                const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
+                const uint32_t qc_pf = gq % num_q_chunks;
+                const auto qi_pf =
+                    get_q_chunk_info(qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                issue_restore_reads(
+                    qi_pf.is_joint_q ? joint_out_generator : out_generator,
+                    stats_writer,
+                    stats_tile_logical,
+                    nb_pf,
+                    nq_pf,
+                    Sq_chunk_t,
+                    qi_pf.out_slice,
+                    qi_pf.stats_seq_start_tile,
+                    qi_pf.stats_seq_end_tile,
+                    sum_offset,
+                    cb_prev_out,
+                    cb_max_in,
+                    cb_sum_in,
+                    tile_bytes,
+                    stats_tile_bytes);
+            };
+
             for (uint32_t q_index = 0; q_index + global_q_start < global_q_end; ++q_index) {
                 uint32_t global_q_chunk = remap_q_index(global_q_start + q_index, num_q_chunks, use_zigzag_balancing);
 
@@ -513,6 +538,9 @@ void kernel_main() {
                     complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
 
                     // Intra-ring prefetch: issue reads for Q[q+1] during Q[q]'s K-loop.
+                    // Skipped for q_per_core == 2: Q[1] == Q[last] whose deferred save
+                    // hasn't been flushed yet — late-prefetched after the flush instead.
+                    //
                     // Only barrier when next Q's TRID hasn't been cleared yet this ring iter:
                     //   Q[0]: wB(TRID_INNER) — clears all prev-ring inner saves
                     //   Q[N-2]: wB(TRID_LAST) — clears prev-ring Q[N-1] save
@@ -520,64 +548,21 @@ void kernel_main() {
                     // Without this, Q[j+1]'s wB(TRID_INNER) would stall on Q[j]'s
                     // current-ring save (near-zero flight time) for q_per_core >= 5.
                     const uint32_t next_q_index = q_index + 1;
-                    if (next_q_index < q_per_core) {
+                    if (next_q_index < q_per_core && q_per_core > 2) {
                         const uint32_t next_trid = q_trid(next_q_index);
-                        // First inner Q (next_q_index==1) needs the barrier; subsequent
-                        // inner Qs (next_q_index>1 && next_trid==TRID_INNER) don't.
                         if (next_trid != TRID_INNER || next_q_index == 1) {
                             noc_async_write_barrier_with_trid(next_trid);
                         }
-                        const uint32_t next_q_global = global_q_chunk + 1;
-                        const uint32_t nb_next = next_q_global / (NH * num_q_chunks);
-                        const uint32_t nq_next = (next_q_global % (NH * num_q_chunks)) / num_q_chunks;
-                        const uint32_t qc_next = next_q_global % num_q_chunks;
-                        const auto qi_next = get_q_chunk_info(
-                            qc_next, nb_next, nq_next, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                        issue_restore_reads(
-                            qi_next.is_joint_q ? joint_out_generator : out_generator,
-                            stats_writer,
-                            stats_tile_logical,
-                            nb_next,
-                            nq_next,
-                            Sq_chunk_t,
-                            qi_next.out_slice,
-                            qi_next.stats_seq_start_tile,
-                            qi_next.stats_seq_end_tile,
-                            sum_offset,
-                            cb_prev_out,
-                            cb_max_in,
-                            cb_sum_in,
-                            tile_bytes,
-                            stats_tile_bytes);
+                        prefetch_q(global_q_chunk + 1);
                     }
                 }
 
                 // 2. Cross-ring prefetch: Q[N-1] → Q[0] of next ring iter.
-                // Reads fly during Q[N-1]'s K-loop + save drain.
-                if (!single_q_chunk && !is_last_ring_iter && (global_q_chunk + 1 >= global_q_end)) {
+                // Skipped for q_per_core == 2: Q[0]'s deferred save hasn't been flushed
+                // yet — late-prefetched after the flush instead (same as intra-ring above).
+                if (!single_q_chunk && !is_last_ring_iter && (global_q_chunk + 1 >= global_q_end) && q_per_core > 2) {
                     noc_async_write_barrier_with_trid(TRID_FIRST);
-                    const uint32_t gq0 = global_q_start;
-                    const uint32_t nb0 = gq0 / (NH * num_q_chunks);
-                    const uint32_t nq0 = (gq0 % (NH * num_q_chunks)) / num_q_chunks;
-                    const uint32_t qc0 = gq0 % num_q_chunks;
-                    const auto qi0 =
-                        get_q_chunk_info(qc0, nb0, nq0, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                    issue_restore_reads(
-                        qi0.is_joint_q ? joint_out_generator : out_generator,
-                        stats_writer,
-                        stats_tile_logical,
-                        nb0,
-                        nq0,
-                        Sq_chunk_t,
-                        qi0.out_slice,
-                        qi0.stats_seq_start_tile,
-                        qi0.stats_seq_end_tile,
-                        sum_offset,
-                        cb_prev_out,
-                        cb_max_in,
-                        cb_sum_in,
-                        tile_bytes,
-                        stats_tile_bytes);
+                    prefetch_q(global_q_start);
                 }
 
                 // Flush deferred save from previous Q during K-loop window.
@@ -603,6 +588,19 @@ void kernel_main() {
                         out_subblock_h,
                         deferred_trid);
                     deferred_pending = false;
+
+                    // q_per_core == 2: both prefetches above were skipped because the
+                    // deferred Q's data wasn't in DRAM yet. Now that the flush has
+                    // written it, barrier and issue the late prefetch reads.
+                    if (q_per_core == 2) {
+                        if (q_index == 0 && ring_iter > 0) {
+                            noc_async_write_barrier_with_trid(deferred_trid);
+                            prefetch_q(global_q_chunk + 1);
+                        } else if (q_index == last_q_index && !is_last_ring_iter) {
+                            noc_async_write_barrier_with_trid(deferred_trid);
+                            prefetch_q(global_q_start);
+                        }
+                    }
                 }
 
                 // === Compute runs K-loop for this Q chunk ===

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
@@ -116,3 +116,30 @@ inline uint32_t find_last_active_ring_iter(
 
     return last_active;
 }
+
+/**
+ * Count valid (non-skipped) K chunks for a ring iteration.
+ * Same skip logic as compute: local K chunks whose global start tile >= logical_nt are skipped.
+ *
+ * @param num_kv_chunks      Total K chunks this ring iter (local + joint if applicable)
+ * @param num_local_k_chunks Number of local (non-joint) K chunks
+ * @param ring_iter_kv_start_tile  First tile index of this ring iter's KV range
+ * @param Sk_chunk_t         K chunk size in tiles
+ * @param logical_nt         Logical sequence length in tiles (logical_n / TILE_HEIGHT)
+ */
+inline uint32_t count_valid_kv_chunks(
+    uint32_t num_kv_chunks,
+    uint32_t num_local_k_chunks,
+    uint32_t ring_iter_kv_start_tile,
+    uint32_t Sk_chunk_t,
+    uint32_t logical_nt) {
+    uint32_t count = 0;
+    for (uint32_t k = 0; k < num_kv_chunks; ++k) {
+        const bool is_joint = k >= num_local_k_chunks;
+        if (!is_joint && (ring_iter_kv_start_tile + k * Sk_chunk_t >= logical_nt)) {
+            continue;
+        }
+        count++;
+    }
+    return count;
+}


### PR DESCRIPTION
## Problem

In ring SDPA, the writer kernel saves accumulators (output + max/sum stats) to DRAM immediately after compute signals the end of the K-loop. This puts the DRAM writes on the critical path — the next Q chunk's `complete_restore` (which unlocks compute via `cb_push_back`) is blocked until the save finishes. When the write-flush barrier occasionally stalls on DRAM bank contention, compute sits idle waiting for the writer to finish saving and push the next set of accumulator inputs.

## Solution

Defer the `save_accumulators_with_trid` call to the next Q chunk's K-loop window. After compute signals, the writer just stashes the save parameters (instant) and proceeds directly to `complete_restore`, unlocking compute immediately. The deferred flush runs later, while compute is busy with the next K-loop — any DRAM write stalls are hidden behind compute instead of blocking it.

The change is minimal: a few local variables stash the save parameters, and the existing `save_accumulators_with_trid` function is called at the flush point instead of the save point. No new functions or structs needed.

```
Baseline:  ...K-loop -> signal -> save (DRAM writes) -> complete_restore -> K-loop...
                                  ^^^^                   ^^^^
                                  stalls here            compute blocked

Deferred:  ...K-loop -> signal -> stash -> complete_restore -> K-loop...
                                  ^^^^     ^^^^
                                  instant  compute starts immediately
                                           (flush runs later, hidden behind K-loop)
```

SDPA math utilization in WAN2.2 Galaxy improved from **68.7% to 70.7%**.

### Early flush: two cases where late flush is not possible

The deferred flush normally runs **after** the prefetch (late flush), overlapping DRAM writes with K0 compute. However, two cases require flushing **before** the prefetch:

**1. `q_per_core == 2` (stale data)**

When `q_per_core == 2`, `Q[1] == Q[last]`, so both the intra-ring and cross-ring prefetch reads target the same DRAM addresses as the deferred save that hasn't been flushed yet. The prefetch barriers see no outstanding writes and pass immediately, causing reads to fetch stale/uninitialized data.

**2. `total_valid_kv <= 1` (deadlock)**

When there is only 1 valid K chunk per ring tier, compute's sole K chunk is also the last, so `save_to_staging` fires immediately on K0 — reserving `cb_out`/`cb_max_out`/`cb_sum_out` at the top of `sdpa_inner_loop_step` (lines 711-713, 893). If those staging CBs still hold the previous deferred save data, compute blocks. Meanwhile, the writer is blocked on `cb_reserve_back(cb_prev_out)` in the prefetch, waiting for compute to pop `cb_prev_out` during SALAD — which compute can never reach. **Deadlock.**

With >= 2 valid K chunks this doesn't happen: K0 uses ping-pong accumulators (not staging CBs), giving the writer time to prefetch first and flush later during K0's window.

The `total_valid_kv` count is computed per ring iteration using the same skip logic as compute (local K chunks beyond `logical_nt` are skipped), so the condition is accurate regardless of padding or joint K chunks.

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/runs/24471440346)
- [x] [![Nightly tt-metal L2 tests (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/runs/24471442022)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/runs/24471443572)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/runs/24471445264)
- [x] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/runs/24471447099) (same failures as main)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/runs/24471448689)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/runs/24471450222) (same failure as main)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/runs/24471451709) (same failure as main)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sdpa-split-save-writer) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sdpa-split-save-writer) | [#2877](https://github.com/tenstorrent/tt-metal/actions/runs/24471440346) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/sdpa-split-save-writer) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/sdpa-split-save-writer) | [#17537](https://github.com/tenstorrent/tt-metal/actions/runs/24471443572) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sdpa-split-save-writer) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sdpa-split-save-writer) | [#5245](https://github.com/tenstorrent/tt-metal/actions/runs/24471442022) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa-split-save-writer) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa-split-save-writer) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa-split-save-writer) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa-split-save-writer) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa-split-save-writer) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa-split-save-writer) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa-split-save-writer) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/sdpa-split-save-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa-split-save-writer) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa-split-save-writer) |