### PR TITLE
#41702: Port copy, fold, scatter, gather, reshape_on_device kernels to device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -13,6 +14,7 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_in0 = 0;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
@@ -45,11 +47,11 @@ void kernel_main() {
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb_reserve_back(cb_id_in0, onetile);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        cb_in0.reserve_back(onetile);
+        uint32_t l1_write_addr = cb_in0.get_write_ptr();
         uint64_t src_noc_addr = s.get_noc_addr(i);
         noc_async_read(src_noc_addr, l1_write_addr, tile_bytes);
         noc_async_read_barrier();
-        cb_push_back(cb_id_in0, onetile);
+        cb_in0.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -16,6 +17,7 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    experimental::CircularBuffer cb_in0(cb_id_in0);
 
     typedef ShardedInfo<
         get_compile_time_arg_val(2),
@@ -41,12 +43,12 @@ void kernel_main() {
         for (uint32_t k = 0; k < num_shards; k++) {
 #endif
             uint32_t stick_index = i * num_shards + k;
-            cb_reserve_back(cb_id_in0, 1);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            cb_in0.reserve_back(1);
+            uint32_t l1_write_addr = cb_in0.get_write_ptr();
             uint64_t src_noc_addr = s0.get_noc_addr(stick_index);
             noc_async_read(src_noc_addr, l1_write_addr, stick_size);
             noc_async_read_barrier();
-            cb_push_back(cb_id_in0, 1);
+            cb_in0.push_back(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_reader.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 
 FORCE_INLINE uint32_t u32_min(uint32_t a, uint32_t b) { return (a < b) ? a : b; }
@@ -26,12 +27,15 @@ void kernel_main() {
     constexpr uint32_t bytes_per_input_subblock = get_compile_time_arg_val(8);
     constexpr uint32_t bytes_per_output_subblock = get_compile_time_arg_val(9);
 
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+
     constexpr auto src_args = TensorAccessorArgs<10>();
     const auto accessor_src = TensorAccessor(src_args, src_addr);
 
     const uint32_t elements_per_output_subblock = bytes_per_output_subblock / bytes_per_element;
     const uint32_t elements_per_input_subblock = bytes_per_input_subblock / bytes_per_element;
-    cb_reserve_back(cb_id_in0, 1);
+    cb_in0.reserve_back(1);
 
     // To help understand the logic of this kernel, here is a visualization of what a subblock looks like in the
     // input/output tensor: When the tensor page is not too large (i.e., does not cause a CB OOM error), the subblock
@@ -50,7 +54,7 @@ void kernel_main() {
     // Thus, the start of a page will always align with the start of a subblock. This is required to guarantee
     // aligned noc reads/writes.
 
-    const uint32_t input_l1_write_addr = get_write_ptr(cb_id_in0);
+    const uint32_t input_l1_write_addr = cb_in0.get_write_ptr();
 
     for (uint32_t row = start_row; row < start_row + num_rows_to_process; ++row) {
         uint32_t input_start_column = 0;
@@ -73,8 +77,7 @@ void kernel_main() {
                 uint32_t l1_output_subblock_write_addr_offset;
                 uint32_t l1_input_subblock_read_addr_offset;
                 if (output_start_column >= input_start_column) {
-                    cb_reserve_back(
-                        cb_id_in1,
+                    cb_in1.reserve_back(
                         1);  // We are writing a new output subblock, so we need to reserve a slot on the output cb
                     bytes_to_write_to_output_subblock =
                         (output_end_column - output_start_column + 1) * bytes_per_element;
@@ -92,7 +95,7 @@ void kernel_main() {
                 }
 
                 uint32_t l1_output_subblock_write_addr =
-                    get_write_ptr(cb_id_in1);  // write the output subblock to the output cb
+                    cb_in1.get_write_ptr();  // write the output subblock to the output cb
                 tt::data_movement::common::tt_memmove<false, false, true, 0>(
                     l1_output_subblock_write_addr + l1_output_subblock_write_addr_offset,
                     input_l1_write_addr + l1_input_subblock_read_addr_offset,
@@ -125,14 +128,13 @@ void kernel_main() {
                     output_end_column);  // output end column should be the minimum of the next output page end column,
                                          // the end column of the next output subblock and the end of the tensor row
                 // We have processed the entire output subblock, so we must commit it to the output cb
-                cb_push_back(cb_id_in1, 1);
+                cb_in1.push_back(1);
             } else {  // Case where we are finishing reading in an input subblock
                 uint32_t bytes_to_write_to_output_subblock;
                 uint32_t l1_output_subblock_write_addr_offset;
                 uint32_t l1_input_subblock_read_addr_offset;
                 if (output_start_column >= input_start_column) {
-                    cb_reserve_back(
-                        cb_id_in1,
+                    cb_in1.reserve_back(
                         1);  // We are writing a new output subblock, so we need to reserve a slot on the output cb
                     bytes_to_write_to_output_subblock =
                         (input_end_column - output_start_column + 1) * bytes_per_element;
@@ -146,7 +148,7 @@ void kernel_main() {
                 }
 
                 uint32_t l1_output_subblock_write_addr =
-                    get_write_ptr(cb_id_in1);  // Write the output subblock to the output cb
+                    cb_in1.get_write_ptr();  // Write the output subblock to the output cb
                 tt::data_movement::common::tt_memmove<false, false, true, 0>(
                     l1_output_subblock_write_addr + l1_output_subblock_write_addr_offset,
                     input_l1_write_addr + l1_input_subblock_read_addr_offset,
@@ -167,7 +169,7 @@ void kernel_main() {
         }
     }
 
-    cb_push_back(cb_id_in0, 1);
-    cb_wait_front(cb_id_in0, 1);
-    cb_pop_front(cb_id_in0, 1);
+    cb_in0.push_back(1);
+    cb_in0.wait_front(1);
+    cb_in0.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_writer.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 FORCE_INLINE uint32_t u32_min(uint32_t a, uint32_t b) { return (a < b) ? a : b; }
 
@@ -20,6 +21,8 @@ void kernel_main() {
     constexpr uint32_t bytes_per_element = get_compile_time_arg_val(3);
     constexpr uint32_t elements_per_tensor_row = get_compile_time_arg_val(4);
     constexpr uint32_t bytes_per_output_subblock = get_compile_time_arg_val(5);
+
+    experimental::CircularBuffer cb_in1(cb_id_in1);
 
     constexpr auto dst_args = TensorAccessorArgs<6>();
     const auto accessor_dst = TensorAccessor(dst_args, dst_addr);
@@ -42,12 +45,12 @@ void kernel_main() {
             uint64_t output_addr_subblock_offset =
                 ((output_column % elements_per_output_page) / elements_per_output_subblock) * bytes_per_output_subblock;
             uint32_t num_bytes_to_write = (output_end_column - output_column + 1) * bytes_per_element;
-            cb_wait_front(cb_id_in1, 1);
-            uint32_t output_page_read_addr = get_read_ptr(cb_id_in1);
+            cb_in1.wait_front(1);
+            uint32_t output_page_read_addr = cb_in1.get_read_ptr();
             uint64_t output_subblock_noc_addr = accessor_dst.get_noc_addr(output_page_id) + output_addr_subblock_offset;
             noc_async_write(output_page_read_addr, output_subblock_noc_addr, num_bytes_to_write);
             noc_async_write_barrier();
-            cb_pop_front(cb_id_in1, 1);
+            cb_in1.pop_front(1);
             output_column = output_end_column + 1;
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -12,9 +13,10 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    experimental::CircularBuffer cb_out(cb_id_out);
 
 #ifdef OUT_SHARDED
-    cb_wait_front(cb_id_out, num_tiles);
+    cb_out.wait_front(num_tiles);
 #else
 
     // single-tile ublocks
@@ -47,12 +49,12 @@ void kernel_main() {
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb_wait_front(cb_id_out, onetile);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        cb_out.wait_front(onetile);
+        uint32_t l1_read_addr = cb_out.get_read_ptr();
         uint64_t dest_noc_addr = s.get_noc_addr(i);
         noc_async_write(l1_read_addr, dest_noc_addr, tile_bytes);
         noc_async_write_barrier();
-        cb_pop_front(cb_id_out, onetile);
+        cb_out.pop_front(onetile);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -16,6 +17,7 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
     constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    experimental::CircularBuffer cb_out0(cb_id_out0);
 
     typedef ShardedInfo<
         get_compile_time_arg_val(2),
@@ -41,12 +43,12 @@ void kernel_main() {
         for (uint32_t k = 0; k < num_shards; k++) {
 #endif
             uint32_t stick_index = i * num_shards + k;
-            cb_wait_front(cb_id_out0, 1);
-            uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+            cb_out0.wait_front(1);
+            uint32_t l1_read_addr = cb_out0.get_read_ptr();
             uint64_t dst_noc_addr = s0.get_noc_addr(stick_index);
             noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
             noc_async_write_barrier();
-            cb_pop_front(cb_id_out0, 1);
+            cb_out0.pop_front(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
@@ -16,6 +17,8 @@ void kernel_main() {
     constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
     constexpr auto src_args = TensorAccessorArgs<9>();
 
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     const auto s_in = TensorAccessor(src_args, src_addr, stick_nbytes);
 
@@ -23,8 +26,8 @@ void kernel_main() {
     uint32_t curr_src_row_index = get_arg_val<uint32_t>(2);
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         uint32_t curr_src_offset = src_index;
-        cb_reserve_back(cb_id_in0, 1);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        cb_in0.reserve_back(1);
+        uint32_t l1_write_addr = cb_in0.get_write_ptr();
         for (uint32_t i = 0; i < stride_h; i++) {
             for (uint32_t j = 0; j < stride_w; j++) {
                 uint64_t src_noc_addr = get_noc_addr(curr_src_offset, s_in);
@@ -35,7 +38,7 @@ void kernel_main() {
             curr_src_offset += input_width - stride_w;
         }
         noc_async_read_barrier();
-        cb_push_back(cb_id_in0, 1);
+        cb_in0.push_back(1);
 
         curr_src_row_index += stride_w;
         if (curr_src_row_index >= (input_width)) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
@@ -18,6 +21,9 @@ void kernel_main() {
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::Noc noc;
+
     // Initialize interleaved address generator for DRAM access
     constexpr auto src_args = TensorAccessorArgs<3>();
     const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
@@ -27,23 +33,21 @@ void kernel_main() {
     for (uint32_t i = start_block_id; i < end_block_id; ++i) {
         // Reserve space in the circular buffer for a row of tiles
         for (uint32_t j = 0; j < tiles_per_width_dim; ++j) {
-            cb_reserve_back(cb_id_in0, tiles_per_channel_dim);
-            uint64_t l1_write_addr = get_write_ptr(cb_id_in0);
+            cb_in0.reserve_back(tiles_per_channel_dim);
 
             // Read each tile in the current row
             for (uint32_t k = 0; k < tiles_per_channel_dim; ++k) {
                 // Calculate tile index and read from DRAM to L1
                 uint32_t tile_index = tiles_per_width_dim * tiles_per_channel_dim * i + tiles_per_channel_dim * j + k;
-                noc_async_read_tile(tile_index, s, l1_write_addr);
-
-                l1_write_addr += tile_bytes;
+                noc.async_read<experimental::Noc::TxnIdMode::DISABLED, tile_bytes>(
+                    s, cb_in0, tile_bytes, {.page_id = tile_index}, {.offset_bytes = k * tile_bytes});
             }
 
-            noc_async_read_barrier();
+            noc.async_read_barrier();
 
             // Ensure all async reads are complete before proceeding
             // Push the completed row of tiles to the circular buffer
-            cb_push_back(cb_id_in0, tiles_per_channel_dim);
+            cb_in0.push_back(tiles_per_channel_dim);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 using namespace tt::data_movement::common;
@@ -20,17 +21,20 @@ void kernel_main() {
     constexpr bool is_l1_aligned = get_compile_time_arg_val(8);
     constexpr auto dst_args = TensorAccessorArgs<9>();
 
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     constexpr uint32_t patch_size = stride_h * stride_w;
     const auto s_out = TensorAccessor(dst_args, dst_addr, stick_nbytes * patch_size);
     uint32_t dst_index = get_arg_val<uint32_t>(1);
-    uint32_t intermed_l1_scratch = get_write_ptr(cb_id_in1);
+    uint32_t intermed_l1_scratch = cb_in1.get_write_ptr();
     // Datatypes will be multiple of 2 bytes only so it is safe to use uint16_t pointer
     volatile tt_l1_ptr uint16_t* patch_data = (volatile uint16_t*)intermed_l1_scratch;
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         uint32_t idx = 0;
-        cb_wait_front(cb_id_in0, 1);
-        uint32_t l1_addr = get_read_ptr(cb_id_in0);
+        cb_in0.wait_front(1);
+        uint32_t l1_addr = cb_in0.get_read_ptr();
         if constexpr (!is_l1_aligned) {
             for (uint32_t i = 0; i < patch_size; i++) {
                 for (uint32_t j = 0; j < (stick_nbytes / 2); j++) {
@@ -47,7 +51,7 @@ void kernel_main() {
             noc_async_write(l1_addr, dst_noc_addr, stick_nbytes * patch_size);
         }
         noc_async_write_barrier();
-        cb_pop_front(cb_id_in0, 1);
+        cb_in0.pop_front(1);
         dst_index++;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "tt-metalium/constants.hpp"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
@@ -18,6 +19,8 @@ void kernel_main() {
     constexpr uint32_t element_size = get_compile_time_arg_val(7);           // Size of each element in bytes
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(8);            // Input circular buffer ID
     constexpr auto dst_args = TensorAccessorArgs<9>();
+
+    experimental::CircularBuffer input_cb(input_cb_id);
 
     // Runtime arguments - Processing parameters
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);        // Base destination address in DRAM
@@ -46,8 +49,8 @@ void kernel_main() {
 
         // Process each tile in the width dimension
         for (uint32_t tile_idx = 0; tile_idx < tiles_per_width_dim; tile_idx++) {
-            cb_wait_front(input_cb_id, tiles_per_channel_dim);
-            uint64_t l1_read_addr = get_write_ptr(input_cb_id);
+            input_cb.wait_front(tiles_per_channel_dim);
+            uint64_t l1_read_addr = input_cb.get_write_ptr();
 
             const uint32_t width_limit =
                 (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
@@ -73,7 +76,7 @@ void kernel_main() {
 
             // Ensure all writes complete before moving to next set of tiles_per_channel_dim tiles
             noc_async_write_barrier();
-            cb_pop_front(input_cb_id, tiles_per_channel_dim);
+            input_cb.pop_front(tiles_per_channel_dim);
         }
 
         // Update patch offset for next block

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
         // Process each tile in the width dimension
         for (uint32_t tile_idx = 0; tile_idx < tiles_per_width_dim; tile_idx++) {
             input_cb.wait_front(tiles_per_channel_dim);
-            uint64_t l1_read_addr = input_cb.get_write_ptr();
+            uint64_t l1_read_addr = input_cb.get_read_ptr();
 
             const uint32_t width_limit =
                 (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t src_cb = get_compile_time_arg_val(0);
@@ -21,6 +22,9 @@ void kernel_main() {
     constexpr uint32_t element_size = get_compile_time_arg_val(12);
     constexpr uint32_t is_reader = get_compile_time_arg_val(13);
 
+    experimental::CircularBuffer cb_src(src_cb);
+    experimental::CircularBuffer cb_dst(dst_cb);
+
     constexpr uint32_t dst_row_size = num_dst_cols * aligned_dst_pixel_size;
     constexpr uint32_t cols_per_core = num_dst_cols / 2;
     constexpr uint32_t process_cols = cols_per_core + ((num_dst_cols % 2) & is_reader);
@@ -31,9 +35,9 @@ void kernel_main() {
     constexpr uint32_t elements_per_pixel = pixel_size / element_size;
     constexpr uint32_t elements_per_aligned_pixel = aligned_pixel_size / element_size;
 
-    uint64_t src_noc_addr = get_noc_addr(get_read_ptr(src_cb));
-    const uint32_t dst_addr_base = get_write_ptr(dst_cb);
-    uint32_t src_addr_base = get_read_ptr(src_cb);
+    uint64_t src_noc_addr = get_noc_addr(cb_src.get_read_ptr());
+    const uint32_t dst_addr_base = cb_dst.get_write_ptr();
+    uint32_t src_addr_base = cb_src.get_read_ptr();
 
     if constexpr (is_aligned) {
         noc_async_read_one_packet_set_state(src_noc_addr, aligned_chunk_size);

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp
@@ -5,9 +5,6 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/noc.h"
-#include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
 
 #include <cstdint>
 

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp
@@ -5,6 +5,9 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 #include <cstdint>
 

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
@@ -81,6 +81,11 @@ void kernel_main() {
     constexpr uint32_t output_tensor_data_format_size =
         get_tile_size(output_tensor_cb_index) / get_tile_hw(input_tensor_cb_index);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer input_index_cb(input_index_tensor_cb_index);
+    experimental::CircularBuffer input_cb(input_tensor_cb_index);
+    experimental::CircularBuffer output_cb(output_tensor_cb_index);
+
     for (uint32_t h = 0; h < Ht; h++) {
         for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
             const uint32_t current_index_tile_id = core_id + core_loop * total_number_of_cores;
@@ -88,23 +93,27 @@ void kernel_main() {
                 break;
             }
             // Read index data
-            cb_reserve_back(input_index_tensor_cb_index, one_tile);
+            input_index_cb.reserve_back(one_tile);
 
-            const uint32_t l1_write_addr_index = get_write_ptr(input_index_tensor_cb_index);
-            noc_async_read_tile(h * Wt_index + current_index_tile_id, input_index_tensor_dram, l1_write_addr_index);
-            noc_async_read_barrier();
+            noc.async_read(
+                input_index_tensor_dram,
+                input_index_cb,
+                input_index_tensor_tile_size_bytes,
+                {.page_id = h * Wt_index + current_index_tile_id},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
 
-            cb_push_back(input_index_tensor_cb_index, one_tile);
-            cb_wait_front(input_index_tensor_cb_index, one_tile);
+            input_index_cb.push_back(one_tile);
+            input_index_cb.wait_front(one_tile);
 
-            cb_reserve_back(output_tensor_cb_index, one_tile);
+            output_cb.reserve_back(one_tile);
 
             for (uint32_t wi = 0; wi < Wt_input; wi++) {
-                cb_wait_front(input_tensor_cb_index, one_tile);
+                input_cb.wait_front(one_tile);
 
-                const uint32_t input_tensor_l1_read_addr = get_read_ptr(input_tensor_cb_index);
-                const uint32_t input_index_tensor_l1_read_addr = get_read_ptr(input_index_tensor_cb_index);
-                const uint32_t output_tensor_l1_read_addr = get_read_ptr(output_tensor_cb_index);
+                const uint32_t input_tensor_l1_read_addr = input_cb.get_read_ptr();
+                const uint32_t input_index_tensor_l1_read_addr = input_index_cb.get_read_ptr();
+                const uint32_t output_tensor_l1_read_addr = output_cb.get_read_ptr();
 
                 uint32_t count = 0;
                 constexpr uint32_t tile_faces = 2;
@@ -148,10 +157,10 @@ void kernel_main() {
                         }  // k loop
                     }  // j loop
                 }  // i loop
-                cb_pop_front(input_tensor_cb_index, one_tile);
+                input_cb.pop_front(one_tile);
             }  // wi loop
-            cb_push_back(output_tensor_cb_index, one_tile);
-            cb_pop_front(input_index_tensor_cb_index, one_tile);
+            output_cb.push_back(one_tile);
+            input_index_cb.pop_front(one_tile);
         }  // core_loop_count loop
     }  // h loop
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
@@ -5,6 +5,9 @@
 #include "gather_common.hpp"
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include <cstdint>
 /*
 This kernel implements a parallel gather operation along the last dimension (Wt_index) of the tensor, enabling support

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
@@ -113,7 +113,7 @@ void kernel_main() {
 
                 const uint32_t input_tensor_l1_read_addr = input_cb.get_read_ptr();
                 const uint32_t input_index_tensor_l1_read_addr = input_index_cb.get_read_ptr();
-                const uint32_t output_tensor_l1_read_addr = output_cb.get_read_ptr();
+                const uint32_t output_tensor_l1_write_addr = output_cb.get_write_ptr();
 
                 uint32_t count = 0;
                 constexpr uint32_t tile_faces = 2;
@@ -151,7 +151,7 @@ void kernel_main() {
 
                                 // Write value to output
                                 write_value_to_tile(
-                                    output_tensor_l1_read_addr, count, output_tensor_data_format_size, value);
+                                    output_tensor_l1_write_addr, count, output_tensor_data_format_size, value);
                                 count++;
                             }  // l loop
                         }  // k loop

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
@@ -170,7 +170,7 @@ void kernel_main() {
 
             const uint32_t input_tensor_l1_read_addr = input_cb.get_read_ptr();
             const uint32_t input_index_tensor_l1_read_addr = input_index_cb.get_read_ptr();
-            const uint32_t output_tensor_l1_read_addr = output_cb.get_read_ptr();
+            const uint32_t output_tensor_l1_write_addr = output_cb.get_write_ptr();
 
             uint32_t count = 0;
             constexpr uint32_t tile_faces = 2;
@@ -208,7 +208,7 @@ void kernel_main() {
 
                             // Write value to output
                             write_value_to_tile(
-                                output_tensor_l1_read_addr, count, output_tensor_data_format_size, value);
+                                output_tensor_l1_write_addr, count, output_tensor_data_format_size, value);
                             count++;
                         }  // l loop
                     }  // k loop

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
@@ -143,25 +143,34 @@ void kernel_main() {
     constexpr uint32_t output_tensor_data_format_size =
         get_tile_size(output_tensor_cb_index) / get_tile_hw(input_tensor_cb_index);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer input_index_cb(input_index_tensor_cb_index);
+    experimental::CircularBuffer input_cb(input_tensor_cb_index);
+    experimental::CircularBuffer output_cb(output_tensor_cb_index);
+
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         // Calculate tile h coordinate
         const uint32_t h = core_loop * total_number_of_cores + core_id;
 
         for (uint32_t w = 0; w < Wt_index; w++) {
             // Read index data
-            cb_reserve_back(input_index_tensor_cb_index, one_tile);
-            const uint32_t l1_write_addr_index = get_write_ptr(input_index_tensor_cb_index);
-            noc_async_read_tile(h * Wt_index + w, input_index_tensor_dram, l1_write_addr_index);
-            noc_async_read_barrier();
-            cb_push_back(input_index_tensor_cb_index, one_tile);
+            input_index_cb.reserve_back(one_tile);
+            noc.async_read(
+                input_index_tensor_dram,
+                input_index_cb,
+                input_index_tensor_tile_size_bytes,
+                {.page_id = h * Wt_index + w},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
+            input_index_cb.push_back(one_tile);
 
-            cb_wait_front(input_tensor_cb_index, Wt_input);
-            cb_wait_front(input_index_tensor_cb_index, one_tile);
-            cb_reserve_back(output_tensor_cb_index, one_tile);
+            input_cb.wait_front(Wt_input);
+            input_index_cb.wait_front(one_tile);
+            output_cb.reserve_back(one_tile);
 
-            const uint32_t input_tensor_l1_read_addr = get_read_ptr(input_tensor_cb_index);
-            const uint32_t input_index_tensor_l1_read_addr = get_read_ptr(input_index_tensor_cb_index);
-            const uint32_t output_tensor_l1_read_addr = get_read_ptr(output_tensor_cb_index);
+            const uint32_t input_tensor_l1_read_addr = input_cb.get_read_ptr();
+            const uint32_t input_index_tensor_l1_read_addr = input_index_cb.get_read_ptr();
+            const uint32_t output_tensor_l1_read_addr = output_cb.get_read_ptr();
 
             uint32_t count = 0;
             constexpr uint32_t tile_faces = 2;
@@ -205,9 +214,9 @@ void kernel_main() {
                     }  // k loop
                 }  // j loop
             }  // i loop
-            cb_push_back(output_tensor_cb_index, one_tile);
-            cb_pop_front(input_index_tensor_cb_index, one_tile);
+            output_cb.push_back(one_tile);
+            input_index_cb.pop_front(one_tile);
         }  // Wt loop
-        cb_pop_front(input_tensor_cb_index, Wt_input);
+        input_cb.pop_front(Wt_input);
     }  // core_loop_count loop
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
@@ -5,6 +5,9 @@
 #include "gather_common.hpp"
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include <cstdint>
 
 /*

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 #include "api/debug/dprint.h"
 
@@ -46,6 +49,10 @@ void kernel_main() {
     const auto output_tensor_dram =
         TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer input_cb(input_tensor_cb_index);
+    experimental::CircularBuffer output_cb(output_tensor_cb_index);
+
     for (uint32_t h = 0; h < Ht; h++) {
         for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
             const uint32_t current_index_tile_id = core_id + core_loop * total_number_of_cores;
@@ -54,20 +61,28 @@ void kernel_main() {
             }
             // Read input data
             for (uint32_t w = 0; w < Wt_input; w++) {
-                cb_reserve_back(input_tensor_cb_index, one_tile);
-                const uint32_t l1_write_addr = get_write_ptr(input_tensor_cb_index);
-                noc_async_read_tile(h * Wt_input + w, input_tensor_dram, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(input_tensor_cb_index, one_tile);
+                input_cb.reserve_back(one_tile);
+                noc.async_read(
+                    input_tensor_dram,
+                    input_cb,
+                    input_tensor_tile_size_bytes,
+                    {.page_id = h * Wt_input + w},
+                    {.offset_bytes = 0});
+                noc.async_read_barrier();
+                input_cb.push_back(one_tile);
             }  // Wt_input loop
 
             // Write output data
-            cb_wait_front(output_tensor_cb_index, one_tile);
+            output_cb.wait_front(one_tile);
 
-            const uint32_t l1_write_addr_output = get_read_ptr(output_tensor_cb_index);
-            noc_async_write_tile(h * Wt_index + current_index_tile_id, output_tensor_dram, l1_write_addr_output);
-            noc_async_write_barrier();
-            cb_pop_front(output_tensor_cb_index, one_tile);
+            noc.async_write(
+                output_cb,
+                output_tensor_dram,
+                output_tensor_tile_size_bytes,
+                {.offset_bytes = 0},
+                {.page_id = h * Wt_index + current_index_tile_id});
+            noc.async_write_barrier();
+            output_cb.pop_front(one_tile);
 
         }  // core_loop_count loop
     }  // h loop

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 #include "api/debug/dprint.h"
 
@@ -54,26 +57,38 @@ void kernel_main() {
     const auto output_tensor_dram =
         TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer input_cb(input_tensor_cb_index);
+    experimental::CircularBuffer output_cb(output_tensor_cb_index);
+
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         // Calculate tile h coordinate
         const uint32_t h = core_loop * total_number_of_cores + core_id;
 
         // Read input data
         for (uint32_t w = 0; w < Wt_input; w++) {
-            cb_reserve_back(input_tensor_cb_index, one_tile);
-            const uint32_t l1_write_addr = get_write_ptr(input_tensor_cb_index);
-            noc_async_read_tile(h * Wt_input + w, input_tensor_dram, l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(input_tensor_cb_index, one_tile);
+            input_cb.reserve_back(one_tile);
+            noc.async_read(
+                input_tensor_dram,
+                input_cb,
+                input_tensor_tile_size_bytes,
+                {.page_id = h * Wt_input + w},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
+            input_cb.push_back(one_tile);
         }  // Wt_input loop
 
         // Write output data
         for (uint32_t w = 0; w < Wt_index; w++) {
-            cb_wait_front(output_tensor_cb_index, one_tile);
-            const uint32_t l1_write_addr_output = get_read_ptr(output_tensor_cb_index);
-            noc_async_write_tile(h * Wt_index + w, output_tensor_dram, l1_write_addr_output);
-            noc_async_write_barrier();
-            cb_pop_front(output_tensor_cb_index, one_tile);
+            output_cb.wait_front(one_tile);
+            noc.async_write(
+                output_cb,
+                output_tensor_dram,
+                output_tensor_tile_size_bytes,
+                {.offset_bytes = 0},
+                {.page_id = h * Wt_index + w});
+            noc.async_write_barrier();
+            output_cb.pop_front(one_tile);
         }  // Wt_index loop
     }  // core_loop_count loop
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_interleaved.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 
 using uint32_t = std::uint32_t;
 
@@ -36,6 +38,8 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(src0_args, src0_addr, tile_bytes);
 
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+
     // Sticks are a row of elements in a single tile (32 elements)
     // Stick id increments row-wise
     // We loop through output tiles row wise, and then read one tile row at a tile to form the output tile
@@ -46,7 +50,7 @@ void kernel_main() {
                 uint32_t base_tile_stick_id = base_tile_row_stick_id;
                 for (uint32_t w = 0; w < output_Wt; w++) {
                     uint32_t output_stick_id = base_tile_stick_id;  // Offset tile id of the current sub tile row
-                    cb_reserve_back(cb_id_in0, onetile);
+                    cb_in0.reserve_back(onetile);
                     for (uint32_t tile_h = 0; tile_h < 32; tile_h++) {
                         uint32_t input_tile_row_to_read = output_stick_id / num_sticks_per_input_tile_row;
                         uint32_t input_tile_col_to_read = output_stick_id % input_Wt;
@@ -60,7 +64,7 @@ void kernel_main() {
                              << 9);  // if intra-tile source h is > 16, add 2*512 to subtile offset
                         banked_addr += ((input_tile_sub_row_to_read & 15) << 5);  // 16 * 2 bytes per face row
 
-                        uint32_t dest_tr0_l1 = get_write_ptr(cb_id_in0);
+                        uint32_t dest_tr0_l1 = cb_in0.get_write_ptr();
                         dest_tr0_l1 +=
                             (((tile_h >> 4) << 1) << 9);  // if intra-tile source h is > 16, add 2*512 to subtile offset
                         dest_tr0_l1 += ((tile_h & 15) << 5);  // 16 * 2 bytes per face row
@@ -101,7 +105,7 @@ void kernel_main() {
                     }
                     noc_async_read_barrier();
                     // notifies the unpacker that the buffer is populated
-                    cb_push_back(cb_id_in0, onetile);
+                    cb_in0.push_back(onetile);
 
                     base_tile_stick_id += 1;
                 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_stick_layout_interleaved_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/reader_unary_reshape_stick_layout_interleaved_multi_core.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -19,19 +21,22 @@ void kernel_main() {
 
     const auto s = TensorAccessor(src_args, src_addr, old_stick_size);
 
+    experimental::CircularBuffer cb_input(cb_in0);
+
     uint32_t i_stick = start_id;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
-        cb_reserve_back(cb_in0, num_sticks_per_cb_push);
-        uint32_t l1_write_addr = get_write_ptr(cb_in0);
+        cb_input.reserve_back(num_sticks_per_cb_push);
+        uint32_t l1_write_addr = cb_input.get_write_ptr();
 
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
             uint64_t read_noc_addr = get_noc_addr(i_stick, s);
+            // Use legacy NOC API for raw address reads
             noc_async_read(read_noc_addr, l1_write_addr, old_stick_size);
             l1_write_addr += old_stick_size;
             i_stick++;
         }
         noc_async_read_barrier();
-        cb_push_back(cb_in0, num_sticks_per_cb_push);
+        cb_input.push_back(num_sticks_per_cb_push);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/writer_unary_reshape_stick_layout_interleaved_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/writer_unary_reshape_stick_layout_interleaved_multi_core.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -17,18 +19,21 @@ void kernel_main() {
 
     const auto s = TensorAccessor(dst_args, dst_addr, new_stick_size);
 
+    experimental::CircularBuffer cb_output(cb_out0);
+
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
-        cb_wait_front(cb_out0, num_sticks_per_cb_push);
-        uint32_t l1_read_addr = get_read_ptr(cb_out0);
+        cb_output.wait_front(num_sticks_per_cb_push);
+        uint32_t l1_read_addr = cb_output.get_read_ptr();
 
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
             uint64_t write_noc_addr = get_noc_addr(i_stick, s);
+            // Use legacy NOC API for raw address writes
             noc_async_write(l1_read_addr, write_noc_addr, new_stick_size);
             l1_read_addr += new_stick_size;
             i_stick += 1;
         }
         noc_async_write_barrier();
-        cb_pop_front(cb_out0, num_sticks_per_cb_push);
+        cb_output.pop_front(num_sticks_per_cb_push);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/common.hpp
@@ -5,6 +5,9 @@
 
 #pragma once
 
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+
 constexpr uint32_t ONE_PAGE = 1;
 
 // supported reduction methods for scatter to be applied for source values coming from recurring indices
@@ -121,14 +124,16 @@ FORCE_INLINE void load_to_cb(
     const uint32_t& offset_bytes,
     const uint32_t& chunk_size_bytes,
     const uint32_t& stick_id) {
-    cb_reserve_back(cb, ONE_PAGE);
+    experimental::CircularBuffer cb_exp(cb);
+    cb_exp.reserve_back(ONE_PAGE);
     const uint64_t source_noc_address = get_noc_addr(stick_id, addr_gtor);
-    const uint32_t l1_write_address = get_write_ptr(cb);
+    const uint32_t l1_write_address = cb_exp.get_write_ptr();
 
+    // Use legacy NOC API for raw address reads
     noc_async_read(source_noc_address + offset_bytes, l1_write_address, chunk_size_bytes);
     noc_async_read_barrier();
 
-    cb_push_back(cb, ONE_PAGE);
+    cb_exp.push_back(ONE_PAGE);
 }
 
 // this function is supposed to write either a whole stick or part of it (76800 elements)
@@ -139,12 +144,14 @@ FORCE_INLINE void write_to_output(
     const uint32_t& offset_bytes,
     const uint32_t& chunk_size_bytes,
     const uint32_t& stick_id) {
-    cb_wait_front(cb, ONE_PAGE);
+    experimental::CircularBuffer cb_exp(cb);
+    cb_exp.wait_front(ONE_PAGE);
     const uint64_t destination_noc_address = get_noc_addr(stick_id, addr_gtor);
-    const uint32_t l1_read_address = get_read_ptr(cb);
+    const uint32_t l1_read_address = cb_exp.get_read_ptr();
 
+    // Use legacy NOC API for raw address writes
     noc_async_write(l1_read_address, destination_noc_address + offset_bytes, chunk_size_bytes);
     noc_async_write_barrier();
 
-    cb_pop_front(cb, ONE_PAGE);
+    cb_exp.pop_front(ONE_PAGE);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 #include "../scatter_bf16_reduction_common.hpp"
 
 #include <array>
@@ -171,8 +173,11 @@ void kernel_main() {
                 input_offset * sizeof(input_std_type),
                 input_chunk_length * sizeof(input_std_type),
                 input_stick_id);
-            cb_wait_front(ctas.input_cb, ONE_PAGE);
-            cb_reserve_back(ctas.fp32_temp_cb, ONE_PAGE);
+            experimental::CircularBuffer input_cb(ctas.input_cb);
+            experimental::CircularBuffer fp32_temp_cb(ctas.fp32_temp_cb);
+            experimental::CircularBuffer output_cb(ctas.output_cb);
+            input_cb.wait_front(ONE_PAGE);
+            fp32_temp_cb.reserve_back(ONE_PAGE);
 
             copy_input_to_fp32_temp(ctas.input_cb, ctas.fp32_temp_cb, input_chunk_length);
 
@@ -201,8 +206,10 @@ void kernel_main() {
                         source_offset * sizeof(input_std_type),
                         source_chunk_length * sizeof(input_std_type),
                         index_stick_id);
-                    cb_wait_front(ctas.index_cb, ONE_PAGE);
-                    cb_wait_front(ctas.source_cb, ONE_PAGE);
+                    experimental::CircularBuffer index_cb(ctas.index_cb);
+                    experimental::CircularBuffer source_cb(ctas.source_cb);
+                    index_cb.wait_front(ONE_PAGE);
+                    source_cb.wait_front(ONE_PAGE);
                     scatter_along_chunk<index_std_type>(
                         ctas.input_cb,
                         ctas.index_cb,
@@ -214,20 +221,20 @@ void kernel_main() {
                         input_chunk_length,
                         index_chunk_length,
                         scatter_reduction_type);
-                    cb_pop_front(ctas.source_cb, ONE_PAGE);
-                    cb_pop_front(ctas.index_cb, ONE_PAGE);
+                    source_cb.pop_front(ONE_PAGE);
+                    index_cb.pop_front(ONE_PAGE);
                 }
             }
 
-            cb_pop_front(ctas.input_cb, ONE_PAGE);
-            cb_push_back(ctas.fp32_temp_cb, ONE_PAGE);
-            cb_wait_front(ctas.fp32_temp_cb, ONE_PAGE);
-            cb_reserve_back(ctas.output_cb, ONE_PAGE);
+            input_cb.pop_front(ONE_PAGE);
+            fp32_temp_cb.push_back(ONE_PAGE);
+            fp32_temp_cb.wait_front(ONE_PAGE);
+            output_cb.reserve_back(ONE_PAGE);
 
             // third phase: push to the output cb with fp32->bf16 conversion
             copy_fp32_temp_to_output(ctas.fp32_temp_cb, ctas.output_cb, input_chunk_length);
-            cb_pop_front(ctas.fp32_temp_cb, ONE_PAGE);
-            cb_push_back(ctas.output_cb, ONE_PAGE);
+            fp32_temp_cb.pop_front(ONE_PAGE);
+            output_cb.push_back(ONE_PAGE);
         }
         next_inplace<N>(coord, input_dims);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_scatter.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 #include "../scatter_common.hpp"
 
 #include <array>
@@ -141,8 +143,10 @@ void kernel_main() {
                 input_offset * sizeof(input_std_type),
                 input_chunk_length * sizeof(input_std_type),
                 input_stick_id);
-            cb_wait_front(ctas.input_cb, ONE_PAGE);
-            cb_reserve_back(ctas.output_cb, ONE_PAGE);
+            experimental::CircularBuffer input_cb(ctas.input_cb);
+            experimental::CircularBuffer output_cb(ctas.output_cb);
+            input_cb.wait_front(ONE_PAGE);
+            output_cb.reserve_back(ONE_PAGE);
 
             copy_input_to_output<input_std_type>(ctas.input_cb, ctas.output_cb, input_chunk_length);
 
@@ -171,8 +175,10 @@ void kernel_main() {
                         source_offset * sizeof(input_std_type),
                         source_chunk_length * sizeof(input_std_type),
                         index_stick_id);
-                    cb_wait_front(ctas.index_cb, ONE_PAGE);
-                    cb_wait_front(ctas.source_cb, ONE_PAGE);
+                    experimental::CircularBuffer index_cb(ctas.index_cb);
+                    experimental::CircularBuffer source_cb(ctas.source_cb);
+                    index_cb.wait_front(ONE_PAGE);
+                    source_cb.wait_front(ONE_PAGE);
                     scatter_along_chunk<input_std_type, index_std_type>(
                         ctas.input_cb,
                         ctas.index_cb,
@@ -183,14 +189,14 @@ void kernel_main() {
                         input_chunk_length,
                         index_chunk_length,
                         scatter_reduction_type);
-                    cb_pop_front(ctas.source_cb, ONE_PAGE);
-                    cb_pop_front(ctas.index_cb, ONE_PAGE);
+                    source_cb.pop_front(ONE_PAGE);
+                    index_cb.pop_front(ONE_PAGE);
                 }
             }
 
                 // third phase: push to the output cb
-                cb_push_back(ctas.output_cb, ONE_PAGE);
-                cb_pop_front(ctas.input_cb, ONE_PAGE);
+            output_cb.push_back(ONE_PAGE);
+            input_cb.pop_front(ONE_PAGE);
         }
         next_inplace<N>(coord, input_dims);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_bf16_reduction_scatter.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 
 #include "../scatter_bf16_reduction_common.hpp"
 

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_scatter.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 
 #include "../scatter_common.hpp"
 


### PR DESCRIPTION
## Summary
- Migrates 24 kernel files across 5 data_movement operations to experimental Device 2.0 APIs
- Operations: `copy` (6), `fold` (5), `gather` (5), `scatter` (5), `reshape_on_device` (3)
- Uses `experimental::Noc` and `experimental::CircularBuffer` APIs

### Migration approach:
- **Full migration (gather, 1 fold kernel):** Both CB and NOC operations use experimental API
- **Partial migration (copy, scatter, reshape_on_device, 4 fold kernels):** CB operations use experimental API, NOC operations use legacy API (required for raw NOC addresses and sharded memory patterns)

### Bug fixes (pre-existing in original code):
- `fold/writer_cb2dram_for_tiled_input.cpp`: Fixed `get_write_ptr()` → `get_read_ptr()` after `wait_front()`
- `gather_reader_single_row_multi_core.cpp`: Fixed `get_read_ptr()` → `get_write_ptr()` after `reserve_back()`
- `gather_reader_single_row_single_core.cpp`: Fixed `get_read_ptr()` → `get_write_ptr()` after `reserve_back()`

## Test plan
- [x] Build passes
- [x] `pytest tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py` - 116 passed
- [x] `pytest tests/ttnn/unit_tests/operations/data_movement/test_gather.py` - 45 passed
- [x] `pytest tests/ttnn/nightly/unit_tests/operations/data_movement/test_gather.py` - 17 passed
- [x] `pytest tests/ttnn/unit_tests/operations/data_movement/test_tosa_scatter.py` - 5 passed
- [x] `pytest tests/ttnn/nightly/unit_tests/operations/data_movement/test_scatter.py` - 85 passed
- [x] `pytest tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py` - 126 passed (also exercises reshape_on_device)
- [x] `pytest tests/ttnn/unit_tests/base_functionality/test_reshape.py` - 320 passed

**Total: 714 tests passed**

Part of #41702

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=device-2.0-migration/copy-fold-scatter-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:device-2.0-migration/copy-fold-scatter-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=device-2.0-migration/copy-fold-scatter-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:device-2.0-migration/copy-fold-scatter-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=device-2.0-migration/copy-fold-scatter-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:device-2.0-migration/copy-fold-scatter-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=device-2.0-migration/copy-fold-scatter-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:device-2.0-migration/copy-fold-scatter-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=device-2.0-migration/copy-fold-scatter-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:device-2.0-migration/copy-fold-scatter-gather)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=device-2.0-migration/copy-fold-scatter-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:device-2.0-migration/copy-fold-scatter-gather)