### PR TITLE
Fixing ND sharding validation interleaved_to_sharded

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
@@ -222,3 +222,77 @@ def test_interleaved_to_dram_sharded_via_to_memory_layout(
     ttnn_output_tensor = ttnn.to_memory_config(ttnn_input_tensor, output_mem_config)
 
     assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+
+
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize(
+    "tensor_shape, nd_shard_shape, shard_grid",
+    [
+        # HEIGHT_SHARDED equivalent: shard covers full width, 4 shards along height
+        [
+            [1, 1, 128, 64],
+            [1, 1, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+        ],
+        # WIDTH_SHARDED equivalent: shard covers full height, 4 shards along width
+        [
+            [1, 1, 64, 256],
+            [1, 1, 64, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+        ],
+        # BLOCK_SHARDED equivalent: shard splits both dims, 2x2 grid
+        [
+            [1, 1, 128, 128],
+            [1, 1, 64, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+        ],
+        # 3D ND shard folding into HEIGHT_SHARDED: batch dim folds into shard height
+        [
+            [4, 32, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
+        ],
+    ],
+)
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR])
+def test_interleaved_to_sharded_nd_with_equivalent_2d(
+    device, layout, tensor_shape, nd_shard_shape, shard_grid, shard_orientation
+):
+    nd_shard_spec = ttnn.NdShardSpec(nd_shard_shape, shard_grid, orientation=shard_orientation)
+    output_mem_config = ttnn.MemoryConfig(ttnn.BufferType.L1, nd_shard_spec)
+
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=layout)
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
+    ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)
+
+    assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+
+
+@pytest.mark.parametrize(
+    "tensor_shape, nd_shard_shape, shard_grid",
+    [
+        # Sharding across non-adjacent dims: volume mismatch prevents 2D flattening
+        [
+            [6, 32, 64],
+            [3, 32, 32],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+        ],
+        # Sharding batch and spatial with non-trivial batch shard: can't fold to 2D
+        [
+            [4, 3, 32, 64],
+            [2, 1, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+        ],
+    ],
+)
+def test_interleaved_to_sharded_rejects_pure_nd(device, tensor_shape, nd_shard_shape, shard_grid):
+    nd_shard_spec = ttnn.NdShardSpec(nd_shard_shape, shard_grid, orientation=ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.BufferType.L1, nd_shard_spec)
+
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
+
+    with pytest.raises(RuntimeError):
+        ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)

--- a/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.cpp
@@ -86,7 +86,16 @@ bool can_use_interleaved_to_sharded(
     //***  Check if the CB size is too large for the L1. If so, reroute this to use the default ttnn::copy ***//
 
     // CB L1 capacity check
-    auto shard_spec = output_mem_config.shard_spec().value();
+    // When the MemoryConfig was created with an nd_shard_spec, the legacy shard_spec is not populated.
+    // Construct the output TensorSpec to get the normalized memory config with the legacy shard_spec.
+    auto resolved_mem_config = output_mem_config;
+    if (!output_mem_config.shard_spec().has_value()) {
+        auto output_spec = ttnn::prim::InterleavedToShardedDeviceOperation::compute_output_specs(
+            ttnn::prim::InterleavedToShardedParams{output_mem_config, resolved_dtype, false},
+            ttnn::prim::InterleavedToShardedInputs{input_tensor, output_tensor});
+        resolved_mem_config = output_spec.memory_config();
+    }
+    auto shard_spec = resolved_mem_config.shard_spec().value();
     bool convert_df = input_tensor.dtype() != resolved_dtype;
     bool dst_is_dram = output_mem_config.buffer_type() == BufferType::DRAM;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -22,6 +22,15 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     if (input_tensor.buffer() == nullptr) {
         return {false, "Operands to shard need to be allocated in buffers on device!"};
     }
+
+    // Reject dtype/layout combinations that would hard-fail during TensorSpec construction in compute_output_specs().
+    // These low-precision packed formats require tiled layout.
+    const bool output_dtype_requires_tile =
+        output_dtype == DataType::BFLOAT8_B || output_dtype == DataType::BFLOAT4_B;
+    if (output_dtype_requires_tile && input_tensor.layout() == Layout::ROW_MAJOR) {
+        return {false, "Output dtype BFLOAT8_B/BFLOAT4_B requires TILE layout, but input tensor layout is ROW_MAJOR"};
+    }
+
     // TensorSpec construction normalizes ND shard specs to equivalent 2D layouts when possible.
     // Use the normalized memory config for validation so that convertible ND specs are accepted.
     auto resolved_output_mem_config = output_mem_config;
@@ -64,14 +73,6 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     }
     if (!output_mem_config.is_sharded()) {
         return {false, "Output memory config must be sharded"};
-    }
-
-    // Reject dtype/layout combinations that would hard-fail during TensorSpec construction in
-    // compute_output_specs(). These low-precision packed formats require tiled layout.
-    const bool output_dtype_requires_tile =
-        output_dtype == DataType::BFLOAT8_B || output_dtype == DataType::BFLOAT4_B;
-    if (output_dtype_requires_tile && input_tensor.layout() == Layout::ROW_MAJOR) {
-        return {false, "Output dtype BFLOAT8_B/BFLOAT4_B requires TILE layout, but input tensor layout is ROW_MAJOR"};
     }
 
     if (resolved_output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -52,6 +52,15 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     if (!output_mem_config.is_sharded()) {
         return {false, "Output memory config must be sharded"};
     }
+
+    // Reject dtype/layout combinations that would hard-fail during TensorSpec construction in
+    // compute_output_specs(). These low-precision packed formats require tiled layout.
+    const bool output_dtype_requires_tile =
+        output_dtype == DataType::BFLOAT8_B || output_dtype == DataType::BFLOAT4_B;
+    if (output_dtype_requires_tile && input_tensor.layout() == Layout::ROW_MAJOR) {
+        return {false, "Output dtype BFLOAT8_B/BFLOAT4_B requires TILE layout, but input tensor layout is ROW_MAJOR"};
+    }
+
     // TensorSpec construction normalizes ND shard specs to equivalent 2D layouts when possible.
     // Use the normalized memory config for validation so that convertible ND specs are accepted.
     auto resolved_output_mem_config = output_mem_config;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -22,12 +22,25 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     if (input_tensor.buffer() == nullptr) {
         return {false, "Operands to shard need to be allocated in buffers on device!"};
     }
+    // TensorSpec construction normalizes ND shard specs to equivalent 2D layouts when possible.
+    // Use the normalized memory config for validation so that convertible ND specs are accepted.
+    auto resolved_output_mem_config = output_mem_config;
+    if (output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
+        auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+        if (output_spec.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
+            return {
+                false,
+                "interleaved_to_sharded does not support ND sharding. Please use ttnn.to_memory_config or "
+                "ttnn.copy instead."};
+        }
+        resolved_output_mem_config = output_spec.memory_config();
+    }
     if (tensor_args.output_tensor.has_value()) {
         const auto& output_tensor = tensor_args.output_tensor.value();
         if (output_tensor.logical_shape() != input_tensor.logical_shape()) {
             return {false, "Mismatched output shape"};
         }
-        if (output_tensor.memory_config() != output_mem_config) {
+        if (output_tensor.memory_config() != resolved_output_mem_config) {
             return {false, "Mismatched output memory config"};
         }
         if (output_tensor.dtype() != output_dtype) {
@@ -61,19 +74,6 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
         return {false, "Output dtype BFLOAT8_B/BFLOAT4_B requires TILE layout, but input tensor layout is ROW_MAJOR"};
     }
 
-    // TensorSpec construction normalizes ND shard specs to equivalent 2D layouts when possible.
-    // Use the normalized memory config for validation so that convertible ND specs are accepted.
-    auto resolved_output_mem_config = output_mem_config;
-    if (output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
-        auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-        if (output_spec.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
-            return {
-                false,
-                "interleaved_to_sharded does not support ND sharding. Please use ttnn.to_memory_config or "
-                "ttnn.copy instead."};
-        }
-        resolved_output_mem_config = output_spec.memory_config();
-    }
     if (resolved_output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
         if (resolved_output_mem_config.buffer_type() != tt::tt_metal::BufferType::L1) {
             return {false, "We don't support DRAM block sharding"};

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -52,16 +52,26 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     if (!output_mem_config.is_sharded()) {
         return {false, "Output memory config must be sharded"};
     }
+    // TensorSpec construction normalizes ND shard specs to equivalent 2D layouts when possible.
+    // Use the normalized memory config for validation so that convertible ND specs are accepted.
+    auto resolved_output_mem_config = output_mem_config;
     if (output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
-        return {false, "interleaved_to_sharded does not support ND sharding. Please use ttnn.to_memory_config or ttnn.copy instead."};
+        auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+        if (output_spec.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
+            return {
+                false,
+                "interleaved_to_sharded does not support ND sharding. Please use ttnn.to_memory_config or "
+                "ttnn.copy instead."};
+        }
+        resolved_output_mem_config = output_spec.memory_config();
     }
-    if (output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
-        if (output_mem_config.buffer_type() != tt::tt_metal::BufferType::L1) {
+    if (resolved_output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
+        if (resolved_output_mem_config.buffer_type() != tt::tt_metal::BufferType::L1) {
             return {false, "We don't support DRAM block sharding"};
         }
     }
     if (input_tensor.layout() == Layout::ROW_MAJOR) {
-        if ((*output_mem_config.shard_spec()).shape[1] * input_tensor.element_size() %
+        if ((*resolved_output_mem_config.shard_spec()).shape[1] * input_tensor.element_size() %
                 tt::tt_metal::hal::get_l1_alignment() != 0) {
             return {false, "Shard page size must currently have L1 aligned page size"};
         }


### PR DESCRIPTION

### Summary
The PR https://github.com/tenstorrent/tt-metal/pull/41789 introduced a check to reject ND sharded output tensors from the `ttnn.interleaved_to_sharded` op. This check was overly-restrictive since it caused output memory configs with an `nd_shard_spec` which have an equivalent 2D `shard_spec` to be rejected by the op. This caused failures in the [Galaxy DeepSeek Unit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/24417049574). This PR changes the validation to only reject ND sharded output tensors with no 2D sharding equivalent, since 2D sharded tensors can take this op.


- [x] [Sanity Tests](https://github.com/tenstorrent/tt-metal/actions/runs/24423947679) - [main results](https://github.com/tenstorrent/tt-metal/actions/runs/24370417026)
- [x] [Blackhole Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/24423974999)
- [x] [Galaxy DeepSeek Unit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/24424009192)  - [main results](https://github.com/tenstorrent/tt-metal/actions/runs/24370512017)
- [x] New/Existing tests for this op
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/runs/24424033002) on the PR branch to catch linting errors early

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/sharded_ops_validation_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/sharded_ops_validation_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/sharded_ops_validation_fix) | [#2776](https://github.com/tenstorrent/tt-metal/actions/runs/24423947679) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/sharded_ops_validation_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/sharded_ops_validation_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/sharded_ops_validation_fix) | [#17500](https://github.com/tenstorrent/tt-metal/actions/runs/24423974999) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/sharded_ops_validation_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/sharded_ops_validation_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/sharded_ops_validation_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/sharded_ops_validation_fix) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/sharded_ops_validation_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/sharded_ops_validation_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/sharded_ops_validation_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/sharded_ops_validation_fix) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/sharded_ops_validation_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/sharded_ops_validation_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/sharded_ops_validation_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/sharded_ops_validation_fix) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/sharded_ops_validation_fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/sharded_ops_validation_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/sharded_ops_validation_fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/sharded_ops_validation_fix) |