### PR TITLE
Add lightweight causal mask for non-streaming ring SDPA

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1732,8 +1732,7 @@ void sdpa_inner_loop(
     const bool is_balanced = false,
     const bool use_zigzag_balancing = false,
     const bool is_last_ring_iter = true) {
-    // TODO: pick up dst_size from dest_helper once available.
-    constexpr uint32_t dst_size = 8;
+    constexpr uint32_t dst_size = DST_ACCUM_MODE ? 4 : 8;
     uint32_t KV_chunks_processed_in_iter = 0;
     const uint32_t q_per_core = iter_q_end - iter_q_start;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1320,6 +1320,31 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
  * @param num_cols   Total K tiles per row (Sk_chunk_t)
  * @param num_rows   Q tiles per chunk (Sq_chunk_t)
  */
+/**
+ * Batch-stamp a single tile onto a range of positions in out_cb using L1 accumulate.
+ * Caller must have already called copy_tile_to_dst_init_short and llk_pack_reconfig_l1_acc(1).
+ *
+ * @tparam dst_batch  Max tiles per DST cycle (DST register capacity, typically 8 for fp16b half-sync).
+ */
+template <uint32_t dst_batch>
+void stamp_tile_range_l1_acc(
+    uint32_t src_cb, uint32_t src_tile_idx, uint32_t out_cb, uint32_t out_offset, uint32_t count) {
+    for (uint32_t base = 0; base < count; base += dst_batch) {
+        uint32_t batch = (count - base < dst_batch) ? (count - base) : dst_batch;
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < batch; i++) {
+            copy_tile(src_cb, src_tile_idx, i);
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        for (uint32_t i = 0; i < batch; i++) {
+            pack_tile<true>(i, out_cb, out_offset + base + i);
+        }
+        tile_regs_release();
+    }
+}
+
+template <uint32_t dst_batch>
 void apply_padded_mask_lightweight_runtime(
     uint32_t neginf_cb,
     uint32_t neginf_tile_idx,
@@ -1332,22 +1357,8 @@ void apply_padded_mask_lightweight_runtime(
     copy_tile_to_dst_init_short(neginf_cb);
     PACK((llk_pack_reconfig_l1_acc(1)));
 
-    constexpr uint32_t DST_BATCH = 8;
     for (uint32_t row = 0; row < num_rows; row++) {
-        uint32_t row_offset = row * num_cols;
-        for (uint32_t base = start; base < num_cols; base += DST_BATCH) {
-            uint32_t batch = (num_cols - base < DST_BATCH) ? (num_cols - base) : DST_BATCH;
-            tile_regs_acquire();
-            for (uint32_t i = 0; i < batch; i++) {
-                copy_tile(neginf_cb, neginf_tile_idx, i);  // Index into the single CB
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            for (uint32_t i = 0; i < batch; i++) {
-                pack_tile<true>(i, out_cb, row_offset + base + i);
-            }
-            tile_regs_release();
-        }
+        stamp_tile_range_l1_acc<dst_batch>(neginf_cb, neginf_tile_idx, out_cb, row * num_cols + start, num_padded);
     }
 
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -1387,12 +1398,65 @@ void apply_partial_mask_lightweight(
 }
 
 /**
+ * Lightweight causal mask: stamps neginf and diagonal tiles onto QKT using L1 accumulate.
+ *
+ * For Q tile-row i (0..num_rows-1) processing K chunk starting at k_low_idx:
+ *   diag_col = q_low_idx + i - k_low_idx
+ *   - diag_col < 0:           entire row above diagonal -> stamp neginf on all num_cols tiles
+ *   - 0 <= diag_col < num_cols: diagonal tile at col diag_col, neginf at cols diag_col+1..num_cols-1
+ *   - diag_col >= num_cols:     entire row below diagonal -> no mask needed
+ */
+template <uint32_t dst_batch>
+void apply_causal_mask_lightweight(
+    uint32_t mask_cb,
+    uint32_t neginf_idx,
+    uint32_t diag_idx,
+    uint32_t out_cb,
+    uint32_t q_low_idx,
+    uint32_t k_low_idx,
+    uint32_t num_rows,
+    uint32_t num_cols) {
+    copy_tile_to_dst_init_short(mask_cb);
+    PACK((llk_pack_reconfig_l1_acc(1)));
+
+    for (uint32_t row = 0; row < num_rows; row++) {
+        int32_t diag_col = (int32_t)(q_low_idx + row) - (int32_t)k_low_idx;
+        uint32_t row_offset = row * num_cols;
+
+        if (diag_col < 0) {
+            // Entire row above diagonal -> stamp all neginf
+            stamp_tile_range_l1_acc<dst_batch>(mask_cb, neginf_idx, out_cb, row_offset, num_cols);
+        } else if ((uint32_t)diag_col < num_cols) {
+            // Stamp the diagonal tile
+            tile_regs_acquire();
+            copy_tile(mask_cb, diag_idx, 0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile<true>(0, out_cb, row_offset + (uint32_t)diag_col);
+            tile_regs_release();
+
+            // Stamp neginf tiles to the right of diagonal
+            uint32_t neginf_start = (uint32_t)diag_col + 1;
+            if (neginf_start < num_cols) {
+                stamp_tile_range_l1_acc<dst_batch>(
+                    mask_cb, neginf_idx, out_cb, row_offset + neginf_start, num_cols - neginf_start);
+            }
+        }
+        // else: diag_col >= num_cols -> entire row below diagonal, no mask needed
+    }
+
+    PACK((llk_pack_reconfig_l1_acc(0)));
+}
+
+/**
  * Context for lightweight mask application in ring joint SDPA.
  * All mask tiles reside in a single CB. A default-constructed instance disables lightweight masking.
  */
 struct LightweightMaskContext {
     bool enabled = false;
+    bool is_causal = false;                  // True only on ring_iter 0 for causal configs
     uint32_t neginf_tile_idx = 0;            // Index of -inf tile in the mask CB
+    uint32_t causal_diag_tile_idx = 0;       // Index of causal diagonal tile in the mask CB
     uint32_t global_n_padded_tiles = 0;      // Fully padded K tile columns for global_n chunk
     uint32_t local_n_padded_tiles = 0;       // Fully padded K tile columns for local_n chunk
     uint32_t joint_n_padded_tiles = 0;       // Fully padded K tile columns for joint_l chunk
@@ -1441,7 +1505,13 @@ struct LightweightMaskContext {
 
     /**
      * Apply the lightweight mask for a given K chunk (non-streaming path).
+     * When is_causal: applies causal stamp, then also applies padding stamp if this K chunk has padding.
+     * When !is_causal: applies padding stamp only.
+     * L1-accumulate stamps are additive, so applying both is safe (-inf + -inf = -inf, -inf + 0 = -inf).
+     *
+     * @tparam dst_size  DST register capacity (8 for fp16b half-sync, 4 for fp32_dest_acc).
      */
+    template <uint32_t dst_size>
     void apply(
         uint32_t cb_mask_in,
         uint32_t cb_qk_im,
@@ -1454,7 +1524,22 @@ struct LightweightMaskContext {
         bool local_n_needs_masking,
         uint32_t global_n_mask_chunk_id,
         uint32_t local_n_mask_chunk_id,
-        uint32_t joint_n_mask_chunk_id) const {
+        uint32_t joint_n_mask_chunk_id,
+        uint32_t q_low_idx = 0) const {
+        if (is_causal) {
+            uint32_t k_low_idx = k_chunk * Sk_chunk_t;
+            apply_causal_mask_lightweight<dst_size>(
+                cb_mask_in,
+                neginf_tile_idx,
+                causal_diag_tile_idx,
+                cb_qk_im,
+                q_low_idx,
+                k_low_idx,
+                Sq_chunk_t,
+                Sk_chunk_t);
+        }
+
+        // Apply padding stamp (also when is_causal — the causal stamp doesn't handle K padding).
         uint32_t num_padded, boundary_col, partial_tile_idx;
         bool has_partial;
         resolve_for_chunk(
@@ -1477,7 +1562,7 @@ struct LightweightMaskContext {
                 cb_mask_in, partial_tile_idx, cb_qk_im, boundary_col, Sk_chunk_t, Sq_chunk_t);
         }
         if (num_padded > 0) {
-            apply_padded_mask_lightweight_runtime(
+            apply_padded_mask_lightweight_runtime<dst_size>(
                 cb_mask_in, neginf_tile_idx, cb_qk_im, num_padded, Sk_chunk_t, Sq_chunk_t);
         }
     }
@@ -1647,6 +1732,8 @@ void sdpa_inner_loop(
     const bool is_balanced = false,
     const bool use_zigzag_balancing = false,
     const bool is_last_ring_iter = true) {
+    // TODO: pick up dst_size from dest_helper once available.
+    constexpr uint32_t dst_size = 8;
     uint32_t KV_chunks_processed_in_iter = 0;
     const uint32_t q_per_core = iter_q_end - iter_q_start;
 
@@ -1759,20 +1846,18 @@ void sdpa_inner_loop(
              */
 
             bool apply_mask = false;
+            bool needs_padding_mask =
+                (sdpa_type == RING) &&
+                ((ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) ||
+                 (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) ||
+                 (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id));
             if (sdpa_type == RING && !is_causal) {
-                apply_mask = (ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) ||
-                             (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) ||
-                             (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id);
+                apply_mask = needs_padding_mask;
             } else if (is_causal || sliding_window_size > 0) {
-                // Finding the diagonal is harder now that q_chunk_size and k_chunk_size can differ
-                // Q-range = [q_low, q_high)
-                // K-range = [k_low, k_high)
-                // does_overlap = not (q_low >= k_high or k_low >= q_high)
-                // Due to loop bounds, we should never have k_low >= q_high.
                 const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
                 const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
-                // Apply mask if causal overlap or sliding window is active
-                apply_mask = (q_low_idx < k_high_idx) || (sliding_window_size > 0);
+                // Apply mask if causal overlap, sliding window, or this K chunk has padding
+                apply_mask = (q_low_idx < k_high_idx) || (sliding_window_size > 0) || needs_padding_mask;
             } else if constexpr (use_provided_mask) {
                 apply_mask = true;
             } else if constexpr (use_padded_mask) {
@@ -1787,7 +1872,7 @@ void sdpa_inner_loop(
                 /* QK += MASK */
                 reconfig_data_format(cb_qk_im, cb_mask_in);
                 if (lw_mask.enabled) {
-                    lw_mask.apply(
+                    lw_mask.template apply<dst_size>(
                         cb_mask_in,
                         cb_qk_im,
                         Sk_chunk_t,
@@ -1799,7 +1884,8 @@ void sdpa_inner_loop(
                         local_n_needs_masking,
                         global_n_mask_chunk_id,
                         local_n_mask_chunk_id,
-                        joint_n_mask_chunk_id);
+                        joint_n_mask_chunk_id,
+                        q_low_idx);
                 } else {
                     add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -2179,7 +2179,8 @@ void sdpa_standard(
     const uint32_t cb_sum_A,
     const uint32_t cb_sum_B,
     const uint32_t cb_exp_max_diff,
-    const uint32_t cb_out) {
+    const uint32_t cb_out,
+    const LightweightMaskContext& lw_mask = {}) {
     sdpa_inner_loop<
         STANDARD,
         cb_qk_im,
@@ -2252,7 +2253,7 @@ void sdpa_standard(
         0,  // cb_lse_out (not used)
         0,  // cb_prev_out (not used)
         cb_out,
-        {},  // lw_mask (not used)
+        lw_mask,
         is_causal);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -24,6 +24,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/reduce_custom.h"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp"
+#include "cpp/ttnn/kernel_lib/dest_helpers.hpp"
 
 ALWI void sdpa_reduce_copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0) {
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
@@ -1721,7 +1722,7 @@ void sdpa_inner_loop(
     const bool is_balanced = false,
     const bool use_zigzag_balancing = false,
     const bool is_last_ring_iter = true) {
-    constexpr uint32_t dst_size = DST_ACCUM_MODE ? 4 : 8;
+    constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
     uint32_t KV_chunks_processed_in_iter = 0;
     const uint32_t q_per_core = iter_q_end - iter_q_start;
 
@@ -1860,6 +1861,18 @@ void sdpa_inner_loop(
                 /* QK += MASK */
                 reconfig_data_format(cb_qk_im, cb_mask_in);
                 if (lw_mask.enabled) {
+                    // Re-enter reserved state on cb_qk_im so the lightweight mask can be stamped in-place.
+                    // matmul_blocks above already pushed the QK tiles, so tiles_received has been bumped;
+                    // without the pop+push cycle below, reduce_c's cb_wait_front would return immediately
+                    // and unpack could start before the mask stamps land in L1.
+                    // Safe because cb_pop_front only moves rd_ptr (L1 data is untouched), and on a
+                    // single-buffered CB of size qk_chunk_tiles the re-reserved wr_ptr wraps back to the
+                    // same physical region holding the QK scores.
+                    // Warning: this won't work if cb_qk_im is double-buffered -- the stamps would land
+                    // in the other buffer, leaving the QK scores unmasked.
+                    cb_wait_front(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
+                    cb_pop_front(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
+                    cb_reserve_back(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
                     lw_mask.template apply<dst_size>(
                         cb_mask_in,
                         cb_qk_im,
@@ -1874,6 +1887,7 @@ void sdpa_inner_loop(
                         local_n_mask_chunk_id,
                         joint_n_mask_chunk_id,
                         q_low_idx);
+                    cb_push_back(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
                 } else {
                     add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1310,17 +1310,6 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
 }
 
 /**
- * Lightweight padded-K mask: L1-accumulate a single permanently-fronted -inf tile onto padded
- * tile positions in out_cb. Runtime version for ring joint SDPA where num_padded varies per chunk.
- *
- * @param neginf_cb  CB holding mask tiles (tile 0 = -inf), permanently fronted
- * @param neginf_tile_idx  Tile index of the -inf tile within the CB (typically 0)
- * @param out_cb     QK intermediate CB (Sq_chunk_t * Sk_chunk_t tiles, already wait-fronted)
- * @param num_padded Number of fully padded K tile columns per row
- * @param num_cols   Total K tiles per row (Sk_chunk_t)
- * @param num_rows   Q tiles per chunk (Sq_chunk_t)
- */
-/**
  * Batch-stamp a single tile onto a range of positions in out_cb using L1 accumulate.
  * Caller must have already called copy_tile_to_dst_init_short and llk_pack_reconfig_l1_acc(1).
  *

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -57,18 +57,22 @@ void kernel_main() {
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(39) == 1;
 
     // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
-    // Layout: [neginf(0)] [global_n_partial?(1)] [joint_l_partial?(1 or 2)]
-    // Only needed when any K/joint dimension has padding that doesn't fill a chunk.
+    // Layout: [neginf(0)] [causal_diag?(1)] [global_n_partial?] [joint_l_partial?]
+    // Needed when any K/joint dimension has padding, or when causal masking is active.
     constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
     constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
-    constexpr bool needs_lightweight_mask = (local_n_has_padding || global_n_has_padding || joint_has_padding) && !is_causal;
+    constexpr bool needs_lightweight_mask =
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || is_causal;
 
     constexpr uint32_t neginf_tile_idx = 0;
-    constexpr uint32_t global_n_partial_tile_idx = (global_n_partial_col > 0) ? 1 : 0;
+    constexpr uint32_t causal_diag_tile_idx = is_causal ? 1 : 0;
+    constexpr uint32_t base_partial_offset = 1 + (is_causal ? 1 : 0);
+    constexpr uint32_t global_n_partial_tile_idx = (global_n_partial_col > 0) ? base_partial_offset : 0;
     constexpr uint32_t joint_l_partial_tile_idx =
-        (joint_l_partial_col > 0) ? (1 + (global_n_partial_col > 0 ? 1 : 0)) : 0;
-    constexpr uint32_t total_mask_tiles = 1 + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
+        (joint_l_partial_col > 0) ? (base_partial_offset + (global_n_partial_col > 0 ? 1 : 0)) : 0;
+    constexpr uint32_t total_mask_tiles =
+        1 + (is_causal ? 1 : 0) + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
 
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
@@ -177,7 +181,9 @@ void kernel_main() {
         // Build lightweight mask context for this ring iteration
         LightweightMaskContext lw_mask;
         lw_mask.enabled = needs_lightweight_mask;
+        lw_mask.is_causal = (ring_iter == 0 ? is_causal : false);
         lw_mask.neginf_tile_idx = neginf_tile_idx;
+        lw_mask.causal_diag_tile_idx = causal_diag_tile_idx;
         lw_mask.local_n_padded_tiles = local_n_padded_tiles;
         lw_mask.joint_n_padded_tiles = joint_n_padded_tiles;
         lw_mask.global_n_partial_col = global_n_partial_col;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -164,6 +164,7 @@ void kernel_main() {
             lw_mask.is_causal = true;
             lw_mask.neginf_tile_idx = 0;
             lw_mask.causal_diag_tile_idx = 1;
+            cb_wait_front(cb_mask_in, 2);
         }
 
         for (uint32_t phase = 0; phase < num_phases; ++phase) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -156,6 +156,16 @@ void kernel_main() {
         }
     } else {
         // Standard SDPA path (causal, masked, chunked, etc.)
+        constexpr bool use_lightweight_causal_mask = is_causal && !use_provided_mask && (sliding_window_size == 0);
+
+        LightweightMaskContext lw_mask;
+        if constexpr (use_lightweight_causal_mask) {
+            lw_mask.enabled = true;
+            lw_mask.is_causal = true;
+            lw_mask.neginf_tile_idx = 0;
+            lw_mask.causal_diag_tile_idx = 1;
+        }
+
         for (uint32_t phase = 0; phase < num_phases; ++phase) {
             if (phase == 0) {
                 chunked_q_chunk_offset = chunked_q_chunk_offset_phase_1;
@@ -216,7 +226,8 @@ void kernel_main() {
                         cb_sum_A,
                         cb_sum_B,
                         cb_exp_max_diff,
-                        cb_out);
+                        cb_out,
+                        lw_mask);
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -359,18 +359,88 @@ void fill_vertical_tile_bf16(uint32_t cb_id, uint32_t tile_id, uint32_t unpad_co
 }
 
 /**
+ * Fill a bf16 tile with the standard causal diagonal mask pattern:
+ * row r, col c: 0 if c <= r, -inf if c > r.
+ *
+ * bf16 tile layout: 4 faces of 16x16.
+ * Face 0 (rows 0-15, cols 0-15): diagonal — row r has cols 0..r valid, r+1..15 masked
+ * Face 1 (rows 0-15, cols 16-31): entirely -inf (cols > rows for these rows)
+ * Face 2 (rows 16-31, cols 0-15): entirely zero (cols < rows for these rows)
+ * Face 3 (rows 16-31, cols 16-31): same diagonal pattern as face 0 (shifted by 16 in both dims)
+ */
+template <uint32_t tile_bytes>
+void fill_causal_diagonal_tile_bf16(uint32_t cb_id, uint32_t tile_id) {
+    // Start with all zeros
+    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+
+    constexpr uint32_t NEGINF_PAIR = 0xFF80FF80;
+    constexpr uint32_t bf16_per_uint32 = 2;
+    constexpr uint32_t uint32_per_face_row = tt::constants::FACE_WIDTH / bf16_per_uint32;  // 8
+    constexpr uint32_t uint32_per_face = tt::constants::FACE_HW / bf16_per_uint32;         // 128
+
+    volatile tt_l1_ptr uint32_t* ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+
+    // Face offsets in uint32 words
+    constexpr uint32_t face_offsets[4] = {
+        0,                    // Face 0: rows[0:16], cols[0:16]
+        uint32_per_face,      // Face 1: rows[0:16], cols[16:32]
+        2 * uint32_per_face,  // Face 2: rows[16:32], cols[0:16]
+        3 * uint32_per_face   // Face 3: rows[16:32], cols[16:32]
+    };
+
+    // Face 1: entirely -inf (cols 16-31 > rows 0-15)
+    for (uint32_t i = 0; i < uint32_per_face; i++) {
+        ptr[face_offsets[1] + i] = NEGINF_PAIR;
+    }
+
+    // Face 2: entirely zero — already done by fill_tile_zeros
+
+    // Face 0 and Face 3: diagonal pattern (identical — both have local row r with cols 0..r valid, r+1..15 masked)
+    constexpr uint32_t diag_faces[2] = {0, 3};
+    for (uint32_t f = 0; f < 2; f++) {
+        uint32_t face_base = face_offsets[diag_faces[f]];
+        for (uint32_t row = 0; row < tt::constants::FACE_HEIGHT; row++) {
+            // First masked column in this row: row + 1
+            uint32_t first_masked = row + 1;
+            if (first_masked >= tt::constants::FACE_WIDTH) {
+                continue;  // Row 15: all cols 0-15 are valid
+            }
+
+            uint32_t row_base = face_base + row * uint32_per_face_row;
+            uint32_t boundary_word = first_masked / bf16_per_uint32;
+            uint32_t boundary_pos = first_masked % bf16_per_uint32;
+
+            // Boundary word: low bf16 may be valid (col = first_masked - 1 = row)
+            if (boundary_pos != 0) {
+                // Low 16 bits = col row (valid, 0), high 16 bits = col row+1 (masked, -inf)
+                ptr[row_base + boundary_word] = 0xFF800000;
+                boundary_word++;
+            }
+
+            // Remaining words: all -inf
+            for (uint32_t w = boundary_word; w < uint32_per_face_row; w++) {
+                ptr[row_base + w] = NEGINF_PAIR;
+            }
+        }
+    }
+}
+
+/**
  * Generate lightweight mask tiles into a single CB for ring joint SDPA.
- * Layout: [neginf_tile(0)] [global_n_partial_tile?(1)] [joint_l_partial_tile?(1 or 2)]
+ * Layout: [neginf_tile(0)] [causal_diag_tile?(1)] [global_n_partial_tile?] [joint_l_partial_tile?]
  * Tiles are pushed once and stay permanently fronted for the entire kernel lifetime.
  *
  * @tparam global_n_partial_col  Column within tile where global_n padding starts (0 = tile-aligned, no partial)
  * @tparam joint_l_partial_col   Column within tile where joint_l padding starts (0 = tile-aligned, no partial)
  * @tparam cb_mask_in            CB to generate mask tiles into (must be constexpr for get_tile_size)
+ * @tparam is_causal_lw          Whether to include the causal diagonal tile
  */
-template <uint32_t global_n_partial_col, uint32_t joint_l_partial_col, uint32_t cb_mask_in>
+template <uint32_t global_n_partial_col, uint32_t joint_l_partial_col, uint32_t cb_mask_in, bool is_causal_lw = false>
 void generate_lightweight_mask_tiles() {
     constexpr uint32_t partial_mask_tiles = (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
-    constexpr uint32_t total_mask_tiles = 1 + partial_mask_tiles;
+    constexpr uint32_t causal_diag_tiles = is_causal_lw ? 1 : 0;
+    constexpr uint32_t total_mask_tiles = 1 + causal_diag_tiles + partial_mask_tiles;
     constexpr uint32_t mask_tile_size_bytes = get_tile_size(cb_mask_in);
 
     cb_reserve_back(cb_mask_in, total_mask_tiles);
@@ -378,9 +448,15 @@ void generate_lightweight_mask_tiles() {
     // Tile 0: neginf tile
     fill_neginf_tile<mask_tile_size_bytes>(cb_mask_in, 0);
 
+    uint32_t tile_idx = 1;
+
+    // Tile 1 (if causal): causal diagonal tile
+    if constexpr (is_causal_lw) {
+        fill_causal_diagonal_tile_bf16<mask_tile_size_bytes>(cb_mask_in, tile_idx++);
+    }
+
     // Subsequent tiles: partial mask tiles for boundary conditions
     if constexpr (partial_mask_tiles > 0) {
-        uint32_t tile_idx = 1;  // Start after the neginf tile
         if constexpr (global_n_partial_col > 0) {
             fill_vertical_tile_bf16<mask_tile_size_bytes>(cb_mask_in, tile_idx++, global_n_partial_col);
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -401,7 +401,7 @@ void kernel_main() {
     generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
 
     // Lightweight mask: generate all mask tiles once into single CB before the ring loop.
-    // Only needed when any K/joint dimension has padding that doesn't fill a chunk.
+    // Needed when any K/joint dimension has padding, or when causal masking is active.
     constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
     constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -405,9 +405,10 @@ void kernel_main() {
     constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
     constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
-    constexpr bool needs_lightweight_mask = (local_n_has_padding || global_n_has_padding || joint_has_padding) && !is_causal;
+    constexpr bool needs_lightweight_mask =
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || is_causal;
     if constexpr (needs_lightweight_mask) {
-        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in>();
+        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in, is_causal>();
     }
 
     const uint32_t last_active_ring_iter =
@@ -682,19 +683,6 @@ void kernel_main() {
 
                 if (q_chunk < half_sequence && is_balanced && ring_index < ring_id) {
                     continue;
-                }
-
-                if (is_causal) {
-                    generate_mask<false, 0, true, cb_mask_in>(
-                        Sq_chunk_t,
-                        Sk_chunk_t,
-                        q_chunk,
-                        0,
-                        ring_iter_needs_global_n_mask || ring_iter_needs_local_n_mask,
-                        ring_iter_needs_joint_n_mask,
-                        ring_iter_needs_global_n_mask ? global_n_within_ring_iter : local_padded_N,
-                        L,
-                        causality);
                 }
 
                 // If not on the first iteration, read LSE and previous output chunk.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -74,15 +74,25 @@ void kernel_main() {
     generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
 
-    // Lightweight mask: generate a single -inf tile once, leave permanently fronted.
+    // Lightweight mask: generate template tiles once, leave permanently fronted.
+    // Non-causal: 1 tile (neginf). Causal: 2 tiles (neginf + diagonal).
     if constexpr (use_lightweight_mask) {
-        const uint32_t mask_tile_size_bytes = get_tile_size(cb_mask_in);
-        cb_reserve_back(cb_mask_in, 1);
+        constexpr uint32_t mask_tile_size_bytes = get_tile_size(cb_mask_in);
+        constexpr uint32_t lw_mask_tiles = is_causal ? 2 : 1;
+        cb_reserve_back(cb_mask_in, lw_mask_tiles);
+
+        // Tile 0: all -inf
         auto* ptr = reinterpret_cast<uint32_t*>(get_write_ptr(cb_mask_in));
         for (uint32_t i = 0; i < mask_tile_size_bytes / sizeof(uint32_t); i++) {
             ptr[i] = 0xFF80FF80;  // -inf in bfloat16
         }
-        cb_push_back(cb_mask_in, 1);
+
+        // Tile 1: causal diagonal (0 where col<=row, -inf where col>row)
+        if constexpr (is_causal) {
+            fill_causal_diagonal_tile_bf16<mask_tile_size_bytes>(cb_mask_in, 1);
+        }
+
+        cb_push_back(cb_mask_in, lw_mask_tiles);
     }
 
     if constexpr (is_chunked) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -153,7 +153,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
     uint32_t q_tiles = Sq_chunk_t * DHt * 2;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;            // double buffer
     uint32_t v_tiles = Sk_chunk_t * vDHt * 2;           // double buffer
-    uint32_t mask_tiles = Sq_chunk_t * Sk_chunk_t * 2;  // double buffer
+    uint32_t mask_tiles = 2;                            // lightweight: neginf + causal diagonal
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t out_im_tiles = Sq_chunk_t * vDHt;
     uint32_t out0_t = Sq_chunk_t * vDHt;
@@ -266,7 +266,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         false,  //(std::uint32_t)use_padded_mask,
         true,   //(uint32_t)is_chunked,
         0,      //(uint32_t)sliding_window_size,
-        0,      // arg 20: lightweight mask (unused in ring distributed)
+        1,      // arg 20: lightweight causal mask
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 
@@ -348,7 +348,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
     tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_k.dtype());
     tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_v.dtype());
 
-    tt::DataFormat mask_df = tt::DataFormat::Bfp4_b;
+    tt::DataFormat mask_df = tt::DataFormat::Float16_b;
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -194,18 +194,20 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const uint32_t Sq_chunk_t = q_chunk_size / tt::constants::TILE_HEIGHT;
     const uint32_t Sk_chunk_t = k_chunk_size / tt::constants::TILE_HEIGHT;
 
-    // Lightweight mask: only needed when any K/joint dimension has padding that doesn't fill a chunk.
+    // Lightweight mask: needed when any K/joint dimension has padding, or when causal masking is active.
     const bool local_n_has_padding = (local_padded_Nt % Sk_chunk_t) != 0;
     const bool global_n_has_padding = (args.logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool joint_has_padding = L > 0 && (L % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
-    const bool needs_lightweight_mask = (local_n_has_padding || global_n_has_padding || joint_has_padding) && !args.is_causal;
+    const bool needs_lightweight_mask =
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || args.is_causal;
 
     // Partial tile support when padding boundary falls inside a tile.
     const uint32_t global_n_partial_col = args.logical_n % tt::constants::TILE_HEIGHT;
     const uint32_t joint_l_partial_col = L % tt::constants::TILE_HEIGHT;
     const uint32_t partial_mask_tiles = (global_n_partial_col != 0 ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
-    // Single CB holds: 1 neginf tile + up to 2 partial mask tiles
-    const uint32_t total_lightweight_mask_tiles = 1 + partial_mask_tiles;
+    const uint32_t causal_diag_tiles = args.is_causal ? 1 : 0;
+    // Single CB holds: 1 neginf tile + optional causal diagonal + up to 2 partial mask tiles
+    const uint32_t total_lightweight_mask_tiles = 1 + causal_diag_tiles + partial_mask_tiles;
 
     const uint32_t num_local_q_chunks = tt::div_up(local_padded_N, q_chunk_size);
     const uint32_t num_joint_q_chunks = tt::div_up(L, q_chunk_size);
@@ -481,7 +483,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const tt::DataFormat v_df_early = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
     const tt::DataFormat out_df_early = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     const tt::DataFormat im_df_early = tt::DataFormat::Float16_b;
-    const tt::DataFormat mask_df_early = (args.is_causal ? tt::DataFormat::Bfp4_b : tt::DataFormat::Float16_b);
+    const tt::DataFormat mask_df_early = tt::DataFormat::Float16_b;
     const bool uniform_dataformat =
         (q_df_early == k_df_early && q_df_early == v_df_early && q_df_early == out_df_early &&
          q_df_early == mask_df_early && q_df_early == im_df_early);
@@ -548,7 +550,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // This is done only in the non-causal case:
     // Lightweight mask: both streaming and non-streaming paths use Float16_b
     // to support L1-accumulation and avoid Bfp4_b precision loss.
-    tt::DataFormat mask_df = (args.is_causal ? tt::DataFormat::Bfp4_b : tt::DataFormat::Float16_b);
+    tt::DataFormat mask_df = tt::DataFormat::Float16_b;
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
@@ -587,20 +589,13 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                             .set_page_size(tt::CBIndex::c_2, v_tile_size);
     CreateCircularBuffer(program, core_grid, c_in2_config);
 
-    if (args.is_causal) {
-        // attn_mask input
-        auto c_in3_config = CircularBufferConfig(mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
-                                .set_page_size(tt::CB::c_in3, mask_tile_size);
+    // Lightweight mask CB: holds neginf + optional causal diagonal + optional partial tiles.
+    // Used for both causal (ring_iter 0) and padding (ring_iter > 0) masking.
+    if (needs_lightweight_mask) {
+        auto c_in3_config =
+            CircularBufferConfig(total_lightweight_mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
+                .set_page_size(tt::CB::c_in3, mask_tile_size);
         CreateCircularBuffer(program, core_grid, c_in3_config);
-    }
-    else {
-        // Lightweight mask: single CB holds 1 neginf tile + up to 2 partial mask tiles
-        if (needs_lightweight_mask) {
-            auto c_in3_config =
-                CircularBufferConfig(total_lightweight_mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
-                    .set_page_size(tt::CB::c_in3, mask_tile_size);
-            CreateCircularBuffer(program, core_grid, c_in3_config);
-        }
     }
 
     // scale input

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -547,8 +547,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
     tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
 
-    // This is done only in the non-causal case:
-    // Lightweight mask: both streaming and non-streaming paths use Float16_b
+    // Lightweight mask: both causal and non-causal paths use Float16_b
     // to support L1-accumulation and avoid Bfp4_b precision loss.
     tt::DataFormat mask_df = tt::DataFormat::Float16_b;
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -400,12 +400,14 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         Sk,
         Sq_chunk_t);
 
-    const bool lightweight_mask = use_streaming_compute && use_padded_mask;
+    const bool lightweight_causal = is_causal && !use_provided_mask && sliding_window_size.value_or(0) == 0;
+    const bool lightweight_mask = (use_streaming_compute && use_padded_mask) || lightweight_causal;
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;            // double buffer
     uint32_t v_tiles = Sk_chunk_t * vDHt * 2;           // double buffer
-    uint32_t mask_tiles = lightweight_mask ? 1 : Sq_chunk_t * Sk_chunk_t * 2;  // double buffer
+    uint32_t mask_tiles =
+        lightweight_mask ? (lightweight_causal ? 2 : 1) : Sq_chunk_t * Sk_chunk_t * 2;  // double buffer
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t out_im_tiles = Sq_chunk_t * vDHt;
     uint32_t out0_t = Sq_chunk_t * vDHt;
@@ -575,7 +577,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         (std::uint32_t)use_padded_mask,
         (uint32_t)is_chunked,
         sliding_window_size.value_or(0),
-        (std::uint32_t)(use_streaming_compute && use_padded_mask),  // arg 20: lightweight mask for v2
+        (std::uint32_t)(lightweight_mask),  // arg 20: lightweight mask (causal or streaming padded)
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -658,7 +660,6 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     uint32_t q_tile_size = tt::tile_size(q_df);
     uint32_t k_tile_size = tt::tile_size(k_df);
     uint32_t v_tile_size = tt::tile_size(v_df);
-    uint32_t mask_tile_size = tt::tile_size(mask_df);
     uint32_t out_tile_size = tt::tile_size(out_df);
     uint32_t scalar_tile_size = tt::tile_size(scalar_df);
     uint32_t im_tile_size = tt::tile_size(im_df);
@@ -689,13 +690,12 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     // Only create mask buffer if it's going to be used
     if (use_provided_mask or is_causal or use_padded_mask) {
-        // Lightweight mask: single bfloat16 -inf tile (no Bfp4_b round-trip artifacts).
+        // Lightweight mask: Float16_b, mask_tiles already computed (1 for padding, 2 for causal).
         // Legacy: full Sq×Sk double-buffered matrix in Bfp4_b.
-        uint32_t actual_mask_tiles = lightweight_mask ? 1 : mask_tiles;
         tt::DataFormat actual_mask_df = lightweight_mask ? tt::DataFormat::Float16_b : mask_df;
-        uint32_t actual_mask_tile_size = lightweight_mask ? tt::tile_size(actual_mask_df) : mask_tile_size;
+        uint32_t actual_mask_tile_size = tt::tile_size(actual_mask_df);
         auto c_in3_config =
-            CircularBufferConfig(actual_mask_tiles * actual_mask_tile_size, {{tt::CBIndex::c_3, actual_mask_df}})
+            CircularBufferConfig(mask_tiles * actual_mask_tile_size, {{tt::CBIndex::c_3, actual_mask_df}})
                 .set_page_size(tt::CBIndex::c_3, actual_mask_tile_size);
         CreateCircularBuffer(program, core_grid, c_in3_config);
     }


### PR DESCRIPTION
### Ticket
Related to causal ring joint attention performance improvements.

### Problem description

Causal ring joint attention previously materialized a full `Sq_chunk_t × Sk_chunk_t` mask tensor in the **writer** kernel for every Q chunk on every K chunk overlapping the diagonal. This required per-Q-chunk writer↔compute synchronization and a large `cb_mask_in` sized at `Sq*Sk` tiles.

### What's changed

Replace the full materialized causal mask with lightweight L1-accumulate stamping using 2-4 permanently-fronted template tiles in compute.

A causal mask has only 3 distinct tile patterns:
- **Below diagonal** (col ≤ row): valid scores, tile is zero → no-op
- **Above diagonal** (col > row for entire tile): masked → all -inf
- **On the diagonal**: upper-right triangle is -inf, lower-left is zero

`apply_causal_mask_lightweight()` runs after `QK = Q @ K^T` and stamps the neginf/diagonal tiles on-the-fly per Q tile-row based on diagonal position. Causal masking only applies on `ring_iter == 0` (local K/V). Composes correctly with padding masks via additive L1-accumulate.

`cb_mask_in` shrinks from `Sq_chunk_t * Sk_chunk_t` tiles to **2-4 tiles**. Format changed from `Bfp4_b` to `Float16_b` (required for L1-accumulate correctness).

#### Changes

- **dataflow_common.hpp**: Add `fill_causal_diagonal_tile_bf16()`. Extend `generate_lightweight_mask_tiles` with `is_causal_lw` template param.
- **compute_common.hpp**: Add `stamp_tile_range_l1_acc()` helper. Add `apply_causal_mask_lightweight()`. Extend `LightweightMaskContext` with `is_causal` and `causal_diag_tile_idx`. Update `apply()` to handle both causal and padding stamps.
- **ring_joint_sdpa.cpp**: Enable `needs_lightweight_mask` for causal, update tile index layout, set `lw_mask.is_causal` per ring iteration.
- **ring_joint_sdpa_program_factory.cpp**: Unify mask CB sizing for both causal and non-causal. Change mask format from `Bfp4_b` to `Float16_b`.
- **ring_joint_writer.cpp**: Remove per-Q-chunk `generate_mask()` call for causal.

#### Accuracy Results (QB, 4x BH)

| Test | PCC | Status |
|------|-----|--------|
| mla_100k-q160-k160 (causal+balanced) | 0.9995 | PASSED |
| mla_128k-q128-k128 (causal+balanced) | 0.9997 | PASSED |
| wan2_2_1xGLX-q288-k512 (non-causal) | — | PASSED (no regression) |

#### Math Utilization (compute-only profiling, CCLs + DRAM disabled)

mla_100k-q160-k160 (causal+balanced, 4x BH):

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Duration | 5.118 ms | 5.110 ms | -0.2% |
| Math Util | 59.1% | 59.2% | +0.1% |
| FPU Util | 59.1-60.7% | 59.2-60.8% | ~same |
| Cores used | 87/100 | 87/100 | same |
| Iters/core | 560 | 560 | same |

Perf-neutral in compute-only profiling — the real benefit is eliminating writer-compute synchronization for mask generation.

## Test plan

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [x] [![Nightly tt-metal L2 tests (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [ ] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:dnijemcevic/causal_lw_mask)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dnijemcevic/causal_lw_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dnijemcevic/causal_lw_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dnijemcevic/causal_lw_mask)