### PR TITLE
Bug: Fixing DEVICE_PRINT argument reordering

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
@@ -225,3 +225,11 @@ TEST_F(DevicePrintFormatUpdatesFixture, PrintStringTypes) {
     TestFormatUpdate(
         "tests/tt_metal/tt_metal/test_kernels/device_print/print_string_types.cpp", ttsl::make_span(messages));
 }
+
+TEST_F(DevicePrintFormatUpdatesFixture, PrintReorder) {
+    std::vector<std::string_view> messages = {
+        "u16_1: {4,H} u16_2: {5,H} u32_1: {0,I} u32_2: {1,I} u32_3: {2,I} u32_4: {3,I}\n"sv,
+    };
+
+    TestFormatUpdate("tests/tt_metal/tt_metal/test_kernels/device_print/print_reorder.cpp", ttsl::make_span(messages));
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -264,3 +264,11 @@ TEST_F(DevicePrintOutputFixture, PrintStringTypes) {
 
     TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_string_types.cpp", messages);
 }
+
+TEST_F(DevicePrintOutputFixture, PrintReorder) {
+    std::vector<std::string> messages = {
+        "u16_1: 16 u16_2: 32 u32_1: 1 u32_2: 2 u32_3: 4 u32_4: 8",
+    };
+
+    TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_reorder.cpp", messages);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_reorder.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_reorder.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+
+/*
+ * Test printing from a kernel running on BRISC.
+ */
+
+void kernel_main() {
+    uint16_t u16_1 = 16, u16_2 = 32;
+    uint32_t u32_1 = 1, u32_2 = 2, u32_3 = 4, u32_4 = 8;
+
+    DEVICE_PRINT(
+        "u16_1: {} u16_2: {} u32_1: {} u32_2: {} u32_3: {} u32_4: {}\n", u16_1, u16_2, u32_1, u32_2, u32_3, u32_4);
+}

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -1104,7 +1104,6 @@ constexpr auto update_format_string(const char (&format)[N]) {
 
     helpers::static_string<result_len> result;
 
-    constexpr auto type_infos = get_types_info<Args...>();
     constexpr auto arg_reorder = get_arg_reorder<Args...>();
 
     std::size_t type_index = 0;
@@ -1128,7 +1127,14 @@ constexpr auto update_format_string(const char (&format)[N]) {
             result.push_back('{');
 
             // Output the index (updated with reordered index)
-            result.push_back_uint32(arg_reorder[arg_index]);
+            auto reordered_index = arg_reorder[arg_index];
+            for (size_t j = 0; j < arg_reorder.size(); j++) {
+                if (arg_reorder[j] == arg_index) {
+                    reordered_index = j;
+                    break;
+                }
+            }
+            result.push_back_uint32(reordered_index);
 
             // Add comma and type character (enum types emit extended type info)
             result.push_back(',');


### PR DESCRIPTION
Fixing argument reordering in `DEVICE_PRINT` format string. Argument serialization was correct, but format string had wrong argument order. Added test that verified bug and now that it fixes it.

Also, removing one warning that caused noise when there was a build break.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_device_print_reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/fix_device_print_reordering) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/fix_device_print_reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/fix_device_print_reordering) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/fix_device_print_reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/fix_device_print_reordering) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/fix_device_print_reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/fix_device_print_reordering) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/fix_device_print_reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/fix_device_print_reordering) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/fix_device_print_reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/fix_device_print_reordering) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/fix_device_print_reordering) |