### PR TITLE
Fix multi-host mesh trace capture TT_FATAL on remote device coordinates

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1099,21 +1099,27 @@ void FDMeshCommandQueue::record_end() {
     // trace to ensure they are equal at the end.
 
     // Calculate device ranges that have an identical set of programs that run on them (including no programs at all).
-    std::vector<MeshCoordinateRange> device_ranges{MeshCoordinateRange{mesh_device_->shape()}};
+    // Restrict to the local mesh partition so that multi-host traces only process locally-owned devices.
+    auto local_mesh_range = mesh_device_->get_view().get_local_mesh_coord_range();
+    std::vector<MeshCoordinateRange> device_ranges{local_mesh_range};
     for (auto& trace_node : trace_nodes_) {
         for (auto& [device_range, program] : trace_node.trace_nodes) {
+            auto local_device_range = local_mesh_range.intersection(device_range);
+            if (!local_device_range.has_value()) {
+                continue;
+            }
             bool intersection_found = false;
             std::vector<size_t> device_range_idxs_to_invalidate;
             for (size_t i = 0; i < device_ranges.size(); i++) {
                 auto& existing_range = device_ranges[i];
                 TT_FATAL(
-                    existing_range.dims() == device_range.dims(),
+                    existing_range.dims() == local_device_range->dims(),
                     "Invalid mismatching dimensions for existing {} vs device range {}",
                     existing_range.dims(),
-                    device_range.dims());
-                if (existing_range.intersects(device_range)) {
+                    local_device_range->dims());
+                if (existing_range.intersects(*local_device_range)) {
                     intersection_found = true;
-                    auto intersection = *existing_range.intersection(device_range);
+                    auto intersection = *existing_range.intersection(*local_device_range);
                     if (intersection != existing_range) {
                         auto complement = subtract(existing_range, intersection);
                         device_range_idxs_to_invalidate.push_back(i);
@@ -1135,7 +1141,7 @@ void FDMeshCommandQueue::record_end() {
                         device_ranges.end());
                 }
             } else {
-                device_ranges.push_back(device_range);
+                device_ranges.push_back(*local_device_range);
             }
         }
     }


### PR DESCRIPTION
### Summary

Bug fix. Fixes #42137

PR #41094 rewrote the mesh trace dispatch path (`FDMeshCommandQueue::record_end()`) to use deferred `TraceNode` assembly. The new code computed `device_ranges` starting from the full mesh shape and later called `mesh_device_->get_device(range.start_coord())` on each range to obtain a `sysmem_manager` for trace data generation. In multi-host (DUAL) deployments, some ranges cover only remote devices, and `MeshDeviceViewImpl::get_device()` fatals on remote coordinates:

```
TT_FATAL: Cannot get device for remote device at coordinate MeshCoordinate([3, 1])
```

The old implementation explicitly intersected program ranges with the local mesh view before touching device-local state. This PR restores that filtering by:

1. Seeding `device_ranges` with the local mesh partition (`get_local_mesh_coord_range()`) instead of the full mesh shape.
2. Intersecting each trace node's `device_range` with the local range before feeding it into the range-splitting algorithm, skipping fully-remote program ranges.

This ensures all coordinates in `device_ranges` are guaranteed local, so `get_device(range.start_coord())` never hits a remote coordinate. Ranges covering only remote devices are handled by their owning host independently.

### Notes for reviewers

The key change is small — two lines to restrict `device_ranges` to the local partition and a few lines to clip each trace node's device range to the local mesh before the splitting loop. The rest of the diff is mechanical: replacing `device_range` with `*local_device_range` inside the loop body.

Devices with no local programs still get correct trace data (dummy GO signals for dispatch state equalization), matching the pre-#41094 behavior.

Validated: multi-host trace tests (`test_dual_galaxy_mesh_device_trace`, `test_quad_galaxy_mesh_device_trace`) and DeepSeek multi-host module tests via `multi-host-physical.yaml` and `multi-host-deepseekv3.yaml`.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fixmultidevicetrace) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fixmultidevicetrace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fixmultidevicetrace) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fixmultidevicetrace) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixmultidevicetrace) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fixmultidevicetrace)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixmultidevicetrace) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixmultidevicetrace) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixmultidevicetrace) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fixmultidevicetrace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixmultidevicetrace) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixmultidevicetrace) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixmultidevicetrace) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fixmultidevicetrace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixmultidevicetrace) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixmultidevicetrace) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixmultidevicetrace) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fixmultidevicetrace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixmultidevicetrace) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixmultidevicetrace) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixmultidevicetrace) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fixmultidevicetrace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixmultidevicetrace) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixmultidevicetrace) |