### PR TITLE
Add on-device expert frequency tracking for MoE layers

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -49,6 +49,7 @@ class DecoderStage(StageKind):
         num_routed_experts: int,
         use_hardcoded_expert_index: bool,
         enable_routing: bool,
+        freq_window_size: int = 0,
     ) -> None:
         if state_dict is None and weights is None:
             raise ValueError("Either state_dict or weights must be provided")
@@ -65,6 +66,7 @@ class DecoderStage(StageKind):
         self._num_routed_experts = num_routed_experts
         self._use_hardcoded_expert_index = use_hardcoded_expert_index
         self._enable_routing = enable_routing
+        self._freq_window_size = freq_window_size
         self._state: dict[str, Any] = {}
 
     def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
@@ -177,6 +179,8 @@ class DecoderStage(StageKind):
             persistent_next_iter_semaphore=self._state.get("persistent_next_iter_semaphore"),
             persistent_mode=self._persistent_mode,
             is_torus=self._is_torus,
+            expert_freq_tensor=d.get("expert_freq_tensor"),
+            freq_window_size=self._freq_window_size,
         )
 
     def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
@@ -229,6 +233,24 @@ class DecoderStage(StageKind):
                 is_moe=False,
                 preloaded_weights=self._weights,
             )
+        # Create expert frequency tracking tensor on the sender core
+        if self._is_moe:
+            sender_core = ttnn.CoreCoord(mesh_device.compute_with_storage_grid_size().x - 1, self.MOE_SENDER_CORE.y)
+            sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core, sender_core)])
+            freq_shard_spec = ttnn.ShardSpec(sender_core_grid, (1, 257), ttnn.ShardOrientation.ROW_MAJOR)
+            freq_mem_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, freq_shard_spec
+            )
+            expert_freq_tensor = ttnn.from_torch(
+                torch.zeros((1, 257), dtype=torch.int32),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=mesh_device,
+                memory_config=freq_mem_config,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
+            d["expert_freq_tensor"] = expert_freq_tensor
+
         ttnn.synchronize_device(mesh_device)
 
         recv_socket = pipeline_block.get_downstream_socket()
@@ -250,6 +272,14 @@ class DecoderStage(StageKind):
         self._state["decoder_program_context"] = self._build_decoder_program_context()
 
         logger.info(f"[rank={my_mesh_id}] {type(self).__name__} setup complete")
+
+    def read_expert_frequencies(self) -> list[torch.Tensor]:
+        """Read expert frequency counters from device. Returns list of (256,) uint32 tensors, one per mesh device."""
+        freq_tensor = self._state["d"].get("expert_freq_tensor")
+        if freq_tensor is None:
+            raise RuntimeError("Expert frequency tracking not enabled (not MoE stage)")
+        raw = ttnn.to_torch(freq_tensor, mesh_composer=ttnn.ListMeshToTensor(freq_tensor.device()))
+        return [r.squeeze(0)[:256] for r in raw]
 
     def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
         DecoderBlock.execute(*self._state["decoder_program_context"])
@@ -278,6 +308,7 @@ class MoEDecoderStage(DecoderStage):
         use_hardcoded_expert_index: bool = False,
         enable_routing: bool = True,
         is_torus: bool = True,
+        freq_window_size: int = 0,
     ) -> None:
         super().__init__(
             state_dict,
@@ -291,6 +322,7 @@ class MoEDecoderStage(DecoderStage):
             num_routed_experts=num_routed_experts,
             use_hardcoded_expert_index=use_hardcoded_expert_index,
             enable_routing=enable_routing,
+            freq_window_size=freq_window_size,
         )
 
 

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -2493,6 +2493,36 @@ void kernel_main() {
             gate();
         }
 
+        // 4a. Update expert frequency counters (sender core BRISC only)
+        {
+            DeviceZoneScopedN("FREQ_UPDATE");
+#if defined(COMPILE_FOR_BRISC)
+            constexpr uint32_t expert_freq_l1_addr = get_named_compile_time_arg_val("expert_freq_l1_addr");
+            constexpr uint32_t freq_window_size = get_named_compile_time_arg_val("freq_window_size");
+            if constexpr (Core::is_sender_core && expert_freq_l1_addr != 0) {
+                volatile tt_l1_ptr uint32_t* freq_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(expert_freq_l1_addr);
+
+                // Tumbling window reset
+                uint32_t iter = freq_ptr[256] + 1;
+                constexpr bool use_full_range = (freq_window_size == 0);
+                bool reset = use_full_range ? (iter == 0) : (iter >= freq_window_size);
+                if (reset) {
+                    for (uint32_t j = 0; j < 257; j++) freq_ptr[j] = 0;
+                    iter = 0;
+                }
+                freq_ptr[256] = iter;
+
+                // Increment the 8 selected experts — read from gate output indices CB
+                volatile tt_l1_ptr uint16_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
+                    get_read_ptr(get_named_compile_time_arg_val("gate_output_indices_cb")));
+                for (uint32_t i = 0; i < 8; i++) {
+                    freq_ptr[static_cast<uint32_t>(index_ptr[i])]++;
+                }
+            }
+#endif
+        }
+
         // 5. Mcast Index: Broadcast expert indices to gate_proj cores only
         // Uses dedicated mcast with IsReceiverCore=is_gate_proj_core so only gate_proj
         // cores push to CB 10. Other grid cores just drain the semaphore (no CB ops).

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -200,6 +200,8 @@ class DecoderBlock:
         persistent_next_iter_semaphore=None,
         persistent_mode=False,
         is_torus=True,
+        expert_freq_tensor=None,
+        freq_window_size=0,
     ):
         """Build io_tensors and mesh_program_descriptor without executing.
 
@@ -291,6 +293,8 @@ class DecoderBlock:
             persistent_mode=persistent_mode,
             bcast_sender_coord=sender_coord,
             is_torus=is_torus,
+            expert_freq_tensor=expert_freq_tensor,
+            freq_window_size=freq_window_size,
         )
 
         moe._build_descriptors()

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -1081,6 +1081,37 @@ void kernel_main() {
             gate();
         }
 
+        // 4a. Update expert frequency counters (sender core BRISC only)
+        {
+            DeviceZoneScopedN("FREQ_UPDATE");
+#if defined(COMPILE_FOR_BRISC)
+            constexpr uint32_t expert_freq_l1_addr = get_named_compile_time_arg_val("expert_freq_l1_addr");
+            constexpr uint32_t freq_window_size = get_named_compile_time_arg_val("freq_window_size");
+            if constexpr (Core::is_sender_core && expert_freq_l1_addr != 0) {
+                volatile tt_l1_ptr uint32_t* freq_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(expert_freq_l1_addr);
+
+                // Tumbling window reset
+                uint32_t iter = freq_ptr[256] + 1;
+                constexpr bool use_full_range = (freq_window_size == 0);
+                bool reset = use_full_range ? (iter == 0) : (iter >= freq_window_size);
+                if (reset) {
+                    for (uint32_t j = 0; j < 257; j++) freq_ptr[j] = 0;
+                    iter = 0;
+                }
+                freq_ptr[256] = iter;
+
+                // Increment the 8 selected experts — read from gate output indices CB
+                // before it is consumed by the index mcast below
+                volatile tt_l1_ptr uint16_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
+                    get_read_ptr(get_named_compile_time_arg_val("gate_output_indices_cb")));
+                for (uint32_t i = 0; i < 8; i++) {
+                    freq_ptr[static_cast<uint32_t>(index_ptr[i])]++;
+                }
+            }
+#endif
+        }
+
         // 5. Mcast Index: Broadcast expert indices to gate_proj cores only
         // Uses dedicated mcast with IsReceiverCore=is_gate_proj_core so only gate_proj
         // cores push to CB 10. Other grid cores just drain the semaphore (no CB ops).

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -120,6 +120,10 @@ class MoeContext:
     bcast_sender_coord: Any = None
     socket: Any = None
 
+    # Expert frequency tracking
+    expert_freq_tensor: Any = None
+    freq_window_size: int = 0  # 0 = full uint32 range
+
     # CB reconfig
     reconfig_moe_cbs: bool = False
 
@@ -4453,6 +4457,8 @@ class MoeOp:
         downstream_sockets=None,
         persistent_next_iter_semaphore=None,
         persistent_mode=False,
+        expert_freq_tensor=None,
+        freq_window_size=0,
     ):
         """Setup both routed and shared expert contexts, then overlap CBs with SDPA buffers."""
         self.noc_mode = noc_mode
@@ -4594,6 +4600,9 @@ class MoeOp:
             bcast_semaphores=bcast_semaphores,
             bcast_sender_coord=bcast_sender_coord,
             socket=socket,
+            # Expert frequency tracking
+            expert_freq_tensor=expert_freq_tensor,
+            freq_window_size=freq_window_size,
         )
 
         # Shared descriptors (populated by _build_descriptors)
@@ -4686,6 +4695,9 @@ class MoeOp:
         ncrisc_args += [("persistent_next_iter_sem_addr", self.persistent_next_iter_sem_addr)]
         brisc_args += [("persistent_next_iter_sem_addr", self.persistent_next_iter_sem_addr)]
         trisc_args += [("persistent_next_iter_sem_addr", self.persistent_next_iter_sem_addr)]
+        # Expert frequency tracking
+        freq_addr = self.ctx.expert_freq_tensor.buffer_address() if self.ctx.expert_freq_tensor is not None else 0
+        brisc_args += [("expert_freq_l1_addr", freq_addr), ("freq_window_size", self.ctx.freq_window_size)]
 
     def _build_semaphore_descriptors(self):
         """Build semaphore descriptors — empty, global semaphores are used instead."""
@@ -4865,6 +4877,9 @@ class MoeOp:
         # Per-worker downstream sockets for reduce workers to send reduced output
         downstream_sockets=None,
         cb_id_context=None,
+        # Expert frequency tracking
+        expert_freq_tensor=None,
+        freq_window_size=0,
     ):
         """
         Execute the full fused MoE operation (routed + shared expert).
@@ -4939,6 +4954,8 @@ class MoeOp:
             cb_id_context=cb_id_context,
             persistent_next_iter_semaphore=persistent_next_iter_semaphore,
             persistent_mode=persistent_mode,
+            expert_freq_tensor=expert_freq_tensor,
+            freq_window_size=freq_window_size,
         )
 
         # ==================================================================

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -684,6 +684,21 @@ def create_decoder_block_tensors(
     sender_core_from_residual = attn_output.memory_config().shard_spec.grid.bounding_box().end
     mcast_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), sender_core_from_residual)])
 
+    # Expert frequency tracking tensor on the sender core
+    expert_freq_tensor = None
+    if is_moe:
+        sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core_from_residual, sender_core_from_residual)])
+        freq_shard_spec = ttnn.ShardSpec(sender_core_grid, (1, 257), ttnn.ShardOrientation.ROW_MAJOR)
+        freq_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, freq_shard_spec)
+        expert_freq_tensor = ttnn.from_torch(
+            torch.zeros((1, 257), dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=submesh,
+            memory_config=freq_mem_config,
+            mesh_mapper=mesh_mapper,
+        )
+
     # ══════════════════════════════════════════════════════════════════════════
     # Golden model PyTorch tensors (only when state_dict is available)
     # ══════════════════════════════════════════════════════════════════════════
@@ -863,6 +878,8 @@ def create_decoder_block_tensors(
                 "moe_ref_gate_output_indices": moe_ref_gate_output_indices,
                 "moe_ref_reduce_intermediate": moe_ref_reduce_intermediate,
                 "moe_ref_reduce_output": moe_ref_reduce_output,
+                "expert_freq_tensor": expert_freq_tensor,
+                "rigged_expert_ids": rigged_expert_ids,
             }
         )
     return result
@@ -1159,10 +1176,56 @@ def test_decoder(
         fabric_config=device_params["fabric_config"],
         persistent_next_iter_semaphore=persistent_next_iter_semaphore,
         persistent_mode=False,
+        expert_freq_tensor=d.get("expert_freq_tensor"),
     )
     for i in range(num_iters):
         moe_final_output_tensor, attention_block_output_tensor = DecoderBlock.execute(*decoder_program_context)
     ttnn.synchronize_device(submesh)
+
+    # Validate expert frequency counters
+    if d.get("expert_freq_tensor") is not None and enable_routing:
+        freq_torch = ttnn.to_torch(d["expert_freq_tensor"], mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+        total_iters = num_iters * num_internal_iterations
+        rigged_expert_ids = d.get("rigged_expert_ids")
+
+        for dev_idx in range(freq_torch.shape[0]):
+            counters = freq_torch[dev_idx, :256].to(torch.int64)
+            iter_count = freq_torch[dev_idx, 256].item()
+            nonzero_mask = counters != 0
+            nonzero_indices = torch.where(nonzero_mask)[0]
+            nonzero_counts = counters[nonzero_mask]
+            logger.info(
+                f"Device {dev_idx}: expert freq iteration_count={iter_count}, "
+                f"nonzero experts ({len(nonzero_indices)}): "
+                f"{dict(zip(nonzero_indices.tolist(), nonzero_counts.tolist()))}"
+            )
+
+            # Iteration counter must match
+            assert (
+                iter_count == total_iters
+            ), f"Device {dev_idx}: iteration counter {iter_count} != expected {total_iters}"
+
+            # Structural: exactly 8 experts selected per iteration, so sum == 8 * total_iters
+            assert (
+                counters.sum().item() == 8 * total_iters
+            ), f"Device {dev_idx}: counter sum {counters.sum().item()} != expected {8 * total_iters}"
+
+            if rigged_expert_ids is not None:
+                # Rigged: we know exactly which 8 global expert IDs were forced
+                expected_global_ids = set()
+                for grp, local_ids in rigged_expert_ids.items():
+                    for local_id in local_ids:
+                        expected_global_ids.add(grp * 32 + local_id)
+                actual_ids = set(nonzero_indices.tolist())
+                assert actual_ids == expected_global_ids, (
+                    f"Device {dev_idx}: frequency nonzero experts {sorted(actual_ids)} "
+                    f"!= expected rigged experts {sorted(expected_global_ids)}"
+                )
+                # Each rigged expert should have count == total_iters
+                for eid in expected_global_ids:
+                    assert (
+                        counters[eid].item() == total_iters
+                    ), f"Device {dev_idx}: expert {eid} count {counters[eid].item()} != {total_iters}"
 
     kv_cache_output_torch = ttnn.to_torch(d["ttnn_kv_cache"], mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
 


### PR DESCRIPTION
Adds a (1,257) uint32 L1-sharded tensor on the sender core that tracks how often each of the 256 routed experts is selected. The kernel updates counters between gate selection and index mcast (BRISC only, zero overhead when disabled via constexpr guard). Includes tumbling window reset support, host readback API, and validated test assertions for rigged expert variants.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
