### PR TITLE
Wan 4xGLX: Use experimental ring attention

### DIFF
--- a/models/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -140,6 +140,18 @@ class WanAttention(Module):
             exp_approx_mode=False,  # NOTE: False is more correct
         )
 
+        self.use_exp_ring_sdpa = (
+            self.parallel_config.tensor_parallel.factor == 4 and self.parallel_config.sequence_parallel.factor == 32
+        )
+
+        if self.use_exp_ring_sdpa:
+            self.exp_ring_sdpa_program_config = ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=full_grid,
+                q_chunk_size=ring_sdpa_chunk_size[0],
+                k_chunk_size=ring_sdpa_chunk_size[1],
+                exp_approx_mode=False,
+            )
+
         self.sdpa_compute_kernel_config = ttnn.init_device_compute_kernel_config(
             self.mesh_device.arch(),
             math_fidelity=ttnn.MathFidelity.HiFi2,
@@ -370,35 +382,66 @@ class WanAttention(Module):
             # Self attention
             if self.parallel_config.sequence_parallel.factor > 1:
                 # HACK: pass null joint inputs to take advantage of ring attention, even though this is self-attention.
-                spatial_BHNE, prompt_BHLE, _lse = ttnn.transformer.ring_joint_scaled_dot_product_attention(
-                    q_BHNE,
-                    k_BHNE,
-                    v_BHNE,
-                    self.dummy_joint_input,
-                    self.dummy_joint_input,
-                    self.dummy_joint_input,
-                    persistent_output_buffer_k=self.ccl_manager.get_ag_ping_pong_buffer(
-                        k_BHNE.shape, 2, self.parallel_config.sequence_parallel.mesh_axis
-                    ),
-                    persistent_output_buffer_v=self.ccl_manager.get_ag_ping_pong_buffer(
-                        v_BHNE.shape, 2, self.parallel_config.sequence_parallel.mesh_axis
-                    ),
-                    joint_strategy="rear",
-                    logical_n=N,
-                    program_config=self.ring_sdpa_program_config,
-                    compute_kernel_config=self.sdpa_compute_kernel_config,
-                    dim=2,
-                    multi_device_global_semaphore=self.ccl_manager.get_ag_ping_pong_semaphore(
-                        self.parallel_config.sequence_parallel.mesh_axis
-                    ),
-                    num_links=self.ccl_manager.num_links,
-                    cluster_axis=self.parallel_config.sequence_parallel.mesh_axis,
-                    mesh_device=self.mesh_device,
-                    topology=self.ccl_manager.topology,
-                    subdevice_id=self.ccl_manager.ccl_sub_device_id,
-                    ccl_core_grid_offset=(self.sdpa_worker_grid[0], 0),  # Place CCL in last column
-                    use_column_major_ccl=True,  # WAN2.2 specific: use column-major CCL allocation
-                )
+                if self.use_exp_ring_sdpa:
+                    spatial_BHNE, prompt_BHLE, _lse = ttnn.transformer.exp_ring_joint_scaled_dot_product_attention(
+                        q_BHNE,
+                        k_BHNE,
+                        v_BHNE,
+                        self.dummy_joint_input,
+                        self.dummy_joint_input,
+                        self.dummy_joint_input,
+                        persistent_output_buffer_k=self.ccl_manager.get_ag_ping_pong_buffer(
+                            k_BHNE.shape, 2, self.parallel_config.sequence_parallel.mesh_axis
+                        ),
+                        persistent_output_buffer_v=self.ccl_manager.get_ag_ping_pong_buffer(
+                            v_BHNE.shape, 2, self.parallel_config.sequence_parallel.mesh_axis
+                        ),
+                        joint_strategy="rear",
+                        logical_n=N,
+                        program_config=self.exp_ring_sdpa_program_config,
+                        compute_kernel_config=self.sdpa_compute_kernel_config,
+                        dim=2,
+                        multi_device_global_semaphore=self.ccl_manager.get_exp_ring_ping_pong_semaphore(
+                            self.parallel_config.sequence_parallel.mesh_axis
+                        ),
+                        num_links=self.ccl_manager.num_links,
+                        cluster_axis=self.parallel_config.sequence_parallel.mesh_axis,
+                        mesh_device=self.mesh_device,
+                        topology=self.ccl_manager.topology,
+                        subdevice_id=self.ccl_manager.ccl_sub_device_id,
+                        num_workers_per_link=5,
+                        num_buffers_per_channel=32,
+                    )
+                else:
+                    spatial_BHNE, prompt_BHLE, _lse = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+                        q_BHNE,
+                        k_BHNE,
+                        v_BHNE,
+                        self.dummy_joint_input,
+                        self.dummy_joint_input,
+                        self.dummy_joint_input,
+                        persistent_output_buffer_k=self.ccl_manager.get_ag_ping_pong_buffer(
+                            k_BHNE.shape, 2, self.parallel_config.sequence_parallel.mesh_axis
+                        ),
+                        persistent_output_buffer_v=self.ccl_manager.get_ag_ping_pong_buffer(
+                            v_BHNE.shape, 2, self.parallel_config.sequence_parallel.mesh_axis
+                        ),
+                        joint_strategy="rear",
+                        logical_n=N,
+                        program_config=self.ring_sdpa_program_config,
+                        compute_kernel_config=self.sdpa_compute_kernel_config,
+                        dim=2,
+                        multi_device_global_semaphore=self.ccl_manager.get_ag_ping_pong_semaphore(
+                            self.parallel_config.sequence_parallel.mesh_axis
+                        ),
+                        num_links=self.ccl_manager.num_links,
+                        cluster_axis=self.parallel_config.sequence_parallel.mesh_axis,
+                        mesh_device=self.mesh_device,
+                        topology=self.ccl_manager.topology,
+                        subdevice_id=self.ccl_manager.ccl_sub_device_id,
+                        ccl_core_grid_offset=(self.sdpa_worker_grid[0], 0),
+                        use_column_major_ccl=True,
+                    )
             else:
                 spatial_BHNE = ttnn.transformer.scaled_dot_product_attention(
                     q_BHNE,

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -40,6 +40,7 @@ class CCLManager:
         self.rs_ping_pong_idx = [0, 0]
         self.rs_ping_pong_idx_fused = [0, 0]
         self.ag_ping_pong_idx = [0, 0]
+        self.exp_ring_ping_pong_idx = [0, 0]
         self.np_ping_pong_idx = [0, 0]
         self.sr_ping_pong_idx = [0, 0]
         self.barrier_idx = [0, 0]
@@ -76,6 +77,13 @@ class CCLManager:
         self.ag_ping_pong_semaphores = {
             0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(ag_n_sems)],
             1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(ag_n_sems)],
+        }
+
+        # Initialize exp ring joint SDPA semaphores (num_links per set, 2 sets for ping pong)
+        exp_ring_n_sems = self.num_links * 2
+        self.exp_ring_ping_pong_semaphores = {
+            0: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(exp_ring_n_sems)],
+            1: [ttnn.create_global_semaphore(self.mesh_device, self.ccl_cores, 0) for _ in range(exp_ring_n_sems)],
         }
 
         # Initialize neighbor pad semaphores
@@ -229,6 +237,21 @@ class CCLManager:
         n_sems = 2
         self.ag_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.ag_ping_pong_semaphores[mesh_axis][cur_idx * n_sems : (cur_idx + 1) * n_sems]
+
+    def get_exp_ring_ping_pong_semaphore(self, mesh_axis):
+        """
+        Get semaphores for exp ring joint SDPA operations.
+
+        Args:
+            mesh_axis: The mesh axis (0 or 1) to get semaphores for
+
+        Returns:
+            List of num_links semaphores for the current ping pong cycle
+        """
+        cur_idx = self.exp_ring_ping_pong_idx[mesh_axis]
+        n_sems = self.num_links
+        self.exp_ring_ping_pong_idx[mesh_axis] = (cur_idx + 1) % 2
+        return self.exp_ring_ping_pong_semaphores[mesh_axis][cur_idx * n_sems : (cur_idx + 1) * n_sems]
 
     def get_np_ping_pong_semaphore(self, mesh_axis):
         """


### PR DESCRIPTION
### Summary
experimental ring attention was merged in https://github.com/tenstorrent/tt-metal/pull/40733. It is specifically constructed to work with Wan on Quad. 
This PR enables experimental ring attention in that configuration.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/use_exp_ring_attention) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/use_exp_ring_attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/use_exp_ring_attention) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/use_exp_ring_attention) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cglagovich/use_exp_ring_attention) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=cglagovich/use_exp_ring_attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cglagovich/use_exp_ring_attention) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cglagovich/use_exp_ring_attention) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/use_exp_ring_attention) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/use_exp_ring_attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/use_exp_ring_attention) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/use_exp_ring_attention) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/use_exp_ring_attention) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/use_exp_ring_attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/use_exp_ring_attention) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/use_exp_ring_attention) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/use_exp_ring_attention) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/use_exp_ring_attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/use_exp_ring_attention) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/use_exp_ring_attention) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/use_exp_ring_attention) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/use_exp_ring_attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/use_exp_ring_attention) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/use_exp_ring_attention) |