### PR TITLE
Fix false packer tile_index assert for non-standard tile shapes

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
@@ -30,11 +30,10 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_pcc, skip_with_llk_assert
+from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_b1.micro_ops.matmul.op import Matmul
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39472")
 @pytest.mark.parametrize(
     "M, K, N, in0_dtype, in1_dtype, transpose, fused_activation, fp32_dest_acc_en",
     [
@@ -208,7 +207,6 @@ def test_matmul_single_core(device, M, K, N, in0_dtype, in1_dtype, transpose, fu
     logger.info(f"✓ Single-core matmul{activation_str}{fp32_str} test passed!")
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39472")
 @pytest.mark.parametrize(
     "M, K, N, in0_dtype, in1_dtype, transpose, fused_activation, fp32_dest_acc_en, core_grid",
     [

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa.py
@@ -16,11 +16,10 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_pcc, skip_with_llk_assert
+from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_b1.micro_ops.sdpa.op import SdpaSingleCore
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39472")
 @pytest.mark.parametrize(
     "num_tiles_k, num_tiles_v, chunk_size, num_chunks, scale",
     [

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_tail.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_tail.py
@@ -20,11 +20,10 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_pcc, skip_with_llk_assert
+from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_b1.micro_ops.sdpa_tail.op import SdpaTailSingleCore
 
 
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker configuration verification. Issue: #39472")
 @pytest.mark.parametrize(
     "width, block_size, num_blocks, dense",
     [

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_block_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_block_api.h
@@ -39,9 +39,9 @@ inline void llk_pack_block_contiguous_mop_config(const std::uint32_t output) {
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_block_contiguous(std::uint32_t tile_index, std::uint32_t output, std::uint32_t num_tiles) {
     LLK_ASSERT(
-        ((num_tiles > 0) &&
-         ((tile_index + num_tiles - 1) < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>())),
-        "Dst tile exceeds packer destination capacity");
+        ((num_tiles >= 1 && num_tiles <= 8) &&
+         ((tile_index + num_tiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>())),
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     std::uint8_t output_id = get_output_id(output);
     std::uint32_t pack_tile_addr =

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -172,7 +172,9 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
             pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output))),
         "");
 
-    LLK_ASSERT((tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
+    LLK_ASSERT(
+        (tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
     _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
 }
 
@@ -280,7 +282,7 @@ inline void llk_pack_rows(
     const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
     LLK_ASSERT(
         (dst_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
-        "Dst tile exceeds maximum allowed for the given tile shape and accumulation mode.");
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     // Pack rows uses pack_reads_per_xy_plane=1 (set in _llk_pack_rows_init_) for row packing,
     // which differs from standard tile face_r_dim. Use ProgramByTile to skip face_r_dim check.
@@ -310,7 +312,9 @@ inline void llk_matmul_pack(
         (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
             pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output))),
         "");
-    LLK_ASSERT(((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
+    LLK_ASSERT(
+        ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t pack_tile_addr =

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -172,7 +172,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
             pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output))),
         "");
 
-    LLK_ASSERT((tile_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    LLK_ASSERT((tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
     _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
 }
 
@@ -279,7 +279,7 @@ inline void llk_pack_rows(
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
     LLK_ASSERT(
-        (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        (dst_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
         "Dst tile exceeds maximum allowed for the given tile shape and accumulation mode.");
 
     // Pack rows uses pack_reads_per_xy_plane=1 (set in _llk_pack_rows_init_) for row packing,
@@ -310,7 +310,7 @@ inline void llk_matmul_pack(
         (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
             pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output))),
         "");
-    LLK_ASSERT(((start_tile_index + ntiles - 1) < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    LLK_ASSERT(((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t pack_tile_addr =

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -158,7 +158,9 @@ inline std::uint32_t get_output_tile_address(std::uint8_t output_id, std::uint32
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, bool untilize = false>
 inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32_t output_tile_index = 0) {
-    LLK_ASSERT((tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
+    LLK_ASSERT(
+        (tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     std::uint8_t output_id = get_output_id(output);
 
@@ -246,7 +248,9 @@ inline void llk_matmul_pack(
         (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
             pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output))),
         "");
-    LLK_ASSERT(((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
+    LLK_ASSERT(
+        ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t pack_tile_addr =
@@ -285,7 +289,9 @@ inline void llk_pack_rows_init(const std::uint32_t num_rows) { _llk_pack_rows_in
  */
 inline void llk_pack_rows(
     const std::uint32_t dst_index, const std::uint32_t output, const std::uint32_t output_index = 0) {
-    LLK_ASSERT((dst_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
+    LLK_ASSERT(
+        (dst_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
@@ -347,7 +353,9 @@ inline void llk_pack_fast_tilize_block(
     const std::uint32_t output_tile_index,
     const std::uint32_t unit_dim,
     const std::uint32_t num_units) {
-    LLK_ASSERT((tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
+    LLK_ASSERT(
+        (tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -158,7 +158,7 @@ inline std::uint32_t get_output_tile_address(std::uint8_t output_id, std::uint32
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, bool untilize = false>
 inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32_t output_tile_index = 0) {
-    LLK_ASSERT((tile_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    LLK_ASSERT((tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
 
     std::uint8_t output_id = get_output_id(output);
 
@@ -246,7 +246,7 @@ inline void llk_matmul_pack(
         (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
             pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output))),
         "");
-    LLK_ASSERT(((start_tile_index + ntiles - 1) < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    LLK_ASSERT(((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t pack_tile_addr =
@@ -285,7 +285,7 @@ inline void llk_pack_rows_init(const std::uint32_t num_rows) { _llk_pack_rows_in
  */
 inline void llk_pack_rows(
     const std::uint32_t dst_index, const std::uint32_t output, const std::uint32_t output_index = 0) {
-    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    LLK_ASSERT((dst_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
 
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
@@ -347,7 +347,7 @@ inline void llk_pack_fast_tilize_block(
     const std::uint32_t output_tile_index,
     const std::uint32_t unit_dim,
     const std::uint32_t num_units) {
-    LLK_ASSERT((tile_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    LLK_ASSERT((tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()), "");
 
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
@@ -869,6 +869,11 @@ inline std::uint32_t get_pack_dest_max_tiles()
     const std::uint32_t w_stride =
         (cfg_read(PCK0_ADDR_CTRL_ZW_REG_0_Wstride_ADDR32) & PCK0_ADDR_CTRL_ZW_REG_0_Wstride_MASK) >> PCK0_ADDR_CTRL_ZW_REG_0_Wstride_SHAMT;
 
+    if ((w_stride == 0U) || ((w_stride & (w_stride - 1U)) != 0U))
+    {
+        return 0U;
+    }
+
     return DEST_PHYSICAL_SIZE >> __builtin_ctz(w_stride);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
@@ -863,7 +863,7 @@ constexpr std::uint32_t get_dest_max_tiles()
  * W-stride from the packer config is in the same byte-oriented addressing units.
  */
 template <DstSync SYNC_MODE, bool ACCUM_MODE>
-inline std::uint32_t get_pack_dest_max_tiles()
+__attribute__((noinline)) std::uint32_t get_pack_dest_max_tiles()
 {
     constexpr std::uint32_t dest_sync_region_size_bytes = SYNC_MODE == DstSync::SyncHalf ? DEST_REGISTER_HALF_SIZE_BYTES : DEST_REGISTER_FULL_SIZE_BYTES;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
@@ -826,7 +826,7 @@ constexpr std::uint32_t DstTileSizeLog2[3] = {
 };
 
 /**
- * @brief Calculates the maximum number of destination tiles that can fit in the destination register.
+ * @brief Calculates the maximum number of tiles that can fit in the math's destination region.
  *
  * @tparam SYNC_MODE   Destination synchronization mode (SyncHalf or SyncFull)
  * @tparam ACCUM_MODE Accumulation mode: true for 32-bit (FP32), false for 16-bit
@@ -847,6 +847,29 @@ constexpr std::uint32_t get_dest_max_tiles()
                                                                                 : (ACCUM_MODE ? DEST_REGISTER_FULL_SIZE >> 1 : DEST_REGISTER_FULL_SIZE);
 
     return DEST_REGISTER_SIZE >> DstTileSizeLog2[static_cast<int>(TILE_SHAPE)];
+}
+
+/**
+ * @brief Returns the maximum number of tiles that fit in the packer's dest region
+ *        based on the currently configured W-stride (read from the hardware config register).
+ *
+ * Unlike get_dest_max_tiles<..., DstTileShape>, this does not assume a fixed tile shape.
+ * It reads the actual W-stride that the packer is configured with, so it works correctly
+ * even when kernels reconfigure the stride for non-standard tile dimensions (e.g. 8x32).
+ *
+ * The dest physical size in stride-address-units is constant regardless of ACCUM_MODE
+ * because FP32 halves the row count but doubles the datum size, which cancels out
+ * against the doubled x_stride already baked into the configured W-stride.
+ */
+template <DstSync SYNC_MODE, bool ACCUM_MODE>
+inline std::uint32_t get_pack_dest_max_tiles()
+{
+    constexpr std::uint32_t DEST_PHYSICAL_SIZE = (SYNC_MODE == DstSync::SyncHalf ? DEST_REGISTER_HALF_SIZE : DEST_REGISTER_FULL_SIZE) * FACE_C_DIM * 2;
+
+    const std::uint32_t w_stride =
+        (cfg_read(PCK0_ADDR_CTRL_ZW_REG_0_Wstride_ADDR32) & PCK0_ADDR_CTRL_ZW_REG_0_Wstride_MASK) >> PCK0_ADDR_CTRL_ZW_REG_0_Wstride_SHAMT;
+
+    return DEST_PHYSICAL_SIZE >> __builtin_ctz(w_stride);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
@@ -857,24 +857,27 @@ constexpr std::uint32_t get_dest_max_tiles()
  * It reads the actual W-stride that the packer is configured with, so it works correctly
  * even when kernels reconfigure the stride for non-standard tile dimensions (e.g. 8x32).
  *
- * The dest physical size in stride-address-units is constant regardless of ACCUM_MODE
- * because FP32 halves the row count but doubles the datum size, which cancels out
- * against the doubled x_stride already baked into the configured W-stride.
+ * Byte capacity of the dest sync region (DEST_REGISTER_{HALF,FULL}_SIZE_BYTES) is constant
+ * regardless of ACCUM_MODE because FP32 halves the row count but doubles the datum size,
+ * which cancels out against the doubled x_stride already baked into the configured W-stride.
+ * W-stride from the packer config is in the same byte-oriented addressing units.
  */
 template <DstSync SYNC_MODE, bool ACCUM_MODE>
 inline std::uint32_t get_pack_dest_max_tiles()
 {
-    constexpr std::uint32_t DEST_PHYSICAL_SIZE = (SYNC_MODE == DstSync::SyncHalf ? DEST_REGISTER_HALF_SIZE : DEST_REGISTER_FULL_SIZE) * FACE_C_DIM * 2;
+    constexpr std::uint32_t dest_sync_region_size_bytes = SYNC_MODE == DstSync::SyncHalf ? DEST_REGISTER_HALF_SIZE_BYTES : DEST_REGISTER_FULL_SIZE_BYTES;
 
     const std::uint32_t w_stride =
         (cfg_read(PCK0_ADDR_CTRL_ZW_REG_0_Wstride_ADDR32) & PCK0_ADDR_CTRL_ZW_REG_0_Wstride_MASK) >> PCK0_ADDR_CTRL_ZW_REG_0_Wstride_SHAMT;
 
+    // Reject invalid stride: __builtin_ctz(0) is undefined. Reject non-power-of-two strides because
+    // dest_sync_region_size_bytes >> __builtin_ctz(w_stride) is only equivalent to dividing by w_stride when w_stride is a power of two.
     if ((w_stride == 0U) || ((w_stride & (w_stride - 1U)) != 0U))
     {
         return 0U;
     }
 
-    return DEST_PHYSICAL_SIZE >> __builtin_ctz(w_stride);
+    return dest_sync_region_size_bytes >> __builtin_ctz(w_stride);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -670,6 +670,11 @@ inline std::uint32_t get_pack_dest_max_tiles()
     const std::uint32_t w_stride =
         (cfg_read(PCK0_ADDR_CTRL_ZW_REG_0_Wstride_ADDR32) & PCK0_ADDR_CTRL_ZW_REG_0_Wstride_MASK) >> PCK0_ADDR_CTRL_ZW_REG_0_Wstride_SHAMT;
 
+    if ((w_stride == 0U) || ((w_stride & (w_stride - 1U)) != 0U))
+    {
+        return 0U;
+    }
+
     return DEST_PHYSICAL_SIZE >> __builtin_ctz(w_stride);
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -658,24 +658,27 @@ constexpr std::uint32_t get_dest_max_tiles()
  * It reads the actual W-stride that the packer is configured with, so it works correctly
  * even when kernels reconfigure the stride for non-standard tile dimensions (e.g. 8x32).
  *
- * The dest physical size in stride-address-units is constant regardless of ACCUM_MODE
- * because FP32 halves the row count but doubles the datum size, which cancels out
- * against the doubled x_stride already baked into the configured W-stride.
+ * Byte capacity of the dest sync region (DEST_REGISTER_{HALF,FULL}_SIZE_BYTES) is constant
+ * regardless of ACCUM_MODE because FP32 halves the row count but doubles the datum size,
+ * which cancels out against the doubled x_stride already baked into the configured W-stride.
+ * W-stride from the packer config is in the same byte-oriented addressing units.
  */
 template <DstSync SYNC_MODE, bool ACCUM_MODE>
 inline std::uint32_t get_pack_dest_max_tiles()
 {
-    constexpr std::uint32_t DEST_PHYSICAL_SIZE = (SYNC_MODE == DstSync::SyncHalf ? DEST_REGISTER_HALF_SIZE : DEST_REGISTER_FULL_SIZE) * FACE_C_DIM * 2;
+    constexpr std::uint32_t dest_sync_region_size_bytes = SYNC_MODE == DstSync::SyncHalf ? DEST_REGISTER_HALF_SIZE_BYTES : DEST_REGISTER_FULL_SIZE_BYTES;
 
     const std::uint32_t w_stride =
         (cfg_read(PCK0_ADDR_CTRL_ZW_REG_0_Wstride_ADDR32) & PCK0_ADDR_CTRL_ZW_REG_0_Wstride_MASK) >> PCK0_ADDR_CTRL_ZW_REG_0_Wstride_SHAMT;
 
+    // Reject invalid stride: __builtin_ctz(0) is undefined. Reject non-power-of-two strides because
+    // dest_sync_region_size_bytes >> __builtin_ctz(w_stride) is only equivalent to dividing by w_stride when w_stride is a power of two.
     if ((w_stride == 0U) || ((w_stride & (w_stride - 1U)) != 0U))
     {
         return 0U;
     }
 
-    return DEST_PHYSICAL_SIZE >> __builtin_ctz(w_stride);
+    return dest_sync_region_size_bytes >> __builtin_ctz(w_stride);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -627,7 +627,7 @@ constexpr std::uint32_t DstTileSizeLog2[3] = {
 };
 
 /**
- * @brief Calculates the maximum number of destination tiles that can fit in the destination register.
+ * @brief Calculates the maximum number of tiles that can fit in the math's destination region.
  *
  * @tparam SYNC_MODE   Destination synchronization mode (SyncHalf or SyncFull)
  * @tparam ACCUM_MODE Accumulation mode: true for 32-bit (FP32), false for 16-bit
@@ -648,6 +648,29 @@ constexpr std::uint32_t get_dest_max_tiles()
                                                                                 : (ACCUM_MODE ? DEST_REGISTER_FULL_SIZE >> 1 : DEST_REGISTER_FULL_SIZE);
 
     return DEST_REGISTER_SIZE >> DstTileSizeLog2[static_cast<int>(TILE_SHAPE)];
+}
+
+/**
+ * @brief Returns the maximum number of tiles that fit in the packer's dest region
+ *        based on the currently configured W-stride (read from the hardware config register).
+ *
+ * Unlike get_dest_max_tiles<..., DstTileShape>, this does not assume a fixed tile shape.
+ * It reads the actual W-stride that the packer is configured with, so it works correctly
+ * even when kernels reconfigure the stride for non-standard tile dimensions (e.g. 8x32).
+ *
+ * The dest physical size in stride-address-units is constant regardless of ACCUM_MODE
+ * because FP32 halves the row count but doubles the datum size, which cancels out
+ * against the doubled x_stride already baked into the configured W-stride.
+ */
+template <DstSync SYNC_MODE, bool ACCUM_MODE>
+inline std::uint32_t get_pack_dest_max_tiles()
+{
+    constexpr std::uint32_t DEST_PHYSICAL_SIZE = (SYNC_MODE == DstSync::SyncHalf ? DEST_REGISTER_HALF_SIZE : DEST_REGISTER_FULL_SIZE) * FACE_C_DIM * 2;
+
+    const std::uint32_t w_stride =
+        (cfg_read(PCK0_ADDR_CTRL_ZW_REG_0_Wstride_ADDR32) & PCK0_ADDR_CTRL_ZW_REG_0_Wstride_MASK) >> PCK0_ADDR_CTRL_ZW_REG_0_Wstride_SHAMT;
+
+    return DEST_PHYSICAL_SIZE >> __builtin_ctz(w_stride);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -664,7 +664,7 @@ constexpr std::uint32_t get_dest_max_tiles()
  * W-stride from the packer config is in the same byte-oriented addressing units.
  */
 template <DstSync SYNC_MODE, bool ACCUM_MODE>
-inline std::uint32_t get_pack_dest_max_tiles()
+__attribute__((noinline)) std::uint32_t get_pack_dest_max_tiles()
 {
     constexpr std::uint32_t dest_sync_region_size_bytes = SYNC_MODE == DstSync::SyncHalf ? DEST_REGISTER_HALF_SIZE_BYTES : DEST_REGISTER_FULL_SIZE_BYTES;
 


### PR DESCRIPTION
### Summary

Issue: https://github.com/tenstorrent/tt-metal/issues/39472

Add get_pack_dest_max_tiles() to compute the packer's max dest tile index from the actual configured W-stride register, instead of hardcoding DstTileShape::Tile32x32
Replace all packer LLK_ASSERT tile-index bounds checks to use the new function (BH: llk_pack, llk_pack_rows, llk_matmul_pack; WH: same + llk_pack_fast_tilize_block)
Remove @skip_with_llk_assert decorators from deepseek_v3 tests that were masking this false assert

### Notes for reviewers

#### Problem
The packer's llk_pack assert unconditionally assumed every tile occupies 64 dest rows (DstTileShape::Tile32x32), giving a max of 8 tiles in half-dest. Kernels that reconfigure the packer W-stride for smaller tiles (e.g. 8x32 SDPA tiles using 16 dest rows each) triggered a false assert at tile_index >= 8, even though the hardware can hold up to 32 such tiles.

The MATH thread is unaffected because it addresses dest via direct row offsets (TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset, ...)) rather than a stride-multiplied counter, so its DstTileShape::Tile32x32 asserts are self-consistent.

#### Solution
get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>() reads the W-stride from PCK0_ADDR_CTRL_ZW_REG_0 and computes DEST_PHYSICAL_SIZE >> ctz(w_stride). The dest physical size (DEST_REGISTER_HALF_SIZE * FACE_C_DIM * 2 = 16384) is constant regardless of FP32 mode because the halved row count and doubled datum size cancel against the doubled x_stride already baked into W-stride.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_packer_tile_index_assert_checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [#2817](https://github.com/tenstorrent/tt-metal/actions/runs/24449658739) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_packer_tile_index_assert_checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [#17512](https://github.com/tenstorrent/tt-metal/actions/runs/24449671596) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_packer_tile_index_assert_checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_packer_tile_index_assert_checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_packer_tile_index_assert_checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_packer_tile_index_assert_checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_packer_tile_index_assert_checks) |