### PR TITLE
Fix for reductions ignoring explicit sharded output_mem_config

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
@@ -87,3 +87,68 @@ def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_le
         atol=atol,
         frobenius_threshold=frobenius_threshold,
     )
+
+
+@pytest.mark.parametrize("op", ["max", "var"])
+def test_nd_sharded_reduce_h_no_output_shard_spec(op, device, function_level_defaults):
+    """Reduce with ND_SHARDED output MemoryConfig that omits nd_shard_spec.
+
+    The shard spec is optional in MemoryConfig. When absent, the reduce operation
+    should infer grid and shard shape from the input tensor.
+    Parametrized over max (ReduceDeviceOperation) and var (WelfordReduceDeviceOperation)
+    to cover both code paths.
+    """
+    grid_size = (8, 4)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need {grid_size} grid size to run this test but core grid is {compute_grid_size}")
+
+    N = 1
+    C = 1
+    H = 64
+    W = 2048
+
+    interleaved_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.BufferType.L1,
+    )
+    nd_sharded_out_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.ND_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+    )
+
+    x = torch.randn((N, C, H, W)).bfloat16()
+
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+    ).to(device, interleaved_mem_config)
+
+    xt = ttnn.interleaved_to_sharded(
+        xt,
+        grid_size,
+        [N * C * H, W // (grid_size[0] * grid_size[1])],
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.ShardOrientation.COL_MAJOR,
+    )
+
+    ttnn_op = getattr(ttnn, op)
+    torch_op_name = {"max": "amax", "min": "amin"}.get(op, op)
+    torch_op = getattr(torch, torch_op_name)
+
+    yt = ttnn_op(xt, 2, memory_config=nd_sharded_out_config)
+    y = torch_op(x, 2)
+
+    yt = ttnn.sharded_to_interleaved(yt, interleaved_mem_config)
+    tt_got_back = yt.cpu().to_torch()
+
+    assert_numeric_metrics(
+        y,
+        tt_got_back,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=0.02,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -398,18 +398,21 @@ def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op, explicit_ou
     assert passing, f"op={op} {output_pcc}, torch: {torch_output_tensor}, ttnn: {output_tensor}"
 
 
-# Test that generic reduction ops work correctly with Width and Height sharding.
+# Test that generic reduction ops work correctly with Width, Height, and Block sharding.
 @pytest.mark.parametrize(
-    "input_shape, shard_2d_shape, end_x, end_y, memory_layout",
+    "input_shape, shard_2d_shape, end_x, end_y, memory_layout, dim",
     [
         # HEIGHT_SHARDED: each core gets a horizontal slice (some rows, full width)
-        ([8, 8, 32, 32], [1024, 32], 1, 0, ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
-        ([4, 4, 64, 64], [512, 64], 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
+        ([8, 8, 32, 32], [1024, 32], 1, 0, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, -2),
+        ([4, 4, 64, 64], [512, 64], 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, -2),
         # WIDTH_SHARDED: each core gets a vertical slice (full height, some columns)
-        ([8, 8, 32, 128], [2048, 32], 3, 0, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
-        ([4, 4, 64, 256], [1024, 32], 7, 0, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
+        ([8, 8, 32, 128], [2048, 32], 3, 0, ttnn.TensorMemoryLayout.WIDTH_SHARDED, -2),
+        ([4, 4, 64, 256], [1024, 32], 7, 0, ttnn.TensorMemoryLayout.WIDTH_SHARDED, -2),
         # BLOCK_SHARDED: both height and width split across a 2D grid
-        ([4, 4, 64, 64], [512, 32], 1, 1, ttnn.TensorMemoryLayout.BLOCK_SHARDED),
+        ([4, 4, 64, 64], [512, 32], 1, 1, ttnn.TensorMemoryLayout.BLOCK_SHARDED, -2),
+        # Also test W reduction case to validate shard-shape recomputation when
+        # the reduced output width becomes one tile.
+        ([4, 4, 64, 64], [512, 32], 1, 1, ttnn.TensorMemoryLayout.BLOCK_SHARDED, -1),
     ],
 )
 @pytest.mark.parametrize("keepdim", [True])
@@ -417,7 +420,17 @@ def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op, explicit_ou
 @pytest.mark.parametrize("op", ["mean", "sum", "max", "min", "std", "var"])
 @pytest.mark.parametrize("explicit_output_mem_config", [True, False])
 def test_generic_ops_wh_block_shard(
-    device, input_shape, shard_2d_shape, end_x, end_y, memory_layout, keepdim, layout, op, explicit_output_mem_config
+    device,
+    input_shape,
+    shard_2d_shape,
+    end_x,
+    end_y,
+    memory_layout,
+    dim,
+    keepdim,
+    layout,
+    op,
+    explicit_output_mem_config,
 ):
     # To reduce the number of tests, we only test sum and var with explicit output mem_config.
     # This exercises both known code paths where this could make a meaningful difference.
@@ -425,8 +438,6 @@ def test_generic_ops_wh_block_shard(
         pytest.skip("explicit output mem_config only tested for sum and var")
 
     torch.manual_seed(0)
-    dim = -2
-
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(end_x, end_y))}),
         shard_2d_shape,
@@ -518,6 +529,11 @@ def test_generic_ops_wh_block_shard(
         # Width is split across cores, height stays full
         expected_shard_h = output_2d_height
         expected_shard_w = (output_2d_width + num_cores - 1) // num_cores
+
+    # The output is always TILE layout, so each per-core shard must contain
+    # whole tiles. Round up both shard dimensions to tile boundaries.
+    expected_shard_h = round_up_to_tile(expected_shard_h)
+    expected_shard_w = round_up_to_tile(expected_shard_w)
 
     actual_shard_shape = list(output_shard_spec.shape)
     assert actual_shard_shape == [expected_shard_h, expected_shard_w], (

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -316,7 +316,13 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
 @pytest.mark.parametrize("keepdim", [True])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("op", ["mean", "sum", "max", "min", "std", "var"])
-def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op):
+@pytest.mark.parametrize("explicit_output_mem_config", [True, False])
+def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op, explicit_output_mem_config):
+    # To reduce the number of tests, we only test sum and var with explicit output mem_config.
+    # This exercises both known code paths where this could make a meaningful difference.
+    if explicit_output_mem_config and op not in ("sum", "var"):
+        pytest.skip("explicit output mem_config only tested for sum and var")
+
     torch.manual_seed(0)
     dim = -2
     input_shape, shard_shape, end_x, end_y = shapes
@@ -344,7 +350,10 @@ def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op):
         layout=layout,
         memory_config=memory_config,
     )
-    op_output_tensor = ttnn_op(input_tensor, dim=dim, keepdim=keepdim)
+    if explicit_output_mem_config:
+        op_output_tensor = ttnn_op(input_tensor, dim=dim, keepdim=keepdim, memory_config=memory_config)
+    else:
+        op_output_tensor = ttnn_op(input_tensor, dim=dim, keepdim=keepdim)
 
     # Verify output is sharded with correct properties (doc: "Output sharding will mirror the input")
     output_mem_config = op_output_tensor.memory_config()
@@ -399,12 +408,22 @@ def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op):
         # WIDTH_SHARDED: each core gets a vertical slice (full height, some columns)
         ([8, 8, 32, 128], [2048, 32], 3, 0, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
         ([4, 4, 64, 256], [1024, 32], 7, 0, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
+        # BLOCK_SHARDED: both height and width split across a 2D grid
+        ([4, 4, 64, 64], [512, 32], 1, 1, ttnn.TensorMemoryLayout.BLOCK_SHARDED),
     ],
 )
 @pytest.mark.parametrize("keepdim", [True])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("op", ["mean", "sum", "max", "min", "std", "var"])
-def test_generic_ops_wh_shard(device, input_shape, shard_2d_shape, end_x, end_y, memory_layout, keepdim, layout, op):
+@pytest.mark.parametrize("explicit_output_mem_config", [True, False])
+def test_generic_ops_wh_block_shard(
+    device, input_shape, shard_2d_shape, end_x, end_y, memory_layout, keepdim, layout, op, explicit_output_mem_config
+):
+    # To reduce the number of tests, we only test sum and var with explicit output mem_config.
+    # This exercises both known code paths where this could make a meaningful difference.
+    if explicit_output_mem_config and op not in ("sum", "var"):
+        pytest.skip("explicit output mem_config only tested for sum and var")
+
     torch.manual_seed(0)
     dim = -2
 
@@ -434,7 +453,10 @@ def test_generic_ops_wh_shard(device, input_shape, shard_2d_shape, end_x, end_y,
         layout=layout,
         memory_config=memory_config,
     )
-    op_output_tensor = ttnn_op(input_tensor, dim=dim, keepdim=keepdim)
+    if explicit_output_mem_config:
+        op_output_tensor = ttnn_op(input_tensor, dim=dim, keepdim=keepdim, memory_config=memory_config)
+    else:
+        op_output_tensor = ttnn_op(input_tensor, dim=dim, keepdim=keepdim)
 
     # Verify output is sharded with correct properties (doc: "Output sharding will mirror the input")
     output_mem_config = op_output_tensor.memory_config()
@@ -486,6 +508,12 @@ def test_generic_ops_wh_shard(device, input_shape, shard_2d_shape, end_x, end_y,
         # Height is split across cores, width stays full
         expected_shard_h = (output_2d_height + num_cores - 1) // num_cores
         expected_shard_w = output_2d_width
+    elif memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
+        # Height split across grid rows, width split across grid columns
+        num_rows = end_y + 1
+        num_cols = end_x + 1
+        expected_shard_h = (output_2d_height + num_rows - 1) // num_rows
+        expected_shard_w = (output_2d_width + num_cols - 1) // num_cols
     else:
         # Width is split across cores, height stays full
         expected_shard_h = output_2d_height

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -100,28 +100,44 @@ def test_mean_scaling_factor(device, shape, dim, scalar):
     )
 
 
-@pytest.mark.parametrize("mem_config", [None, ttnn.DRAM_MEMORY_CONFIG, "block"])
+@pytest.mark.parametrize("mem_config", [None, ttnn.DRAM_MEMORY_CONFIG, "block", "height"])
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_mean_shard(device, mem_config, keepdim):
     torch.manual_seed(0)
-    if mem_config is None and not keepdim:
-        pytest.skip("Skipping because reshape does not work in this scenario. Issue #35145")
-    torch_input_tensor = torch.randn(1, 1024, 160, dtype=torch.bfloat16)
-    block_sharded_config = ttnn.create_sharded_memory_config(
-        shape=(1, 1024, 160),
-        core_grid=ttnn.CoreGrid(x=5, y=8),
-        strategy=ttnn.ShardStrategy.BLOCK,
-        use_height_and_width_as_shard_shape=False,
-    )
+    if mem_config == "height":
+        # Height 100 is intentionally non-tile-aligned (not a multiple of 32).
+        # Physical height pads to 128, so shard height 32 across 4 cores is valid.
+        # After reducing dim=-1 with keepdim=False the output shape is (1, 100),
+        # which exercises reshape_tiled's shard spec recomputation for HEIGHT_SHARDED.
+        torch_input_tensor = torch.randn(1, 100, 160, dtype=torch.bfloat16)
+        sharded_config = ttnn.create_sharded_memory_config(
+            shape=(32, 160),
+            core_grid=ttnn.CoreGrid(x=1, y=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            use_height_and_width_as_shard_shape=True,
+        )
+    else:
+        torch_input_tensor = torch.randn(1, 1024, 160, dtype=torch.bfloat16)
+        sharded_config = ttnn.create_sharded_memory_config(
+            shape=(1, 1024, 160),
+            core_grid=ttnn.CoreGrid(x=5, y=8),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            use_height_and_width_as_shard_shape=False,
+        )
+
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
-        memory_config=block_sharded_config,
+        memory_config=sharded_config,
     )
 
-    memory_config = block_sharded_config if mem_config == "block" else mem_config
+    if mem_config in ("block", "height"):
+        memory_config = sharded_config
+    else:
+        memory_config = mem_config
+
     output_tensor = ttnn.mean(
         input_tensor,
         dim=-1,
@@ -137,5 +153,5 @@ def test_mean_shard(device, mem_config, keepdim):
         pcc_threshold=0.999,
         rtol=0.610,
         atol=0.002,
-        frobenius_threshold=0.005,
+        frobenius_threshold=0.0055,
     )

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -200,7 +200,10 @@ TensorSpec TensorSpec::block_sharded(CoreRange grid, ShardOrientation orientatio
     auto shard_width =
         div_up(physical_shape().width(), orientation == ShardOrientation::ROW_MAJOR ? grid_size.x : grid_size.y);
     NdShardSpec shard_spec(
-        Shape({static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)}), grid, orientation);
+        Shape({static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)}),
+        grid,
+        orientation,
+        ShardDistributionStrategy::GRID_2D);
     return sharded(std::move(shard_spec), ShardShapeAlignment::RECOMMENDED);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -285,21 +285,20 @@ ttnn::Tensor reshape_tiled(
     }
 
     auto updated_mem_config = memory_config;
-    if (updated_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-        auto shard_spec = updated_mem_config.shard_spec().value();
-        shard_spec.shape[1] = requested_padded_shape_3d[-1];
-        updated_mem_config = updated_mem_config.with_shard_spec(shard_spec);
-    }
-
     // If block/height-sharded output, compute the correct shard spec
     if (updated_mem_config.is_sharded()) {
-        // Synthesize TensorLayout from padded shape
-        auto synthetic_layout = tt::tt_metal::TensorLayout::fromPaddedShape(
+        // Synthesize a TensorLayout that reproduces the requested padded shape via an explicit alignment, but with an
+        // interleaved MemoryConfig (no shard_spec). Dropping the shard_spec is what lets the TensorSpec constructor
+        // below skip its shape-fits-shard-grid validation, which would otherwise apply the *input* shard_spec to the
+        // *output* shape and fatal. Pinning the alignment to requested_padded_shape_3d's last two dims (rather than
+        // relying on the page_config's default tile alignment) ensures synthetic_spec.physical_shape() exactly
+        // matches the requested padded shape, even if compute_padded_shape ever produced dims that exceed
+        // tile alignment (e.g., due to shard-aware padding).
+        auto synthetic_layout = TensorLayout(
             tensor3d.dtype(),
-            tensor3d.tensor_spec().page_config(),
-            updated_mem_config,
-            requested_shape_3d,
-            requested_padded_shape_3d);
+            PageConfig(tensor3d.layout()),
+            MemoryConfig(updated_mem_config.buffer_type()),
+            tt::tt_metal::Alignment{requested_padded_shape_3d[-2], requested_padded_shape_3d[-1]});
 
         // Construct synthetic TensorSpec
         tt::tt_metal::TensorSpec synthetic_spec(requested_shape_3d, synthetic_layout);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -287,7 +287,7 @@ ttnn::Tensor reshape_tiled(
     auto updated_mem_config = memory_config;
     if (updated_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
         auto shard_spec = updated_mem_config.shard_spec().value();
-        shard_spec.shape[1] = requested_shape_3d[-1];
+        shard_spec.shape[1] = requested_padded_shape_3d[-1];
         updated_mem_config = updated_mem_config.with_shard_spec(shard_spec);
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -287,18 +287,19 @@ ttnn::Tensor reshape_tiled(
     auto updated_mem_config = memory_config;
     // If block/height-sharded output, compute the correct shard spec
     if (updated_mem_config.is_sharded()) {
-        // Synthesize a TensorLayout that reproduces the requested padded shape via an explicit alignment, but with an
-        // interleaved MemoryConfig (no shard_spec). Dropping the shard_spec is what lets the TensorSpec constructor
-        // below skip its shape-fits-shard-grid validation, which would otherwise apply the *input* shard_spec to the
-        // *output* shape and fatal. Pinning the alignment to requested_padded_shape_3d's last two dims (rather than
-        // relying on the page_config's default tile alignment) ensures synthetic_spec.physical_shape() exactly
-        // matches the requested padded shape, even if compute_padded_shape ever produced dims that exceed
-        // tile alignment (e.g., due to shard-aware padding).
-        auto synthetic_layout = TensorLayout(
+        // Synthesize TensorLayout from the requested padded shape, but with an interleaved
+        // MemoryConfig (no shard_spec). Dropping the shard_spec is what lets the TensorSpec
+        // constructor below skip its shape-fits-shard-grid validation, which would otherwise
+        // apply the *input* shard_spec to the *output* shape and fatal. The padded shape
+        // passed here ends up baked into the layout's alignment, so synthetic_spec.physical_shape()
+        // exactly matches the requested padded shape, even if compute_padded_shape ever produced
+        // dimensions that exceed tile alignment (e.g., due to shard-aware padding).
+        auto synthetic_layout = tt::tt_metal::TensorLayout::fromPaddedShape(
             tensor3d.dtype(),
-            PageConfig(tensor3d.layout()),
+            tensor3d.tensor_spec().page_config(),
             MemoryConfig(updated_mem_config.buffer_type()),
-            tt::tt_metal::Alignment{requested_padded_shape_3d[-2], requested_padded_shape_3d[-1]});
+            requested_shape_3d,
+            requested_padded_shape_3d);
 
         // Construct synthetic TensorSpec
         tt::tt_metal::TensorSpec synthetic_spec(requested_shape_3d, synthetic_layout);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -22,4 +22,89 @@ tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
     }
     TT_THROW("Unsupported reduce dim");
 }
+
+tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
+    const tt::tt_metal::Shape& output_shape,
+    tt::tt_metal::DataType output_dtype,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::MemoryConfig& input_mem_config,
+    tt::tt_metal::ReduceOpDim reduce_dim) {
+    using namespace tt::tt_metal;
+
+    TensorSpec tensor_spec(
+        output_shape,
+        TensorLayout(output_dtype, PageConfig(Layout::TILE), MemoryConfig(output_mem_config.buffer_type())));
+
+    TensorMemoryLayout mem_layout = output_mem_config.memory_layout();
+
+    if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED || mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
+        mem_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        // Grid and orientation are identical in both spec formats (nd_shard_spec and shard_spec)
+        // when both are populated. Pick whichever is available from the output config,
+        // falling back to the input tensor's shard spec for backward compatibility.
+        const auto& nd = output_mem_config.nd_shard_spec();
+        const auto& legacy = output_mem_config.shard_spec();
+        const auto& input_nd = input_mem_config.nd_shard_spec();
+        const auto& input_legacy = input_mem_config.shard_spec();
+        auto get_grid_and_orientation = [&]() -> std::pair<const CoreRangeSet&, ShardOrientation> {
+            if (nd) {
+                return {nd->grid, nd->orientation};
+            }
+            if (legacy) {
+                return {legacy->grid, legacy->orientation};
+            }
+            if (input_nd) {
+                return {input_nd->grid, input_nd->orientation};
+            }
+            if (input_legacy) {
+                return {input_legacy->grid, input_legacy->orientation};
+            }
+            TT_THROW(
+                "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set "
+                "on the output memory config or the input tensor",
+                mem_layout);
+        };
+        const auto& [grid, orientation] = get_grid_and_orientation();
+
+        // For width/height/block sharding modes, the output shard shape is fully determined
+        // by the output physical shape and the core grid. Just delegate to the
+        // appropriate TensorSpec builder.
+        if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+            return tensor_spec.width_sharded(grid, orientation);
+        }
+        if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            return tensor_spec.height_sharded(grid, orientation);
+        }
+        TT_FATAL(
+            grid.ranges().size() == 1,
+            "Block sharding requires a single CoreRange, got {} ranges",
+            grid.ranges().size());
+        return tensor_spec.block_sharded(grid.bounding_box(), orientation);
+    }
+
+    // ND sharding: adjust per-logical-dimension shard shape for reduced dims.
+    // Fall back to the input tensor's nd_shard_spec when the output config omits it.
+    if (mem_layout == TensorMemoryLayout::ND_SHARDED) {
+        const auto& nd_shard_spec = output_mem_config.nd_shard_spec();
+        const auto& input_nd_shard_spec = input_mem_config.nd_shard_spec();
+        TT_FATAL(
+            nd_shard_spec.has_value() || input_nd_shard_spec.has_value(),
+            "ND_SHARDED memory layout requires nd_shard_spec to be set "
+            "on the output memory config or the input tensor");
+        auto nd_shard_spec_copy = nd_shard_spec.has_value() ? *nd_shard_spec : *input_nd_shard_spec;
+        if (reduce_dim == ReduceOpDim::W || reduce_dim == ReduceOpDim::HW) {
+            nd_shard_spec_copy.shard_shape[-1] = 1;
+        }
+        if ((reduce_dim == ReduceOpDim::H || reduce_dim == ReduceOpDim::HW) &&
+            nd_shard_spec_copy.shard_shape.rank() > 1) {
+            nd_shard_spec_copy.shard_shape[-2] = 1;
+        }
+        return tensor_spec.sharded(std::move(nd_shard_spec_copy), TensorSpec::ShardShapeAlignment::REQUIRED);
+    }
+
+    // Guard against unexpected new memory layouts.
+    TT_FATAL(mem_layout == TensorMemoryLayout::INTERLEAVED, "Unexpected memory layout: {}", mem_layout);
+    // Interleaved tensor: tensor_spec already has everything we need.
+    return tensor_spec;
+}
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -107,4 +107,22 @@ tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
     // Interleaved tensor: tensor_spec already has everything we need.
     return tensor_spec;
 }
+
+void validate_reduce_sharded_buffer_types(
+    const tt::tt_metal::MemoryConfig& input_mem_config,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    std::string_view op_name) {
+    TT_FATAL(
+        !output_mem_config.is_sharded() || output_mem_config.is_l1(),
+        "{}: sharded output memory layout {} is only supported with L1 buffers, got buffer type {}",
+        op_name,
+        output_mem_config.memory_layout(),
+        output_mem_config.buffer_type());
+    TT_FATAL(
+        !input_mem_config.is_sharded() || input_mem_config.is_l1(),
+        "{}: sharded input memory layout {} is only supported with L1 buffers, got buffer type {}",
+        op_name,
+        input_mem_config.memory_layout(),
+        input_mem_config.buffer_type());
+}
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace tt::tt_metal {
@@ -42,5 +44,17 @@ tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::MemoryConfig& input_mem_config,
     tt::tt_metal::ReduceOpDim reduce_dim);
+
+// Enforces the documented contract that, for reduction-style ops, any sharded
+// participant (input or output) must live in L1.  Sharded layouts and DRAM
+// buffers use disjoint coordinate spaces (worker cores vs DRAM bank cores), so
+// silently borrowing a grid across buffer types — as the shard-spec fallback
+// in `build_reduce_output_tensor_spec` would otherwise allow — produces an
+// invalid spec.  Pass an `op_name` (e.g. "reduce", "Std/Var reduction") for a
+// readable error message.
+void validate_reduce_sharded_buffer_types(
+    const tt::tt_metal::MemoryConfig& input_mem_config,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    std::string_view op_name);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -22,4 +22,25 @@ namespace ttnn::prim {
 tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
     const tt::tt_metal::Tensor& input_tensors, tt::tt_metal::ReduceOpDim reduce_dim);
 
+// Builds a tilized TensorSpec for a reduction-style op output, given the
+// already shape-adjusted output shape and the dimension that was reduced.
+//
+// Handles all currently supported output memory layouts:
+//   - INTERLEAVED: returns the basic spec.
+//   - WIDTH/HEIGHT/BLOCK_SHARDED: delegates to the corresponding TensorSpec
+//     builder using the grid/orientation taken from `output_mem_config` if
+//     available, otherwise falling back to `input_mem_config`.
+//   - ND_SHARDED: copies the ND shard spec (from `output_mem_config` or, as a
+//     fallback, `input_mem_config`) and sets the shard shape entries for the
+//     reduced dim(s) to 1.
+//
+// `input_mem_config` is the memory config of the reduction's input tensor and
+// is only consulted as a fallback when the output config omits a shard spec.
+tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
+    const tt::tt_metal::Shape& output_shape,
+    tt::tt_metal::DataType output_dtype,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::MemoryConfig& input_mem_config,
+    tt::tt_metal::ReduceOpDim reduce_dim);
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -50,87 +50,12 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
             break;
     }
 
-    TensorSpec tensor_spec(
+    return build_reduce_output_tensor_spec(
         output_shape,
-        tt::tt_metal::TensorLayout(
-            operation_attributes.output_dtype,
-            tt::tt_metal::PageConfig(Layout::TILE),
-            MemoryConfig(operation_attributes.output_mem_config.buffer_type())));
-
-    TensorMemoryLayout mem_layout = operation_attributes.output_mem_config.memory_layout();
-
-    if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED || mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        mem_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        // Grid and orientation are identical in both spec formats (nd_shard_spec and shard_spec)
-        // when both are populated. Pick whichever is available from the output config,
-        // falling back to the input tensor's shard spec for backward compatibility.
-        const auto& nd = operation_attributes.output_mem_config.nd_shard_spec();
-        const auto& legacy = operation_attributes.output_mem_config.shard_spec();
-        const auto& input_nd = tensor_args.memory_config().nd_shard_spec();
-        const auto& input_legacy = tensor_args.memory_config().shard_spec();
-        auto get_grid_and_orientation = [&]() -> std::pair<const CoreRangeSet&, ShardOrientation> {
-            if (nd) {
-                return {nd->grid, nd->orientation};
-            }
-            if (legacy) {
-                return {legacy->grid, legacy->orientation};
-            }
-            if (input_nd) {
-                return {input_nd->grid, input_nd->orientation};
-            }
-            if (input_legacy) {
-                return {input_legacy->grid, input_legacy->orientation};
-            }
-            TT_THROW(
-                "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set "
-                "on the output memory config or the input tensor",
-                mem_layout);
-        };
-        const auto& [grid, orientation] = get_grid_and_orientation();
-
-        // For width/height/block sharding modes, the output shard shape is fully determined
-        // by the output physical shape and the core grid. Just delegate to the
-        // appropriate TensorSpec builder.
-        if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-            return tensor_spec.width_sharded(grid, orientation);
-        }
-        if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-            return tensor_spec.height_sharded(grid, orientation);
-        }
-        TT_FATAL(
-            grid.ranges().size() == 1,
-            "Block sharding requires a single CoreRange, got {} ranges",
-            grid.ranges().size());
-        return tensor_spec.block_sharded(grid.bounding_box(), orientation);
-    }
-
-    // ND sharding: adjust per-logical-dimension shard shape for reduced dims.
-    // Fall back to the input tensor's nd_shard_spec when the output config omits it.
-    if (mem_layout == TensorMemoryLayout::ND_SHARDED) {
-        const auto& nd_shard_spec = operation_attributes.output_mem_config.nd_shard_spec();
-        const auto& input_nd_shard_spec = tensor_args.memory_config().nd_shard_spec();
-        TT_FATAL(
-            nd_shard_spec.has_value() || input_nd_shard_spec.has_value(),
-            "ND_SHARDED memory layout requires nd_shard_spec to be set "
-            "on the output memory config or the input tensor");
-        auto nd_shard_spec_copy = nd_shard_spec.has_value() ? *nd_shard_spec : *input_nd_shard_spec;
-        if (operation_attributes.dim == tt::tt_metal::ReduceOpDim::W ||
-            operation_attributes.dim == tt::tt_metal::ReduceOpDim::HW) {
-            nd_shard_spec_copy.shard_shape[-1] = 1;
-        }
-        if ((operation_attributes.dim == tt::tt_metal::ReduceOpDim::H ||
-             operation_attributes.dim == tt::tt_metal::ReduceOpDim::HW) &&
-            nd_shard_spec_copy.shard_shape.rank() > 1) {
-            nd_shard_spec_copy.shard_shape[-2] = 1;
-        }
-        return tensor_spec.sharded(
-            std::move(nd_shard_spec_copy), tt::tt_metal::TensorSpec::ShardShapeAlignment::REQUIRED);
-    }
-
-    // Guard against unexpected new memory layouts.
-    TT_FATAL(mem_layout == TensorMemoryLayout::INTERLEAVED, "Unexpected memory layout: {}", mem_layout);
-    // Interleaved tensor: tensor_spec already has everything we need.
-    return tensor_spec;
+        operation_attributes.output_dtype,
+        operation_attributes.output_mem_config,
+        tensor_args.memory_config(),
+        operation_attributes.dim);
 }
 
 ReduceDeviceOperation::tensor_return_value_t ReduceDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -57,16 +57,42 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
             tt::tt_metal::PageConfig(Layout::TILE),
             MemoryConfig(operation_attributes.output_mem_config.buffer_type())));
 
-    if (operation_attributes.output_mem_config.nd_shard_spec().has_value()) {
-        const auto& nd_shard_spec = *operation_attributes.output_mem_config.nd_shard_spec();
-        if (operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-            return tensor_spec.width_sharded(nd_shard_spec.grid, nd_shard_spec.orientation);
-        }
-        if (operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-            return tensor_spec.height_sharded(nd_shard_spec.grid, nd_shard_spec.orientation);
-        }
+    TensorMemoryLayout mem_layout = operation_attributes.output_mem_config.memory_layout();
 
-        auto nd_shard_spec_copy = nd_shard_spec;
+    if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED || mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
+        mem_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        // Grid and orientation are identical in both spec formats (nd_shard_spec and shard_spec)
+        // when both are populated. Pick whichever is available.
+        const auto& nd = operation_attributes.output_mem_config.nd_shard_spec();
+        const auto& legacy = operation_attributes.output_mem_config.shard_spec();
+        TT_FATAL(
+            nd.has_value() || legacy.has_value(),
+            "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set",
+            mem_layout);
+        const CoreRangeSet& grid = nd ? nd->grid : legacy->grid;
+        ShardOrientation orientation = nd ? nd->orientation : legacy->orientation;
+
+        // For width/height/block sharding modes, the output shard shape is fully determined
+        // by the output physical shape and the core grid. Just delegate to the
+        // appropriate TensorSpec builder.
+        if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+            return tensor_spec.width_sharded(grid, orientation);
+        }
+        if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            return tensor_spec.height_sharded(grid, orientation);
+        }
+        TT_FATAL(
+            grid.ranges().size() == 1,
+            "Block sharding requires a single CoreRange, got {} ranges",
+            grid.ranges().size());
+        return tensor_spec.block_sharded(grid.bounding_box(), orientation);
+    }
+
+    // ND sharding: adjust per-logical-dimension shard shape for reduced dims.
+    if (mem_layout == TensorMemoryLayout::ND_SHARDED) {
+        const auto& nd_shard_spec = operation_attributes.output_mem_config.nd_shard_spec();
+        TT_FATAL(nd_shard_spec.has_value(), "ND_SHARDED memory layout requires nd_shard_spec to be set");
+        auto nd_shard_spec_copy = *nd_shard_spec;
         if (operation_attributes.dim == tt::tt_metal::ReduceOpDim::W ||
             operation_attributes.dim == tt::tt_metal::ReduceOpDim::HW) {
             nd_shard_spec_copy.shard_shape[-1] = 1;
@@ -80,6 +106,9 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
             std::move(nd_shard_spec_copy), tt::tt_metal::TensorSpec::ShardShapeAlignment::REQUIRED);
     }
 
+    // Guard against unexpected new memory layouts.
+    TT_FATAL(mem_layout == TensorMemoryLayout::INTERLEAVED, "Unexpected memory layout: {}", mem_layout);
+    // Interleaved tensor: tensor_spec already has everything we need.
     return tensor_spec;
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -62,15 +62,31 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
     if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED || mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
         mem_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         // Grid and orientation are identical in both spec formats (nd_shard_spec and shard_spec)
-        // when both are populated. Pick whichever is available.
+        // when both are populated. Pick whichever is available from the output config,
+        // falling back to the input tensor's shard spec for backward compatibility.
         const auto& nd = operation_attributes.output_mem_config.nd_shard_spec();
         const auto& legacy = operation_attributes.output_mem_config.shard_spec();
-        TT_FATAL(
-            nd.has_value() || legacy.has_value(),
-            "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set",
-            mem_layout);
-        const CoreRangeSet& grid = nd ? nd->grid : legacy->grid;
-        ShardOrientation orientation = nd ? nd->orientation : legacy->orientation;
+        const auto& input_nd = tensor_args.memory_config().nd_shard_spec();
+        const auto& input_legacy = tensor_args.memory_config().shard_spec();
+        auto get_grid_and_orientation = [&]() -> std::pair<const CoreRangeSet&, ShardOrientation> {
+            if (nd) {
+                return {nd->grid, nd->orientation};
+            }
+            if (legacy) {
+                return {legacy->grid, legacy->orientation};
+            }
+            if (input_nd) {
+                return {input_nd->grid, input_nd->orientation};
+            }
+            if (input_legacy) {
+                return {input_legacy->grid, input_legacy->orientation};
+            }
+            TT_THROW(
+                "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set "
+                "on the output memory config or the input tensor",
+                mem_layout);
+        };
+        auto [grid, orientation] = get_grid_and_orientation();
 
         // For width/height/block sharding modes, the output shard shape is fully determined
         // by the output physical shape and the core grid. Just delegate to the
@@ -89,10 +105,15 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
     }
 
     // ND sharding: adjust per-logical-dimension shard shape for reduced dims.
+    // Fall back to the input tensor's nd_shard_spec when the output config omits it.
     if (mem_layout == TensorMemoryLayout::ND_SHARDED) {
         const auto& nd_shard_spec = operation_attributes.output_mem_config.nd_shard_spec();
-        TT_FATAL(nd_shard_spec.has_value(), "ND_SHARDED memory layout requires nd_shard_spec to be set");
-        auto nd_shard_spec_copy = *nd_shard_spec;
+        const auto& input_nd_shard_spec = tensor_args.memory_config().nd_shard_spec();
+        TT_FATAL(
+            nd_shard_spec.has_value() || input_nd_shard_spec.has_value(),
+            "ND_SHARDED memory layout requires nd_shard_spec to be set "
+            "on the output memory config or the input tensor");
+        auto nd_shard_spec_copy = nd_shard_spec.has_value() ? *nd_shard_spec : *input_nd_shard_spec;
         if (operation_attributes.dim == tt::tt_metal::ReduceOpDim::W ||
             operation_attributes.dim == tt::tt_metal::ReduceOpDim::HW) {
             nd_shard_spec_copy.shard_shape[-1] = 1;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -24,7 +24,7 @@ ReduceDeviceOperation::program_factory_t ReduceDeviceOperation::select_program_f
 }
 
 void ReduceDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     TT_FATAL(
         tensor_args.storage_type() == StorageType::DEVICE,
         "Operands to reduce need to be on device! Got storage type: {}",
@@ -36,6 +36,7 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
             tensor_args.dtype() == DataType::BFLOAT8_B || tensor_args.dtype() == DataType::UINT32,
         "Only FLOAT32, BFLOAT16, BFLOAT8_B, and UINT32 are supported for generic reduction - got {}",
         tensor_args.dtype());
+    validate_reduce_sharded_buffer_types(tensor_args.memory_config(), operation_attributes.output_mem_config, "reduce");
 }
 
 ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -86,7 +86,7 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
                 "on the output memory config or the input tensor",
                 mem_layout);
         };
-        auto [grid, orientation] = get_grid_and_orientation();
+        const auto& [grid, orientation] = get_grid_and_orientation();
 
         // For width/height/block sharding modes, the output shard shape is fully determined
         // by the output physical shape and the core grid. Just delegate to the

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
@@ -17,7 +17,7 @@ WelfordReduceDeviceOperation::program_factory_t WelfordReduceDeviceOperation::se
 }
 
 void WelfordReduceDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     TT_FATAL(
         tensor_args.storage_type() == StorageType::DEVICE,
         "Operands to Std/Var reductions need to be on device! Got storage type: {}",
@@ -33,6 +33,8 @@ void WelfordReduceDeviceOperation::validate_on_program_cache_miss(
         tensor_args.logical_shape().rank() >= 2,
         "Welford reduce only supports tensors with at least 2 dimensions, got rank: {}",
         tensor_args.logical_shape().rank());
+    validate_reduce_sharded_buffer_types(
+        tensor_args.memory_config(), operation_attributes.output_mem_config, "Std/Var reduction");
 }
 
 WelfordReduceDeviceOperation::spec_return_value_t WelfordReduceDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
@@ -101,7 +101,7 @@ WelfordReduceDeviceOperation::spec_return_value_t WelfordReduceDeviceOperation::
                 "on the output memory config or the input tensor",
                 mem_layout);
         };
-        auto [grid, orientation] = get_grid_and_orientation();
+        const auto& [grid, orientation] = get_grid_and_orientation();
 
         // For width/height/block sharding modes, the output shard shape is fully determined
         // by the output physical shape and the core grid. Just delegate to the

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
@@ -65,87 +65,12 @@ WelfordReduceDeviceOperation::spec_return_value_t WelfordReduceDeviceOperation::
         output_shape[-1] = 1;
     }
 
-    TensorSpec tensor_spec(
+    return build_reduce_output_tensor_spec(
         output_shape,
-        tt::tt_metal::TensorLayout(
-            operation_attributes.output_dtype,
-            tt::tt_metal::PageConfig(Layout::TILE),
-            MemoryConfig(operation_attributes.output_mem_config.buffer_type())));
-
-    TensorMemoryLayout mem_layout = operation_attributes.output_mem_config.memory_layout();
-
-    if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED || mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        mem_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        // Grid and orientation are identical in both spec formats (nd_shard_spec and shard_spec)
-        // when both are populated. Pick whichever is available from the output config,
-        // falling back to the input tensor's shard spec for backward compatibility.
-        const auto& nd = operation_attributes.output_mem_config.nd_shard_spec();
-        const auto& legacy = operation_attributes.output_mem_config.shard_spec();
-        const auto& input_nd = tensor_args.memory_config().nd_shard_spec();
-        const auto& input_legacy = tensor_args.memory_config().shard_spec();
-        auto get_grid_and_orientation = [&]() -> std::pair<const CoreRangeSet&, ShardOrientation> {
-            if (nd) {
-                return {nd->grid, nd->orientation};
-            }
-            if (legacy) {
-                return {legacy->grid, legacy->orientation};
-            }
-            if (input_nd) {
-                return {input_nd->grid, input_nd->orientation};
-            }
-            if (input_legacy) {
-                return {input_legacy->grid, input_legacy->orientation};
-            }
-            TT_THROW(
-                "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set "
-                "on the output memory config or the input tensor",
-                mem_layout);
-        };
-        const auto& [grid, orientation] = get_grid_and_orientation();
-
-        // For width/height/block sharding modes, the output shard shape is fully determined
-        // by the output physical shape and the core grid. Just delegate to the
-        // appropriate TensorSpec builder.
-        if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-            return tensor_spec.width_sharded(grid, orientation);
-        }
-        if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-            return tensor_spec.height_sharded(grid, orientation);
-        }
-        TT_FATAL(
-            grid.ranges().size() == 1,
-            "Block sharding requires a single CoreRange, got {} ranges",
-            grid.ranges().size());
-        return tensor_spec.block_sharded(grid.bounding_box(), orientation);
-    }
-
-    // ND sharding: adjust per-logical-dimension shard shape for reduced dims.
-    // Fall back to the input tensor's nd_shard_spec when the output config omits it.
-    if (mem_layout == TensorMemoryLayout::ND_SHARDED) {
-        const auto& nd_shard_spec = operation_attributes.output_mem_config.nd_shard_spec();
-        const auto& input_nd_shard_spec = tensor_args.memory_config().nd_shard_spec();
-        TT_FATAL(
-            nd_shard_spec.has_value() || input_nd_shard_spec.has_value(),
-            "ND_SHARDED memory layout requires nd_shard_spec to be set "
-            "on the output memory config or the input tensor");
-        auto nd_shard_spec_copy = nd_shard_spec.has_value() ? *nd_shard_spec : *input_nd_shard_spec;
-        if (operation_attributes.reduce_dim == tt::tt_metal::ReduceOpDim::W ||
-            operation_attributes.reduce_dim == tt::tt_metal::ReduceOpDim::HW) {
-            nd_shard_spec_copy.shard_shape[-1] = 1;
-        }
-        if ((operation_attributes.reduce_dim == tt::tt_metal::ReduceOpDim::H ||
-             operation_attributes.reduce_dim == tt::tt_metal::ReduceOpDim::HW) &&
-            nd_shard_spec_copy.shard_shape.rank() > 1) {
-            nd_shard_spec_copy.shard_shape[-2] = 1;
-        }
-        return tensor_spec.sharded(
-            std::move(nd_shard_spec_copy), tt::tt_metal::TensorSpec::ShardShapeAlignment::REQUIRED);
-    }
-
-    // Guard against unexpected new memory layouts.
-    TT_FATAL(mem_layout == TensorMemoryLayout::INTERLEAVED, "Unexpected memory layout: {}", mem_layout);
-    // Interleaved tensor: tensor_spec already has everything we need.
-    return tensor_spec;
+        operation_attributes.output_dtype,
+        operation_attributes.output_mem_config,
+        tensor_args.memory_config(),
+        operation_attributes.reduce_dim);
 }
 
 WelfordReduceDeviceOperation::tensor_return_value_t WelfordReduceDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
@@ -72,16 +72,42 @@ WelfordReduceDeviceOperation::spec_return_value_t WelfordReduceDeviceOperation::
             tt::tt_metal::PageConfig(Layout::TILE),
             MemoryConfig(operation_attributes.output_mem_config.buffer_type())));
 
-    if (operation_attributes.output_mem_config.nd_shard_spec().has_value()) {
-        const auto& nd_shard_spec = *operation_attributes.output_mem_config.nd_shard_spec();
-        if (operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-            return tensor_spec.width_sharded(nd_shard_spec.grid, nd_shard_spec.orientation);
-        }
-        if (operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-            return tensor_spec.height_sharded(nd_shard_spec.grid, nd_shard_spec.orientation);
-        }
+    TensorMemoryLayout mem_layout = operation_attributes.output_mem_config.memory_layout();
 
-        auto nd_shard_spec_copy = nd_shard_spec;
+    if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED || mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
+        mem_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        // Grid and orientation are identical in both spec formats (nd_shard_spec and shard_spec)
+        // when both are populated. Pick whichever is available.
+        const auto& nd = operation_attributes.output_mem_config.nd_shard_spec();
+        const auto& legacy = operation_attributes.output_mem_config.shard_spec();
+        TT_FATAL(
+            nd.has_value() || legacy.has_value(),
+            "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set",
+            mem_layout);
+        const CoreRangeSet& grid = nd ? nd->grid : legacy->grid;
+        ShardOrientation orientation = nd ? nd->orientation : legacy->orientation;
+
+        // For width/height/block sharding modes, the output shard shape is fully determined
+        // by the output physical shape and the core grid. Just delegate to the
+        // appropriate TensorSpec builder.
+        if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+            return tensor_spec.width_sharded(grid, orientation);
+        }
+        if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            return tensor_spec.height_sharded(grid, orientation);
+        }
+        TT_FATAL(
+            grid.ranges().size() == 1,
+            "Block sharding requires a single CoreRange, got {} ranges",
+            grid.ranges().size());
+        return tensor_spec.block_sharded(grid.bounding_box(), orientation);
+    }
+
+    // ND sharding: adjust per-logical-dimension shard shape for reduced dims.
+    if (mem_layout == TensorMemoryLayout::ND_SHARDED) {
+        const auto& nd_shard_spec = operation_attributes.output_mem_config.nd_shard_spec();
+        TT_FATAL(nd_shard_spec.has_value(), "ND_SHARDED memory layout requires nd_shard_spec to be set");
+        auto nd_shard_spec_copy = *nd_shard_spec;
         if (operation_attributes.reduce_dim == tt::tt_metal::ReduceOpDim::W ||
             operation_attributes.reduce_dim == tt::tt_metal::ReduceOpDim::HW) {
             nd_shard_spec_copy.shard_shape[-1] = 1;
@@ -95,6 +121,9 @@ WelfordReduceDeviceOperation::spec_return_value_t WelfordReduceDeviceOperation::
             std::move(nd_shard_spec_copy), tt::tt_metal::TensorSpec::ShardShapeAlignment::REQUIRED);
     }
 
+    // Guard against unexpected new memory layouts.
+    TT_FATAL(mem_layout == TensorMemoryLayout::INTERLEAVED, "Unexpected memory layout: {}", mem_layout);
+    // Interleaved tensor: tensor_spec already has everything we need.
     return tensor_spec;
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
@@ -77,15 +77,31 @@ WelfordReduceDeviceOperation::spec_return_value_t WelfordReduceDeviceOperation::
     if (mem_layout == TensorMemoryLayout::WIDTH_SHARDED || mem_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
         mem_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         // Grid and orientation are identical in both spec formats (nd_shard_spec and shard_spec)
-        // when both are populated. Pick whichever is available.
+        // when both are populated. Pick whichever is available from the output config,
+        // falling back to the input tensor's shard spec for backward compatibility.
         const auto& nd = operation_attributes.output_mem_config.nd_shard_spec();
         const auto& legacy = operation_attributes.output_mem_config.shard_spec();
-        TT_FATAL(
-            nd.has_value() || legacy.has_value(),
-            "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set",
-            mem_layout);
-        const CoreRangeSet& grid = nd ? nd->grid : legacy->grid;
-        ShardOrientation orientation = nd ? nd->orientation : legacy->orientation;
+        const auto& input_nd = tensor_args.memory_config().nd_shard_spec();
+        const auto& input_legacy = tensor_args.memory_config().shard_spec();
+        auto get_grid_and_orientation = [&]() -> std::pair<const CoreRangeSet&, ShardOrientation> {
+            if (nd) {
+                return {nd->grid, nd->orientation};
+            }
+            if (legacy) {
+                return {legacy->grid, legacy->orientation};
+            }
+            if (input_nd) {
+                return {input_nd->grid, input_nd->orientation};
+            }
+            if (input_legacy) {
+                return {input_legacy->grid, input_legacy->orientation};
+            }
+            TT_THROW(
+                "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set "
+                "on the output memory config or the input tensor",
+                mem_layout);
+        };
+        auto [grid, orientation] = get_grid_and_orientation();
 
         // For width/height/block sharding modes, the output shard shape is fully determined
         // by the output physical shape and the core grid. Just delegate to the
@@ -104,10 +120,15 @@ WelfordReduceDeviceOperation::spec_return_value_t WelfordReduceDeviceOperation::
     }
 
     // ND sharding: adjust per-logical-dimension shard shape for reduced dims.
+    // Fall back to the input tensor's nd_shard_spec when the output config omits it.
     if (mem_layout == TensorMemoryLayout::ND_SHARDED) {
         const auto& nd_shard_spec = operation_attributes.output_mem_config.nd_shard_spec();
-        TT_FATAL(nd_shard_spec.has_value(), "ND_SHARDED memory layout requires nd_shard_spec to be set");
-        auto nd_shard_spec_copy = *nd_shard_spec;
+        const auto& input_nd_shard_spec = tensor_args.memory_config().nd_shard_spec();
+        TT_FATAL(
+            nd_shard_spec.has_value() || input_nd_shard_spec.has_value(),
+            "ND_SHARDED memory layout requires nd_shard_spec to be set "
+            "on the output memory config or the input tensor");
+        auto nd_shard_spec_copy = nd_shard_spec.has_value() ? *nd_shard_spec : *input_nd_shard_spec;
         if (operation_attributes.reduce_dim == tt::tt_metal::ReduceOpDim::W ||
             operation_attributes.reduce_dim == tt::tt_metal::ReduceOpDim::HW) {
             nd_shard_spec_copy.shard_shape[-1] = 1;


### PR DESCRIPTION
### Summary
Reduction ops were ignoring sharded configuration provided through explicit `output_mem_config`.
This was root-caused to the code that was relying on presence of `nd_shard_spec` in `output_mem_config`, which may not always be present for sharded layouts (sometimes it's stored in `shard_spec`) 
This change:
- Switches to using `memory_layout` directly to determine whether the tensor is sharded.
- Adds missing handling for `BLOCK_SHARDED` layout.
- Copilot caught an issue in `TensorSpec::block_sharded`, which in turn revealed an issue in `ttnn::operations::data_movement::reshape_tiled`. Both issues are now addressed. The fix for the latter issue also resolves #35145
- Adds defensive asserts.
- Updates unit tests to cover various uncovered cases.

Closes #41981
Closes #35145

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec_41981_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec_41981_sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fplavec_41981_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fplavec_41981_sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec_41981_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec_41981_sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fplavec_41981_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fplavec_41981_sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec_41981_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec_41981_sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec_41981_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec_41981_sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec_41981_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec_41981_sharded)