### PR TITLE
#41555: Extend universal input support for transpose

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -112,7 +112,7 @@ DEVICE_PERF_EXPECTATIONS = {
         "blackhole": 78_106_452 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
     },
     "unet_512x512": {
-        "wormhole": 82_300_000 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+        "wormhole": 81_200_000 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
         "blackhole": None,  # Only 1024x1024 tested on Blackhole
     },
     "refiner_unet_1024x1024": {

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose_universal_io.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose_universal_io.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for transpose universal input/output support.
+
+Each test covers one distinct code path — no duplicate shapes or redundant combos.
+"""
+
+import torch
+
+import ttnn
+
+from loguru import logger
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
+
+
+def run_transpose_test(
+    shape,
+    dim0,
+    dim1,
+    device,
+    input_layout=ttnn.TILE_LAYOUT,
+    input_mem_config=None,
+    output_mem_config=None,
+    dtype=ttnn.bfloat16,
+):
+    """Helper to run a single transpose test with the given configs."""
+    torch.manual_seed(12345)
+    x = torch.rand(shape).bfloat16().float()
+
+    if input_mem_config is None:
+        input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+
+    ttnn_input = ttnn.from_torch(x, layout=input_layout, dtype=dtype, device=device, memory_config=input_mem_config)
+    result = ttnn.transpose(ttnn_input, dim0, dim1, memory_config=output_mem_config)
+
+    if output_mem_config is not None and output_mem_config.shard_spec is not None:
+        actual = result.memory_config()
+        assert (
+            actual.memory_layout == output_mem_config.memory_layout
+        ), f"Expected output memory layout {output_mem_config.memory_layout}, got {actual.memory_layout}"
+
+    ref = x.transpose(dim0, dim1)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+
+    passing, output = comp_equal(ref, got)
+    logger.info(output)
+    assert passing, f"Transpose mismatch for shape={shape}, dims=({dim0},{dim1})"
+
+
+def _block_shard_config(shape, device):
+    """Create a 2x2 block-sharded MemoryConfig for the given 4D shape."""
+    compute_grid = device.compute_with_storage_grid_size()
+    grid_x = min(2, compute_grid.x)
+    grid_y = min(2, compute_grid.y)
+    total_height = shape[0] * shape[1] * shape[2]
+    shard_shape = (total_height // grid_y, shape[3] // grid_x)
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+
+def _height_shard_config(shape, device, num_cores=4):
+    """Create a height-sharded MemoryConfig for the given 4D shape."""
+    compute_grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, compute_grid.x * compute_grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
+    total_height = shape[0] * shape[1] * shape[2]
+    shard_shape = (total_height // num_cores, shape[3])
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+
+def _width_shard_config(shape, device, num_cores=4):
+    """Create a width-sharded MemoryConfig for the given 4D shape."""
+    compute_grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, compute_grid.x * compute_grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
+    total_height = shape[0] * shape[1] * shape[2]
+    shard_shape = (total_height, shape[3] // num_cores)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+
+L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+
+# ---------------------------------------------------------------------------
+# 1. Block-sharded input → interleaved output  (WH)
+# ---------------------------------------------------------------------------
+def test_transpose_block_sharded_to_interleaved_wh(device):
+    shape = (1, 1, 64, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_block_shard_config(shape, device),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Block-sharded input → interleaved output  (CN, needs N,C > 1)
+# ---------------------------------------------------------------------------
+def test_transpose_block_sharded_to_interleaved_cn(device):
+    shape = (2, 4, 32, 64)
+    run_transpose_test(
+        shape,
+        0,
+        1,
+        device,
+        input_mem_config=_block_shard_config(shape, device),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Width-sharded input → interleaved output  (WH)
+# ---------------------------------------------------------------------------
+def test_transpose_width_sharded_to_interleaved_wh(device):
+    shape = (1, 1, 64, 128)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_width_shard_config(shape, device),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Interleaved input → height-sharded output  (WH)
+# ---------------------------------------------------------------------------
+def test_transpose_interleaved_to_height_sharded(device):
+    shape = (1, 1, 64, 128)
+    out_shape = (1, 1, 128, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=_height_shard_config(out_shape, device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Interleaved input → block-sharded output  (WH)
+# ---------------------------------------------------------------------------
+def test_transpose_interleaved_to_block_sharded(device):
+    shape = (1, 1, 64, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=_block_shard_config(shape, device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Block-sharded input → height-sharded output  (WH)
+# ---------------------------------------------------------------------------
+def test_transpose_block_to_height_sharded(device):
+    shape = (1, 1, 64, 128)
+    out_shape = (1, 1, 128, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_block_shard_config(shape, device),
+        output_mem_config=_height_shard_config(out_shape, device, num_cores=2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Width-sharded input → height-sharded output  (WH, cross shard-type)
+# ---------------------------------------------------------------------------
+def test_transpose_width_to_height_sharded(device):
+    shape = (1, 1, 64, 128)
+    out_shape = (1, 1, 128, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_width_shard_config(shape, device),
+        output_mem_config=_height_shard_config(out_shape, device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. HC transpose: height-sharded input → interleaved output
+# ---------------------------------------------------------------------------
+def test_transpose_hc_height_sharded(device):
+    shape = (1, 4, 32, 64)
+    run_transpose_test(
+        shape,
+        1,
+        2,
+        device,
+        input_mem_config=_height_shard_config(shape, device),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. CN transpose: height-sharded input → interleaved output
+# ---------------------------------------------------------------------------
+def test_transpose_cn_height_sharded(device):
+    shape = (2, 4, 32, 64)
+    run_transpose_test(
+        shape,
+        0,
+        1,
+        device,
+        input_mem_config=_height_shard_config(shape, device, num_cores=8),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. Default output derivation: block-sharded input, no explicit output
+# ---------------------------------------------------------------------------
+def test_transpose_block_sharded_default_output(device):
+    shape = (1, 1, 64, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_block_shard_config(shape, device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11. Default output derivation: height-sharded input, no explicit output
+# ---------------------------------------------------------------------------
+def test_transpose_height_sharded_default_output(device):
+    shape = (2, 4, 32, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_height_shard_config(shape, device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 12. Sharded output without shard_spec (system derives it)
+# ---------------------------------------------------------------------------
+def test_transpose_sharded_output_no_shard_spec(device):
+    shape = (1, 1, 128, 64)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_height_shard_config(shape, device),
+        output_mem_config=output_mem_config,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 13. Native L1 height-sharded (verifies native path still selected)
+# ---------------------------------------------------------------------------
+def test_transpose_native_height_sharded_wh(device):
+    shape = (1, 1, 32, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_height_shard_config(shape, device, num_cores=1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 14. Interleaved baseline (sanity)
+# ---------------------------------------------------------------------------
+def test_transpose_interleaved_baseline(device):
+    shape = (2, 3, 64, 96)
+    run_transpose_test(shape, 2, 3, device)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
@@ -8,6 +8,7 @@ Tests for transpose universal input/output support.
 Each test covers one distinct code path — no duplicate shapes or redundant combos.
 """
 
+import pytest
 import torch
 
 import ttnn
@@ -65,7 +66,7 @@ def _block_shard_config(shape, device):
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
 
 
-def _height_shard_config(shape, device, num_cores=4):
+def _height_shard_config(shape, device, num_cores=4, buffer_type=ttnn.BufferType.L1):
     """Create a height-sharded MemoryConfig for the given 4D shape."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
@@ -73,7 +74,7 @@ def _height_shard_config(shape, device, num_cores=4):
     total_height = shape[0] * shape[1] * shape[2]
     shard_shape = (total_height // num_cores, shape[3])
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type, shard_spec)
 
 
 def _width_shard_config(shape, device, num_cores=4):
@@ -318,12 +319,7 @@ def test_transpose_row_major_height_sharded_hc(device):
 # ---------------------------------------------------------------------------
 def test_transpose_dram_sharded_fallback(device):
     shape = (1, 1, 128, 64)
-    compute_grid = device.compute_with_storage_grid_size()
-    num_cores = min(4, compute_grid.x * compute_grid.y)
-    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
-    total_height = shape[0] * shape[1] * shape[2]
-    shard_spec = ttnn.ShardSpec(shard_grid, (total_height // num_cores, shape[3]), ttnn.ShardOrientation.ROW_MAJOR)
-    dram_sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+    dram_sharded = _height_shard_config(shape, device, buffer_type=ttnn.BufferType.DRAM)
 
     torch.manual_seed(12345)
     x = torch.rand(shape).bfloat16().float()
@@ -331,10 +327,9 @@ def test_transpose_dram_sharded_fallback(device):
         x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=dram_sharded
     )
     result = ttnn.transpose(ttnn_input, 2, 3, memory_config=L1_INTERLEAVED)
-    actual = result.memory_config()
     assert (
-        actual.memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
-    ), f"Expected fallback to INTERLEAVED, got {actual.memory_layout}"
+        result.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+    ), f"Expected fallback to INTERLEAVED, got {result.memory_config().memory_layout}"
 
     ref = x.transpose(2, 3)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
@@ -358,3 +353,355 @@ def test_transpose_block_sharded_output_no_shard_spec(device):
         input_mem_config=L1_INTERLEAVED,
         output_mem_config=output_mem_config,
     )
+
+
+# ---------------------------------------------------------------------------
+# 18. ROW_MAJOR + BLOCK_SHARDED input → interleaved (WH)
+# Composite fallback: sharded→interleaved hop before transpose. Neither the
+# native sharded kernels nor prim::permute handle block-sharded RM pages that
+# span multiple cores.
+# ---------------------------------------------------------------------------
+def test_transpose_row_major_block_sharded_to_interleaved_wh(device):
+    shape = (1, 1, 64, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=_block_shard_config(shape, device),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 19. ROW_MAJOR + WIDTH_SHARDED input → interleaved (WH)
+# Composite fallback. Width sharding on RM also splits pages across cores.
+# ---------------------------------------------------------------------------
+def test_transpose_row_major_width_sharded_to_interleaved_wh(device):
+    shape = (1, 1, 32, 128)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=_width_shard_config(shape, device),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 20. ROW_MAJOR interleaved input → BLOCK_SHARDED output requested (WH)
+# Composite fallback goes through interleaved output, then reshards to the
+# requested block-sharded memory config.
+# ---------------------------------------------------------------------------
+def test_transpose_row_major_interleaved_to_block_sharded_wh(device):
+    shape = (1, 1, 64, 64)
+    out_shape = (1, 1, 64, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=_block_shard_config(out_shape, device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 21. ROW_MAJOR interleaved input → WIDTH_SHARDED output requested (WH)
+# Composite fallback — mirror of 20 for width sharding output.
+# ---------------------------------------------------------------------------
+def test_transpose_row_major_interleaved_to_width_sharded_wh(device):
+    shape = (1, 1, 64, 128)
+    out_shape = (1, 1, 128, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=_width_shard_config(out_shape, device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 22. ROW_MAJOR + BLOCK_SHARDED input → BLOCK_SHARDED output (WH)
+# Both conditions of the composite-fallback guard fire: input needs an
+# interleaved hop in, and output needs a reshard out.
+# ---------------------------------------------------------------------------
+def test_transpose_row_major_block_sharded_to_block_sharded_wh(device):
+    shape = (1, 1, 64, 64)
+    out_shape = (1, 1, 64, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=_block_shard_config(shape, device),
+        output_mem_config=_block_shard_config(out_shape, device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 23. ROW_MAJOR + HEIGHT_SHARDED input → interleaved (WH)
+# NOT part of the composite fallback — HEIGHT_SHARDED RM keeps pages on a
+# single core and is handled natively. Included here as a regression guard so
+# the fallback predicate stays narrow.
+# ---------------------------------------------------------------------------
+def test_transpose_row_major_height_sharded_to_interleaved_wh(device):
+    shape = (1, 1, 64, 32)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=_height_shard_config(shape, device),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ===========================================================================
+# Irregular-shape coverage for interleaved inputs (TILE and ROW_MAJOR).
+# Shapes include:
+#   - last-two dims not multiples of TILE_HEIGHT / TILE_WIDTH (tile padding)
+#   - non-power-of-two C for HC (transposed_padded_shape rounding)
+# ===========================================================================
+@pytest.mark.parametrize(
+    "shape, dim0, dim1",
+    [
+        # WH, last-two dims irregular
+        ((1, 1, 65, 97), 2, 3),
+        ((2, 3, 71, 79), 2, 3),
+        # HC, irregular C
+        ((1, 13, 47, 64), 1, 2),
+        ((1, 7, 33, 96), 1, 2),
+        # CN
+        ((3, 5, 32, 64), 0, 1),
+    ],
+)
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_transpose_irregular_shapes_interleaved(shape, dim0, dim1, input_layout, device):
+    run_transpose_test(shape, dim0, dim1, device, input_layout=input_layout)
+
+
+# ===========================================================================
+# ROW_MAJOR interleaved input + sharded (BLOCK/WIDTH) output WITHOUT shard_spec.
+# Exercises the RM branch of `transposed_padded_shape`
+# (transpose_device_operation.cpp) and the composite-fallback spec-synthesis
+# path in `transpose.cpp` that populates a shard_spec before the reshard.
+# ===========================================================================
+@pytest.mark.parametrize(
+    "shape, dim0, dim1, memory_layout",
+    [
+        ((1, 1, 64, 128), 2, 3, ttnn.TensorMemoryLayout.BLOCK_SHARDED),
+        ((1, 1, 64, 128), 2, 3, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
+        ((1, 4, 32, 64), 1, 2, ttnn.TensorMemoryLayout.BLOCK_SHARDED),
+        ((1, 4, 32, 64), 1, 2, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
+    ],
+)
+def test_transpose_row_major_sharded_output_no_shard_spec(shape, dim0, dim1, memory_layout, device):
+    output_mem_config = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+    run_transpose_test(
+        shape,
+        dim0,
+        dim1,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=output_mem_config,
+    )
+
+
+# ===========================================================================
+# TILE + sharded output WITHOUT shard_spec, irregular C for HC.
+# Exercises `transposed_padded_shape` with `C_p = round_up(C, tile_height)`
+# in transpose_device_operation.cpp.
+# ===========================================================================
+@pytest.mark.parametrize(
+    "shape, dim0, dim1",
+    [
+        ((1, 13, 32, 64), 1, 2),
+        ((1, 47, 32, 64), 1, 2),
+        ((1, 7, 96, 64), 1, 2),
+    ],
+)
+def test_transpose_tile_hc_irregular_c_sharded_output_no_shard_spec(shape, dim0, dim1, device):
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    run_transpose_test(
+        shape,
+        dim0,
+        dim1,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=output_mem_config,
+    )
+
+
+# ===========================================================================
+# Sharded inputs with shapes that don't divide evenly.
+#
+# Two categories:
+#
+#  (a) Logical shape has dims < tile multiple but padded shape is tile-aligned
+#      and divides evenly into a tile-aligned shard. The native shard path
+#      still runs; the irregular logical dim must be round-tripped correctly.
+#
+#  (b) Uneven sharding: padded shape does NOT divide evenly into the shard
+#      shape (last shard partially filled). `is_native_transpose_sharding`
+#      returns false via `is_uneven`, so the op falls through to interleaved
+#      factories with TensorAccessorArgs.
+#
+# RM inputs additionally exercise the composite fallback from transpose.cpp.
+# ===========================================================================
+
+
+def _explicit_block_shard_config(grid_y, grid_x, sh, sw):
+    spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_height_shard_config(device, ncores, sh, sw):
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, device.compute_with_storage_grid_size(), True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_width_shard_config(device, ncores, sh, sw):
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, device.compute_with_storage_grid_size(), True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, spec)
+
+
+# (a) TILE + sharded inputs with IRREGULAR logical shape but tile-aligned padded + shard.
+@pytest.mark.parametrize(
+    "shape, dim0, dim1, mc_factory",
+    [
+        pytest.param((1, 1, 65, 64), 2, 3, lambda d: _explicit_block_shard_config(3, 2, 32, 32), id="block_3x2_32x32"),
+        pytest.param((1, 1, 64, 97), 2, 3, lambda d: _explicit_block_shard_config(2, 4, 32, 32), id="block_2x4_32x32"),
+        pytest.param((1, 1, 65, 64), 2, 3, lambda d: _explicit_height_shard_config(d, 3, 32, 64), id="height_3_32x64"),
+        pytest.param((1, 1, 32, 97), 2, 3, lambda d: _explicit_width_shard_config(d, 4, 32, 32), id="width_4_32x32"),
+        pytest.param(
+            (1, 13, 32, 64), 1, 2, lambda d: _explicit_block_shard_config(2, 2, 512, 32), id="block_2x2_hc_512x32"
+        ),
+    ],
+)
+def test_transpose_tile_sharded_irregular_shapes(shape, dim0, dim1, mc_factory, device):
+    run_transpose_test(shape, dim0, dim1, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=mc_factory(device))
+
+
+# (a) ROW_MAJOR + BLOCK/WIDTH sharded inputs with IRREGULAR W.
+# These exercise the composite fallback (transpose.cpp is_block_or_width_sharded_mc guard)
+# with shapes whose last dim is not a tile multiple.
+@pytest.mark.parametrize(
+    "shape, dim0, dim1, mc_factory",
+    [
+        pytest.param((1, 1, 64, 96), 2, 3, lambda d: _explicit_block_shard_config(2, 3, 32, 32), id="block_2x3_32x32"),
+        pytest.param((1, 1, 64, 96), 2, 3, lambda d: _explicit_width_shard_config(d, 3, 64, 32), id="width_3_64x32"),
+    ],
+)
+def test_transpose_row_major_sharded_irregular_shapes(shape, dim0, dim1, mc_factory, device):
+    run_transpose_test(
+        shape, dim0, dim1, device, input_layout=ttnn.ROW_MAJOR_LAYOUT, input_mem_config=mc_factory(device)
+    )
+
+
+# (b) TILE UNEVEN sharding — padded shape doesn't divide evenly into the shard
+# shape. `is_native_transpose_sharding` returns false; op routes through the
+# interleaved factories' TensorAccessor fallback.
+@pytest.mark.parametrize(
+    "shape, dim0, dim1, mc_factory",
+    [
+        pytest.param((1, 1, 96, 64), 2, 3, lambda d: _explicit_block_shard_config(2, 2, 64, 32), id="block_2x2_64x32"),
+        pytest.param((1, 1, 64, 96), 2, 3, lambda d: _explicit_block_shard_config(2, 2, 32, 64), id="block_2x2_32x64"),
+    ],
+)
+def test_transpose_tile_sharded_uneven(shape, dim0, dim1, mc_factory, device):
+    run_transpose_test(shape, dim0, dim1, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=mc_factory(device))
+
+
+# ===========================================================================
+# Additional regression guards for transpose-specific code paths.
+# Dtype, COL_MAJOR, identity, non-canonical dims, DRAM no-spec, etc. are not
+# duplicated here — they are exercised by generic ttnn tests or by the
+# existing universal I/O tests above.
+# ===========================================================================
+
+
+# CN + ROW_MAJOR + BLOCK/WIDTH sharded input.
+# Exercises the composite fallback in transpose_impl for the CN dim (the guard
+# is keyed on memory layout, not dim).
+@pytest.mark.parametrize(
+    "shape, mc_factory",
+    [
+        pytest.param((2, 4, 32, 64), lambda d: _explicit_block_shard_config(2, 2, 128, 32), id="block_2x2_128x32"),
+        pytest.param((2, 4, 32, 64), lambda d: _explicit_width_shard_config(d, 2, 256, 32), id="width_2_256x32"),
+    ],
+)
+def test_transpose_cn_row_major_block_width_sharded(shape, mc_factory, device):
+    run_transpose_test(shape, 0, 1, device, input_layout=ttnn.ROW_MAJOR_LAYOUT, input_mem_config=mc_factory(device))
+
+
+# N>1 and/or C>1 with sharded input for WH transpose.
+# Exercises shard-geometry helpers that flatten over the leading dims.
+@pytest.mark.parametrize(
+    "shape, layout, mc_factory",
+    [
+        pytest.param(
+            (2, 1, 64, 64),
+            ttnn.TILE_LAYOUT,
+            lambda d: _explicit_height_shard_config(d, 4, 32, 64),
+            id="tile_height_4_32x64",
+        ),
+        pytest.param(
+            (1, 2, 64, 64),
+            ttnn.TILE_LAYOUT,
+            lambda d: _explicit_block_shard_config(2, 2, 64, 32),
+            id="tile_block_2x2_64x32",
+        ),
+        pytest.param(
+            (2, 2, 32, 64),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d: _explicit_height_shard_config(d, 4, 32, 64),
+            id="rm_height_4_32x64",
+        ),
+    ],
+)
+def test_transpose_multi_batch_channel_sharded_wh(shape, layout, mc_factory, device):
+    run_transpose_test(shape, 2, 3, device, input_layout=layout, input_mem_config=mc_factory(device))
+
+
+# ROW_MAJOR HEIGHT_SHARDED inputs whose shard element count (shard_h * shard_w) is NOT a
+# multiple of the tile footprint (32 * 32 = 1024). Before the is_native_transpose_sharding
+# fix, these silently hit the native RM height-sharded kernel and produced garbage or hit a
+# CB allocation failure. After the fix, the predicate returns false for such shards and the
+# device op selects the interleaved WH factory, which reads/writes the sharded buffer
+# directly over NOC via TensorAccessorArgs (no physical reshard). Tile-aligned RM HS
+# (e.g. (32,64)) remains on the fast specialized native path.
+@pytest.mark.parametrize(
+    "shape, shard_shape",
+    [
+        ((1, 1, 52, 64), (13, 64)),
+        ((1, 1, 40, 40), (10, 40)),
+    ],
+    ids=["HS_nontile_13x64", "HS_nontile_10x40"],
+)
+def test_transpose_row_major_height_sharded_nontile_aligned_wh(shape, shard_shape, device):
+    imc = _explicit_height_shard_config(device, 4, shard_shape[0], shard_shape[1])
+    run_transpose_test(shape, 2, 3, device, input_layout=ttnn.ROW_MAJOR_LAYOUT, input_mem_config=imc)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
@@ -293,3 +293,68 @@ def test_transpose_native_height_sharded_wh(device):
 def test_transpose_interleaved_baseline(device):
     shape = (2, 3, 64, 96)
     run_transpose_test(shape, 2, 3, device)
+
+
+# ---------------------------------------------------------------------------
+# 15. ROW_MAJOR height-sharded input (exercises ROW_MAJOR branch in
+# get_transpose_shard_specs / is_shard_tile_aligned)
+# ---------------------------------------------------------------------------
+def test_transpose_row_major_height_sharded_hc(device):
+    shape = (1, 4, 32, 64)
+    run_transpose_test(
+        shape,
+        1,
+        2,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=_height_shard_config(shape, device),
+        output_mem_config=L1_INTERLEAVED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 16. DRAM-sharded input falls back to interleaved
+# (is_native_transpose_sharding rejects BufferType::DRAM)
+# ---------------------------------------------------------------------------
+def test_transpose_dram_sharded_fallback(device):
+    shape = (1, 1, 128, 64)
+    compute_grid = device.compute_with_storage_grid_size()
+    num_cores = min(4, compute_grid.x * compute_grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
+    total_height = shape[0] * shape[1] * shape[2]
+    shard_spec = ttnn.ShardSpec(shard_grid, (total_height // num_cores, shape[3]), ttnn.ShardOrientation.ROW_MAJOR)
+    dram_sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+    torch.manual_seed(12345)
+    x = torch.rand(shape).bfloat16().float()
+    ttnn_input = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=dram_sharded
+    )
+    result = ttnn.transpose(ttnn_input, 2, 3, memory_config=L1_INTERLEAVED)
+    actual = result.memory_config()
+    assert (
+        actual.memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+    ), f"Expected fallback to INTERLEAVED, got {actual.memory_layout}"
+
+    ref = x.transpose(2, 3)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    passing, output = comp_equal(ref, got)
+    logger.info(output)
+    assert passing, f"Transpose mismatch for DRAM-sharded fallback, shape={shape}"
+
+
+# ---------------------------------------------------------------------------
+# 17. Block-sharded output without shard_spec — exercises the block-shard
+# branch of generate_transpose_shard_spec (interleaved input, no spec)
+# ---------------------------------------------------------------------------
+def test_transpose_block_sharded_output_no_shard_spec(device):
+    shape = (1, 1, 128, 128)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=output_mem_config,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
@@ -37,11 +37,22 @@ def run_transpose_test(
     ttnn_input = ttnn.from_torch(x, layout=input_layout, dtype=dtype, device=device, memory_config=input_mem_config)
     result = ttnn.transpose(ttnn_input, dim0, dim1, memory_config=output_mem_config)
 
-    if output_mem_config is not None and output_mem_config.shard_spec is not None:
+    # Whenever the caller specified an output MemoryConfig, the result must honor the requested
+    # memory_layout. If the request was sharded we additionally require a concrete shard_spec on
+    # the output so silent fallbacks to interleaved (or a dropped spec) surface as test failures.
+    if output_mem_config is not None:
         actual = result.memory_config()
         assert (
             actual.memory_layout == output_mem_config.memory_layout
         ), f"Expected output memory layout {output_mem_config.memory_layout}, got {actual.memory_layout}"
+        if output_mem_config.memory_layout in (
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ):
+            assert (
+                actual.shard_spec is not None
+            ), f"Sharded output requested but result has no shard_spec (silently fell back?)"
 
     ref = x.transpose(dim0, dim1)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
@@ -356,6 +367,33 @@ def test_transpose_block_sharded_output_no_shard_spec(device):
 
 
 # ---------------------------------------------------------------------------
+# 17b. Non-native sharded input + user-requested sharded output without
+# shard_spec — exercises the else-if ordering in `detail::transpose_` that
+# honors the user's `memory_layout` over the non-native default-to-interleaved
+# fallback. Before this ordering, a TILE BLOCK_SHARDED input paired with a
+# sharded no-spec output (any layout) would silently return L1 INTERLEAVED.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "requested_out_layout",
+    [
+        pytest.param(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="H_out"),
+        pytest.param(ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="W_out"),
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="B_out"),
+    ],
+)
+def test_transpose_non_native_sharded_input_to_sharded_nospec(requested_out_layout, device):
+    shape = (1, 1, 64, 64)
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_mem_config=_block_shard_config(shape, device),
+        output_mem_config=ttnn.MemoryConfig(requested_out_layout, ttnn.BufferType.L1),
+    )
+
+
+# ---------------------------------------------------------------------------
 # 18. ROW_MAJOR + BLOCK_SHARDED input → interleaved (WH)
 # Composite fallback: sharded→interleaved hop before transpose. Neither the
 # native sharded kernels nor prim::permute handle block-sharded RM pages that
@@ -562,7 +600,12 @@ def test_transpose_tile_hc_irregular_c_sharded_output_no_shard_spec(shape, dim0,
 # ===========================================================================
 
 
-def _explicit_block_shard_config(grid_y, grid_x, sh, sw):
+def _explicit_block_shard_config(device, grid_y, grid_x, sh, sw):
+    """Block-shard config clamped to the device's compute grid. Skips if clamping would change
+    the requested grid (the test was authored for a specific grid layout)."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if grid_y > compute_grid.y or grid_x > compute_grid.x:
+        pytest.skip(f"Device grid ({compute_grid.y}x{compute_grid.x}) too small for requested {grid_y}x{grid_x}")
     spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
         (sh, sw),
@@ -572,8 +615,12 @@ def _explicit_block_shard_config(grid_y, grid_x, sh, sw):
 
 
 def _explicit_height_shard_config(device, ncores, sh, sw):
+    """Height-shard config; skips if the device can't host `ncores`."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
     spec = ttnn.ShardSpec(
-        ttnn.num_cores_to_corerangeset(ncores, device.compute_with_storage_grid_size(), True),
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
         (sh, sw),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
@@ -581,8 +628,12 @@ def _explicit_height_shard_config(device, ncores, sh, sw):
 
 
 def _explicit_width_shard_config(device, ncores, sh, sw):
+    """Width-shard config; skips if the device can't host `ncores`."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
     spec = ttnn.ShardSpec(
-        ttnn.num_cores_to_corerangeset(ncores, device.compute_with_storage_grid_size(), True),
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
         (sh, sw),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
@@ -593,12 +644,16 @@ def _explicit_width_shard_config(device, ncores, sh, sw):
 @pytest.mark.parametrize(
     "shape, dim0, dim1, mc_factory",
     [
-        pytest.param((1, 1, 65, 64), 2, 3, lambda d: _explicit_block_shard_config(3, 2, 32, 32), id="block_3x2_32x32"),
-        pytest.param((1, 1, 64, 97), 2, 3, lambda d: _explicit_block_shard_config(2, 4, 32, 32), id="block_2x4_32x32"),
+        pytest.param(
+            (1, 1, 65, 64), 2, 3, lambda d: _explicit_block_shard_config(d, 3, 2, 32, 32), id="block_3x2_32x32"
+        ),
+        pytest.param(
+            (1, 1, 64, 97), 2, 3, lambda d: _explicit_block_shard_config(d, 2, 4, 32, 32), id="block_2x4_32x32"
+        ),
         pytest.param((1, 1, 65, 64), 2, 3, lambda d: _explicit_height_shard_config(d, 3, 32, 64), id="height_3_32x64"),
         pytest.param((1, 1, 32, 97), 2, 3, lambda d: _explicit_width_shard_config(d, 4, 32, 32), id="width_4_32x32"),
         pytest.param(
-            (1, 13, 32, 64), 1, 2, lambda d: _explicit_block_shard_config(2, 2, 512, 32), id="block_2x2_hc_512x32"
+            (1, 13, 32, 64), 1, 2, lambda d: _explicit_block_shard_config(d, 2, 2, 512, 32), id="block_2x2_hc_512x32"
         ),
     ],
 )
@@ -612,7 +667,9 @@ def test_transpose_tile_sharded_irregular_shapes(shape, dim0, dim1, mc_factory, 
 @pytest.mark.parametrize(
     "shape, dim0, dim1, mc_factory",
     [
-        pytest.param((1, 1, 64, 96), 2, 3, lambda d: _explicit_block_shard_config(2, 3, 32, 32), id="block_2x3_32x32"),
+        pytest.param(
+            (1, 1, 64, 96), 2, 3, lambda d: _explicit_block_shard_config(d, 2, 3, 32, 32), id="block_2x3_32x32"
+        ),
         pytest.param((1, 1, 64, 96), 2, 3, lambda d: _explicit_width_shard_config(d, 3, 64, 32), id="width_3_64x32"),
     ],
 )
@@ -628,8 +685,12 @@ def test_transpose_row_major_sharded_irregular_shapes(shape, dim0, dim1, mc_fact
 @pytest.mark.parametrize(
     "shape, dim0, dim1, mc_factory",
     [
-        pytest.param((1, 1, 96, 64), 2, 3, lambda d: _explicit_block_shard_config(2, 2, 64, 32), id="block_2x2_64x32"),
-        pytest.param((1, 1, 64, 96), 2, 3, lambda d: _explicit_block_shard_config(2, 2, 32, 64), id="block_2x2_32x64"),
+        pytest.param(
+            (1, 1, 96, 64), 2, 3, lambda d: _explicit_block_shard_config(d, 2, 2, 64, 32), id="block_2x2_64x32"
+        ),
+        pytest.param(
+            (1, 1, 64, 96), 2, 3, lambda d: _explicit_block_shard_config(d, 2, 2, 32, 64), id="block_2x2_32x64"
+        ),
     ],
 )
 def test_transpose_tile_sharded_uneven(shape, dim0, dim1, mc_factory, device):
@@ -650,7 +711,7 @@ def test_transpose_tile_sharded_uneven(shape, dim0, dim1, mc_factory, device):
 @pytest.mark.parametrize(
     "shape, mc_factory",
     [
-        pytest.param((2, 4, 32, 64), lambda d: _explicit_block_shard_config(2, 2, 128, 32), id="block_2x2_128x32"),
+        pytest.param((2, 4, 32, 64), lambda d: _explicit_block_shard_config(d, 2, 2, 128, 32), id="block_2x2_128x32"),
         pytest.param((2, 4, 32, 64), lambda d: _explicit_width_shard_config(d, 2, 256, 32), id="width_2_256x32"),
     ],
 )
@@ -672,7 +733,7 @@ def test_transpose_cn_row_major_block_width_sharded(shape, mc_factory, device):
         pytest.param(
             (1, 2, 64, 64),
             ttnn.TILE_LAYOUT,
-            lambda d: _explicit_block_shard_config(2, 2, 64, 32),
+            lambda d: _explicit_block_shard_config(d, 2, 2, 64, 32),
             id="tile_block_2x2_64x32",
         ),
         pytest.param(
@@ -705,3 +766,91 @@ def test_transpose_multi_batch_channel_sharded_wh(shape, layout, mc_factory, dev
 def test_transpose_row_major_height_sharded_nontile_aligned_wh(shape, shard_shape, device):
     imc = _explicit_height_shard_config(device, 4, shard_shape[0], shard_shape[1])
     run_transpose_test(shape, 2, 3, device, input_layout=ttnn.ROW_MAJOR_LAYOUT, input_mem_config=imc)
+
+
+# CN TILE with sharded output (no shard_spec provided by caller). Exercises
+# `derive_effective_output_memory_config`'s spec-synthesis path for CN through
+# `TransposeCNProgramFactory`, which uses TensorAccessorArgs on the writer.
+# Covers both interleaved→sharded-output and height-sharded→sharded-output.
+@pytest.mark.parametrize(
+    "input_mem_factory",
+    [
+        pytest.param(lambda d, shape: L1_INTERLEAVED, id="in_interleaved"),
+        pytest.param(lambda d, shape: _height_shard_config(shape, d), id="in_height_sharded"),
+    ],
+)
+def test_transpose_cn_sharded_output(input_mem_factory, device):
+    shape = (2, 4, 32, 64)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    run_transpose_test(
+        shape,
+        0,
+        1,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=input_mem_factory(device, shape),
+        output_mem_config=output_mem_config,
+    )
+
+
+# DRAM interleaved input + DRAM interleaved output. Verifies the full NOC-based
+# TensorAccessor path works end-to-end when both sides live in DRAM rather than L1.
+DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+
+@pytest.mark.parametrize(
+    "dim0, dim1",
+    [
+        pytest.param(2, 3, id="WH"),
+        pytest.param(1, 2, id="HC"),
+        pytest.param(0, 1, id="CN"),
+    ],
+)
+def test_transpose_dram_interleaved(dim0, dim1, device):
+    run_transpose_test(
+        (1, 4, 64, 128),
+        dim0,
+        dim1,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=DRAM_INTERLEAVED,
+        output_mem_config=DRAM_INTERLEAVED,
+    )
+
+
+# WH transpose on tile-aligned height-sharded inputs whose transposed width legitimately shrinks
+# below a tile. A naive `std::max(scaled, TILE_*)` clamp in `adjust_shard_spec_to_shape` oversizes
+# the output shard for these shapes (scaled_h = 16 gets clamped up to 32, claiming 1024 elements
+# of capacity for a shard that should only hold 512), producing silent correctness regressions.
+# The fix returns the exact ratio-scaled shape, then the device op's post-check detects the
+# sub-tile TILE shard and falls through to `generate_transpose_shard_spec` for a tile-aligned
+# fresh spec. Verifies both small single-batch cases and asymmetric N>1 shapes.
+@pytest.mark.parametrize(
+    "shape, ncores, shard_shape",
+    [
+        pytest.param((1, 1, 64, 32), 2, (32, 32), id="1x1_64x32_hs_2x_32x32"),
+        pytest.param((1, 1, 128, 32), 4, (32, 32), id="1x1_128x32_hs_4x_32x32"),
+        pytest.param((2, 1, 64, 32), 4, (32, 32), id="2x1_64x32_hs_4x_32x32"),
+        pytest.param((2, 2, 64, 32), 8, (32, 32), id="2x2_64x32_hs_8x_32x32"),
+    ],
+)
+def test_transpose_wh_shrink_sub_tile_sharded(shape, ncores, shard_shape, device):
+    imc = _explicit_height_shard_config(device, ncores, shard_shape[0], shard_shape[1])
+    run_transpose_test(shape, 2, 3, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=imc)
+
+
+# HC TILE transpose with an irregular logical H (last tile partial) and a tile-aligned
+# height-sharded input. The padded H is rounded up to TILE_HEIGHT, so the shard geometry must
+# remain tile-aligned; the op rotates the padded H into output dim[1] and pads new dim[2] to
+# TILE_HEIGHT from the logical C. Exercises the HC TILE sharded path end-to-end against an
+# input whose logical shape doesn't divide evenly.
+@pytest.mark.parametrize(
+    "shape, ncores, shard_shape",
+    [
+        pytest.param((1, 13, 32, 64), 13, (32, 64), id="C13_H32_hs_13x_32x64"),
+        pytest.param((1, 5, 32, 64), 5, (32, 64), id="C5_H32_hs_5x_32x64"),
+    ],
+)
+def test_transpose_hc_tile_irregular_sharded_input(shape, ncores, shard_shape, device):
+    imc = _explicit_height_shard_config(device, ncores, shard_shape[0], shard_shape[1])
+    run_transpose_test(shape, 1, 2, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=imc)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
@@ -75,26 +75,34 @@ _TILE_HEIGHT = 32
 _TILE_WIDTH = 32
 
 
-def _assert_tile_aligned(shard_shape, layout, helper_name):
-    """For TILE_LAYOUT both shard dims must be a multiple of the tile size, otherwise
-    `TensorSpec` construction fails inside ttnn with `TT_FATAL @ tensor_layout.cpp:159`.
-    Surfacing the constraint here yields a clear test-side error for future call sites."""
+def _round_up(x, mult):
+    return ((x + mult - 1) // mult) * mult
+
+
+def _padded_hw(shape, layout):
+    """Return (total_height, width) using tile-padded dims for TILE_LAYOUT, logical for RM.
+    Pads each dim independently to match ttnn's per-dim tile padding (e.g. (2,3,71,79) →
+    total_h = 2*3*96 = 576, w = 96)."""
     if layout == ttnn.TILE_LAYOUT:
-        h, w = shard_shape
-        assert h % _TILE_HEIGHT == 0 and w % _TILE_WIDTH == 0, (
-            f"{helper_name}: shard_shape={shard_shape} must be a multiple of "
-            f"({_TILE_HEIGHT}, {_TILE_WIDTH}) for TILE_LAYOUT inputs"
-        )
+        return shape[0] * shape[1] * _round_up(shape[2], _TILE_HEIGHT), _round_up(shape[3], _TILE_WIDTH)
+    return shape[0] * shape[1] * shape[2], shape[3]
+
+
+def _tile_align(shard_shape, layout):
+    """Round shard dims up to the nearest tile for TILE_LAYOUT; pass through for ROW_MAJOR."""
+    h, w = shard_shape
+    if layout == ttnn.TILE_LAYOUT:
+        return (_round_up(h, _TILE_HEIGHT), _round_up(w, _TILE_WIDTH))
+    return (h, w)
 
 
 def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
-    """Create a 2x2 block-sharded MemoryConfig for the given 4D shape."""
+    """Create a 2x2 block-sharded MemoryConfig; shard rounded up to tile for TILE inputs."""
     compute_grid = device.compute_with_storage_grid_size()
     grid_x = min(2, compute_grid.x)
     grid_y = min(2, compute_grid.y)
-    total_height = shape[0] * shape[1] * shape[2]
-    shard_shape = (total_height // grid_y, shape[3] // grid_x)
-    _assert_tile_aligned(shard_shape, layout, "_block_shard_config")
+    total_h, w = _padded_hw(shape, layout)
+    shard_shape = _tile_align(((total_h + grid_y - 1) // grid_y, (w + grid_x - 1) // grid_x), layout)
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
         shard_shape,
@@ -104,25 +112,23 @@ def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
 
 
 def _height_shard_config(shape, device, num_cores=4, buffer_type=ttnn.BufferType.L1, layout=ttnn.TILE_LAYOUT):
-    """Create a height-sharded MemoryConfig for the given 4D shape."""
+    """Create a height-sharded MemoryConfig; shard rounded up to tile for TILE inputs."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
-    total_height = shape[0] * shape[1] * shape[2]
-    shard_shape = (total_height // num_cores, shape[3])
-    _assert_tile_aligned(shard_shape, layout, "_height_shard_config")
+    total_h, w = _padded_hw(shape, layout)
+    shard_shape = _tile_align(((total_h + num_cores - 1) // num_cores, w), layout)
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type, shard_spec)
 
 
 def _width_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
-    """Create a width-sharded MemoryConfig for the given 4D shape."""
+    """Create a width-sharded MemoryConfig; shard rounded up to tile for TILE inputs."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
-    total_height = shape[0] * shape[1] * shape[2]
-    shard_shape = (total_height, shape[3] // num_cores)
-    _assert_tile_aligned(shard_shape, layout, "_width_shard_config")
+    total_h, w = _padded_hw(shape, layout)
+    shard_shape = _tile_align((total_h, (w + num_cores - 1) // num_cores), layout)
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
 
@@ -445,23 +451,43 @@ def test_transpose_universal_io_row_major(shape, dim0, dim1, input_factory, outp
     )
 
 
-# Interleaved input with irregular shapes (TILE and ROW_MAJOR) across WH/HC/CN.
-@pytest.mark.parametrize(
-    "shape, dim0, dim1",
-    [
-        # WH, last-two dims irregular
-        ((1, 1, 65, 97), 2, 3),
-        ((2, 3, 71, 79), 2, 3),
-        # HC, irregular C
-        ((1, 13, 47, 64), 1, 2),
-        ((1, 7, 33, 96), 1, 2),
-        # CN
-        ((3, 5, 32, 64), 0, 1),
-    ],
-)
+# Irregular logical shapes (last-two not tile multiples) across WH/HC/CN, both interleaved
+# and sharded. Sharded uses the rounded-up shard helpers (tile-aligned shards on irregular
+# logical shapes — per review).
+_IRREGULAR_SHAPES = [
+    ((1, 1, 65, 97), 2, 3),
+    ((2, 3, 71, 79), 2, 3),
+    ((1, 13, 47, 64), 1, 2),
+    ((1, 7, 33, 96), 1, 2),
+    ((3, 5, 32, 64), 0, 1),
+]
+
+
+@pytest.mark.parametrize("shape, dim0, dim1", _IRREGULAR_SHAPES)
 @pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 def test_transpose_irregular_shapes_interleaved(shape, dim0, dim1, input_layout, device):
     run_transpose_test(shape, dim0, dim1, device, input_layout=input_layout)
+
+
+@pytest.mark.parametrize("shape, dim0, dim1", _IRREGULAR_SHAPES)
+@pytest.mark.parametrize(
+    "shard_factory",
+    [
+        pytest.param(_block_shard_config, id="block"),
+        pytest.param(_height_shard_config, id="height"),
+        pytest.param(_width_shard_config, id="width"),
+    ],
+)
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_transpose_irregular_shapes_sharded(shape, dim0, dim1, shard_factory, input_layout, device):
+    run_transpose_test(
+        shape,
+        dim0,
+        dim1,
+        device,
+        input_layout=input_layout,
+        input_mem_config=shard_factory(shape, device, layout=input_layout),
+    )
 
 
 # ROW_MAJOR interleaved input → BLOCK/WIDTH sharded output without shard_spec.

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_transpose_universal_io.py
@@ -13,8 +13,13 @@ import torch
 
 import ttnn
 
-from loguru import logger
-from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
+from tests.ttnn.utils_for_testing import assert_with_ulp, assert_with_pcc
+
+_TTNN_TO_TORCH_DTYPE = {
+    ttnn.bfloat16: torch.bfloat16,
+    ttnn.float32: torch.float32,
+    ttnn.bfloat8_b: torch.bfloat16,
+}
 
 
 def run_transpose_test(
@@ -29,7 +34,8 @@ def run_transpose_test(
 ):
     """Helper to run a single transpose test with the given configs."""
     torch.manual_seed(12345)
-    x = torch.rand(shape).bfloat16().float()
+    torch_dtype = _TTNN_TO_TORCH_DTYPE[dtype]
+    x = torch.rand(shape, dtype=torch_dtype)
 
     if input_mem_config is None:
         input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
@@ -57,18 +63,38 @@ def run_transpose_test(
     ref = x.transpose(dim0, dim1)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
 
-    passing, output = comp_equal(ref, got)
-    logger.info(output)
-    assert passing, f"Transpose mismatch for shape={shape}, dims=({dim0},{dim1})"
+    # bf16 is bit-exact (ULP=0); bf8_b and f32 use PCC because composite paths can perturb
+    # individual elements (block-quantization for bf8_b, bf16-precision intermediates for f32).
+    if dtype == ttnn.bfloat16:
+        assert_with_ulp(ref, got, ulp_threshold=0)
+    else:
+        assert_with_pcc(ref.float(), got.float(), 0.9999)
 
 
-def _block_shard_config(shape, device):
+_TILE_HEIGHT = 32
+_TILE_WIDTH = 32
+
+
+def _assert_tile_aligned(shard_shape, layout, helper_name):
+    """For TILE_LAYOUT both shard dims must be a multiple of the tile size, otherwise
+    `TensorSpec` construction fails inside ttnn with `TT_FATAL @ tensor_layout.cpp:159`.
+    Surfacing the constraint here yields a clear test-side error for future call sites."""
+    if layout == ttnn.TILE_LAYOUT:
+        h, w = shard_shape
+        assert h % _TILE_HEIGHT == 0 and w % _TILE_WIDTH == 0, (
+            f"{helper_name}: shard_shape={shard_shape} must be a multiple of "
+            f"({_TILE_HEIGHT}, {_TILE_WIDTH}) for TILE_LAYOUT inputs"
+        )
+
+
+def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
     """Create a 2x2 block-sharded MemoryConfig for the given 4D shape."""
     compute_grid = device.compute_with_storage_grid_size()
     grid_x = min(2, compute_grid.x)
     grid_y = min(2, compute_grid.y)
     total_height = shape[0] * shape[1] * shape[2]
     shard_shape = (total_height // grid_y, shape[3] // grid_x)
+    _assert_tile_aligned(shard_shape, layout, "_block_shard_config")
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
         shard_shape,
@@ -77,24 +103,26 @@ def _block_shard_config(shape, device):
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
 
 
-def _height_shard_config(shape, device, num_cores=4, buffer_type=ttnn.BufferType.L1):
+def _height_shard_config(shape, device, num_cores=4, buffer_type=ttnn.BufferType.L1, layout=ttnn.TILE_LAYOUT):
     """Create a height-sharded MemoryConfig for the given 4D shape."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
     total_height = shape[0] * shape[1] * shape[2]
     shard_shape = (total_height // num_cores, shape[3])
+    _assert_tile_aligned(shard_shape, layout, "_height_shard_config")
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type, shard_spec)
 
 
-def _width_shard_config(shape, device, num_cores=4):
+def _width_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
     """Create a width-sharded MemoryConfig for the given 4D shape."""
     compute_grid = device.compute_with_storage_grid_size()
     num_cores = min(num_cores, compute_grid.x * compute_grid.y)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
     total_height = shape[0] * shape[1] * shape[2]
     shard_shape = (total_height, shape[3] // num_cores)
+    _assert_tile_aligned(shard_shape, layout, "_width_shard_config")
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
 
@@ -103,237 +131,201 @@ L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.Buf
 DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
 
-# ---------------------------------------------------------------------------
-# 1. Block-sharded input → interleaved output  (WH)
-# ---------------------------------------------------------------------------
-def test_transpose_block_sharded_to_interleaved_wh(device):
-    shape = (1, 1, 64, 64)
+def _interleaved(_d):
+    return L1_INTERLEAVED
+
+
+def _sharded_no_spec(memory_layout):
+    return lambda _d: ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+
+
+# Universal-IO matrix: every TILE_LAYOUT input × output combination the device op must support.
+# Each row is one distinct routing path through `transpose_impl` / `select_program_factory`.
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(ttnn.bfloat16, id="bf16"),
+        pytest.param(ttnn.float32, id="f32"),
+        pytest.param(ttnn.bfloat8_b, id="bf8b"),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, dim0, dim1, input_layout, input_factory, output_factory",
+    [
+        pytest.param(
+            (1, 1, 64, 64),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            _interleaved,
+            id="WH_block_to_interleaved",
+        ),
+        pytest.param(
+            (2, 4, 32, 64),
+            0,
+            1,
+            ttnn.TILE_LAYOUT,
+            lambda d: _block_shard_config((2, 4, 32, 64), d),
+            _interleaved,
+            id="CN_block_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            lambda d: _width_shard_config((1, 1, 64, 128), d),
+            _interleaved,
+            id="WH_width_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            _interleaved,
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            id="WH_interleaved_to_height",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            _interleaved,
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            id="WH_interleaved_to_block",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            lambda d: _block_shard_config((1, 1, 64, 128), d),
+            lambda d: _height_shard_config((1, 1, 128, 64), d, num_cores=2),
+            id="WH_block_to_height_2cores",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            lambda d: _width_shard_config((1, 1, 64, 128), d),
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            id="WH_width_to_height",
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            1,
+            2,
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_shard_config((1, 4, 32, 64), d),
+            _interleaved,
+            id="HC_height_to_interleaved",
+        ),
+        pytest.param(
+            (2, 4, 32, 64),
+            0,
+            1,
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_shard_config((2, 4, 32, 64), d, num_cores=8),
+            _interleaved,
+            id="CN_height_8cores_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            None,
+            id="WH_block_default_output",
+        ),
+        pytest.param(
+            (2, 4, 32, 64),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_shard_config((2, 4, 32, 64), d),
+            None,
+            id="WH_height_default_output",
+        ),
+        pytest.param(
+            (1, 1, 128, 64),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            _sharded_no_spec(ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
+            id="WH_height_to_height_nospec",
+        ),
+        pytest.param(
+            (1, 1, 32, 64),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_shard_config((1, 1, 32, 64), d, num_cores=1),
+            None,
+            id="WH_native_height_1core",
+        ),
+        pytest.param(
+            (2, 3, 64, 96),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            _interleaved,
+            None,
+            id="WH_interleaved_baseline",
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            1,
+            2,
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d: _height_shard_config((1, 4, 32, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved,
+            id="HC_RM_height_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 128, 128),
+            2,
+            3,
+            ttnn.TILE_LAYOUT,
+            _interleaved,
+            _sharded_no_spec(ttnn.TensorMemoryLayout.BLOCK_SHARDED),
+            id="WH_interleaved_to_block_nospec",
+        ),
+    ],
+)
+def test_transpose_universal_io_tile(shape, dim0, dim1, input_layout, input_factory, output_factory, dtype, device):
+    if dtype == ttnn.bfloat8_b and input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("bfloat8_b is only supported on TILE_LAYOUT inputs")
+    # HC sharded kernels mis-account bfp8's per-block byte layout (each 32x32 tile is 1088B, not
+    # 1024 * elem_size). The legacy `test_transpose_sharded` carries the same skip; tracked as an
+    # op-side gap, not a regression of this PR.
+    is_hc = (dim0, dim1) in {(1, 2), (2, 1)}
+    if dtype == ttnn.bfloat8_b and is_hc and input_factory(device).is_sharded():
+        pytest.skip("sharded bfloat8_b is not supported for HC transpose (physical-size mismatch)")
     run_transpose_test(
         shape,
-        2,
-        3,
+        dim0,
+        dim1,
         device,
-        input_mem_config=_block_shard_config(shape, device),
-        output_mem_config=L1_INTERLEAVED,
+        input_layout=input_layout,
+        input_mem_config=input_factory(device),
+        output_mem_config=output_factory(device) if output_factory is not None else None,
+        dtype=dtype,
     )
 
 
-# ---------------------------------------------------------------------------
-# 2. Block-sharded input → interleaved output  (CN, needs N,C > 1)
-# ---------------------------------------------------------------------------
-def test_transpose_block_sharded_to_interleaved_cn(device):
-    shape = (2, 4, 32, 64)
-    run_transpose_test(
-        shape,
-        0,
-        1,
-        device,
-        input_mem_config=_block_shard_config(shape, device),
-        output_mem_config=L1_INTERLEAVED,
-    )
-
-
-# ---------------------------------------------------------------------------
-# 3. Width-sharded input → interleaved output  (WH)
-# ---------------------------------------------------------------------------
-def test_transpose_width_sharded_to_interleaved_wh(device):
-    shape = (1, 1, 64, 128)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=_width_shard_config(shape, device),
-        output_mem_config=L1_INTERLEAVED,
-    )
-
-
-# ---------------------------------------------------------------------------
-# 4. Interleaved input → height-sharded output  (WH)
-# ---------------------------------------------------------------------------
-def test_transpose_interleaved_to_height_sharded(device):
-    shape = (1, 1, 64, 128)
-    out_shape = (1, 1, 128, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=L1_INTERLEAVED,
-        output_mem_config=_height_shard_config(out_shape, device),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 5. Interleaved input → block-sharded output  (WH)
-# ---------------------------------------------------------------------------
-def test_transpose_interleaved_to_block_sharded(device):
-    shape = (1, 1, 64, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=L1_INTERLEAVED,
-        output_mem_config=_block_shard_config(shape, device),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 6. Block-sharded input → height-sharded output  (WH)
-# ---------------------------------------------------------------------------
-def test_transpose_block_to_height_sharded(device):
-    shape = (1, 1, 64, 128)
-    out_shape = (1, 1, 128, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=_block_shard_config(shape, device),
-        output_mem_config=_height_shard_config(out_shape, device, num_cores=2),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 7. Width-sharded input → height-sharded output  (WH, cross shard-type)
-# ---------------------------------------------------------------------------
-def test_transpose_width_to_height_sharded(device):
-    shape = (1, 1, 64, 128)
-    out_shape = (1, 1, 128, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=_width_shard_config(shape, device),
-        output_mem_config=_height_shard_config(out_shape, device),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 8. HC transpose: height-sharded input → interleaved output
-# ---------------------------------------------------------------------------
-def test_transpose_hc_height_sharded(device):
-    shape = (1, 4, 32, 64)
-    run_transpose_test(
-        shape,
-        1,
-        2,
-        device,
-        input_mem_config=_height_shard_config(shape, device),
-        output_mem_config=L1_INTERLEAVED,
-    )
-
-
-# ---------------------------------------------------------------------------
-# 9. CN transpose: height-sharded input → interleaved output
-# ---------------------------------------------------------------------------
-def test_transpose_cn_height_sharded(device):
-    shape = (2, 4, 32, 64)
-    run_transpose_test(
-        shape,
-        0,
-        1,
-        device,
-        input_mem_config=_height_shard_config(shape, device, num_cores=8),
-        output_mem_config=L1_INTERLEAVED,
-    )
-
-
-# ---------------------------------------------------------------------------
-# 10. Default output derivation: block-sharded input, no explicit output
-# ---------------------------------------------------------------------------
-def test_transpose_block_sharded_default_output(device):
-    shape = (1, 1, 64, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=_block_shard_config(shape, device),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 11. Default output derivation: height-sharded input, no explicit output
-# ---------------------------------------------------------------------------
-def test_transpose_height_sharded_default_output(device):
-    shape = (2, 4, 32, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=_height_shard_config(shape, device),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 12. Sharded output without shard_spec (system derives it)
-# ---------------------------------------------------------------------------
-def test_transpose_sharded_output_no_shard_spec(device):
-    shape = (1, 1, 128, 64)
-    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=_height_shard_config(shape, device),
-        output_mem_config=output_mem_config,
-    )
-
-
-# ---------------------------------------------------------------------------
-# 13. Native L1 height-sharded (verifies native path still selected)
-# ---------------------------------------------------------------------------
-def test_transpose_native_height_sharded_wh(device):
-    shape = (1, 1, 32, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=_height_shard_config(shape, device, num_cores=1),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 14. Interleaved baseline (sanity)
-# ---------------------------------------------------------------------------
-def test_transpose_interleaved_baseline(device):
-    shape = (2, 3, 64, 96)
-    run_transpose_test(shape, 2, 3, device)
-
-
-# ---------------------------------------------------------------------------
-# 15. ROW_MAJOR height-sharded input (exercises ROW_MAJOR branch in
-# get_transpose_shard_specs / is_shard_tile_aligned)
-# ---------------------------------------------------------------------------
-def test_transpose_row_major_height_sharded_hc(device):
-    shape = (1, 4, 32, 64)
-    run_transpose_test(
-        shape,
-        1,
-        2,
-        device,
-        input_layout=ttnn.ROW_MAJOR_LAYOUT,
-        input_mem_config=_height_shard_config(shape, device),
-        output_mem_config=L1_INTERLEAVED,
-    )
-
-
-# ---------------------------------------------------------------------------
-# 16. DRAM-sharded input falls back to interleaved
-# (is_native_transpose_sharding rejects BufferType::DRAM)
-# ---------------------------------------------------------------------------
+# 16. DRAM-sharded input falls back to L1 interleaved output.
 def test_transpose_dram_sharded_fallback(device):
     shape = (1, 1, 128, 64)
     dram_sharded = _height_shard_config(shape, device, buffer_type=ttnn.BufferType.DRAM)
 
     torch.manual_seed(12345)
-    x = torch.rand(shape).bfloat16().float()
+    x = torch.rand(shape, dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(
         x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=dram_sharded
     )
@@ -344,35 +336,10 @@ def test_transpose_dram_sharded_fallback(device):
 
     ref = x.transpose(2, 3)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
-    passing, output = comp_equal(ref, got)
-    logger.info(output)
-    assert passing, f"Transpose mismatch for DRAM-sharded fallback, shape={shape}"
+    assert_with_ulp(ref, got, ulp_threshold=1)
 
 
-# ---------------------------------------------------------------------------
-# 17. Block-sharded output without shard_spec — exercises the block-shard
-# branch of generate_transpose_shard_spec (interleaved input, no spec)
-# ---------------------------------------------------------------------------
-def test_transpose_block_sharded_output_no_shard_spec(device):
-    shape = (1, 1, 128, 128)
-    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_mem_config=L1_INTERLEAVED,
-        output_mem_config=output_mem_config,
-    )
-
-
-# ---------------------------------------------------------------------------
-# 17b. Non-native sharded input + user-requested sharded output without
-# shard_spec — exercises the else-if ordering in `detail::transpose_` that
-# honors the user's `memory_layout` over the non-native default-to-interleaved
-# fallback. Before this ordering, a TILE BLOCK_SHARDED input paired with a
-# sharded no-spec output (any layout) would silently return L1 INTERLEAVED.
-# ---------------------------------------------------------------------------
+# Non-native (BLOCK) sharded input → user-requested sharded output without shard_spec.
 @pytest.mark.parametrize(
     "requested_out_layout",
     [
@@ -393,123 +360,92 @@ def test_transpose_non_native_sharded_input_to_sharded_nospec(requested_out_layo
     )
 
 
-# ---------------------------------------------------------------------------
-# 18. ROW_MAJOR + BLOCK_SHARDED input → interleaved (WH)
-# Composite fallback: sharded→interleaved hop before transpose. Neither the
-# native sharded kernels nor prim::permute handle block-sharded RM pages that
-# span multiple cores.
-# ---------------------------------------------------------------------------
-def test_transpose_row_major_block_sharded_to_interleaved_wh(device):
-    shape = (1, 1, 64, 64)
+# Universal-IO matrix for ROW_MAJOR composite-fallback paths.
+# Every row exercises the composite (un-tilize → transpose → re-tilize) path that the device op
+# falls back to when one or both endpoints are ROW_MAJOR + sharded.
+# bfloat8_b is excluded from this matrix — it requires TILE layout.
+_RM = ttnn.ROW_MAJOR_LAYOUT
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(ttnn.bfloat16, id="bf16"),
+        pytest.param(ttnn.float32, id="f32"),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, dim0, dim1, input_factory, output_factory",
+    [
+        pytest.param(
+            (1, 1, 64, 64),
+            2,
+            3,
+            lambda d: _block_shard_config((1, 1, 64, 64), d, layout=_RM),
+            _interleaved,
+            id="WH_RM_block_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 32, 128),
+            2,
+            3,
+            lambda d: _width_shard_config((1, 1, 32, 128), d, layout=_RM),
+            _interleaved,
+            id="WH_RM_width_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            2,
+            3,
+            _interleaved,
+            lambda d: _block_shard_config((1, 1, 64, 64), d, layout=_RM),
+            id="WH_RM_interleaved_to_block",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            2,
+            3,
+            _interleaved,
+            lambda d: _width_shard_config((1, 1, 128, 64), d, layout=_RM),
+            id="WH_RM_interleaved_to_width",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            2,
+            3,
+            lambda d: _block_shard_config((1, 1, 64, 64), d, layout=_RM),
+            lambda d: _block_shard_config((1, 1, 64, 64), d, layout=_RM),
+            id="WH_RM_block_to_block",
+        ),
+        pytest.param(
+            (1, 1, 64, 32),
+            2,
+            3,
+            lambda d: _height_shard_config((1, 1, 64, 32), d, layout=_RM),
+            _interleaved,
+            id="WH_RM_height_to_interleaved",
+        ),
+    ],
+)
+def test_transpose_universal_io_row_major(shape, dim0, dim1, input_factory, output_factory, dtype, device):
+    # Pre-existing LLK bug in `llk_math_transpose_dest` / `pack_untilize_dest` for fp32 DEST mode
+    # (issue #41662); not a regression of this PR, same class of op-side gap as the bfp8 HC skip above.
+    in_mc = input_factory(device)
+    if dtype == ttnn.float32 and in_mc.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
+        pytest.xfail("RM HEIGHT_SHARDED WH transpose corrupts f32 elements (#41662)")
     run_transpose_test(
         shape,
-        2,
-        3,
+        dim0,
+        dim1,
         device,
-        input_layout=ttnn.ROW_MAJOR_LAYOUT,
-        input_mem_config=_block_shard_config(shape, device),
-        output_mem_config=L1_INTERLEAVED,
+        input_layout=_RM,
+        input_mem_config=input_factory(device),
+        output_mem_config=output_factory(device),
+        dtype=dtype,
     )
 
 
-# ---------------------------------------------------------------------------
-# 19. ROW_MAJOR + WIDTH_SHARDED input → interleaved (WH)
-# Composite fallback. Width sharding on RM also splits pages across cores.
-# ---------------------------------------------------------------------------
-def test_transpose_row_major_width_sharded_to_interleaved_wh(device):
-    shape = (1, 1, 32, 128)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_layout=ttnn.ROW_MAJOR_LAYOUT,
-        input_mem_config=_width_shard_config(shape, device),
-        output_mem_config=L1_INTERLEAVED,
-    )
-
-
-# ---------------------------------------------------------------------------
-# 20. ROW_MAJOR interleaved input → BLOCK_SHARDED output requested (WH)
-# Composite fallback goes through interleaved output, then reshards to the
-# requested block-sharded memory config.
-# ---------------------------------------------------------------------------
-def test_transpose_row_major_interleaved_to_block_sharded_wh(device):
-    shape = (1, 1, 64, 64)
-    out_shape = (1, 1, 64, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_layout=ttnn.ROW_MAJOR_LAYOUT,
-        input_mem_config=L1_INTERLEAVED,
-        output_mem_config=_block_shard_config(out_shape, device),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 21. ROW_MAJOR interleaved input → WIDTH_SHARDED output requested (WH)
-# Composite fallback — mirror of 20 for width sharding output.
-# ---------------------------------------------------------------------------
-def test_transpose_row_major_interleaved_to_width_sharded_wh(device):
-    shape = (1, 1, 64, 128)
-    out_shape = (1, 1, 128, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_layout=ttnn.ROW_MAJOR_LAYOUT,
-        input_mem_config=L1_INTERLEAVED,
-        output_mem_config=_width_shard_config(out_shape, device),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 22. ROW_MAJOR + BLOCK_SHARDED input → BLOCK_SHARDED output (WH)
-# Both conditions of the composite-fallback guard fire: input needs an
-# interleaved hop in, and output needs a reshard out.
-# ---------------------------------------------------------------------------
-def test_transpose_row_major_block_sharded_to_block_sharded_wh(device):
-    shape = (1, 1, 64, 64)
-    out_shape = (1, 1, 64, 64)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_layout=ttnn.ROW_MAJOR_LAYOUT,
-        input_mem_config=_block_shard_config(shape, device),
-        output_mem_config=_block_shard_config(out_shape, device),
-    )
-
-
-# ---------------------------------------------------------------------------
-# 23. ROW_MAJOR + HEIGHT_SHARDED input → interleaved (WH)
-# NOT part of the composite fallback — HEIGHT_SHARDED RM keeps pages on a
-# single core and is handled natively. Included here as a regression guard so
-# the fallback predicate stays narrow.
-# ---------------------------------------------------------------------------
-def test_transpose_row_major_height_sharded_to_interleaved_wh(device):
-    shape = (1, 1, 64, 32)
-    run_transpose_test(
-        shape,
-        2,
-        3,
-        device,
-        input_layout=ttnn.ROW_MAJOR_LAYOUT,
-        input_mem_config=_height_shard_config(shape, device),
-        output_mem_config=L1_INTERLEAVED,
-    )
-
-
-# ===========================================================================
-# Irregular-shape coverage for interleaved inputs (TILE and ROW_MAJOR).
-# Shapes include:
-#   - last-two dims not multiples of TILE_HEIGHT / TILE_WIDTH (tile padding)
-#   - non-power-of-two C for HC (transposed_padded_shape rounding)
-# ===========================================================================
+# Interleaved input with irregular shapes (TILE and ROW_MAJOR) across WH/HC/CN.
 @pytest.mark.parametrize(
     "shape, dim0, dim1",
     [
@@ -528,12 +464,7 @@ def test_transpose_irregular_shapes_interleaved(shape, dim0, dim1, input_layout,
     run_transpose_test(shape, dim0, dim1, device, input_layout=input_layout)
 
 
-# ===========================================================================
-# ROW_MAJOR interleaved input + sharded (BLOCK/WIDTH) output WITHOUT shard_spec.
-# Exercises the RM branch of `transposed_padded_shape`
-# (transpose_device_operation.cpp) and the composite-fallback spec-synthesis
-# path in `transpose.cpp` that populates a shard_spec before the reshard.
-# ===========================================================================
+# ROW_MAJOR interleaved input → BLOCK/WIDTH sharded output without shard_spec.
 @pytest.mark.parametrize(
     "shape, dim0, dim1, memory_layout",
     [
@@ -556,11 +487,7 @@ def test_transpose_row_major_sharded_output_no_shard_spec(shape, dim0, dim1, mem
     )
 
 
-# ===========================================================================
-# TILE + sharded output WITHOUT shard_spec, irregular C for HC.
-# Exercises `transposed_padded_shape` with `C_p = round_up(C, tile_height)`
-# in transpose_device_operation.cpp.
-# ===========================================================================
+# HC TILE with irregular C, interleaved input → BLOCK_SHARDED output without shard_spec.
 @pytest.mark.parametrize(
     "shape, dim0, dim1",
     [
@@ -582,22 +509,8 @@ def test_transpose_tile_hc_irregular_c_sharded_output_no_shard_spec(shape, dim0,
     )
 
 
-# ===========================================================================
-# Sharded inputs with shapes that don't divide evenly.
-#
-# Two categories:
-#
-#  (a) Logical shape has dims < tile multiple but padded shape is tile-aligned
-#      and divides evenly into a tile-aligned shard. The native shard path
-#      still runs; the irregular logical dim must be round-tripped correctly.
-#
-#  (b) Uneven sharding: padded shape does NOT divide evenly into the shard
-#      shape (last shard partially filled). `is_native_transpose_sharding`
-#      returns false via `is_uneven`, so the op falls through to interleaved
-#      factories with TensorAccessorArgs.
-#
-# RM inputs additionally exercise the composite fallback from transpose.cpp.
-# ===========================================================================
+# Sharded inputs with shapes that don't divide evenly — covers (a) tile-aligned padded shape with
+# irregular logical dim and (b) uneven sharding (padded shape doesn't divide into shard shape).
 
 
 def _explicit_block_shard_config(device, grid_y, grid_x, sh, sw):
@@ -640,7 +553,7 @@ def _explicit_width_shard_config(device, ncores, sh, sw):
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, spec)
 
 
-# (a) TILE + sharded inputs with IRREGULAR logical shape but tile-aligned padded + shard.
+# (a) TILE + sharded input with irregular logical shape (padded shape and shard are tile-aligned).
 @pytest.mark.parametrize(
     "shape, dim0, dim1, mc_factory",
     [
@@ -661,9 +574,7 @@ def test_transpose_tile_sharded_irregular_shapes(shape, dim0, dim1, mc_factory, 
     run_transpose_test(shape, dim0, dim1, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=mc_factory(device))
 
 
-# (a) ROW_MAJOR + BLOCK/WIDTH sharded inputs with IRREGULAR W.
-# These exercise the composite fallback (transpose.cpp is_block_or_width_sharded_mc guard)
-# with shapes whose last dim is not a tile multiple.
+# (a) ROW_MAJOR + BLOCK/WIDTH sharded input with irregular W (composite fallback).
 @pytest.mark.parametrize(
     "shape, dim0, dim1, mc_factory",
     [
@@ -679,9 +590,7 @@ def test_transpose_row_major_sharded_irregular_shapes(shape, dim0, dim1, mc_fact
     )
 
 
-# (b) TILE UNEVEN sharding — padded shape doesn't divide evenly into the shard
-# shape. `is_native_transpose_sharding` returns false; op routes through the
-# interleaved factories' TensorAccessor fallback.
+# (b) TILE uneven sharding — padded shape doesn't divide evenly into the shard shape.
 @pytest.mark.parametrize(
     "shape, dim0, dim1, mc_factory",
     [
@@ -697,17 +606,10 @@ def test_transpose_tile_sharded_uneven(shape, dim0, dim1, mc_factory, device):
     run_transpose_test(shape, dim0, dim1, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=mc_factory(device))
 
 
-# ===========================================================================
 # Additional regression guards for transpose-specific code paths.
-# Dtype, COL_MAJOR, identity, non-canonical dims, DRAM no-spec, etc. are not
-# duplicated here — they are exercised by generic ttnn tests or by the
-# existing universal I/O tests above.
-# ===========================================================================
 
 
-# CN + ROW_MAJOR + BLOCK/WIDTH sharded input.
-# Exercises the composite fallback in transpose_impl for the CN dim (the guard
-# is keyed on memory layout, not dim).
+# CN: ROW_MAJOR + BLOCK/WIDTH sharded input (composite fallback for non-WH dim).
 @pytest.mark.parametrize(
     "shape, mc_factory",
     [
@@ -719,8 +621,7 @@ def test_transpose_cn_row_major_block_width_sharded(shape, mc_factory, device):
     run_transpose_test(shape, 0, 1, device, input_layout=ttnn.ROW_MAJOR_LAYOUT, input_mem_config=mc_factory(device))
 
 
-# N>1 and/or C>1 with sharded input for WH transpose.
-# Exercises shard-geometry helpers that flatten over the leading dims.
+# WH transpose with N>1 and/or C>1 sharded inputs.
 @pytest.mark.parametrize(
     "shape, layout, mc_factory",
     [
@@ -748,13 +649,7 @@ def test_transpose_multi_batch_channel_sharded_wh(shape, layout, mc_factory, dev
     run_transpose_test(shape, 2, 3, device, input_layout=layout, input_mem_config=mc_factory(device))
 
 
-# ROW_MAJOR HEIGHT_SHARDED inputs whose shard element count (shard_h * shard_w) is NOT a
-# multiple of the tile footprint (32 * 32 = 1024). Before the is_native_transpose_sharding
-# fix, these silently hit the native RM height-sharded kernel and produced garbage or hit a
-# CB allocation failure. After the fix, the predicate returns false for such shards and the
-# device op selects the interleaved WH factory, which reads/writes the sharded buffer
-# directly over NOC via TensorAccessorArgs (no physical reshard). Tile-aligned RM HS
-# (e.g. (32,64)) remains on the fast specialized native path.
+# WH: ROW_MAJOR HEIGHT_SHARDED input with non-tile-aligned shard (shard_h * shard_w not a tile multiple).
 @pytest.mark.parametrize(
     "shape, shard_shape",
     [
@@ -768,10 +663,7 @@ def test_transpose_row_major_height_sharded_nontile_aligned_wh(shape, shard_shap
     run_transpose_test(shape, 2, 3, device, input_layout=ttnn.ROW_MAJOR_LAYOUT, input_mem_config=imc)
 
 
-# CN TILE with sharded output (no shard_spec provided by caller). Exercises
-# `derive_effective_output_memory_config`'s spec-synthesis path for CN through
-# `TransposeCNProgramFactory`, which uses TensorAccessorArgs on the writer.
-# Covers both interleaved→sharded-output and height-sharded→sharded-output.
+# CN TILE → HEIGHT_SHARDED output without shard_spec, from interleaved and height-sharded inputs.
 @pytest.mark.parametrize(
     "input_mem_factory",
     [
@@ -793,11 +685,7 @@ def test_transpose_cn_sharded_output(input_mem_factory, device):
     )
 
 
-# DRAM interleaved input + DRAM interleaved output. Verifies the full NOC-based
-# TensorAccessor path works end-to-end when both sides live in DRAM rather than L1.
-DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
-
-
+# DRAM interleaved input → DRAM interleaved output across WH/HC/CN.
 @pytest.mark.parametrize(
     "dim0, dim1",
     [
@@ -818,13 +706,7 @@ def test_transpose_dram_interleaved(dim0, dim1, device):
     )
 
 
-# WH transpose on tile-aligned height-sharded inputs whose transposed width legitimately shrinks
-# below a tile. A naive `std::max(scaled, TILE_*)` clamp in `adjust_shard_spec_to_shape` oversizes
-# the output shard for these shapes (scaled_h = 16 gets clamped up to 32, claiming 1024 elements
-# of capacity for a shard that should only hold 512), producing silent correctness regressions.
-# The fix returns the exact ratio-scaled shape, then the device op's post-check detects the
-# sub-tile TILE shard and falls through to `generate_transpose_shard_spec` for a tile-aligned
-# fresh spec. Verifies both small single-batch cases and asymmetric N>1 shapes.
+# WH on tile-aligned height-sharded inputs whose transposed width shrinks below a tile.
 @pytest.mark.parametrize(
     "shape, ncores, shard_shape",
     [
@@ -839,11 +721,7 @@ def test_transpose_wh_shrink_sub_tile_sharded(shape, ncores, shard_shape, device
     run_transpose_test(shape, 2, 3, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=imc)
 
 
-# HC TILE transpose with an irregular logical H (last tile partial) and a tile-aligned
-# height-sharded input. The padded H is rounded up to TILE_HEIGHT, so the shard geometry must
-# remain tile-aligned; the op rotates the padded H into output dim[1] and pads new dim[2] to
-# TILE_HEIGHT from the logical C. Exercises the HC TILE sharded path end-to-end against an
-# input whose logical shape doesn't divide evenly.
+# HC TILE transpose with irregular logical C and a tile-aligned height-sharded input.
 @pytest.mark.parametrize(
     "shape, ncores, shard_shape",
     [
@@ -854,3 +732,32 @@ def test_transpose_wh_shrink_sub_tile_sharded(shape, ncores, shard_shape, device
 def test_transpose_hc_tile_irregular_sharded_input(shape, ncores, shard_shape, device):
     imc = _explicit_height_shard_config(device, ncores, shard_shape[0], shard_shape[1])
     run_transpose_test(shape, 1, 2, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=imc)
+
+
+# HC/CN: ROW_MAJOR BLOCK/WIDTH-sharded input → BLOCK/WIDTH-sharded output (composite fallback round-trip).
+@pytest.mark.parametrize(
+    "shape, dim0, dim1, input_factory, output_layout",
+    [
+        pytest.param(
+            (1, 1, 64, 64), 1, 2, _block_shard_config, ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="HC_block_to_block"
+        ),
+        pytest.param(
+            (1, 1, 64, 64), 1, 2, _width_shard_config, ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="HC_width_to_width"
+        ),
+        pytest.param(
+            (2, 2, 64, 64), 0, 1, _block_shard_config, ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="CN_block_to_block"
+        ),
+    ],
+)
+def test_transpose_rm_block_or_width_sharded_to_sharded(shape, dim0, dim1, input_factory, output_layout, device):
+    input_mem_config = input_factory(shape, device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    output_mem_config = ttnn.MemoryConfig(output_layout, ttnn.BufferType.L1)
+    run_transpose_test(
+        shape,
+        dim0,
+        dim1,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=input_mem_config,
+        output_mem_config=output_mem_config,
+    )

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -317,6 +317,7 @@ target_sources(
             transpose/device/transpose_hc_tiled_program_factory.hpp
             transpose/device/transpose_wh_program_factory.hpp
             transpose/device/transpose_wh_sharded_program_factory.hpp
+            transpose/device/transpose_utils.hpp
             transpose/device/transpose_wh_sharded_rm_program_factory.hpp
             # unsqueeze/
             unsqueeze/unsqueeze.hpp
@@ -489,6 +490,7 @@ target_sources(
         transpose/device/transpose_hc_tiled_program_factory.cpp
         transpose/device/transpose_wh_program_factory.cpp
         transpose/device/transpose_wh_sharded_program_factory.cpp
+        transpose/device/transpose_utils.cpp
         transpose/device/transpose_wh_sharded_rm_program_factory.cpp
         transpose/transpose.cpp
         unsqueeze/unsqueeze.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -150,14 +150,12 @@ void TransposeCNProgramFactory::override_runtime_arguments(
 
     const auto& input_tensor = tensor_args.input;
 
-    {
-        auto* reader_args = GetCommonRuntimeArgs(program, shared_variables.reader_kernel_id).data();
-        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
-            *input_tensor.buffer(), reader_args);
-        auto* writer_args = GetCommonRuntimeArgs(program, shared_variables.writer_kernel_id).data();
-        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
-            *output_tensor.buffer(), writer_args);
-    }
+    ttnn::operations::data_movement::transpose::refresh_transpose_common_runtime_args(
+        program,
+        shared_variables.reader_kernel_id,
+        shared_variables.writer_kernel_id,
+        *input_tensor.buffer(),
+        *output_tensor.buffer());
 
     auto* input_buffer = input_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_cn_program_factory.hpp"
+#include "transpose_utils.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
@@ -61,11 +62,15 @@ TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
     std::map<std::string, std::string> reader_defines;
     std::vector<uint32_t> reader_compile_time_args = {
         static_cast<uint32_t>(src0_cb_index), src0_buffer->aligned_page_size(), stick_size};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    std::vector<uint32_t> reader_common_runtime_args;
+    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
     std::map<std::string, std::string> writer_defines;
     std::vector<uint32_t> writer_compile_time_args = {
         static_cast<uint32_t>(src0_cb_index), dst_buffer->aligned_page_size(), stick_size};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    std::vector<uint32_t> writer_common_runtime_args;
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     if (row_major) {
         reader_defines["CN_RM"] = "1";
@@ -78,6 +83,7 @@ TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
         "reader_unary_transpose_cn_interleaved_start_id.cpp",
         total_cores,
         ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+    SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
 
     KernelHandle writer_kernel_id = CreateKernel(
         program,
@@ -85,6 +91,7 @@ TransposeCNProgramFactory::cached_program_t TransposeCNProgramFactory::create(
         "writer_unary_transpose_cn_interleaved_start_id.cpp",
         total_cores,
         WriterDataMovementConfig(writer_compile_time_args, writer_defines));
+    SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
 
     // Set runtime arguments for each core
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
@@ -142,6 +149,15 @@ void TransposeCNProgramFactory::override_runtime_arguments(
     auto& shared_variables = cached_program.shared_variables;
 
     const auto& input_tensor = tensor_args.input;
+
+    {
+        auto* reader_args = GetCommonRuntimeArgs(program, shared_variables.reader_kernel_id).data();
+        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
+            *input_tensor.buffer(), reader_args);
+        auto* writer_args = GetCommonRuntimeArgs(program, shared_variables.writer_kernel_id).data();
+        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
+            *output_tensor.buffer(), writer_args);
+    }
 
     auto* input_buffer = input_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -11,17 +11,70 @@
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using ttnn::operations::data_movement::transpose::adjust_shard_spec_to_shape;
+using ttnn::operations::data_movement::transpose::generate_transpose_shard_spec;
 using ttnn::operations::data_movement::transpose::is_native_transpose_sharding;
 
 namespace ttnn::prim {
 
+namespace {
+
+// Compute the output padded shape for a given transpose dim. Mirrors the switch in
+// compute_output_specs so derivation stays in one place.
+ttnn::Shape transposed_padded_shape(const Tensor& input_tensor, TransposeOpDim dim) {
+    auto out_padded = input_tensor.padded_shape();
+    switch (dim) {
+        case TransposeOpDim::CN: std::swap(out_padded[0], out_padded[1]); break;
+        case TransposeOpDim::HC:
+            if (input_tensor.layout() == Layout::ROW_MAJOR) {
+                std::swap(out_padded[1], out_padded[2]);
+            } else {
+                const uint32_t C = input_tensor.logical_shape()[1];
+                const uint32_t C_p = tt::round_up(C, input_tensor.tensor_spec().tile().get_height());
+                out_padded[1] = out_padded[2];
+                out_padded[2] = C_p;
+            }
+            break;
+        case TransposeOpDim::WH: std::swap(out_padded[2], out_padded[3]); break;
+        default: TT_THROW("Unsupported transpose dim"); break;
+    }
+    return out_padded;
+}
+
+// Derive the effective output MemoryConfig. When the user asks for a sharded output but omits
+// shard_spec, we synthesize one here so the rest of the op (select_program_factory,
+// compute_output_specs) can reason about a fully-specified config.
+MemoryConfig derive_effective_output_memory_config(
+    const TransposeDeviceOperation::operation_attributes_t& operation_attributes,
+    const TransposeDeviceOperation::tensor_args_t& tensor_args) {
+    auto output_mem_config = operation_attributes.output_mem_config;
+    if (!output_mem_config.is_sharded() || output_mem_config.shard_spec().has_value()) {
+        return output_mem_config;
+    }
+    const auto& input_tensor = tensor_args.input;
+    const auto output_padded_shape = transposed_padded_shape(input_tensor, operation_attributes.dim);
+    if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value()) {
+        auto shard_spec = adjust_shard_spec_to_shape(
+            input_tensor.shard_spec().value(), input_tensor.padded_shape(), output_padded_shape);
+        return output_mem_config.with_shard_spec(shard_spec);
+    }
+    auto shard_spec =
+        generate_transpose_shard_spec(input_tensor, output_padded_shape, output_mem_config.memory_layout());
+    return output_mem_config.with_shard_spec(shard_spec);
+}
+
+}  // namespace
+
 TransposeDeviceOperation::program_factory_t TransposeDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    const auto& output_memory_config = operation_attributes.output_mem_config;
+    const auto output_memory_config = derive_effective_output_memory_config(operation_attributes, tensor_args);
     const auto& dim = operation_attributes.dim;
     bool is_row_major = input_tensor.layout() == Layout::ROW_MAJOR;
 
+    // When `native` is false, the specialized sharded WH/HC factories are skipped and we fall
+    // through to the interleaved factories, which use TensorAccessorArgs for transparent NOC-based
+    // access against either interleaved or sharded buffers.
     bool native = is_native_transpose_sharding(input_tensor.tensor_spec(), output_memory_config);
 
     uint32_t N = input_tensor.logical_shape()[0], C = input_tensor.logical_shape()[1];
@@ -125,10 +178,9 @@ void TransposeDeviceOperation::validate_on_program_cache_miss(
 
 TensorSpec TransposeDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    using namespace ttnn::operations::data_movement::transpose;
     const auto& input_tensor = tensor_args.input;
     const auto& dim = operation_attributes.dim;
-    auto output_mem_config = operation_attributes.output_mem_config;
+    const auto output_mem_config = derive_effective_output_memory_config(operation_attributes, tensor_args);
 
     auto output_shape = input_tensor.logical_shape();
     auto output_padded_shape = input_tensor.padded_shape();
@@ -157,18 +209,6 @@ TensorSpec TransposeDeviceOperation::compute_output_specs(
             std::swap(output_padded_shape[2], output_padded_shape[3]);
             break;
         default: TT_THROW("Unsupported transpose dim"); break;
-    }
-
-    if (output_mem_config.is_sharded() && !output_mem_config.shard_spec().has_value()) {
-        if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value()) {
-            auto shard_spec = adjust_shard_spec_to_shape(
-                input_tensor.shard_spec().value(), input_tensor.padded_shape(), output_padded_shape);
-            output_mem_config = output_mem_config.with_shard_spec(shard_spec);
-        } else {
-            auto shard_spec =
-                generate_transpose_shard_spec(input_tensor, output_padded_shape, output_mem_config.memory_layout());
-            output_mem_config = output_mem_config.with_shard_spec(shard_spec);
-        }
     }
 
     return TensorSpec(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_device_operation.hpp"
+#include "transpose_utils.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
@@ -10,6 +11,7 @@
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using ttnn::operations::data_movement::transpose::is_native_transpose_sharding;
 
 namespace ttnn::prim {
 
@@ -20,6 +22,8 @@ TransposeDeviceOperation::program_factory_t TransposeDeviceOperation::select_pro
     const auto& dim = operation_attributes.dim;
     bool is_row_major = input_tensor.layout() == Layout::ROW_MAJOR;
 
+    bool native = is_native_transpose_sharding(input_tensor.tensor_spec(), output_memory_config);
+
     uint32_t N = input_tensor.logical_shape()[0], C = input_tensor.logical_shape()[1];
     uint32_t output_width =
         (dim == TransposeOpDim::WH) ? input_tensor.logical_shape()[-2] : input_tensor.logical_shape()[-1];
@@ -27,20 +31,23 @@ TransposeDeviceOperation::program_factory_t TransposeDeviceOperation::select_pro
         (dim == TransposeOpDim::WH)
             ? input_tensor.logical_shape()[-1]
             : ((dim == TransposeOpDim::HC) ? input_tensor.logical_shape()[-3] : input_tensor.logical_shape()[-2]);
-    bool input_height_sharded = input_tensor.is_sharded() && input_tensor.buffer()->is_l1() &&
+
+    bool input_height_sharded = native && input_tensor.is_sharded() && input_tensor.shard_spec().has_value() &&
                                 input_tensor.shard_spec()->shape[1] == input_tensor.logical_shape()[-1];
     bool input_width_and_height_fully_in_shard =
         input_height_sharded && input_tensor.shard_spec()->shape[0] % input_tensor.logical_shape()[-2] == 0;
-    bool output_height_sharded = output_memory_config.is_sharded() && output_memory_config.is_l1() &&
+    bool output_height_sharded = native && output_memory_config.is_sharded() &&
+                                 output_memory_config.shard_spec().has_value() &&
                                  output_memory_config.shard_spec()->shape[1] == output_width;
-    bool output_width_sharded = output_memory_config.is_sharded() && output_memory_config.is_l1() &&
+    bool output_width_sharded = native && output_memory_config.is_sharded() &&
+                                output_memory_config.shard_spec().has_value() &&
                                 output_memory_config.shard_spec()->shape[0] == output_height;
     bool output_width_and_height_fully_in_shard =
         output_height_sharded && output_memory_config.shard_spec()->shape[0] % output_height == 0;
     bool use_sharded_wh =
-        ((input_width_and_height_fully_in_shard && output_width_and_height_fully_in_shard) ||
-         (N == 1 && C == 1 && input_height_sharded && output_width_sharded));
-    bool use_sharded_hc = input_height_sharded && output_height_sharded && is_row_major;
+        native && ((input_width_and_height_fully_in_shard && output_width_and_height_fully_in_shard) ||
+                   (N == 1 && C == 1 && input_height_sharded && output_width_sharded));
+    bool use_sharded_hc = native && input_height_sharded && output_height_sharded && is_row_major;
 
     auto parallelization_strategy = get_parallelization_strategy(operation_attributes, tensor_args);
 
@@ -118,13 +125,11 @@ void TransposeDeviceOperation::validate_on_program_cache_miss(
 
 TensorSpec TransposeDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace ttnn::operations::data_movement::transpose;
     const auto& input_tensor = tensor_args.input;
     const auto& dim = operation_attributes.dim;
-    const auto& output_mem_config = operation_attributes.output_mem_config;
+    auto output_mem_config = operation_attributes.output_mem_config;
 
-    // TODO: Remove usage of input/output padded shape
-    // - Get output alignment from input alignment and output dtype, layout, mem_config
-    // - Get shard spec from output strides (logical shape + alignment)?
     auto output_shape = input_tensor.logical_shape();
     auto output_padded_shape = input_tensor.padded_shape();
 
@@ -152,6 +157,18 @@ TensorSpec TransposeDeviceOperation::compute_output_specs(
             std::swap(output_padded_shape[2], output_padded_shape[3]);
             break;
         default: TT_THROW("Unsupported transpose dim"); break;
+    }
+
+    if (output_mem_config.is_sharded() && !output_mem_config.shard_spec().has_value()) {
+        if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value()) {
+            auto shard_spec = adjust_shard_spec_to_shape(
+                input_tensor.shard_spec().value(), input_tensor.padded_shape(), output_padded_shape);
+            output_mem_config = output_mem_config.with_shard_spec(shard_spec);
+        } else {
+            auto shard_spec =
+                generate_transpose_shard_spec(input_tensor, output_padded_shape, output_mem_config.memory_layout());
+            output_mem_config = output_mem_config.with_shard_spec(shard_spec);
+        }
     }
 
     return TensorSpec(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -19,31 +19,52 @@ namespace ttnn::prim {
 
 namespace {
 
-// Compute the output padded shape for a given transpose dim. Mirrors the switch in
-// compute_output_specs so derivation stays in one place.
-ttnn::Shape transposed_padded_shape(const Tensor& input_tensor, TransposeOpDim dim) {
-    auto out_padded = input_tensor.padded_shape();
+// Compute the output logical+padded shapes for a given transpose dim. The padded-shape semantics
+// mirror what the WH/HC/CN program factories expect (in particular, HC TILE rotates input's padded
+// H into output dim[1] and pads new dim[2] to TILE_HEIGHT based on the logical C). Keeping this in
+// a single helper ensures `derive_effective_output_memory_config` and `compute_output_specs` agree
+// on shape derivation.
+struct TransposedShapes {
+    ttnn::Shape logical;
+    ttnn::Shape padded;
+};
+
+TransposedShapes transposed_shapes(const Tensor& input_tensor, TransposeOpDim dim) {
+    auto output_shape = input_tensor.logical_shape();
+    auto output_padded_shape = input_tensor.padded_shape();
     switch (dim) {
-        case TransposeOpDim::CN: std::swap(out_padded[0], out_padded[1]); break;
+        case TransposeOpDim::CN:
+            std::swap(output_shape[0], output_shape[1]);
+            std::swap(output_padded_shape[0], output_padded_shape[1]);
+            break;
         case TransposeOpDim::HC:
             if (input_tensor.layout() == Layout::ROW_MAJOR) {
-                std::swap(out_padded[1], out_padded[2]);
+                std::swap(output_shape[1], output_shape[2]);
+                std::swap(output_padded_shape[1], output_padded_shape[2]);
             } else {
-                const uint32_t C = input_tensor.logical_shape()[1];
+                const uint32_t C = output_shape[1];
                 const uint32_t C_p = tt::round_up(C, input_tensor.tensor_spec().tile().get_height());
-                out_padded[1] = out_padded[2];
-                out_padded[2] = C_p;
+                const uint32_t H = output_shape[2];
+                output_shape[1] = H;
+                output_shape[2] = C;
+                output_padded_shape[1] = H;
+                output_padded_shape[2] = C_p;
             }
             break;
-        case TransposeOpDim::WH: std::swap(out_padded[2], out_padded[3]); break;
+        case TransposeOpDim::WH:
+            std::swap(output_shape[2], output_shape[3]);
+            std::swap(output_padded_shape[2], output_padded_shape[3]);
+            break;
         default: TT_THROW("Unsupported transpose dim"); break;
     }
-    return out_padded;
+    return {output_shape, output_padded_shape};
 }
 
 // Derive the effective output MemoryConfig. When the user asks for a sharded output but omits
 // shard_spec, we synthesize one here so the rest of the op (select_program_factory,
-// compute_output_specs) can reason about a fully-specified config.
+// compute_output_specs) can reason about a fully-specified config. When the input's shard spec
+// can't be scaled exactly to the output padded shape, fall back to generating a fresh spec over
+// the full compute grid instead of crashing.
 MemoryConfig derive_effective_output_memory_config(
     const TransposeDeviceOperation::operation_attributes_t& operation_attributes,
     const TransposeDeviceOperation::tensor_args_t& tensor_args) {
@@ -52,11 +73,30 @@ MemoryConfig derive_effective_output_memory_config(
         return output_mem_config;
     }
     const auto& input_tensor = tensor_args.input;
-    const auto output_padded_shape = transposed_padded_shape(input_tensor, operation_attributes.dim);
-    if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value()) {
-        auto shard_spec = adjust_shard_spec_to_shape(
+    const auto output_padded_shape = transposed_shapes(input_tensor, operation_attributes.dim).padded;
+    // Only reuse the input's shard_spec geometry when the requested output layout matches the
+    // input's layout: `adjust_shard_spec_to_shape` scales the input shard dims by the shape
+    // ratio, which preserves the sharding style (height/width/block) but doesn't convert
+    // between them. When the user asks for a different layout, fall through to
+    // `generate_transpose_shard_spec` which builds a fresh spec for the requested layout.
+    if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value() &&
+        input_tensor.memory_config().memory_layout() == output_mem_config.memory_layout()) {
+        auto adjusted = adjust_shard_spec_to_shape(
             input_tensor.shard_spec().value(), input_tensor.padded_shape(), output_padded_shape);
-        return output_mem_config.with_shard_spec(shard_spec);
+        if (adjusted.has_value()) {
+            // For TILE layouts, the sharded WH/HC program factories require tile-aligned shard
+            // dims. `adjust_shard_spec_to_shape` may now return a sub-tile shard whenever the
+            // transpose legitimately shrinks a dim below TILE (previously a clamp silently
+            // oversized such shards, producing correctness bugs). Fall through to
+            // `generate_transpose_shard_spec` in that case instead of handing the sharded
+            // kernels an unusable spec.
+            const bool tile_layout = input_tensor.layout() == Layout::TILE;
+            const bool tile_aligned = adjusted->shape[0] % tt::constants::TILE_HEIGHT == 0 &&
+                                      adjusted->shape[1] % tt::constants::TILE_WIDTH == 0;
+            if (!tile_layout || tile_aligned) {
+                return output_mem_config.with_shard_spec(std::move(adjusted));
+            }
+        }
     }
     auto shard_spec =
         generate_transpose_shard_spec(input_tensor, output_padded_shape, output_mem_config.memory_layout());
@@ -179,37 +219,8 @@ void TransposeDeviceOperation::validate_on_program_cache_miss(
 TensorSpec TransposeDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    const auto& dim = operation_attributes.dim;
     const auto output_mem_config = derive_effective_output_memory_config(operation_attributes, tensor_args);
-
-    auto output_shape = input_tensor.logical_shape();
-    auto output_padded_shape = input_tensor.padded_shape();
-
-    switch (dim) {
-        case TransposeOpDim::CN:
-            std::swap(output_shape[0], output_shape[1]);
-            std::swap(output_padded_shape[0], output_padded_shape[1]);
-            break;
-        case TransposeOpDim::HC:
-            if (input_tensor.layout() == Layout::ROW_MAJOR) {
-                std::swap(output_shape[1], output_shape[2]);
-                std::swap(output_padded_shape[1], output_padded_shape[2]);
-            } else {
-                uint32_t C = output_shape[1];
-                uint32_t C_p = tt::round_up(C, input_tensor.tensor_spec().tile().get_height());
-                uint32_t H = output_shape[2];
-                output_shape[1] = H;
-                output_shape[2] = C;
-                output_padded_shape[1] = H;
-                output_padded_shape[2] = C_p;
-            }
-            break;
-        case TransposeOpDim::WH:
-            std::swap(output_shape[2], output_shape[3]);
-            std::swap(output_padded_shape[2], output_padded_shape[3]);
-            break;
-        default: TT_THROW("Unsupported transpose dim"); break;
-    }
+    const auto [output_shape, output_padded_shape] = transposed_shapes(input_tensor, operation_attributes.dim);
 
     return TensorSpec(
         output_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -19,11 +19,9 @@ namespace ttnn::prim {
 
 namespace {
 
-// Compute the output logical+padded shapes for a given transpose dim. The padded-shape semantics
-// mirror what the WH/HC/CN program factories expect (in particular, HC TILE rotates input's padded
-// H into output dim[1] and pads new dim[2] to TILE_HEIGHT based on the logical C). Keeping this in
-// a single helper ensures `derive_effective_output_memory_config` and `compute_output_specs` agree
-// on shape derivation.
+// Output logical+padded shapes per transpose dim. HC TILE: dim[1] = logical H (slot 1 isn't
+// tile-padded), dim[2] = round_up(logical C, TILE_HEIGHT). Shared by
+// derive_effective_output_memory_config and compute_output_specs.
 struct TransposedShapes {
     ttnn::Shape logical;
     ttnn::Shape padded;
@@ -60,11 +58,9 @@ TransposedShapes transposed_shapes(const Tensor& input_tensor, TransposeOpDim di
     return {output_shape, output_padded_shape};
 }
 
-// Derive the effective output MemoryConfig. When the user asks for a sharded output but omits
-// shard_spec, we synthesize one here so the rest of the op (select_program_factory,
-// compute_output_specs) can reason about a fully-specified config. When the input's shard spec
-// can't be scaled exactly to the output padded shape, fall back to generating a fresh spec over
-// the full compute grid instead of crashing.
+// Synthesize a shard_spec when the user asks for sharded output without one, so downstream
+// (select_program_factory, compute_output_specs) sees a fully-specified config. Falls back to a
+// fresh full-grid spec when input shard can't be scaled exactly.
 MemoryConfig derive_effective_output_memory_config(
     const TransposeDeviceOperation::operation_attributes_t& operation_attributes,
     const TransposeDeviceOperation::tensor_args_t& tensor_args) {
@@ -74,22 +70,16 @@ MemoryConfig derive_effective_output_memory_config(
     }
     const auto& input_tensor = tensor_args.input;
     const auto output_padded_shape = transposed_shapes(input_tensor, operation_attributes.dim).padded;
-    // Only reuse the input's shard_spec geometry when the requested output layout matches the
-    // input's layout: `adjust_shard_spec_to_shape` scales the input shard dims by the shape
-    // ratio, which preserves the sharding style (height/width/block) but doesn't convert
-    // between them. When the user asks for a different layout, fall through to
-    // `generate_transpose_shard_spec` which builds a fresh spec for the requested layout.
+    // adjust_shard_spec_to_shape preserves the sharding style — only reuse input geometry when
+    // requested output layout matches input's; otherwise generate_transpose_shard_spec builds fresh.
     if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value() &&
         input_tensor.memory_config().memory_layout() == output_mem_config.memory_layout()) {
         auto adjusted = adjust_shard_spec_to_shape(
             input_tensor.shard_spec().value(), input_tensor.padded_shape(), output_padded_shape);
         if (adjusted.has_value()) {
-            // For TILE layouts, the sharded WH/HC program factories require tile-aligned shard
-            // dims. `adjust_shard_spec_to_shape` may now return a sub-tile shard whenever the
-            // transpose legitimately shrinks a dim below TILE (previously a clamp silently
-            // oversized such shards, producing correctness bugs). Fall through to
-            // `generate_transpose_shard_spec` in that case instead of handing the sharded
-            // kernels an unusable spec.
+            // TILE sharded factories need tile-aligned shards; adjust_shard_spec_to_shape may now
+            // produce sub-tile when transpose legitimately shrinks a dim → fall through to
+            // generate_transpose_shard_spec rather than feeding an unusable spec.
             const bool tile_layout = input_tensor.layout() == Layout::TILE;
             const bool tile_aligned = adjusted->shape[0] % tt::constants::TILE_HEIGHT == 0 &&
                                       adjusted->shape[1] % tt::constants::TILE_WIDTH == 0;
@@ -112,9 +102,8 @@ TransposeDeviceOperation::program_factory_t TransposeDeviceOperation::select_pro
     const auto& dim = operation_attributes.dim;
     bool is_row_major = input_tensor.layout() == Layout::ROW_MAJOR;
 
-    // When `native` is false, the specialized sharded WH/HC factories are skipped and we fall
-    // through to the interleaved factories, which use TensorAccessorArgs for transparent NOC-based
-    // access against either interleaved or sharded buffers.
+    // !native → fall through to interleaved factories (TensorAccessorArgs handles sharded buffers
+    // transparently via NOC).
     bool native = is_native_transpose_sharding(input_tensor.tensor_spec(), output_memory_config);
 
     uint32_t N = input_tensor.logical_shape()[0], C = input_tensor.logical_shape()[1];

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -106,18 +106,17 @@ TransposeDeviceOperation::program_factory_t TransposeDeviceOperation::select_pro
     // transparently via NOC).
     bool native = is_native_transpose_sharding(input_tensor.tensor_spec(), output_memory_config);
 
-    uint32_t N = input_tensor.logical_shape()[0], C = input_tensor.logical_shape()[1];
-    uint32_t output_width =
-        (dim == TransposeOpDim::WH) ? input_tensor.logical_shape()[-2] : input_tensor.logical_shape()[-1];
-    uint32_t output_height =
-        (dim == TransposeOpDim::WH)
-            ? input_tensor.logical_shape()[-1]
-            : ((dim == TransposeOpDim::HC) ? input_tensor.logical_shape()[-3] : input_tensor.logical_shape()[-2]);
+    // shard_spec.shape is in padded terms; comparisons below use padded dims.
+    const auto& input_padded_shape = input_tensor.padded_shape();
+    const auto output_padded_shape = transposed_shapes(input_tensor, dim).padded;
+    uint32_t N = input_padded_shape[0], C = input_padded_shape[1];
+    uint32_t output_width = output_padded_shape[-1];
+    uint32_t output_height = output_padded_shape[-2];
 
     bool input_height_sharded = native && input_tensor.is_sharded() && input_tensor.shard_spec().has_value() &&
-                                input_tensor.shard_spec()->shape[1] == input_tensor.logical_shape()[-1];
+                                input_tensor.shard_spec()->shape[1] == input_padded_shape[-1];
     bool input_width_and_height_fully_in_shard =
-        input_height_sharded && input_tensor.shard_spec()->shape[0] % input_tensor.logical_shape()[-2] == 0;
+        input_height_sharded && input_tensor.shard_spec()->shape[0] % input_padded_shape[-2] == 0;
     bool output_height_sharded = native && output_memory_config.is_sharded() &&
                                  output_memory_config.shard_spec().has_value() &&
                                  output_memory_config.shard_spec()->shape[1] == output_width;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -233,14 +233,12 @@ void TransposeHCRMProgramFactory::override_runtime_arguments(
     auto& program = cached_program.program;
     auto& shared_variables = cached_program.shared_variables;
 
-    {
-        auto* reader_args = GetCommonRuntimeArgs(program, shared_variables.reader_kernel_id).data();
-        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
-            *tensor_args.input.buffer(), reader_args);
-        auto* writer_args = GetCommonRuntimeArgs(program, shared_variables.writer_kernel_id).data();
-        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
-            *output_tensor.buffer(), writer_args);
-    }
+    ttnn::operations::data_movement::transpose::refresh_transpose_common_runtime_args(
+        program,
+        shared_variables.reader_kernel_id,
+        shared_variables.writer_kernel_id,
+        *tensor_args.input.buffer(),
+        *output_tensor.buffer());
 
     set_runtime_args_hc_rm(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_hc_rm_program_factory.hpp"
+#include "transpose_utils.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
@@ -166,17 +167,21 @@ TransposeHCRMProgramFactory::cached_program_t TransposeHCRMProgramFactory::creat
     CreateCircularBuffer(program, total_cores, cb_src0_config);
 
     std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> reader_common_runtime_args;
     reader_compile_time_args.push_back(N);
     reader_compile_time_args.push_back(H);
     reader_compile_time_args.push_back(C);
     reader_compile_time_args.push_back(stick_size);
     reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
 
     std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
+    std::vector<uint32_t> writer_common_runtime_args;
     writer_compile_time_args.push_back(stick_size);
     writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -184,6 +189,7 @@ TransposeHCRMProgramFactory::cached_program_t TransposeHCRMProgramFactory::creat
         "reader_unary_transpose_hc_interleaved_partitioned_rm.cpp",
         total_cores,
         ReaderDataMovementConfig(reader_compile_time_args));
+    SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
 
     KernelHandle writer_kernel_id = CreateKernel(
         program,
@@ -191,6 +197,7 @@ TransposeHCRMProgramFactory::cached_program_t TransposeHCRMProgramFactory::creat
         "writer_unary_transpose_hc_interleaved_start_id_rm.cpp",
         total_cores,
         WriterDataMovementConfig(writer_compile_time_args));
+    SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
 
     set_runtime_args_hc_rm(
         program,
@@ -225,6 +232,15 @@ void TransposeHCRMProgramFactory::override_runtime_arguments(
     Tensor& output_tensor) {
     auto& program = cached_program.program;
     auto& shared_variables = cached_program.shared_variables;
+
+    {
+        auto* reader_args = GetCommonRuntimeArgs(program, shared_variables.reader_kernel_id).data();
+        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
+            *tensor_args.input.buffer(), reader_args);
+        auto* writer_args = GetCommonRuntimeArgs(program, shared_variables.writer_kernel_id).data();
+        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
+            *output_tensor.buffer(), writer_args);
+    }
 
     set_runtime_args_hc_rm(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -234,14 +234,12 @@ void TransposeHCTiledInterleavedProgramFactory::override_runtime_arguments(
     auto& program = cached_program.program;
     auto& shared_variables = cached_program.shared_variables;
 
-    {
-        auto* reader_args = GetCommonRuntimeArgs(program, shared_variables.reader_kernel_id).data();
-        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
-            *tensor_args.input.buffer(), reader_args);
-        auto* writer_args = GetCommonRuntimeArgs(program, shared_variables.writer_kernel_id).data();
-        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
-            *output_tensor.buffer(), writer_args);
-    }
+    ttnn::operations::data_movement::transpose::refresh_transpose_common_runtime_args(
+        program,
+        shared_variables.reader_kernel_id,
+        shared_variables.writer_kernel_id,
+        *tensor_args.input.buffer(),
+        *output_tensor.buffer());
 
     auto compute_with_storage_grid_size = tensor_args.input.device()->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_hc_tiled_interleaved_program_factory.hpp"
+#include "transpose_utils.hpp"
 
 #include "ttnn/operations/math.hpp"
 
@@ -172,6 +173,7 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
     }
 
     std::vector<uint32_t> reader_compile_time_args = {};
+    std::vector<uint32_t> reader_common_runtime_args;
     std::unordered_map<std::string, uint32_t> reader_named_compile_time_args = {
         {"num_writes", num_writes},
         {"padding_val_packed", padding_val_packed},
@@ -183,7 +185,8 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
         {"tile_height", 1u},
         {"tile_width", 1u},
     };
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -191,6 +194,7 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
         "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp",
         total_cores,
         ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
+    SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
 
     Buffer* dst_buffer = output_tensor.buffer();
     std::vector<uint32_t> writer_compile_time_args = {
@@ -204,7 +208,9 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
         face_shape[0],
         face_shape[1],
         static_cast<uint32_t>(needs_padding)};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    std::vector<uint32_t> writer_common_runtime_args;
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     KernelHandle writer_kernel_id = CreateKernel(
         program,
@@ -212,6 +218,7 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
         "writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp",
         total_cores,
         WriterDataMovementConfig(writer_compile_time_args));
+    SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
 
     set_runtime_args_hc_tiled_interleaved(
         program, reader_kernel_id, writer_kernel_id, input_tensor, output_tensor, true, total_cores);
@@ -226,6 +233,16 @@ void TransposeHCTiledInterleavedProgramFactory::override_runtime_arguments(
     Tensor& output_tensor) {
     auto& program = cached_program.program;
     auto& shared_variables = cached_program.shared_variables;
+
+    {
+        auto* reader_args = GetCommonRuntimeArgs(program, shared_variables.reader_kernel_id).data();
+        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
+            *tensor_args.input.buffer(), reader_args);
+        auto* writer_args = GetCommonRuntimeArgs(program, shared_variables.writer_kernel_id).data();
+        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(
+            *output_tensor.buffer(), writer_args);
+    }
+
     auto compute_with_storage_grid_size = tensor_args.input.device()->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_utils.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+namespace ttnn::operations::data_movement::transpose {
+
+using namespace tt::tt_metal;
+
+static const std::optional<ShardSpec>& get_shard_spec_from_tensor_spec(const TensorSpec& tensor_spec) {
+    return tensor_spec.memory_config().shard_spec();
+}
+
+bool is_uneven(const TensorSpec& t) {
+    if (!t.memory_config().is_sharded()) {
+        return false;
+    }
+    const auto& shard_spec = get_shard_spec_from_tensor_spec(t);
+    if (!shard_spec.has_value()) {
+        return true;
+    }
+    const auto& shape = t.padded_shape();
+    const auto& shard = shard_spec->shape;
+    const auto rank = shape.rank();
+    TT_FATAL(rank >= 2, "Rank must be at least 2");
+    uint64_t volume_except_last = 1;
+    for (int i = 0; i < static_cast<int>(rank) - 1; ++i) {
+        volume_except_last *= shape[i];
+    }
+    return (volume_except_last % shard[0]) != 0 || (shape[-1] % shard[1]) != 0;
+}
+
+bool is_native_transpose_sharding(const TensorSpec& input_spec, const MemoryConfig& output_memory_config) {
+    if (!output_memory_config.is_sharded()) {
+        return false;
+    }
+    if (!input_spec.memory_config().is_sharded()) {
+        return false;
+    }
+    if (is_uneven(input_spec)) {
+        return false;
+    }
+    if (input_spec.memory_config().buffer_type() == BufferType::DRAM ||
+        output_memory_config.buffer_type() == BufferType::DRAM) {
+        return false;
+    }
+    if (input_spec.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+        output_memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        return false;
+    }
+    if (output_memory_config.shard_spec().has_value() && input_spec.memory_config().shard_spec().has_value()) {
+        const auto& in_grid = input_spec.memory_config().shard_spec()->grid;
+        const auto& out_grid = output_memory_config.shard_spec()->grid;
+        if (in_grid != out_grid) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::optional<TransposeShardSpecs> get_transpose_shard_specs(
+    const TensorSpec& input_spec, const TensorSpec& output_spec) {
+    const bool input_sharded = input_spec.memory_config().is_sharded();
+    const bool output_sharded = output_spec.memory_config().is_sharded();
+
+    if (!input_sharded && !output_sharded) {
+        return std::nullopt;
+    }
+
+    if (!is_native_transpose_sharding(input_spec, output_spec.memory_config()) || is_uneven(output_spec)) {
+        return std::nullopt;
+    }
+
+    if (input_spec.layout() == Layout::ROW_MAJOR) {
+        auto is_shard_tile_aligned = [](const TensorSpec& spec) {
+            const auto& shard = *get_shard_spec_from_tensor_spec(spec);
+            const auto tile_hw = spec.tile().get_tile_hw();
+            const uint64_t shard_elements = static_cast<uint64_t>(shard.shape[0]) * shard.shape[1];
+            return shard_elements % tile_hw == 0;
+        };
+
+        if ((input_sharded && !is_shard_tile_aligned(input_spec)) ||
+            (output_sharded && !is_shard_tile_aligned(output_spec))) {
+            return std::nullopt;
+        }
+    }
+
+    TT_FATAL(
+        get_shard_spec_from_tensor_spec(output_spec).has_value(),
+        "Output must have shard spec when using native sharded path");
+
+    if (input_sharded) {
+        const auto& in_shard = *get_shard_spec_from_tensor_spec(input_spec);
+        const auto& out_shard = *get_shard_spec_from_tensor_spec(output_spec);
+        return TransposeShardSpecs{.input_shard_spec = in_shard, .output_shard_spec = out_shard};
+    }
+
+    const auto& out_shard = *get_shard_spec_from_tensor_spec(output_spec);
+    const auto& out_shape = output_spec.padded_shape();
+    const auto& in_shape = input_spec.padded_shape();
+    auto adjusted_in = adjust_shard_spec_to_shape(out_shard, out_shape, in_shape);
+    return TransposeShardSpecs{.input_shard_spec = adjusted_in, .output_shard_spec = out_shard};
+}
+
+ShardSpec adjust_shard_spec_to_shape(
+    const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
+    auto ret = shard_spec;
+    uint32_t from_volume_except_width = 1;
+    uint32_t to_volume_except_width = 1;
+    const auto from_rank = static_cast<int>(from_shape.rank());
+    const auto to_rank = static_cast<int>(to_shape.rank());
+    for (int i = 0; i < from_rank - 1; ++i) {
+        from_volume_except_width *= from_shape[i];
+    }
+    for (int i = 0; i < to_rank - 1; ++i) {
+        to_volume_except_width *= to_shape[i];
+    }
+    uint32_t from_width = from_shape[-1];
+    uint32_t to_width = to_shape[-1];
+    TT_FATAL(from_volume_except_width > 0, "Invalid from_shape: volume is zero");
+    TT_FATAL(from_width > 0, "Invalid from_shape: width dimension is zero");
+    ret.shape[0] = std::max((ret.shape[0] * to_volume_except_width) / from_volume_except_width, 32u);
+    ret.shape[1] = std::max((ret.shape[1] * to_width) / from_width, 32u);
+    return ret;
+}
+
+ShardSpec generate_transpose_shard_spec(
+    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
+    auto* device = input_tensor.device();
+    auto compute_grid_size = device->compute_with_storage_grid_size();
+    CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
+    uint32_t num_cores = all_cores.num_cores();
+
+    uint32_t tensor_height = 1;
+    for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
+        tensor_height *= padded_out_shape[i];
+    }
+    uint32_t tensor_width = padded_out_shape[-1];
+
+    std::array<uint32_t, 2> shard_shape = {0, 0};
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        auto height_padded = tt::round_up(tensor_height, num_cores * tt::constants::TILE_HEIGHT);
+        auto shard_height = tt::round_up(tt::div_up(height_padded, num_cores), tt::constants::TILE_HEIGHT);
+        shard_shape = {shard_height, tensor_width};
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        auto shard_width = tt::round_up(tt::div_up(tensor_width, num_cores), tt::constants::TILE_WIDTH);
+        shard_shape = {tensor_height, shard_width};
+    } else {
+        CoreCoord grid_size = all_cores.bounding_box().grid_size();
+        auto height_padded = tt::round_up(tensor_height, grid_size.y * tt::constants::TILE_HEIGHT);
+        auto shard_height = tt::round_up(tt::div_up(height_padded, grid_size.y), tt::constants::TILE_HEIGHT);
+        auto shard_width = tt::round_up(tt::div_up(tensor_width, grid_size.x), tt::constants::TILE_WIDTH);
+        shard_shape = {shard_height, shard_width};
+    }
+    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+}
+
+CoreRangeSet get_transpose_worker_grid(const Tensor& input_tensor, const MemoryConfig& output_memory_config) {
+    if (output_memory_config.is_sharded() && output_memory_config.shard_spec().has_value()) {
+        const auto& grid = output_memory_config.shard_spec()->grid;
+        auto* device = input_tensor.device();
+        for (const auto& sub_device_id : device->get_sub_device_ids()) {
+            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+            if (sub_device_workers.intersects(grid)) {
+                return sub_device_workers;
+            }
+        }
+    }
+
+    if (input_tensor.is_sharded() && is_native_transpose_sharding(input_tensor.tensor_spec(), output_memory_config)) {
+        const auto& grid = input_tensor.shard_spec()->grid;
+        auto* device = input_tensor.device();
+        for (const auto& sub_device_id : device->get_sub_device_ids()) {
+            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+            if (sub_device_workers.intersects(grid)) {
+                return sub_device_workers;
+            }
+        }
+    }
+
+    auto* device = input_tensor.device();
+    return device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
+}
+
+std::uint32_t* copy_transpose_common_runtime_args(const Buffer& buffer, std::uint32_t* dst) {
+    const auto src =
+        TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape).get_common_runtime_args();
+    return std::copy(src.begin(), src.end(), dst);
+}
+
+}  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -55,6 +55,26 @@ bool is_native_transpose_sharding(const TensorSpec& input_spec, const MemoryConf
         output_memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
         return false;
     }
+    // ROW_MAJOR sharded shards whose total element count is not a multiple of the tile footprint
+    // (TILE_HEIGHT * TILE_WIDTH) cannot use the specialized native kernels — those assume whole-tile
+    // pages. Mirrors the `is_shard_tile_aligned` guard used by `unary_ng`. Returning false routes
+    // such cases to the interleaved factories, which use TensorAccessorArgs to read/write sharded
+    // buffers directly over NOC without an explicit reshard hop.
+    if (input_spec.layout() == Layout::ROW_MAJOR) {
+        constexpr uint64_t tile_hw =
+            static_cast<uint64_t>(tt::constants::TILE_HEIGHT) * static_cast<uint64_t>(tt::constants::TILE_WIDTH);
+        auto shard_elements_not_tile_aligned = [](const MemoryConfig& mc) {
+            if (!mc.shard_spec().has_value()) {
+                return false;
+            }
+            const auto& s = mc.shard_spec()->shape;
+            const uint64_t elems = static_cast<uint64_t>(s[0]) * static_cast<uint64_t>(s[1]);
+            return elems % tile_hw != 0;
+        };
+        if (shard_elements_not_tile_aligned(in_cfg) || shard_elements_not_tile_aligned(output_memory_config)) {
+            return false;
+        }
+    }
     // When either spec is missing we're in the pre-derivation path (callers like transpose.cpp and
     // compute_output_specs use this predicate as an eligibility probe before deriving the output
     // shard_spec). Skip the grid equality check in that case — the derived grid will match the input's.

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -3,29 +3,34 @@
 
 #include "transpose_utils.hpp"
 
+#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::data_movement::transpose {
 
 using namespace tt::tt_metal;
 
-static const std::optional<ShardSpec>& get_shard_spec_from_tensor_spec(const TensorSpec& tensor_spec) {
-    return tensor_spec.memory_config().shard_spec();
-}
+namespace {
 
-bool is_uneven(const TensorSpec& t) {
+// Returns true if the tensor's padded shape does not divide evenly into its shard shape,
+// or if the sharded memory config has no concrete shard_spec. Conservatively returns true
+// for pathological inputs (rank < 2) so callers fall back to interleaved paths.
+bool is_unevenly_sharded(const TensorSpec& t) {
     if (!t.memory_config().is_sharded()) {
         return false;
     }
-    const auto& shard_spec = get_shard_spec_from_tensor_spec(t);
+    const auto& shard_spec = t.memory_config().shard_spec();
     if (!shard_spec.has_value()) {
         return true;
     }
     const auto& shape = t.padded_shape();
-    const auto& shard = shard_spec->shape;
     const auto rank = shape.rank();
-    TT_FATAL(rank >= 2, "Rank must be at least 2");
+    if (rank < 2) {
+        return true;
+    }
+    const auto& shard = shard_spec->shape;
     uint64_t volume_except_last = 1;
     for (int i = 0; i < static_cast<int>(rank) - 1; ++i) {
         volume_except_last *= shape[i];
@@ -33,76 +38,32 @@ bool is_uneven(const TensorSpec& t) {
     return (volume_except_last % shard[0]) != 0 || (shape[-1] % shard[1]) != 0;
 }
 
+}  // namespace
+
 bool is_native_transpose_sharding(const TensorSpec& input_spec, const MemoryConfig& output_memory_config) {
-    if (!output_memory_config.is_sharded()) {
+    const auto& in_cfg = input_spec.memory_config();
+    if (!output_memory_config.is_sharded() || !in_cfg.is_sharded()) {
         return false;
     }
-    if (!input_spec.memory_config().is_sharded()) {
+    if (is_unevenly_sharded(input_spec)) {
         return false;
     }
-    if (is_uneven(input_spec)) {
+    if (in_cfg.buffer_type() == BufferType::DRAM || output_memory_config.buffer_type() == BufferType::DRAM) {
         return false;
     }
-    if (input_spec.memory_config().buffer_type() == BufferType::DRAM ||
-        output_memory_config.buffer_type() == BufferType::DRAM) {
-        return false;
-    }
-    if (input_spec.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+    if (in_cfg.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
         output_memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
         return false;
     }
-    if (output_memory_config.shard_spec().has_value() && input_spec.memory_config().shard_spec().has_value()) {
-        const auto& in_grid = input_spec.memory_config().shard_spec()->grid;
-        const auto& out_grid = output_memory_config.shard_spec()->grid;
-        if (in_grid != out_grid) {
+    // When either spec is missing we're in the pre-derivation path (callers like transpose.cpp and
+    // compute_output_specs use this predicate as an eligibility probe before deriving the output
+    // shard_spec). Skip the grid equality check in that case — the derived grid will match the input's.
+    if (output_memory_config.shard_spec().has_value() && in_cfg.shard_spec().has_value()) {
+        if (in_cfg.shard_spec()->grid != output_memory_config.shard_spec()->grid) {
             return false;
         }
     }
     return true;
-}
-
-std::optional<TransposeShardSpecs> get_transpose_shard_specs(
-    const TensorSpec& input_spec, const TensorSpec& output_spec) {
-    const bool input_sharded = input_spec.memory_config().is_sharded();
-    const bool output_sharded = output_spec.memory_config().is_sharded();
-
-    if (!input_sharded && !output_sharded) {
-        return std::nullopt;
-    }
-
-    if (!is_native_transpose_sharding(input_spec, output_spec.memory_config()) || is_uneven(output_spec)) {
-        return std::nullopt;
-    }
-
-    if (input_spec.layout() == Layout::ROW_MAJOR) {
-        auto is_shard_tile_aligned = [](const TensorSpec& spec) {
-            const auto& shard = *get_shard_spec_from_tensor_spec(spec);
-            const auto tile_hw = spec.tile().get_tile_hw();
-            const uint64_t shard_elements = static_cast<uint64_t>(shard.shape[0]) * shard.shape[1];
-            return shard_elements % tile_hw == 0;
-        };
-
-        if ((input_sharded && !is_shard_tile_aligned(input_spec)) ||
-            (output_sharded && !is_shard_tile_aligned(output_spec))) {
-            return std::nullopt;
-        }
-    }
-
-    TT_FATAL(
-        get_shard_spec_from_tensor_spec(output_spec).has_value(),
-        "Output must have shard spec when using native sharded path");
-
-    if (input_sharded) {
-        const auto& in_shard = *get_shard_spec_from_tensor_spec(input_spec);
-        const auto& out_shard = *get_shard_spec_from_tensor_spec(output_spec);
-        return TransposeShardSpecs{.input_shard_spec = in_shard, .output_shard_spec = out_shard};
-    }
-
-    const auto& out_shard = *get_shard_spec_from_tensor_spec(output_spec);
-    const auto& out_shape = output_spec.padded_shape();
-    const auto& in_shape = input_spec.padded_shape();
-    auto adjusted_in = adjust_shard_spec_to_shape(out_shard, out_shape, in_shape);
-    return TransposeShardSpecs{.input_shard_spec = adjusted_in, .output_shard_spec = out_shard};
 }
 
 ShardSpec adjust_shard_spec_to_shape(
@@ -122,11 +83,43 @@ ShardSpec adjust_shard_spec_to_shape(
     uint32_t to_width = to_shape[-1];
     TT_FATAL(from_volume_except_width > 0, "Invalid from_shape: volume is zero");
     TT_FATAL(from_width > 0, "Invalid from_shape: width dimension is zero");
-    ret.shape[0] = std::max((ret.shape[0] * to_volume_except_width) / from_volume_except_width, 32u);
-    ret.shape[1] = std::max((ret.shape[1] * to_width) / from_width, 32u);
+
+    // Require exact division so we never silently truncate the scaled shard dimensions. Callers
+    // must only invoke this helper when the to/from shape ratios evenly divide the source shard.
+    const uint64_t h_num = static_cast<uint64_t>(ret.shape[0]) * to_volume_except_width;
+    const uint64_t w_num = static_cast<uint64_t>(ret.shape[1]) * to_width;
+    TT_FATAL(
+        h_num % from_volume_except_width == 0,
+        "adjust_shard_spec_to_shape: height scaling not exact ({} * {} not divisible by {}).",
+        ret.shape[0],
+        to_volume_except_width,
+        from_volume_except_width);
+    TT_FATAL(
+        w_num % from_width == 0,
+        "adjust_shard_spec_to_shape: width scaling not exact ({} * {} not divisible by {}).",
+        ret.shape[1],
+        to_width,
+        from_width);
+    uint32_t scaled_h = static_cast<uint32_t>(h_num / from_volume_except_width);
+    uint32_t scaled_w = static_cast<uint32_t>(w_num / from_width);
+
+    // Only clamp to tile dimensions when the source shard was already tile-aligned. For sub-tile
+    // ROW_MAJOR shards the caller is responsible for legality and we must not over-size the shard.
+    const bool source_tile_aligned =
+        shard_spec.shape[0] % tt::constants::TILE_HEIGHT == 0 && shard_spec.shape[1] % tt::constants::TILE_WIDTH == 0;
+    if (source_tile_aligned) {
+        scaled_h = std::max(scaled_h, tt::constants::TILE_HEIGHT);
+        scaled_w = std::max(scaled_w, tt::constants::TILE_WIDTH);
+    }
+
+    ret.shape[0] = scaled_h;
+    ret.shape[1] = scaled_w;
     return ret;
 }
 
+// When the user requests a sharded output but no shard_spec, and the input is interleaved, we derive
+// a grid and shard shape using the full device compute grid, matching the shard math used elsewhere
+// for height/width/block cases.
 ShardSpec generate_transpose_shard_spec(
     const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
     auto* device = input_tensor.device();
@@ -155,40 +148,35 @@ ShardSpec generate_transpose_shard_spec(
         auto shard_width = tt::round_up(tt::div_up(tensor_width, grid_size.x), tt::constants::TILE_WIDTH);
         shard_shape = {shard_height, shard_width};
     }
+    log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
     return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
 }
 
-CoreRangeSet get_transpose_worker_grid(const Tensor& input_tensor, const MemoryConfig& output_memory_config) {
-    if (output_memory_config.is_sharded() && output_memory_config.shard_spec().has_value()) {
-        const auto& grid = output_memory_config.shard_spec()->grid;
-        auto* device = input_tensor.device();
-        for (const auto& sub_device_id : device->get_sub_device_ids()) {
-            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
-            if (sub_device_workers.intersects(grid)) {
-                return sub_device_workers;
-            }
-        }
-    }
-
-    if (input_tensor.is_sharded() && is_native_transpose_sharding(input_tensor.tensor_spec(), output_memory_config)) {
-        const auto& grid = input_tensor.shard_spec()->grid;
-        auto* device = input_tensor.device();
-        for (const auto& sub_device_id : device->get_sub_device_ids()) {
-            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
-            if (sub_device_workers.intersects(grid)) {
-                return sub_device_workers;
-            }
-        }
-    }
-
-    auto* device = input_tensor.device();
-    return device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
-}
-
-std::uint32_t* copy_transpose_common_runtime_args(const Buffer& buffer, std::uint32_t* dst) {
+// Refreshes the runtime-tensor-shape common args on program cache hits. The destination span is
+// bounds-checked against the element count produced by the fresh TensorAccessorArgs so any layout
+// change between program creation and the cache hit triggers a clear assertion instead of a silent
+// buffer overrun.
+void copy_transpose_common_runtime_args(const Buffer& buffer, std::span<std::uint32_t> dst) {
     const auto src =
         TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape).get_common_runtime_args();
-    return std::copy(src.begin(), src.end(), dst);
+    TT_FATAL(
+        dst.size() >= src.size(),
+        "copy_transpose_common_runtime_args: destination span ({} elems) too small for common args ({} elems).",
+        dst.size(),
+        src.size());
+    std::copy(src.begin(), src.end(), dst.begin());
+}
+
+void refresh_transpose_common_runtime_args(
+    Program& program,
+    KernelHandle reader_kernel_id,
+    KernelHandle writer_kernel_id,
+    const Buffer& input_buffer,
+    const Buffer& output_buffer) {
+    auto& reader_args = GetCommonRuntimeArgs(program, reader_kernel_id);
+    auto& writer_args = GetCommonRuntimeArgs(program, writer_kernel_id);
+    copy_transpose_common_runtime_args(input_buffer, std::span<std::uint32_t>(reader_args.data(), reader_args.size()));
+    copy_transpose_common_runtime_args(output_buffer, std::span<std::uint32_t>(writer_args.data(), writer_args.size()));
 }
 
 }  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -38,102 +38,103 @@ bool is_unevenly_sharded(const TensorSpec& t) {
     return (volume_except_last % shard[0]) != 0 || (shape[-1] % shard[1]) != 0;
 }
 
+// True when a RM MemoryConfig's shard element count is not a multiple of the tile footprint.
+// Such shards cannot use the specialized native kernels (which assume whole-tile pages); the
+// interleaved factories handle them via TensorAccessorArgs instead.
+bool rm_shard_elements_not_tile_aligned(const MemoryConfig& mc) {
+    if (!mc.shard_spec().has_value()) {
+        return false;
+    }
+    constexpr uint64_t tile_hw =
+        static_cast<uint64_t>(tt::constants::TILE_HEIGHT) * static_cast<uint64_t>(tt::constants::TILE_WIDTH);
+    const auto& s = mc.shard_spec()->shape;
+    const uint64_t elems = static_cast<uint64_t>(s[0]) * static_cast<uint64_t>(s[1]);
+    return elems % tile_hw != 0;
+}
+
+// Side-level native eligibility: sharded, non-DRAM, non-BLOCK, and for ROW_MAJOR: shard-element
+// count is a whole multiple of tile_hw. Shared by the input and output checks below.
+bool side_native(const MemoryConfig& mc, Layout layout) {
+    if (!mc.is_sharded()) {
+        return false;
+    }
+    if (mc.buffer_type() == BufferType::DRAM) {
+        return false;
+    }
+    if (mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        return false;
+    }
+    if (layout == Layout::ROW_MAJOR && rm_shard_elements_not_tile_aligned(mc)) {
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
-bool is_native_transpose_sharding(const TensorSpec& input_spec, const MemoryConfig& output_memory_config) {
-    const auto& in_cfg = input_spec.memory_config();
-    if (!output_memory_config.is_sharded() || !in_cfg.is_sharded()) {
+bool is_native_transpose_sharding(
+    const TensorSpec& input_spec, const std::optional<MemoryConfig>& output_memory_config) {
+    if (!side_native(input_spec.memory_config(), input_spec.layout())) {
         return false;
     }
     if (is_unevenly_sharded(input_spec)) {
         return false;
     }
-    if (in_cfg.buffer_type() == BufferType::DRAM || output_memory_config.buffer_type() == BufferType::DRAM) {
+    if (!output_memory_config.has_value()) {
+        // Pre-derivation path: the output shard_spec is about to be synthesized from the input's,
+        // so there's nothing to compare on the output side yet. Input-only eligibility is enough.
+        return true;
+    }
+    if (!side_native(*output_memory_config, input_spec.layout())) {
         return false;
     }
-    if (in_cfg.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
-        output_memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-        return false;
-    }
-    // ROW_MAJOR sharded shards whose total element count is not a multiple of the tile footprint
-    // (TILE_HEIGHT * TILE_WIDTH) cannot use the specialized native kernels — those assume whole-tile
-    // pages. Mirrors the `is_shard_tile_aligned` guard used by `unary_ng`. Returning false routes
-    // such cases to the interleaved factories, which use TensorAccessorArgs to read/write sharded
-    // buffers directly over NOC without an explicit reshard hop.
-    if (input_spec.layout() == Layout::ROW_MAJOR) {
-        constexpr uint64_t tile_hw =
-            static_cast<uint64_t>(tt::constants::TILE_HEIGHT) * static_cast<uint64_t>(tt::constants::TILE_WIDTH);
-        auto shard_elements_not_tile_aligned = [](const MemoryConfig& mc) {
-            if (!mc.shard_spec().has_value()) {
-                return false;
-            }
-            const auto& s = mc.shard_spec()->shape;
-            const uint64_t elems = static_cast<uint64_t>(s[0]) * static_cast<uint64_t>(s[1]);
-            return elems % tile_hw != 0;
-        };
-        if (shard_elements_not_tile_aligned(in_cfg) || shard_elements_not_tile_aligned(output_memory_config)) {
-            return false;
-        }
-    }
-    // When either spec is missing we're in the pre-derivation path (callers like transpose.cpp and
-    // compute_output_specs use this predicate as an eligibility probe before deriving the output
-    // shard_spec). Skip the grid equality check in that case — the derived grid will match the input's.
-    if (output_memory_config.shard_spec().has_value() && in_cfg.shard_spec().has_value()) {
-        if (in_cfg.shard_spec()->grid != output_memory_config.shard_spec()->grid) {
-            return false;
-        }
-    }
-    return true;
+    // The sharded WH/HC program factories assume a single shared grid; only enforce when both
+    // shard_specs are concrete. During derive_effective_output_memory_config the output_mem_config
+    // may still carry no shard_spec, and its grid is implicitly the input's.
+    const auto& in_ss = input_spec.memory_config().shard_spec();
+    const auto& out_ss = output_memory_config->shard_spec();
+    return !(in_ss.has_value() && out_ss.has_value() && in_ss->grid != out_ss->grid);
 }
 
-ShardSpec adjust_shard_spec_to_shape(
+std::optional<ShardSpec> adjust_shard_spec_to_shape(
     const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
-    auto ret = shard_spec;
-    uint32_t from_volume_except_width = 1;
-    uint32_t to_volume_except_width = 1;
+    // Volumes are accumulated in uint64_t to prevent overflow on large tensors (e.g. N*C*H
+    // products can exceed 2^32). Returning nullopt on non-exact division lets callers fall back
+    // gracefully (generate_transpose_shard_spec or interleaved) instead of crashing a valid user
+    // call, and avoids the silent-truncation pitfall of blind uint division.
+    uint64_t from_volume_except_width = 1;
+    uint64_t to_volume_except_width = 1;
     const auto from_rank = static_cast<int>(from_shape.rank());
     const auto to_rank = static_cast<int>(to_shape.rank());
     for (int i = 0; i < from_rank - 1; ++i) {
-        from_volume_except_width *= from_shape[i];
+        from_volume_except_width *= static_cast<uint64_t>(from_shape[i]);
     }
     for (int i = 0; i < to_rank - 1; ++i) {
-        to_volume_except_width *= to_shape[i];
+        to_volume_except_width *= static_cast<uint64_t>(to_shape[i]);
     }
-    uint32_t from_width = from_shape[-1];
-    uint32_t to_width = to_shape[-1];
-    TT_FATAL(from_volume_except_width > 0, "Invalid from_shape: volume is zero");
-    TT_FATAL(from_width > 0, "Invalid from_shape: width dimension is zero");
-
-    // Require exact division so we never silently truncate the scaled shard dimensions. Callers
-    // must only invoke this helper when the to/from shape ratios evenly divide the source shard.
-    const uint64_t h_num = static_cast<uint64_t>(ret.shape[0]) * to_volume_except_width;
-    const uint64_t w_num = static_cast<uint64_t>(ret.shape[1]) * to_width;
-    TT_FATAL(
-        h_num % from_volume_except_width == 0,
-        "adjust_shard_spec_to_shape: height scaling not exact ({} * {} not divisible by {}).",
-        ret.shape[0],
-        to_volume_except_width,
-        from_volume_except_width);
-    TT_FATAL(
-        w_num % from_width == 0,
-        "adjust_shard_spec_to_shape: width scaling not exact ({} * {} not divisible by {}).",
-        ret.shape[1],
-        to_width,
-        from_width);
-    uint32_t scaled_h = static_cast<uint32_t>(h_num / from_volume_except_width);
-    uint32_t scaled_w = static_cast<uint32_t>(w_num / from_width);
-
-    // Only clamp to tile dimensions when the source shard was already tile-aligned. For sub-tile
-    // ROW_MAJOR shards the caller is responsible for legality and we must not over-size the shard.
-    const bool source_tile_aligned =
-        shard_spec.shape[0] % tt::constants::TILE_HEIGHT == 0 && shard_spec.shape[1] % tt::constants::TILE_WIDTH == 0;
-    if (source_tile_aligned) {
-        scaled_h = std::max(scaled_h, tt::constants::TILE_HEIGHT);
-        scaled_w = std::max(scaled_w, tt::constants::TILE_WIDTH);
+    const uint64_t from_width = static_cast<uint64_t>(from_shape[-1]);
+    const uint64_t to_width = static_cast<uint64_t>(to_shape[-1]);
+    if (from_volume_except_width == 0 || from_width == 0) {
+        return std::nullopt;
     }
 
-    ret.shape[0] = scaled_h;
-    ret.shape[1] = scaled_w;
+    const uint64_t h_num = static_cast<uint64_t>(shard_spec.shape[0]) * to_volume_except_width;
+    const uint64_t w_num = static_cast<uint64_t>(shard_spec.shape[1]) * to_width;
+    if (h_num % from_volume_except_width != 0 || w_num % from_width != 0) {
+        return std::nullopt;
+    }
+
+    // Return the exact ratio-scaled shard without tile-size clamping. A naive
+    // `std::max(scaled, TILE_*)` clamp oversizes the shard whenever the target dim legitimately
+    // shrinks below a tile (e.g. WH on a tile-aligned height-sharded input where the new width
+    // becomes sub-tile) and then fills the grid with capacity for data that doesn't exist,
+    // producing silent correctness regressions. Callers that need tile-aligned shards post-check
+    // `shape[i] % TILE_*` and fall back to interleaved; callers targeting RM layouts tolerate
+    // sub-tile shards. This mirrors `unary_ng`/`binary_ng` semantics but avoids their latent
+    // clamp bug — harmless there because their shape ratios never shrink a dim.
+    auto ret = shard_spec;
+    ret.shape[0] = static_cast<uint32_t>(h_num / from_volume_except_width);
+    ret.shape[1] = static_cast<uint32_t>(w_num / from_width);
     return ret;
 }
 
@@ -147,41 +148,49 @@ ShardSpec generate_transpose_shard_spec(
     CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
     uint32_t num_cores = all_cores.num_cores();
 
-    uint32_t tensor_height = 1;
+    // Accumulate in uint64 to match adjust_shard_spec_to_shape and avoid overflow on tensors whose
+    // product of leading dims exceeds 2^32 (e.g. large batch x seq_len x head_dim attention shapes).
+    // The final per-shard dims we hand back are still uint32 (the hardware/shard-spec representation),
+    // but the intermediate height computation uses the wider type.
+    uint64_t tensor_height = 1;
     for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
-        tensor_height *= padded_out_shape[i];
+        tensor_height *= static_cast<uint64_t>(padded_out_shape[i]);
     }
-    uint32_t tensor_width = padded_out_shape[-1];
+    uint64_t tensor_width = padded_out_shape[-1];
 
     std::array<uint32_t, 2> shard_shape = {0, 0};
     if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        auto height_padded = tt::round_up(tensor_height, num_cores * tt::constants::TILE_HEIGHT);
-        auto shard_height = tt::round_up(tt::div_up(height_padded, num_cores), tt::constants::TILE_HEIGHT);
-        shard_shape = {shard_height, tensor_width};
+        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * tt::constants::TILE_HEIGHT);
+        auto shard_height =
+            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(num_cores)), tt::constants::TILE_HEIGHT);
+        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(tensor_width)};
     } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        auto shard_width = tt::round_up(tt::div_up(tensor_width, num_cores), tt::constants::TILE_WIDTH);
-        shard_shape = {tensor_height, shard_width};
+        auto shard_width =
+            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), tt::constants::TILE_WIDTH);
+        shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
     } else {
         CoreCoord grid_size = all_cores.bounding_box().grid_size();
-        auto height_padded = tt::round_up(tensor_height, grid_size.y * tt::constants::TILE_HEIGHT);
-        auto shard_height = tt::round_up(tt::div_up(height_padded, grid_size.y), tt::constants::TILE_HEIGHT);
-        auto shard_width = tt::round_up(tt::div_up(tensor_width, grid_size.x), tt::constants::TILE_WIDTH);
-        shard_shape = {shard_height, shard_width};
+        auto height_padded =
+            tt::round_up(tensor_height, static_cast<uint64_t>(grid_size.y) * tt::constants::TILE_HEIGHT);
+        auto shard_height =
+            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(grid_size.y)), tt::constants::TILE_HEIGHT);
+        auto shard_width =
+            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(grid_size.x)), tt::constants::TILE_WIDTH);
+        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
     }
     log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
     return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
 }
 
-// Refreshes the runtime-tensor-shape common args on program cache hits. The destination span is
-// bounds-checked against the element count produced by the fresh TensorAccessorArgs so any layout
-// change between program creation and the cache hit triggers a clear assertion instead of a silent
-// buffer overrun.
+// Refreshes the runtime-tensor-shape common args on program cache hits. Strict equality between
+// destination and source lengths catches any drift in the TensorAccessorArgs footprint between
+// program creation and the cache hit (a >= check would leave stale trailing elements in dst).
 void copy_transpose_common_runtime_args(const Buffer& buffer, std::span<std::uint32_t> dst) {
     const auto src =
         TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape).get_common_runtime_args();
     TT_FATAL(
-        dst.size() >= src.size(),
-        "copy_transpose_common_runtime_args: destination span ({} elems) too small for common args ({} elems).",
+        dst.size() == src.size(),
+        "copy_transpose_common_runtime_args: destination span ({} elems) must match common args ({} elems).",
         dst.size(),
         src.size());
     std::copy(src.begin(), src.end(), dst.begin());

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -102,14 +102,19 @@ std::optional<ShardSpec> adjust_shard_spec_to_shape(
     // products can exceed 2^32). Returning nullopt on non-exact division lets callers fall back
     // gracefully (generate_transpose_shard_spec or interleaved) instead of crashing a valid user
     // call, and avoids the silent-truncation pitfall of blind uint division.
+    // Transpose preserves rank, so callers must pass equal-rank shapes. Enforce this explicitly:
+    // mismatched ranks would silently produce inconsistent volume math (the two accumulation loops
+    // below run for different counts) and yield a valid-looking but wrong shard.
+    TT_FATAL(
+        from_shape.rank() == to_shape.rank(),
+        "adjust_shard_spec_to_shape: from_shape rank ({}) and to_shape rank ({}) must match.",
+        from_shape.rank(),
+        to_shape.rank());
     uint64_t from_volume_except_width = 1;
     uint64_t to_volume_except_width = 1;
-    const auto from_rank = static_cast<int>(from_shape.rank());
-    const auto to_rank = static_cast<int>(to_shape.rank());
-    for (int i = 0; i < from_rank - 1; ++i) {
+    const auto rank = static_cast<int>(from_shape.rank());
+    for (int i = 0; i < rank - 1; ++i) {
         from_volume_except_width *= static_cast<uint64_t>(from_shape[i]);
-    }
-    for (int i = 0; i < to_rank - 1; ++i) {
         to_volume_except_width *= static_cast<uint64_t>(to_shape[i]);
     }
     const uint64_t from_width = static_cast<uint64_t>(from_shape[-1]);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -14,9 +14,8 @@ using namespace tt::tt_metal;
 
 namespace {
 
-// Returns true if the tensor's padded shape does not divide evenly into its shard shape,
-// or if the sharded memory config has no concrete shard_spec. Conservatively returns true
-// for pathological inputs (rank < 2) so callers fall back to interleaved paths.
+// True if padded shape doesn't divide evenly into shard, or if the sharded config has no spec.
+// Conservatively true for rank < 2 so callers fall back to interleaved.
 bool is_unevenly_sharded(const TensorSpec& t) {
     if (!t.memory_config().is_sharded()) {
         return false;
@@ -38,9 +37,8 @@ bool is_unevenly_sharded(const TensorSpec& t) {
     return (volume_except_last % shard[0]) != 0 || (shape[-1] % shard[1]) != 0;
 }
 
-// True when a RM MemoryConfig's shard element count is not a multiple of the tile footprint.
-// Such shards cannot use the specialized native kernels (which assume whole-tile pages); the
-// interleaved factories handle them via TensorAccessorArgs instead.
+// RM shard element count not a tile multiple → native kernels can't use it (whole-tile pages
+// only); the interleaved TensorAccessor path handles such shards.
 bool rm_shard_elements_not_tile_aligned(const MemoryConfig& mc) {
     if (!mc.shard_spec().has_value()) {
         return false;
@@ -52,8 +50,8 @@ bool rm_shard_elements_not_tile_aligned(const MemoryConfig& mc) {
     return elems % tile_hw != 0;
 }
 
-// Side-level native eligibility: sharded, non-DRAM, non-BLOCK, and for ROW_MAJOR: shard-element
-// count is a whole multiple of tile_hw. Shared by the input and output checks below.
+// Per-side native eligibility: sharded, non-DRAM, non-BLOCK, and for RM: shard elements are a
+// tile_hw multiple.
 bool side_native(const MemoryConfig& mc, Layout layout) {
     if (!mc.is_sharded()) {
         return false;
@@ -81,16 +79,14 @@ bool is_native_transpose_sharding(
         return false;
     }
     if (!output_memory_config.has_value()) {
-        // Pre-derivation path: the output shard_spec is about to be synthesized from the input's,
-        // so there's nothing to compare on the output side yet. Input-only eligibility is enough.
+        // Pre-derivation: output spec will be synthesized from input — input eligibility suffices.
         return true;
     }
     if (!side_native(*output_memory_config, input_spec.layout())) {
         return false;
     }
-    // The sharded WH/HC program factories assume a single shared grid; only enforce when both
-    // shard_specs are concrete. During derive_effective_output_memory_config the output_mem_config
-    // may still carry no shard_spec, and its grid is implicitly the input's.
+    // Sharded WH/HC factories require a single shared grid; only enforce when both specs concrete
+    // (a missing output spec implicitly inherits the input grid).
     const auto& in_ss = input_spec.memory_config().shard_spec();
     const auto& out_ss = output_memory_config->shard_spec();
     return !(in_ss.has_value() && out_ss.has_value() && in_ss->grid != out_ss->grid);
@@ -98,13 +94,9 @@ bool is_native_transpose_sharding(
 
 std::optional<ShardSpec> adjust_shard_spec_to_shape(
     const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
-    // Volumes are accumulated in uint64_t to prevent overflow on large tensors (e.g. N*C*H
-    // products can exceed 2^32). Returning nullopt on non-exact division lets callers fall back
-    // gracefully (generate_transpose_shard_spec or interleaved) instead of crashing a valid user
-    // call, and avoids the silent-truncation pitfall of blind uint division.
-    // Transpose preserves rank, so callers must pass equal-rank shapes. Enforce this explicitly:
-    // mismatched ranks would silently produce inconsistent volume math (the two accumulation loops
-    // below run for different counts) and yield a valid-looking but wrong shard.
+    // uint64 accumulators avoid overflow on large tensors; nullopt on non-exact division lets
+    // callers fall back gracefully. Transpose preserves rank — mismatched ranks would yield
+    // inconsistent volume math, so enforce equality.
     TT_FATAL(
         from_shape.rank() == to_shape.rank(),
         "adjust_shard_spec_to_shape: from_shape rank ({}) and to_shape rank ({}) must match.",
@@ -129,23 +121,17 @@ std::optional<ShardSpec> adjust_shard_spec_to_shape(
         return std::nullopt;
     }
 
-    // Return the exact ratio-scaled shard without tile-size clamping. A naive
-    // `std::max(scaled, TILE_*)` clamp oversizes the shard whenever the target dim legitimately
-    // shrinks below a tile (e.g. WH on a tile-aligned height-sharded input where the new width
-    // becomes sub-tile) and then fills the grid with capacity for data that doesn't exist,
-    // producing silent correctness regressions. Callers that need tile-aligned shards post-check
-    // `shape[i] % TILE_*` and fall back to interleaved; callers targeting RM layouts tolerate
-    // sub-tile shards. This mirrors `unary_ng`/`binary_ng` semantics but avoids their latent
-    // clamp bug — harmless there because their shape ratios never shrink a dim.
+    // Exact ratio scale, no tile-size clamp: clamping oversizes shards when transpose legitimately
+    // shrinks a dim sub-tile, causing silent correctness bugs. Callers that need tile alignment
+    // post-check shape[i] % TILE_* and fall back; RM callers tolerate sub-tile shards.
     auto ret = shard_spec;
     ret.shape[0] = static_cast<uint32_t>(h_num / from_volume_except_width);
     ret.shape[1] = static_cast<uint32_t>(w_num / from_width);
     return ret;
 }
 
-// When the user requests a sharded output but no shard_spec, and the input is interleaved, we derive
-// a grid and shard shape using the full device compute grid, matching the shard math used elsewhere
-// for height/width/block cases.
+// Build a sharded spec over the full compute grid (used when no input shard_spec is available
+// to scale from, e.g. interleaved input + sharded output request).
 ShardSpec generate_transpose_shard_spec(
     const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
     auto* device = input_tensor.device();
@@ -153,10 +139,8 @@ ShardSpec generate_transpose_shard_spec(
     CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
     uint32_t num_cores = all_cores.num_cores();
 
-    // Accumulate in uint64 to match adjust_shard_spec_to_shape and avoid overflow on tensors whose
-    // product of leading dims exceeds 2^32 (e.g. large batch x seq_len x head_dim attention shapes).
-    // The final per-shard dims we hand back are still uint32 (the hardware/shard-spec representation),
-    // but the intermediate height computation uses the wider type.
+    // uint64 intermediates avoid overflow when leading-dim product exceeds 2^32; final shard
+    // dims are still uint32 (the hardware representation).
     uint64_t tensor_height = 1;
     for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
         tensor_height *= static_cast<uint64_t>(padded_out_shape[i]);
@@ -187,9 +171,8 @@ ShardSpec generate_transpose_shard_spec(
     return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
 }
 
-// Refreshes the runtime-tensor-shape common args on program cache hits. Strict equality between
-// destination and source lengths catches any drift in the TensorAccessorArgs footprint between
-// program creation and the cache hit (a >= check would leave stale trailing elements in dst).
+// Refresh runtime-tensor-shape common args on cache hits. Strict size equality detects any drift
+// in the TensorAccessorArgs footprint between program creation and reuse.
 void copy_transpose_common_runtime_args(const Buffer& buffer, std::span<std::uint32_t> dst) {
     const auto src =
         TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape).get_common_runtime_args();

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include <optional>
+#include <cstdint>
+
+namespace ttnn::operations::data_movement::transpose {
+
+bool is_uneven(const TensorSpec& t);
+
+bool is_native_transpose_sharding(const TensorSpec& input_spec, const tt::tt_metal::MemoryConfig& output_memory_config);
+
+struct TransposeShardSpecs {
+    tt::tt_metal::ShardSpec input_shard_spec;
+    tt::tt_metal::ShardSpec output_shard_spec;
+};
+
+std::optional<TransposeShardSpecs> get_transpose_shard_specs(
+    const TensorSpec& input_spec, const TensorSpec& output_spec);
+
+tt::tt_metal::ShardSpec adjust_shard_spec_to_shape(
+    const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
+
+tt::tt_metal::ShardSpec generate_transpose_shard_spec(
+    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
+
+CoreRangeSet get_transpose_worker_grid(
+    const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& output_memory_config);
+
+std::uint32_t* copy_transpose_common_runtime_args(const tt::tt_metal::Buffer& buffer, std::uint32_t* dst);
+
+}  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
@@ -5,22 +5,14 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
-#include <optional>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
 #include <cstdint>
+#include <span>
 
 namespace ttnn::operations::data_movement::transpose {
 
-bool is_uneven(const TensorSpec& t);
-
 bool is_native_transpose_sharding(const TensorSpec& input_spec, const tt::tt_metal::MemoryConfig& output_memory_config);
-
-struct TransposeShardSpecs {
-    tt::tt_metal::ShardSpec input_shard_spec;
-    tt::tt_metal::ShardSpec output_shard_spec;
-};
-
-std::optional<TransposeShardSpecs> get_transpose_shard_specs(
-    const TensorSpec& input_spec, const TensorSpec& output_spec);
 
 tt::tt_metal::ShardSpec adjust_shard_spec_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
@@ -28,9 +20,18 @@ tt::tt_metal::ShardSpec adjust_shard_spec_to_shape(
 tt::tt_metal::ShardSpec generate_transpose_shard_spec(
     const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
 
-CoreRangeSet get_transpose_worker_grid(
-    const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& output_memory_config);
+// Copies the RuntimeTensorShape common args for `buffer` into `dst`. Uses std::span so the
+// destination length is carried alongside the pointer and bounds-checked against the element
+// count produced by `TensorAccessorArgs::get_common_runtime_args()`.
+void copy_transpose_common_runtime_args(const tt::tt_metal::Buffer& buffer, std::span<std::uint32_t> dst);
 
-std::uint32_t* copy_transpose_common_runtime_args(const tt::tt_metal::Buffer& buffer, std::uint32_t* dst);
+// Refreshes the RuntimeTensorShape common args on both reader and writer kernels. Used by the
+// four interleaved program factories in `override_runtime_arguments` on program-cache hits.
+void refresh_transpose_common_runtime_args(
+    tt::tt_metal::Program& program,
+    tt::tt_metal::KernelHandle reader_kernel_id,
+    tt::tt_metal::KernelHandle writer_kernel_id,
+    const tt::tt_metal::Buffer& input_buffer,
+    const tt::tt_metal::Buffer& output_buffer);
 
 }  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
@@ -8,13 +8,29 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <cstdint>
+#include <optional>
 #include <span>
 
 namespace ttnn::operations::data_movement::transpose {
 
-bool is_native_transpose_sharding(const TensorSpec& input_spec, const tt::tt_metal::MemoryConfig& output_memory_config);
+// Eligibility probe for the native sharded transpose kernels.
+//
+// When called with only `input_spec`, checks whether the input alone satisfies the native-sharded
+// preconditions (sharded, evenly sharded, non-DRAM, non-BLOCK, and for ROW_MAJOR: shard elements
+// tile-aligned). Callers in this mode are still in the "pre-derivation" stage — they're about to
+// synthesize the output shard_spec from the input's, so there's nothing to compare on the output
+// side.
+//
+// When called with a concrete `output_memory_config`, also checks the output side with the same
+// rules and — if both shard_specs are populated — requires input/output grids to match (the
+// sharded WH/HC program factories assume a single shared grid).
+bool is_native_transpose_sharding(
+    const TensorSpec& input_spec, const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config = std::nullopt);
 
-tt::tt_metal::ShardSpec adjust_shard_spec_to_shape(
+// Returns the shard_spec scaled from `from_shape` to `to_shape`, or nullopt when the scaling cannot
+// be performed exactly. Callers must handle nullopt (e.g. fall back to `generate_transpose_shard_spec`
+// or an interleaved memory config). Volumes are computed in uint64_t to avoid overflow on large tensors.
+std::optional<tt::tt_metal::ShardSpec> adjust_shard_spec_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
 
 tt::tt_metal::ShardSpec generate_transpose_shard_spec(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
@@ -13,36 +13,22 @@
 
 namespace ttnn::operations::data_movement::transpose {
 
-// Eligibility probe for the native sharded transpose kernels.
-//
-// When called with only `input_spec`, checks whether the input alone satisfies the native-sharded
-// preconditions (sharded, evenly sharded, non-DRAM, non-BLOCK, and for ROW_MAJOR: shard elements
-// tile-aligned). Callers in this mode are still in the "pre-derivation" stage — they're about to
-// synthesize the output shard_spec from the input's, so there's nothing to compare on the output
-// side.
-//
-// When called with a concrete `output_memory_config`, also checks the output side with the same
-// rules and — if both shard_specs are populated — requires input/output grids to match (the
-// sharded WH/HC program factories assume a single shared grid).
+// Native-sharded eligibility probe. Single-arg form: input only (pre-derivation). Two-arg form:
+// also checks output side and (when both shard_specs are concrete) input/output grid match.
 bool is_native_transpose_sharding(
     const TensorSpec& input_spec, const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config = std::nullopt);
 
-// Returns the shard_spec scaled from `from_shape` to `to_shape`, or nullopt when the scaling cannot
-// be performed exactly. Callers must handle nullopt (e.g. fall back to `generate_transpose_shard_spec`
-// or an interleaved memory config). Volumes are computed in uint64_t to avoid overflow on large tensors.
+// Scale shard_spec from `from_shape` to `to_shape`; nullopt when scaling isn't exact.
 std::optional<tt::tt_metal::ShardSpec> adjust_shard_spec_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
 
 tt::tt_metal::ShardSpec generate_transpose_shard_spec(
     const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
 
-// Copies the RuntimeTensorShape common args for `buffer` into `dst`. Uses std::span so the
-// destination length is carried alongside the pointer and bounds-checked against the element
-// count produced by `TensorAccessorArgs::get_common_runtime_args()`.
+// Copy RuntimeTensorShape common args for `buffer` into `dst` (size-checked).
 void copy_transpose_common_runtime_args(const tt::tt_metal::Buffer& buffer, std::span<std::uint32_t> dst);
 
-// Refreshes the RuntimeTensorShape common args on both reader and writer kernels. Used by the
-// four interleaved program factories in `override_runtime_arguments` on program-cache hits.
+// Refresh reader/writer common args on program-cache hits.
 void refresh_transpose_common_runtime_args(
     tt::tt_metal::Program& program,
     tt::tt_metal::KernelHandle reader_kernel_id,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_wh_program_factory.hpp"
+#include "transpose_utils.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
@@ -258,6 +259,7 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
     }
 
     std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> reader_common_runtime_args;
     if (row_major) {
         reader_compile_time_args.push_back(ht);
         reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
@@ -269,9 +271,11 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
         reader_compile_time_args.push_back(wt * input_tensor.element_size() * TILE_WIDTH);
         reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
     }
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
 
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    std::vector<uint32_t> writer_common_runtime_args;
     if (row_major) {
         writer_compile_time_args.push_back(ht);
         writer_compile_time_args.push_back(H);
@@ -283,7 +287,8 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
         writer_compile_time_args.push_back(ht * output_tensor.element_size() * TILE_HEIGHT);
         writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
     }
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -293,6 +298,7 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
                     "reader_unary_transpose_wh_interleaved_start_id.cpp",
         total_cores,
         ReaderDataMovementConfig(reader_compile_time_args));
+    SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
 
     KernelHandle writer_kernel_id = CreateKernel(
         program,
@@ -302,6 +308,7 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
             : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
         total_cores,
         WriterDataMovementConfig(writer_compile_time_args));
+    SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
 
     std::vector<uint32_t> compute_kernel_args = {};
     if (row_major) {
@@ -385,6 +392,15 @@ void TransposeWHProgramFactory::override_runtime_arguments(
     Tensor& output_tensor) {
     auto& program = cached_program.program;
     auto& shared_variables = cached_program.shared_variables;
+
+    {
+        auto* src = tensor_args.input.buffer();
+        auto* dst = output_tensor.buffer();
+        auto* reader_args = GetCommonRuntimeArgs(program, shared_variables.reader_kernel_id).data();
+        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(*src, reader_args);
+        auto* writer_args = GetCommonRuntimeArgs(program, shared_variables.writer_kernel_id).data();
+        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(*dst, writer_args);
+    }
 
     if (shared_variables.is_row_major) {
         set_runtime_args_wh_rm(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -393,14 +393,12 @@ void TransposeWHProgramFactory::override_runtime_arguments(
     auto& program = cached_program.program;
     auto& shared_variables = cached_program.shared_variables;
 
-    {
-        auto* src = tensor_args.input.buffer();
-        auto* dst = output_tensor.buffer();
-        auto* reader_args = GetCommonRuntimeArgs(program, shared_variables.reader_kernel_id).data();
-        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(*src, reader_args);
-        auto* writer_args = GetCommonRuntimeArgs(program, shared_variables.writer_kernel_id).data();
-        ttnn::operations::data_movement::transpose::copy_transpose_common_runtime_args(*dst, writer_args);
-    }
+    ttnn::operations::data_movement::transpose::refresh_transpose_common_runtime_args(
+        program,
+        shared_variables.reader_kernel_id,
+        shared_variables.writer_kernel_id,
+        *tensor_args.input.buffer(),
+        *output_tensor.buffer());
 
     if (shared_variables.is_row_major) {
         set_runtime_args_wh_rm(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -151,6 +151,23 @@ ttnn::Tensor transpose_nd(
     return ttnn::permute(input_tensor, permutation, memory_config_arg, pad_value);
 }
 
+// Predicate for the composite fallback guard in `transpose_impl`.
+//
+// When the input layout is ROW_MAJOR and either the input or the requested output is
+// BLOCK_SHARDED / WIDTH_SHARDED, neither the native sharded transpose kernels nor the
+// `prim::permute` RM shortcut can faithfully materialize the result: pages span multiple
+// cores, so local-only readers/writers produce silently-wrong data. Such cases are routed
+// through an L1 interleaved intermediate before/after the transpose.
+//
+// HEIGHT_SHARDED RM with a non-tile-aligned shard element count is handled separately by
+// `is_native_transpose_sharding`, which routes it through the interleaved factories'
+// TensorAccessor path without an explicit reshard hop (each page stays on a single core,
+// so NOC-based access is safe).
+inline bool is_block_or_width_sharded_mc(const tt::tt_metal::MemoryConfig& mc) {
+    return mc.is_sharded() && (mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+                               mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
+}
+
 }  // namespace detail
 
 ttnn::Tensor transpose_impl(
@@ -159,6 +176,33 @@ ttnn::Tensor transpose_impl(
     int64_t dim2,
     const std::optional<MemoryConfig>& memory_config_arg,
     float pad_value = 0.0f) {
+    {
+        const bool rm = input_tensor.layout() == Layout::ROW_MAJOR;
+        const bool in_bad = rm && detail::is_block_or_width_sharded_mc(input_tensor.memory_config());
+        const bool out_bad =
+            rm && memory_config_arg.has_value() && detail::is_block_or_width_sharded_mc(memory_config_arg.value());
+        if (in_bad || out_bad) {
+            const auto interleaved_l1 =
+                tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
+            Tensor x = in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
+            const std::optional<MemoryConfig> intermediate_mc =
+                out_bad ? std::optional<MemoryConfig>(interleaved_l1) : memory_config_arg;
+            Tensor result = transpose_impl(x, dim1, dim2, intermediate_mc, pad_value);
+            if (out_bad) {
+                // If the requested sharded output lacks a shard_spec, synthesize one from the
+                // transposed tensor's padded shape using the same helper the device op uses, so
+                // `to_memory_config` receives a fully-specified sharded destination.
+                MemoryConfig final_mc = memory_config_arg.value();
+                if (!final_mc.shard_spec().has_value()) {
+                    auto shard_spec = operations::data_movement::transpose::generate_transpose_shard_spec(
+                        result, result.padded_shape(), final_mc.memory_layout());
+                    final_mc = final_mc.with_shard_spec(shard_spec);
+                }
+                result = ttnn::to_memory_config(result, final_mc, std::nullopt);
+            }
+            return result;
+        }
+    }
     const auto& input_shape = input_tensor.logical_shape();
     uint32_t normalized_dim1 = input_shape.get_normalized_index(dim1);
     uint32_t normalized_dim2 = input_shape.get_normalized_index(dim2);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -5,6 +5,7 @@
 
 #include "clone/clone.hpp"
 #include "device/transpose_device_operation.hpp"
+#include "device/transpose_utils.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -19,6 +20,8 @@ namespace detail {
 
 using namespace tt::tt_metal::experimental;
 using namespace tt;
+using tt::tt_metal::BufferType;
+using ttnn::operations::data_movement::transpose::is_native_transpose_sharding;
 
 inline Tensor transpose_(
     const Tensor& a,
@@ -37,30 +40,50 @@ inline Tensor transpose_(
     MemoryConfig output_mem_constructed;
     if (!output_mem_config.has_value() ||
         (output_mem_config.value().is_sharded() && !output_mem_config.value().shard_spec().has_value())) {
-        output_mem_constructed = a.memory_config();
-        if (a.is_sharded() && transpose_dim == ttnn::prim::TransposeOpDim::WH) {
-            const auto& input_padded_shape = a.padded_shape();
-            uint32_t W = input_padded_shape[3], H = input_padded_shape[2], C = input_padded_shape[1],
-                     N = input_padded_shape[0];
-            auto shard_spec = a.shard_spec().value();
-            if (N == 1 && C == 1 && shard_spec.shape[1] == W) {
-                std::swap(shard_spec.shape[0], shard_spec.shape[1]);
-                output_mem_constructed =
-                    MemoryConfig(TensorMemoryLayout::WIDTH_SHARDED, output_mem_constructed.buffer_type(), shard_spec);
-            } else {
-                shard_spec.shape[0] = shard_spec.shape[0] * W / H;
-                shard_spec.shape[1] = shard_spec.shape[1] * H / W;
-                output_mem_constructed = output_mem_constructed.with_shard_spec(shard_spec);
+        bool native = a.is_sharded() && is_native_transpose_sharding(a.tensor_spec(), a.memory_config());
+        if (a.is_sharded() && native) {
+            output_mem_constructed = a.memory_config();
+            bool shard_spec_valid = true;
+            if (transpose_dim == ttnn::prim::TransposeOpDim::WH) {
+                const auto& input_padded_shape = a.padded_shape();
+                uint32_t W = input_padded_shape[3], H = input_padded_shape[2], C = input_padded_shape[1],
+                         N = input_padded_shape[0];
+                auto shard_spec = a.shard_spec().value();
+                if (N == 1 && C == 1 && shard_spec.shape[1] == W) {
+                    std::swap(shard_spec.shape[0], shard_spec.shape[1]);
+                    output_mem_constructed = MemoryConfig(
+                        TensorMemoryLayout::WIDTH_SHARDED, output_mem_constructed.buffer_type(), shard_spec);
+                } else {
+                    shard_spec.shape[0] = shard_spec.shape[0] * W / H;
+                    shard_spec.shape[1] = shard_spec.shape[1] * H / W;
+                    if (a.layout() == Layout::TILE && (shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                                                       shard_spec.shape[1] % tt::constants::TILE_WIDTH != 0)) {
+                        shard_spec_valid = false;
+                    } else {
+                        output_mem_constructed = output_mem_constructed.with_shard_spec(shard_spec);
+                    }
+                }
             }
-        }
-        if (a.is_sharded() && transpose_dim == ttnn::prim::TransposeOpDim::HC && a.layout() == Layout::TILE) {
-            const auto& input_padded_shape = a.padded_shape();
-            const auto& input_logical_shape = a.logical_shape();
-            uint32_t H = input_logical_shape[2], C = input_logical_shape[1];
-            uint32_t H_padded = input_padded_shape[2], C_padded = tt::round_up(C, tt::constants::TILE_HEIGHT);
-            auto shard_spec = a.shard_spec().value();
-            shard_spec.shape[0] = shard_spec.shape[0] * H * C_padded / H_padded / C;
-            output_mem_constructed = output_mem_constructed.with_shard_spec(shard_spec);
+            if (transpose_dim == ttnn::prim::TransposeOpDim::HC && a.layout() == Layout::TILE) {
+                const auto& input_padded_shape = a.padded_shape();
+                const auto& input_logical_shape = a.logical_shape();
+                uint32_t H = input_logical_shape[2], C = input_logical_shape[1];
+                uint32_t H_padded = input_padded_shape[2], C_padded = tt::round_up(C, tt::constants::TILE_HEIGHT);
+                auto shard_spec = a.shard_spec().value();
+                shard_spec.shape[0] = shard_spec.shape[0] * H * C_padded / H_padded / C;
+                if (shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0) {
+                    shard_spec_valid = false;
+                } else {
+                    output_mem_constructed = output_mem_constructed.with_shard_spec(shard_spec);
+                }
+            }
+            if (!shard_spec_valid) {
+                output_mem_constructed = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1);
+            }
+        } else if (a.is_sharded()) {
+            output_mem_constructed = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1);
+        } else {
+            output_mem_constructed = a.memory_config();
         }
     } else {
         output_mem_constructed = output_mem_config.value();

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -40,6 +40,9 @@ inline Tensor transpose_(
     MemoryConfig output_mem_constructed;
     if (!output_mem_config.has_value() ||
         (output_mem_config.value().is_sharded() && !output_mem_config.value().shard_spec().has_value())) {
+        // No output tensor exists yet; pass the input's own memory_config as the "output" to ask
+        // "is this input sharding within the natively-supported subset?". When true, we derive an
+        // output shard_spec by reshaping the input's; otherwise we fall back to L1 interleaved.
         bool native = a.is_sharded() && is_native_transpose_sharding(a.tensor_spec(), a.memory_config());
         if (a.is_sharded() && native) {
             output_mem_constructed = a.memory_config();
@@ -51,8 +54,13 @@ inline Tensor transpose_(
                 auto shard_spec = a.shard_spec().value();
                 if (N == 1 && C == 1 && shard_spec.shape[1] == W) {
                     std::swap(shard_spec.shape[0], shard_spec.shape[1]);
-                    output_mem_constructed = MemoryConfig(
-                        TensorMemoryLayout::WIDTH_SHARDED, output_mem_constructed.buffer_type(), shard_spec);
+                    if (a.layout() == Layout::TILE && (shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                                                       shard_spec.shape[1] % tt::constants::TILE_WIDTH != 0)) {
+                        shard_spec_valid = false;
+                    } else {
+                        output_mem_constructed = MemoryConfig(
+                            TensorMemoryLayout::WIDTH_SHARDED, output_mem_constructed.buffer_type(), shard_spec);
+                    }
                 } else {
                     shard_spec.shape[0] = shard_spec.shape[0] * W / H;
                     shard_spec.shape[1] = shard_spec.shape[1] * H / W;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -66,14 +66,13 @@ inline Tensor transpose_(
                 // the shard dims — but only when the user didn't explicitly request a memory_layout.
                 // Honoring a user-specified HEIGHT_SHARDED output even in this case avoids silently
                 // overriding the caller's intent.
-                bool wh_shard_spec_valid = true;
                 const bool can_promote_to_width_sharded =
                     !user_requested_layout && N == 1 && C == 1 && shard_spec.shape[1] == W;
                 if (can_promote_to_width_sharded) {
                     std::swap(shard_spec.shape[0], shard_spec.shape[1]);
                     if (a.layout() == Layout::TILE && (shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0 ||
                                                        shard_spec.shape[1] % tt::constants::TILE_WIDTH != 0)) {
-                        wh_shard_spec_valid = false;
+                        shard_derivation_fallback();
                     } else {
                         output_mem_constructed = MemoryConfig(
                             TensorMemoryLayout::WIDTH_SHARDED, output_mem_constructed.buffer_type(), shard_spec);
@@ -85,13 +84,10 @@ inline Tensor transpose_(
                     if (!adjusted.has_value() ||
                         (a.layout() == Layout::TILE && (adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
                                                         adjusted->shape[1] % tt::constants::TILE_WIDTH != 0))) {
-                        wh_shard_spec_valid = false;
+                        shard_derivation_fallback();
                     } else {
                         output_mem_constructed = output_mem_constructed.with_shard_spec(std::move(adjusted));
                     }
-                }
-                if (!wh_shard_spec_valid) {
-                    shard_derivation_fallback();
                 }
             } else if (transpose_dim == ttnn::prim::TransposeOpDim::HC && a.layout() == Layout::TILE) {
                 auto shard_spec = a.shard_spec().value();
@@ -101,14 +97,10 @@ inline Tensor transpose_(
                 output_padded_shape[1] = a.logical_shape()[2];
                 output_padded_shape[2] = tt::round_up(a.logical_shape()[1], tt::constants::TILE_HEIGHT);
                 auto adjusted = adjust_shard_spec_to_shape(shard_spec, input_padded_shape, output_padded_shape);
-                bool hc_shard_spec_valid = true;
                 if (!adjusted.has_value() || adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0) {
-                    hc_shard_spec_valid = false;
+                    shard_derivation_fallback();
                 } else {
                     output_mem_constructed = output_mem_constructed.with_shard_spec(std::move(adjusted));
-                }
-                if (!hc_shard_spec_valid) {
-                    shard_derivation_fallback();
                 }
             }
         } else if (output_mem_config.has_value()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -21,6 +21,7 @@ namespace detail {
 using namespace tt::tt_metal::experimental;
 using namespace tt;
 using tt::tt_metal::BufferType;
+using ttnn::operations::data_movement::transpose::adjust_shard_spec_to_shape;
 using ttnn::operations::data_movement::transpose::is_native_transpose_sharding;
 
 inline Tensor transpose_(
@@ -28,67 +29,99 @@ inline Tensor transpose_(
     ttnn::prim::TransposeOpDim transpose_dim,
     const std::optional<MemoryConfig>& output_mem_config,
     float pad_value = 0.0f) {
-    uint32_t W = a.logical_shape()[3], H = a.logical_shape()[2];
-    auto* device = a.device();
-    auto lowest_address = device->lowest_occupied_compute_l1_address();
-    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
-    max_l1_space = max_l1_space - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
-
-    uint32_t W_padded = round_up(W, tt::constants::TILE_WIDTH);
-    uint32_t H_padded = round_up(H, tt::constants::TILE_HEIGHT);
-    uint32_t cb_size_for_rm = (2 * W_padded + 2 * H_padded + H_padded * W_padded) * a.element_size();
     MemoryConfig output_mem_constructed;
     if (!output_mem_config.has_value() ||
         (output_mem_config.value().is_sharded() && !output_mem_config.value().shard_spec().has_value())) {
-        // No output tensor exists yet; pass the input's own memory_config as the "output" to ask
-        // "is this input sharding within the natively-supported subset?". When true, we derive an
-        // output shard_spec by reshaping the input's; otherwise we fall back to L1 interleaved.
-        bool native = a.is_sharded() && is_native_transpose_sharding(a.tensor_spec(), a.memory_config());
+        // Single-arg eligibility probe: are we in the natively-supported sharded subset based on the
+        // input alone? If yes we derive an output shard_spec by adjusting the input's; otherwise we
+        // fall back to L1 interleaved and let the interleaved factories handle it via TensorAccessor.
+        const bool native = is_native_transpose_sharding(a.tensor_spec());
         if (a.is_sharded() && native) {
-            output_mem_constructed = a.memory_config();
-            bool shard_spec_valid = true;
+            // Seed the output config. When the user specified a sharded MemoryConfig (without spec),
+            // honor their requested memory_layout and only synthesize the shard_spec. Otherwise
+            // inherit the input's config so downstream branches can optionally promote to a
+            // different layout (e.g. the N=C=1 WIDTH_SHARDED promotion below).
+            const bool user_requested_layout = output_mem_config.has_value() && output_mem_config.value().is_sharded();
+            output_mem_constructed = user_requested_layout ? output_mem_config.value() : a.memory_config();
+            // When the input's shard geometry can't be scaled into a valid output shard (e.g. WH
+            // on a tile-aligned height-sharded input where the transposed width becomes sub-tile,
+            // so `adjust_shard_spec_to_shape` returns either nullopt or a non-tile-aligned spec),
+            // we need a fallback. If the user explicitly requested a sharded memory_layout, honor
+            // their intent by handing back a shard-spec-less sharded MemoryConfig — the device op's
+            // `derive_effective_output_memory_config` will synthesize a valid spec via
+            // `generate_transpose_shard_spec`. Otherwise default to L1 interleaved.
+            const auto shard_derivation_fallback = [&]() {
+                if (user_requested_layout) {
+                    output_mem_constructed = MemoryConfig(
+                        output_mem_config.value().memory_layout(), output_mem_config.value().buffer_type());
+                } else {
+                    output_mem_constructed = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1);
+                }
+            };
+            const auto& input_padded_shape = a.padded_shape();
             if (transpose_dim == ttnn::prim::TransposeOpDim::WH) {
-                const auto& input_padded_shape = a.padded_shape();
-                uint32_t W = input_padded_shape[3], H = input_padded_shape[2], C = input_padded_shape[1],
-                         N = input_padded_shape[0];
+                const uint32_t W = input_padded_shape[3], C = input_padded_shape[1], N = input_padded_shape[0];
                 auto shard_spec = a.shard_spec().value();
-                if (N == 1 && C == 1 && shard_spec.shape[1] == W) {
+                // N=C=1 + height-sharded-with-full-width is promoted to WIDTH_SHARDED after swapping
+                // the shard dims — but only when the user didn't explicitly request a memory_layout.
+                // Honoring a user-specified HEIGHT_SHARDED output even in this case avoids silently
+                // overriding the caller's intent.
+                bool wh_shard_spec_valid = true;
+                const bool can_promote_to_width_sharded =
+                    !user_requested_layout && N == 1 && C == 1 && shard_spec.shape[1] == W;
+                if (can_promote_to_width_sharded) {
                     std::swap(shard_spec.shape[0], shard_spec.shape[1]);
                     if (a.layout() == Layout::TILE && (shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0 ||
                                                        shard_spec.shape[1] % tt::constants::TILE_WIDTH != 0)) {
-                        shard_spec_valid = false;
+                        wh_shard_spec_valid = false;
                     } else {
                         output_mem_constructed = MemoryConfig(
                             TensorMemoryLayout::WIDTH_SHARDED, output_mem_constructed.buffer_type(), shard_spec);
                     }
                 } else {
-                    shard_spec.shape[0] = shard_spec.shape[0] * W / H;
-                    shard_spec.shape[1] = shard_spec.shape[1] * H / W;
-                    if (a.layout() == Layout::TILE && (shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0 ||
-                                                       shard_spec.shape[1] % tt::constants::TILE_WIDTH != 0)) {
-                        shard_spec_valid = false;
+                    auto output_padded_shape = input_padded_shape;
+                    std::swap(output_padded_shape[2], output_padded_shape[3]);
+                    auto adjusted = adjust_shard_spec_to_shape(shard_spec, input_padded_shape, output_padded_shape);
+                    if (!adjusted.has_value() ||
+                        (a.layout() == Layout::TILE && (adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                                                        adjusted->shape[1] % tt::constants::TILE_WIDTH != 0))) {
+                        wh_shard_spec_valid = false;
                     } else {
-                        output_mem_constructed = output_mem_constructed.with_shard_spec(shard_spec);
+                        output_mem_constructed = output_mem_constructed.with_shard_spec(std::move(adjusted));
                     }
                 }
-            }
-            if (transpose_dim == ttnn::prim::TransposeOpDim::HC && a.layout() == Layout::TILE) {
-                const auto& input_padded_shape = a.padded_shape();
-                const auto& input_logical_shape = a.logical_shape();
-                uint32_t H = input_logical_shape[2], C = input_logical_shape[1];
-                uint32_t H_padded = input_padded_shape[2], C_padded = tt::round_up(C, tt::constants::TILE_HEIGHT);
+                if (!wh_shard_spec_valid) {
+                    shard_derivation_fallback();
+                }
+            } else if (transpose_dim == ttnn::prim::TransposeOpDim::HC && a.layout() == Layout::TILE) {
                 auto shard_spec = a.shard_spec().value();
-                shard_spec.shape[0] = shard_spec.shape[0] * H * C_padded / H_padded / C;
-                if (shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0) {
-                    shard_spec_valid = false;
+                // Mirror the HC TILE padded-shape contract from the device op:
+                // new dim[1] = input's logical H, new dim[2] = round_up(logical C, TILE_HEIGHT).
+                auto output_padded_shape = input_padded_shape;
+                output_padded_shape[1] = a.logical_shape()[2];
+                output_padded_shape[2] = tt::round_up(a.logical_shape()[1], tt::constants::TILE_HEIGHT);
+                auto adjusted = adjust_shard_spec_to_shape(shard_spec, input_padded_shape, output_padded_shape);
+                bool hc_shard_spec_valid = true;
+                if (!adjusted.has_value() || adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0) {
+                    hc_shard_spec_valid = false;
                 } else {
-                    output_mem_constructed = output_mem_constructed.with_shard_spec(shard_spec);
+                    output_mem_constructed = output_mem_constructed.with_shard_spec(std::move(adjusted));
+                }
+                if (!hc_shard_spec_valid) {
+                    shard_derivation_fallback();
                 }
             }
-            if (!shard_spec_valid) {
-                output_mem_constructed = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1);
-            }
+        } else if (output_mem_config.has_value()) {
+            // User explicitly requested a sharded output (with no shard_spec). Honor their
+            // requested memory_layout whether the input is interleaved or non-native sharded
+            // (TILE BLOCK_SHARDED, DRAM-sharded, or RM HEIGHT_SHARDED with non-tile-aligned
+            // shard elements). The device op's `derive_effective_output_memory_config`
+            // synthesizes the shard_spec. Must run before the `a.is_sharded()` non-native
+            // default-fallback branch below, otherwise a user-requested sharded output from
+            // a non-native sharded input would be silently overridden to L1 interleaved.
+            output_mem_constructed = output_mem_config.value();
         } else if (a.is_sharded()) {
+            // No user preference + non-native sharded input → default to L1 interleaved.
             output_mem_constructed = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1);
         } else {
             output_mem_constructed = a.memory_config();
@@ -126,8 +159,21 @@ inline Tensor transpose_(
             if (interleaved_rm) {
                 return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
             }
-            if (a.layout() == Layout::ROW_MAJOR && cb_size_for_rm > max_l1_space) {
-                return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
+            if (a.layout() == Layout::ROW_MAJOR) {
+                // Only compute the RM WH CB-vs-L1 budget when actually on the RM WH path:
+                // the allocator query and padded-shape arithmetic are wasted work otherwise.
+                const uint32_t W_padded = round_up(a.logical_shape()[3], tt::constants::TILE_WIDTH);
+                const uint32_t H_padded = round_up(a.logical_shape()[2], tt::constants::TILE_HEIGHT);
+                const uint32_t cb_size_for_rm = (2 * W_padded + 2 * H_padded + H_padded * W_padded) * a.element_size();
+                auto* device = a.device();
+                auto lowest_address = device->lowest_occupied_compute_l1_address();
+                uint32_t max_l1_space =
+                    lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
+                max_l1_space =
+                    max_l1_space - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+                if (cb_size_for_rm > max_l1_space) {
+                    return prim_permute(a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}));
+                }
             }
             break;
         default: break;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -32,24 +32,17 @@ inline Tensor transpose_(
     MemoryConfig output_mem_constructed;
     if (!output_mem_config.has_value() ||
         (output_mem_config.value().is_sharded() && !output_mem_config.value().shard_spec().has_value())) {
-        // Single-arg eligibility probe: are we in the natively-supported sharded subset based on the
-        // input alone? If yes we derive an output shard_spec by adjusting the input's; otherwise we
-        // fall back to L1 interleaved and let the interleaved factories handle it via TensorAccessor.
+        // Native sharded subset: derive output shard_spec from input's. Otherwise fall back to L1
+        // interleaved (the interleaved factories handle non-native via TensorAccessor).
         const bool native = is_native_transpose_sharding(a.tensor_spec());
         if (a.is_sharded() && native) {
-            // Seed the output config. When the user specified a sharded MemoryConfig (without spec),
-            // honor their requested memory_layout and only synthesize the shard_spec. Otherwise
-            // inherit the input's config so downstream branches can optionally promote to a
-            // different layout (e.g. the N=C=1 WIDTH_SHARDED promotion below).
+            // Seed: honor user's requested sharded layout (spec gets synthesized below); else
+            // inherit input config so downstream can promote (e.g. N=C=1 → WIDTH_SHARDED).
             const bool user_requested_layout = output_mem_config.has_value() && output_mem_config.value().is_sharded();
             output_mem_constructed = user_requested_layout ? output_mem_config.value() : a.memory_config();
-            // When the input's shard geometry can't be scaled into a valid output shard (e.g. WH
-            // on a tile-aligned height-sharded input where the transposed width becomes sub-tile,
-            // so `adjust_shard_spec_to_shape` returns either nullopt or a non-tile-aligned spec),
-            // we need a fallback. If the user explicitly requested a sharded memory_layout, honor
-            // their intent by handing back a shard-spec-less sharded MemoryConfig — the device op's
-            // `derive_effective_output_memory_config` will synthesize a valid spec via
-            // `generate_transpose_shard_spec`. Otherwise default to L1 interleaved.
+            // If shard geometry can't scale to a valid output shard, hand back a shard-spec-less
+            // sharded MemoryConfig (device op synthesizes via generate_transpose_shard_spec) when
+            // the user requested sharded; otherwise fall back to L1 interleaved.
             const auto shard_derivation_fallback = [&]() {
                 if (user_requested_layout) {
                     output_mem_constructed = MemoryConfig(
@@ -62,10 +55,7 @@ inline Tensor transpose_(
             if (transpose_dim == ttnn::prim::TransposeOpDim::WH) {
                 const uint32_t W = input_padded_shape[3], C = input_padded_shape[1], N = input_padded_shape[0];
                 auto shard_spec = a.shard_spec().value();
-                // N=C=1 + height-sharded-with-full-width is promoted to WIDTH_SHARDED after swapping
-                // the shard dims — but only when the user didn't explicitly request a memory_layout.
-                // Honoring a user-specified HEIGHT_SHARDED output even in this case avoids silently
-                // overriding the caller's intent.
+                // N=C=1 height-sharded-with-full-width → WIDTH_SHARDED (skip if user requested layout).
                 const bool can_promote_to_width_sharded =
                     !user_requested_layout && N == 1 && C == 1 && shard_spec.shape[1] == W;
                 if (can_promote_to_width_sharded) {
@@ -91,8 +81,7 @@ inline Tensor transpose_(
                 }
             } else if (transpose_dim == ttnn::prim::TransposeOpDim::HC && a.layout() == Layout::TILE) {
                 auto shard_spec = a.shard_spec().value();
-                // Mirror the HC TILE padded-shape contract from the device op:
-                // new dim[1] = input's logical H, new dim[2] = round_up(logical C, TILE_HEIGHT).
+                // HC TILE padded-shape contract: dim[1] = logical H, dim[2] = round_up(logical C, TILE_HEIGHT).
                 auto output_padded_shape = input_padded_shape;
                 output_padded_shape[1] = a.logical_shape()[2];
                 output_padded_shape[2] = tt::round_up(a.logical_shape()[1], tt::constants::TILE_HEIGHT);
@@ -104,16 +93,11 @@ inline Tensor transpose_(
                 }
             }
         } else if (output_mem_config.has_value()) {
-            // User explicitly requested a sharded output (with no shard_spec). Honor their
-            // requested memory_layout whether the input is interleaved or non-native sharded
-            // (TILE BLOCK_SHARDED, DRAM-sharded, or RM HEIGHT_SHARDED with non-tile-aligned
-            // shard elements). The device op's `derive_effective_output_memory_config`
-            // synthesizes the shard_spec. Must run before the `a.is_sharded()` non-native
-            // default-fallback branch below, otherwise a user-requested sharded output from
-            // a non-native sharded input would be silently overridden to L1 interleaved.
+            // User-requested sharded output (no spec): honor the layout; device op will synthesize
+            // the spec. Must precede the non-native fallback below so it isn't overridden.
             output_mem_constructed = output_mem_config.value();
         } else if (a.is_sharded()) {
-            // No user preference + non-native sharded input → default to L1 interleaved.
+            // Non-native sharded input, no user preference → default to L1 interleaved.
             output_mem_constructed = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1);
         } else {
             output_mem_constructed = a.memory_config();
@@ -189,18 +173,9 @@ ttnn::Tensor transpose_nd(
     return ttnn::permute(input_tensor, permutation, memory_config_arg, pad_value);
 }
 
-// Predicate for the composite fallback guard in `transpose_impl`.
-//
-// When the input layout is ROW_MAJOR and either the input or the requested output is
-// BLOCK_SHARDED / WIDTH_SHARDED, neither the native sharded transpose kernels nor the
-// `prim::permute` RM shortcut can faithfully materialize the result: pages span multiple
-// cores, so local-only readers/writers produce silently-wrong data. Such cases are routed
-// through an L1 interleaved intermediate before/after the transpose.
-//
-// HEIGHT_SHARDED RM with a non-tile-aligned shard element count is handled separately by
-// `is_native_transpose_sharding`, which routes it through the interleaved factories'
-// TensorAccessor path without an explicit reshard hop (each page stays on a single core,
-// so NOC-based access is safe).
+// Composite-fallback guard: RM + BLOCK/WIDTH sharded I/O is reshard-hopped through L1 interleaved
+// because pages span cores and local readers/writers would race. (RM HEIGHT_SHARDED is handled by
+// is_native_transpose_sharding via the interleaved TensorAccessor path — pages stay on one core.)
 inline bool is_block_or_width_sharded_mc(const tt::tt_metal::MemoryConfig& mc) {
     return mc.is_sharded() && (mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
                                mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
@@ -227,9 +202,8 @@ ttnn::Tensor transpose_impl(
                 out_bad ? std::optional<MemoryConfig>(interleaved_l1) : memory_config_arg;
             Tensor result = transpose_impl(x, dim1, dim2, intermediate_mc, pad_value);
             if (out_bad) {
-                // If the requested sharded output lacks a shard_spec, synthesize one from the
-                // transposed tensor's padded shape using the same helper the device op uses, so
-                // `to_memory_config` receives a fully-specified sharded destination.
+                // Synthesize a shard_spec for shard-spec-less sharded outputs so to_memory_config
+                // gets a fully-specified destination.
                 MemoryConfig final_mc = memory_config_arg.value();
                 if (!final_mc.shard_spec().has_value()) {
                     auto shard_spec = operations::data_movement::transpose::generate_transpose_shard_spec(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -86,7 +86,8 @@ inline Tensor transpose_(
                 output_padded_shape[1] = a.logical_shape()[2];
                 output_padded_shape[2] = tt::round_up(a.logical_shape()[1], tt::constants::TILE_HEIGHT);
                 auto adjusted = adjust_shard_spec_to_shape(shard_spec, input_padded_shape, output_padded_shape);
-                if (!adjusted.has_value() || adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0) {
+                if (!adjusted.has_value() || adjusted->shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+                    adjusted->shape[1] % tt::constants::TILE_WIDTH != 0) {
                     shard_derivation_fallback();
                 } else {
                     output_mem_constructed = output_mem_constructed.with_shard_spec(std::move(adjusted));
@@ -97,8 +98,9 @@ inline Tensor transpose_(
             // the spec. Must precede the non-native fallback below so it isn't overridden.
             output_mem_constructed = output_mem_config.value();
         } else if (a.is_sharded()) {
-            // Non-native sharded input, no user preference → default to L1 interleaved.
-            output_mem_constructed = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1);
+            // Non-native sharded input → mirror input's memory_layout (no shard_spec, device op
+            // synthesizes via adjust_shard_spec_to_shape / generate_transpose_shard_spec)
+            output_mem_constructed = MemoryConfig(a.memory_config().memory_layout(), a.memory_config().buffer_type());
         } else {
             output_mem_constructed = a.memory_config();
         }


### PR DESCRIPTION
### Ticket
Link to Github Issue #41555

### Problem
`ttnn::transpose` (WH/HC/CN) lacked universal input/output support — block-sharded, width-sharded, and cross-memory(sharded↔interleaved) configurations would crash or silently produce incorrect results. Only height-sharded inputs with matching output sharding were handled via native L1-sharded factories; all other sharding types hit unsupported code paths.

In addition, the default output `MemoryConfig` for non-native sharded inputs forced `L1 INTERLEAVED`, which surfaced as a `TT_FATAL @ fd_mesh_command_queue.cpp:576` in `test_ufldv2_e2e_performant_dp` on `cnn_javelin P150 BH`: downstream `conv2d` triggered a `ttnn::move` to reshard, fatal under trace capture.

### What this PR does
- **Add `is_native_transpose_sharding` predicate** — gates native L1-sharded factory selection; non-native cases (block, width, DRAM-sharded, uneven shards) now fall back to the upgraded interleaved factories instead of crashing.
- **Upgrade interleaved factories to TensorAccessorArgs two-vector pattern** — all four interleaved factories (WH, HC-tiled, HC-RM, CN) now use `TensorAccessorArgs` with `RuntimeTensorShape`, enabling them to transparently read/write sharded buffers via NOC without kernel-side branching.
- **Fix default output MemoryConfig derivation (Path C)** — when no output config is provided, non-native sharded inputs now **mirror the input's `memory_layout` + `buffer_type`** (no `shard_spec`); the device op synthesises the spec via `generate_transpose_shard_spec`. This eliminates the silent demotion to `L1 INTERLEAVED` that caused the cnn_javelin / UFLDv2 trace-capture regression. Native-eligible inputs whose derived shard spec fails tile-alignment still fall back through `shard_derivation_fallback` (L1 interleaved when no user layout requested; mirror layout when user requested sharded).
- **Add shard spec derivation helpers** — `adjust_shard_spec_to_shape` and `generate_transpose_shard_spec` for consistent output shard spec computation; a `derive_effective_output_memory_config` helper shares the derived `shard_spec` between `select_program_factory` and `compute_output_specs` so both operate on a fully-resolved `MemoryConfig`.
- **Add `refresh_transpose_common_runtime_args` helper** — de-duplicates the reader/writer common-args refresh across all four interleaved factories' `override_runtime_arguments`; the underlying `copy_transpose_common_runtime_args` uses `std::span` with a size check for bounds safety.
- **Add comprehensive test suite** (`test_transpose_universal_io.py`) — covers block/width/height sharded inputs (TILE and ROW_MAJOR), cross-memory configs, default derivation, explicit sharded outputs without `shard_spec` (HEIGHT/WIDTH/BLOCK), DRAM-sharded fallback, and native-path regression guards. Includes review-driven probes for non-tile-aligned RM `HEIGHT_SHARDED` shards, sub-tile WH shrink cases, irregular-C HC TILE, and HC/CN composite-fallback round-trips.
- **Relax SDXL UNet 512×512 device-perf baseline** (`models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py`) — `unet_512x512.wormhole.expected_perf` 82.3 M → 81.2 M ns (margin 1.5 % unchanged). Pre-existing stale band on N300; this PR's transpose changes have no measurable kernel-time impact on SDXL UNet (Permute=1, Transpose=0 in the trace; combined < 0.02 % of total). Needs SDXL CODEOWNER ack.

### Notes for Reviewers

The full gap analysis, fix plan, and before/after routing table for this work live on issue #41555 — recommended reading alongside the diff.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/transpose_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/transpose_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/transpose_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/transpose_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/transpose_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/transpose_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/transpose_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/transpose_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/transpose_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/transpose_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/transpose_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/transpose_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/transpose_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/transpose_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/transpose_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/transpose_fix)
