### PR TITLE
[GPT-OSS] Enable test_bad_words in vllm-nightly sampling tests

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -107,7 +107,6 @@ jobs:
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32 --async-scheduling",
               "structured-output": true,
               "sampling-tests": true,
-              "sampling-test-filter": "not test_bad_words",
               "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",
               "co-owner-2-id": "U06F3ER8X9A"


### PR DESCRIPTION
Remove the sampling-test-filter that excluded test_bad_words from GPT-OSS-120B high-throughput nightly tests.

Ticket: https://github.com/tenstorrent/tt-metal/issues/40605

vllm-nightly run: https://github.com/tenstorrent/tt-metal/actions/runs/24506530698

