### PR TITLE
Fix MultiCoreDRAMFold cached kernel handle order

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -241,7 +241,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
         cores_with_rtargs.push_back(core);
     }
 
-    return {std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cores_with_rtargs}};
+    return {std::move(program), {unary_writer_kernel_id, unary_reader_kernel_id, cores_with_rtargs}};
 }
 
 Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
@@ -382,7 +382,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
         cores_with_rtargs.push_back(core);
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, cores_with_rtargs}};
+    return {std::move(program), {writer_kernel_id, reader_kernel_id, cores_with_rtargs}};
 }
 
 Fold::MultiCoreDRAMFold::cached_program_t Fold::MultiCoreDRAMFold::create(


### PR DESCRIPTION
[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=moconnor/fix-fold-dram-kernel-order)](https://github.com/tenstorrent/tt-metal/actions/runs/24453859616)
[![(TM-DM) Data Movement Test Suite](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-data-movement-wrapper.yaml/badge.svg?branch=moconnor/fix-fold-dram-kernel-order)](https://github.com/tenstorrent/tt-metal/actions/runs/24453846323)

## Summary
- fix `MultiCoreDRAMFold` cached kernel handle ordering on the DRAM fold path
- keep the change targeted to the two cached-program return sites

## Context
- follow-up to the original failing PR: #39293

## Root cause
`MultiCoreDRAMFold::shared_variables_t` stores fields in `writer_kernel_id, reader_kernel_id` order, but both DRAM factory helpers returned `{reader_kernel_id, writer_kernel_id, cores_with_rtargs}`.

That meant cache-hit `override_runtime_arguments()` patched the wrong kernels: the reader kernel got the destination address and the writer kernel got the source address.

There is also an inconsistency that made this easy to miss:
- `MultiCore` stores `reader, writer`
- `MultiCoreDRAMFold` stores `writer, reader`

This change just makes the two DRAM fold factories return handles in the order `MultiCoreDRAMFold` actually stores them.

## Validation
- clean `aus-wh-20` Wormhole repro from a fresh worktree and fresh rebuild
- repo-local `ttnn` import, not site-packages `ttnn`
- minimal 2-call row-major DRAM fold repro on one open device, shape `(1, 224, 224, 3)`, `stride_h=stride_w=32`
- before fix: run 0 exact, run 1 corrupted (`max_abs=0.99609375`)
- after fix: run 0 exact, run 1 exact (`max_abs=0.0`)

## CI
- `Sanity tests` manual dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/24453859616
- `(TM-DM) Data Movement Test Suite` manual dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/24453846323
- `PR - Sanity tests` auto-created a skipped wrapper run on this same-repo branch, so I dispatched `sanity-tests.yaml` directly instead

cc @afuller-TT @ayerofieiev-tt
