### PR TITLE
Fix DeepSeek module tests

### DIFF
--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py
@@ -336,7 +336,7 @@ def _build_lm_head_inputs(
     weight_config = get_test_weight_config(
         LMHead1D, hf_config, (lm_head_state_dict,), cache_path, mesh_device, force_recalculate_weight_config
     )
-    model_config = get_model_config(LMHead1D, mode, mesh_device)
+    model_config = get_model_config(LMHead1D, mode, hf_config, mesh_device)
     model_state = LMHead1D.create_state(mesh_device, None)  # CCL not needed for linear only
     run_config = create_run_config(model_config, weight_config, model_state)
 

--- a/models/demos/deepseek_v3/tests/test_bspm_demo.py
+++ b/models/demos/deepseek_v3/tests/test_bspm_demo.py
@@ -279,7 +279,7 @@ def _run_one_decode_step(
         for _ in range(hf_config.num_hidden_layers)
     )
 
-    model_config = get_model_config(RowBatchedModel, "decode", hf_config, mesh_device)
+    model_config = get_model_config(RowBatchedModel, "decode", hf_config, mesh_device, batch_size_per_row=USERS_PER_ROW)
     model_state = RowBatchedModel.create_state(hf_config, paged_config, mesh_device, ccl, paged_input_caches)
     model_shared_state = RowBatchedModel.create_shared_state(hf_config, mesh_device)
     run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -80,7 +80,7 @@ def test_forward_pass(
         test_name="test_lm_head1d",
         real_weights=False,
     )
-    model_config = get_model_config(LMHead1D, mode, mesh_device)
+    model_config = get_model_config(LMHead1D, mode, hf_config, mesh_device)
     model_state = LMHead1D.create_state(mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)
 

--- a/models/demos/deepseek_v3/tt/lm_head1d.py
+++ b/models/demos/deepseek_v3/tt/lm_head1d.py
@@ -169,7 +169,7 @@ class LMHead1D(AbstractModule):
         }
 
     @classmethod
-    def prefill_model_config(cls, mesh_device: ttnn.Device) -> ModelPrefillConfig:
+    def prefill_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelPrefillConfig:
         """Generate model configuration for this module."""
         # Construct the config
         return {

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -132,7 +132,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                 )
             ],
             "norm": DistributedRMSNorm.prefill_model_config(hf_config, mesh_device),
-            "lm_head": LMHead1D.prefill_model_config(mesh_device),
+            "lm_head": LMHead1D.prefill_model_config(hf_config, mesh_device),
         }
         if cls._has_mtp_layer(hf_config):
             model_cfg["mtp"] = MTP2D.prefill_model_config(

--- a/models/demos/deepseek_v3/tt/mtp.py
+++ b/models/demos/deepseek_v3/tt/mtp.py
@@ -143,7 +143,7 @@ class MTP2D(AbstractModule):
             batch_size_per_row=batch_size_per_row,
         )
         head_norm_cfg = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
-        head_cfg = LMHead1D.prefill_model_config(mesh_device)
+        head_cfg = LMHead1D.prefill_model_config(hf_config, mesh_device)
         return {
             "embedding": Embedding2D.prefill_model_config(hf_config, mesh_device),
             "hidden_norm_reshard": ReshardConfig(memory_config=hidden_norm_cfg["input_memory_config"]),


### PR DESCRIPTION
### Summary
Relates to https://github.com/tenstorrent/tt-metal/issues/42014 - added batch_size_per_row parameter to get_model_config
Fixed test_lm_head1d after https://github.com/tenstorrent/tt-metal/pull/41479 - hf_config parameter to get_model_config

### Notes for reviewers
hf_config in LMHead1D.prefill_model_config is not used but added for compatibility with decode
- [X] [Deepseek module tests](https://github.com/tenstorrent/tt-metal/actions/runs/24427014250) - passes
- [X] [Deepseek final-op tests](https://github.com/tenstorrent/tt-metal/actions/runs/24421581642) - passes

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtsishkouski/fix_test_bspm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtsishkouski/fix_test_bspm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtsishkouski/fix_test_bspm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtsishkouski/fix_test_bspm) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtsishkouski/fix_test_bspm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtsishkouski/fix_test_bspm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtsishkouski/fix_test_bspm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtsishkouski/fix_test_bspm) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtsishkouski/fix_test_bspm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtsishkouski/fix_test_bspm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtsishkouski/fix_test_bspm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtsishkouski/fix_test_bspm) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtsishkouski/fix_test_bspm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtsishkouski/fix_test_bspm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtsishkouski/fix_test_bspm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtsishkouski/fix_test_bspm) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtsishkouski/fix_test_bspm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtsishkouski/fix_test_bspm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtsishkouski/fix_test_bspm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtsishkouski/fix_test_bspm) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtsishkouski/fix_test_bspm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtsishkouski/fix_test_bspm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtsishkouski/fix_test_bspm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtsishkouski/fix_test_bspm) |