### PR TITLE
#42092: add LLK asserts to check for CB bounds

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -77,6 +77,12 @@ inline void llk_unpack_AB_reduce_block_max_row(
     std::uint32_t address_a = base_address_a + offset_address_a;
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
 
+    LLK_ASSERT(
+        get_local_cb_interface(operandA_id).fifo_rd_ptr +
+                (row_start_index + block_ct_dim) * get_local_cb_interface(operandA_id).fifo_page_size <=
+            get_local_cb_interface(operandA_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
     _llk_unpack_AB_reduce_block_max_row_<respect_trigger>(address_a, base_address_b);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -78,10 +78,7 @@ inline void llk_unpack_AB_reduce_block_max_row(
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
 
     LLK_ASSERT(
-        get_local_cb_interface(operandA_id).fifo_rd_ptr +
-                (row_start_index + block_ct_dim) * get_local_cb_interface(operandA_id).fifo_page_size <=
-            get_local_cb_interface(operandA_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+        cb_access_within_bounds(operandA_id, row_start_index, block_ct_dim), "Indexed tile read exceeds CB boundary");
 
     _llk_unpack_AB_reduce_block_max_row_<respect_trigger>(address_a, base_address_b);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -80,6 +80,12 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     std::uint32_t address_a = base_address_a + offset_address_a;
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
 
+    LLK_ASSERT(
+        get_local_cb_interface(operandA_id).fifo_rd_ptr +
+                (row_start_index + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
+            get_local_cb_interface(operandA_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
     _llk_unpack_AB_reduce_block_max_row_runtime_(address_a, base_address_b, respect_trigger);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -80,6 +80,9 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     std::uint32_t address_a = base_address_a + offset_address_a;
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
 
+    // This may miss some cases because block_ct_dim should be used instead of 1.
+    // That value is not available at this point in time and upstream team is okay
+    // with this and does not want to plumb through the value.
     LLK_ASSERT(
         get_local_cb_interface(operandA_id).fifo_rd_ptr +
                 (row_start_index + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -83,11 +83,7 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     // This may miss some cases because block_ct_dim should be used instead of 1.
     // That value is not available at this point in time and upstream team is okay
     // with this and does not want to plumb through the value.
-    LLK_ASSERT(
-        get_local_cb_interface(operandA_id).fifo_rd_ptr +
-                (row_start_index + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
-            get_local_cb_interface(operandA_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandA_id, row_start_index, 1), "Indexed tile read exceeds CB boundary");
 
     _llk_unpack_AB_reduce_block_max_row_runtime_(address_a, base_address_b, respect_trigger);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -39,16 +39,8 @@ inline void llk_unpack_AB_sub_bcast_col_custom(
     const std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     const std::uint32_t address_b = base_address_b + offset_address_b;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operandA_id).fifo_rd_ptr +
-                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
-            get_local_cb_interface(operandA_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(
-        get_local_cb_interface(operandB_id).fifo_rd_ptr +
-                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
-            get_local_cb_interface(operandB_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
 
     _llk_unpack_AB_sub_bcast_col_custom_<BType>(address_a, address_b, ct_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -39,5 +39,16 @@ inline void llk_unpack_AB_sub_bcast_col_custom(
     const std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     const std::uint32_t address_b = base_address_b + offset_address_b;
 
+    LLK_ASSERT(
+        get_local_cb_interface(operandA_id).fifo_rd_ptr +
+                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
+            get_local_cb_interface(operandA_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(
+        get_local_cb_interface(operandB_id).fifo_rd_ptr +
+                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
+            get_local_cb_interface(operandB_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
     _llk_unpack_AB_sub_bcast_col_custom_<BType>(address_a, address_b, ct_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_A_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_A_custom_api.h
@@ -14,11 +14,7 @@ inline void llk_unpack_A_custom(const std::uint32_t operand, const std::uint32_t
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operand_id).fifo_rd_ptr +
-                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
-            get_local_cb_interface(operand_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
 
     WAYPOINT("UPAW");
     _llk_unpack_A_custom_(address);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_A_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_A_custom_api.h
@@ -14,6 +14,12 @@ inline void llk_unpack_A_custom(const std::uint32_t operand, const std::uint32_t
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
+    LLK_ASSERT(
+        get_local_cb_interface(operand_id).fifo_rd_ptr +
+                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
+            get_local_cb_interface(operand_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
     WAYPOINT("UPAW");
     _llk_unpack_A_custom_(address);
     WAYPOINT("UPAD");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -41,6 +41,17 @@ inline void llk_unpack_AB(
     std::uint32_t address_b = base_address_b + offset_address_b;
 
     LLK_ASSERT(
+        get_local_cb_interface(operandA_id).fifo_rd_ptr +
+                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
+            get_local_cb_interface(operandA_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(
+        get_local_cb_interface(operandB_id).fifo_rd_ptr +
+                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
+            get_local_cb_interface(operandB_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
+    LLK_ASSERT(
         (are_unpackers_AB_configured_correctly(
             unpack_src_format[operandA_id],
             unpack_dst_format[operandA_id],

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -40,16 +40,8 @@ inline void llk_unpack_AB(
     std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operandA_id).fifo_rd_ptr +
-                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
-            get_local_cb_interface(operandA_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(
-        get_local_cb_interface(operandB_id).fifo_rd_ptr +
-                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
-            get_local_cb_interface(operandB_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
 
     LLK_ASSERT(
         (are_unpackers_AB_configured_correctly(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -44,16 +44,8 @@ inline void llk_unpack_AB_reduce(
     std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operandA_id).fifo_rd_ptr +
-                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
-            get_local_cb_interface(operandA_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(
-        get_local_cb_interface(operandB_id).fifo_rd_ptr +
-                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
-            get_local_cb_interface(operandB_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
 
     WAYPOINT("UABW");
     _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -44,6 +44,17 @@ inline void llk_unpack_AB_reduce(
     std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
 
+    LLK_ASSERT(
+        get_local_cb_interface(operandA_id).fifo_rd_ptr +
+                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
+            get_local_cb_interface(operandA_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(
+        get_local_cb_interface(operandB_id).fifo_rd_ptr +
+                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
+            get_local_cb_interface(operandB_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
     WAYPOINT("UABW");
     _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);
     WAYPOINT("UABD");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -71,11 +71,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operand_id).fifo_rd_ptr +
-                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
-            get_local_cb_interface(operand_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
 
     LLK_ASSERT(
         (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
@@ -103,11 +99,7 @@ inline void llk_unpack_A_block(
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size;
     std::uint32_t address = base_address + start_tile_index * offset_address;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operand_id).fifo_rd_ptr +
-                (start_tile_index + ntiles) * get_local_cb_interface(operand_id).fifo_page_size <=
-            get_local_cb_interface(operand_id).fifo_limit,
-        "Block tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operand_id, start_tile_index, ntiles), "Block tile read exceeds CB boundary");
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -72,6 +72,12 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     std::uint32_t address = base_address + offset_address;
 
     LLK_ASSERT(
+        get_local_cb_interface(operand_id).fifo_rd_ptr +
+                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
+            get_local_cb_interface(operand_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
+    LLK_ASSERT(
         (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
             unpack_src_format[operand_id],
             unpack_dst_format[operand_id],
@@ -96,6 +102,12 @@ inline void llk_unpack_A_block(
     std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size;
     std::uint32_t address = base_address + start_tile_index * offset_address;
+
+    LLK_ASSERT(
+        get_local_cb_interface(operand_id).fifo_rd_ptr +
+                (start_tile_index + ntiles) * get_local_cb_interface(operand_id).fifo_page_size <=
+            get_local_cb_interface(operand_id).fifo_limit,
+        "Block tile read exceeds CB boundary");
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
@@ -37,6 +37,12 @@ inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t t
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
+    LLK_ASSERT(
+        get_local_cb_interface(operand_id).fifo_rd_ptr +
+                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
+            get_local_cb_interface(operand_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
     WAYPOINT("UPRW");
     _llk_unpack_reduce_<type, dim>(address);
     WAYPOINT("UPRD");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
@@ -37,11 +37,7 @@ inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t t
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operand_id).fifo_rd_ptr +
-                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
-            get_local_cb_interface(operand_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
 
     WAYPOINT("UPRW");
     _llk_unpack_reduce_<type, dim>(address);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -10,6 +10,7 @@
 #include "llk_pack_common.h"
 #include "stream_interface.h"
 #include "stream_io_map.h"
+#include "llk_assert.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 using namespace ckernel;
@@ -75,6 +76,10 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
 
     get_local_cb_interface(output).fifo_wr_ptr += num_words;
     get_local_cb_interface(output).fifo_wr_tile_ptr = 0;
+
+    LLK_ASSERT(
+        get_local_cb_interface(output).fifo_wr_ptr <= get_local_cb_interface(output).fifo_limit,
+        "CB push_back: fifo_wr_ptr exceeds fifo_limit");
 
     if (get_local_cb_interface(output).fifo_wr_ptr >= get_local_cb_interface(output).fifo_limit) {
         get_local_cb_interface(output).fifo_wr_ptr -= get_local_cb_interface(output).fifo_size;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -9,6 +9,7 @@
 #include "llk_unpack_common_api.h"
 #include "stream_interface.h"
 #include "stream_io_map.h"
+#include "llk_assert.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 using namespace ckernel;
@@ -42,6 +43,10 @@ inline void llk_pop_tiles(
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
     get_local_cb_interface(input).fifo_rd_ptr += num_words;
+
+    LLK_ASSERT(
+        get_local_cb_interface(input).fifo_rd_ptr <= get_local_cb_interface(input).fifo_limit,
+        "CB pop_front: fifo_rd_ptr exceeds fifo_limit");
 
     if (get_local_cb_interface(input).fifo_rd_ptr >= get_local_cb_interface(input).fifo_limit) {
         get_local_cb_interface(input).fifo_rd_ptr -= get_local_cb_interface(input).fifo_size;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -41,6 +41,17 @@ inline void llk_unpack_AB(
     std::uint32_t address_b = base_address_b + offset_address_b;
 
     LLK_ASSERT(
+        get_local_cb_interface(operandA_id).fifo_rd_ptr +
+                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
+            get_local_cb_interface(operandA_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(
+        get_local_cb_interface(operandB_id).fifo_rd_ptr +
+                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
+            get_local_cb_interface(operandB_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
+    LLK_ASSERT(
         (are_unpackers_AB_configured_correctly(
             unpack_src_format[operandA_id],
             unpack_dst_format[operandA_id],

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -40,16 +40,8 @@ inline void llk_unpack_AB(
     std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operandA_id).fifo_rd_ptr +
-                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
-            get_local_cb_interface(operandA_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(
-        get_local_cb_interface(operandB_id).fifo_rd_ptr +
-                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
-            get_local_cb_interface(operandB_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
 
     LLK_ASSERT(
         (are_unpackers_AB_configured_correctly(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -44,16 +44,8 @@ inline void llk_unpack_AB_reduce(
     std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operandA_id).fifo_rd_ptr +
-                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
-            get_local_cb_interface(operandA_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(
-        get_local_cb_interface(operandB_id).fifo_rd_ptr +
-                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
-            get_local_cb_interface(operandB_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
 
     WAYPOINT("UABW");
     _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -44,6 +44,17 @@ inline void llk_unpack_AB_reduce(
     std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
 
+    LLK_ASSERT(
+        get_local_cb_interface(operandA_id).fifo_rd_ptr +
+                (tile_index_a + 1) * get_local_cb_interface(operandA_id).fifo_page_size <=
+            get_local_cb_interface(operandA_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(
+        get_local_cb_interface(operandB_id).fifo_rd_ptr +
+                (tile_index_b + 1) * get_local_cb_interface(operandB_id).fifo_page_size <=
+            get_local_cb_interface(operandB_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
     WAYPOINT("UABW");
     _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);
     WAYPOINT("UABD");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -71,11 +71,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operand_id).fifo_rd_ptr +
-                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
-            get_local_cb_interface(operand_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
 
     LLK_ASSERT(
         (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
@@ -103,11 +99,7 @@ inline void llk_unpack_A_block(
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size;
     std::uint32_t address = base_address + start_tile_index * offset_address;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operand_id).fifo_rd_ptr +
-                (start_tile_index + ntiles) * get_local_cb_interface(operand_id).fifo_page_size <=
-            get_local_cb_interface(operand_id).fifo_limit,
-        "Block tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operand_id, start_tile_index, ntiles), "Block tile read exceeds CB boundary");
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -72,6 +72,12 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     std::uint32_t address = base_address + offset_address;
 
     LLK_ASSERT(
+        get_local_cb_interface(operand_id).fifo_rd_ptr +
+                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
+            get_local_cb_interface(operand_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
+    LLK_ASSERT(
         (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
             unpack_src_format[operand_id],
             unpack_dst_format[operand_id],
@@ -96,6 +102,12 @@ inline void llk_unpack_A_block(
     std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size;
     std::uint32_t address = base_address + start_tile_index * offset_address;
+
+    LLK_ASSERT(
+        get_local_cb_interface(operand_id).fifo_rd_ptr +
+                (start_tile_index + ntiles) * get_local_cb_interface(operand_id).fifo_page_size <=
+            get_local_cb_interface(operand_id).fifo_limit,
+        "Block tile read exceeds CB boundary");
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
@@ -37,6 +37,12 @@ inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t t
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
+    LLK_ASSERT(
+        get_local_cb_interface(operand_id).fifo_rd_ptr +
+                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
+            get_local_cb_interface(operand_id).fifo_limit,
+        "Indexed tile read exceeds CB boundary");
+
     WAYPOINT("UPRW");
     _llk_unpack_reduce_<type, dim>(address);
     WAYPOINT("UPRD");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
@@ -37,11 +37,7 @@ inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t t
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
-    LLK_ASSERT(
-        get_local_cb_interface(operand_id).fifo_rd_ptr +
-                (tile_index + 1) * get_local_cb_interface(operand_id).fifo_page_size <=
-            get_local_cb_interface(operand_id).fifo_limit,
-        "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
 
     WAYPOINT("UPRW");
     _llk_unpack_reduce_<type, dim>(address);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -10,6 +10,7 @@
 #include "stream_interface.h"
 #include "stream_io_map.h"
 #include "llk_pack_common.h"
+#include "llk_assert.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 using namespace ckernel;
@@ -75,6 +76,10 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
 
     get_local_cb_interface(output).fifo_wr_ptr += num_words;
     get_local_cb_interface(output).fifo_wr_tile_ptr = 0;
+
+    LLK_ASSERT(
+        get_local_cb_interface(output).fifo_wr_ptr <= get_local_cb_interface(output).fifo_limit,
+        "CB push_back: fifo_wr_ptr exceeds fifo_limit");
 
     if (get_local_cb_interface(output).fifo_wr_ptr >= get_local_cb_interface(output).fifo_limit) {
         get_local_cb_interface(output).fifo_wr_ptr -= get_local_cb_interface(output).fifo_size;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -9,6 +9,7 @@
 #include "stream_interface.h"
 #include "stream_io_map.h"
 #include "llk_unpack_common_api.h"
+#include "llk_assert.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 using namespace ckernel;
@@ -93,6 +94,10 @@ inline void llk_pop_tiles(
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
     get_local_cb_interface(input).fifo_rd_ptr += num_words;
+
+    LLK_ASSERT(
+        get_local_cb_interface(input).fifo_rd_ptr <= get_local_cb_interface(input).fifo_limit,
+        "CB pop_front: fifo_rd_ptr exceeds fifo_limit");
 
     if (get_local_cb_interface(input).fifo_rd_ptr >= get_local_cb_interface(input).fifo_limit) {
         get_local_cb_interface(input).fifo_rd_ptr -= get_local_cb_interface(input).fifo_size;

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -108,7 +108,8 @@ FORCE_INLINE RemoteReceiverCBInterface& get_remote_receiver_cb_interface(uint32_
     return cb_interface[cb_id].remote_receiver_cb_interface;
 }
 
-FORCE_INLINE bool cb_access_within_bounds(uint32_t cb_id, uint32_t start_tile_index, uint32_t num_tiles) {
+__attribute__((noinline)) inline bool cb_access_within_bounds(
+    uint32_t cb_id, uint32_t start_tile_index, uint32_t num_tiles) {
     const auto& cb = get_local_cb_interface(cb_id);
     return cb.fifo_rd_ptr + (start_tile_index + num_tiles) * cb.fifo_page_size <= cb.fifo_limit;
 }

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -108,8 +108,7 @@ FORCE_INLINE RemoteReceiverCBInterface& get_remote_receiver_cb_interface(uint32_
     return cb_interface[cb_id].remote_receiver_cb_interface;
 }
 
-__attribute__((noinline)) inline bool cb_access_within_bounds(
-    uint32_t cb_id, uint32_t start_tile_index, uint32_t num_tiles) {
+__attribute__((noinline)) bool cb_access_within_bounds(uint32_t cb_id, uint32_t start_tile_index, uint32_t num_tiles) {
     const auto& cb = get_local_cb_interface(cb_id);
     return cb.fifo_rd_ptr + (start_tile_index + num_tiles) * cb.fifo_page_size <= cb.fifo_limit;
 }

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -108,6 +108,11 @@ FORCE_INLINE RemoteReceiverCBInterface& get_remote_receiver_cb_interface(uint32_
     return cb_interface[cb_id].remote_receiver_cb_interface;
 }
 
+FORCE_INLINE bool cb_access_within_bounds(uint32_t cb_id, uint32_t start_tile_index, uint32_t num_tiles) {
+    const auto& cb = get_local_cb_interface(cb_id);
+    return cb.fifo_rd_ptr + (start_tile_index + num_tiles) * cb.fifo_page_size <= cb.fifo_limit;
+}
+
 #if defined(COMPILE_FOR_TRISC)
 constexpr uint32_t cb_addr_shift = CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT;
 #else


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #42092 

I was not happy that there was no checks for bad CB usage causing https://github.com/tenstorrent/tt-metal/issues/40854 and asked AI to add in checks.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Tested locally that with 
```
export TT_METAL_LLK_ASSERTS=1
export TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS=1
export TT_METAL_WATCHER=12
```
the test added for the issue with bad CB usage leads to watcher failing with an assert.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42092_cb_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-42092_cb_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42092_cb_asserts) | [#2862](https://github.com/tenstorrent/tt-metal/actions/runs/24466360704) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42092_cb_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-42092_cb_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42092_cb_asserts) | [#17524](https://github.com/tenstorrent/tt-metal/actions/runs/24463029547) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42092_cb_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-42092_cb_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42092_cb_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42092_cb_asserts) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42092_cb_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-42092_cb_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42092_cb_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42092_cb_asserts) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42092_cb_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-42092_cb_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42092_cb_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42092_cb_asserts) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42092_cb_asserts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-42092_cb_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42092_cb_asserts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42092_cb_asserts) |