### PR TITLE
[skip ci] Add galaxy e2e tests to choose-your-pipeline

### DIFF
--- a/.github/workflows/galaxy-e2e-tests-impl.yaml
+++ b/.github/workflows/galaxy-e2e-tests-impl.yaml
@@ -15,12 +15,16 @@ on:
       enabled-skus:
         required: true
         type: string
+      test-selection:
+        required: false
+        type: string
+        default: "all"
 
 jobs:
   load-test-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      matrix: ${{ steps.apply-test-selection.outputs.matrix }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/galaxy_e2e_tests.yaml
     steps:
@@ -49,6 +53,24 @@ jobs:
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
             ./.github/sku_config.yaml
+      - name: Apply test selection
+        id: apply-test-selection
+        run: |
+          MATRIX='${{ steps.build-matrix.outputs.matrix }}'
+          if [ "${{ inputs.test-selection }}" = "all" ]; then
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$MATRIX" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            FILTERED=$(echo "$MATRIX" | jq -c --arg id "${{ inputs.test-selection }}" '[.[] | select(.id == $id)]')
+            if [ "$FILTERED" = "[]" ]; then
+              echo "::error::No tests found for test-selection '${{ inputs.test-selection }}'. Ensure id matches tests/pipeline_reorg/galaxy_e2e_tests.yaml and enabled-skus includes the needed SKU."
+              exit 1
+            fi
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILTERED" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
 
   galaxy-e2e-tests:
     needs: load-test-matrix

--- a/.github/workflows/galaxy-e2e-tests.yaml
+++ b/.github/workflows/galaxy-e2e-tests.yaml
@@ -77,3 +77,4 @@ jobs:
                 )
             )
         }}
+      test-selection: all

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -100,6 +100,33 @@ on:
           - mochi
           - qwenimage
         default: 'disabled'
+      galaxy-e2e:
+        description: 'Galaxy e2e tests: all, one suite (see tests/pipeline_reorg/galaxy_e2e_tests.yaml ids), or disabled'
+        required: false
+        type: choice
+        options:
+          - disabled
+          - all
+          - galaxy-ccl
+          - galaxy-moe
+          - galaxy-fabric-unit
+          - galaxy-fabric-2d-torus-nightly
+          - galaxy-fabric-multi-mesh-4x4-2x4s
+          - galaxy-fabric-multi-mesh-2x8-2x4s
+          - bh-galaxy-ccl
+          - bh-galaxy-fabric-torus-stability
+          - bh-galaxy-socket-pipeline
+        default: 'disabled'
+      galaxy-e2e-wormhole:
+        description: 'E2e: include wh_galaxy SKUs (matches standalone Galaxy e2e wormhole checkbox)'
+        required: false
+        type: boolean
+        default: true
+      galaxy-e2e-blackhole:
+        description: 'E2e: include bh_galaxy SKUs (matches standalone Galaxy e2e blackhole checkbox)'
+        required: false
+        type: boolean
+        default: false
       platform:
         required: false
         type: choice
@@ -134,6 +161,7 @@ jobs:
       run-integration: ${{ steps.logic.outputs.run-integration }}
       run-demo: ${{ steps.logic.outputs.run-demo }}
       run-model-perf: ${{ steps.logic.outputs.run-model-perf }}
+      run-e2e: ${{ steps.logic.outputs.run-e2e }}
     steps:
       - name: Determine test execution
         id: logic
@@ -146,6 +174,7 @@ jobs:
               echo "run-integration=${{ inputs.galaxy-integration != 'disabled' }}" >> $GITHUB_OUTPUT
               echo "run-demo=${{ inputs.galaxy-demo != 'disabled' }}" >> $GITHUB_OUTPUT
               echo "run-model-perf=${{ inputs.galaxy-perf != 'disabled' }}" >> $GITHUB_OUTPUT
+              echo "run-e2e=${{ inputs.galaxy-e2e != 'disabled' }}" >> $GITHUB_OUTPUT
               ;;
             "models-mandatory")
               echo "run-sanity=true" >> $GITHUB_OUTPUT
@@ -153,6 +182,7 @@ jobs:
               echo "run-integration=false" >> $GITHUB_OUTPUT
               echo "run-demo=false" >> $GITHUB_OUTPUT
               echo "run-model-perf=false" >> $GITHUB_OUTPUT
+              echo "run-e2e=false" >> $GITHUB_OUTPUT
               ;;
             "models-extended")
               echo "run-sanity=true" >> $GITHUB_OUTPUT
@@ -160,6 +190,7 @@ jobs:
               echo "run-integration=false" >> $GITHUB_OUTPUT
               echo "run-demo=true" >> $GITHUB_OUTPUT
               echo "run-model-perf=true" >> $GITHUB_OUTPUT
+              echo "run-e2e=false" >> $GITHUB_OUTPUT
               ;;
             "op-pr")
               echo "run-sanity=false" >> $GITHUB_OUTPUT
@@ -167,6 +198,7 @@ jobs:
               echo "run-integration=false" >> $GITHUB_OUTPUT
               echo "run-demo=false" >> $GITHUB_OUTPUT
               echo "run-model-perf=false" >> $GITHUB_OUTPUT
+              echo "run-e2e=false" >> $GITHUB_OUTPUT
               ;;
             "nightly")
               echo "run-sanity=false" >> $GITHUB_OUTPUT
@@ -174,6 +206,7 @@ jobs:
               echo "run-integration=true" >> $GITHUB_OUTPUT
               echo "run-demo=true" >> $GITHUB_OUTPUT
               echo "run-model-perf=true" >> $GITHUB_OUTPUT
+              echo "run-e2e=false" >> $GITHUB_OUTPUT
               ;;
             "hw-self-test")
               echo "run-sanity=false" >> $GITHUB_OUTPUT
@@ -181,6 +214,7 @@ jobs:
               echo "run-integration=true" >> $GITHUB_OUTPUT
               echo "run-demo=false" >> $GITHUB_OUTPUT
               echo "run-model-perf=true" >> $GITHUB_OUTPUT
+              echo "run-e2e=false" >> $GITHUB_OUTPUT
               ;;
             *)
               echo "run-sanity=true" >> $GITHUB_OUTPUT
@@ -188,6 +222,7 @@ jobs:
               echo "run-integration=false" >> $GITHUB_OUTPUT
               echo "run-demo=false" >> $GITHUB_OUTPUT
               echo "run-model-perf=false" >> $GITHUB_OUTPUT
+              echo "run-e2e=false" >> $GITHUB_OUTPUT
               ;;
           esac
   build-artifact:
@@ -256,3 +291,27 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       enabled-skus: wh_galaxy_perf
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-perf || 'all' }}
+  galaxy-e2e-tests:
+    if: ${{ needs.determine-tests.outputs.run-e2e == 'true' }}
+    needs: [build-artifact, determine-tests]
+    secrets: inherit
+    uses: ./.github/workflows/galaxy-e2e-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      enabled-skus: >-
+        ${{
+          inputs.galaxy-e2e-wormhole && inputs.galaxy-e2e-blackhole
+            && 'wh_galaxy,bh_galaxy'
+            || (
+              inputs.galaxy-e2e-wormhole
+                && 'wh_galaxy'
+                || (
+                  inputs.galaxy-e2e-blackhole
+                    && 'bh_galaxy'
+                    || ''
+                )
+            )
+        }}
+      test-selection: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-e2e || 'all' }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -163,6 +163,13 @@ jobs:
       run-model-perf: ${{ steps.logic.outputs.run-model-perf }}
       run-e2e: ${{ steps.logic.outputs.run-e2e }}
     steps:
+      - name: Validate e2e SKU selection
+        if: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-e2e != 'disabled' }}
+        run: |
+          if [ "${{ inputs.galaxy-e2e-wormhole }}" = "false" ] && [ "${{ inputs.galaxy-e2e-blackhole }}" = "false" ]; then
+            echo "::error::Galaxy e2e tests are enabled (galaxy-e2e='${{ inputs.galaxy-e2e }}') but no SKUs are selected. Enable at least one of 'galaxy-e2e-wormhole' or 'galaxy-e2e-blackhole'."
+            exit 1
+          fi
       - name: Determine test execution
         id: logic
         # Skip all but galaxy-sanity if trigger-type is not manual

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -1,6 +1,7 @@
 # This file defines the test matrix for the Galaxy e2e tests pipeline.
 
 # Each entry represents a parallel job with the following keys:
+#   id: Stable slug for workflow_dispatch / jq filtering (must match pipeline-select-galaxy).
 #   name: The display name for the job in GitHub Actions.
 #   cmd: The exact command to run for the test.
 #   skus: A mapping of SKU names to their configuration.
@@ -12,7 +13,8 @@
 # For max allowed timeout refer to .github/time_budget.yaml
 
 # Wormhole Galaxy e2e tests
-- name: Galaxy CCL tests
+- id: galaxy-ccl
+  name: Galaxy CCL tests
   cmd: pytest tests/nightly/tg/ccl --ignore tests/nightly/tg/ccl/moe
   skus:
     wh_galaxy:
@@ -20,7 +22,8 @@
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
 
-- name: Galaxy MoE tests
+- id: galaxy-moe
+  name: Galaxy MoE tests
   cmd: TT_MESH_GRAPH_DESC_PATH="tests/tt_metal/tt_fabric/custom_mesh_descriptors/single_galaxy_1x16_torus_graph_descriptor.textproto" pytest tests/nightly/tg/ccl/moe
   skus:
     wh_galaxy:
@@ -28,7 +31,8 @@
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
 
-- name: Galaxy Fabric unit tests
+- id: galaxy-fabric-unit
+  name: Galaxy Fabric unit tests
   cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*"
   skus:
     wh_galaxy:
@@ -38,7 +42,8 @@
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
 
-- name: Galaxy Fabric 2D Torus Nightly Tests
+- id: galaxy-fabric-2d-torus-nightly
+  name: Galaxy Fabric 2D Torus Nightly Tests
   cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml
   skus:
     wh_galaxy:
@@ -46,7 +51,8 @@
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
 
-- name: Galaxy Fabric Multi-Mesh 4x4 and 2x4s stability tests
+- id: galaxy-fabric-multi-mesh-4x4-2x4s
+  name: Galaxy Fabric Multi-Mesh 4x4 and 2x4s stability tests
   cmd: |
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
     tt-run --rank-binding 4x4_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_stability_short_running.yaml
@@ -56,7 +62,8 @@
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
 
-- name: Galaxy Fabric Multi-mesh 2x8 and 2x4s stability tests
+- id: galaxy-fabric-multi-mesh-2x8-2x4s
+  name: Galaxy Fabric Multi-mesh 2x8 and 2x4s stability tests
   cmd: |
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
     tt-run --rank-binding 2x8_2x4_3_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_stability_short_running.yaml
@@ -67,7 +74,8 @@
   team: scaleout
 
 # Blackhole Galaxy e2e tests
-- name: BH Galaxy CCL tests
+- id: bh-galaxy-ccl
+  name: BH Galaxy CCL tests
   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
   skus:
     bh_galaxy:
@@ -75,7 +83,8 @@
   owner_id: U05ACKAJTHS # Naif Tarafdar, Camilo Vega
   team: ttnn
 
-- name: BH Galaxy Fabric Torus Stability Tests
+- id: bh-galaxy-fabric-torus-stability
+  name: BH Galaxy Fabric Torus Stability Tests
   cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
   skus:
     bh_galaxy:
@@ -83,7 +92,8 @@
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: scaleout
 
-- name: BH Galaxy Socket Pipeline Single Galaxy
+- id: bh-galaxy-socket-pipeline
+  name: BH Galaxy Socket Pipeline Single Galaxy
   cmd: |
     python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
     tt-run --rank-binding bh_galaxy_split_4x2_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root --tag-output" ./build/test/tt_metal/multihost/socket_pipeline/multiprocess/unit_tests_pipeline


### PR DESCRIPTION
### Summary
Galaxy e2e tests were absent from the galaxy choose-your-pipeline dropdown.

Added to the CYP so those working on MoE, etc. can launch the longer running tests without unnecessarily eating a small cluster of galaxies.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-tg-choose-more) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-tg-choose-more)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-tg-choose-more) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-tg-choose-more) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-tg-choose-more) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-tg-choose-more)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-tg-choose-more) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-tg-choose-more) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-tg-choose-more) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-tg-choose-more)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-tg-choose-more) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-tg-choose-more) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-tg-choose-more) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-tg-choose-more)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-tg-choose-more) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-tg-choose-more) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-tg-choose-more) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-tg-choose-more)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-tg-choose-more) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-tg-choose-more) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-tg-choose-more) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-tg-choose-more)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-tg-choose-more) | [#2275](https://github.com/tenstorrent/tt-metal/actions/runs/24409571706) |