### PR TITLE
Disable test_multi_device on single device

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -5,9 +5,6 @@
 # Tests that apply to all architectures are duplicated in each section.
 
 wormhole_b0:
-  # Multi-device tests
-  - tests/ttnn/unit_tests/base_functionality/test_multi_device.py # ttnn.from_torch uses to_layout for distributed tensors which is not supported by TTSim
-
   # Base functionality - simulator limitations (tilize/untilize, layout conversion)
   - tests/ttnn/unit_tests/base_functionality/test_comparison_mode.py
   - tests/ttnn/unit_tests/base_functionality/test_expand.py

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -5,6 +5,9 @@
 # Tests that apply to all architectures are duplicated in each section.
 
 wormhole_b0:
+  # Multi-device tests
+  - tests/ttnn/unit_tests/base_functionality/test_multi_device.py # ttnn.from_torch uses to_layout for distributed tensors which is not supported by TTSim
+
   # Base functionality - simulator limitations (tilize/untilize, layout conversion)
   - tests/ttnn/unit_tests/base_functionality/test_comparison_mode.py
   - tests/ttnn/unit_tests/base_functionality/test_expand.py

--- a/tests/ttnn/unit_tests/base_functionality/test_multi_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_multi_device.py
@@ -9,6 +9,7 @@ import tempfile
 from loguru import logger
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.tests_common.skip_reasons import LEGACY_CCL_SKIP
+from models.common.utility_functions import is_single_chip, ti_skip
 
 from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 
@@ -475,6 +476,7 @@ def test_multi_device_permute(mesh_device, layout, memory_config, dtype):
     assert_with_pcc(torch_golden, torch_loop_back_tensor, pcc=0.9999)
 
 
+@ti_skip(is_single_chip(), "Test is not supported on single-chip")
 @pytest.mark.parametrize(
     "device_params",
     [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
@@ -587,6 +589,7 @@ def test_sharded_matmul(mesh_device):
     print(attn_1B4P)
 
 
+@ti_skip(is_single_chip(), "Test is not supported on single-chip")
 def test_4b_tensor(mesh_device):
     tensor = ttnn.from_torch(
         torch.randn(1, 1, 32, 32),
@@ -614,6 +617,7 @@ def test_4b_tensor(mesh_device):
     )
 
 
+@ti_skip(is_single_chip(), "Test is not supported on single-chip")
 def test_slicing(mesh_device):
     tensor = ttnn.from_torch(
         torch.randn(1, 32, 32, 32),
@@ -627,6 +631,7 @@ def test_slicing(mesh_device):
     assert all([device_tensor.shape == tensor.shape for device_tensor in ttnn.get_device_tensors(tensor)])
 
 
+@ti_skip(is_single_chip(), "Test is not supported on single-chip")
 def test_clone(mesh_device):
     results_11BH = ttnn.from_torch(
         torch.randn(1, 1, 32, 128),


### PR DESCRIPTION
### Summary
[Link to github issue](https://github.com/tenstorrent/tt-metal/issues/42122)
test_multi_device was recently removed from tests/pipeline_reorg/ttsim-skip-list.yaml in this PR: https://github.com/tenstorrent/tt-metal/pull/41990

The following PR enables ttnn.from_torch to perform layout/typecast operations on the device for distributed tensors: https://github.com/tenstorrent/tt-metal/pull/41726

Since tt-sim doesn’t support these operations, [sanity test pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/24420169479/job/71347794138) fails.
We need to skip multi-device tests when running on a single device

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asala/disable-test_multi_device-for-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [#2777](https://github.com/tenstorrent/tt-metal/actions/runs/24424284373) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asala/disable-test_multi_device-for-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asala/disable-test_multi_device-for-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asala/disable-test_multi_device-for-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asala/disable-test_multi_device-for-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asala/disable-test_multi_device-for-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asala/disable-test_multi_device-for-ttsim) |