### PR TITLE
Fix Llama 3.2 Vision key remapping and cross-attention config regression

### DIFF
--- a/models/tt_transformers/tests/test_load_checkpoints.py
+++ b/models/tt_transformers/tests/test_load_checkpoints.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Lightweight (CPU-only, no model download) regression tests for the
+multimodal HF-key-remapping pipeline in load_checkpoints.py.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from models.tt_transformers.tt.load_checkpoints import (
+    convert_hf_to_meta_mllama,
+    map_hf_to_meta_keys_mllama,
+    split_hf_keys,
+    standardize_hf_keys_multimodal,
+)
+
+
+def _make_mllama_config(num_hidden_layers=4, cross_attention_layers=None):
+    """Build a minimal config object accepted by map_hf_to_meta_keys_mllama."""
+    if cross_attention_layers is None:
+        cross_attention_layers = [1]
+    return SimpleNamespace(
+        text_config=SimpleNamespace(
+            num_hidden_layers=num_hidden_layers,
+            cross_attention_layers=cross_attention_layers,
+        )
+    )
+
+
+def _make_sample_mllama_state_dict():
+    """Return a minimal HF-format state_dict that covers the projector keys
+    plus the embed_tokens and lm_head keys required by map_hf_to_meta_keys_mllama."""
+    t = torch.zeros(1)
+    return {
+        "model.multi_modal_projector.weight": t,
+        "model.multi_modal_projector.bias": t,
+        "model.vision_model.layernorm_pre.weight": t,
+        "model.vision_model.layernorm_pre.bias": t,
+        # Both must be present so standardize_hf_keys (called inside
+        # standardize_hf_keys_multimodal) doesn't delete embed_tokens.
+        "lm_head.weight": torch.zeros(16, 4),
+        "model.embed_tokens.weight": torch.zeros(16, 4),
+    }
+
+
+class TestMllamaProjectorKeyRemap:
+    """Ensure model.multi_modal_projector.* keys survive the two-stage
+    multimodal pipeline and land as vision_model.vision_projection.*."""
+
+    def test_projector_keys_after_full_pipeline(self):
+        state_dict = _make_sample_mllama_state_dict()
+        config = _make_mllama_config()
+
+        state_dict = standardize_hf_keys_multimodal(state_dict)
+        state_dict = split_hf_keys(state_dict)
+        state_dict = map_hf_to_meta_keys_mllama(state_dict, config)
+
+        assert "vision_model.vision_projection.weight" in state_dict
+        assert "vision_model.vision_projection.bias" in state_dict
+        assert not any("multi_modal_projector" in k for k in state_dict)
+
+    def test_projector_keys_via_convert_hf_to_meta_mllama(self):
+        """Standardize_hf_keys_multimodal() -> convert_hf_to_meta_mllama().
+        Asserts model.multi_modal_projector.weight ends up as
+        vision_model.vision_projection.weight."""
+        state_dict = _make_sample_mllama_state_dict()
+        config = _make_mllama_config()
+        head_dim = 64
+
+        state_dict = standardize_hf_keys_multimodal(state_dict)
+        state_dict = convert_hf_to_meta_mllama(state_dict, head_dim, config)
+
+        assert "vision_model.vision_projection.weight" in state_dict
+        assert "vision_model.vision_projection.bias" in state_dict
+        assert not any("multi_modal_projector" in k for k in state_dict)
+
+    def test_projector_keys_without_standardize(self):
+        """map_hf_to_meta_keys_mllama should also work when called directly
+        with the original model.-prefixed keys (backward compat)."""
+        t = torch.zeros(1)
+        state_dict = {
+            "model.multi_modal_projector.weight": t,
+            "model.multi_modal_projector.bias": t,
+            "model.embed_tokens.weight": torch.zeros(16, 4),
+        }
+        config = _make_mllama_config()
+
+        state_dict = split_hf_keys(state_dict)
+        state_dict = map_hf_to_meta_keys_mllama(state_dict, config)
+
+        assert "vision_model.vision_projection.weight" in state_dict
+        assert "vision_model.vision_projection.bias" in state_dict

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -661,6 +661,7 @@ def map_hf_to_meta_keys_mllama(loaded_weights, config):
         (r"^vision_model.post_tile_positional_embedding.gate", r"vision_model.post_tile_pos_embed.gate"),
         (r"^vision_model.", r"vision_model.vision_encoder."),
         (r"^model.multi_modal_projector.", r"vision_model.vision_projection."),
+        (r"^multi_modal_projector.", r"vision_model.vision_projection."),
     ]
 
     self_attn_replacements = {

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2705,7 +2705,8 @@ class ModelArgs:
         self.is_multimodal = "vision_config" in config or self.is_vision()
         self.vision_chunk_size = config.get("vision_chunk_size", 896)
         self.vision_max_num_chunks = config.get("vision_max_num_chunks", 4)
-        self.vision_num_cross_attention_layers = config.get("vision_num_cross_attention_layers", -1)
+        if "vision_num_cross_attention_layers" in config:
+            self.vision_num_cross_attention_layers = config["vision_num_cross_attention_layers"]
 
         self.vision_dim = 1280
         self.vision_mlp_ratio = 4


### PR DESCRIPTION
## Problem

Commit 81188eb00d2 ([Mistral] Mistral-Small-3.1-24B-Instruct-2503 #40502) introduced two regressions that break Llama 3.2 Vision (11B and 90B) on T3K:

1. **`KeyError: 'vision_model.vision_projection.weight'`** — `standardize_hf_keys_multimodal()` strips the `model.` prefix from `model.multi_modal_projector.*`, but `map_hf_to_meta_keys_mllama()` only had a regex for the original prefixed form, leaving projector keys unmapped.

2. **`IndexError: list index out of range`** in `llama_cross_attention_transformer_text.py` — New defaults added to `_set_params_from_dict()` unconditionally overwrite `vision_num_cross_attention_layers` with −1 (the key doesn't exist in `merged_text_config`), wiping out the correct value of 20 computed from `cross_attention_layers`. This produces an empty fusion schedule and empty `xattn_caches`.

## Fix

- **`load_checkpoints.py`**: Add regex `(r"^multi_modal_projector.", r"vision_model.vision_projection.")` so the mapper handles both prefixed and stripped forms.
- **`model_config.py`**: Guard the `vision_num_cross_attention_layers` assignment so it only applies when the key actually exists in the config dict.
- **`test_load_checkpoints.py`**: New lightweight CPU-only regression tests exercising `standardize_hf_keys_multimodal()` → `convert_hf_to_meta_mllama()` and asserting `model.multi_modal_projector.weight` maps to `vision_model.vision_projection.weight`.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=adam/llama-vision-key-mapping-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:adam/llama-vision-key-mapping-fix) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=adam/llama-vision-key-mapping-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:adam/llama-vision-key-mapping-fix) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=adam/llama-vision-key-mapping-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:adam/llama-vision-key-mapping-fix) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=adam/llama-vision-key-mapping-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:adam/llama-vision-key-mapping-fix) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=adam/llama-vision-key-mapping-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:adam/llama-vision-key-mapping-fix) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=adam/llama-vision-key-mapping-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:adam/llama-vision-key-mapping-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:adam/llama-vision-key-mapping-fix) |