### PR TITLE
Fix Conv3d auto-blocking L1 overflow for large kernels

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
@@ -479,6 +479,78 @@ def test_conv3d_float32(device):
     )
 
 
+def test_conv3d_qwen_patch_embed_l1_overflow(device):
+    """Reproduce tt-xla#3983: Conv3d with Qwen2.5-VL patch embed parameters overflows L1.
+
+    Without custom blocking, the static CB allocation for Conv3d with out_channels=1280
+    and kernel=(2,14,14) grows to ~1,738,528 B, exceeding the 1,499,136 B L1 limit.
+    This test uses default auto-blocking (no config) to replicate the exact failure path.
+    """
+    torch.manual_seed(42)
+
+    N, C, D, H, W = 1024, 3, 2, 14, 14
+    out_channels = 1280
+    kernel_size = (2, 14, 14)
+    stride = (2, 14, 14)
+    padding = (0, 0, 0)
+    groups = 1
+
+    input_tensor = torch.randn(N, C, D, H, W, dtype=torch.float32)
+
+    conv3d_module = nn.Conv3d(
+        C,
+        out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        bias=False,
+        padding_mode="zeros",
+    )
+
+    # Prepare input for TTNN (NCDHW -> NDHWC, pad channels to alignment)
+    tt_input = prepare_input_tensor(input_tensor, C, device)
+
+    kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    # Prepare weights — use default C_in_block=0 (auto) to trigger the overflow
+    w = conv3d_module.weight.data
+    tt_weight = ttnn.from_torch(w, dtype=ttnn.DataType.BFLOAT16, pad_value=0)
+
+    # No bias (matching the Qwen2.5-VL model exactly)
+    tt_output = ttnn.experimental.conv3d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        device=device,
+        bias_tensor=None,
+        dtype=ttnn.bfloat16,
+        output_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        padding_mode="zeros",
+        groups=groups,
+        compute_kernel_config=kernel_config,
+    )
+
+    D_out = _out_size(D, padding[0], stride[0], kernel_size[0], 1)
+    H_out = _out_size(H, padding[1], stride[1], kernel_size[1], 1)
+    W_out = _out_size(W, padding[2], stride[2], kernel_size[2], 1)
+
+    tt_output = reshape_output(tt_output, N, D_out, H_out, W_out, out_channels, device)
+
+    gt_output = conv3d_module(input_tensor)
+    assert tt_output.shape == gt_output.shape
+    pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
+    logger.info(f"Compare conv3d torch vs ttnn (qwen patch embed): {pcc_message}")
+    assert pcc_passed, pcc_message
+
+
 @pytest.mark.parametrize(
     "C_in_block",
     [32, 64],

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
@@ -7,12 +7,61 @@
 #include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/hal.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::experimental {
+
+// Estimate the total circular buffer bytes that the program factory will allocate for
+// a given C_in_block / C_out_block combination.  The formula mirrors the CB creation
+// sequence in conv3d_program_factory.cpp so that auto-blocking can pick values that
+// are guaranteed to fit in L1.
+static uint64_t estimate_conv3d_cb_bytes(
+    uint32_t C_in_block,
+    uint32_t C_out_block,
+    uint32_t C_in,
+    const std::array<uint32_t, 3>& kernel_size,
+    uint32_t num_patches,
+    uint32_t tile_size,
+    uint32_t fp32_tile_size,
+    uint32_t dtype_bytes,
+    bool use_bias,
+    bool fp32_dest_acc_en) {
+    uint32_t patch_size = kernel_size[0] * kernel_size[1] * kernel_size[2] * C_in_block;
+    uint32_t padded_patch_size = tt::round_up(patch_size, tt::constants::TILE_WIDTH);
+    uint32_t padded_patch_size_bytes = padded_patch_size * dtype_bytes;
+
+    uint32_t matmul_M_t = tt::div_up(num_patches, tt::constants::TILE_HEIGHT);
+    uint32_t matmul_K_t = tt::div_up(patch_size, tt::constants::TILE_WIDTH);
+    uint32_t matmul_N_t = tt::div_up(C_out_block, tt::constants::TILE_WIDTH);
+
+    uint32_t C_in_num_blocks = tt::div_up(C_in, C_in_block);
+    bool use_fp32_partials = fp32_dest_acc_en && C_in_num_blocks > 1;
+    uint32_t partial_tile_size = use_fp32_partials ? fp32_tile_size : tile_size;
+
+    uint32_t vol2col_rm_pages = std::min(num_patches, 2 * tt::constants::TILE_HEIGHT);
+
+    uint64_t total = 0;
+    total += (uint64_t)padded_patch_size_bytes * vol2col_rm_pages;   // vol2col_rm
+    total += (uint64_t)tile_size * matmul_M_t * matmul_K_t;          // vol2col_tiled
+    total += (uint64_t)tile_size * matmul_K_t * matmul_N_t;          // weight_tiled
+    total += (uint64_t)partial_tile_size * matmul_M_t * matmul_N_t;  // matmul_interm
+    total += (uint64_t)tile_size * matmul_M_t * matmul_N_t;          // matmul_result_rm
+    if (use_fp32_partials) {
+        total += tile_size;  // zero tile for FPU accumulate
+    }
+    if (C_in_num_blocks > 1) {
+        total += (uint64_t)partial_tile_size * matmul_M_t * matmul_N_t;  // reduction
+        total += tile_size;                                              // worker_ack
+    }
+    if (use_bias) {
+        total += (uint64_t)tile_size * matmul_N_t;  // bias
+    }
+    return total;
+}
 
 static Tensor prepare_and_check_weight_tensor(
     const Tensor& weight_tensor,
@@ -54,20 +103,92 @@ ttnn::Tensor conv3d(
     uint32_t groups_,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-    // If no config provided, use conservative default blocking:
-    // minimal spatial blocks (1,1,1), smallest valid channel blocks (TILE_WIDTH) to minimize L1 pressure
-    auto config = config_opt.value_or(ttnn::experimental::prim::Conv3dConfig(
-        tt::tt_metal::DataType::BFLOAT16,                        // weights_dtype
-        tt::tt_metal::Layout::ROW_MAJOR,                         // output_layout
-        1,                                                       // T_out_block
-        1,                                                       // W_out_block
-        1,                                                       // H_out_block
-        tt::constants::TILE_WIDTH,                               // C_out_block (one tile width)
-        tt::constants::TILE_WIDTH,                               // C_in_block (one tile width, min L1)
-        dilation_,                                               // dilation (match the op's dilation)
-        32,                                                      // alignment
-        input_tensor.device()->compute_with_storage_grid_size()  // use full device grid
-        ));
+    ttnn::experimental::prim::Conv3dConfig config = [&]() {
+        if (config_opt.has_value()) {
+            return config_opt.value();
+        }
+        // Auto-blocking: pick the largest C_in_block that keeps total CB allocation within L1.
+        // The dominant CB consumers are vol2col_tiled and weight_tiled, both proportional to
+        // matmul_K_t = ceil(kD*kH*kW*C_in_block / TILE_WIDTH).  For large kernels (e.g. 2×14×14
+        // in Qwen2.5-VL), a fixed C_in_block=TILE_WIDTH can overflow L1.
+        auto grid_size = input_tensor.device()->compute_with_storage_grid_size();
+        uint32_t C_in = input_tensor.logical_shape()[-1];  // last dim is channels (NDHWC layout)
+        uint32_t C_out_block = tt::constants::TILE_WIDTH;
+        uint32_t num_patches = 1;  // T_out_block=1, H_out_block=1, W_out_block=1
+
+        // Get tile sizes for the input data format
+        auto data_format = tt::tt_metal::datatype_to_dataformat_converter(dtype_);
+        uint32_t tile_size = tt::tile_size(data_format);
+        uint32_t fp32_tile_size = tt::tile_size(tt::DataFormat::Float32);
+        uint32_t dtype_bytes = tt::datum_size(data_format);
+
+        auto resolved_compute_config =
+            ttnn::init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
+        auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+            get_compute_kernel_config_args(tt::tt_metal::hal::get_arch(), resolved_compute_config);
+
+        bool use_bias = bias_tensor.has_value();
+
+        // L1 budget for CBs (same reserve as program factory)
+        constexpr uint32_t L1_KERNEL_CODE_RESERVE = 200 * 1024;
+        uint32_t l1_cb_budget = tt::tt_metal::hal::get_max_worker_l1_unreserved_size() - L1_KERNEL_CODE_RESERVE;
+
+        // Try C_in_block values from largest (full C_in) down to 1, halving each time.
+        // Pick the largest that fits in L1.
+        uint32_t best_c_in_block = 0;
+        for (uint32_t candidate = C_in; candidate >= 1; candidate /= 2) {
+            if (C_in % candidate != 0) {
+                continue;  // C_in_block must evenly divide C_in
+            }
+            uint64_t estimated_bytes = estimate_conv3d_cb_bytes(
+                candidate,
+                C_out_block,
+                C_in,
+                kernel_size_,
+                num_patches,
+                tile_size,
+                fp32_tile_size,
+                dtype_bytes,
+                use_bias,
+                fp32_dest_acc_en);
+            log_debug(
+                tt::LogOp,
+                "Conv3d auto-blocking: candidate C_in_block={}, estimated CB bytes={}, budget={}",
+                candidate,
+                estimated_bytes,
+                l1_cb_budget);
+            if (estimated_bytes <= l1_cb_budget) {
+                best_c_in_block = candidate;
+                break;
+            }
+        }
+
+        TT_FATAL(
+            best_c_in_block > 0,
+            "Conv3d auto-blocking: cannot find a C_in_block that fits in L1 ({} bytes). "
+            "kernel_size={}x{}x{}, C_in={}, C_out={}. Provide an explicit Conv3dConfig.",
+            l1_cb_budget,
+            kernel_size_[0],
+            kernel_size_[1],
+            kernel_size_[2],
+            C_in,
+            output_channels_);
+
+        log_debug(tt::LogOp, "Conv3d auto-blocking: selected C_in_block={}", best_c_in_block);
+
+        return ttnn::experimental::prim::Conv3dConfig(
+            tt::tt_metal::DataType::BFLOAT16,  // weights_dtype
+            tt::tt_metal::Layout::ROW_MAJOR,   // output_layout
+            1,                                 // T_out_block
+            1,                                 // W_out_block
+            1,                                 // H_out_block
+            C_out_block,                       // C_out_block
+            best_c_in_block,                   // C_in_block (adaptively chosen)
+            dilation_,                         // dilation
+            32,                                // alignment
+            grid_size                          // use full device grid
+        );
+    }();
 
     Tensor prepared_weight_tensor = prepare_and_check_weight_tensor(weight_tensor, groups_, config, device);
     return ttnn::prim::conv3d(


### PR DESCRIPTION
## Summary

- Fix `ttnn::experimental::conv3d` L1 overflow when called without an explicit `Conv3dConfig` for large kernels (e.g. Qwen 2.5 VL's `kernel=(2,14,14)`)
- Replace fixed `C_in_block = TILE_WIDTH (32)` with adaptive auto-blocking that estimates CB sizes and picks the largest `C_in_block` that fits in L1
- Add `test_conv3d_qwen_patch_embed_l1_overflow` sanity test reproducing the exact failure from tt-xla#3983

## Details

The auto-blocking path used a fixed `C_in_block = 32` regardless of kernel size. For large spatial kernels, this made `patch_size = kD × kH × kW × C_in_block` very large, causing the `vol2col_tiled` and `weight_tiled` circular buffers to exceed the ~1.5 MB L1 limit.

The fix adds `estimate_conv3d_cb_bytes()` that mirrors the CB allocation logic from `conv3d_program_factory.cpp`, then iterates from `C_in_block = C_in` downward (halving each step) to find the largest value that fits. For the Qwen 2.5 VL case, this selects `C_in_block=16` (829 KB total CBs) instead of `32` (1.6 MB — overflow).

Resolves #42146
Related: https://github.com/tenstorrent/tt-xla/issues/3983

## Test plan

- [x] `test_conv3d_qwen_patch_embed_l1_overflow` — was L1 overflow, now passes with PCC 0.999992
- [x] `test_conv3d_no_config` (3 cases) — auto-blocking regression check, all pass
- [x] `test_conv3d_qwen_shapes` — explicit blocking still works, passes
- [x] `test_conv3d_non_aligned_output_channels` (4 cases) — passes
- [x] `test_conv3d_float32` — passes
- [x] `test_conv3d_fp32_reduction_c_in_blocking` (2 cases) — passes
- [x] All 12 non-sweep conv3d tests pass with 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow) |