### PR TITLE
Use fast-dispatch when sending `q_ab_kv_a` overlapped tensor to device

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import os
+import socket
 import sys
 import time
 from datetime import datetime, timezone
@@ -162,6 +163,9 @@ def write_weight_load_performance_report(
     perf_report: WeightProviderPerformanceReport,
     mesh_id: int,
     weight_provider_name: str,
+    model_directory: str | None,
+    cache_directory: str | None,
+    hostname: str,
 ) -> Path:
     report_path = get_report_path_for_mesh(weight_perf_report_path, mesh_id)
     report_path.parent.mkdir(parents=True, exist_ok=True)
@@ -171,6 +175,9 @@ def write_weight_load_performance_report(
             stage_id=mesh_id,
             weight_provider_name=weight_provider_name,
             timestamp_utc=timestamp_utc,
+            model_directory=model_directory,
+            cache_directory=cache_directory,
+            hostname=hostname,
         )
         + "\n",
         encoding="utf-8",
@@ -216,11 +223,16 @@ def run_demo(
         logger.info("Weight loading performance summary (mesh_id={}):\n{}", my_mesh_id, perf_report.summary())
         if weight_perf_report_path is not None:
             weight_provider_name = type(model_pipeline.weight_provider).__name__
+            model_directory = str(model_path.resolve()) if model_path is not None else None
+            cache_directory = str(cache_path.resolve()) if cache_path is not None else None
             report_path = write_weight_load_performance_report(
                 weight_perf_report_path=weight_perf_report_path,
                 perf_report=perf_report,
                 mesh_id=my_mesh_id,
                 weight_provider_name=weight_provider_name,
+                model_directory=model_directory,
+                cache_directory=cache_directory,
+                hostname=socket.gethostname(),
             )
             logger.info("Wrote weight performance report (mesh_id={}): {}", my_mesh_id, report_path)
 

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -9,6 +9,7 @@ import contextlib
 import os
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -19,6 +20,7 @@ import ttnn
 from conftest import bh_2d_mesh_device_context
 from models.demos.deepseek_v3_b1.demo.model_pipeline import ModelPipeline
 from models.demos.deepseek_v3_b1.demo.pipeline import create_fabric_router_config
+from models.demos.deepseek_v3_b1.demo.weight_provider import WeightProviderPerformanceReport
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-R1-0528"
 
@@ -131,11 +133,49 @@ def create_parser() -> argparse.ArgumentParser:
             "this is omitted, defaults to deepseek_v3_b1."
         ),
     )
+    parser.add_argument(
+        "--weight-perf-report-path",
+        type=Path,
+        default=None,
+        help=(
+            "Optional JSON output path for serialized weight performance report. "
+            "When set, each process writes a mesh-id-suffixed file."
+        ),
+    )
     return parser
 
 
 def load_tokenizer(tokenizer_name_or_path: str):
     return AutoTokenizer.from_pretrained(tokenizer_name_or_path, trust_remote_code=True)
+
+
+def get_report_path_for_mesh(base_path: Path, mesh_id: int) -> Path:
+    mesh_suffix = f".mesh_{mesh_id}"
+    if base_path.suffix:
+        return base_path.with_name(f"{base_path.stem}{mesh_suffix}{base_path.suffix}")
+    return base_path.with_name(f"{base_path.name}{mesh_suffix}")
+
+
+def write_weight_load_performance_report(
+    *,
+    weight_perf_report_path: Path,
+    perf_report: WeightProviderPerformanceReport,
+    mesh_id: int,
+    weight_provider_name: str,
+) -> Path:
+    report_path = get_report_path_for_mesh(weight_perf_report_path, mesh_id)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp_utc = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    report_path.write_text(
+        perf_report.to_json(
+            stage_id=mesh_id,
+            weight_provider_name=weight_provider_name,
+            timestamp_utc=timestamp_utc,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return report_path
 
 
 def run_demo(
@@ -152,13 +192,13 @@ def run_demo(
     moe_layer_id_override: int | None = None,
     launch_only: bool = False,
     io_socket_descriptor_prefix: str | None = None,
+    weight_perf_report_path: Path | None = None,
 ) -> None:
     """Run the pod pipeline. Requires 4, 16, or 64 distributed processes."""
     iterations = max_new_tokens
     logger.info(f"Starting DeepSeek V3 B1 demo (iterations={iterations})")
 
     with open_mesh_device() as mesh_device:
-        # Initialize model pipeline
         model_pipeline = ModelPipeline(
             mesh_device=mesh_device,
             weights_mode=weights_mode,
@@ -172,6 +212,18 @@ def run_demo(
         )
 
         my_mesh_id = mesh_device.get_system_mesh_id()
+        perf_report = model_pipeline.weight_provider.get_performance_report()
+        logger.info("Weight loading performance summary (mesh_id={}):\n{}", my_mesh_id, perf_report.summary())
+        if weight_perf_report_path is not None:
+            weight_provider_name = type(model_pipeline.weight_provider).__name__
+            report_path = write_weight_load_performance_report(
+                weight_perf_report_path=weight_perf_report_path,
+                perf_report=perf_report,
+                mesh_id=my_mesh_id,
+                weight_provider_name=weight_provider_name,
+            )
+            logger.info("Wrote weight performance report (mesh_id={}): {}", my_mesh_id, report_path)
+
         if my_mesh_id == 0 and not launch_only:
             tokenizer = load_tokenizer(tokenizer_name_or_path)
             messages = [{"role": "user", "content": prompt}]
@@ -246,6 +298,7 @@ def main(argv: list[str] | None = None) -> int:
         moe_layer_id_override=args.moe_layer_id_override,
         launch_only=args.launch_only,
         io_socket_descriptor_prefix=io_socket_descriptor_prefix,
+        weight_perf_report_path=args.weight_perf_report_path,
     )
     print(file=sys.stdout, flush=True)
     return 0

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -23,6 +23,27 @@ from models.demos.deepseek_v3_b1.demo.weight_provider import (
 from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
 
 
+def create_weight_provider(
+    weights_mode: Literal["synthetic", "real", "state_dict"],
+    *,
+    cache_path: Path | None = None,
+    model_path: Path | None = None,
+) -> WeightProvider:
+    if weights_mode == "real":
+        if cache_path is None:
+            raise ValueError("weights_mode='real' requires cache_path")
+        if model_path is None:
+            raise ValueError("weights_mode='real' requires model_path")
+        return CacheWeightProvider(cache_path, model_path)
+    if weights_mode == "state_dict":
+        if model_path is None:
+            raise ValueError("weights_mode='state_dict' requires model_path")
+        return StateDictWeightProvider(model_path)
+    if weights_mode == "synthetic":
+        return SyntheticWeightProvider()
+    raise ValueError(f"Unknown weights_mode: {weights_mode!r}")
+
+
 class ModelPipeline:
     def __init__(
         self,
@@ -54,23 +75,11 @@ class ModelPipeline:
         ttnn.enable_asynchronous_slow_dispatch(self.mesh_device)
 
         # Each host loads/creates only the weights for its stage via the provider.
-        if weights_mode == "real":
-            if cache_path is None:
-                raise ValueError("weights_mode='real' requires cache_path")
-            if model_path is None:
-                raise ValueError("weights_mode='real' requires model_path")
-            provider: WeightProvider = CacheWeightProvider(cache_path, model_path)
-        elif weights_mode == "state_dict":
-            if model_path is None:
-                raise ValueError("weights_mode='state_dict' requires model_path")
-            provider = StateDictWeightProvider(model_path)
-        elif weights_mode == "synthetic":
-            provider = SyntheticWeightProvider()
-        else:
-            raise ValueError(f"Unknown weights_mode: {weights_mode!r}")
+        self.weight_provider = create_weight_provider(weights_mode, cache_path=cache_path, model_path=model_path)
+
         config = create_pipeline_configuration_from_num_procs(
             num_procs,
-            provider,
+            self.weight_provider,
             lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
             lm_head_persistent_mode=lm_head_persistent_mode,
             dense_layer_id_override=dense_layer_id_override,
@@ -168,7 +177,6 @@ class ModelPipeline:
                 on_token(next_token_id)
             if return_generated_tokens:
                 generated_tokens.append(next_token_id)
-            logger.debug("Decode step {} output token: {}", i + 1, next_token_id)
 
         logger.debug("Generation complete ({} tokens generated)", 1 + num_decode_steps)
         if return_generated_tokens:

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -29,6 +29,7 @@ from models.demos.deepseek_v3_b1.weights.prepare import (
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
     DeepSeekV3MTPWeights,
+    DenseRoutedExpertWeights,
     MoERoutedExpertWeights,
     OverlappedTensor,
     prepare_attention_weights,
@@ -37,6 +38,7 @@ from models.demos.deepseek_v3_b1.weights.prepare import (
     prepare_lm_head_weights,
     prepare_moe_layer_weights,
     prepare_mtp_weights,
+    prepare_q_ab_kv_a_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
 )
@@ -243,7 +245,7 @@ class CacheWeightProvider:
         return prepare_lm_head_weights(self._state_dict, device, cache_config=self._cache_config(device))
 
     def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        """Load MoE layer from tensor cache; routed experts use fast dispatch, rest uses slow dispatch."""
+        """Load MoE layer from tensor cache; FD-safe weights use fast dispatch, rest uses slow dispatch."""
         t_load = time.perf_counter()
         cache_config = self._cache_config(device)
         setup_s = time.perf_counter() - t_load
@@ -263,6 +265,15 @@ class CacheWeightProvider:
                 cache_config=cache_config,
             )
             routed_prepare_s = time.perf_counter() - t0
+            t0 = time.perf_counter()
+            q_ab = prepare_q_ab_kv_a_weights(
+                device,
+                self._state_dict,
+                layer_id,
+                move_to_device=True,
+                cache_config=cache_config,
+            )
+            q_ab_prepare_s = time.perf_counter() - t0
             t_before_teardown = time.perf_counter()
         t_after_with = time.perf_counter()
         fd_teardown_s = t_after_with - t_before_teardown
@@ -270,6 +281,7 @@ class CacheWeightProvider:
         logger.info(f"CacheWeightProvider MoE layer {layer_id}: setup (cache_config) {setup_s:.3f}s")
         logger.info(f"CacheWeightProvider MoE layer {layer_id}: fast_dispatch initialize {fd_init_s:.3f}s")
         logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_routed_expert_weights {routed_prepare_s:.3f}s")
+        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_q_ab_kv_a_weights (FD) {q_ab_prepare_s:.3f}s")
         logger.info(f"CacheWeightProvider MoE layer {layer_id}: fast_dispatch terminate {fd_teardown_s:.3f}s")
 
         t0 = time.perf_counter()
@@ -280,9 +292,10 @@ class CacheWeightProvider:
             is_moe=True,
             move_to_device=True,
             cache_config=cache_config,
+            preloaded_q_ab=q_ab,
         )
         attn_s = time.perf_counter() - t0
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_attention_weights {attn_s:.3f}s")
+        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_attention_weights (SD) {attn_s:.3f}s")
         t0 = time.perf_counter()
         shared = prepare_shared_expert_weights(
             device,
@@ -296,7 +309,7 @@ class CacheWeightProvider:
         logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_shared_expert_weights {shared_s:.3f}s")
 
         total_s = time.perf_counter() - t_load
-        sum_parts = setup_s + fd_init_s + routed_prepare_s + fd_teardown_s + attn_s + shared_s
+        sum_parts = setup_s + fd_init_s + routed_prepare_s + q_ab_prepare_s + fd_teardown_s + attn_s + shared_s
         overhead_s = total_s - sum_parts
         logger.info(
             f"CacheWeightProvider MoE layer {layer_id}: load_moe_layer total {total_s:.3f}s "
@@ -327,12 +340,78 @@ class CacheWeightProvider:
         )
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        return prepare_dense_layer_weights(
+        """Load dense layer; FD-safe weights (routed experts, q_ab_kv_a) use fast dispatch."""
+        t_load = time.perf_counter()
+        cache_config = self._cache_config(device)
+
+        with ttnn.device.setup_fast_dispatch(device):
+            t0 = time.perf_counter()
+            routed = prepare_routed_expert_weights(
+                device,
+                self._state_dict,
+                layer_id,
+                is_moe=False,
+                move_to_device=True,
+                cache_config=cache_config,
+            )
+            routed_s = time.perf_counter() - t0
+            t0 = time.perf_counter()
+            q_ab = prepare_q_ab_kv_a_weights(
+                device,
+                self._state_dict,
+                layer_id,
+                move_to_device=True,
+                cache_config=cache_config,
+            )
+            q_ab_s = time.perf_counter() - t0
+
+        ttnn.enable_asynchronous_slow_dispatch(device)
+
+        t0 = time.perf_counter()
+        attn = prepare_attention_weights(
             device,
             self._state_dict,
             layer_id,
+            is_moe=False,
             move_to_device=True,
-            cache_config=self._cache_config(device),
+            cache_config=cache_config,
+            preloaded_q_ab=q_ab,
+        )
+        attn_s = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        shared = prepare_shared_expert_weights(
+            device,
+            self._state_dict,
+            layer_id,
+            is_moe=False,
+            move_to_device=True,
+            cache_config=cache_config,
+        )
+        shared_s = time.perf_counter() - t0
+
+        assert isinstance(routed, DenseRoutedExpertWeights)
+        total_s = time.perf_counter() - t_load
+        logger.info(
+            f"CacheWeightProvider dense layer {layer_id}: total {total_s:.3f}s "
+            f"(routed FD {routed_s:.3f}s, q_ab FD {q_ab_s:.3f}s, attn SD {attn_s:.3f}s, shared SD {shared_s:.3f}s)"
+        )
+        return DeepSeekV3DenseLayerWeights(
+            q_a_proj=attn.q_a_proj,
+            q_b_proj=attn.q_b_proj,
+            kv_a_proj=attn.kv_a_proj,
+            o_proj=attn.o_proj,
+            attn_norm=attn.attn_norm,
+            q_norm=attn.q_norm,
+            kv_norm=attn.kv_norm,
+            ffn_norm=attn.ffn_norm,
+            kv_b1_proj=attn.kv_b1_proj,
+            kv_b2_proj=attn.kv_b2_proj,
+            shared_gate_proj=shared.shared_gate_proj,
+            shared_up_proj=shared.shared_up_proj,
+            shared_down_proj=shared.shared_down_proj,
+            routed_gate_proj=routed.routed_gate_proj,
+            routed_up_proj=routed.routed_up_proj,
+            routed_down_proj=routed.routed_down_proj,
         )
 
     def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -86,6 +86,9 @@ class WeightProviderPerformanceReport:
         stage_id: int | None = None,
         weight_provider_name: str | None = None,
         timestamp_utc: str | None = None,
+        model_directory: str | None = None,
+        cache_directory: str | None = None,
+        hostname: str | None = None,
     ) -> dict[str, object]:
         report: dict[str, object] = {
             "total_s": self.total_s,
@@ -106,6 +109,12 @@ class WeightProviderPerformanceReport:
             report["weight_provider_name"] = weight_provider_name
         if timestamp_utc is not None:
             report["timestamp_utc"] = timestamp_utc
+        if model_directory is not None:
+            report["model_directory"] = model_directory
+        if cache_directory is not None:
+            report["cache_directory"] = cache_directory
+        if hostname is not None:
+            report["hostname"] = hostname
         return report
 
     def to_json(
@@ -115,12 +124,18 @@ class WeightProviderPerformanceReport:
         stage_id: int | None = None,
         weight_provider_name: str | None = None,
         timestamp_utc: str | None = None,
+        model_directory: str | None = None,
+        cache_directory: str | None = None,
+        hostname: str | None = None,
     ) -> str:
         return json.dumps(
             self.to_dict(
                 stage_id=stage_id,
                 weight_provider_name=weight_provider_name,
                 timestamp_utc=timestamp_utc,
+                model_directory=model_directory,
+                cache_directory=cache_directory,
+                hostname=hostname,
             ),
             indent=indent,
         )

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -10,12 +10,13 @@ StateDictWeightProvider loads HuggingFace safetensors and runs the same prepare_
 
 from __future__ import annotations
 
+import json
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
 import torch
-from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
@@ -44,8 +45,115 @@ from models.demos.deepseek_v3_b1.weights.prepare import (
 )
 
 
+@dataclass(frozen=True)
+class LoadPhase:
+    name: str
+    elapsed_s: float
+
+
+@dataclass(frozen=True)
+class LoadRecord:
+    method: str
+    layer_id: int | None
+    total_s: float
+    phases: list[LoadPhase]
+
+
+@dataclass
+class WeightProviderPerformanceReport:
+    records: list[LoadRecord] = field(default_factory=list)
+
+    @property
+    def total_s(self) -> float:
+        return sum(record.total_s for record in self.records)
+
+    def summary(self) -> str:
+        if not self.records:
+            return "No weight load performance records."
+        lines = [f"weight_loads={len(self.records)} total={self.total_s:.3f}s"]
+        for record in self.records:
+            layer_desc = "" if record.layer_id is None else f" layer={record.layer_id}"
+            phase_desc = ", ".join(f"{phase.name}={phase.elapsed_s:.3f}s" for phase in record.phases)
+            if phase_desc:
+                lines.append(f"{record.method}{layer_desc}: total={record.total_s:.3f}s ({phase_desc})")
+            else:
+                lines.append(f"{record.method}{layer_desc}: total={record.total_s:.3f}s")
+        return "\n".join(lines)
+
+    def to_dict(
+        self,
+        *,
+        stage_id: int | None = None,
+        weight_provider_name: str | None = None,
+        timestamp_utc: str | None = None,
+    ) -> dict[str, object]:
+        report: dict[str, object] = {
+            "total_s": self.total_s,
+            "record_count": len(self.records),
+            "records": [
+                {
+                    "method": record.method,
+                    "layer_id": record.layer_id,
+                    "total_s": record.total_s,
+                    "phases": [{"name": phase.name, "elapsed_s": phase.elapsed_s} for phase in record.phases],
+                }
+                for record in self.records
+            ],
+        }
+        if stage_id is not None:
+            report["stage_id"] = stage_id
+        if weight_provider_name is not None:
+            report["weight_provider_name"] = weight_provider_name
+        if timestamp_utc is not None:
+            report["timestamp_utc"] = timestamp_utc
+        return report
+
+    def to_json(
+        self,
+        indent: int = 2,
+        *,
+        stage_id: int | None = None,
+        weight_provider_name: str | None = None,
+        timestamp_utc: str | None = None,
+    ) -> str:
+        return json.dumps(
+            self.to_dict(
+                stage_id=stage_id,
+                weight_provider_name=weight_provider_name,
+                timestamp_utc=timestamp_utc,
+            ),
+            indent=indent,
+        )
+
+
+class PhaseTracker:
+    """Accumulates sub-phase timings for one load_* call."""
+
+    def __init__(self) -> None:
+        self._start_s = time.perf_counter()
+        self._current_phase_name: str | None = None
+        self._current_phase_start_s: float | None = None
+        self._phases: list[LoadPhase] = []
+
+    def phase(self, name: str) -> None:
+        now = time.perf_counter()
+        if self._current_phase_name is not None and self._current_phase_start_s is not None:
+            self._phases.append(LoadPhase(name=self._current_phase_name, elapsed_s=now - self._current_phase_start_s))
+        self._current_phase_name = name
+        self._current_phase_start_s = now
+
+    def finish(self) -> tuple[float, list[LoadPhase]]:
+        now = time.perf_counter()
+        if self._current_phase_name is not None and self._current_phase_start_s is not None:
+            self._phases.append(LoadPhase(name=self._current_phase_name, elapsed_s=now - self._current_phase_start_s))
+        return now - self._start_s, list(self._phases)
+
+
 class WeightProvider(Protocol):
     """Provides embedding and LM head weights on demand; each host loads only what its stage needs."""
+
+    def get_performance_report(self) -> WeightProviderPerformanceReport:
+        ...
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
         ...
@@ -204,7 +312,21 @@ def _build_synthetic_mtp_state_dict(mtp_layer_idx: int = _MTP_LAYER_IDX) -> dict
     }
 
 
-class CacheWeightProvider:
+class PerformanceTrackingWeightProvider:
+    def __init__(self) -> None:
+        self._perf = WeightProviderPerformanceReport()
+
+    def get_performance_report(self) -> WeightProviderPerformanceReport:
+        return self._perf
+
+    def create_tracker(self) -> PhaseTracker:
+        return PhaseTracker()
+
+    def record(self, method: str, layer_id: int | None, total_s: float, phases: list[LoadPhase]) -> None:
+        self._perf.records.append(LoadRecord(method=method, layer_id=layer_id, total_s=total_s, phases=phases))
+
+
+class CacheWeightProvider(PerformanceTrackingWeightProvider):
     """Load weights through TensorCache-backed ``prepare_*`` calls with LazyStateDict miss source.
 
     The cache directory is created on first use if it does not already exist.
@@ -219,6 +341,7 @@ class CacheWeightProvider:
         hf_revision: str = "local",
         schema_version: int = 1,
     ) -> None:
+        super().__init__()
         cache_path = Path(cache_path)
         model_path = Path(model_path)
         assert model_path.exists(), f"Model path does not exist: {model_path}"
@@ -239,22 +362,29 @@ class CacheWeightProvider:
         return CacheConfig(cache=self._cache, context=context)
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        return prepare_embedding_weights(self._state_dict, device, cache_config=self._cache_config(device))
+        tracker = self.create_tracker()
+        tracker.phase("prepare_embedding_weights")
+        result = prepare_embedding_weights(self._state_dict, device, cache_config=self._cache_config(device))
+        total_s, phases = tracker.finish()
+        self.record(method="load_embedding", layer_id=None, total_s=total_s, phases=phases)
+        return result
 
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        return prepare_lm_head_weights(self._state_dict, device, cache_config=self._cache_config(device))
+        tracker = self.create_tracker()
+        tracker.phase("prepare_lm_head_weights")
+        result = prepare_lm_head_weights(self._state_dict, device, cache_config=self._cache_config(device))
+        total_s, phases = tracker.finish()
+        self.record(method="load_lm_head", layer_id=None, total_s=total_s, phases=phases)
+        return result
 
     def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
         """Load MoE layer from tensor cache; FD-safe weights use fast dispatch, rest uses slow dispatch."""
-        t_load = time.perf_counter()
+        tracker = self.create_tracker()
+        tracker.phase("setup")
         cache_config = self._cache_config(device)
-        setup_s = time.perf_counter() - t_load
-
-        t_before_with = time.perf_counter()
+        tracker.phase("fast_dispatch_init")
         with ttnn.device.setup_fast_dispatch(device):
-            t_after_fd_init = time.perf_counter()
-            fd_init_s = t_after_fd_init - t_before_with
-            t0 = time.perf_counter()
+            tracker.phase("prepare_routed_expert_weights")
             routed = prepare_routed_expert_weights(
                 device,
                 self._state_dict,
@@ -264,8 +394,7 @@ class CacheWeightProvider:
                 move_to_device=True,
                 cache_config=cache_config,
             )
-            routed_prepare_s = time.perf_counter() - t0
-            t0 = time.perf_counter()
+            tracker.phase("prepare_q_ab_kv_a_weights")
             q_ab = prepare_q_ab_kv_a_weights(
                 device,
                 self._state_dict,
@@ -273,18 +402,9 @@ class CacheWeightProvider:
                 move_to_device=True,
                 cache_config=cache_config,
             )
-            q_ab_prepare_s = time.perf_counter() - t0
-            t_before_teardown = time.perf_counter()
-        t_after_with = time.perf_counter()
-        fd_teardown_s = t_after_with - t_before_teardown
+            tracker.phase("fast_dispatch_teardown")
 
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: setup (cache_config) {setup_s:.3f}s")
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: fast_dispatch initialize {fd_init_s:.3f}s")
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_routed_expert_weights {routed_prepare_s:.3f}s")
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_q_ab_kv_a_weights (FD) {q_ab_prepare_s:.3f}s")
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: fast_dispatch terminate {fd_teardown_s:.3f}s")
-
-        t0 = time.perf_counter()
+        tracker.phase("prepare_attention_weights")
         attn = prepare_attention_weights(
             device,
             self._state_dict,
@@ -294,9 +414,7 @@ class CacheWeightProvider:
             cache_config=cache_config,
             preloaded_q_ab=q_ab,
         )
-        attn_s = time.perf_counter() - t0
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_attention_weights (SD) {attn_s:.3f}s")
-        t0 = time.perf_counter()
+        tracker.phase("prepare_shared_expert_weights")
         shared = prepare_shared_expert_weights(
             device,
             self._state_dict,
@@ -305,16 +423,8 @@ class CacheWeightProvider:
             move_to_device=True,
             cache_config=cache_config,
         )
-        shared_s = time.perf_counter() - t0
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_shared_expert_weights {shared_s:.3f}s")
-
-        total_s = time.perf_counter() - t_load
-        sum_parts = setup_s + fd_init_s + routed_prepare_s + q_ab_prepare_s + fd_teardown_s + attn_s + shared_s
-        overhead_s = total_s - sum_parts
-        logger.info(
-            f"CacheWeightProvider MoE layer {layer_id}: load_moe_layer total {total_s:.3f}s "
-            f"(sum of parts {sum_parts:.3f}s; unaccounted {overhead_s:+.3f}s — logging / small gaps)"
-        )
+        total_s, phases = tracker.finish()
+        self.record(method="load_moe_layer", layer_id=layer_id, total_s=total_s, phases=phases)
         assert isinstance(attn.gate_mm, OverlappedTensor)
         assert attn.gate_bias is not None
         assert isinstance(routed, MoERoutedExpertWeights)
@@ -341,11 +451,13 @@ class CacheWeightProvider:
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
         """Load dense layer; FD-safe weights (routed experts, q_ab_kv_a) use fast dispatch."""
-        t_load = time.perf_counter()
+        tracker = self.create_tracker()
+        tracker.phase("setup")
         cache_config = self._cache_config(device)
 
+        tracker.phase("fast_dispatch_init")
         with ttnn.device.setup_fast_dispatch(device):
-            t0 = time.perf_counter()
+            tracker.phase("prepare_routed_expert_weights")
             routed = prepare_routed_expert_weights(
                 device,
                 self._state_dict,
@@ -354,8 +466,7 @@ class CacheWeightProvider:
                 move_to_device=True,
                 cache_config=cache_config,
             )
-            routed_s = time.perf_counter() - t0
-            t0 = time.perf_counter()
+            tracker.phase("prepare_q_ab_kv_a_weights")
             q_ab = prepare_q_ab_kv_a_weights(
                 device,
                 self._state_dict,
@@ -363,11 +474,11 @@ class CacheWeightProvider:
                 move_to_device=True,
                 cache_config=cache_config,
             )
-            q_ab_s = time.perf_counter() - t0
+            tracker.phase("fast_dispatch_teardown")
 
         ttnn.enable_asynchronous_slow_dispatch(device)
 
-        t0 = time.perf_counter()
+        tracker.phase("prepare_attention_weights")
         attn = prepare_attention_weights(
             device,
             self._state_dict,
@@ -377,8 +488,7 @@ class CacheWeightProvider:
             cache_config=cache_config,
             preloaded_q_ab=q_ab,
         )
-        attn_s = time.perf_counter() - t0
-        t0 = time.perf_counter()
+        tracker.phase("prepare_shared_expert_weights")
         shared = prepare_shared_expert_weights(
             device,
             self._state_dict,
@@ -387,14 +497,10 @@ class CacheWeightProvider:
             move_to_device=True,
             cache_config=cache_config,
         )
-        shared_s = time.perf_counter() - t0
 
         assert isinstance(routed, DenseRoutedExpertWeights)
-        total_s = time.perf_counter() - t_load
-        logger.info(
-            f"CacheWeightProvider dense layer {layer_id}: total {total_s:.3f}s "
-            f"(routed FD {routed_s:.3f}s, q_ab FD {q_ab_s:.3f}s, attn SD {attn_s:.3f}s, shared SD {shared_s:.3f}s)"
-        )
+        total_s, phases = tracker.finish()
+        self.record(method="load_dense_layer", layer_id=layer_id, total_s=total_s, phases=phases)
         return DeepSeekV3DenseLayerWeights(
             q_a_proj=attn.q_a_proj,
             q_b_proj=attn.q_b_proj,
@@ -415,13 +521,23 @@ class CacheWeightProvider:
         )
 
     def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
-        return prepare_mtp_weights(self._state_dict, device, cache_config=self._cache_config(device))
+        tracker = self.create_tracker()
+        tracker.phase("prepare_mtp_weights")
+        result = prepare_mtp_weights(self._state_dict, device, cache_config=self._cache_config(device))
+        total_s, phases = tracker.finish()
+        self.record(method="load_mtp", layer_id=None, total_s=total_s, phases=phases)
+        return result
 
 
-class SyntheticWeightProvider:
+class SyntheticWeightProvider(PerformanceTrackingWeightProvider):
     """Create deterministic synthetic embedding and LM head weights in place (no cache)."""
 
+    def __init__(self) -> None:
+        super().__init__()
+
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
+        tracker = self.create_tracker()
+        tracker.phase("prepare_embedding_weights")
         emb_w = torch.zeros(
             (LogicalModelDimensions.VOCAB_SIZE, LogicalModelDimensions.HIDDEN_SIZE), dtype=torch.bfloat16
         )
@@ -429,9 +545,14 @@ class SyntheticWeightProvider:
             torch.arange(LogicalModelDimensions.VOCAB_SIZE),
             torch.arange(LogicalModelDimensions.VOCAB_SIZE, dtype=torch.int64) % LogicalModelDimensions.HIDDEN_SIZE,
         ] = 1
-        return prepare_embedding_weights({"model.embed_tokens.weight": emb_w}, device, move_to_device=True)
+        result = prepare_embedding_weights({"model.embed_tokens.weight": emb_w}, device, move_to_device=True)
+        total_s, phases = tracker.finish()
+        self.record(method="load_embedding", layer_id=None, total_s=total_s, phases=phases)
+        return result
 
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        tracker = self.create_tracker()
+        tracker.phase("prepare_lm_head_weights")
         # Stride for synthetic one-hot pattern: 101 matmul cores × 160 per core (matches LM head sampling op layout).
         _lm_head_n_synthetic = 101 * 160
         lm_w = torch.full(
@@ -441,7 +562,7 @@ class SyntheticWeightProvider:
             torch.arange(LogicalModelDimensions.HIDDEN_SIZE, dtype=torch.int64) % _lm_head_n_synthetic,
             torch.arange(LogicalModelDimensions.HIDDEN_SIZE),
         ] = 1
-        return prepare_lm_head_weights(
+        result = prepare_lm_head_weights(
             {
                 "lm_head.weight": lm_w,
                 "model.norm.weight": torch.ones(LogicalModelDimensions.HIDDEN_SIZE, dtype=torch.bfloat16),
@@ -449,48 +570,92 @@ class SyntheticWeightProvider:
             device,
             move_to_device=True,
         )
+        total_s, phases = tracker.finish()
+        self.record(method="load_lm_head", layer_id=None, total_s=total_s, phases=phases)
+        return result
 
     def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        tracker = self.create_tracker()
+        tracker.phase("prepare_moe_layer_weights")
         sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
-        return prepare_moe_layer_weights(
+        result = prepare_moe_layer_weights(
             device, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS, move_to_device=True
         )
+        total_s, phases = tracker.finish()
+        self.record(method="load_moe_layer", layer_id=layer_id, total_s=total_s, phases=phases)
+        return result
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        tracker = self.create_tracker()
+        tracker.phase("prepare_dense_layer_weights")
         sd = _build_synthetic_dense_state_dict(layer_id)
-        return prepare_dense_layer_weights(device, sd, layer_id, move_to_device=True)
+        result = prepare_dense_layer_weights(device, sd, layer_id, move_to_device=True)
+        total_s, phases = tracker.finish()
+        self.record(method="load_dense_layer", layer_id=layer_id, total_s=total_s, phases=phases)
+        return result
 
     def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
+        tracker = self.create_tracker()
+        tracker.phase("prepare_mtp_weights")
         sd = _build_synthetic_mtp_state_dict()
-        return prepare_mtp_weights(sd, device, move_to_device=True)
+        result = prepare_mtp_weights(sd, device, move_to_device=True)
+        total_s, phases = tracker.finish()
+        self.record(method="load_mtp", layer_id=None, total_s=total_s, phases=phases)
+        return result
 
 
-class StateDictWeightProvider:
+class StateDictWeightProvider(PerformanceTrackingWeightProvider):
     """Load real HF safetensors via LazyStateDict and prepare weights at runtime (no tensorbin cache)."""
 
     def __init__(self, model_path: Path) -> None:
+        super().__init__()
         model_path = Path(model_path)
         assert model_path.exists(), f"Model path does not exist: {model_path}"
         assert model_path.is_dir(), f"Model path is not a directory: {model_path}"
         self._state_dict = LazyStateDict(model_path)
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        return prepare_embedding_weights(self._state_dict, device, move_to_device=True)
+        tracker = self.create_tracker()
+        tracker.phase("prepare_embedding_weights")
+        result = prepare_embedding_weights(self._state_dict, device, move_to_device=True)
+        total_s, phases = tracker.finish()
+        self.record(method="load_embedding", layer_id=None, total_s=total_s, phases=phases)
+        return result
 
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        return prepare_lm_head_weights(self._state_dict, device, move_to_device=True)
+        tracker = self.create_tracker()
+        tracker.phase("prepare_lm_head_weights")
+        result = prepare_lm_head_weights(self._state_dict, device, move_to_device=True)
+        total_s, phases = tracker.finish()
+        self.record(method="load_lm_head", layer_id=None, total_s=total_s, phases=phases)
+        return result
 
     def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        return prepare_moe_layer_weights(
+        tracker = self.create_tracker()
+        tracker.phase("prepare_moe_layer_weights")
+        result = prepare_moe_layer_weights(
             device,
             self._state_dict,
             layer_id,
             num_routed_experts=NUM_ROUTED_EXPERTS,
             move_to_device=True,
         )
+        total_s, phases = tracker.finish()
+        self.record(method="load_moe_layer", layer_id=layer_id, total_s=total_s, phases=phases)
+        return result
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        return prepare_dense_layer_weights(device, self._state_dict, layer_id, move_to_device=True)
+        tracker = self.create_tracker()
+        tracker.phase("prepare_dense_layer_weights")
+        result = prepare_dense_layer_weights(device, self._state_dict, layer_id, move_to_device=True)
+        total_s, phases = tracker.finish()
+        self.record(method="load_dense_layer", layer_id=layer_id, total_s=total_s, phases=phases)
+        return result
 
     def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
-        return prepare_mtp_weights(self._state_dict, device, move_to_device=True)
+        tracker = self.create_tracker()
+        tracker.phase("prepare_mtp_weights")
+        result = prepare_mtp_weights(self._state_dict, device, move_to_device=True)
+        total_s, phases = tracker.finish()
+        self.record(method="load_mtp", layer_id=None, total_s=total_s, phases=phases)
+        return result

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -659,38 +659,32 @@ def create_gate_indices_tensor(
     )
 
 
-def prepare_attention_weights(
+def prepare_q_ab_kv_a_weights(
     device,
     state_dict: dict[str, torch.Tensor],
     layer_idx: int,
     *,
-    is_moe: bool,
     move_to_device: bool = False,
     cache_config: CacheConfig | None = None,
-) -> AttentionWeights:
-    """Prepare attention fusion groups for one layer (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)."""
+) -> dict[str, OverlappedTensor]:
+    """Prepare the q_ab_kv_a fusion group for one layer.
+
+    This fusion group uses cores (0,0)-(11,7) + (0,8)-(8,9) and does NOT
+    touch column 12, making it safe for fast dispatch loading.
+
+    Returns:
+        Dict with keys ``q_a_proj``, ``q_b_proj``, ``kv_a_proj``.
+    """
     if cache_config is None:
         cache_config = CacheConfig.ephemeral(move_to_device=move_to_device)
     mla_tp, _ = _tp_factors(device)
     mesh_shape = (device.shape[0], device.shape[1]) if device.get_num_devices() > 1 else (1, 1)
 
-    logger.debug(
-        "Converting attention fusion groups for layer {} (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)",
-        layer_idx,
-    )
-    t0 = time.perf_counter()
-
     q_a_key = _key(layer_idx, "self_attn.q_a_proj.weight")
     q_b_key = _key(layer_idx, "self_attn.q_b_proj.weight")
     kv_a_key = _key(layer_idx, "self_attn.kv_a_proj_with_mqa.weight")
-    kv_b_key = _key(layer_idx, "self_attn.kv_b_proj.weight")
-    o_proj_key = _key(layer_idx, "self_attn.o_proj.weight")
-    attn_norm_key = _key(layer_idx, "input_layernorm.weight")
-    q_norm_key = _key(layer_idx, "self_attn.q_a_layernorm.weight")
-    kv_norm_key = _key(layer_idx, "self_attn.kv_a_layernorm.weight")
-    ffn_norm_key = _key(layer_idx, "post_attention_layernorm.weight")
 
-    def _preprocess_q_ab_kv_a(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    def _preprocess(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         q_a = t[q_a_key].T.contiguous()
         q_b = deinterleave_q_b_proj(t[q_b_key])
         kv_a = t[kv_a_key].T.contiguous()
@@ -705,14 +699,64 @@ def prepare_attention_weights(
     q_ab_views = cache_config.cache.get_or_create(
         q_ab_fp,
         device,
-        preprocess=_preprocess_q_ab_kv_a,
+        preprocess=_preprocess,
         raw_tensors=lambda: {k: state_dict[k] for k in (q_a_key, q_b_key, kv_a_key)},
     )
     if not isinstance(q_ab_views, dict):
         raise TypeError("expected dict[str, OverlappedTensor] for q_ab_kv_a cache entry")
-    q_a_proj = q_ab_views["q_a_proj"]
-    q_b_proj = q_ab_views["q_b_proj"]
-    kv_a_proj = q_ab_views["kv_a_proj"]
+    return q_ab_views
+
+
+def prepare_attention_weights(
+    device,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    *,
+    is_moe: bool,
+    move_to_device: bool = False,
+    cache_config: CacheConfig | None = None,
+    preloaded_q_ab: dict[str, OverlappedTensor] | None = None,
+) -> AttentionWeights:
+    """Prepare attention fusion groups for one layer (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms).
+
+    Args:
+        preloaded_q_ab: If provided, skip loading the q_ab_kv_a fusion group and use
+            these pre-loaded views instead.  Useful when q_ab_kv_a was already loaded
+            in a fast dispatch context.
+    """
+    if cache_config is None:
+        cache_config = CacheConfig.ephemeral(move_to_device=move_to_device)
+    mla_tp, _ = _tp_factors(device)
+    mesh_shape = (device.shape[0], device.shape[1]) if device.get_num_devices() > 1 else (1, 1)
+
+    logger.debug(
+        "Converting attention fusion groups for layer {} (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)",
+        layer_idx,
+    )
+    t0 = time.perf_counter()
+
+    if preloaded_q_ab is not None:
+        q_a_proj = preloaded_q_ab["q_a_proj"]
+        q_b_proj = preloaded_q_ab["q_b_proj"]
+        kv_a_proj = preloaded_q_ab["kv_a_proj"]
+    else:
+        q_ab_views = prepare_q_ab_kv_a_weights(
+            device,
+            state_dict,
+            layer_idx,
+            move_to_device=move_to_device,
+            cache_config=cache_config,
+        )
+        q_a_proj = q_ab_views["q_a_proj"]
+        q_b_proj = q_ab_views["q_b_proj"]
+        kv_a_proj = q_ab_views["kv_a_proj"]
+
+    kv_b_key = _key(layer_idx, "self_attn.kv_b_proj.weight")
+    o_proj_key = _key(layer_idx, "self_attn.o_proj.weight")
+    attn_norm_key = _key(layer_idx, "input_layernorm.weight")
+    q_norm_key = _key(layer_idx, "self_attn.q_a_layernorm.weight")
+    kv_norm_key = _key(layer_idx, "self_attn.kv_a_layernorm.weight")
+    ffn_norm_key = _key(layer_idx, "post_attention_layernorm.weight")
 
     def _preprocess_kv_b12(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         kv_b1, kv_b2 = split_kv_b_proj(t[kv_b_key])


### PR DESCRIPTION
### Summary

This change optimizes how the DeepSeekV3 B1 attention weights are loaded by using fast-dispatch when loading the `q_ab_kv_a` overlapped tensor, improving load time of MoE layers to ~6.5 seconds. 

This pull request also adds performance reporting for weight loading in the DeepSeek V3 B1 demo pipeline, making it easier to analyze and optimize model startup times.

**Refactoring and optimization of attention weight preparation:**

* Introduced a new `prepare_q_ab_kv_a_weights` function to separately handle the preparation of the `q_ab_kv_a` fusion group, making it safe for fast dispatch and returning only the relevant projections (`q_a_proj`, `q_b_proj`, `kv_a_proj`).
* Refactored `prepare_attention_weights` to optionally accept preloaded `q_ab_kv_a` weights, avoiding redundant loading when already loaded in a fast dispatch context.

**Changes to MoE and dense layer loading logic:**

* Updated `load_moe_layer` to separately load `q_ab_kv_a` weights with fast dispatch, pass them into `prepare_attention_weights`, and log the timing for each step. [[1]](diffhunk://#diff-d885b4620f5341be455b204ef59972883ff9f283d5c7d94dd9e3d2001492fc02R268-R276) [[2]](diffhunk://#diff-d885b4620f5341be455b204ef59972883ff9f283d5c7d94dd9e3d2001492fc02R286) [[3]](diffhunk://#diff-d885b4620f5341be455b204ef59972883ff9f283d5c7d94dd9e3d2001492fc02R297-R300) [[4]](diffhunk://#diff-d885b4620f5341be455b204ef59972883ff9f283d5c7d94dd9e3d2001492fc02L301-R314)
* Overhauled `load_dense_layer` to mirror the MoE approach: it now loads routed expert weights and `q_ab_kv_a` with fast dispatch, then uses them in attention and shared expert weight preparation, with detailed timing and logging.

**Weight load performance reporting:**

* Added a `WeightProviderPerformanceReport` dataclass and supporting structures (`LoadPhase`, `LoadRecord`, `PhaseTracker`) to record timing for each phase of weight loading. Each weight provider now implements a `get_performance_report()` method to retrieve this data. [[1]](diffhunk://#diff-d885b4620f5341be455b204ef59972883ff9f283d5c7d94dd9e3d2001492fc02R42-R157) [[2]](diffhunk://#diff-d885b4620f5341be455b204ef59972883ff9f283d5c7d94dd9e3d2001492fc02L205-R329)
* Each weight loading method in `CacheWeightProvider` is now instrumented to record detailed phase timings, replacing previous ad-hoc logging.
* Added a CLI argument `--weight-perf-report-path` to optionally output a JSON performance report per mesh, including metadata such as mesh ID and timestamp. Helper functions were added to handle report file naming and serialization. [[1]](diffhunk://#diff-b5a805c38bfaad6b32e44a92e79c50496b943dfca25d36fd011672e188257da2R136-R180) [[2]](diffhunk://#diff-b5a805c38bfaad6b32e44a92e79c50496b943dfca25d36fd011672e188257da2R195-L161) [[3]](diffhunk://#diff-b5a805c38bfaad6b32e44a92e79c50496b943dfca25d36fd011672e188257da2R215-R226) [[4]](diffhunk://#diff-b5a805c38bfaad6b32e44a92e79c50496b943dfca25d36fd011672e188257da2R301)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/use-fd-for-weight-load) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/use-fd-for-weight-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/use-fd-for-weight-load) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/use-fd-for-weight-load) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/use-fd-for-weight-load) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/use-fd-for-weight-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/use-fd-for-weight-load) | [#17479](https://github.com/tenstorrent/tt-metal/actions/runs/24409603512) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/use-fd-for-weight-load) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/use-fd-for-weight-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/use-fd-for-weight-load) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/use-fd-for-weight-load) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/use-fd-for-weight-load) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/use-fd-for-weight-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/use-fd-for-weight-load) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/use-fd-for-weight-load) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/use-fd-for-weight-load) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/use-fd-for-weight-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/use-fd-for-weight-load) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/use-fd-for-weight-load) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/use-fd-for-weight-load) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/use-fd-for-weight-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/use-fd-for-weight-load) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/use-fd-for-weight-load) |