### PR TITLE
Remove unused APPROXIMATE template parameter from SFPU API functions

### DIFF
--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_add.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_add.rst
@@ -180,7 +180,7 @@ The core of this example is the custom SFPI function ``my_add_tiles``. It's impl
 
     // High-level API function
     void my_add_tile(uint32_t idx_dst0, uint32_t idx_dst1, uint32_t idx_out0) {
-        MATH(_llk_math_eltwise_binary_sfpu_params_<false>(add_tile_face, idx_dst0, idx_dst1, idx_out0));
+        MATH(_llk_math_eltwise_binary_sfpu_params_(add_tile_face, idx_dst0, idx_dst1, idx_out0));
     }
 
 

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -195,7 +195,7 @@ The ``my_smoothstep_tiles`` function uses the layered abstraction pattern shown 
     // High-level API function
     // Accepts `edge0`, `edge1` and `inv_delta` as parameters
     inline void my_smoothstep_tile(uint32_t idx_dst0, float edge0, float edge1, float inv_delta) {
-        MATH(_llk_math_eltwise_unary_sfpu_params_<false>(
+        MATH(_llk_math_eltwise_unary_sfpu_params_(
             smoothstep_tile_face,
             idx_dst0,
             VectorMode::RC, // Apply on all 4 faces of the tile

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -13,7 +13,7 @@ namespace ckernel {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
     // Don't need the second addrmod so set type to unused
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         sfpu::deepseek_moe_gate_topk_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -19,21 +19,21 @@ inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sort_top4_groups(
     uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_top8(
     uint dst_index, uint32_t eps, uint32_t scale, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, eps, scale);
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add_rsqrt.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add_rsqrt_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt, APPROXIMATE>(sfpu::init_add_rsqrt<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt>(sfpu::init_add_rsqrt<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, int ITERATIONS = 8>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add_rsqrt.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_add_rsqrt_init() {
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_add_rsqrt(
     uint dst_index, uint32_t param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_add_rsqrt<APPROXIMATE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>,
         dst_index,
         vector_mode,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -13,7 +13,7 @@ namespace ckernel {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
     // Don't need the second addrmod so set type to unused
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         sfpu::deepseek_moe_gate_topk_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -19,21 +19,21 @@ inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sort_top4_groups(
     uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_top8(
     uint dst_index, uint32_t eps, uint32_t scale, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, eps, scale);
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -422,7 +422,7 @@ void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
  */
 template <bool SDPA_EXP_APPROX_MODE, int vector_mode = (int)VectorMode::C, bool final_norm = false>
 void fused_max_sub_exp_add_tile(uint32_t idst, int scale_bf16) {
-    _llk_math_eltwise_unary_sfpu_params_<false /*APPROXIMATE*/>(
+    _llk_math_eltwise_unary_sfpu_params_(
         calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE, final_norm>, idst, vector_mode, scale_bf16);
 }
 #endif

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -320,7 +320,7 @@ def test_conv2d_auto_sliced_vae_performance():
     # Extract the device kernel duration result
     device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
 
-    expected_duration_ns = 3082972  # Measured: 3.08ms for Conv2D VAE auto sliced
+    expected_duration_ns = 3089350  # Measured: 3.09ms for Conv2D VAE auto sliced
 
     # Log the performance result
     print(

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -320,7 +320,7 @@ def test_conv2d_auto_sliced_vae_performance():
     # Extract the device kernel duration result
     device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
 
-    expected_duration_ns = 3089350  # Measured: 3.09ms for Conv2D VAE auto sliced
+    expected_duration_ns = 3082972  # Measured: 3.08ms for Conv2D VAE auto sliced
 
     # Log the performance result
     print(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
@@ -9,7 +9,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_add_int_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_add_int_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_binary_sfpu_add_int(
         "Unsupported data format for add_int. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_add_int_<APPROXIMATE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -11,12 +11,12 @@
 namespace ckernel {
 
 inline void llk_math_eltwise_binary_sfpu_add_top_row_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row, true>(sfpu::init_add_top_row);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row>(sfpu::init_add_top_row);
 }
 
 template <DataFormat format>
 inline void llk_math_eltwise_binary_sfpu_add_top_row(uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
-    _llk_math_eltwise_binary_sfpu_params_<true>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_add_top_row<format>,
         dst_index_in_0,
         dst_index_in_1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_atan2.h
@@ -12,15 +12,19 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_atan2_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(
         sfpu::calculate_sfpu_atan2_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void llk_math_eltwise_binary_sfpu_atan2(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sfpu_atan2<APPROXIMATE, ITERATIONS, is_fp32_dest_acc_en>, dst_index0, dst_index1, odst, vector_mode);
+    _llk_math_eltwise_binary_sfpu_params_(
+        sfpu::calculate_sfpu_atan2<APPROXIMATE, ITERATIONS, is_fp32_dest_acc_en>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lt>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
         dst_index1,
@@ -28,13 +28,13 @@ inline void llk_math_eltwise_binary_sfpu_lt_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::gt>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
         dst_index1,
@@ -44,13 +44,13 @@ inline void llk_math_eltwise_binary_sfpu_gt_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::ge>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::ge>,
         dst_index0,
         dst_index1,
@@ -60,13 +60,13 @@ inline void llk_math_eltwise_binary_sfpu_ge_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::le>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::le>,
         dst_index0,
         dst_index1,
@@ -108,13 +108,13 @@ inline void llk_math_eltwise_binary_sfpu_gt_uint16(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_eq_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::eq, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::eq>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_eq_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::eq>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::lt>();
 }
@@ -26,7 +25,6 @@ inline void llk_math_eltwise_binary_sfpu_lt_int32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::gt>();
 }
@@ -42,7 +40,6 @@ inline void llk_math_eltwise_binary_sfpu_gt_int32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::ge>();
 }
@@ -58,7 +55,6 @@ inline void llk_math_eltwise_binary_sfpu_ge_int32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::le>();
 }
@@ -74,15 +70,12 @@ inline void llk_math_eltwise_binary_sfpu_le_int32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_lt_uint16_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_lt_uint16_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::lt>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_uint16(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_uint16<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
         dst_index1,
@@ -90,15 +83,12 @@ inline void llk_math_eltwise_binary_sfpu_lt_uint16(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_gt_uint16_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_gt_uint16_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::gt>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_uint16(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_uint16<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
         dst_index1,
@@ -106,7 +96,6 @@ inline void llk_math_eltwise_binary_sfpu_gt_uint16(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_eq_fp32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::eq>();
 }
@@ -122,15 +111,12 @@ inline void llk_math_eltwise_binary_sfpu_eq_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::ne, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::ne>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ne_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ne>,
         dst_index0,
         dst_index1,
@@ -138,15 +124,12 @@ inline void llk_math_eltwise_binary_sfpu_ne_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::lt>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
         dst_index1,
@@ -154,15 +137,12 @@ inline void llk_math_eltwise_binary_sfpu_lt_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::gt>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
         dst_index1,
@@ -170,15 +150,12 @@ inline void llk_math_eltwise_binary_sfpu_gt_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_le_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_le_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::le>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::le>,
         dst_index0,
         dst_index1,
@@ -186,15 +163,12 @@ inline void llk_math_eltwise_binary_sfpu_le_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::ge>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ge>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_fmod.h
@@ -12,25 +12,25 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_fmod_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::fmod_int32, APPROXIMATE>(sfpu::fmod_int32_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::fmod_int32>(sfpu::fmod_int32_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_fmod_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_fmod_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_fmod_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(sfpu::fmod_binary_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(sfpu::fmod_binary_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binary_fmod(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_fmod<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_pow.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_pow_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(ckernel::sfpu::sfpu_binary_pow_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(ckernel::sfpu::sfpu_binary_pow_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binary_pow(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_pow<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_remainder.h
@@ -12,26 +12,25 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_remainder_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::remainder_int32, APPROXIMATE>(sfpu::remainder_int32_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::remainder_int32>(sfpu::remainder_int32_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_remainder_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_remainder_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_binary_remainder_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
-        sfpu::remainder_binary_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(sfpu::remainder_binary_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_binary_remainder(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_remainder<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
@@ -12,14 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP>
 inline void llk_math_eltwise_binary_sfpu_binop_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
-        ckernel::sfpu::sfpu_binary_init<APPROXIMATE, BINOP>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(ckernel::sfpu::sfpu_binary_init<APPROXIMATE, BINOP>);
 }
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,
@@ -30,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_binop(
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop_mul(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_mul<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,
@@ -41,7 +40,7 @@ inline void llk_math_eltwise_binary_sfpu_binop_mul(
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop_div(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_div<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_bitwise_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_bitwise_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, sfpu::BinaryBitwiseOp BITWISE_OP, DataFormat DATA_FORMAT>
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_binary_sfpu_bitwise(
         "Unsupported data format for bitwise operation. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         DATA_FORMAT == DataFormat::UInt16 ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_bitwise<APPROXIMATE, BITWISE_OP, INSTRUCTION_MODE>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -15,7 +15,7 @@ template <DataFormat DATA_FORMAT>
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
     uint32_t dst_index_in, uint32_t dst_index_out, int vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<DATA_FORMAT, APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
 }
 
@@ -24,13 +24,13 @@ void llk_math_eltwise_binary_sfpu_copy_dest_values(
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
     uint32_t dst_index_in, uint32_t dst_index_out, int vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
 }
 
 inline void llk_math_eltwise_binary_sfpu_copy_dest_values_init() {
     constexpr bool APPROXIMATE = 0;
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(sfpu::copy_dest_value_init);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(sfpu::copy_dest_value_init);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32, APPROXIMATE>(sfpu::div_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32>(sfpu::div_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32_floor.h
@@ -12,25 +12,25 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_floor_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32_floor, APPROXIMATE>(sfpu::div_floor_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32_floor>(sfpu::div_floor_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_floor(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32_floor<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_trunc_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32_trunc, APPROXIMATE>(sfpu::div_trunc_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32_trunc>(sfpu::div_trunc_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_trunc(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32_trunc<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -12,15 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::gcd, APPROXIMATE>(
-        sfpu::calculate_sfpu_gcd_init);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::gcd>(sfpu::calculate_sfpu_gcd_init);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, odst, vector_mode);
+    _llk_math_eltwise_binary_sfpu_params_(sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::gcd>(sfpu::calculate_sfpu_gcd_init);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
@@ -9,15 +9,15 @@
 
 namespace ckernel {
 
-template <SfpuType sfpu_op, bool APPROXIMATE>
+template <SfpuType sfpu_op>
 inline void llk_math_eltwise_binary_sfpu_init() {
     _llk_math_eltwise_binary_sfpu_init_<sfpu_op>();
 }
 
-template <SfpuType sfpu_op, bool APPROXIMATE, class F, class ... ARGS>
-inline void llk_math_eltwise_binary_sfpu_init(F&& init_func, ARGS&& ... args) {
+template <SfpuType sfpu_op, class F, class... ARGS>
+inline void llk_math_eltwise_binary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_binary_sfpu_init_<sfpu_op>();
     init_func(static_cast<ARGS&&>(args)...);
 }
 
-}
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -12,15 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lcm, APPROXIMATE>(
-        sfpu::calculate_sfpu_lcm_init);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lcm>(sfpu::calculate_sfpu_lcm_init);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, odst, vector_mode);
+    _llk_math_eltwise_binary_sfpu_params_(sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::lcm>(sfpu::calculate_sfpu_lcm_init);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
@@ -18,7 +18,6 @@ inline void llk_math_eltwise_binary_sfpu_logsigmoid(
         sfpu::calculate_logsigmoid<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_logsigmoid_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
@@ -14,13 +14,13 @@ namespace ckernel {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_logsigmoid(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_logsigmoid<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_logsigmoid_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
@@ -11,7 +11,6 @@
 namespace ckernel {
 
 // Binary maximum
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::max>(sfpu::binary_max_min_init<true>);
 }
@@ -23,7 +22,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_max(
         ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::max_int32>(sfpu::binary_max_min_int32_init<true, false>);
 }
@@ -35,7 +33,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
         ckernel::sfpu::calculate_binary_max_min_int32<true, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_uint32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::max_uint32>(sfpu::binary_max_min_int32_init<true, true>);
 }
@@ -48,7 +45,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_uint32(
 }
 
 // Binary minimum
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::min>(sfpu::binary_max_min_init<false>);
 }
@@ -60,7 +56,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_min(
         ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::min_int32>(sfpu::binary_max_min_int32_init<false, false>);
 }
@@ -72,7 +67,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
         ckernel::sfpu::calculate_binary_max_min_int32<false, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_uint32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::min_uint32>(sfpu::binary_max_min_int32_init<false, true>);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
@@ -13,74 +13,74 @@ namespace ckernel {
 // Binary maximum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::max, APPROXIMATE>(sfpu::binary_max_min_init<true>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max>(sfpu::binary_max_min_init<true>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::max_int32, APPROXIMATE>(sfpu::binary_max_min_int32_init<true, false>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max_int32>(sfpu::binary_max_min_int32_init<true, false>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<true, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_uint32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::max_uint32, APPROXIMATE>(sfpu::binary_max_min_int32_init<true, true>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max_uint32>(sfpu::binary_max_min_int32_init<true, true>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_uint32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<true, true>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 // Binary minimum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::min, APPROXIMATE>(sfpu::binary_max_min_init<false>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::min>(sfpu::binary_max_min_init<false>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::min_int32, APPROXIMATE>(sfpu::binary_max_min_int32_init<false, false>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::min_int32>(sfpu::binary_max_min_int32_init<false, false>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<false, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_uint32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::min_uint32, APPROXIMATE>(sfpu::binary_max_min_int32_init<false, true>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::min_uint32>(sfpu::binary_max_min_int32_init<false, true>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_uint32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<false, true>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, ckernel::DataLayout layout = ckernel::DataLayout::TILE>
 inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::max_pool_with_indices, APPROXIMATE>(
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max_pool_with_indices>(
         sfpu::init_max_pool_with_indices<APPROXIMATE, layout>);
 }
 
@@ -24,7 +24,7 @@ template <
     ckernel::DataLayout layout = ckernel::DataLayout::TILE,
     bool accumulate = false>
 inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(uint dst_index, uint32_t idx_index, uint32_t chunk) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::
             calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout, accumulate>,
         dst_index,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
@@ -16,9 +16,9 @@ inline void llk_math_eltwise_binary_sfpu_mul_int_init() {
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for mul_int. Supported data formats are: Int32, UInt32, UInt16");
     if constexpr (DATA_FORMAT == DataFormat::UInt16) {
-        llk_math_eltwise_binary_sfpu_init<SfpuType::mul_uint16, APPROXIMATE>(sfpu::_init_mul_int_<APPROXIMATE>);
+        llk_math_eltwise_binary_sfpu_init<SfpuType::mul_uint16>(sfpu::_init_mul_int_<APPROXIMATE>);
     } else {
-        llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32, APPROXIMATE>(sfpu::mul_int32_init<APPROXIMATE>);
+        llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32>(sfpu::mul_int32_init<APPROXIMATE>);
     }
 }
 
@@ -29,11 +29,10 @@ inline void llk_math_eltwise_binary_sfpu_mul_int(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for mul_int. Supported data formats are: Int32, UInt32, UInt16");
     if constexpr (DATA_FORMAT == DataFormat::UInt16) {
-        _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_binary_sfpu_params_(
             sfpu::_mul_int_<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
     } else {
-        _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-            sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
+        _llk_math_eltwise_binary_sfpu_params_(sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -12,14 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32, APPROXIMATE>(sfpu::mul_int32_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32>(sfpu::mul_int32_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
+    _llk_math_eltwise_binary_sfpu_params_(sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
@@ -12,43 +12,37 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_quant_int32_init(const uint zero_point) {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::quant_int32, APPROXIMATE>(
-        sfpu::quant_init<APPROXIMATE>,
-        zero_point);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::quant_int32>(sfpu::quant_init<APPROXIMATE>, zero_point);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_quant_int32(
     uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_quant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_requant_int32_init(const uint zero_point) {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::requant_int32, APPROXIMATE>(
-        sfpu::quant_init<APPROXIMATE>,
-        zero_point);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::requant_int32>(sfpu::quant_init<APPROXIMATE>, zero_point);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_requant_int32(
     uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_requant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_dequant_int32_init(const uint zero_point) {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::dequant_int32, APPROXIMATE>(
-        sfpu::quant_init<APPROXIMATE>,
-        zero_point);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::dequant_int32>(sfpu::quant_init<APPROXIMATE>, zero_point);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_dequant_int32(
     uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_dequant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_rsub_int_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_rsub_int_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_binary_sfpu_rsub_int(
         "Unsupported data format for rsub_int. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_rsub_int<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_shift_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_shift_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_binary_sfpu_left_shift(
         "Unsupported data format for left shift. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_left_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_binary_sfpu_right_shift(
         "Unsupported data format for right shift. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_right_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
@@ -55,7 +55,7 @@ inline void llk_math_eltwise_binary_sfpu_logical_right_shift(
         "Unsupported data format for logical right shift. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_calculate_logical_right_shift_<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_sub_int_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_binary_sfpu_sub_int(
         "Unsupported data format for sub_int. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_sub_int_<APPROXIMATE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
@@ -9,7 +9,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_sub_int_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
@@ -11,14 +11,14 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_xlogy_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_sfpu_binary_init_<APPROXIMATE, BinaryOp::XLOGY>);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_xlogy(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_calculate_sfpu_binary_<APPROXIMATE, BinaryOp::XLOGY, ITERATIONS>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -15,8 +15,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_lgamma_stirling_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::lgamma, APPROXIMATE>(
-        sfpu::lgamma_stirling_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::lgamma>(sfpu::lgamma_stirling_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -24,7 +24,7 @@ inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, int 
         ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_ternary_sfpu_lgamma_adjusted_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::lgamma>();
 }
@@ -36,7 +36,7 @@ inline void llk_math_eltwise_ternary_sfpu_lgamma_adjusted(
     uint32_t dst_index2,
     uint32_t dst_index3,
     int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         ckernel::sfpu::calculate_lgamma_adjusted<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -47,14 +47,13 @@ inline void llk_math_eltwise_ternary_sfpu_lgamma_adjusted(
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_lgamma_stirling_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lgamma, APPROXIMATE>(
-        sfpu::lgamma_stirling_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lgamma>(sfpu::lgamma_stirling_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_lgamma_stirling(
     uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_lgamma_stirling_fp32<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -21,7 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_lgamma_stirling_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
@@ -12,8 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_polygamma_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::polygamma, APPROXIMATE>(
-        sfpu::polygamma_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::polygamma>(sfpu::polygamma_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_polygamma_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_polygamma(
     uint32_t dst_index, uint32_t n_packed, uint32_t scale_packed, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_polygamma<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcdiv.h
@@ -12,7 +12,7 @@ namespace ckernel {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_addcdiv(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_addcdiv<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcmul.h
@@ -12,7 +12,7 @@ namespace ckernel {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_addcmul(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_addcmul<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,
         dst_index1,
@@ -22,7 +22,6 @@ inline void llk_math_eltwise_ternary_sfpu_addcmul(
         value);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_addcmul_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::addcmul>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
@@ -12,7 +12,7 @@ namespace ckernel {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_lerp(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_lerp<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,
         dst_index1,
@@ -21,7 +21,6 @@ inline void llk_math_eltwise_ternary_sfpu_lerp(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_lerp_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::lerp>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -12,7 +12,7 @@ namespace ckernel {
 template <bool APPROXIMATE, DataFormat data_format>
 inline void llk_math_eltwise_ternary_sfpu_where(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, data_format, 8>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::abs, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::abs>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::abs>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -17,14 +17,12 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -40,7 +40,6 @@ inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode
 }
 
 // celu
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_celu_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::celu>();
 }
@@ -59,7 +58,6 @@ inline void llk_math_eltwise_unary_sfpu_celu(
 }
 
 // softshrink
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink>();
 }
@@ -71,7 +69,6 @@ inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, 
 }
 
 // hardshrink
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -16,8 +16,7 @@ namespace ckernel {
 // Hardsigmoid
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardsigmoid, APPROXIMATE>(
-        ckernel::sfpu::_init_hardsigmoid_<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardsigmoid>(ckernel::sfpu::_init_hardsigmoid_<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
@@ -31,7 +30,7 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_m
 // softsign
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_softsign_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::softsign, APPROXIMATE>(ckernel::sfpu::init_softsign<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::softsign>(ckernel::sfpu::init_softsign<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
@@ -43,7 +42,7 @@ inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode
 // celu
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_celu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::celu, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::celu>();
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
@@ -62,7 +61,7 @@ inline void llk_math_eltwise_unary_sfpu_celu(
 // softshrink
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
@@ -74,7 +73,7 @@ inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, 
 // hardshrink
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
 
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         static_cast<void (*)()>(ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
         dst_index,
         vector_mode);
@@ -36,7 +36,7 @@ inline void llk_math_eltwise_unary_sfpu_softsign_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
@@ -49,7 +49,7 @@ inline void llk_math_eltwise_unary_sfpu_celu_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_celu(
     uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         [](uint32_t alpha, uint32_t alpha_recip) {
             ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
         },
@@ -67,7 +67,7 @@ inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }
 
@@ -79,7 +79,7 @@ inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::add1, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::add1>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::add1>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_add1_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::alt_complex_rotate90, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::alt_complex_rotate90>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::alt_complex_rotate90>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -13,7 +13,7 @@ namespace ckernel {
 template <bool APPROXIMATE, int binop_mode>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
 }
 
@@ -25,14 +25,14 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -17,7 +17,6 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
         sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::cast_fp32_to_fp16a>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::cast_fp32_to_fp16a, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::cast_fp32_to_fp16a>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cbrt_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::cbrt, APPROXIMATE>(sfpu::cube_root_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::cbrt>(sfpu::cube_root_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_cbrt_init() {
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -18,14 +18,14 @@ inline void llk_math_eltwise_unary_sfpu_clamp_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp_int32(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_clamp_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::clamp, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::clamp>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_clamp_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::clamp>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
 template <bool APPROXIMATE /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_cumsum(
     uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
-    _llk_math_eltwise_unary_sfpu_params_<false>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
         dst_index,
         VectorMode::RC_custom,  // Can only work in RC_custom mode

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::cumsum, false>(
+    llk_math_eltwise_unary_sfpu_init<SfpuType::cumsum>(
         sfpu::cumsum_init<false>);  // There is only non APPROXIMATE implementation
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_exp2_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2>(sfpu::exp2_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::expm1>(sfpu::expm1_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
     uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, vector_mode, param0);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -9,12 +9,12 @@
 
 namespace ckernel {
 
-template <SfpuType sfpu_op, bool APPROXIMATE>
+template <SfpuType sfpu_op>
 inline void llk_math_eltwise_unary_sfpu_init() {
     _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
 }
 
-template <SfpuType sfpu_op, bool APPROXIMATE, class F, class... ARGS>
+template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
     init_func(static_cast<ARGS&&>(args)...);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
 }
 
@@ -31,7 +31,7 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base(
     uint dst_index, uint base_scale, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -12,8 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log, APPROXIMATE>(
-        sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log>(sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
@@ -24,7 +23,7 @@ inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (i
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base, APPROXIMATE>(
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base>(
         sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -8,32 +8,32 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 
 // For ops that require only the init function
-#define SFPU_UNARY_KERNEL_INIT(OP, APPROXIMATE) llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>();
+#define SFPU_UNARY_KERNEL_INIT(OP, APPROXIMATE) llk_math_eltwise_unary_sfpu_init<SfpuType::OP>();
 
 // For ops that need a custom init callback
 #define SFPU_INIT_KERNEL_CALL(OP, INIT_CB, APPROXIMATE) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE>)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE>)
 
 // For ops that need a custom init callback but takes one extra init-parameter
 #define SFPU_ONE_PARAM_KERNEL_INIT(OP, INIT_CB, APPROXIMATE, PARAM0) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE>, PARAM0);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE>, PARAM0);
 
 // For ops that need a custom init callback with two template parameters (e.g., APPROXIMATE and legacy_compat or
 // fast_approx)
 #define SFPU_TWO_TEMPLATE_PARAM_INIT(OP, INIT_CB, APPROXIMATE, PARAM0) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE, PARAM0>)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE, PARAM0>)
 
 // For ops that need a custom init callback with three template parameters (e.g., APPROXIMATE, DST_ACCUM and legacy_compat)
 #define SFPU_THREE_TEMPLATE_PARAM_INIT(OP, INIT_CB, APPROXIMATE, PARAM0, PARAM1) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE, PARAM0, PARAM1>)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE, PARAM0, PARAM1>)
 
 // For ops that need a custom init callback and take two extra init-parameters
 #define SFPU_TWO_PARAM_KERNEL_INIT(OP, INIT_CB, APPROXIMATE, PARAM0, PARAM1) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE>, PARAM0, PARAM1)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE>, PARAM0, PARAM1)
 
 // For ops where init takes multiple template parameters (e.g., approximate, scale).
 #define SFPU_TEMPLATE_INIT_KERNEL(OP, INIT_CB, APPROX, SCALE, CLAMP_NEGATIVE) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROX>(INIT_CB<APPROX, SCALE, CLAMP_NEGATIVE>)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROX, SCALE, CLAMP_NEGATIVE>)
 
 // For the int32 comparison variants
 #define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0)      \

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -36,24 +36,29 @@
     llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROX>(INIT_CB<APPROX, SCALE, CLAMP_NEGATIVE>)
 
 // For the int32 comparison variants
-#define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                 \
-        ckernel::sfpu::calculate_comp_unary_int<APPROXIMATE, SfpuType::OP, ITERATIONS>, DST_IDX, (int)VectorMode::MODE, PARAM0);
+#define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0)      \
+    _llk_math_eltwise_unary_sfpu_params_(                                               \
+        ckernel::sfpu::calculate_comp_unary_int<APPROXIMATE, SfpuType::OP, ITERATIONS>, \
+        DST_IDX,                                                                        \
+        (int)VectorMode::MODE,                                                          \
+        PARAM0);
 
 // For the int32 comparison variants with underscore in callback
 #define SFPU_COMP_INT32_KERNEL_UNDERSCORE(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                            \
-        ckernel::sfpu::_calculate_comp_unary_int_<APPROXIMATE, SfpuType::OP, ITERATIONS>, DST_IDX, (int)VectorMode::MODE, PARAM0);
+    _llk_math_eltwise_unary_sfpu_params_(                                                     \
+        ckernel::sfpu::_calculate_comp_unary_int_<APPROXIMATE, SfpuType::OP, ITERATIONS>,     \
+        DST_IDX,                                                                              \
+        (int)VectorMode::MODE,                                                                \
+        PARAM0);
 
 // For ops where the compute functor is not "calculate_<OP>", but an arbitrary function name (e.g., relu_min, relu_max,
 // etc.),and which take one extra runtime uint parameter
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                         \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For unary ops with one extra uint parameter AND an additional template param (ITERATIONS)
 #define SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(FN, MODE, APPROXIMATE, EXTRA_PARAM, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
+    _llk_math_eltwise_unary_sfpu_params_(                                                            \
         ckernel::sfpu::FN<APPROXIMATE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For unary ops with one extra uint parameter AND additional template params (DATA_FORMAT, ITERATIONS)
@@ -64,22 +69,21 @@
         "Unsupported data format. Supported: Int32, UInt32, UInt16");                                               \
     constexpr InstrModLoadStore _INSTRUCTION_MODE =                                                                 \
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;                   \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                           \
         ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For ops with exactly two extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_TWO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
 
 // For ops with exactly two extra uint parameters AND DST_ACCUM_MODE as template param
 #define SFPU_UNARY_TWO_PARAM_KERNEL_WITH_DST_ACCUM(FN, MODE, APPROXIMATE, DST_ACCUM, DST_IDX, PARAM0, PARAM1) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                        \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                     \
         ckernel::sfpu::FN<APPROXIMATE, DST_ACCUM>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
 
 // For ops with exactly three extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_THREE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1, PARAM2) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                           \
+    _llk_math_eltwise_unary_sfpu_params_(                                                        \
         ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1, PARAM2)
 
 // For ops with exactly three extra uint parameters AND DST_ACCUM_MODE as template param
@@ -90,26 +94,26 @@
 
 // For ops without extra uint parameter
 #define SFPU_UNARY_NO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE)
 
 // For ops without extra uint parameter with ITERATIONS
 #define SFPU_UNARY_NO_PARAM_KERNEL_FN_ITERATIONS(FN, MODE, APPROXIMATE, DST_IDX, ITERATIONS) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
 
 // For ops without extra uint parameters with type and iteration
 #define SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(FN, TYPE, MODE, APPROXIMATE, DST_IDX, ITERATIONS) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                        \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                     \
         ckernel::sfpu::FN<SfpuType::TYPE, APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
 
 // For ops where compute takes extra args
 #define SFPU_UNARY_PARAMS_KERNEL_EXTRA_ARGS(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                      \
+    _llk_math_eltwise_unary_sfpu_params_(                                                   \
         ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1);
 
 // For ops with multiple template parameters and one runtime parameter (e.g., scale)
 #define SFPU_TEMPLATE_PARAMS_KERNEL_FN(                                                                      \
     FN, APPROXIMATE, IS_FP32_DEST_ACC_EN, SCALE_EN, CLAMP_NEGATIVE, ITERATIONS, DST_IDX, VECTOR_MODE, SCALE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                       \
+    _llk_math_eltwise_unary_sfpu_params_(                                                       \
         ckernel::sfpu::FN<APPROXIMATE, IS_FP32_DEST_ACC_EN, SCALE_EN, ITERATIONS, CLAMP_NEGATIVE>,           \
         DST_IDX,                                                                                             \
         VECTOR_MODE,                                                                                         \
@@ -117,52 +121,48 @@
 
 // For kernels with one template parameter and one extra runtime argument.
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                         \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN_FLOAT(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                               \
+    _llk_math_eltwise_unary_sfpu_params_(                                            \
         ckernel::sfpu::FN<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN_INT(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                             \
+    _llk_math_eltwise_unary_sfpu_params_(                                          \
         ckernel::sfpu::FN<sfpi::vInt, APPROXIMATE, 8, uint32_t>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For kernels whose functor takes one template parameter (e.g., <APPROXIMATE>)
 #define SFPU_ONE_PARAM_KERNEL(FN, APPROXIMATE, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, VECTOR_MODE)
 
 // For kernels whose functor takes two template parameters (e.g., <APPROXIMATE, ITER/USE_FP32>)
 #define SFPU_TWO_PARAM_KERNEL(FN, APPROXIMATE, T2, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE)
 
 // For kernels whose functor takes two template parameters (e.g., <APPROXIMATE, ITER>) and one extra runtime param.
 #define SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(FN, APPROXIMATE, T2, DST_IDX, VECTOR_MODE, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE, PARAM0)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, ITER, USE_FP32>)
 #define SFPU_THREE_PARAM_KERNEL_ITER_FIRST(FN, APPROXIMATE, ITER, FP32, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                            \
-        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, ITER, FP32>, DST_IDX, VECTOR_MODE)
 
 // For functors with <APPROXIMATE, USE_FP32, ITER>
 #define SFPU_THREE_PARAM_KERNEL_FP32_FIRST(FN, APPROXIMATE, FP32, ITER, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                               \
-        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, FP32, ITER>, DST_IDX, VECTOR_MODE)
 
 // For unary ops with four template parameters (APPROXIMATE, ITER, fp32_dest_acc_en, legacy_compat)
 #define SFPU_FOUR_PARAM_KERNEL_ITER_FIRST_FN(FN, APPROXIMATE, ITER, FP32, LEGACY_COMPAT, DST_IDX, MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                  \
+    _llk_math_eltwise_unary_sfpu_params_(                                                               \
         ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
 
 // For unary ops with four template parameters (APPROXIMATE, fp32_dest_acc_en, FP32_FIRST, legacy_compat)
 #define SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN(FN, APPROXIMATE, FP32, ITER, LEGACY_COMPAT, DST_IDX, MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                  \
-        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER, LEGACY_COMPAT>, DST_IDX, MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, FP32, ITER, LEGACY_COMPAT>, DST_IDX, MODE)
 
 // For unary ops with five template parameters (APPROXIMATE, ITER, fp32_dest_acc_en, FAST_APPROX, legacy_compat)
 #define SFPU_FIVE_PARAM_KERNEL_ITER_FIRST_FN(FN, APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT, DST_IDX, MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                               \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                            \
         ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, DATA_FORMAT, ITERATIONS>).
@@ -181,20 +181,20 @@
         : (DATA_FORMAT == DataFormat::UInt16)                                     ? InstrModLoadStore::LO16        \
         : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32       \
                                                                                   : InstrModLoadStore::DEFAULT;    \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                             \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                          \
         ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE);
 
 // For the compare with zero ops (eqz, nez, ltz, gtz, lez, gez)
 #define SFPU_ZERO_KERNEL(OP, MODE, APPROXIMATE, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(   \
+    _llk_math_eltwise_unary_sfpu_params_(                \
         ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::OP>, DST_IDX, (int)VectorMode::MODE, 8);
 
 // Generalized macro for compare-with-zero ops for any type (e.g., int, uint16)
 #define SFPU_ZERO_KERNEL_TYPE(TYPE, OP, MODE, APPROXIMATE, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(              \
+    _llk_math_eltwise_unary_sfpu_params_(                           \
         ckernel::sfpu::TYPE<APPROXIMATE, SfpuType::OP>, DST_IDX, (int)VectorMode::MODE);
 
 // For log1p op that needs three template parameters
 #define SFPU_UNARY_NO_PARAM_KERNEL_LOG1P_FN(FN, MODE, APPROXIMATE, FAST_APPROX, FP32, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                         \
+    _llk_math_eltwise_unary_sfpu_params_(                                                      \
         ckernel::sfpu::FN<APPROXIMATE, FAST_APPROX, FP32>, DST_IDX, (int)VectorMode::MODE)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -89,7 +89,7 @@
 // For ops with exactly three extra uint parameters AND DST_ACCUM_MODE as template param
 #define SFPU_UNARY_THREE_PARAM_KERNEL_WITH_DST_ACCUM(                  \
     FN, MODE, APPROXIMATE, DST_ACCUM, DST_IDX, PARAM0, PARAM1, PARAM2) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                 \
+    _llk_math_eltwise_unary_sfpu_params_(                              \
         ckernel::sfpu::FN<APPROXIMATE, DST_ACCUM>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1, PARAM2)
 
 // For ops without extra uint parameter

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::mask>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::mask, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::mask>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -17,19 +17,16 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask(
     uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
     if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
+        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
     } else if (data_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
+        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -13,7 +13,7 @@ namespace ckernel {
 // Unary maximum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max, APPROXIMATE>(sfpu::unary_max_min_init<true>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max>(sfpu::unary_max_min_init<true>);
 }
 
 template <bool APPROXIMATE>
@@ -24,8 +24,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_int32, APPROXIMATE>(
-        sfpu::unary_max_min_int32_init<true, false>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_int32>(sfpu::unary_max_min_int32_init<true, false>);
 }
 
 template <bool APPROXIMATE>
@@ -37,8 +36,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_uint32, APPROXIMATE>(
-        sfpu::unary_max_min_int32_init<true, true>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_uint32>(sfpu::unary_max_min_int32_init<true, true>);
 }
 
 template <bool APPROXIMATE>
@@ -51,7 +49,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
 // Unary minimum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min, APPROXIMATE>(sfpu::unary_max_min_init<false>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min>(sfpu::unary_max_min_init<false>);
 }
 
 template <bool APPROXIMATE>
@@ -62,8 +60,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, i
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_int32, APPROXIMATE>(
-        sfpu::unary_max_min_int32_init<false, false>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_int32>(sfpu::unary_max_min_int32_init<false, false>);
 }
 
 template <bool APPROXIMATE>
@@ -75,8 +72,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_uint32, APPROXIMATE>(
-        sfpu::unary_max_min_int32_init<false, true>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_uint32>(sfpu::unary_max_min_int32_init<false, true>);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -31,7 +31,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -44,7 +44,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -56,7 +56,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -69,7 +69,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -82,7 +82,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -11,7 +11,6 @@
 namespace ckernel {
 
 // Unary maximum
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max>(sfpu::unary_max_min_init<true>);
 }
@@ -22,7 +21,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_int32>(sfpu::unary_max_min_int32_init<true, false>);
 }
@@ -34,7 +32,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
         ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_uint32>(sfpu::unary_max_min_int32_init<true, true>);
 }
@@ -47,7 +44,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
 }
 
 // Unary minimum
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min>(sfpu::unary_max_min_init<false>);
 }
@@ -58,7 +54,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, i
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_int32>(sfpu::unary_max_min_int32_init<false, false>);
 }
@@ -70,7 +65,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
         ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_uint32>(sfpu::unary_max_min_int32_init<false, true>);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::power, APPROXIMATE>(ckernel::sfpu::sfpu_unary_pow_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::power>(ckernel::sfpu::sfpu_unary_pow_init);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
@@ -24,7 +24,7 @@ inline void llk_math_eltwise_unary_sfpu_power(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::power, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::power>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_power_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_power(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
 }
 
@@ -30,7 +30,7 @@ inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, vector_mode, exponent);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::power>(ckernel::sfpu::sfpu_unary_pow_init);
 }
@@ -22,7 +21,6 @@ inline void llk_math_eltwise_unary_sfpu_power(
         ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::power>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_rdiv_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::rdiv, APPROXIMATE>(sfpu::rdiv_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::rdiv>(sfpu::rdiv_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_rdiv_init() {
 template <bool APPROXIMATE, bool fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rdiv(
     uint32_t dst_index, uint32_t value, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_rdiv<APPROXIMATE, fp32_dest_acc_en, rounding_mode, ITERATIONS>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_reduce_init() {
 template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce(
     uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, VectorMode vector_mode) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode, ct_dim, rt_dim);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -10,12 +10,12 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, PoolType pool_type, DataFormat format>
+template <PoolType pool_type, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::reduce>(sfpu::init_reduce<pool_type, format>);
 }
 
-template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce(
     uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, VectorMode vector_mode) {
     _llk_math_eltwise_unary_sfpu_params_(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, PoolType pool_type, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce, APPROXIMATE>(sfpu::init_reduce<pool_type, format>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce>(sfpu::init_reduce<pool_type, format>);
 }
 
 template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -20,7 +20,6 @@ namespace ckernel {
  * from different input positions are accumulated into their corresponding embedding rows.
  *
  */
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::reshuffle_rows>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -22,7 +22,7 @@ namespace ckernel {
  */
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::reshuffle_rows, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reshuffle_rows>();
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -47,8 +47,7 @@ inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
     uint dst_index, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
+    _llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_rpow_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::rpow, APPROXIMATE>(sfpu::sfpu_binary_pow_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::rpow>(sfpu::sfpu_binary_pow_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_rpow_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_rpow(uint dst_index, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode, base_val);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
         dst_index,
         vector_mode);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool legacy_compat>
 inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt, APPROXIMATE>(sfpu::rsqrt_init<APPROXIMATE, legacy_compat>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt>(sfpu::rsqrt_init<APPROXIMATE, legacy_compat>);
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32(uint dst_index, uint scalar, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_selu_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::selu>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_selu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::selu, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::selu>();
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_selu_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_selu(
     uint dst_index, uint scale, uint alpha, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_selu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid, APPROXIMATE>(sfpu::sigmoid_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid>(sfpu::sigmoid_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx>(sfpu::sigmoid_appx_init);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx, APPROXIMATE>(sfpu::sigmoid_appx_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx>(sfpu::sigmoid_appx_init);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_sign_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign(
     uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sign, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::sign>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sign>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_signbit_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_init);
 }
@@ -21,7 +20,6 @@ inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode 
         ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_int32_init);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
@@ -28,7 +28,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_signbit_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::signbit, APPROXIMATE>(ckernel::sfpu::signbit_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_init);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode 
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::signbit, APPROXIMATE>(ckernel::sfpu::signbit_int32_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_int32_init);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu>(sfpu::silu_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_silu_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::square, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::square>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_square_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::square>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>(sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh>(sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_derivative_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh_derivative_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh_derivative, APPROXIMATE>(sfpu::tanh_derivative_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh_derivative>(sfpu::tanh_derivative_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_threshold_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::threshold, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::threshold>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_threshold_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_threshold(
     uint dst_index, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         static_cast<void (*)(uint32_t, uint32_t)>(ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -9,7 +9,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_threshold_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::threshold>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -13,7 +13,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort, APPROXIMATE>(sfpu::topk_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort>(sfpu::topk_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -25,7 +25,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     int i_end_step,
     int i_start_step,
     int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
         vector_mode,
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
         dst_index,
         vector_mode,
@@ -56,7 +56,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int logk,
     int skip_second,
     int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -161,72 +161,59 @@ inline void llk_math_eltwise_unary_sfpu_typecast_init() {
     constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
 
     if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_fp32_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_fp32_to_fp16b<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::UInt16 && (out_format == DataFormat::UInt32 || out_format == DataFormat::Int32)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(
             ckernel::sfpu::init_typecast_uint16_to_uint32<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(
             ckernel::sfpu::init_typecast_uint32_to_uint16<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_int32_to_uint16<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_int32_to_uint16<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint32_to_fp32<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint32_to_fp32<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_int32_to_fp32<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_int32_to_fp32<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint16_to_fp32<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint16_to_fp32<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::UInt16 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint16_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint16_to_fp16b<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::Int32 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_int32_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_int32_to_fp16b<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::UInt32 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint32_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint32_to_fp16b<APPROXIMATE>);
     } else if constexpr (
         (in_format == DataFormat::Float32 || in_format == DataFormat::Float16_b || in_format == DataFormat::Bfp8_b ||
          in_format == DataFormat::Bfp4_b) &&
         out_format == DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_fp32_to_uint16<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_fp32_to_uint16<APPROXIMATE>);
     } else if constexpr (
         (in_format == DataFormat::Float32 || in_format == DataFormat::Float16_b || in_format == DataFormat::Bfp8_b ||
          in_format == DataFormat::Bfp4_b) &&
         out_format == DataFormat::UInt8) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_fp32_to_uint8<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_fp32_to_uint8<APPROXIMATE>);
     } else if constexpr (
         (in_format == DataFormat::Int32 || in_format == DataFormat::UInt32 || in_format == DataFormat::UInt16) &&
         out_format == DataFormat::UInt8) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint_to_uint8<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint_to_uint8<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::Float32) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint32_to_fp32<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint32_to_fp32<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::UInt8 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint32_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint32_to_fp16b<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(
             ckernel::sfpu::init_typecast_uint32_to_uint16<APPROXIMATE>);
     } else {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>();
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>();
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -16,76 +16,76 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
     constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
 
     if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float16_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by packer
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp8_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float16_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp8_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
         // Calls same kernel as UInt32 case
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
@@ -96,22 +96,22 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp8_b) {
         // no SFPU kernel needed, handled by packer
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp4_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp4_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
@@ -129,28 +129,28 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
         (in_format == DataFormat::Float32 || in_format == DataFormat::Float16_b || in_format == DataFormat::Bfp8_b ||
          in_format == DataFormat::Bfp4_b) &&
         out_format == DataFormat::UInt8) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint8<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (
         (in_format == DataFormat::Int32 || in_format == DataFormat::UInt32 || in_format == DataFormat::UInt16) &&
         out_format == DataFormat::UInt8) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint_to_uint8<APPROXIMATE, 8, (in_format == DataFormat::UInt16)>,
             dst_index,
             vector_mode);
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::Float32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (
         in_format == DataFormat::UInt8 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (
         in_format == DataFormat::UInt8 && (out_format == DataFormat::Int32 || out_format == DataFormat::UInt32)) {
         // No SFPU kernel needed.
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
@@ -9,7 +9,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_add_int_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_int.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_add_int_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_binary_sfpu_add_int(
         "Unsupported data format for add_int. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_add_int_<APPROXIMATE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -11,12 +11,12 @@
 namespace ckernel {
 
 inline void llk_math_eltwise_binary_sfpu_add_top_row_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row, true>(sfpu::init_add_top_row);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row>(sfpu::init_add_top_row);
 }
 
 template <DataFormat format>
 inline void llk_math_eltwise_binary_sfpu_add_top_row(uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
-    _llk_math_eltwise_binary_sfpu_params_<true>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_add_top_row<format>,
         dst_index_in_0,
         dst_index_in_1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_atan2.h
@@ -12,15 +12,19 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_atan2_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(
         sfpu::calculate_sfpu_atan2_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void llk_math_eltwise_binary_sfpu_atan2(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sfpu_atan2<APPROXIMATE, ITERATIONS, is_fp32_dest_acc_en>, dst_index0, dst_index1, odst, vector_mode);
+    _llk_math_eltwise_binary_sfpu_params_(
+        sfpu::calculate_sfpu_atan2<APPROXIMATE, ITERATIONS, is_fp32_dest_acc_en>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lt>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
         dst_index1,
@@ -28,13 +28,13 @@ inline void llk_math_eltwise_binary_sfpu_lt_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::gt>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
         dst_index1,
@@ -44,13 +44,13 @@ inline void llk_math_eltwise_binary_sfpu_gt_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::ge>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::ge>,
         dst_index0,
         dst_index1,
@@ -60,13 +60,13 @@ inline void llk_math_eltwise_binary_sfpu_ge_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::le>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::le>,
         dst_index0,
         dst_index1,
@@ -108,13 +108,13 @@ inline void llk_math_eltwise_binary_sfpu_gt_uint16(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_eq_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::eq, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::eq>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_eq_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::eq>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::lt>();
 }
@@ -26,7 +25,6 @@ inline void llk_math_eltwise_binary_sfpu_lt_int32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::gt>();
 }
@@ -42,7 +40,6 @@ inline void llk_math_eltwise_binary_sfpu_gt_int32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::ge>();
 }
@@ -58,7 +55,6 @@ inline void llk_math_eltwise_binary_sfpu_ge_int32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::le>();
 }
@@ -74,15 +70,12 @@ inline void llk_math_eltwise_binary_sfpu_le_int32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_lt_uint16_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_lt_uint16_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::lt>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_uint16(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_uint16<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
         dst_index1,
@@ -90,15 +83,12 @@ inline void llk_math_eltwise_binary_sfpu_lt_uint16(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_gt_uint16_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_gt_uint16_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::gt>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_uint16(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_uint16<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
         dst_index1,
@@ -106,7 +96,6 @@ inline void llk_math_eltwise_binary_sfpu_gt_uint16(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_eq_fp32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::eq>();
 }
@@ -122,15 +111,12 @@ inline void llk_math_eltwise_binary_sfpu_eq_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::ne, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::ne>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ne_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ne>,
         dst_index0,
         dst_index1,
@@ -138,15 +124,12 @@ inline void llk_math_eltwise_binary_sfpu_ne_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::lt>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lt_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
         dst_index1,
@@ -154,15 +137,12 @@ inline void llk_math_eltwise_binary_sfpu_lt_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::gt>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gt_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
         dst_index1,
@@ -170,15 +150,12 @@ inline void llk_math_eltwise_binary_sfpu_gt_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_le_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_le_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::le>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_le_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::le>,
         dst_index0,
         dst_index1,
@@ -186,15 +163,12 @@ inline void llk_math_eltwise_binary_sfpu_le_fp32(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
-}
+inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() { llk_math_eltwise_binary_sfpu_init<SfpuType::ge>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_ge_fp32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ge>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_fmod.h
@@ -12,25 +12,25 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_fmod_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::fmod_int32, APPROXIMATE>(sfpu::fmod_int32_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::fmod_int32>(sfpu::fmod_int32_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_fmod_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_fmod_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_fmod_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(sfpu::fmod_binary_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(sfpu::fmod_binary_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binary_fmod(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_fmod<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_pow.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_pow_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(ckernel::sfpu::sfpu_binary_pow_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(ckernel::sfpu::sfpu_binary_pow_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binary_pow(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_pow<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_remainder.h
@@ -12,26 +12,25 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_remainder_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::remainder_int32, APPROXIMATE>(sfpu::remainder_int32_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::remainder_int32>(sfpu::remainder_int32_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_remainder_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_remainder_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_binary_remainder_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
-        sfpu::remainder_binary_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(sfpu::remainder_binary_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_binary_remainder(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_remainder<APPROXIMATE, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binop.h
@@ -12,14 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP>
 inline void llk_math_eltwise_binary_sfpu_binop_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
-        ckernel::sfpu::sfpu_binary_init<APPROXIMATE, BINOP>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(ckernel::sfpu::sfpu_binary_init<APPROXIMATE, BINOP>);
 }
 
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,
@@ -30,7 +29,7 @@ inline void llk_math_eltwise_binary_sfpu_binop(
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop_mul(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_mul<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,
@@ -41,7 +40,7 @@ inline void llk_math_eltwise_binary_sfpu_binop_mul(
 template <bool APPROXIMATE, ckernel::BinaryOp BINOP, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sfpu_binop_div(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_sfpu_binary_div<APPROXIMATE, BINOP, 8, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_bitwise_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_bitwise.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_bitwise_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, sfpu::BinaryBitwiseOp BITWISE_OP, DataFormat DATA_FORMAT>
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_binary_sfpu_bitwise(
         "Unsupported data format for bitwise operation. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         DATA_FORMAT == DataFormat::UInt16 ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_sfpu_binary_bitwise<APPROXIMATE, BITWISE_OP, INSTRUCTION_MODE>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -15,7 +15,7 @@ template <DataFormat DATA_FORMAT>
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
     uint32_t dst_index_in, uint32_t dst_index_out, int vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<DATA_FORMAT, APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
 }
 
@@ -24,13 +24,13 @@ void llk_math_eltwise_binary_sfpu_copy_dest_values(
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
     uint32_t dst_index_in, uint32_t dst_index_out, int vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
 }
 
 inline void llk_math_eltwise_binary_sfpu_copy_dest_values_init() {
     constexpr bool APPROXIMATE = 0;
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(sfpu::copy_dest_value_init);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(sfpu::copy_dest_value_init);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32, APPROXIMATE>(sfpu::div_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32>(sfpu::div_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32_floor.h
@@ -12,25 +12,25 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_floor_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32_floor, APPROXIMATE>(sfpu::div_floor_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32_floor>(sfpu::div_floor_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_floor(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32_floor<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_trunc_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32_trunc, APPROXIMATE>(sfpu::div_trunc_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32_trunc>(sfpu::div_trunc_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_trunc(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_div_int32_trunc<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -12,15 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::gcd, APPROXIMATE>(
-        sfpu::calculate_sfpu_gcd_init);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::gcd>(sfpu::calculate_sfpu_gcd_init);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, odst, vector_mode);
+    _llk_math_eltwise_binary_sfpu_params_(sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_gcd_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::gcd>(sfpu::calculate_sfpu_gcd_init);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
@@ -9,15 +9,15 @@
 
 namespace ckernel {
 
-template <SfpuType sfpu_op, bool APPROXIMATE>
+template <SfpuType sfpu_op>
 inline void llk_math_eltwise_binary_sfpu_init() {
     _llk_math_eltwise_binary_sfpu_init_<sfpu_op>();
 }
 
-template <SfpuType sfpu_op, bool APPROXIMATE, class F, class ... ARGS>
-inline void llk_math_eltwise_binary_sfpu_init(F&& init_func, ARGS&& ... args) {
+template <SfpuType sfpu_op, class F, class... ARGS>
+inline void llk_math_eltwise_binary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_binary_sfpu_init_<sfpu_op>();
     init_func(static_cast<ARGS&&>(args)...);
 }
 
-}
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -12,15 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lcm, APPROXIMATE>(
-        sfpu::calculate_sfpu_lcm_init);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lcm>(sfpu::calculate_sfpu_lcm_init);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, odst, vector_mode);
+    _llk_math_eltwise_binary_sfpu_params_(sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_lcm_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::lcm>(sfpu::calculate_sfpu_lcm_init);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
@@ -18,7 +18,6 @@ inline void llk_math_eltwise_binary_sfpu_logsigmoid(
         sfpu::calculate_logsigmoid<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_logsigmoid_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_logsigmoid.h
@@ -14,13 +14,13 @@ namespace ckernel {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_logsigmoid(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_logsigmoid<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_logsigmoid_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
@@ -11,7 +11,6 @@
 namespace ckernel {
 
 // Binary maximum
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::max>(sfpu::binary_max_min_init<true>);
 }
@@ -23,7 +22,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_max(
         ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::max_int32>(sfpu::binary_max_min_int32_init<true, false>);
 }
@@ -35,7 +33,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
         ckernel::sfpu::calculate_binary_max_min_int32<true, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_uint32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::max_uint32>(sfpu::binary_max_min_int32_init<true, true>);
 }
@@ -48,7 +45,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_uint32(
 }
 
 // Binary minimum
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::min>(sfpu::binary_max_min_init<false>);
 }
@@ -60,7 +56,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_min(
         ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_int32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::min_int32>(sfpu::binary_max_min_int32_init<false, false>);
 }
@@ -72,7 +67,6 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
         ckernel::sfpu::calculate_binary_max_min_int32<false, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_uint32_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::min_uint32>(sfpu::binary_max_min_int32_init<false, true>);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
@@ -13,74 +13,74 @@ namespace ckernel {
 // Binary maximum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::max, APPROXIMATE>(sfpu::binary_max_min_init<true>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max>(sfpu::binary_max_min_init<true>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::max_int32, APPROXIMATE>(sfpu::binary_max_min_int32_init<true, false>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max_int32>(sfpu::binary_max_min_int32_init<true, false>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<true, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_uint32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::max_uint32, APPROXIMATE>(sfpu::binary_max_min_int32_init<true, true>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max_uint32>(sfpu::binary_max_min_int32_init<true, true>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_uint32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<true, true>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 // Binary minimum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::min, APPROXIMATE>(sfpu::binary_max_min_init<false>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::min>(sfpu::binary_max_min_init<false>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::min_int32, APPROXIMATE>(sfpu::binary_max_min_int32_init<false, false>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::min_int32>(sfpu::binary_max_min_int32_init<false, false>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<false, false>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_uint32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::min_uint32, APPROXIMATE>(sfpu::binary_max_min_int32_init<false, true>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::min_uint32>(sfpu::binary_max_min_int32_init<false, true>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_uint32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_max_min_int32<false, true>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, ckernel::DataLayout layout = ckernel::DataLayout::TILE>
 inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::max_pool_with_indices, APPROXIMATE>(
+    llk_math_eltwise_binary_sfpu_init<SfpuType::max_pool_with_indices>(
         sfpu::init_max_pool_with_indices<APPROXIMATE, layout>);
 }
 
@@ -24,7 +24,7 @@ template <
     ckernel::DataLayout layout = ckernel::DataLayout::TILE,
     bool accumulate = false>
 inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(uint dst_index, uint32_t idx_index, uint32_t chunk) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::
             calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout, accumulate>,
         dst_index,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
@@ -16,9 +16,9 @@ inline void llk_math_eltwise_binary_sfpu_mul_int_init() {
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for mul_int. Supported data formats are: Int32, UInt32, UInt16");
     if constexpr (DATA_FORMAT == DataFormat::UInt16) {
-        llk_math_eltwise_binary_sfpu_init<SfpuType::mul_uint16, APPROXIMATE>(sfpu::_init_mul_int_<APPROXIMATE>);
+        llk_math_eltwise_binary_sfpu_init<SfpuType::mul_uint16>(sfpu::_init_mul_int_<APPROXIMATE>);
     } else {
-        llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32, APPROXIMATE>(sfpu::mul_int32_init<APPROXIMATE>);
+        llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32>(sfpu::mul_int32_init<APPROXIMATE>);
     }
 }
 
@@ -29,11 +29,10 @@ inline void llk_math_eltwise_binary_sfpu_mul_int(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
         "Unsupported data format for mul_int. Supported data formats are: Int32, UInt32, UInt16");
     if constexpr (DATA_FORMAT == DataFormat::UInt16) {
-        _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_binary_sfpu_params_(
             sfpu::_mul_int_<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
     } else {
-        _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-            sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
+        _llk_math_eltwise_binary_sfpu_params_(sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_quant.h
@@ -12,43 +12,37 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_quant_int32_init(const uint zero_point) {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::quant_int32, APPROXIMATE>(
-        sfpu::quant_init<APPROXIMATE>,
-        zero_point);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::quant_int32>(sfpu::quant_init<APPROXIMATE>, zero_point);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_quant_int32(
     uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_quant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_requant_int32_init(const uint zero_point) {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::requant_int32, APPROXIMATE>(
-        sfpu::quant_init<APPROXIMATE>,
-        zero_point);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::requant_int32>(sfpu::quant_init<APPROXIMATE>, zero_point);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_requant_int32(
     uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_requant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_dequant_int32_init(const uint zero_point) {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::dequant_int32, APPROXIMATE>(
-        sfpu::quant_init<APPROXIMATE>,
-        zero_point);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::dequant_int32>(sfpu::quant_init<APPROXIMATE>, zero_point);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_dequant_int32(
     uint dst_index0, uint dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_dequant_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_rsub_int_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_rsub_int.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_rsub_int_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8>
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_binary_sfpu_rsub_int(
         "Unsupported data format for rsub_int. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_rsub_int<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_shift_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_shift_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_binary_sfpu_left_shift(
         "Unsupported data format for left shift. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_left_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_binary_sfpu_right_shift(
         "Unsupported data format for right shift. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_binary_right_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,
@@ -55,7 +55,7 @@ inline void llk_math_eltwise_binary_sfpu_logical_right_shift(
         "Unsupported data format for logical right shift. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_calculate_logical_right_shift_<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_sub_int_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8, DataFormat DATA_FORMAT, bool SIGN_MAGNITUDE_FORMAT = false>
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_binary_sfpu_sub_int(
         "Unsupported data format for sub_int. Supported data formats are: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_sub_int_<APPROXIMATE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_sub_int.h
@@ -9,7 +9,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_sub_int_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_xlogy.h
@@ -11,14 +11,14 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_xlogy_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_sfpu_binary_init_<APPROXIMATE, BinaryOp::XLOGY>);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_xlogy(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::_calculate_sfpu_binary_<APPROXIMATE, BinaryOp::XLOGY, ITERATIONS>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -15,8 +15,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_lgamma_stirling_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::lgamma, APPROXIMATE>(
-        sfpu::lgamma_stirling_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::lgamma>(sfpu::lgamma_stirling_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -24,7 +24,7 @@ inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, int 
         ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_ternary_sfpu_lgamma_adjusted_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::lgamma>();
 }
@@ -36,7 +36,7 @@ inline void llk_math_eltwise_ternary_sfpu_lgamma_adjusted(
     uint32_t dst_index2,
     uint32_t dst_index3,
     int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         ckernel::sfpu::calculate_lgamma_adjusted<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -47,14 +47,13 @@ inline void llk_math_eltwise_ternary_sfpu_lgamma_adjusted(
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_lgamma_stirling_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::lgamma, APPROXIMATE>(
-        sfpu::lgamma_stirling_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lgamma>(sfpu::lgamma_stirling_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_binary_sfpu_lgamma_stirling(
     uint32_t dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         sfpu::calculate_lgamma_stirling_fp32<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -21,7 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_lgamma_stirling_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
@@ -12,8 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_polygamma_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::polygamma, APPROXIMATE>(
-        sfpu::polygamma_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::polygamma>(sfpu::polygamma_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_polygamma.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_polygamma_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_polygamma(
     uint32_t dst_index, uint32_t n_packed, uint32_t scale_packed, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_polygamma<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcdiv.h
@@ -12,7 +12,7 @@ namespace ckernel {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_addcdiv(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_addcdiv<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_addcmul.h
@@ -12,7 +12,7 @@ namespace ckernel {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_addcmul(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, uint value, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_addcmul<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,
         dst_index1,
@@ -22,7 +22,6 @@ inline void llk_math_eltwise_ternary_sfpu_addcmul(
         value);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_addcmul_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::addcmul>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
@@ -12,7 +12,7 @@ namespace ckernel {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void llk_math_eltwise_ternary_sfpu_lerp(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         sfpu::calculate_lerp<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
         dst_index0,
         dst_index1,
@@ -21,7 +21,6 @@ inline void llk_math_eltwise_ternary_sfpu_lerp(
         vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_lerp_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::lerp>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -12,7 +12,7 @@ namespace ckernel {
 template <bool APPROXIMATE, DataFormat data_format>
 inline void llk_math_eltwise_ternary_sfpu_where(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_ternary_sfpu_params_(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, data_format, 8>,
         dst_index0,
         dst_index1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::abs, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::abs>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::abs>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -17,14 +17,12 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -15,8 +15,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardsigmoid, APPROXIMATE>(
-        ckernel::sfpu::_init_hardsigmoid_<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardsigmoid>(ckernel::sfpu::_init_hardsigmoid_<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
@@ -30,7 +29,7 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_m
 // softsign
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_softsign_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::softsign, APPROXIMATE>(ckernel::sfpu::init_softsign<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::softsign>(ckernel::sfpu::init_softsign<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
@@ -42,7 +41,7 @@ inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode
 // celu
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_celu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::celu, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::celu>();
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
@@ -61,7 +60,7 @@ inline void llk_math_eltwise_unary_sfpu_celu(
 // softshrink
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
@@ -73,7 +72,7 @@ inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, 
 // hardshrink
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -21,7 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
 
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         static_cast<void (*)()>(ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
         dst_index,
         vector_mode);
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_unary_sfpu_softsign_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
@@ -48,7 +48,7 @@ inline void llk_math_eltwise_unary_sfpu_celu_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_celu(
     uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         [](uint32_t alpha, uint32_t alpha_recip) {
             ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
         },
@@ -66,7 +66,7 @@ inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }
 
@@ -78,7 +78,7 @@ inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -39,7 +39,6 @@ inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode
 }
 
 // celu
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_celu_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::celu>();
 }
@@ -58,7 +57,6 @@ inline void llk_math_eltwise_unary_sfpu_celu(
 }
 
 // softshrink
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink>();
 }
@@ -70,7 +68,6 @@ inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, 
 }
 
 // hardshrink
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::add1, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::add1>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::add1>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_add1_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::alt_complex_rotate90, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::alt_complex_rotate90>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::alt_complex_rotate90>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -13,7 +13,7 @@ namespace ckernel {
 template <bool APPROXIMATE, int binop_mode>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
 }
 
@@ -25,14 +25,14 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -17,7 +17,6 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
         sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::cast_fp32_to_fp16a>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::cast_fp32_to_fp16a, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::cast_fp32_to_fp16a>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cbrt_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::cbrt, APPROXIMATE>(sfpu::cube_root_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::cbrt>(sfpu::cube_root_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_cbrt_init() {
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -18,14 +18,14 @@ inline void llk_math_eltwise_unary_sfpu_clamp_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp_int32(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_clamp_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::clamp, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::clamp>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_clamp_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::clamp>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
 template <bool APPROXIMATE /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_cumsum(
     uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
-    _llk_math_eltwise_unary_sfpu_params_<false>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
         dst_index,
         VectorMode::RC_custom,  // Can only work in RC_custom mode

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::cumsum, false>(
+    llk_math_eltwise_unary_sfpu_init<SfpuType::cumsum>(
         sfpu::cumsum_init<false>);  // There is only non APPROXIMATE implementation
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_exp2_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::exp2>(sfpu::exp2_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::expm1>(sfpu::expm1_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
     uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, vector_mode, param0);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -9,12 +9,12 @@
 
 namespace ckernel {
 
-template <SfpuType sfpu_op, bool APPROXIMATE>
+template <SfpuType sfpu_op>
 inline void llk_math_eltwise_unary_sfpu_init() {
     _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
 }
 
-template <SfpuType sfpu_op, bool APPROXIMATE, class F, class... ARGS>
+template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
     init_func(static_cast<ARGS&&>(args)...);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
 }
 
@@ -31,7 +31,7 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base(
     uint dst_index, uint base_scale, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -12,8 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log, APPROXIMATE>(
-        sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log>(sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
@@ -24,7 +23,7 @@ inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (i
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base, APPROXIMATE>(
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base>(
         sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -8,32 +8,32 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 
 // For ops that require only the init function
-#define SFPU_UNARY_KERNEL_INIT(OP, APPROXIMATE) llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>();
+#define SFPU_UNARY_KERNEL_INIT(OP, APPROXIMATE) llk_math_eltwise_unary_sfpu_init<SfpuType::OP>();
 
 // For ops that need a custom init callback
 #define SFPU_INIT_KERNEL_CALL(OP, INIT_CB, APPROXIMATE) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE>)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE>)
 
 // For ops that need a custom init callback but takes one extra init-parameter
 #define SFPU_ONE_PARAM_KERNEL_INIT(OP, INIT_CB, APPROXIMATE, PARAM0) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE>, PARAM0);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE>, PARAM0);
 
 // For ops that need a custom init callback with two template parameters (e.g., APPROXIMATE and legacy_compat or
 // fast_approx)
 #define SFPU_TWO_TEMPLATE_PARAM_INIT(OP, INIT_CB, APPROXIMATE, PARAM0) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE, PARAM0>)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE, PARAM0>)
 
 // For ops that need a custom init callback with three template parameters (e.g., APPROXIMATE, DST_ACCUM and legacy_compat)
 #define SFPU_THREE_TEMPLATE_PARAM_INIT(OP, INIT_CB, APPROXIMATE, PARAM0, PARAM1) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE, PARAM0, PARAM1>)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE, PARAM0, PARAM1>)
 
 // For ops that need a custom init callback and take two extra init-parameters
 #define SFPU_TWO_PARAM_KERNEL_INIT(OP, INIT_CB, APPROXIMATE, PARAM0, PARAM1) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROXIMATE>(INIT_CB<APPROXIMATE>, PARAM0, PARAM1)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROXIMATE>, PARAM0, PARAM1)
 
 // For ops where init takes multiple template parameters (e.g., approximate, scale).
 #define SFPU_TEMPLATE_INIT_KERNEL(OP, INIT_CB, APPROX, SCALE, CLAMP_NEGATIVE) \
-    llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROX>(INIT_CB<APPROX, SCALE, CLAMP_NEGATIVE>)
+    llk_math_eltwise_unary_sfpu_init<SfpuType::OP>(INIT_CB<APPROX, SCALE, CLAMP_NEGATIVE>)
 
 // For the int32 comparison variants
 #define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0)      \

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -89,7 +89,7 @@
 // For ops with exactly three extra uint parameters AND DST_ACCUM_MODE as template param
 #define SFPU_UNARY_THREE_PARAM_KERNEL_WITH_DST_ACCUM(                  \
     FN, MODE, APPROXIMATE, DST_ACCUM, DST_IDX, PARAM0, PARAM1, PARAM2) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                 \
+    _llk_math_eltwise_unary_sfpu_params_(                              \
         ckernel::sfpu::FN<APPROXIMATE, DST_ACCUM>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1, PARAM2)
 
 // For ops without extra uint parameter

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -36,24 +36,29 @@
     llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROX>(INIT_CB<APPROX, SCALE, CLAMP_NEGATIVE>)
 
 // For the int32 comparison variants
-#define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                 \
-        ckernel::sfpu::calculate_comp_unary_int<APPROXIMATE, SfpuType::OP, ITERATIONS>, DST_IDX, (int)VectorMode::MODE, PARAM0);
+#define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0)      \
+    _llk_math_eltwise_unary_sfpu_params_(                                               \
+        ckernel::sfpu::calculate_comp_unary_int<APPROXIMATE, SfpuType::OP, ITERATIONS>, \
+        DST_IDX,                                                                        \
+        (int)VectorMode::MODE,                                                          \
+        PARAM0);
 
 // For the int32 comparison variants with underscore in callback
 #define SFPU_COMP_INT32_KERNEL_UNDERSCORE(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                            \
-        ckernel::sfpu::_calculate_comp_unary_int_<APPROXIMATE, SfpuType::OP, ITERATIONS>, DST_IDX, (int)VectorMode::MODE, PARAM0);
+    _llk_math_eltwise_unary_sfpu_params_(                                                     \
+        ckernel::sfpu::_calculate_comp_unary_int_<APPROXIMATE, SfpuType::OP, ITERATIONS>,     \
+        DST_IDX,                                                                              \
+        (int)VectorMode::MODE,                                                                \
+        PARAM0);
 
 // For ops where the compute functor is not "calculate_<OP>", but an arbitrary function name (e.g., relu_min, relu_max,
 // etc.),and which take one extra runtime uint parameter
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                         \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For unary ops with one extra uint parameter AND an additional template param (ITERATIONS)
 #define SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(FN, MODE, APPROXIMATE, EXTRA_PARAM, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
+    _llk_math_eltwise_unary_sfpu_params_(                                                            \
         ckernel::sfpu::FN<APPROXIMATE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For unary ops with one extra uint parameter AND additional template params (DATA_FORMAT, ITERATIONS)
@@ -64,22 +69,21 @@
         "Unsupported data format. Supported: Int32, UInt32, UInt16");                                               \
     constexpr InstrModLoadStore _INSTRUCTION_MODE =                                                                 \
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;                   \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                           \
         ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For ops with exactly two extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_TWO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
 
 // For ops with exactly two extra uint parameters AND DST_ACCUM_MODE as template param
 #define SFPU_UNARY_TWO_PARAM_KERNEL_WITH_DST_ACCUM(FN, MODE, APPROXIMATE, DST_ACCUM, DST_IDX, PARAM0, PARAM1) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                        \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                     \
         ckernel::sfpu::FN<APPROXIMATE, DST_ACCUM>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
 
 // For ops with exactly three extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_THREE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1, PARAM2) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                           \
+    _llk_math_eltwise_unary_sfpu_params_(                                                        \
         ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1, PARAM2)
 
 // For ops with exactly three extra uint parameters AND DST_ACCUM_MODE as template param
@@ -90,26 +94,26 @@
 
 // For ops without extra uint parameter
 #define SFPU_UNARY_NO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE)
 
 // For ops without extra uint parameter with ITERATIONS
 #define SFPU_UNARY_NO_PARAM_KERNEL_FN_ITERATIONS(FN, MODE, APPROXIMATE, DST_IDX, ITERATIONS) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
 
 // For ops without extra uint parameters with type and iteration
 #define SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(OP, TYPE, MODE, APPROXIMATE, DST_IDX, ITERATIONS) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                             \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                     \
         ckernel::sfpu::OP<SfpuType::TYPE, APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
 
 // For ops where compute takes extra args
 #define SFPU_UNARY_PARAMS_KERNEL_EXTRA_ARGS(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                      \
+    _llk_math_eltwise_unary_sfpu_params_(                                                   \
         ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1);
 
 // For ops with multiple template parameters and one runtime parameter (e.g., scale)
 #define SFPU_TEMPLATE_PARAMS_KERNEL_FN(                                                                      \
     FN, APPROXIMATE, IS_FP32_DEST_ACC_EN, SCALE_EN, CLAMP_NEGATIVE, ITERATIONS, DST_IDX, VECTOR_MODE, SCALE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                       \
+    _llk_math_eltwise_unary_sfpu_params_(                                                       \
         ckernel::sfpu::FN<APPROXIMATE, IS_FP32_DEST_ACC_EN, SCALE_EN, ITERATIONS, CLAMP_NEGATIVE>,           \
         DST_IDX,                                                                                             \
         VECTOR_MODE,                                                                                         \
@@ -117,52 +121,48 @@
 
 // For kernels with one template parameter and one extra runtime argument.
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                         \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN_FLOAT(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                               \
+    _llk_math_eltwise_unary_sfpu_params_(                                            \
         ckernel::sfpu::FN<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN_INT(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                             \
+    _llk_math_eltwise_unary_sfpu_params_(                                          \
         ckernel::sfpu::FN<sfpi::vInt, APPROXIMATE, 8, uint32_t>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For kernels whose functor takes one template parameter (e.g., <APPROXIMATE>)
 #define SFPU_ONE_PARAM_KERNEL(FN, APPROXIMATE, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, VECTOR_MODE)
 
 // For kernels whose functor takes two template parameters (e.g., <APPROXIMATE, ITER/USE_FP32>)
 #define SFPU_TWO_PARAM_KERNEL(FN, APPROXIMATE, T2, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE)
 
 // For kernels whose functor takes two template parameters (e.g., <APPROXIMATE, ITER>) and one extra runtime param.
 #define SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(FN, APPROXIMATE, T2, DST_IDX, VECTOR_MODE, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE, PARAM0)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, ITER, USE_FP32>)
 #define SFPU_THREE_PARAM_KERNEL_ITER_FIRST(FN, APPROXIMATE, ITER, FP32, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                            \
-        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, ITER, FP32>, DST_IDX, VECTOR_MODE)
 
 // For functors with <APPROXIMATE, USE_FP32, ITER>
 #define SFPU_THREE_PARAM_KERNEL_FP32_FIRST(FN, APPROXIMATE, FP32, ITER, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                               \
-        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, FP32, ITER>, DST_IDX, VECTOR_MODE)
 
 // For unary ops with four template parameters (APPROXIMATE, ITER, fp32_dest_acc_en, legacy_compat)
 #define SFPU_FOUR_PARAM_KERNEL_ITER_FIRST_FN(FN, APPROXIMATE, ITER, FP32, LEGACY_COMPAT, DST_IDX, MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                  \
+    _llk_math_eltwise_unary_sfpu_params_(                                                               \
         ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
 
 // For unary ops with four template parameters (APPROXIMATE, fp32_dest_acc_en, FP32_FIRST, legacy_compat)
 #define SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN(FN, APPROXIMATE, FP32, ITER, LEGACY_COMPAT, DST_IDX, MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                  \
-        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER, LEGACY_COMPAT>, DST_IDX, MODE)
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::FN<APPROXIMATE, FP32, ITER, LEGACY_COMPAT>, DST_IDX, MODE)
 
 // For unary ops with five template parameters (APPROXIMATE, ITER, fp32_dest_acc_en, FAST_APPROX, legacy_compat)
 #define SFPU_FIVE_PARAM_KERNEL_ITER_FIRST_FN(FN, APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT, DST_IDX, MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                               \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                            \
         ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, DATA_FORMAT, ITERATIONS>).
@@ -181,20 +181,20 @@
         : (DATA_FORMAT == DataFormat::UInt16)                                     ? InstrModLoadStore::LO16        \
         : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32       \
                                                                                   : InstrModLoadStore::DEFAULT;    \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                             \
+    _llk_math_eltwise_unary_sfpu_params_(                                                                          \
         ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE);
 
 // For the compare with zero ops (eqz, nez, ltz, gtz, lez, gez)
 #define SFPU_ZERO_KERNEL(OP, MODE, APPROXIMATE, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(   \
+    _llk_math_eltwise_unary_sfpu_params_(                \
         ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::OP>, DST_IDX, (int)VectorMode::MODE, 8);
 
 // Generalized macro for compare-with-zero ops for any type (e.g., int, uint16)
 #define SFPU_ZERO_KERNEL_TYPE(TYPE, OP, MODE, APPROXIMATE, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(              \
+    _llk_math_eltwise_unary_sfpu_params_(                           \
         ckernel::sfpu::TYPE<APPROXIMATE, SfpuType::OP>, DST_IDX, (int)VectorMode::MODE);
 
 // For log1p op that needs three template parameters
 #define SFPU_UNARY_NO_PARAM_KERNEL_LOG1P_FN(FN, MODE, APPROXIMATE, FAST_APPROX, FP32, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                         \
+    _llk_math_eltwise_unary_sfpu_params_(                                                      \
         ckernel::sfpu::FN<APPROXIMATE, FAST_APPROX, FP32>, DST_IDX, (int)VectorMode::MODE)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::mask>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::mask, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::mask>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -17,19 +17,16 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask(
     uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
     if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
+        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
     } else if (data_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
+        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -13,7 +13,7 @@ namespace ckernel {
 // Unary maximum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max, APPROXIMATE>(sfpu::unary_max_min_init<true>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max>(sfpu::unary_max_min_init<true>);
 }
 
 template <bool APPROXIMATE>
@@ -24,8 +24,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_int32, APPROXIMATE>(
-        sfpu::unary_max_min_int32_init<true, false>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_int32>(sfpu::unary_max_min_int32_init<true, false>);
 }
 
 template <bool APPROXIMATE>
@@ -37,8 +36,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_uint32, APPROXIMATE>(
-        sfpu::unary_max_min_int32_init<true, true>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_uint32>(sfpu::unary_max_min_int32_init<true, true>);
 }
 
 template <bool APPROXIMATE>
@@ -51,7 +49,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
 // Unary minimum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min, APPROXIMATE>(sfpu::unary_max_min_init<false>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min>(sfpu::unary_max_min_init<false>);
 }
 
 template <bool APPROXIMATE>
@@ -62,8 +60,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, i
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_int32, APPROXIMATE>(
-        sfpu::unary_max_min_int32_init<false, false>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_int32>(sfpu::unary_max_min_int32_init<false, false>);
 }
 
 template <bool APPROXIMATE>
@@ -75,8 +72,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_uint32, APPROXIMATE>(
-        sfpu::unary_max_min_int32_init<false, true>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_uint32>(sfpu::unary_max_min_int32_init<false, true>);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -31,7 +31,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -44,7 +44,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -56,7 +56,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -69,7 +69,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
@@ -82,7 +82,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -11,7 +11,6 @@
 namespace ckernel {
 
 // Unary maximum
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max>(sfpu::unary_max_min_init<true>);
 }
@@ -22,7 +21,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_int32>(sfpu::unary_max_min_int32_init<true, false>);
 }
@@ -34,7 +32,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
         ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_uint32>(sfpu::unary_max_min_int32_init<true, true>);
 }
@@ -47,7 +44,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
 }
 
 // Unary minimum
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min>(sfpu::unary_max_min_init<false>);
 }
@@ -58,7 +54,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, i
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_int32>(sfpu::unary_max_min_int32_init<false, false>);
 }
@@ -70,7 +65,6 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
         ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_uint32>(sfpu::unary_max_min_int32_init<false, true>);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_power_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_power(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
 }
 
@@ -30,7 +30,7 @@ inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, vector_mode, exponent);
 }
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::power, APPROXIMATE>(ckernel::sfpu::sfpu_unary_pow_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::power>(ckernel::sfpu::sfpu_unary_pow_init);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
@@ -24,7 +24,7 @@ inline void llk_math_eltwise_unary_sfpu_power(
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::power, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::power>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::power>(ckernel::sfpu::sfpu_unary_pow_init);
 }
@@ -22,7 +21,6 @@ inline void llk_math_eltwise_unary_sfpu_power(
         ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::power>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_rdiv_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::rdiv, APPROXIMATE>(sfpu::rdiv_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::rdiv>(sfpu::rdiv_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_rdiv_init() {
 template <bool APPROXIMATE, bool fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rdiv(
     uint32_t dst_index, uint32_t value, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_rdiv<APPROXIMATE, fp32_dest_acc_en, rounding_mode, ITERATIONS>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_reduce_init() {
 template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce(
     uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, VectorMode vector_mode) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode, ct_dim, rt_dim);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -10,12 +10,12 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, PoolType pool_type, DataFormat format>
+template <PoolType pool_type, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::reduce>(sfpu::init_reduce<pool_type, format>);
 }
 
-template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce(
     uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, VectorMode vector_mode) {
     _llk_math_eltwise_unary_sfpu_params_(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, PoolType pool_type, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce, APPROXIMATE>(sfpu::init_reduce<pool_type, format>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce>(sfpu::init_reduce<pool_type, format>);
 }
 
 template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -20,7 +20,6 @@ namespace ckernel {
  * from different input positions are accumulated into their corresponding embedding rows.
  *
  */
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::reshuffle_rows>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -22,7 +22,7 @@ namespace ckernel {
  */
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::reshuffle_rows, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reshuffle_rows>();
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -47,8 +47,7 @@ inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
     uint dst_index, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
+    _llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_rpow_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::rpow, APPROXIMATE>(sfpu::sfpu_binary_pow_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::rpow>(sfpu::sfpu_binary_pow_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_rpow_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_rpow(uint dst_index, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode, base_val);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
         dst_index,
         vector_mode);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool legacy_compat>
 inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt, APPROXIMATE>(sfpu::rsqrt_init<APPROXIMATE, legacy_compat>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt>(sfpu::rsqrt_init<APPROXIMATE, legacy_compat>);
 }
 
 template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32(uint dst_index, uint scalar, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -9,7 +9,6 @@
 #include "ckernel_sfpu_unary_selu.h"
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_selu_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::selu>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_selu_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_selu(
     uint dst_index, uint scale, uint alpha, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_selu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_selu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::selu, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::selu>();
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid, APPROXIMATE>(sfpu::sigmoid_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid>(sfpu::sigmoid_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx>(sfpu::sigmoid_appx_init);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx, APPROXIMATE>(sfpu::sigmoid_appx_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx>(sfpu::sigmoid_appx_init);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_sign_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign(
     uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sign, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::sign>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sign>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_signbit_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_init);
 }
@@ -21,7 +20,6 @@ inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode 
         ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_int32_init);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
@@ -28,7 +28,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_signbit_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::signbit, APPROXIMATE>(ckernel::sfpu::signbit_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_init);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
@@ -23,7 +23,7 @@ inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode 
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::signbit, APPROXIMATE>(ckernel::sfpu::signbit_int32_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_int32_init);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu>(sfpu::silu_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_silu_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::square, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::square>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_square_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::square>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>(sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh>(sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_derivative_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh_derivative_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh_derivative, APPROXIMATE>(sfpu::tanh_derivative_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh_derivative>(sfpu::tanh_derivative_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_threshold_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::threshold, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::threshold>();
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_threshold_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_threshold(
     uint dst_index, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         static_cast<void (*)(uint32_t, uint32_t)>(ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -9,7 +9,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_threshold_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::threshold>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -17,8 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -10,7 +10,6 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -13,7 +13,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort, APPROXIMATE>(sfpu::topk_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort>(sfpu::topk_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -25,7 +25,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     int i_end_step,
     int i_start_step,
     int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
         vector_mode,
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
         dst_index,
         vector_mode,
@@ -56,7 +56,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int logk,
     int skip_second,
     int vector_mode = (int)VectorMode::RC_custom) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -161,72 +161,59 @@ inline void llk_math_eltwise_unary_sfpu_typecast_init() {
     constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
 
     if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_fp32_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_fp32_to_fp16b<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::UInt16 && (out_format == DataFormat::UInt32 || out_format == DataFormat::Int32)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(
             ckernel::sfpu::init_typecast_uint16_to_uint32<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(
             ckernel::sfpu::init_typecast_uint32_to_uint16<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_int32_to_uint16<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_int32_to_uint16<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint32_to_fp32<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint32_to_fp32<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_int32_to_fp32<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_int32_to_fp32<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint16_to_fp32<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint16_to_fp32<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::UInt16 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint16_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint16_to_fp16b<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::Int32 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_int32_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_int32_to_fp16b<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::UInt32 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint32_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint32_to_fp16b<APPROXIMATE>);
     } else if constexpr (
         (in_format == DataFormat::Float32 || in_format == DataFormat::Float16_b || in_format == DataFormat::Bfp8_b ||
          in_format == DataFormat::Bfp4_b) &&
         out_format == DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_fp32_to_uint16<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_fp32_to_uint16<APPROXIMATE>);
     } else if constexpr (
         (in_format == DataFormat::Float32 || in_format == DataFormat::Float16_b || in_format == DataFormat::Bfp8_b ||
          in_format == DataFormat::Bfp4_b) &&
         out_format == DataFormat::UInt8) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_fp32_to_uint8<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_fp32_to_uint8<APPROXIMATE>);
     } else if constexpr (
         (in_format == DataFormat::Int32 || in_format == DataFormat::UInt32 || in_format == DataFormat::UInt16) &&
         out_format == DataFormat::UInt8) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint_to_uint8<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint_to_uint8<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::Float32) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint32_to_fp32<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint32_to_fp32<APPROXIMATE>);
     } else if constexpr (
         in_format == DataFormat::UInt8 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
-            ckernel::sfpu::init_typecast_uint32_to_fp16b<APPROXIMATE>);
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(ckernel::sfpu::init_typecast_uint32_to_fp16b<APPROXIMATE>);
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>(
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>(
             ckernel::sfpu::init_typecast_uint32_to_uint16<APPROXIMATE>);
     } else {
-        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast, APPROXIMATE>();
+        llk_math_eltwise_unary_sfpu_init<SfpuType::typecast>();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -16,76 +16,76 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
     constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
 
     if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float16_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by packer
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp8_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float16_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp8_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
         // Calls same kernel as UInt32 case
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
@@ -96,22 +96,22 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp8_b) {
         // no SFPU kernel needed, handled by packer
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Int32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp4_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp4_b) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
@@ -129,28 +129,28 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
         (in_format == DataFormat::Float32 || in_format == DataFormat::Float16_b || in_format == DataFormat::Bfp8_b ||
          in_format == DataFormat::Bfp4_b) &&
         out_format == DataFormat::UInt8) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_fp32_to_uint8<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (
         (in_format == DataFormat::Int32 || in_format == DataFormat::UInt32 || in_format == DataFormat::UInt16) &&
         out_format == DataFormat::UInt8) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint_to_uint8<APPROXIMATE, 8, (in_format == DataFormat::UInt16)>,
             dst_index,
             vector_mode);
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::Float32) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (
         in_format == DataFormat::UInt8 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
     } else if constexpr (
         in_format == DataFormat::UInt8 && (out_format == DataFormat::Int32 || out_format == DataFormat::UInt32)) {
         // No SFPU kernel needed.
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::UInt16) {
-        _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        _llk_math_eltwise_unary_sfpu_params_(
             ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
     }
 }

--- a/tt_metal/hw/inc/api/compute/add_int_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/add_int_sfpu.h
@@ -41,6 +41,6 @@ ALWI void add_int_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void add_int_tile_init() { MATH((llk_math_eltwise_binary_sfpu_add_int_init<APPROX>())); }
+ALWI void add_int_tile_init() { MATH((llk_math_eltwise_binary_sfpu_add_int_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/binary_bitwise_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/binary_bitwise_sfpu.h
@@ -52,6 +52,6 @@ ALWI void bitwise_xor_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void binary_bitwise_tile_init() { MATH((llk_math_eltwise_binary_sfpu_bitwise_init<APPROX>())); }
+ALWI void binary_bitwise_tile_init() { MATH((llk_math_eltwise_binary_sfpu_bitwise_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/binary_comp.h
+++ b/tt_metal/hw/inc/api/compute/binary_comp.h
@@ -49,13 +49,13 @@ ALWI void le_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void lt_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_int32_init<APPROX>())); }
+ALWI void lt_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_int32_init())); }
 
-ALWI void gt_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_int32_init<APPROX>())); }
+ALWI void gt_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_int32_init())); }
 
-ALWI void ge_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ge_int32_init<APPROX>())); }
+ALWI void ge_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ge_int32_init())); }
 
-ALWI void le_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_le_int32_init<APPROX>())); }
+ALWI void le_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_le_int32_init())); }
 
 // clang-format off
 /**
@@ -89,8 +89,8 @@ ALWI void gt_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
  * Please refer to documentation for any_init.
  */
 
-ALWI void lt_uint16_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_uint16_init<APPROX>())); }
+ALWI void lt_uint16_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_uint16_init())); }
 
-ALWI void gt_uint16_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_uint16_init<APPROX>())); }
+ALWI void gt_uint16_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_uint16_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/binary_max_min.h
+++ b/tt_metal/hw/inc/api/compute/binary_max_min.h
@@ -37,7 +37,7 @@ ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 /**
  * Please refer to documentation.
  */
-ALWI void binary_max_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max_int32_init<APPROX>())); }
+ALWI void binary_max_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max_int32_init())); }
 
 // clang-format off
 /**
@@ -65,7 +65,7 @@ ALWI void binary_max_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) 
 /**
  * Please refer to documentation.
  */
-ALWI void binary_max_uint32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max_uint32_init<APPROX>())); }
+ALWI void binary_max_uint32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max_uint32_init())); }
 
 // clang-format off
 /**
@@ -93,7 +93,7 @@ ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, int vec
 /**
  * Please refer to documentation.
  */
-ALWI void binary_max_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max_init<APPROX>())); }
+ALWI void binary_max_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max_init())); }
 
 // clang-format off
 /**
@@ -121,7 +121,7 @@ ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 /**
  * Please refer to documentation.
  */
-ALWI void binary_min_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_min_int32_init<APPROX>())); }
+ALWI void binary_min_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_min_int32_init())); }
 
 // clang-format off
 /**
@@ -149,7 +149,7 @@ ALWI void binary_min_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) 
 /**
  * Please refer to documentation.
  */
-ALWI void binary_min_uint32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_min_uint32_init<APPROX>())); }
+ALWI void binary_min_uint32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_min_uint32_init())); }
 
 // clang-format off
 /**
@@ -177,6 +177,6 @@ ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, int vec
 /**
  * Please refer to documentation.
  */
-ALWI void binary_min_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_min_init<APPROX>())); }
+ALWI void binary_min_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_min_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/binary_shift.h
+++ b/tt_metal/hw/inc/api/compute/binary_shift.h
@@ -95,6 +95,6 @@ ALWI void binary_logical_right_shift_tile(uint32_t idst0, uint32_t idst1, uint32
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void binary_shift_tile_init() { MATH((llk_math_eltwise_binary_sfpu_shift_init<APPROX>())); }
+ALWI void binary_shift_tile_init() { MATH((llk_math_eltwise_binary_sfpu_shift_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -182,7 +182,7 @@ ALWI void tanh_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void signbit_tile_init() { MATH((llk_math_eltwise_unary_sfpu_signbit_init<APPROX>())); }
+ALWI void signbit_tile_init() { MATH((llk_math_eltwise_unary_sfpu_signbit_init())); }
 
 // clang-format off
 /**
@@ -203,7 +203,7 @@ ALWI void signbit_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_signbi
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void signbit_tile_int32_init() { MATH((llk_math_eltwise_unary_sfpu_signbit_int32_init<APPROX>())); }
+ALWI void signbit_tile_int32_init() { MATH((llk_math_eltwise_unary_sfpu_signbit_int32_init())); }
 
 // clang-format off
 /**
@@ -240,7 +240,7 @@ ALWI void abs_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_abs<APPROX
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void abs_tile_init() { MATH((llk_math_eltwise_unary_sfpu_abs_init<APPROX>())); }
+ALWI void abs_tile_init() { MATH((llk_math_eltwise_unary_sfpu_abs_init())); }
 
 // clang-format off
 /**
@@ -279,7 +279,7 @@ ALWI void sign_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_sign<APPR
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void sign_tile_init() { MATH((llk_math_eltwise_unary_sfpu_sign_init<APPROX>())); }
+ALWI void sign_tile_init() { MATH((llk_math_eltwise_unary_sfpu_sign_init())); }
 
 // clang-format off
 /**
@@ -300,7 +300,7 @@ ALWI void square_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_square<
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void square_tile_init() { MATH((llk_math_eltwise_unary_sfpu_square_init<APPROX>())); }
+ALWI void square_tile_init() { MATH((llk_math_eltwise_unary_sfpu_square_init())); }
 
 // clang-format off
 /**
@@ -321,7 +321,7 @@ ALWI void tiled_prod_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_til
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void tiled_prod_tile_init() { MATH((llk_math_eltwise_unary_sfpu_tiled_prod_init<APPROX>())); }
+ALWI void tiled_prod_tile_init() { MATH((llk_math_eltwise_unary_sfpu_tiled_prod_init())); }
 
 // POWER : y = x^(const param0)
 // clang-format off
@@ -346,7 +346,7 @@ ALWI void power_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void power_tile_init() { MATH((llk_math_eltwise_unary_sfpu_power_init<APPROX>())); }
+ALWI void power_tile_init() { MATH((llk_math_eltwise_unary_sfpu_power_init())); }
 
 // POWER_ITERATIVE : y = x^(const param0)
 // clang-format off
@@ -373,7 +373,7 @@ ALWI void power_iterative_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void power_iterative_tile_init() { MATH((llk_math_eltwise_unary_sfpu_power_iterative_init<APPROX>())); }
+ALWI void power_iterative_tile_init() { MATH((llk_math_eltwise_unary_sfpu_power_iterative_init())); }
 
 // clang-format off
 // exp2 : y = 2 ^ x  ==> [y = exp(x * log(2))]
@@ -420,7 +420,7 @@ ALWI void heaviside_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void heaviside_tile_init() { MATH((llk_math_eltwise_unary_sfpu_heaviside_init<APPROX>())); }
+ALWI void heaviside_tile_init() { MATH((llk_math_eltwise_unary_sfpu_heaviside_init())); }
 
 // expm1 : (exp(x) - 1)
 // clang-format off
@@ -795,7 +795,7 @@ ALWI void unary_max_int32_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void unary_max_int32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_max_int32_init<APPROX>())); }
+ALWI void unary_max_int32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_max_int32_init())); }
 
 // unary_max : if x > value --> x, else value
 // clang-format off
@@ -820,7 +820,7 @@ ALWI void unary_max_uint32_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void unary_max_uint32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_max_uint32_init<APPROX>())); }
+ALWI void unary_max_uint32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_max_uint32_init())); }
 
 // unary_max : if x > value --> x, else value
 // clang-format off
@@ -845,7 +845,7 @@ ALWI void unary_max_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void unary_max_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_max_init<APPROX>())); }
+ALWI void unary_max_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_max_init())); }
 
 // clang-format off
 /**
@@ -869,7 +869,7 @@ ALWI void alt_complex_rotate90_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void alt_complex_rotate90_tile_init() { MATH((llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init<APPROX>())); }
+ALWI void alt_complex_rotate90_tile_init() { MATH((llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init())); }
 
 // unary_min : if x < value --> x, else value
 // clang-format off
@@ -894,7 +894,7 @@ ALWI void unary_min_int32_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void unary_min_int32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_min_int32_init<APPROX>())); }
+ALWI void unary_min_int32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_min_int32_init())); }
 
 // unary_min : if x < value --> x, else value
 // clang-format off
@@ -919,7 +919,7 @@ ALWI void unary_min_uint32_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void unary_min_uint32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_min_uint32_init<APPROX>())); }
+ALWI void unary_min_uint32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_min_uint32_init())); }
 
 // unary_min : if x < value --> x, else value
 // clang-format off
@@ -944,7 +944,7 @@ ALWI void unary_min_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void unary_min_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_min_init<APPROX>())); }
+ALWI void unary_min_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_min_init())); }
 
 ALWI uint32_t get_compute_special_value_flags() {
     uint32_t ret_val = 0;

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -677,7 +677,8 @@ ALWI void sfpu_reduce(uint32_t idst, uint32_t ct_dim = 1, uint32_t rt_dim = 1) {
         "Unsupported pool type. Supported pool types: SUM, AVG, MAX, MIN");
 
     // This kernel is optimized for 32x32 tiles and uses RC_custom vector mode for custom reduction
-    MATH((llk_math_eltwise_unary_sfpu_reduce<true, pool_type, reduce_dim, format>(idst, ct_dim, rt_dim, VectorMode::RC_custom)));
+    MATH((llk_math_eltwise_unary_sfpu_reduce<pool_type, reduce_dim, format>(
+        idst, ct_dim, rt_dim, VectorMode::RC_custom)));
 }
 
 /**
@@ -698,7 +699,7 @@ ALWI void sfpu_reduce_init() {
             format == DataFormat::UInt16 || format == DataFormat::Float16_b,
         "Unsupported data format. Supported formats: Float32, Int32, UInt32, UInt16, Float16_b");
 
-    MATH((llk_math_eltwise_unary_sfpu_reduce_init<true, pool_type, format>()));
+    MATH((llk_math_eltwise_unary_sfpu_reduce_init<pool_type, format>()));
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/eltwise_binary_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary_sfpu.h
@@ -97,16 +97,16 @@ ALWI void rsub_binary_tile_init() {
 
 ALWI void power_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_pow_init<APPROX>())); }
 
-ALWI void eq_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_eq_fp32_init<APPROX>())); }
+ALWI void eq_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_eq_fp32_init())); }
 
-ALWI void ne_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ne_fp32_init<APPROX>())); }
+ALWI void ne_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ne_fp32_init())); }
 
-ALWI void lt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_fp32_init<APPROX>())); }
+ALWI void lt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_fp32_init())); }
 
-ALWI void gt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_fp32_init<APPROX>())); }
+ALWI void gt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_fp32_init())); }
 
-ALWI void le_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_le_fp32_init<APPROX>())); }
+ALWI void le_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_le_fp32_init())); }
 
-ALWI void ge_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ge_fp32_init<APPROX>())); }
+ALWI void ge_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ge_fp32_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
@@ -75,7 +75,7 @@ ALWI void celu_tile(uint32_t idst, uint32_t alpha, uint32_t alpha_recip) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void celu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_celu_init<APPROX>())); }
+ALWI void celu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_celu_init())); }
 
 // clang-format off
  /**
@@ -98,7 +98,7 @@ ALWI void celu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_celu_init<APPROX>
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void softshrink_tile_init() { MATH((llk_math_eltwise_unary_sfpu_softshrink_init<APPROX>())); }
+ALWI void softshrink_tile_init() { MATH((llk_math_eltwise_unary_sfpu_softshrink_init())); }
 
 // clang-format off
 /**
@@ -124,6 +124,6 @@ ALWI void hardshrink_tile(uint32_t idst, uint32_t param0) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void hardshrink_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardshrink_init<APPROX>())); }
+ALWI void hardshrink_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardshrink_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/addcmul.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/addcmul.h
@@ -45,6 +45,6 @@ ALWI void addcmul_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void addcmul_tile_init() { MATH((llk_math_eltwise_ternary_sfpu_addcmul_init<APPROX>())); }
+ALWI void addcmul_tile_init() { MATH((llk_math_eltwise_ternary_sfpu_addcmul_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/binop_with_scalar.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/binop_with_scalar.h
@@ -86,6 +86,6 @@ ALWI void sub_unary_tile_int32(uint32_t idst, uint32_t param1) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void binop_with_scalar_tile_init() { MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_init<APPROX>())); }
+ALWI void binop_with_scalar_tile_init() { MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/clamp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/clamp.h
@@ -52,6 +52,6 @@ ALWI void clamp_tile_int32(uint32_t idst, uint32_t param0, uint32_t param1) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void clamp_tile_init() { MATH((llk_math_eltwise_unary_sfpu_clamp_init<APPROX>())); }
+ALWI void clamp_tile_init() { MATH((llk_math_eltwise_unary_sfpu_clamp_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/erf_erfc.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/erf_erfc.h
@@ -63,7 +63,7 @@ ALWI void erfc_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(erfc, sfpu::erfc_init, t
  */
 // clang-format on
 ALWI void erfc_tile(uint32_t idst) {
-    MATH(_llk_math_eltwise_unary_sfpu_params_<true>(sfpu::calculate_erfc<>, idst, (int)VectorMode::RC));
+    MATH(_llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_erfc<>, idst, (int)VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/hardmish.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/hardmish.h
@@ -38,6 +38,6 @@ ALWI void hardmish_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_hardm
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void hardmish_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardmish_init<APPROX>())); }
+ALWI void hardmish_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardmish_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/hardtanh.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/hardtanh.h
@@ -34,6 +34,6 @@ ALWI void hardtanh_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void hardtanh_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardtanh_init<APPROX>())); }
+ALWI void hardtanh_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardtanh_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/lerp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/lerp.h
@@ -31,6 +31,6 @@ ALWI void lerp_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t ods
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void lerp_tile_init() { MATH((llk_math_eltwise_ternary_sfpu_lerp_init<APPROX>())); }
+ALWI void lerp_tile_init() { MATH((llk_math_eltwise_ternary_sfpu_lerp_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/lgamma.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/lgamma.h
@@ -98,8 +98,6 @@ ALWI void lgamma_adjusted_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, u
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void lgamma_adjusted_tile_init() {
-    MATH((llk_math_eltwise_ternary_sfpu_lgamma_adjusted_init<APPROX, DST_ACCUM_MODE>()));
-}
+ALWI void lgamma_adjusted_tile_init() { MATH((llk_math_eltwise_ternary_sfpu_lgamma_adjusted_init<DST_ACCUM_MODE>())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rsub.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rsub.h
@@ -36,7 +36,7 @@ ALWI void rsub_tile(uint32_t idst, uint32_t scalar) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void rsub_tile_init() { MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_init<APPROX>())); }
+ALWI void rsub_tile_init() { MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_init())); }
 
 // clang-format off
 /**
@@ -60,6 +60,6 @@ ALWI void rsub_unary_int32_tile(uint32_t idst, uint32_t scalar) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void rsub_unary_int32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_rsub_int32_init<APPROX>())); }
+ALWI void rsub_unary_int32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_rsub_int32_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/selu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/selu.h
@@ -34,6 +34,6 @@ ALWI void selu_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void selu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_selu_init<APPROX>())); }
+ALWI void selu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_selu_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/threshold.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/threshold.h
@@ -33,6 +33,6 @@ ALWI void threshold_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void threshold_tile_init() { MATH((llk_math_eltwise_unary_sfpu_threshold_init<APPROX>())); }
+ALWI void threshold_tile_init() { MATH((llk_math_eltwise_unary_sfpu_threshold_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/gcd.h
+++ b/tt_metal/hw/inc/api/compute/gcd.h
@@ -36,6 +36,6 @@ ALWI void gcd_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void gcd_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gcd_init<APPROX>())); }
+ALWI void gcd_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gcd_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/lcm.h
+++ b/tt_metal/hw/inc/api/compute/lcm.h
@@ -36,6 +36,6 @@ ALWI void lcm_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void lcm_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lcm_init<APPROX>())); }
+ALWI void lcm_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lcm_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/logsigmoid.h
+++ b/tt_metal/hw/inc/api/compute/logsigmoid.h
@@ -34,6 +34,6 @@ ALWI void logsigmoid_tile(uint32_t idst_in0, uint32_t idst_in1, uint32_t idst_ou
  *
  * Return value: None
  */
-ALWI void logsigmoid_tile_init() { MATH((llk_math_eltwise_binary_sfpu_logsigmoid_init<APPROX>())); }
+ALWI void logsigmoid_tile_init() { MATH((llk_math_eltwise_binary_sfpu_logsigmoid_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/mask.h
+++ b/tt_metal/hw/inc/api/compute/mask.h
@@ -14,7 +14,7 @@
 namespace ckernel {
 
 ALWI void mask_tile_init() {
-    MATH((llk_math_eltwise_unary_sfpu_mask_init<true>()));  // TODO(AP): move out init
+    MATH((llk_math_eltwise_unary_sfpu_mask_init()));  // TODO(AP): move out init
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/reshuffle.h
+++ b/tt_metal/hw/inc/api/compute/reshuffle.h
@@ -34,6 +34,6 @@ ALWI void reshuffle_rows_tile(uint32_t idst, uint32_t idx_addr) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void reshuffle_rows_tile_init() { MATH((llk_math_eltwise_unary_sfpu_reshuffle_rows_init<APPROX>())); }
+ALWI void reshuffle_rows_tile_init() { MATH((llk_math_eltwise_unary_sfpu_reshuffle_rows_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/sub_int_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/sub_int_sfpu.h
@@ -68,8 +68,8 @@ ALWI void rsub_int_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void sub_int_tile_init() { MATH((llk_math_eltwise_binary_sfpu_sub_int_init<APPROX>())); }
+ALWI void sub_int_tile_init() { MATH((llk_math_eltwise_binary_sfpu_sub_int_init())); }
 
-ALWI void rsub_int_tile_init() { MATH((llk_math_eltwise_binary_sfpu_rsub_int_init<APPROX>())); }
+ALWI void rsub_int_tile_init() { MATH((llk_math_eltwise_binary_sfpu_rsub_int_init())); }
 
 }  // namespace ckernel

--- a/tt_metal/programming_examples/custom_sfpi_add/kernels/compute/tiles_add.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_add/kernels/compute/tiles_add.cpp
@@ -105,7 +105,7 @@ inline void my_add_tile_face(const uint32_t dst_index_in0, const uint32_t dst_in
  * and writes the result to tile idx_out0 in the Dst registers.
  */
 inline void my_add_tile(uint32_t idx_dst0, uint32_t idx_dst1, uint32_t idx_out0) {
-    MATH(_llk_math_eltwise_binary_sfpu_params_<false>(my_add_tile_face, idx_dst0, idx_dst1, idx_out0));
+    MATH(_llk_math_eltwise_binary_sfpu_params_(my_add_tile_face, idx_dst0, idx_dst1, idx_out0));
 }
 
 void kernel_main() {

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp
@@ -56,8 +56,7 @@ inline void smoothstep_tile_face(float edge0, float edge1, float inv_delta) {
  *   - Results written to specified Dst register
  */
 inline void my_smoothstep_tiles(uint32_t idx_dst0, float edge0, float edge1, float inv_delta) {
-    MATH(_llk_math_eltwise_unary_sfpu_params_<false>(
-        smoothstep_tile_face, idx_dst0, VectorMode::RC, edge0, edge1, inv_delta));
+    MATH(_llk_math_eltwise_unary_sfpu_params_(smoothstep_tile_face, idx_dst0, VectorMode::RC, edge0, edge1, inv_delta));
 }
 
 void kernel_main() {

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_nonlinear_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_nonlinear_quasar_test.cpp
@@ -105,7 +105,7 @@ struct sfpu_op_dispatcher<SfpuType::exponential>
 {
     static void call(int tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_exp_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_exp_<true>, tile_idx, num_sfpu_iterations);
     }
 };
 
@@ -119,7 +119,7 @@ struct sfpu_op_dispatcher<SfpuType::gelu>
 
     static void call(int tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_gelu_, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_gelu_, tile_idx, num_sfpu_iterations);
     }
 };
 
@@ -128,7 +128,7 @@ struct sfpu_op_dispatcher<SfpuType::relu>
 {
     static void call(int tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_relu_, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_relu_, tile_idx, num_sfpu_iterations);
     }
 };
 
@@ -137,7 +137,7 @@ struct sfpu_op_dispatcher<SfpuType::reciprocal>
 {
     static void call(int tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_reciprocal_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_reciprocal_<true>, tile_idx, num_sfpu_iterations);
     }
 };
 
@@ -146,7 +146,7 @@ struct sfpu_op_dispatcher<SfpuType::sqrt>
 {
     static void call(int tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_sqrt_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_sqrt_<true>, tile_idx, num_sfpu_iterations);
     }
 };
 
@@ -155,7 +155,7 @@ struct sfpu_op_dispatcher<SfpuType::tanh>
 {
     static void call(int tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_tanh_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_tanh_<true>, tile_idx, num_sfpu_iterations);
     }
 };
 
@@ -164,7 +164,7 @@ struct sfpu_op_dispatcher<SfpuType::sigmoid>
 {
     static void call(int tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_sigmoid_, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_sigmoid_, tile_idx, num_sfpu_iterations);
     }
 };
 
@@ -173,7 +173,7 @@ struct sfpu_op_dispatcher<SfpuType::silu>
 {
     static void call(int tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_silu_, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_silu_, tile_idx, num_sfpu_iterations);
     }
 };
 

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_rsqrt_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_rsqrt_quasar_test.cpp
@@ -128,7 +128,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Apply SFPU rsqrt to all tiles
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(ckernel::sfpu::_calculate_rsqrt_, params.DST_INDEX + i, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_rsqrt_, params.DST_INDEX + i, num_sfpu_iterations);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_quasar_test.cpp
@@ -127,7 +127,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Apply SFPU square to all tiles
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(ckernel::sfpu::_calculate_square_, params.DST_INDEX + i, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_square_, params.DST_INDEX + i, num_sfpu_iterations);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -142,7 +142,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_square_, params.DST_INDEX + i, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_square_, params.DST_INDEX + i, num_sfpu_iterations);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -337,7 +337,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 if (first_iteration)
                 {
                     // same as calling ckernel::llk_math_eltwise_unary_sfpu_topk_local_sort from metal.
-                    _llk_math_eltwise_unary_sfpu_params_<APPROX>(
+                    _llk_math_eltwise_unary_sfpu_params_(
                         ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROX, is_fp32_dest_acc_en, TOPK_STABLE_SORT>,
                         dst_index,
                         vector_mode,
@@ -350,7 +350,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 else
                 {
                     // Same as calling ckernel::llk_math_eltwise_unary_sfpu_topk_rebuild from metal.
-                    _llk_math_eltwise_unary_sfpu_params_<APPROX>(
+                    _llk_math_eltwise_unary_sfpu_params_(
                         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROX, is_fp32_dest_acc_en, TOPK_STABLE_SORT>,
                         dst_index,
                         vector_mode,
@@ -362,7 +362,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 }
 
                 // Always a second operation.
-                _llk_math_eltwise_unary_sfpu_params_<APPROX>(
+                _llk_math_eltwise_unary_sfpu_params_(
                     ckernel::sfpu::calculate_bitonic_topk_merge<APPROX, is_fp32_dest_acc_en, TOPK_SORT_DIRECTION, TOPK_STABLE_SORT>,
                     dst_index,
                     vector_mode,
@@ -373,7 +373,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 if (last_iteration)
                 {
                     // Same as calling ckernel::llk_math_eltwise_unary_sfpu_topk_rebuild from metal.
-                    _llk_math_eltwise_unary_sfpu_params_<APPROX>(
+                    _llk_math_eltwise_unary_sfpu_params_(
                         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROX, is_fp32_dest_acc_en, TOPK_STABLE_SORT>,
                         dst_index,
                         vector_mode,

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu_params.h
@@ -10,7 +10,7 @@
 #include "llk_math_eltwise_binary_sfpu.h"
 #include "llk_sfpu_types.h"
 
-template <bool APPROXIMATE, typename Callable, typename... Args>
+template <typename Callable, typename... Args>
 inline void _llk_math_eltwise_binary_sfpu_params_(
     Callable&& sfpu_func,
     std::uint32_t dst_index_in0,

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
@@ -10,7 +10,7 @@
 #include "llk_math_eltwise_ternary_sfpu.h"
 #include "llk_sfpu_types.h"
 
-template <bool APPROXIMATE, typename Callable, typename... Args>
+template <typename Callable, typename... Args>
 inline void _llk_math_eltwise_ternary_sfpu_params_(
     Callable&& sfpu_func,
     std::uint32_t dst_index_in0,

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
@@ -10,7 +10,7 @@
 #include "llk_math_eltwise_unary_sfpu.h"
 #include "llk_sfpu_types.h"
 
-template <bool APPROXIMATE, typename Callable, typename... Args>
+template <typename Callable, typename... Args>
 inline void _llk_math_eltwise_unary_sfpu_params_(
     Callable&& sfpu_func, std::uint32_t dst_index, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
 {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
@@ -76,15 +76,12 @@ inline void _llk_math_eltwise_unary_sfpu_init_()
 
 /**
  * @brief Runs SFPU operation for a tile (default 32x32)
- * @tparam APPROXIMATE: Some sfpu functions have 2 implementations
- * either less accurate and more performant mode, or more accurate but less performant mode
- * APPROXIMATE flag is set for more performant but less accurate mode
  * @param: sfpu_func: function pointer to the sfpu functions to run, can look at list of functions here: common/inc/sfpu/cmath_sfpu*
  * @param: dst_tile_index: Starting tile index in the destination register, values = 0 - 15
  * @param: args: variable number of args can be passed into this function, that will be passed
  * to the SFPU function pointer
  */
-template <bool APPROXIMATE, class F, class... ARGS>
+template <class F, class... ARGS>
 inline void _llk_math_eltwise_unary_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, ARGS&&... args)
 {
     _llk_math_eltwise_unary_sfpu_start_(dst_tile_index);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary_sfpu_params.h
@@ -10,7 +10,7 @@
 #include "llk_math_eltwise_binary_sfpu.h"
 #include "llk_sfpu_types.h"
 
-template <bool APPROXIMATE, typename Callable, typename... Args>
+template <typename Callable, typename... Args>
 inline void _llk_math_eltwise_binary_sfpu_params_(
     Callable&& sfpu_func,
     std::uint32_t dst_index_in0,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_ternary_sfpu_params.h
@@ -10,7 +10,7 @@
 #include "llk_math_eltwise_ternary_sfpu.h"
 #include "llk_sfpu_types.h"
 
-template <bool APPROXIMATE, typename Callable, typename... Args>
+template <typename Callable, typename... Args>
 inline void _llk_math_eltwise_ternary_sfpu_params_(
     Callable&& sfpu_func,
     std::uint32_t dst_index_in0,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
@@ -10,7 +10,7 @@
 #include "llk_math_eltwise_unary_sfpu.h"
 #include "llk_sfpu_types.h"
 
-template <bool APPROXIMATE, typename Callable, typename... Args>
+template <typename Callable, typename... Args>
 inline void _llk_math_eltwise_unary_sfpu_params_(
     Callable&& sfpu_func, std::uint32_t dst_index, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
 {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -34,7 +34,7 @@ inline void pack_init_activation() {};
 
 template <>
 inline void pack_init_activation<MoEActivationFunction::SWIGLU>() {
-    PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
+    PACK((llk_math_eltwise_binary_sfpu_swiglu_init()));
 };
 
 template <>
@@ -56,8 +56,8 @@ inline void pack_compute_activation<MoEActivationFunction::SILU>() {
 
 template <>
 inline void pack_compute_activation<MoEActivationFunction::SWIGLU>() {
-    PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(0, 1, 0)));
-    PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(2, 3, 2)));
+    PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(0, 1, 0)));
+    PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(2, 3, 2)));
 };
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/compute.cpp
@@ -143,7 +143,7 @@ void kernel_main() {
     mm_block_init(cb_s2c_in, cb_r2c_w0_w1, cb_s2c_in2, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
 
     // Initialize SFPU for GPT-OSS SwiGLU activation
-    PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
+    PACK((llk_math_eltwise_binary_sfpu_swiglu_init()));
 
     //-------------------------------------------------------------------------
     // Expert loop
@@ -244,8 +244,8 @@ void kernel_main() {
 
                 PACK(TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
-                PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(0, 1, 0)));
-                PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(2, 3, 2)));
+                PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(0, 1, 0)));
+                PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(2, 3, 2)));
 
                 PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
@@ -408,8 +408,8 @@ void kernel_main() {
             PACK(TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
             // SwiGLU activation
-            PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(0, 1, 0)));
-            PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(2, 3, 2)));
+            PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(0, 1, 0)));
+            PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(2, 3, 2)));
             PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
             pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2, /*output_tile_index=*/tile_id);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -121,13 +121,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_swiglu_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(ckernel::sfpu::swiglu_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(ckernel::sfpu::swiglu_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, class Config = ckernel::sfpu::SwiGLUConfigGPTOSS>
 inline void llk_math_eltwise_binary_sfpu_swiglu(
     uint gate_tile, uint32_t up_tile, uint32_t out_tile, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+    _llk_math_eltwise_binary_sfpu_params_(
         ckernel::sfpu::calculate_swiglu<is_fp32_dest_acc_en, 8, Config>, gate_tile, up_tile, out_tile, vector_mode);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -14,13 +14,13 @@
 //
 // Usage:
 //   // With default GPT-OSS config (alpha=1.702, clamp_limit=7.0):
-//   PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
-//   PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(gate, up, out)));
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu_init()));
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(gate, up, out)));
 //
 //   // With custom config:
 //   struct MyConfig { static constexpr float alpha = 1.0f; static constexpr float clamp_limit = 5.0f; };
-//   PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
-//   PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false, MyConfig>(gate, up, out)));
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu_init()));
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu<false, MyConfig>(gate, up, out)));
 //
 // This header is designed to be reusable across different models.
 // Include it from a compute kernel that runs SFPU on the PACK or MATH thread.
@@ -109,7 +109,6 @@ inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, c
     }
 }
 
-template <bool APPROXIMATION_MODE>
 inline void swiglu_init() {
     // SwiGLU uses sigmoid internally, which needs reciprocal table init.
     _init_reciprocal_<false, false>();
@@ -119,12 +118,11 @@ inline void swiglu_init() {
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_swiglu_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(ckernel::sfpu::swiglu_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused>(ckernel::sfpu::swiglu_init);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, class Config = ckernel::sfpu::SwiGLUConfigGPTOSS>
+template <bool is_fp32_dest_acc_en = false, class Config = ckernel::sfpu::SwiGLUConfigGPTOSS>
 inline void llk_math_eltwise_binary_sfpu_swiglu(
     uint gate_tile, uint32_t up_tile, uint32_t out_tile, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
@@ -139,8 +139,7 @@ inline void _llk_math_add_bias_init_() {
 }
 
 inline void _llk_math_add_bias_(uint32_t input_index) {
-    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_add_bias_, input_index, VectorMode::RC_custom);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_add_bias_, input_index, VectorMode::RC_custom);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
@@ -134,8 +134,7 @@ inline void _add_bias_() {
 }  // namespace sfpu
 
 inline void _llk_math_add_bias_init_() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(
-        ckernel::sfpu::_add_bias_configure_addrmod_);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_add_bias_configure_addrmod_);
 }
 
 inline void _llk_math_add_bias_(uint32_t input_index) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
@@ -152,7 +152,7 @@ inline void _top2_calculate_top2_() {
 }  // namespace sfpu
 
 inline void _llk_math_sum_top2_tile_init_() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(ckernel::sfpu::_top2_configure_addrmod_);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_top2_configure_addrmod_);
 }
 
 inline void _llk_math_sum_top2_tile_(uint32_t dst_index) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
@@ -156,8 +156,7 @@ inline void _llk_math_sum_top2_tile_init_() {
 }
 
 inline void _llk_math_sum_top2_tile_(uint32_t dst_index) {
-    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_top2_calculate_top2_, dst_index, VectorMode::RC_custom);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_top2_calculate_top2_, dst_index, VectorMode::RC_custom);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
@@ -165,7 +165,7 @@ inline void _calculate_top4_() {
 }  // namespace sfpu
 
 inline void _llk_math_top4_tile_init_() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(ckernel::sfpu::_top4_configure_addrmod_);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_top4_configure_addrmod_);
 }
 
 inline void _llk_math_top4_tile_(uint32_t dst_index) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
@@ -169,8 +169,7 @@ inline void _llk_math_top4_tile_init_() {
 }
 
 inline void _llk_math_top4_tile_(uint32_t dst_index) {
-    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_calculate_top4_, dst_index, VectorMode::RC_custom);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_top4_, dst_index, VectorMode::RC_custom);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
@@ -431,8 +431,7 @@ inline void _top8_merge_() {
 }  // namespace sfpu
 
 inline void _llk_math_top8_merge_init_() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(
-        ckernel::sfpu::_top8_merge_configure_addrmod_);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_top8_merge_configure_addrmod_);
 }
 
 template <uint32_t column_idx>

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
@@ -437,8 +437,7 @@ inline void _llk_math_top8_merge_init_() {
 
 template <uint32_t column_idx>
 inline void _llk_math_top8_merge_() {
-    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_top8_merge_<column_idx>, 0, VectorMode::RC_custom);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_top8_merge_<column_idx>, 0, VectorMode::RC_custom);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
@@ -610,7 +610,7 @@ inline void _calculate_top8_tile_(uint32_t tile_index) {
 }  // namespace sfpu
 
 inline void _llk_math_top8_tile_init_() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(ckernel::sfpu::_top8_configure_addrmod_);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_top8_configure_addrmod_);
 }
 
 inline void _llk_math_top8_tile_(uint32_t tile_index, uint32_t dst_index) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
@@ -614,7 +614,7 @@ inline void _llk_math_top8_tile_init_() {
 }
 
 inline void _llk_math_top8_tile_(uint32_t tile_index, uint32_t dst_index) {
-    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
+    _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_calculate_top8_tile_, dst_index, VectorMode::RC_custom, tile_index);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -58,7 +58,7 @@ inline void ema_sfpi_tile(
     float alpha,
     float beta,
     bool first_sample) {
-    MATH(_llk_math_eltwise_binary_sfpu_params_<false>(
+    MATH(_llk_math_eltwise_binary_sfpu_params_(
         ema_sfpi_face, inp_dst_index, prv_dst_index, out_dst_index,
         VectorMode::RC, alpha, beta, first_sample));
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -263,8 +263,7 @@ void calculate_recip_first_column() {
 
 template <bool legacy_compat = true>
 void recip_tile_first_column(uint32_t idst) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROX /*APPROXIMATE*/>(
-        calculate_recip_first_column<legacy_compat>, idst, (int)VectorMode::C);
+    _llk_math_eltwise_unary_sfpu_params_(calculate_recip_first_column<legacy_compat>, idst, (int)VectorMode::C);
 }
 #endif
 
@@ -850,7 +849,7 @@ void calculate_exponential_first_column() {
 
 template <bool SDPA_EXP_APPROX_MODE, uint16_t scale_bf16>
 void exp_tile_first_column(uint32_t idst) {
-    _llk_math_eltwise_unary_sfpu_params_<false /*APPROXIMATE*/>(
+    _llk_math_eltwise_unary_sfpu_params_(
         calculate_exponential_first_column<SDPA_EXP_APPROX_MODE, scale_bf16>, idst, (int)VectorMode::C);
 }
 #endif  // defined(TRISC_MATH) || defined(TRISC_PACK)
@@ -945,7 +944,7 @@ void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
 
 template <bool SDPA_EXP_APPROX_MODE, int vector_mode = (int)VectorMode::C>
 void fused_max_sub_exp_add_tile(uint32_t idst, int scale_bf16) {
-    _llk_math_eltwise_unary_sfpu_params_<false /*APPROXIMATE*/>(
+    _llk_math_eltwise_unary_sfpu_params_(
         calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE>, idst, vector_mode, scale_bf16);
 }
 #endif
@@ -1113,7 +1112,7 @@ void calculate_softplus_first_column(uint param0, uint param1, uint param2) {
 }
 
 void softplus_tile_first_column(uint32_t idst, uint beta, uint beta_reciprocal, uint threshold) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROX /*APPROXIMATE*/>(
+    _llk_math_eltwise_unary_sfpu_params_(
         calculate_softplus_first_column<APPROX>, idst, (int)VectorMode::C, beta, beta_reciprocal, threshold);
 }
 #endif


### PR DESCRIPTION
### Summary

The `APPROXIMATE` template parameter on `_llk_math_eltwise_unary_sfpu_params_`, `_llk_math_eltwise_binary_sfpu_params_`, `_llk_math_eltwise_ternary_sfpu_params_`, `llk_math_eltwise_unary_sfpu_init`, and `llk_math_eltwise_binary_sfpu_init` is not used within those functions — `APPROXIMATE` is only meaningful on the SFPU compute functors themselves (which are passed as callable arguments). Removing it from the wrapper/dispatch layer eliminates a redundant template parameter, reducing template bloat and simplifying the API surface.

Changes across 192 files (blackhole + wormhole_b0 + downstream consumers):

- **Unary ops**: Remove `APPROXIMATE` from `_llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(...)` → `_llk_math_eltwise_unary_sfpu_params_(...)` and `llk_math_eltwise_unary_sfpu_init<SfpuType, APPROXIMATE>` → `llk_math_eltwise_unary_sfpu_init<SfpuType>`
- **Binary ops**: Same removal pattern for binary sfpu init and params functions
- **Ternary ops**: Same removal pattern for ternary sfpu params functions
- **Macros**: Updated all `SFPU_*` macros in `llk_math_eltwise_unary_sfpu_macros.h` to drop the parameter from the dispatch calls
- **Downstream callers**: Updated SDPA, DeepSeek MOE, custom SFPI examples, and test sources

### Notes for reviewers

- The `APPROXIMATE` parameter was already being forwarded solely to the SFPU compute functor via its own template argument — the params/init wrappers never used it internally.
- Both blackhole and wormhole_b0 LLK libraries receive identical changes.
- Model kernel includes (deepseek_v3_b1) are updated to match.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/refactor_sfpu_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/refactor_sfpu_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/refactor_sfpu_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/refactor_sfpu_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/refactor_sfpu_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/refactor_sfpu_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/refactor_sfpu_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/refactor_sfpu_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/refactor_sfpu_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/refactor_sfpu_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/refactor_sfpu_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/refactor_sfpu_api)