### PR TITLE
Fix TensixDirectedStreamRegWriteRead to use a stream reg not cleared by firmware

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -206,7 +206,15 @@ namespace tt::tt_metal {
 TEST_F(MeshDeviceFixture, TensixDirectedStreamRegWriteRead) {
     CoreCoord start_core{0, 0};
     const uint32_t stream_id = 0;
-    const uint32_t stream_reg = 4;
+    // Register index 7 maps to STREAM_BUF_SIZE_REG_INDEX on Wormhole and
+    // STREAM_REMOTE_DEST_REG_INDEX on Blackhole. Both are plain read/write
+    // with no side effects and are not used by firmware. Avoid indices that
+    // firmware's init_sync_registers() touches on stream 0:
+    // STREAM_REMOTE_DEST_BUF_START_REG_INDEX (WH=3, BH=8),
+    // STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX (WH=4, BH=10), and
+    // STREAM_REMOTE_DEST_WR_PTR_REG_INDEX (WH=5, BH=11, zeroed as a side
+    // effect of writing BUF_START).
+    const uint32_t stream_reg = 7;
 
     for (const std::shared_ptr<distributed::MeshDevice>& mesh_device : this->devices_) {
         auto& cq = mesh_device->mesh_command_queue();


### PR DESCRIPTION
### Summary

Bug fix. The `TensixDirectedStreamRegWriteRead` test was using `stream_reg=4` (hardcoded), which on Wormhole maps to `STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX` — the same register that trisc0 firmware's `init_sync_registers()` clears between programs. While timing makes this unlikely to cause failures on hardware today, it manifests as a real failure in tt-sim when the simulated clocking code in the UMD is modified, changing the relative timing enough for the firmware clear to race with the test's write.

Changed to index 7, which maps to safe, side-effect-free registers on both architectures:
- **Wormhole**: `STREAM_BUF_SIZE_REG_INDEX` (17 bits, no side effects)
- **Blackhole**: `STREAM_REMOTE_DEST_REG_INDEX` (18 bits, no side effects)

### Notes for reviewers

The comment in the test explains the full reasoning, including which indices are forbidden on each architecture and why. See also `tt-isa-documentation/WormholeB0/NoC/Overlay/AsGeneralUse.md` for the register properties reference.


### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fixstreamregtest) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fixstreamregtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fixstreamregtest) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fixstreamregtest) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixstreamregtest) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fixstreamregtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixstreamregtest) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixstreamregtest) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixstreamregtest) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fixstreamregtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixstreamregtest) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixstreamregtest) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixstreamregtest) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fixstreamregtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixstreamregtest) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixstreamregtest) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixstreamregtest) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fixstreamregtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixstreamregtest) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixstreamregtest) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixstreamregtest) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fixstreamregtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixstreamregtest) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixstreamregtest) |