### PR TITLE
Fix DeepSeek broadcast all-gather default subdevice

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1110,7 +1110,6 @@ class MLA1D(AbstractModule):
             cluster_axis=1,
             dim=2,
             memory_config=ttnn.L1_MEMORY_CONFIG,
-            subdevice_id=ttnn.SubDeviceId(0),
             use_broadcast=True,
         )
 

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -111,6 +111,7 @@ def run_all_gather_impl(
     use_semaphore_free_all_gather_impl=False,
     sub_core_grids=None,
     use_broadcast=False,
+    use_explicit_subdevice_id=True,
 ):
     use_sub_devices = False
     torch.manual_seed(0)
@@ -223,38 +224,40 @@ def run_all_gather_impl(
     def run_op(i):  # absolutely disgusting if-else condition because changing every call site is a humongous PITA
         if use_semaphore_free_all_gather_impl and all_gather_function == ttnn.experimental.all_gather_async:
             logger.info(f"Using new all-gather")
-            tt_all_gather_out_tensor = ttnn.all_gather(
-                input_tensor_mesh_list[i],
-                dim=dim,
-                cluster_axis=cluster_axis,
-                num_links=num_links,
-                memory_config=mem_config_ag,
-                topology=all_gather_topology,
-                chunks_per_sync=chunks_per_sync,
-                num_workers_per_link=num_workers_per_link,
-                num_buffers_per_channel=num_buffers_per_channel,
-                subdevice_id=worker_sub_device_id,
-                sub_core_grids=sub_core_grids,
-            )
+            all_gather_kwargs = {
+                "dim": dim,
+                "cluster_axis": cluster_axis,
+                "num_links": num_links,
+                "memory_config": mem_config_ag,
+                "topology": all_gather_topology,
+                "chunks_per_sync": chunks_per_sync,
+                "num_workers_per_link": num_workers_per_link,
+                "num_buffers_per_channel": num_buffers_per_channel,
+                "sub_core_grids": sub_core_grids,
+            }
+            if use_explicit_subdevice_id:
+                all_gather_kwargs["subdevice_id"] = worker_sub_device_id
+            tt_all_gather_out_tensor = ttnn.all_gather(input_tensor_mesh_list[i], **all_gather_kwargs)
         else:
             logger.info(f"Using experimental all-gather")
-            tt_all_gather_out_tensor = all_gather_function(
-                input_tensor_mesh_list[i],
-                persistent_output_buffer=persistent_output_buffers[i] if use_persistent_buffers else None,
-                dim=dim,
-                multi_device_global_semaphore=ccl_semaphore_handles[i],
-                num_links=num_links,
-                memory_config=mem_config_ag,
-                topology=all_gather_topology,
-                subdevice_id=worker_sub_device_id,
-                barrier_semaphore=barrier_semaphore_handles[i] if use_barrier else None,
-                cluster_axis=cluster_axis,
-                chunks_per_sync=chunks_per_sync,
-                num_workers_per_link=num_workers_per_link,
-                num_buffers_per_channel=num_buffers_per_channel,
-                sub_core_grids=sub_core_grids,
-                use_broadcast=use_broadcast,
-            )
+            all_gather_async_kwargs = {
+                "persistent_output_buffer": persistent_output_buffers[i] if use_persistent_buffers else None,
+                "dim": dim,
+                "multi_device_global_semaphore": ccl_semaphore_handles[i],
+                "num_links": num_links,
+                "memory_config": mem_config_ag,
+                "topology": all_gather_topology,
+                "barrier_semaphore": barrier_semaphore_handles[i] if use_barrier else None,
+                "cluster_axis": cluster_axis,
+                "chunks_per_sync": chunks_per_sync,
+                "num_workers_per_link": num_workers_per_link,
+                "num_buffers_per_channel": num_buffers_per_channel,
+                "sub_core_grids": sub_core_grids,
+                "use_broadcast": use_broadcast,
+            }
+            if use_explicit_subdevice_id:
+                all_gather_async_kwargs["subdevice_id"] = worker_sub_device_id
+            tt_all_gather_out_tensor = all_gather_function(input_tensor_mesh_list[i], **all_gather_async_kwargs)
 
         return tt_all_gather_out_tensor
 

--- a/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
@@ -219,6 +219,41 @@ def test_all_gather_deepseek(
     ttnn.ReadDeviceProfiler(submesh_device)
 
 
+@skip_for_blackhole("This test is for wormhole")
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_linear"],
+)
+def test_all_gather_async_broadcast_without_explicit_subdevice(
+    mesh_device,
+    all_gather_topology,
+):
+    submesh_device = mesh_device.create_submesh(ttnn.MeshShape((1, 4)))
+    run_all_gather_impl(
+        submesh_device,
+        num_devices=4,
+        ag_output_shape=[1, 1, 32, 1024],
+        dim=3,
+        num_links=1,
+        ag_input_dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mem_config_input=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        mem_config_ag=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        all_gather_topology=all_gather_topology,
+        enable_trace=False,
+        num_iters=1,
+        cluster_axis=1,
+        use_broadcast=True,
+        use_explicit_subdevice_id=False,
+    )
+    ttnn.ReadDeviceProfiler(submesh_device)
+
+
 @pytest.mark.parametrize("num_links", [1], ids=["1links"])
 @pytest.mark.parametrize(
     "num_devices, ag_output_shape, dim, layout, ag_input_dtype",

--- a/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
@@ -254,6 +254,47 @@ def test_all_gather_async_broadcast_without_explicit_subdevice(
     ttnn.ReadDeviceProfiler(submesh_device)
 
 
+@skip_for_blackhole("This test is for wormhole")
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_linear"],
+)
+def test_all_gather_async_broadcast_rejects_noncontiguous_width_gather(
+    mesh_device,
+    all_gather_topology,
+):
+    submesh_device = mesh_device.create_submesh(ttnn.MeshShape((1, 4)))
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="Broadcast all-gather currently only supports gather dims whose preceding page-ordered dimensions are singleton",
+        ):
+            run_all_gather_impl(
+                submesh_device,
+                num_devices=4,
+                ag_output_shape=[1, 1, 64, 1024],
+                dim=3,
+                num_links=1,
+                ag_input_dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mem_config_input=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+                mem_config_ag=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+                all_gather_topology=all_gather_topology,
+                enable_trace=False,
+                num_iters=1,
+                cluster_axis=1,
+                use_broadcast=True,
+                use_explicit_subdevice_id=False,
+            )
+    finally:
+        submesh_device.reset_sub_device_stall_group()
+
+
 @pytest.mark.parametrize("num_links", [1], ids=["1links"])
 @pytest.mark.parametrize(
     "num_devices, ag_output_shape, dim, layout, ag_input_dtype",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
@@ -13,9 +13,32 @@
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/experimental/ccl/composite_common.hpp"
 
+#include <algorithm>
+
+#include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/math.hpp>
 
 namespace ttnn::experimental::prim {
+
+namespace {
+
+bool via_broadcast_has_contiguous_output_slice(const Tensor& input_tensor, int32_t gather_dim) {
+    const auto padded_shape = input_tensor.padded_shape();
+    std::vector<uint32_t> page_extents(padded_shape.begin(), padded_shape.end());
+    if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
+        TT_FATAL(page_extents.size() >= 2, "Broadcast all-gather requires rank >= 2 for tile layout");
+        page_extents[page_extents.size() - 2] =
+            tt::div_up(page_extents[page_extents.size() - 2], tt::constants::TILE_HEIGHT);
+        page_extents[page_extents.size() - 1] =
+            tt::div_up(page_extents[page_extents.size() - 1], tt::constants::TILE_WIDTH);
+    }
+
+    return std::all_of(
+        page_extents.begin(), page_extents.begin() + gather_dim, [](const auto& extent) { return extent == 1; });
+}
+
+}  // namespace
 
 AllGatherAsyncVersion select_version(const AllGatherAsyncParams& operation_attributes) {
     // Check for minimal sharded case
@@ -167,6 +190,16 @@ void AllGatherAsyncDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(input_tensor.logical_shape().rank() >= 2, "AllGatherAsync requires tensor of rank 2 or greater");
     } else {
         TT_FATAL(input_tensor.logical_shape().rank() == 4, "Llama specific all_gather requires tensor of rank 4");
+    }
+
+    if (version == AllGatherAsyncVersion::VIA_BROADCAST) {
+        TT_FATAL(
+            via_broadcast_has_contiguous_output_slice(input_tensor, args.dim),
+            "Broadcast all-gather currently only supports gather dims whose preceding page-ordered dimensions are "
+            "singleton. Got dim {} with padded shape {} and layout {}",
+            args.dim,
+            input_tensor.padded_shape(),
+            input_tensor.layout());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
@@ -24,7 +24,7 @@ namespace ttnn::experimental::prim {
 namespace {
 
 bool via_broadcast_has_contiguous_output_slice(const Tensor& input_tensor, int32_t gather_dim) {
-    const auto padded_shape = input_tensor.padded_shape();
+    const auto& padded_shape = input_tensor.padded_shape();
     std::vector<uint32_t> page_extents(padded_shape.begin(), padded_shape.end());
     if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
         TT_FATAL(page_extents.size() >= 2, "Broadcast all-gather requires rank >= 2 for tile layout");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
@@ -102,7 +102,6 @@ AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::cre
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
 
-    TT_ASSERT(operation_attributes.sub_device_id.has_value(), "function currently does not support subdevices");
     auto sender_worker_core_range =
         get_cores_close_to_erisc(operation_attributes.num_links * num_workers_per_link, true);
     auto sender_worker_cores = corerange_to_cores(sender_worker_core_range);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp
@@ -116,12 +116,16 @@ AllGatherViaBroadcastFactory::cached_program_t AllGatherViaBroadcastFactory::cre
         cb_page_size *= 4;
     }
 
-    // per device input and output page numbers
-    uint32_t num_input_pages = input_tensor.buffer()->num_pages();
-    for (uint32_t i = 0; i < operation_attributes.dim; ++i) {
-        num_input_pages /= input_tensor.logical_shape()[i];
-    }
-    uint32_t num_output_pages = (num_input_pages * input_page_size) / output_page_size;
+    // Per-device page counts are defined by the local shard buffer, not by raw logical dims.
+    // Converting pages via logical_shape() breaks tiled tensors and can zero out num_input_pages.
+    const uint32_t num_input_pages = input_tensor.buffer()->num_pages();
+    TT_FATAL(num_input_pages > 0, "Broadcast all-gather requires at least one input page");
+    TT_FATAL(
+        (num_input_pages * input_page_size) % output_page_size == 0,
+        "Broadcast all-gather requires per-device bytes ({}) to be divisible by output page size ({})",
+        num_input_pages * input_page_size,
+        output_page_size);
+    const uint32_t num_output_pages = (num_input_pages * input_page_size) / output_page_size;
     // offset into the gathered tensor
     uint32_t write_page_offset = num_output_pages * ring_index;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
@@ -209,9 +209,11 @@ void kernel_main() {
                 break;
             };
             auto out_page_start = l1_read_addr + output * out_page_size;
-            auto tensor_page_addr = tensor0_addrgen.get_noc_addr(page_id + output, 0);
-            writer.send(out_page_start, tensor_page_addr);
-            noc_async_write(out_page_start, tensor_page_addr, out_page_size);
+            auto local_tensor_page_addr = tensor0_addrgen.get_noc_addr(page_id + output, 0);
+            auto fabric_tensor_page_addr =
+                tt::tt_fabric::linear::addrgen_detail::get_noc_address(tensor0_addrgen, page_id + output, 0);
+            writer.send(out_page_start, fabric_tensor_page_addr);
+            noc_async_write(out_page_start, local_tensor_page_addr, out_page_size);
         }
         page_id += outputs_per_cb_page;
 


### PR DESCRIPTION
## Summary
- remove the stale explicit-subdevice requirement from the broadcast all-gather TTNN path
- drop the DeepSeek `SubDeviceId(0)` workaround that was added to satisfy that stale assert
- keep the fix scoped to the actual API bug instead of forcing the demo onto an explicit-subdevice path

## Root Cause
The broadcast all-gather factory already has a default-subdevice fallback derived from the mesh device, but `AllGatherViaBroadcastFactory::create_at` still asserted that `sub_device_id` had to be provided explicitly.

That made `models/demos/deepseek_v3/tt/mla/mla1d.py` add `subdevice_id=ttnn.SubDeviceId(0)` as a workaround. In the full DeepSeek demo path, that is not paired with the subdevice-manager / stall-group setup used by the focused unit tests, so the `profile_decode` path could enter a mixed default-mesh / explicit-subdevice execution context and hang after the first MoE block.

## Validation
- local rebuild of `ttnn/_ttnn.so`
- `pytest -svv models/demos/deepseek_v3/demo/test_demo.py -k profile_decode --timeout=1500`
  - before fix: local repro stalled after `first_moe_layer`
  - after fix: `PASSED` (`1 passed, 10 deselected`, `9.59s`)

## CI requested
- `(Galaxy) perf tests` with `model=deepseek_v3`
- `(Galaxy) DeepSeek tests` with `test-type=all`

Fixes #42044.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=codex/deepseek-broadcast-default-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=codex/deepseek-broadcast-default-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=codex/deepseek-broadcast-default-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=codex/deepseek-broadcast-default-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=codex/deepseek-broadcast-default-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=codex/deepseek-broadcast-default-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/deepseek-broadcast-default-subdevice) |