### PR TITLE
Fix stale address_offset in generic_op CB rebinding

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CircularBuffers.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CircularBuffers.rst
@@ -9,4 +9,6 @@ CircularBuffers
 
 .. doxygenfunction:: tt::tt_metal::UpdateCircularBufferPageSize
 
-.. doxygenfunction:: tt::tt_metal::UpdateDynamicCircularBufferAddress
+.. doxygenfunction:: tt::tt_metal::UpdateDynamicCircularBufferAddress(Program &program, CBHandle cb_handle, const Buffer &buffer)
+
+.. doxygenfunction:: tt::tt_metal::UpdateDynamicCircularBufferAddress(Program &program, CBHandle cb_handle, const Buffer &buffer, uint32_t address_offset)

--- a/tests/ttnn/unit_tests/base_functionality/test_cb_address_offset.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_cb_address_offset.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/base_functionality/test_cb_address_offset.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_cb_address_offset.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test: cb_descriptor_from_sharded_tensor address_offset preserved on cache hit.
+
+Regression test for https://github.com/tenstorrent/tt-metal/issues/42072.
+Verifies that generic_op correctly applies CBDescriptor.address_offset when
+rebinding CB buffers on cached program reuse.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+KERNEL_SOURCE = """
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t output_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(2);
+    constexpr uint32_t page_size = get_compile_time_arg_val(3);
+
+    // Input CB is tensor-backed (pre-filled via setup_sharded_buffer)
+    cb_reserve_back(input_cb, num_pages);
+    cb_push_back(input_cb, num_pages);
+
+    // Copy input -> output via local NOC read
+    cb_wait_front(input_cb, num_pages);
+    uint32_t src_addr = get_read_ptr(input_cb);
+
+    cb_reserve_back(output_cb, num_pages);
+    uint32_t dst_addr = get_write_ptr(output_cb);
+
+    noc_async_read(get_noc_addr(src_addr), dst_addr, num_pages * page_size);
+    noc_async_read_barrier();
+
+    cb_push_back(output_cb, num_pages);
+    cb_pop_front(input_cb, num_pages);
+}
+"""
+
+K = 1024
+PAGE_SIZE = 64  # 1x32 bfloat16 tile
+NUM_PAGES = K * 2 // PAGE_SIZE  # 32
+REGION_BYTES = NUM_PAGES * PAGE_SIZE  # 2048
+
+
+@pytest.mark.parametrize("device", [(1,)], indirect=True)
+def test_cb_address_offset_preserved_on_cache_hit(device):
+    """generic_op must preserve CBDescriptor.address_offset across cached invocations."""
+    core = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))])
+
+    # Fused buffer: region A (offset 0) = 1.0, region B (offset REGION_BYTES) = 2.0
+    region_a = torch.ones(1, K, dtype=torch.bfloat16)
+    region_b = torch.full((1, K), 2.0, dtype=torch.bfloat16)
+    raw = torch.cat([region_a.view(-1), region_b.view(-1)]).view(torch.uint8)
+    buf = raw.view(torch.int32).unsqueeze(0)
+    n_uint32 = buf.shape[1]
+
+    fused = ttnn.from_torch(
+        buf,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(core, (1, n_uint32), ttnn.ShardOrientation.ROW_MAJOR),
+        ),
+    )
+
+    out_tensor = ttnn.from_torch(
+        torch.zeros(1, n_uint32 // 2, dtype=torch.int32),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(core, (1, n_uint32 // 2), ttnn.ShardOrientation.ROW_MAJOR),
+        ),
+    )
+
+    def build_pd(offset):
+        in_cb = ttnn.cb_descriptor_from_sharded_tensor(
+            0, fused, address_offset=offset, total_size=REGION_BYTES, core_ranges=core
+        )
+        in_cb.format_descriptors = [ttnn.CBFormatDescriptor(0, ttnn.bfloat16, PAGE_SIZE)]
+
+        out_cb = ttnn.cb_descriptor_from_sharded_tensor(1, out_tensor, total_size=REGION_BYTES, core_ranges=core)
+        out_cb.format_descriptors = [ttnn.CBFormatDescriptor(1, ttnn.bfloat16, PAGE_SIZE)]
+
+        kernel = ttnn.KernelDescriptor(
+            kernel_source=KERNEL_SOURCE,
+            source_type=ttnn.KernelDescriptor.SourceType.SOURCE_CODE,
+            core_ranges=core,
+            compile_time_args=[0, 1, NUM_PAGES, PAGE_SIZE],
+            config=ttnn.DataMovementConfigDescriptor(
+                processor=ttnn.DataMovementProcessor.RISCV_1, noc=ttnn.NOC.RISCV_0_default
+            ),
+        )
+        return ttnn.ProgramDescriptor(cbs=[in_cb, out_cb], kernels=[kernel])
+
+    def run(offset, label):
+        pd = build_pd(offset)
+        mesh_pd = ttnn.MeshProgramDescriptor()
+        coord = ttnn.MeshCoordinate(0, 0)
+        mesh_pd[ttnn.MeshCoordinateRange(coord, coord)] = pd
+        ttnn.generic_op([fused, out_tensor], mesh_pd)
+        ttnn.synchronize_device(device)
+        result = ttnn.to_torch(out_tensor).view(torch.uint8).view(torch.bfloat16).float()
+        val = result.mean().item()
+        logger.info(f"{label}: mean={val:.4f}")
+        return val
+
+    # First call: offset=0, reads region A (1.0). Creates cached program.
+    val_a = run(0, "offset=0 (expect 1.0)")
+    assert abs(val_a - 1.0) < 0.01, f"First call wrong: {val_a}"
+
+    # Second call: offset=REGION_BYTES, reads region B (2.0). Cache hit.
+    # Bug: cached program's address_offset_ is stale (0), so it reads region A again.
+    val_b = run(REGION_BYTES, f"offset={REGION_BYTES} (expect 2.0)")
+    assert abs(val_b - 2.0) < 0.01, (
+        f"address_offset lost on cache hit! "
+        f"val_b={val_b:.4f} (expected 2.0, got {val_a:.4f}). "
+        f"Cached program uses stale address_offset from first call."
+    )

--- a/tt_metal/api/tt-metalium/circular_buffer_config.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer_config.hpp
@@ -87,6 +87,8 @@ public:
 
     uint32_t address_offset() const;
 
+    void set_address_offset(uint32_t offset);
+
     const Buffer* shadow_global_buffer{nullptr};
 
     class Builder {

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -273,6 +273,8 @@ void UpdateCircularBufferPageSize(Program& program, CBHandle cb_handle, uint8_t 
  */
 // clang-format on
 void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, const Buffer& buffer);
+void UpdateDynamicCircularBufferAddress(
+    Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t address_offset);
 
 // clang-format off
 /**

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -213,6 +213,8 @@ uint32_t CircularBufferConfig::buffer_size() const { return this->buffer_size_; 
 
 uint32_t CircularBufferConfig::address_offset() const { return this->address_offset_; }
 
+void CircularBufferConfig::set_address_offset(uint32_t offset) { this->address_offset_ = offset; }
+
 CircularBufferConfig::Builder CircularBufferConfig::Builder::LocalBuilder(
     CircularBufferConfig& parent, uint8_t buffer_index) {
     auto is_remote_index = parent.remote_buffer_indices_.contains(buffer_index);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1500,6 +1500,15 @@ void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, co
     circular_buffer->assign_global_address();
 }
 
+void UpdateDynamicCircularBufferAddress(
+    Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t address_offset) {
+    auto circular_buffer = program.impl().get_circular_buffer(cb_handle);
+    TT_FATAL(!circular_buffer->is_global_circular_buffer(), "CircularBuffer must not be a GlobalCircularBuffer!");
+    circular_buffer->config().set_address_offset(address_offset);
+    circular_buffer->config().set_globally_allocated_address(buffer);
+    circular_buffer->assign_global_address();
+}
+
 void UpdateDynamicCircularBufferAddressAndTotalSize(
     Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t total_size) {
     auto circular_buffer = program.impl().get_circular_buffer(cb_handle);

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -102,7 +102,7 @@ void override_program_runtime_arguments(
             }
         }
         if (cb_desc.buffer != nullptr) {
-            UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.buffer);
+            UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.buffer, cb_desc.address_offset);
         }
         if (cb_desc.global_circular_buffer != nullptr) {
             experimental::UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.global_circular_buffer);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/42072

### Problem description
`cb_descriptor_from_sharded_tensor` with `address_offset > 0` works correctly on the first `generic_op` invocation, but the offset is silently lost on subsequent (cache-hit) invocations. `override_program_runtime_arguments()` calls `UpdateDynamicCircularBufferAddress` which uses `config_.address_offset()` to recompute the CB address — but `address_offset_` retains the stale value from the first invocation and is never updated from `cb_desc.address_offset`.

### What's changed
- Added `set_address_offset(uint32_t)` to `CircularBufferConfig` (setter for the field the constructor already sets)
- Added `UpdateDynamicCircularBufferAddress` overload that accepts `address_offset` parameter
- `generic_op_program_factory.cpp`: pass `cb_desc.address_offset` through when rebinding CB buffers on cache hits

### What's the impact
5 files changed, 16 insertions, 1 deletion. The existing no-offset `UpdateDynamicCircularBufferAddress` overload is unchanged — all other callers are unaffected.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/42072_stale_address_offset)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/42072_stale_address_offset)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/42072_stale_address_offset)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/42072_stale_address_offset)
- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/42072_stale_address_offset)
- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/42072_stale_address_offset)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [#2726](https://github.com/tenstorrent/tt-metal/actions/runs/24405707039) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [#17474](https://github.com/tenstorrent/tt-metal/actions/runs/24405720798) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [#5193](https://github.com/tenstorrent/tt-metal/actions/runs/24405739634) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [#862](https://github.com/tenstorrent/tt-metal/actions/runs/24405829677) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/42072_stale_address_offset) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/42072_stale_address_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/42072_stale_address_offset) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/42072_stale_address_offset) |