### PR TITLE
Add Fabric2D mesh shape assertion for CCLs

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -1701,12 +1701,18 @@ void validate_fabric_2d_dynamic_config() {
     auto physical_mesh_shapes = tt::tt_fabric::get_physical_mesh_shapes();
     TT_FATAL(
         physical_mesh_shapes.size() == 1,
-        "Fabric 2D dynamic CCLs expected a single Physical Mesh to be instantiated, but got {} meshes",
+        "Fabric 2D CCLs expected a single Physical Mesh to be instantiated, but got {} meshes",
         physical_mesh_shapes.size());
     const auto& physical_mesh_shape = physical_mesh_shapes.begin()->second;
     TT_FATAL(
-        physical_mesh_shape.dims() == 2,
-        "Fabric 2D dynamic CCLs are not supported for mesh shape with more than 2 dimensions");
+        physical_mesh_shape.dims() == 2, "Fabric 2D CCLs are not supported for mesh shape with more than 2 dimensions");
+    TT_FATAL(
+        physical_mesh_shape[0] == 1 || physical_mesh_shape[1] == 1 ||
+            (physical_mesh_shape[0] == 2 && physical_mesh_shape[1] == 2),
+        "Fabric 2D CCLs are only supported for 1D physical meshes (1xN or Nx1) OR 2x2 ring that is equivalent to 1D, "
+        "but physical mesh shape is configured as {}x{}",
+        physical_mesh_shape[0],
+        physical_mesh_shape[1]);
 }
 
 std::tuple<size_t, size_t, bool> get_forward_backward_configuration(


### PR DESCRIPTION
### Summary
Fixes #41794.

Adds back the assertion removed in https://github.com/tenstorrent/tt-metal/pull/31253.
Fabric2D CCLs only support 1D shapes ([1, N] or [N, 1]), 2D physical meshes require the kernels to use different multicast args to take all 4 north/south/east/west directions into account.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/ccl-assert) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/ccl-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/ccl-assert) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/ccl-assert) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:scardoza/ccl-assert) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=scardoza/ccl-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:scardoza/ccl-assert) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:scardoza/ccl-assert) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/ccl-assert) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/ccl-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/ccl-assert) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/ccl-assert) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/ccl-assert) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/ccl-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/ccl-assert) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/ccl-assert) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/ccl-assert) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/ccl-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/ccl-assert) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/ccl-assert) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/ccl-assert) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/ccl-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/ccl-assert) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/ccl-assert) |