### PR TITLE
Add per core allcator mode to overlap_tensors function

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -463,6 +463,11 @@ def test_o_proj_tp4_shuffled_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, me
     in one ``overlap_tensors`` call).  Per mesh device, o_proj is the ``shuffle_q_a`` pack of the
     ``(8192, 1792)`` slice (``tp_dim=(1, 0)``), shard ``(4096, 32)`` on 112 cores.
     """
+    import os
+
+    if os.environ.get("TT_METAL_ALLOCATOR_MODE_HYBRID", "0") != "1":
+        pytest.skip("Requires TT_METAL_ALLOCATOR_MODE_HYBRID=1 for per-core allocation")
+
     num_devices = mesh_rows * mesh_cols
     if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -506,7 +506,7 @@ def test_o_proj_tp4_shuffled_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, me
         kv_raw,
         submesh,
         o_proj_dtype=o_proj_dtype,
-        mla_proj_dtype=o_proj_dtype,
+        q_ab_dtype=o_proj_dtype,
     )
     o_proj = fused["o_proj"]
     gate_mm = fused["gate_mm"]

--- a/models/demos/deepseek_v3_b1/weights/overlap/__init__.py
+++ b/models/demos/deepseek_v3_b1/weights/overlap/__init__.py
@@ -7,6 +7,7 @@
 from models.demos.deepseek_v3_b1.weights.overlap.packing import (
     OverlapEntry,
     OverlappedTensor,
+    assert_uniform_per_core_addresses,
     overlap_tensors,
 )
 from models.demos.deepseek_v3_b1.weights.overlap.spec import (
@@ -18,6 +19,7 @@ __all__ = [
     "OverlapEntry",
     "OverlappedTensor",
     "OverlappedTensorSpec",
+    "assert_uniform_per_core_addresses",
     "max_shard_bytes",
     "overlap_tensors",
 ]

--- a/models/demos/deepseek_v3_b1/weights/overlap/packing.py
+++ b/models/demos/deepseek_v3_b1/weights/overlap/packing.py
@@ -13,6 +13,28 @@ import ttnn
 from models.demos.deepseek_v3_b1.weights.overlap.spec import OverlappedTensorSpec, _core_list, _greedy_place
 
 
+def assert_uniform_per_core_addresses(tensor: ttnn.Tensor, cores: list[tuple[int, int]]) -> None:
+    """Assert that a per-core allocated tensor has the same L1 address on every core.
+
+    Per-core allocation bypasses lockstep, giving each core an independent L1
+    address.  The overlap system relies on CB setup broadcasting a single base
+    address to all cores, so addresses *must* be uniform.  This holds when the
+    tensor is the first per-core allocation on the device.
+    """
+    if not cores:
+        return
+    first = ttnn.CoreCoord(*cores[0])
+    addr0 = tensor.experimental_per_core_buffer_address(first)
+    for x, y in cores[1:]:
+        cc = ttnn.CoreCoord(x, y)
+        addr = tensor.experimental_per_core_buffer_address(cc)
+        assert addr == addr0, (
+            f"Per-core overlap buffer has non-uniform L1 addresses: "
+            f"core ({first.x},{first.y})=0x{addr0:x} vs core ({x},{y})=0x{addr:x}. "
+            f"Ensure this is the first per-core allocation on the device."
+        )
+
+
 def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedTensorSpec) -> bytes:
     match spec.dtype:
         case ttnn.bfloat8_b:
@@ -43,6 +65,7 @@ def overlap_tensors(
     entries: list[OverlapEntry],
     device: ttnn.Device,
     move_to_device: bool = True,
+    per_core: bool = False,
 ) -> dict[str, OverlappedTensor]:
     """Overlap a list of tensors into a single fused tensor.
 
@@ -66,6 +89,12 @@ def overlap_tensors(
         entries: A flat list of ``OverlapEntry`` items.
         device: The mesh device to place the fused tensor on.
         move_to_device: If True (default), place the result on device.
+        per_core: If True, use per-core L1 allocation instead of lockstep.
+            Eliminates the lockstep memory tax on cores not in the fused
+            buffer.  Must be the first per-core allocation on the device
+            so that all cores receive the same L1 address.  Falls back to
+            lockstep silently when ``TT_METAL_ALLOCATOR_MODE_HYBRID=1``
+            is not set.
 
     Returns:
         A dict of ``OverlappedTensor`` views, keyed by tensor name.
@@ -153,6 +182,8 @@ def overlap_tensors(
         ttnn.BufferType.L1,
         shard_spec,
     )
+    if per_core:
+        mem_config.experimental_set_per_core_allocation(True)
 
     if num_devices == 1:
         mesh_mapper = ttnn.ReplicateTensorToMesh(device)
@@ -168,6 +199,9 @@ def overlap_tensors(
         memory_config=mem_config,
         mesh_mapper=mesh_mapper,
     )
+
+    if per_core and move_to_device:
+        assert_uniform_per_core_addresses(fused, all_cores_deduped)
 
     result = {}
     for eidx, entry in enumerate(entries):

--- a/models/demos/deepseek_v3_b1/weights/transforms/attention.py
+++ b/models/demos/deepseek_v3_b1/weights/transforms/attention.py
@@ -182,9 +182,14 @@ def fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
     mla_proj_dtype: ttnn.DataType = ttnn.bfloat8_b,
     move_to_device: bool = True,
 ) -> dict[str, OverlappedTensor]:
-    """Fuse TP4 ``shuffle_q_a`` o_proj, gate_mm, norms, and q_a / q_b / kv_a into one L1 buffer.
+    """Fuse TP4 ``shuffle_q_a`` o_proj, norms, and q_a / q_b / kv_a into one per-core L1 buffer.
+
+    ``gate_mm`` is excluded from the overlap and returned as a standalone
+    ``OverlappedTensor`` backed by its own per-core allocated tensor, avoiding
+    lockstep L1 reservation on the ~115 cores used by the fused buffer.
 
     Requires a **4×2** mesh.  ``o_proj_weights`` shape ``(16384, 7168)``.
+    Must be the first per-core allocation on the device.
     """
     o_cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
     q_cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
@@ -219,10 +224,9 @@ def fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
         q_cfg, mesh_shape, q_a_proj_weights, q_b_proj_weights, kv_a_proj_weights, mla_proj_dtype
     )
 
-    return overlap_tensors(
+    result = overlap_tensors(
         [
             OverlapEntry("o_proj", o_packed, o_spec),
-            OverlapEntry("gate_mm", gate_mm_weights, o_cfg.gate_mm),
             OverlapEntry("attn_norm", attn_norm, o_cfg.attn_norm),
             OverlapEntry("q_norm", q_norm, o_cfg.q_norm),
             OverlapEntry("ffn_norm", ffn_norm, o_cfg.ffn_norm),
@@ -231,7 +235,18 @@ def fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
         ],
         device=device,
         move_to_device=move_to_device,
+        per_core=True,
     )
+
+    gate_mm_result = overlap_tensors(
+        [OverlapEntry("gate_mm", gate_mm_weights, o_cfg.gate_mm)],
+        device=device,
+        move_to_device=move_to_device,
+        per_core=True,
+    )
+    result["gate_mm"] = gate_mm_result["gate_mm"]
+
+    return result
 
 
 def fuse_kv_b12(

--- a/models/demos/deepseek_v3_b1/weights/transforms/attention.py
+++ b/models/demos/deepseek_v3_b1/weights/transforms/attention.py
@@ -72,9 +72,17 @@ def _make_q_ab_kv_a_overlap_entries(
     q_a_proj_weights: torch.Tensor,
     q_b_proj_weights: torch.Tensor,
     kv_a_proj_weights: torch.Tensor,
-    dtype: ttnn.DataType,
+    q_ab_dtype: ttnn.DataType,
+    kv_a_dtype: ttnn.DataType | None = None,
 ) -> list[OverlapEntry]:
-    """Validate MLA proj weights and build three :class:`OverlapEntry` items (no I/O)."""
+    """Validate MLA proj weights and build three :class:`OverlapEntry` items (no I/O).
+
+    When ``kv_a_dtype`` is ``None`` (used by :func:`fuse_q_ab_kv_a`) it
+    defaults to ``q_ab_dtype``.
+    """
+    if kv_a_dtype is None:
+        kv_a_dtype = q_ab_dtype
+
     q_b_tp = cfg.q_b_shard_spec.tp(mesh_shape)
 
     assert (
@@ -100,17 +108,17 @@ def _make_q_ab_kv_a_overlap_entries(
         OverlapEntry(
             "q_a_proj",
             q_a_packed,
-            replace(cfg.q_a_shard_spec, raw_tensor_shape=tuple(q_a_packed.shape), dtype=dtype),
+            replace(cfg.q_a_shard_spec, raw_tensor_shape=tuple(q_a_packed.shape), dtype=q_ab_dtype),
         ),
         OverlapEntry(
             "q_b_proj",
             q_b_preprocessed,
-            replace(cfg.q_b_shard_spec, raw_tensor_shape=tuple(q_b_preprocessed.shape), dtype=dtype),
+            replace(cfg.q_b_shard_spec, raw_tensor_shape=tuple(q_b_preprocessed.shape), dtype=q_ab_dtype),
         ),
         OverlapEntry(
             "kv_a_proj",
             kv_reordered,
-            replace(cfg.kv_a_shard_spec, raw_tensor_shape=tuple(kv_reordered.shape), dtype=dtype),
+            replace(cfg.kv_a_shard_spec, raw_tensor_shape=tuple(kv_reordered.shape), dtype=kv_a_dtype),
         ),
     ]
 
@@ -179,7 +187,8 @@ def fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
     device,
     *,
     o_proj_dtype: ttnn.DataType = ttnn.bfloat8_b,
-    mla_proj_dtype: ttnn.DataType = ttnn.bfloat8_b,
+    q_ab_dtype: ttnn.DataType = ttnn.bfloat8_b,
+    kv_a_dtype: ttnn.DataType = ttnn.bfloat8_b,
     move_to_device: bool = True,
 ) -> dict[str, OverlappedTensor]:
     """Fuse TP4 ``shuffle_q_a`` o_proj, norms, and q_a / q_b / kv_a into one per-core L1 buffer.
@@ -221,7 +230,7 @@ def fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
     )
 
     q_entries = _make_q_ab_kv_a_overlap_entries(
-        q_cfg, mesh_shape, q_a_proj_weights, q_b_proj_weights, kv_a_proj_weights, mla_proj_dtype
+        q_cfg, mesh_shape, q_a_proj_weights, q_b_proj_weights, kv_a_proj_weights, q_ab_dtype, kv_a_dtype
     )
 
     result = overlap_tensors(

--- a/models/demos/deepseek_v3_b1/weights/transforms/attention.py
+++ b/models/demos/deepseek_v3_b1/weights/transforms/attention.py
@@ -73,16 +73,9 @@ def _make_q_ab_kv_a_overlap_entries(
     q_b_proj_weights: torch.Tensor,
     kv_a_proj_weights: torch.Tensor,
     q_ab_dtype: ttnn.DataType,
-    kv_a_dtype: ttnn.DataType | None = None,
+    kv_a_dtype: ttnn.DataType,
 ) -> list[OverlapEntry]:
-    """Validate MLA proj weights and build three :class:`OverlapEntry` items (no I/O).
-
-    When ``kv_a_dtype`` is ``None`` (used by :func:`fuse_q_ab_kv_a`) it
-    defaults to ``q_ab_dtype``.
-    """
-    if kv_a_dtype is None:
-        kv_a_dtype = q_ab_dtype
-
+    """Validate MLA proj weights and build three :class:`OverlapEntry` items (no I/O)."""
     q_b_tp = cfg.q_b_shard_spec.tp(mesh_shape)
 
     assert (
@@ -136,7 +129,7 @@ def fuse_q_ab_kv_a(
     cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
     mesh_shape = (device.shape[0], device.shape[1]) if device.get_num_devices() > 1 else (1, 1)
     entries = _make_q_ab_kv_a_overlap_entries(
-        cfg, mesh_shape, q_a_proj_weights, q_b_proj_weights, kv_a_proj_weights, dtype
+        cfg, mesh_shape, q_a_proj_weights, q_b_proj_weights, kv_a_proj_weights, dtype, dtype
     )
     return overlap_tensors(entries, device=device, move_to_device=move_to_device)
 


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kwerblinskiTT/per_core_mode_in_overlap_tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kwerblinskiTT/per_core_mode_in_overlap_tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kwerblinskiTT/per_core_mode_in_overlap_tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kwerblinskiTT/per_core_mode_in_overlap_tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kwerblinskiTT/per_core_mode_in_overlap_tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kwerblinskiTT/per_core_mode_in_overlap_tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/per_core_mode_in_overlap_tensors) |