### PR TITLE
#41702: Port transpose, permute kernels to device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/untilize.h"
 #include "api/compute/pack_untilize.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t x_block_size = get_named_compile_time_arg_val("x_block_size");
@@ -23,6 +24,9 @@ void kernel_main() {
     constexpr auto cb_in = tt::CBIndex::c_0;
     constexpr auto cb_tilize = tt::CBIndex::c_1;
     constexpr auto cb_out = tt::CBIndex::c_2;
+
+    experimental::CircularBuffer cb_tilize_exp(cb_tilize);
+    experimental::CircularBuffer cb_out_exp(cb_out);
 
     unary_op_init_common(cb_in, cb_out);
     transpose_wh_init(cb_tilize, cb_out);
@@ -38,7 +42,7 @@ void kernel_main() {
             compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(1, x_block_size);
 
         // transpose input
-        cb_wait_front(cb_tilize, 1);
+        cb_tilize_exp.wait_front(1);
         transpose_wh_init_short(cb_tilize);
         pack_untilize_dest_init<1>(cb_out);
 
@@ -47,16 +51,16 @@ void kernel_main() {
         tile_regs_commit();
 
         // pack and untilize
-        cb_reserve_back(cb_out, w_block_size);
+        cb_out_exp.reserve_back(w_block_size);
 
         tile_regs_wait();
         pack_untilize_dest<1>(cb_out);  // pack call
         tile_regs_release();
 
-        cb_push_back(cb_out, w_block_size);
+        cb_out_exp.push_back(w_block_size);
 
         pack_untilize_uninit(cb_out);
 
-        cb_pop_front(cb_tilize, 1);
+        cb_tilize_exp.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/untilize.h"
 #include "api/compute/pack_untilize.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     // X = output width
@@ -30,6 +31,9 @@ void kernel_main() {
     constexpr auto cb_tilize = tt::CBIndex::c_1;
     constexpr auto cb_out = tt::CBIndex::c_2;
 
+    experimental::CircularBuffer cb_tilize_exp(cb_tilize);
+    experimental::CircularBuffer cb_out_exp(cb_out);
+
     unary_op_init_common(cb_in, cb_out);
 
     for (uint32_t block = start_block; block < end_block; block++) {
@@ -43,7 +47,7 @@ void kernel_main() {
             compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(1);
 
         // transpose input
-        cb_wait_front(cb_tilize, 1);
+        cb_tilize_exp.wait_front(1);
 
         transpose_wh_init_short(cb_tilize);
         pack_untilize_dest_init<1>(cb_out);
@@ -53,16 +57,16 @@ void kernel_main() {
         tile_regs_commit();
 
         // pack and untilize
-        cb_reserve_back(cb_out, 1);
+        cb_out_exp.reserve_back(1);
 
         tile_regs_wait();
         pack_untilize_dest<1>(cb_out);  // pack call
         tile_regs_release();
 
-        cb_push_back(cb_out, 1);
+        cb_out_exp.push_back(1);
 
         pack_untilize_uninit(cb_out);
 
-        cb_pop_front(cb_tilize, 1);
+        cb_tilize_exp.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t N = get_named_compile_time_arg_val("N");
@@ -99,8 +100,9 @@ void kernel_main() {
         }
 
         // Reserve space in the circular buffer for the X-block length
-        cb_reserve_back(tt::CBIndex::c_0, x_block_size);
-        uint32_t src_buffer_l1_addr = get_write_ptr(tt::CBIndex::c_0);
+        experimental::CircularBuffer cb(tt::CBIndex::c_0);
+        cb.reserve_back(x_block_size);
+        uint32_t src_buffer_l1_addr = cb.get_write_ptr();
 
         // We read in 'x_block_len' chunks along the X dimension
         uint32_t page_offset = 0;
@@ -119,6 +121,6 @@ void kernel_main() {
         // Wait for all async reads to complete before proceeding
         noc_async_read_barrier();
         // Push the filled block into the circular buffer
-        cb_push_back(tt::CBIndex::c_0, x_block_size);
+        cb.push_back(x_block_size);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
@@ -4,9 +4,13 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr uint32_t N = get_named_compile_time_arg_val("N");
+    constexpr uint32_t page_size = get_named_compile_time_arg_val("page_size");
     constexpr uint32_t num_rows = get_named_compile_time_arg_val("num_rows");
     constexpr auto src_args = TensorAccessorArgs<0>();
 
@@ -15,13 +19,14 @@ void kernel_main() {
     const uint32_t end_row = get_arg_val<uint32_t>(2);
 
     const auto s0 = TensorAccessor(src_args, src_addr);
+    experimental::CircularBuffer cb(tt::CBIndex::c_0);
+    experimental::Noc noc;
 
     uint32_t curr_addr = src_addr;
     for (uint32_t row = start_row; row < end_row; ++row) {
-        cb_reserve_back(tt::CBIndex::c_0, 1);
-        uint32_t src_buffer_l1_addr = get_write_ptr(tt::CBIndex::c_0);
-        noc_async_read_page(row, s0, src_buffer_l1_addr);
-        noc_async_read_barrier();
-        cb_push_back(tt::CBIndex::c_0, 1);
+        cb.reserve_back(1);
+        noc.async_read(s0, cb, page_size, {.page_id = row}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     // X = output width
@@ -178,8 +179,9 @@ void kernel_main() {
         }
 
         // Reserve a slot in the circular buffer, get L1 pointer
-        cb_reserve_back(tt::CBIndex::c_0, 1);
-        uint32_t src_buffer_l1_addr = get_write_ptr(tt::CBIndex::c_0);
+        experimental::CircularBuffer cb(tt::CBIndex::c_0);
+        cb.reserve_back(1);
+        uint32_t src_buffer_l1_addr = cb.get_write_ptr();
 
         // --------------------------------------------------------------------
         // 5.1) Async read for [x_start..x_end)
@@ -261,7 +263,7 @@ void kernel_main() {
 
         // Wait for reads to complete, push the tile
         noc_async_read_barrier();
-        cb_push_back(tt::CBIndex::c_0, 1);
+        cb.push_back(1);
     }
 
     // ------------------------------------------------------------------------
@@ -269,9 +271,10 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     if constexpr (needs_y_padding) {
         // We store one chunk of padding in c_3
-        cb_reserve_back(tt::CBIndex::c_3, 1);
-        uint32_t l1_write_addr = get_write_ptr(tt::CBIndex::c_3);
+        experimental::CircularBuffer cb3(tt::CBIndex::c_3);
+        cb3.reserve_back(1);
+        uint32_t l1_write_addr = cb3.get_write_ptr();
         tt::data_movement::common::fill_with_val(l1_write_addr, num_writes, padding_val_packed);
-        cb_push_back(tt::CBIndex::c_3, 1);
+        cb3.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr uint32_t N = get_named_compile_time_arg_val("rank");
@@ -18,8 +21,11 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = 0;
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
     const auto s = TensorAccessor(src_args, src_addr);
+    experimental::CircularBuffer cb(cb_id_in0);
+    experimental::Noc noc;
 
     // start at runtime arg 3 since address/start_block/end_block make up the first 3 args
     uint32_t output_tiled_shape[N], inv_perm[N], src_strides[N];
@@ -29,7 +35,6 @@ void kernel_main() {
         src_strides[i - 3] = get_arg_val<uint32_t>(i + 2 * N);
     }
 
-    uint32_t src_buffer_l1_addr = get_write_ptr(tt::CBIndex::c_0);
     uint32_t curr_addr = src_addr;
     for (uint32_t tile = start_tile; tile < end_tile; ++tile) {
         // Compute multi-dimensional index for the source tile
@@ -53,10 +58,9 @@ void kernel_main() {
             src_linear_idx += src_multi_idx[i] * src_strides[i];
         }
 
-        cb_reserve_back(cb_id_in0, onetile);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(src_linear_idx, s, l1_write_addr);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, onetile);
+        cb.reserve_back(onetile);
+        noc.async_read(s, cb, tile_bytes, {.page_id = src_linear_idx}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     // Compile-time constants
@@ -30,6 +31,7 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t cb_id_in = tt::CBIndex::c_2;
+    experimental::CircularBuffer cb_in(cb_id_in);
 
     // Precompute bytes-per-block along X
     constexpr uint32_t x_block_size_bytes = x_block_size * element_size;
@@ -133,8 +135,8 @@ void kernel_main() {
         }
 
         // Wait for the transposed block data to be ready in the input CB
-        cb_wait_front(cb_id_in, w_block_size);
-        uint32_t transposed_buffer_read_addr = get_read_ptr(cb_id_in);
+        cb_in.wait_front(w_block_size);
+        uint32_t transposed_buffer_read_addr = cb_in.get_read_ptr();
 
         // Iterate over the W dimension elements
         for (uint32_t w = w_start; w < w_end; ++w) {
@@ -162,6 +164,6 @@ void kernel_main() {
         noc_async_write_barrier();
 
         // Pop the block from the input circular buffer, as we're done writing it
-        cb_pop_front(cb_id_in, w_block_size);
+        cb_in.pop_front(w_block_size);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t N = get_named_compile_time_arg_val("N");
@@ -16,6 +17,7 @@ void kernel_main() {
     const uint32_t end_row = get_arg_val<uint32_t>(2);
 
     const auto s0 = TensorAccessor(dst_args, dst_addr);
+    experimental::CircularBuffer cb(tt::CBIndex::c_0);
 
     // start at runtime arg 3 since address/start_block/end_block make up the first 3 args
     uint32_t input_shape[N], perm[N], dest_strides[N];
@@ -25,7 +27,6 @@ void kernel_main() {
         dest_strides[i - 3] = get_arg_val<uint32_t>(i + 2 * N);
     }
 
-    uint32_t src_buffer_l1_addr = get_write_ptr(tt::CBIndex::c_0);
     uint32_t curr_addr = dst_addr;
     for (uint32_t row = start_row; row < end_row; ++row) {
         // Compute multi-dimensional index for the source row
@@ -49,11 +50,11 @@ void kernel_main() {
         for (uint32_t i = 0; i < N - 1; ++i) {
             dest_linear_idx += dest_multi_idx[i] * dest_strides[i];
         }
-        cb_wait_front(tt::CBIndex::c_0, 1);
-        uint32_t l1_read_addr = get_read_ptr(tt::CBIndex::c_0);
+        cb.wait_front(1);
+        uint32_t l1_read_addr = cb.get_read_ptr();
         uint64_t dst_noc_addr = s0.get_noc_addr(dest_linear_idx);
         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
         noc_async_write_barrier();
-        cb_pop_front(tt::CBIndex::c_0, 1);
+        cb.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_generic.cpp
@@ -3,6 +3,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     // X = output width
@@ -73,6 +74,7 @@ void kernel_main() {
     constexpr uint32_t X_t = X_p / TILE_HEIGHT;
 
     constexpr auto cb_out = tt::CBIndex::c_2;
+    experimental::CircularBuffer cb_out_exp(cb_out);
 
     //--------------------------------------------------------------------------
     // 3) Runtime Arguments
@@ -206,8 +208,8 @@ void kernel_main() {
         }
 
         // Wait for 1 tile from cb_out
-        cb_wait_front(cb_out, 1);
-        uint32_t transposed_buffer_read_addr = get_read_ptr(cb_out);
+        cb_out_exp.wait_front(1);
+        uint32_t transposed_buffer_read_addr = cb_out_exp.get_read_ptr();
 
         // ---------------------------------------------------------------------
         // 6.1) Write out each W in [w_start..w_end)
@@ -247,7 +249,7 @@ void kernel_main() {
             }
         }
         noc_async_write_barrier();
-        cb_pop_front(cb_out, 1);
+        cb_out_exp.pop_front(1);
     }
 
     //--------------------------------------------------------------------------
@@ -262,8 +264,9 @@ void kernel_main() {
         // We'll reuse 'dest_multi_idx' for tile indexing
         dest_multi_idx[RANK - 2] = y_t;  // fix the tile dimension in the RANK-2 dimension
 
-        cb_wait_front(tt::CBIndex::c_3, 1);
-        uint32_t l1_read_ptr = get_read_ptr(tt::CBIndex::c_3);
+        experimental::CircularBuffer cb3(tt::CBIndex::c_3);
+        cb3.wait_front(1);
+        uint32_t l1_read_ptr = cb3.get_read_ptr();
 
         for (uint32_t tile_idx = start_padding_tile_idx; tile_idx < end_padding_tile_idx; ++tile_idx) {
             // Unflatten 'tile_idx' => dest_multi_idx
@@ -302,6 +305,6 @@ void kernel_main() {
             }
         }
         noc_async_write_barrier();
-        cb_pop_front(tt::CBIndex::c_3, 1);
+        cb3.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
@@ -4,6 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/circular_buffer.h"
 
 // ------------------------------------------------------------------
 // 1) unflatten_index<RANK>:
@@ -106,8 +107,10 @@ void kernel_main() {
     constexpr uint32_t SUBTILE_LINE_BYTES = FACE_WIDTH * element_size;
 
     // Address generator
+    const uint32_t tile_bytes = get_tile_size(cb_id_out0);
 
     const auto s = TensorAccessor(dst_args, dst_addr);
+    experimental::CircularBuffer cb_out(cb_id_out0);
 
     // ------------------------------------------------------------------------
     // 3) Height dimension remainder logic
@@ -223,8 +226,8 @@ void kernel_main() {
         uint32_t base_output_face_line_offset_bytes = output_face_line_offset * element_size;
 
         // 6d) Wait for data block
-        cb_wait_front(cb_id_out0, 1);
-        uint32_t base_l1_read_addr = get_read_ptr(cb_id_out0);
+        cb_out.wait_front(1);
+        uint32_t base_l1_read_addr = cb_out.get_read_ptr();
 
         // 6e) Loop over faces in the height dimension
         for (uint8_t face_h = 0; face_h < num_faces_h; ++face_h) {
@@ -272,15 +275,16 @@ void kernel_main() {
             }
         }
         noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, 1);
+        cb_out.pop_front(1);
     }
 
     // ------------------------------------------------------------------------
     // 7) Handle padding if needed
     // ------------------------------------------------------------------------
     if constexpr (needs_padding) {
-        cb_wait_front(tt::CBIndex::c_1, 1);
-        uint32_t l1_read_ptr = get_read_ptr(tt::CBIndex::c_1);
+        experimental::CircularBuffer cb1(tt::CBIndex::c_1);
+        cb1.wait_front(1);
+        uint32_t l1_read_ptr = cb1.get_read_ptr();
 
         // We'll reuse 'dest_multi_idx' for tile indexing
         constexpr uint32_t x_t = output_H_tiled - 1;
@@ -327,6 +331,6 @@ void kernel_main() {
             }
         }
         noc_async_write_barrier();
-        cb_pop_front(tt::CBIndex::c_1, 1);
+        cb1.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
@@ -5,19 +5,23 @@
 #include <cstdint>
 
 #include "api/compute/transpose_wh.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t NHtWt = get_arg_val<uint32_t>(0);
 
     transpose_wh_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 
+    experimental::CircularBuffer cb_in(tt::CBIndex::c_0);
+    experimental::CircularBuffer cb_out(tt::CBIndex::c_16);
+
     // transpose a row-major block:
     // - assumes the tiles come in in column major order from reader
     // - uses reader_unary_transpose_wh
     // - transpose_wh each tile
     for (uint32_t n = 0; n < NHtWt; n++) {
-        cb_wait_front(tt::CBIndex::c_0, 1);
-        cb_reserve_back(tt::CBIndex::c_16, 1);
+        cb_in.wait_front(1);
+        cb_out.reserve_back(1);
 
         tile_regs_acquire();
         transpose_wh_tile(tt::CBIndex::c_0, 0, 0);
@@ -27,7 +31,7 @@ void kernel_main() {
         pack_tile(0, tt::CBIndex::c_16);
         tile_regs_release();
 
-        cb_push_back(tt::CBIndex::c_16, 1);
-        cb_pop_front(tt::CBIndex::c_0, 1);
+        cb_out.push_back(1);
+        cb_in.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/untilize.h"
 #include "api/compute/pack_untilize.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "experimental/circular_buffer.h"
 
 template <
     uint32_t Wt,
@@ -17,8 +18,9 @@ template <
     bool use_narrow_row,
     uint32_t row_size,
     uint32_t pack_num_pages_last_col,
-    uint32_t pack_num_pages_last_row_col>
-ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, uint32_t cb_out) {
+    uint32_t pack_num_pages_last_row_col,
+    uint32_t cb_out>
+ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, experimental::CircularBuffer& cb_out_buf) {
     uint32_t tile_idx = 0;
 
     transpose_wh_init_short(cb_tilize);
@@ -33,17 +35,17 @@ ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, uint32_t c
         tile_regs_commit();
 
         if (w == Wt - 1) {  // last row
-            cb_reserve_back(cb_out, pack_num_pages_last_row_col);
+            cb_out_buf.reserve_back(pack_num_pages_last_row_col);
             tile_regs_wait();
             pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
             tile_regs_release();
-            cb_push_back(cb_out, pack_num_pages_last_row_col);
+            cb_out_buf.push_back(pack_num_pages_last_row_col);
         } else {
-            cb_reserve_back(cb_out, pack_num_pages_last_col);
+            cb_out_buf.reserve_back(pack_num_pages_last_col);
             tile_regs_wait();
             pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
             tile_regs_release();
-            cb_push_back(cb_out, pack_num_pages_last_col);
+            cb_out_buf.push_back(pack_num_pages_last_col);
         }
         tile_idx = tile_idx - HtWt + 1;
     }
@@ -63,8 +65,8 @@ constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) 
     return 1;
 }
 
-template <uint32_t Wt, uint32_t Ht, uint32_t HtWt>
-ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, uint32_t cb_out) {
+template <uint32_t Wt, uint32_t Ht, uint32_t HtWt, uint32_t cb_out>
+ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, experimental::CircularBuffer& cb_out_buf) {
     uint32_t tile_idx = 0;
 
     transpose_wh_init_short(cb_tilize);
@@ -73,7 +75,7 @@ ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, uint32_t cb_out) {
     constexpr uint32_t full_ct_dim = Ht;
     pack_untilize_dest_init<block_ct_dim, full_ct_dim>(cb_out);
     for (uint32_t w = 0; w < Wt; ++w) {
-        cb_reserve_back(cb_out, Ht);
+        cb_out_buf.reserve_back(Ht);
         for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
             tile_regs_acquire();
             for (uint32_t h = 0; h < block_ct_dim; ++h) {
@@ -86,9 +88,9 @@ ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, uint32_t cb_out) {
             pack_untilize_dest<block_ct_dim, full_ct_dim>(cb_out, 1, b);
             tile_regs_release();
         }
-        cb_push_back(cb_out, Ht);
+        cb_out_buf.push_back(Ht);
 
-        cb_wait_front(cb_out, Ht);
+        cb_out_buf.wait_front(Ht);
         tile_idx = tile_idx - HtWt + 1;
     }
     pack_untilize_uninit(cb_out);
@@ -124,15 +126,18 @@ void kernel_main() {
 #ifdef SHARDED
     constexpr auto cb_in = tt::CBIndex::c_24;
     constexpr auto cb_tilize = tt::CBIndex::c_25;
-    constexpr auto cb_out =
+    constexpr auto cb_out_idx =
         (Ht > 8) ? tt::CBIndex::c_27 : tt::CBIndex::c_16;  // temporary fix until pack_untilze is fully fixed
 #else
     constexpr auto cb_in = tt::CBIndex::c_0;
     constexpr auto cb_tilize = tt::CBIndex::c_24;
-    constexpr auto cb_out = tt::CBIndex::c_16;
+    constexpr auto cb_out_idx = tt::CBIndex::c_16;
 #endif
 
-    unary_op_init_common(cb_in, cb_out);
+    experimental::CircularBuffer cb_tilize_buf(cb_tilize);
+    experimental::CircularBuffer cb_out(cb_out_idx);
+
+    unary_op_init_common(cb_in, cb_out_idx);
 
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         // Tilize input with activation pattern (Ht rows × Wt tiles)
@@ -145,7 +150,7 @@ void kernel_main() {
             compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(Ht);
 
         // transpose
-        cb_wait_front(cb_tilize, HtWt);
+        cb_tilize_buf.wait_front(HtWt);
         uint32_t tile_idx = 0;
 #ifdef SHARDED
         if constexpr (use_narrow_row) {
@@ -156,14 +161,15 @@ void kernel_main() {
                 use_narrow_row,
                 row_size,
                 pack_num_pages_last_col,
-                pack_num_pages_last_row_col>(cb_tilize, cb_out);
+                pack_num_pages_last_row_col,
+                cb_out_idx>(cb_tilize, cb_out);
         } else {
-            transpose_with_pack_untilize<Wt, Ht, HtWt>(cb_tilize, cb_out);
+            transpose_with_pack_untilize<Wt, Ht, HtWt, cb_out_idx>(cb_tilize, cb_out);
         }
 #else
-        transpose_with_pack_untilize<Wt, Ht, HtWt>(cb_tilize, cb_out);
+        transpose_with_pack_untilize<Wt, Ht, HtWt, cb_out_idx>(cb_tilize, cb_out);
 #endif
 
-        cb_pop_front(cb_tilize, HtWt);
+        cb_tilize_buf.pop_front(HtWt);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -127,7 +127,7 @@ void kernel_main() {
     constexpr auto cb_in = tt::CBIndex::c_24;
     constexpr auto cb_tilize = tt::CBIndex::c_25;
     constexpr auto cb_out_idx =
-        (Ht > 8) ? tt::CBIndex::c_27 : tt::CBIndex::c_16;  // temporary fix until pack_untilze is fully fixed
+        (Ht > 8) ? tt::CBIndex::c_27 : tt::CBIndex::c_16;  // temporary fix until pack_untilize is fully fixed
 #else
     constexpr auto cb_in = tt::CBIndex::c_0;
     constexpr auto cb_tilize = tt::CBIndex::c_24;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "api/compute/transpose_wh.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t NHtWt = get_arg_val<uint32_t>(0);
@@ -18,6 +19,9 @@ void kernel_main() {
 
     transpose_wh_init(cb_id_in, cb_id_out);
 
+    experimental::CircularBuffer cb_in(cb_id_in);
+    experimental::CircularBuffer cb_out(cb_id_out);
+
     // transpose a row-major block:
     // - uses reader_unary_transpose_wh
     // - transpose_wh each tile
@@ -25,8 +29,8 @@ void kernel_main() {
     uint32_t tile_idx = 0;
     uint32_t tile_idx_N = 0;
 
-    cb_wait_front(cb_id_in, NHtWt);
-    cb_reserve_back(cb_id_out, NHtWt);
+    cb_in.wait_front(NHtWt);
+    cb_out.reserve_back(NHtWt);
     for (uint32_t n = 0; n < N; ++n) {
         tile_idx = tile_idx_N;
         for (uint32_t w = 0; w < Wt; ++w) {
@@ -43,6 +47,6 @@ void kernel_main() {
         }
         tile_idx_N += HtWt;
     }
-    cb_push_back(cb_id_out, NHtWt);
-    cb_pop_front(cb_id_in, NHtWt);
+    cb_out.push_back(NHtWt);
+    cb_in.pop_front(NHtWt);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -19,6 +22,7 @@ void kernel_main() {
     uint32_t n = get_arg_val<uint32_t>(9);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
     constexpr uint32_t read_size = get_compile_time_arg_val(2);
     constexpr auto src_args = TensorAccessorArgs<3>();
 
@@ -27,18 +31,20 @@ void kernel_main() {
 
     const auto s = TensorAccessor(src_args, src_addr);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_id_in0);
+
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t page_idx = start_id;
     for (uint32_t i = 0; i < num_pages; ++i) {
-        cb_reserve_back(cb_id_in0, onepage);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        cb.reserve_back(onepage);
 #ifdef CN_RM
-        tt::data_movement::common::noc_async_read_sharded(l1_write_addr, s, page_idx, 0, read_size);
+        noc.async_read(s, cb, read_size, {.page_id = page_idx, .offset_bytes = 0}, {.offset_bytes = 0});
 #else
-        noc_async_read_page(page_idx, s, l1_write_addr);
+        noc.async_read(s, cb, page_size, {.page_id = page_idx}, {.offset_bytes = 0});
 #endif
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, onepage);
+        noc.async_read_barrier();
+        cb.push_back(onepage);
         page_idx++;
         hw++;
         if (hw == HtWt) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 using uint32_t = std::uint32_t;
 
@@ -42,14 +43,17 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(src_args, src0_addr);
 
-    uint32_t intermed_l1_scratch = MISALIGNED ? get_write_ptr(1) : 0;
+    experimental::CircularBuffer cb(cb_id_in0);
+    experimental::CircularBuffer cb_scratch(1);
+
+    uint32_t intermed_l1_scratch = MISALIGNED ? cb_scratch.get_write_ptr() : 0;
     volatile tt_l1_ptr uint8_t* intermed_l1_scratch_ptr = (volatile uint8_t*)intermed_l1_scratch;
     for (uint32_t t = 0; t < num_tiles; t++) {
         auto h32 = (h & 31);
 
-        cb_reserve_back(cb_id_in0, onetile);
+        cb.reserve_back(onetile);
 
-        uint32_t dest_tr0_l1 = get_write_ptr(cb_id_in0);
+        uint32_t dest_tr0_l1 = cb.get_write_ptr();
         // uint32_t save_dest = dest_tr0_l1;
         uint32_t cSubtileOffs = 0;
         for (uint32_t sub = 0; sub < 4; sub++) {
@@ -144,7 +148,7 @@ void kernel_main() {
         noc_async_read_barrier();
 
         // notifies the unpacker that the buffer is populated
-        cb_push_back(cb_id_in0, onetile);
+        cb.push_back(onetile);
         wt++;
         if (wt == WT) {  // End of row
             wt = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -29,14 +32,18 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<5>();
     const auto s = TensorAccessor(src_args, src_addr);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_in0);
+
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
-        cb_reserve_back(cb_in0, num_read_per_barrier);
-        uint32_t l1_write_addr = get_write_ptr(cb_in0);
+        cb.reserve_back(num_read_per_barrier);
+        uint32_t l1_write_offset = 0;
 
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
-            tt::data_movement::common::noc_async_read_sharded(l1_write_addr, s, i_stick, 0, stick_size_bytes);
-            l1_write_addr += stick_size_bytes;
+            noc.async_read(
+                s, cb, stick_size_bytes, {.page_id = i_stick, .offset_bytes = 0}, {.offset_bytes = l1_write_offset});
+            l1_write_offset += stick_size_bytes;
 
             curr_c++;
             i_stick += H;
@@ -53,7 +60,7 @@ void kernel_main() {
                 }
             }
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_in0, num_read_per_barrier);
+        noc.async_read_barrier();
+        cb.push_back(num_read_per_barrier);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -34,7 +37,12 @@ void kernel_main() {
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const auto s = TensorAccessor(src_args, src_addr);
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_id_in0);
+    experimental::CircularBuffer cb_padding(tt::CBIndex::c_1);
 
 // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS
@@ -56,19 +64,18 @@ void kernel_main() {
         } else {
             linear_tile_index = i;
         }
-        cb_reserve_back(cb_id_in0, onetile);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(linear_tile_index, s, l1_write_addr);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, onetile);
+        cb.reserve_back(onetile);
+        noc.async_read(s, cb, tile_bytes, {.page_id = linear_tile_index}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(onetile);
     }
     if constexpr (needs_padding) {
         // Add padding
-        cb_reserve_back(tt::CBIndex::c_1, 1);
-        uint32_t l1_write_addr = get_write_ptr(tt::CBIndex::c_1);
+        cb_padding.reserve_back(1);
+        uint32_t l1_write_addr = cb_padding.get_write_ptr();
         // Fill with padding value
         // if bfloat16 num_writes = FACE_WIDTH / (sizeof(uint32_t))/(element_size)
         tt::data_movement::common::fill_with_val(l1_write_addr, num_writes, padding_val_packed);
-        cb_push_back(tt::CBIndex::c_1, 1);
+        cb_padding.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
 #ifdef USE_SPECIAL_CASE
@@ -21,14 +22,17 @@ void kernel_main() {
     constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
 
+    experimental::CircularBuffer cb_in(cb_in0);
+    experimental::CircularBuffer cb_out(cb_out0);
+
     if (read_single_h_block_per_core) {
         uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
         uint32_t l1_write_offset = 0;
 
         for (uint32_t core = 0; core < num_cores_read; ++core) {
-            uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset[core];
+            uint32_t l1_read_addr = cb_in.get_read_ptr() + read_stick_offset[core];
             uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
-            uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset;
+            uint32_t l1_write_addr = cb_out.get_write_ptr() + l1_write_offset;
 
             noc_async_read_one_packet_set_state(noc_read_addr, stick_size_bytes);
 
@@ -41,8 +45,8 @@ void kernel_main() {
             noc_async_read_barrier();
         }
     } else {
-        uint32_t l1_write_addr = get_write_ptr(cb_out0);
-        uint32_t l1_read_addr = get_read_ptr(cb_in0);
+        uint32_t l1_write_addr = cb_out.get_write_ptr();
+        uint32_t l1_read_addr = cb_in.get_read_ptr();
 
         for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
             for (uint32_t core = 0; core < num_cores_read; ++core) {
@@ -91,8 +95,11 @@ void kernel_main() {
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    cb_reserve_back(cb_out0, num_sticks_per_core);
-    uint32_t l1_write_addr = get_write_ptr(cb_out0);
+    experimental::CircularBuffer cb_in(cb_in0);
+    experimental::CircularBuffer cb_out(cb_out0);
+
+    cb_out.reserve_back(num_sticks_per_core);
+    uint32_t l1_write_addr = cb_out.get_write_ptr();
 
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core; ++iter) {
@@ -117,7 +124,7 @@ void kernel_main() {
             worker_y_physical = shard_grid_y_map[shard_grid_inner_dim_id];
         }
 
-        uint32_t l1_read_addr = get_read_ptr(cb_in0) + stick_id_in_shard * stick_size_bytes;
+        uint32_t l1_read_addr = cb_in.get_read_ptr() + stick_id_in_shard * stick_size_bytes;
 
         uint64_t read_noc_addr = get_noc_addr(worker_x_physical, worker_y_physical, l1_read_addr);
         noc_async_read(read_noc_addr, l1_write_addr, stick_size_bytes);
@@ -140,7 +147,7 @@ void kernel_main() {
     }
 
     noc_async_read_barrier();
-    cb_push_back(cb_out0, num_sticks_per_core);
+    cb_out.push_back(num_sticks_per_core);
 
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -18,13 +21,17 @@ void kernel_main() {
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_id_in0);
+
 #ifdef REDUCE_SCALER
     constexpr uint32_t cb_in_2 = 2;
     constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
-    cb_reserve_back(cb_in_2, 1);
+    experimental::CircularBuffer cb_scaler(cb_in_2);
+    cb_scaler.reserve_back(1);
     if (scaler != 0) {
         uint16_t u = uint16_t(scaler >> 16);
-        auto ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_in_2));
+        auto ptr = reinterpret_cast<uint16_t*>(cb_scaler.get_write_ptr());
         for (int j = 0; j < 1024; j++) {
             ptr[j] = uint16_t(0);
         }
@@ -35,12 +42,13 @@ void kernel_main() {
             }
         }
     }
-    cb_push_back(cb_in_2, 1);
+    cb_scaler.push_back(1);
 #endif
 
     uint32_t i_tile_N = 0;  // first tile in current batch
     uint32_t i_tile = 0;
 
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const auto s = TensorAccessor(src_args, src_addr);
 
     // this reader will read a NHW tensor in NWH order
@@ -48,12 +56,11 @@ void kernel_main() {
         i_tile = i_tile_N;
         for (uint32_t w = 0; w < Wt; w++) {
             for (uint32_t h = 0; h < Ht; h++) {
-                cb_reserve_back(cb_id_in0, onetile);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(i_tile, s, l1_write_addr);
-                noc_async_read_barrier();
+                cb.reserve_back(onetile);
+                noc.async_read(s, cb, tile_bytes, {.page_id = i_tile}, {.offset_bytes = 0});
+                noc.async_read_barrier();
 
-                cb_push_back(cb_id_in0, onetile);
+                cb.push_back(onetile);
                 i_tile += Wt;  // stride in H
             }  // Ht
             i_tile -= HtWt;  // go back to H=0

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -22,7 +25,11 @@ void kernel_main() {
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const auto s = TensorAccessor(src_args, src_addr);
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_id_in0);
 
     uint32_t ht = start_ht;
     uint32_t wt = start_wt;
@@ -30,12 +37,11 @@ void kernel_main() {
 
     // this reader will read a NHW tensor in NWH order
     for (uint32_t i = 0; i < num_tiles; i++) {
-        cb_reserve_back(cb_id_in0, onetile);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(i_tile, s, l1_write_addr);
-        noc_async_read_barrier();
+        cb.reserve_back(onetile);
+        noc.async_read(s, cb, tile_bytes, {.page_id = i_tile}, {.offset_bytes = 0});
+        noc.async_read_barrier();
 
-        cb_push_back(cb_id_in0, onetile);
+        cb.push_back(onetile);
         i_tile += Wt;  // stride in H
         ht += 1;
         if (ht == Ht) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -27,21 +30,29 @@ void kernel_main() {
 
     const auto s = TensorAccessor(src_args, src_addr);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_in0);
+
     uint32_t i_stick = start_id;
 
     // this reader will read a NHW tensor in NWH order
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         for (uint32_t h = 0; h < Ht; ++h) {
-            cb_reserve_back(cb_in0, Wt);
-            uint32_t l1_write_addr = get_write_ptr(cb_in0);
+            cb.reserve_back(Wt);
+            uint32_t l1_write_offset = 0;
             uint32_t H_curr = h == Ht - 1 ? H_per_tile_last : H_per_tile;
             for (uint32_t h_datum = 0; h_datum < H_curr; ++h_datum) {
-                tt::data_movement::common::noc_async_read_sharded(l1_write_addr, s, i_stick, 0, stick_size_bytes);
-                l1_write_addr += l1_write_offset_bytes;
+                noc.async_read(
+                    s,
+                    cb,
+                    stick_size_bytes,
+                    {.page_id = i_stick, .offset_bytes = 0},
+                    {.offset_bytes = l1_write_offset});
+                l1_write_offset += l1_write_offset_bytes;
                 i_stick += 1;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_in0, Wt);
+            noc.async_read_barrier();
+            cb.push_back(Wt);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_sharded_rm.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(0);
@@ -19,15 +20,18 @@ void kernel_main() {
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    uint32_t l1_read_addr = get_read_ptr(cb_in0);
+    experimental::CircularBuffer cb_src(cb_in0);
+    experimental::CircularBuffer cb_dst(cb_in);
+
+    uint32_t l1_read_addr = cb_src.get_read_ptr();
     uint64_t read_noc_addr = get_noc_addr(l1_read_addr);
 
     noc_async_read_one_packet_set_state(read_noc_addr, stick_size_bytes);
 
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         for (uint32_t h = 0; h < Ht; ++h) {
-            cb_reserve_back(cb_in, Wt);
-            uint32_t l1_write_addr = get_write_ptr(cb_in);
+            cb_dst.reserve_back(Wt);
+            uint32_t l1_write_addr = cb_dst.get_write_ptr();
             uint32_t H_curr = h == Ht - 1 ? H_per_tile_last : H_per_tile;
             for (uint32_t h_datum = 0; h_datum < H_curr; ++h_datum) {
                 noc_async_read_one_packet_with_state(read_noc_addr, l1_write_addr);
@@ -35,7 +39,7 @@ void kernel_main() {
                 read_noc_addr += stick_size_bytes;
             }
             noc_async_read_barrier();
-            cb_push_back(cb_in, Wt);
+            cb_dst.push_back(Wt);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
@@ -3,6 +3,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -10,6 +13,7 @@ void kernel_main() {
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
     constexpr uint32_t write_size = get_compile_time_arg_val(2);
     constexpr auto dst_args = TensorAccessorArgs<3>();
 
@@ -17,17 +21,19 @@ void kernel_main() {
 
     const auto s = TensorAccessor(dst_args, dst_addr);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_id_out);
+
     uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_wait_front(cb_id_out, onepage);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        cb.wait_front(onepage);
 #ifdef CN_RM
-        tt::data_movement::common::noc_async_write_sharded(l1_read_addr, s, i, 0, write_size);
+        noc.async_write(cb, s, write_size, {.offset_bytes = 0}, {.page_id = i, .offset_bytes = 0});
 #else
-        noc_async_write_page(i, s, l1_read_addr);
+        noc.async_write(cb, s, page_size, {.offset_bytes = 0}, {.page_id = i});
 #endif
 
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out, onepage);
+        noc.async_write_barrier();
+        cb.pop_front(onepage);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
@@ -4,6 +4,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -19,17 +22,21 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<3>();
     const auto s = TensorAccessor(dst_args, dst_addr);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_out0);
+
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
-        cb_wait_front(cb_out0, num_read_per_barrier);
-        uint32_t l1_read_addr = get_read_ptr(cb_out0);
+        cb.wait_front(num_read_per_barrier);
+        uint32_t l1_read_offset = 0;
 
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
-            tt::data_movement::common::noc_async_write_sharded(l1_read_addr, s, i_stick, 0, stick_size_bytes);
-            l1_read_addr += stick_size_bytes;
+            noc.async_write(
+                cb, s, stick_size_bytes, {.offset_bytes = l1_read_offset}, {.page_id = i_stick, .offset_bytes = 0});
+            l1_read_offset += stick_size_bytes;
             i_stick += 1;
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_out0, num_read_per_barrier);
+        noc.async_write_barrier();
+        cb.pop_front(num_read_per_barrier);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -4,6 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     // Retrieve arguments
@@ -43,6 +44,9 @@ void kernel_main() {
 
     // Initialize address generator
     const auto s = TensorAccessor(dst_args, dst_addr);
+
+    experimental::CircularBuffer cb(cb_id_out0);
+    experimental::CircularBuffer cb_padding(tt::CBIndex::c_1);
 
     // Calculate actual data height in the last tile
     constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;
@@ -84,8 +88,8 @@ void kernel_main() {
         uint32_t output_h = h * TILE_HEIGHT;
 
         // Synchronization and read address retrieval
-        cb_wait_front(cb_id_out0, 1);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+        cb.wait_front(1);
+        uint32_t l1_read_addr = cb.get_read_ptr();
 
         // Determine the number of faces in the height dimension
         uint8_t num_faces_h = (h == H_t - 1) ? remainder_faces_h : NUM_FACES_H;
@@ -147,14 +151,14 @@ void kernel_main() {
         noc_async_write_barrier();
 
         // Remove the processed tile from the front of the buffer
-        cb_pop_front(cb_id_out0, 1);
+        cb.pop_front(1);
     }
 
     // add padding
     if constexpr (needs_padding) {
-        cb_wait_front(tt::CBIndex::c_1, 1);
+        cb_padding.wait_front(1);
 
-        uint32_t l1_read_ptr = get_read_ptr(tt::CBIndex::c_1);
+        uint32_t l1_read_ptr = cb_padding.get_read_ptr();
 
         constexpr uint32_t c_t = C_t - 1;
         constexpr uint8_t C_in_tile = C % TILE_HEIGHT;
@@ -188,6 +192,6 @@ void kernel_main() {
             }
         }
         noc_async_write_barrier();
-        cb_pop_front(tt::CBIndex::c_1, 1);
+        cb_padding.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     bool read_single_h_block_per_core = get_arg_val<uint32_t>(0) == 1;
@@ -21,14 +22,17 @@ void kernel_main() {
     constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
 
+    experimental::CircularBuffer cb_in(cb_in0);
+    experimental::CircularBuffer cb_out(cb_out0);
+
     if (read_single_h_block_per_core) {
         uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
 
         uint32_t l1_write_offset = 0;
         for (uint32_t core = 0; core < num_cores_read; ++core) {
-            uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset[core] + src_read_stick_offset;
+            uint32_t l1_read_addr = cb_in.get_read_ptr() + read_stick_offset[core] + src_read_stick_offset;
             uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
-            uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset + dst_write_stick_offset;
+            uint32_t l1_write_addr = cb_out.get_write_ptr() + l1_write_offset + dst_write_stick_offset;
             for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
                 noc_async_read_one_packet(noc_read_addr, l1_write_addr, stick_size_bytes);
                 noc_read_addr += read_stick_stride;
@@ -38,8 +42,8 @@ void kernel_main() {
             noc_async_read_barrier();
         }
     } else {
-        uint32_t l1_write_addr = get_write_ptr(cb_out0) + dst_write_stick_offset;
-        uint32_t l1_read_addr = get_read_ptr(cb_in0) + src_read_stick_offset;
+        uint32_t l1_write_addr = cb_out.get_write_ptr() + dst_write_stick_offset;
+        uint32_t l1_read_addr = cb_in.get_read_ptr() + src_read_stick_offset;
 
         for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
             for (uint32_t core = 0; core < num_cores_read; ++core) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -4,6 +4,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -26,21 +29,25 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<10>();
     const auto s = TensorAccessor(dst_args, dst_addr);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_out0);
+
     uint32_t i_stick = start_id;
 
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         for (uint32_t w = 0; w < Wt; ++w) {
-            cb_wait_front(cb_out0, Ht);
-            uint32_t l1_read_addr = get_read_ptr(cb_out0);
+            cb.wait_front(Ht);
+            uint32_t l1_read_offset = 0;
             uint32_t W_curr = w == Wt - 1 ? W_per_tile_last : W_per_tile;
             for (uint32_t w_datum = 0; w_datum < W_curr; ++w_datum) {
-                tt::data_movement::common::noc_async_write_sharded(l1_read_addr, s, i_stick, 0, stick_size_bytes);
+                noc.async_write(
+                    cb, s, stick_size_bytes, {.offset_bytes = l1_read_offset}, {.page_id = i_stick, .offset_bytes = 0});
 
-                l1_read_addr += l1_read_offset_bytes;
+                l1_read_offset += l1_read_offset_bytes;
                 i_stick += 1;
             }
-            noc_async_write_barrier();
-            cb_pop_front(cb_out0, Ht);
+            noc.async_write_barrier();
+            cb.pop_front(Ht);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(0);
@@ -18,7 +19,10 @@ void kernel_main() {
 
     const uint32_t stick_size_bytes = H_size_bytes;
 
-    uint32_t l1_write_addr = get_write_ptr(cb_out0);
+    experimental::CircularBuffer cb_src(cb_out);
+    experimental::CircularBuffer cb_dst(cb_out0);
+
+    uint32_t l1_write_addr = cb_dst.get_write_ptr();
     uint64_t write_noc_addr = get_noc_addr(l1_write_addr);
 
     // temporary fix until pack_untilze is fully fixed
@@ -27,8 +31,8 @@ void kernel_main() {
 
         for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
             for (uint32_t w = 0; w < Wt; ++w) {
-                cb_wait_front(cb_out, Ht);
-                uint32_t l1_read_addr = get_read_ptr(cb_out);
+                cb_src.wait_front(Ht);
+                uint32_t l1_read_addr = cb_src.get_read_ptr();
                 uint32_t W_curr = w == Wt - 1 ? W_per_tile_last : W_per_tile;
                 for (uint32_t w_datum = 0; w_datum < W_curr; ++w_datum) {
                     noc_async_write_one_packet_with_state(l1_read_addr, write_noc_addr);
@@ -36,7 +40,7 @@ void kernel_main() {
                     write_noc_addr += stick_size_bytes;
                 }
                 noc_async_writes_flushed();
-                cb_pop_front(cb_out, Ht);
+                cb_src.pop_front(Ht);
             }
         }
         noc_async_write_barrier();


### PR DESCRIPTION
## Summary
- Migrates 28 kernel files to use experimental Device 2.0 APIs
  - `ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/` (18 files)
  - `ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/` (10 files)
- Uses `experimental::Noc`, `experimental::CircularBuffer` APIs
- Sharded kernels use partial migration (CB experimental, NOC legacy) due to `get_noc_addr(x, y, addr)` limitations

## Test plan
- [x] Build passes
- [x] `pytest tests/ttnn/unit_tests/operations/data_movement/test_permute.py` - 1588 passed, 1 skipped
- [x] `pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py` - 272 passed, 202 skipped

Part of #41702

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

Remaining failures in sanity tests and bh-post-commit as of Apr 21 are all unrelated and are present in other runs.

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=device-2.0-migration/transpose-perm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:device-2.0-migration/transpose-perm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=device-2.0-migration/transpose-perm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:device-2.0-migration/transpose-perm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=device-2.0-migration/transpose-perm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:device-2.0-migration/transpose-perm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=device-2.0-migration/transpose-perm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:device-2.0-migration/transpose-perm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=device-2.0-migration/transpose-perm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:device-2.0-migration/transpose-perm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=device-2.0-migration/transpose-perm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:device-2.0-migration/transpose-perm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=device-2.0-migration/transpose-perm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:device-2.0-migration/transpose-perm)