### PR TITLE
Hzhou/moe+mla

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -198,7 +198,8 @@ jobs:
             (test_ds_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
             (test_ds_mul_device_perf and ((decode and 1) or (prefill and 128))) or
             (test_ds_reduce_scatter_post_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_all_gather_preff1_3_device_perf and ((decode and 1) or (prefill and 128)))
+            (test_ds_all_gather_preff1_3_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_moe_forward_device_perf and ((decode and 1) or (prefill and 128)))
           )'
           CI_FUSED_OP_DEVICE_PERF_K_EXPR="$(printf '%s' "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" | tr '\n' ' ' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')"
           pytest models/demos/deepseek_v3/tests/fused_op_unit_tests -k "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" --timeout 600 --durations=0

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -199,7 +199,8 @@ jobs:
             (test_ds_mul_device_perf and ((decode and 1) or (prefill and 128))) or
             (test_ds_reduce_scatter_post_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
             (test_ds_all_gather_preff1_3_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_moe_forward_device_perf and ((decode and 1) or (prefill and 128)))
+            (test_ds_moe_forward_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_mla_forward_device_perf and ((decode and 1) or (prefill and 128)))
           )'
           CI_FUSED_OP_DEVICE_PERF_K_EXPR="$(printf '%s' "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" | tr '\n' ' ' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')"
           pytest models/demos/deepseek_v3/tests/fused_op_unit_tests -k "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" --timeout 600 --durations=0

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -94,7 +94,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         ARCH_NAME: ${{ matrix.test-group.arch }}
-        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized
+        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
         DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
         MESH_DEVICE: TG
         # Required for BenchmarkData to save to Superset

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -94,7 +94,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         ARCH_NAME: ${{ matrix.test-group.arch }}
-        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
+        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized
         DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
         MESH_DEVICE: TG
         # Required for BenchmarkData to save to Superset
@@ -124,7 +124,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Prepare custom DeepSeek cache directory
+      - name: Prepare custom weights cache directory
         if: ${{ inputs.recreate_weights_cache == 'Yes' }}
         env:
           INPUT_CACHE_DIR: ${{ inputs.new_cache_dir }}
@@ -154,8 +154,6 @@ jobs:
           echo "Copying test_io_cache from CI directory..."
           rm -rf "${NEW_DIR}/test_io_cache"
           cp -r "${CACHE_BASE}/CI/test_io_cache" "${NEW_DIR}/test_io_cache"
-          echo "Clearing tests_cache so this workflow regenerates it in the current DeepSeek cache format..."
-          rm -rf "${NEW_DIR}/tests_cache"
           chmod -R a+rwX "${NEW_DIR}"
           echo "DEEPSEEK_V3_CACHE=${NEW_DIR}" >> $GITHUB_ENV
       - name: Run DeepSeek unit tests
@@ -164,6 +162,11 @@ jobs:
         run: |
           uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
           pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
+      - name: Validate weight cache
+        if: ${{ matrix.test-group.test-type == 'module' || matrix.test-group.test-type == 'final-op-unit' }}
+        timeout-minutes: 10
+        run: |
+          python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/tests_cache" || true
       - name: Run DeepSeek module tests
         if: ${{ matrix.test-group.test-type == 'module' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
@@ -172,7 +175,7 @@ jobs:
           pytest models/demos/deepseek_v3/tests -x \
             --ignore=models/demos/deepseek_v3/tests/unit \
             --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests \
-            -m "not t3k_compat" \
+            --ignore=models/demos/deepseek_v3/tests/t3k_compat \
             --timeout 600 --durations=0
       - name: Run DeepSeek op unit tests (Device Performance)
         if: ${{ matrix.test-group.test-type == 'final-op-unit' }}
@@ -183,23 +186,27 @@ jobs:
           echo "=============================================="
           echo "Device Performance Tests"
           echo "=============================================="
-          bash models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_device_perf_tracy.sh
+          echo "DeepSeek fused-op device perf tests (CI-curated selection)"
+          CI_FUSED_OP_DEVICE_PERF_K_EXPR='
+          (
+            (test_ds_embedding_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_all_gather_embedding_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_lm_head_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_rms_norm_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_distributed_norm_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_ff1_3_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_mul_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_reduce_scatter_post_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_all_gather_preff1_3_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_moe_forward_device_perf and ((decode and 1) or (prefill and 128)))
+          )'
+          CI_FUSED_OP_DEVICE_PERF_K_EXPR="$(printf '%s' "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" | tr '\n' ' ' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')"
+          pytest models/demos/deepseek_v3/tests/fused_op_unit_tests -k "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" --timeout 600 --durations=0
 
           echo "=============================================="
           echo "All device perf tests completed!"
           echo "=============================================="
-      - name: Validate regenerated DeepSeek cache directory
-        # The shared CI cache root is still on the legacy format. Only validate
-        # branch-created/recreated cache directories that this workflow owns,
-        # after the current job has had a chance to regenerate tests_cache.
-        if: ${{ inputs.recreate_weights_cache == 'Yes' && (matrix.test-group.test-type == 'module' || matrix.test-group.test-type == 'final-op-unit') }}
-        timeout-minutes: 10
-        run: |
-          if [[ -d "$DEEPSEEK_V3_CACHE/tests_cache" ]]; then
-            python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/tests_cache"
-          else
-            echo "No DeepSeek tests_cache present under $DEEPSEEK_V3_CACHE after regeneration; skipping cache validation."
-          fi
       - name: Run DeepSeek long seq len module tests
         if: ${{ matrix.test-group.test-type == 'long-seq-module' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -186,24 +186,73 @@ jobs:
           echo "=============================================="
           echo "Device Performance Tests"
           echo "=============================================="
-          echo "DeepSeek fused-op device perf tests (CI-curated selection)"
-          CI_FUSED_OP_DEVICE_PERF_K_EXPR='
-          (
-            (test_ds_embedding_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_all_gather_embedding_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_lm_head_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_rms_norm_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_distributed_norm_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_ff1_3_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_mul_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_reduce_scatter_post_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_all_gather_preff1_3_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_moe_forward_device_perf and ((decode and 1) or (prefill and 128))) or
-            (test_ds_mla_forward_device_perf and ((decode and 1) or (prefill and 128)))
-          )'
-          CI_FUSED_OP_DEVICE_PERF_K_EXPR="$(printf '%s' "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" | tr '\n' ' ' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')"
-          pytest models/demos/deepseek_v3/tests/fused_op_unit_tests -k "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" --timeout 600 --durations=0
+          echo "DeepSeek fused-op device perf tests (direct Tracy calls)"
+          PROFILER_DIR="generated/profiler/deepseek_v3_fused_ops_device_perf"
+          TRACY_TIMEOUT_PORT=5000
+          TRACY_OP_SUPPORT_COUNT=10000
+
+          run_tracy_case() {
+            local name="$1"
+            local perf_env_var="$2"
+            local test_target="$3"
+            local k_expr="$4"
+
+            echo ""
+            echo "--------------------------------------------------------------------------------"
+            echo "Case: $name"
+            echo "Target: $test_target"
+            echo "Expr: $k_expr"
+            echo "--------------------------------------------------------------------------------"
+
+            env "${perf_env_var}=1" python3 -m tracy -p -r \
+              -o "$PROFILER_DIR" \
+              --check-exit-code \
+              --op-support-count "$TRACY_OP_SUPPORT_COUNT" \
+              -t "$TRACY_TIMEOUT_PORT" \
+              -a device_kernel_duration \
+              -m "pytest $test_target -k \"$k_expr\""
+            sleep 10
+          }
+
+          # Embedding
+          run_tracy_case "embedding decode seq1 (trace+pcache)" "DS_EMBEDDING_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py::test_ds_embedding" "program_cache and not no_program_cache and trace and decode and 1 and real_weights"
+          run_tracy_case "embedding prefill seq128 (eager+pcache)" "DS_EMBEDDING_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py::test_ds_embedding" "program_cache and not no_program_cache and eager and prefill and 128 and real_weights"
+
+          # All-gather embedding
+          run_tracy_case "all_gather_embedding decode seq1 (trace+pcache)" "DS_ALL_GATHER_EMBEDDING_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py::test_ds_all_gather_embedding" "program_cache and not no_program_cache and trace and decode and 1"
+          run_tracy_case "all_gather_embedding prefill seq128 (eager+pcache)" "DS_ALL_GATHER_EMBEDDING_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py::test_ds_all_gather_embedding" "program_cache and not no_program_cache and eager and prefill and 128"
+
+          # LM head
+          run_tracy_case "lm_head decode seq1 (trace+pcache)" "DS_LM_HEAD_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py::test_ds_lm_head" "program_cache and not no_program_cache and trace and decode and 1 and real_weights"
+          run_tracy_case "lm_head prefill seq128 (eager+pcache)" "DS_LM_HEAD_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py::test_ds_lm_head" "program_cache and not no_program_cache and eager and prefill and 128 and real_weights"
+
+          # RMS norm
+          run_tracy_case "rms_norm decode seq1 (trace+pcache)" "DS_RMS_NORM_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py::test_ds_rms_norm" "program_cache and not no_program_cache and trace and decode and 1 and real_weights"
+          run_tracy_case "rms_norm prefill seq128 (eager+pcache)" "DS_RMS_NORM_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py::test_ds_rms_norm" "program_cache and not no_program_cache and eager and prefill and 128 and real_weights"
+
+          # Distributed norm
+          run_tracy_case "distributed_norm decode seq1 (trace+pcache)" "DS_DISTRIBUTED_NORM_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py::test_ds_distributed_norm" "program_cache and not no_program_cache and trace and decode and 1 and real_weights"
+          run_tracy_case "distributed_norm prefill seq128 (eager+pcache)" "DS_DISTRIBUTED_NORM_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py::test_ds_distributed_norm" "program_cache and not no_program_cache and eager and prefill and 128 and real_weights"
+
+          # MLP fused ops
+          run_tracy_case "ff1_3 decode seq1 (trace+pcache)" "DS_FF1_3_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py::test_ds_ff1_3" "program_cache and not no_program_cache and trace and decode and 1"
+          run_tracy_case "ff1_3 prefill seq128 (eager+pcache)" "DS_FF1_3_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py::test_ds_ff1_3" "program_cache and not no_program_cache and eager and prefill and 128"
+          run_tracy_case "ff2 decode seq1 (trace+pcache)" "DS_FF2_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py::test_ds_ff2" "program_cache and not no_program_cache and trace and decode and 1"
+          run_tracy_case "ff2 prefill seq128 (eager+pcache)" "DS_FF2_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py::test_ds_ff2" "program_cache and not no_program_cache and eager and prefill and 128"
+          run_tracy_case "mul decode seq1 (trace+pcache)" "DS_MUL_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py::test_ds_mul" "program_cache and not no_program_cache and trace and decode and 1"
+          run_tracy_case "mul prefill seq128 (eager+pcache)" "DS_MUL_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py::test_ds_mul" "program_cache and not no_program_cache and eager and prefill and 128"
+          run_tracy_case "reduce_scatter_post_ff2 decode seq1 (trace+pcache)" "DS_REDUCE_SCATTER_POST_FF2_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py::test_ds_reduce_scatter_post_ff2" "program_cache and not no_program_cache and trace and decode and 1"
+          run_tracy_case "reduce_scatter_post_ff2 prefill seq128 (eager+pcache)" "DS_REDUCE_SCATTER_POST_FF2_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py::test_ds_reduce_scatter_post_ff2" "program_cache and not no_program_cache and eager and prefill and 128"
+          run_tracy_case "all_gather_preff1_3 decode seq1 (trace+pcache)" "DS_ALL_GATHER_PREFF1_3_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py::test_ds_all_gather_preff1_3" "program_cache and not no_program_cache and trace and decode and 1"
+          run_tracy_case "all_gather_preff1_3 prefill seq128 (eager+pcache)" "DS_ALL_GATHER_PREFF1_3_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py::test_ds_all_gather_preff1_3" "program_cache and not no_program_cache and eager and prefill and 128"
+
+          # MoE fused op
+          run_tracy_case "moe decode seq1 (trace+pcache)" "DS_MOE_FORWARD_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py::test_ds_moe_forward" "test_ds_moe_forward and decode and 1 and real_weights and trace and program_cache and not no_program_cache"
+          run_tracy_case "moe prefill seq128 (eager+pcache)" "DS_MOE_FORWARD_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py::test_ds_moe_forward" "test_ds_moe_forward and prefill and 128 and real_weights and eager and program_cache and not no_program_cache"
+
+          # MLA fused op
+          run_tracy_case "mla decode seq1 (trace+pcache)" "DS_MLA_FORWARD_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py::test_ds_mla_forward" "test_ds_mla_forward and decode and 1 and real_weights and trace and program_cache and not no_program_cache"
+          run_tracy_case "mla prefill seq128 (eager+pcache)" "DS_MLA_FORWARD_DEVICE_PERF" "models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py::test_ds_mla_forward" "test_ds_mla_forward and prefill and 128 and real_weights and eager and program_cache and not no_program_cache"
 
           echo "=============================================="
           echo "All device perf tests completed!"

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import pytest
+from loguru import logger
+
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import collect_device_perf
+from models.demos.deepseek_v3.tests.test_mla import run_test_forward_pass_mla2d
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config
+from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+DEVICE_PERF_ENV_VAR = "DS_MLA_FORWARD_DEVICE_PERF"
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 0.0, "op_to_op": None},
+    ("prefill", 128): {"kernel": 0.0, "op_to_op": None},
+}
+
+
+@pytest.mark.timeout(1200)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": get_fabric_config(), "trace_region_size": 2967552},
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+    ],
+)
+@pytest.mark.parametrize("module_path", [pytest.param("model.layers.0.self_attn", id="real_weights")])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+def test_ds_mla_forward(
+    device_params,
+    mode,
+    seq_len,
+    module_path,
+    program_cache_enabled,
+    trace_mode,
+    hf_config_short,
+    cache_path,
+    mesh_device,
+    ccl,
+    model_path,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict,
+):
+    del set_deterministic_env
+    del device_params
+
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    perf_mode_enabled = os.getenv(DEVICE_PERF_ENV_VAR) is not None
+    if perf_mode_enabled:
+        logger.info(f"[{DEVICE_PERF_ENV_VAR}] MLA perf mode enabled")
+
+    batch_size_per_row = USERS_PER_ROW if mode == "decode" else 1
+    run_test_forward_pass_mla2d(
+        layer_idx=0,
+        mode=mode,
+        seq_len=seq_len,
+        batch_size_per_row=batch_size_per_row,
+        hf_config_short=hf_config_short,
+        cache_path=cache_path,
+        mesh_device=mesh_device,
+        ccl=ccl,
+        model_path=model_path,
+        module_path=module_path,
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        state_dict=state_dict,
+        decode_position_ids=None,
+        perf_mode=perf_mode_enabled,
+        trace_mode=trace_mode,
+        num_iters=DEVICE_PERF_ITERS,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+    ],
+)
+@pytest.mark.timeout(1800)
+def test_ds_mla_forward_device_perf(mode, seq_len):
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0] if mode == "decode" else 1
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_mla_forward_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = (
+        f"test_ds_mla_forward and {mode} and {seq_len} and real_weights and "
+        f"{trace_filter} and program_cache and not no_program_cache"
+    )
+    command = f'pytest {test_path}::test_ds_mla_forward -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=False,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    print(f"[DS_MLA_PERF] op_to_op_latency_us={total_op_to_op_us:.3f}, kernel_time_us={total_kernel_us:.3f}")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py
@@ -69,7 +69,7 @@ def test_ds_mla_forward(
     if perf_mode_enabled:
         logger.info(f"[{DEVICE_PERF_ENV_VAR}] MLA perf mode enabled")
 
-    batch_size_per_row = USERS_PER_ROW if mode == "decode" else 1
+    batch_size_per_row = USERS_PER_ROW
     run_test_forward_pass_mla2d(
         layer_idx=0,
         mode=mode,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from copy import deepcopy
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import collect_device_perf
+from models.demos.deepseek_v3.tests.test_moe import generate_reference_io
+from models.demos.deepseek_v3.tt.moe import MoE
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    assert_hidden_dim_pcc,
+    get_model_config,
+    get_test_weight_config,
+    run_module_forward,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+DEVICE_PERF_ENV_VAR = "DS_MOE_FORWARD_DEVICE_PERF"
+DEVICE_PERF_WARMUP_ITERS = 3
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 0.0, "op_to_op": None},
+    ("prefill", 128): {"kernel": 0.0, "op_to_op": None},
+}
+
+
+@pytest.fixture
+def reference_model(hf_config):
+    torch.use_deterministic_algorithms(True)
+    moe_config = deepcopy(hf_config)
+    moe_config.n_shared_experts = None
+    return DeepseekV3MoE(moe_config).eval()
+
+
+@pytest.mark.timeout(1200)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": get_fabric_config()},
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+@pytest.mark.parametrize("weight_type", [pytest.param("real", id="real_weights")])
+def test_ds_moe_forward(
+    device_params,
+    mode,
+    seq_len,
+    weight_type,
+    set_deterministic_env,
+    reference_model,
+    hf_config,
+    request,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+):
+    del set_deterministic_env
+    del weight_type
+
+    module_path = "model.layers.3.mlp"
+    checkpoint_state_dict = request.getfixturevalue("state_dict")
+    num_tokens = USERS_PER_ROW * mesh_device.shape[0] if mode == "decode" else seq_len
+    state_dict, torch_input, reference_output = generate_reference_io(
+        mode=mode,
+        num_tokens=num_tokens,
+        reference_model=reference_model,
+        hf_config=hf_config,
+        weight_type="real",
+        checkpoint_state_dict=checkpoint_state_dict,
+        module_path=module_path,
+    )
+
+    weight_config = get_test_weight_config(
+        MoE,
+        hf_config,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate=force_recalculate_weight_config,
+        test_name="test_ds_moe_forward",
+        real_weights=True,
+        layer_id=module_path,
+    )
+
+    model_config = get_model_config(
+        MoE, mode, hf_config, mesh_device, device_params["fabric_config"], topk_fallback=True
+    )
+    model_state = MoE.create_state(hf_config, mesh_device, ccl)
+    model_shared_state = MoE.create_shared_state(hf_config, mesh_device)
+    run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
+
+    def build_tt_input():
+        tt_input = ttnn.from_torch(
+            torch_input.unsqueeze(1),
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        return ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
+
+    def run_op():
+        tt_input = build_tt_input()
+        tt_output = run_module_forward(MoE, mode, tt_input, run_config, handle_tensor_parallel=True)
+        return tt_input, tt_output
+
+    tt_input, tt_output = run_op()
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
+    )
+    ttnn.deallocate(tt_input)
+    ttnn.deallocate(tt_output)
+
+    logger.info(f"Mode: {mode}, Num tokens: {num_tokens}, Weight type: real")
+    assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.97)
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is not None:
+        from tracy import signpost
+
+        def op_fn():
+            local_tt_input, local_tt_output = run_op()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(local_tt_input)
+            ttnn.deallocate(local_tt_output)
+
+        for _ in range(DEVICE_PERF_WARMUP_ITERS):
+            op_fn()
+
+        ttnn.synchronize_device(mesh_device)
+        signpost("start")
+        for _ in range(DEVICE_PERF_ITERS):
+            op_fn()
+        signpost("stop")
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+    ],
+)
+@pytest.mark.timeout(1800)
+def test_ds_moe_forward_device_perf(mode, seq_len):
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0] if mode == "decode" else 1
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_moe_forward_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py"
+    expr = f"test_ds_moe_forward and {mode} and {seq_len} and real_weights"
+    command = f'pytest {test_path}::test_ds_moe_forward -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
@@ -14,7 +14,7 @@ from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
 from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import collect_device_perf
 from models.demos.deepseek_v3.tests.test_moe import generate_reference_io
 from models.demos.deepseek_v3.tt.moe import MoE
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
@@ -47,7 +47,7 @@ def reference_model(hf_config):
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": get_fabric_config()},
+        {"fabric_config": get_fabric_config(), "trace_region_size": 2967552},
     ],
     indirect=True,
 )
@@ -63,11 +63,15 @@ def reference_model(hf_config):
     ],
 )
 @pytest.mark.parametrize("weight_type", [pytest.param("real", id="real_weights")])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
 def test_ds_moe_forward(
     device_params,
     mode,
     seq_len,
     weight_type,
+    program_cache_enabled,
+    trace_mode,
     set_deterministic_env,
     reference_model,
     hf_config,
@@ -80,18 +84,48 @@ def test_ds_moe_forward(
     del set_deterministic_env
     del weight_type
 
+    # Trace capture replays pre-compiled binaries. Without program cache,
+    # trace can trigger forbidden compile/program writes during capture.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    perf_mode_enabled = os.getenv(DEVICE_PERF_ENV_VAR) is not None
+    if perf_mode_enabled:
+        logger.info(
+            f"[{DEVICE_PERF_ENV_VAR}] Device perf mode enabled; running initial setup and correctness pass first"
+        )
+
     module_path = "model.layers.3.mlp"
     checkpoint_state_dict = request.getfixturevalue("state_dict")
     num_tokens = USERS_PER_ROW * mesh_device.shape[0] if mode == "decode" else seq_len
-    state_dict, torch_input, reference_output = generate_reference_io(
-        mode=mode,
-        num_tokens=num_tokens,
-        reference_model=reference_model,
-        hf_config=hf_config,
-        weight_type="real",
-        checkpoint_state_dict=checkpoint_state_dict,
-        module_path=module_path,
-    )
+    if perf_mode_enabled:
+        # Perf runs should not depend on reference IO cache files or host-side PCC checks.
+        # Keep real MoE weights (layer-scoped), but use synthetic input for faster bring-up.
+        state_dict = {
+            name: tensor
+            for name, tensor in sub_state_dict(checkpoint_state_dict, module_path + ".").items()
+            if not name.startswith("shared_experts.") and not name.endswith(".weight_scale_inv")
+        }
+        if not state_dict:
+            pytest.skip(f"Checkpoint does not contain routed MoE weights under '{module_path}'")
+        torch_input = torch.randn(1, num_tokens, hf_config.hidden_size, dtype=torch.bfloat16)
+        reference_output = None
+        logger.info(
+            f"[{DEVICE_PERF_ENV_VAR}] Using synthetic input in perf mode (skipping reference IO cache dependency)"
+        )
+    else:
+        state_dict, torch_input, reference_output = generate_reference_io(
+            mode=mode,
+            num_tokens=num_tokens,
+            reference_model=reference_model,
+            hf_config=hf_config,
+            weight_type="real",
+            checkpoint_state_dict=checkpoint_state_dict,
+            module_path=module_path,
+        )
 
     weight_config = get_test_weight_config(
         MoE,
@@ -105,8 +139,10 @@ def test_ds_moe_forward(
         layer_id=module_path,
     )
 
+    # MoE gate topk fallback performs host IO (to_torch/from_torch), which is illegal during trace capture.
+    # Match fused-op trace behavior by forcing pure device topk path when trace_mode is enabled.
     model_config = get_model_config(
-        MoE, mode, hf_config, mesh_device, device_params["fabric_config"], topk_fallback=True
+        MoE, mode, hf_config, mesh_device, device_params["fabric_config"], topk_fallback=not trace_mode
     )
     model_state = MoE.create_state(hf_config, mesh_device, ccl)
     model_shared_state = MoE.create_shared_state(hf_config, mesh_device)
@@ -129,33 +165,60 @@ def test_ds_moe_forward(
         return tt_input, tt_output
 
     tt_input, tt_output = run_op()
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
-    )
-    ttnn.deallocate(tt_input)
-    ttnn.deallocate(tt_output)
+    if perf_mode_enabled:
+        ttnn.deallocate(tt_input)
+        ttnn.deallocate(tt_output)
+        logger.info(f"Mode: {mode}, Num tokens: {num_tokens}, Weight type: real")
+        logger.info(f"[{DEVICE_PERF_ENV_VAR}] Skipping correctness PCC check in perf mode")
+    else:
+        tt_output_torch = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
+        )
+        ttnn.deallocate(tt_input)
+        ttnn.deallocate(tt_output)
+        logger.info(f"Mode: {mode}, Num tokens: {num_tokens}, Weight type: real")
+        assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.97)
 
-    logger.info(f"Mode: {mode}, Num tokens: {num_tokens}, Weight type: real")
-    assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.97)
-
-    if os.getenv(DEVICE_PERF_ENV_VAR) is not None:
+    if perf_mode_enabled:
         from tracy import signpost
 
-        def op_fn():
+        def eager_op_fn():
             local_tt_input, local_tt_output = run_op()
             ttnn.synchronize_device(mesh_device)
             ttnn.deallocate(local_tt_input)
             ttnn.deallocate(local_tt_output)
 
-        for _ in range(DEVICE_PERF_WARMUP_ITERS):
-            op_fn()
+        logger.info(f"[{DEVICE_PERF_ENV_VAR}] Correctness pass complete; entering profiled iteration loops")
+        logger.info(f"[{DEVICE_PERF_ENV_VAR}] Starting warmup phase with {DEVICE_PERF_WARMUP_ITERS} iteration(s)")
+        if trace_mode:
+            trace_input = build_tt_input()
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            trace_output = run_module_forward(MoE, mode, trace_input, run_config, handle_tensor_parallel=True)
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            for _ in range(DEVICE_PERF_WARMUP_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            logger.info(f"[{DEVICE_PERF_ENV_VAR}] Starting perf measurement with {DEVICE_PERF_ITERS} iteration(s)")
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(trace_input)
+            ttnn.deallocate(trace_output)
+        else:
+            for _ in range(DEVICE_PERF_WARMUP_ITERS):
+                eager_op_fn()
 
-        ttnn.synchronize_device(mesh_device)
-        signpost("start")
-        for _ in range(DEVICE_PERF_ITERS):
-            op_fn()
-        signpost("stop")
+            ttnn.synchronize_device(mesh_device)
+            logger.info(f"[{DEVICE_PERF_ENV_VAR}] Starting perf measurement with {DEVICE_PERF_ITERS} iteration(s)")
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                eager_op_fn()
+            signpost("stop")
 
 
 @pytest.mark.parametrize(
@@ -177,7 +240,8 @@ def test_ds_moe_forward_device_perf(mode, seq_len):
     benchmark_data = BenchmarkData()
     step_name = f"ds_moe_forward_device_perf_{mode}_seq{seq_len}"
     test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py"
-    expr = f"test_ds_moe_forward and {mode} and {seq_len} and real_weights"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len} and real_weights"
     command = f'pytest {test_path}::test_ds_moe_forward -k "{expr}"'
 
     perf_profiler.start("run")

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
@@ -262,6 +262,7 @@ def test_ds_moe_forward_device_perf(mode, seq_len):
     total_op_to_op_us = total_op_to_op_ns / 1000.0
     logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
     logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    print(f"[DS_MOE_PERF] op_to_op_latency_us={total_op_to_op_us:.3f}, kernel_time_us={total_kernel_us:.3f}")
     assert total_kernel_ns > 0, "Total kernel duration must be positive."
     assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
     targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py
@@ -142,7 +142,13 @@ def test_ds_moe_forward(
     # MoE gate topk fallback performs host IO (to_torch/from_torch), which is illegal during trace capture.
     # Match fused-op trace behavior by forcing pure device topk path when trace_mode is enabled.
     model_config = get_model_config(
-        MoE, mode, hf_config, mesh_device, device_params["fabric_config"], topk_fallback=not trace_mode
+        MoE,
+        mode,
+        hf_config,
+        mesh_device,
+        device_params["fabric_config"],
+        batch_size_per_row=USERS_PER_ROW,
+        topk_fallback=not trace_mode,
     )
     model_state = MoE.create_state(hf_config, mesh_device, ccl)
     model_shared_state = MoE.create_shared_state(hf_config, mesh_device)

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_device_perf_tracy.sh
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_device_perf_tracy.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# Run DeepSeek fused-op device perf cases using direct Tracy commands.
+# Intended for CI and local debug parity.
+
+set -euo pipefail
+
+PROFILER_DIR="${PROFILER_DIR:-generated/profiler/deepseek_v3_fused_ops_device_perf}"
+TRACY_TIMEOUT_PORT="${TRACY_TIMEOUT_PORT:-5000}"
+TRACY_OP_SUPPORT_COUNT="${TRACY_OP_SUPPORT_COUNT:-10000}"
+
+run_tracy_case() {
+    local name="$1"
+    local perf_env_var="$2"
+    local test_target="$3"
+    local k_expr="$4"
+
+    echo ""
+    echo "--------------------------------------------------------------------------------"
+    echo "Case: $name"
+    echo "Target: $test_target"
+    echo "Expr: $k_expr"
+    echo "--------------------------------------------------------------------------------"
+
+    env "${perf_env_var}=1" python3 -m tracy -p -r \
+        -o "$PROFILER_DIR" \
+        --check-exit-code \
+        --op-support-count "$TRACY_OP_SUPPORT_COUNT" \
+        -t "$TRACY_TIMEOUT_PORT" \
+        -a device_kernel_duration \
+        -m "pytest $test_target -k \"$k_expr\""
+}
+
+echo "=============================================="
+echo "DeepSeek fused-op device perf (direct Tracy)"
+echo "=============================================="
+echo "Profiler dir: $PROFILER_DIR"
+echo "Cases: decode+1(trace+pcache), prefill+128(eager+pcache)"
+echo "=============================================="
+
+# Embedding
+run_tracy_case \
+    "embedding decode seq1 (trace+pcache)" \
+    "DS_EMBEDDING_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py::test_ds_embedding" \
+    "program_cache and not no_program_cache and trace and decode and 1 and real_weights"
+run_tracy_case \
+    "embedding prefill seq128 (eager+pcache)" \
+    "DS_EMBEDDING_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py::test_ds_embedding" \
+    "program_cache and not no_program_cache and eager and prefill and 128 and real_weights"
+
+# All-gather embedding
+run_tracy_case \
+    "all_gather_embedding decode seq1 (trace+pcache)" \
+    "DS_ALL_GATHER_EMBEDDING_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py::test_ds_all_gather_embedding" \
+    "program_cache and not no_program_cache and trace and decode and 1"
+run_tracy_case \
+    "all_gather_embedding prefill seq128 (eager+pcache)" \
+    "DS_ALL_GATHER_EMBEDDING_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py::test_ds_all_gather_embedding" \
+    "program_cache and not no_program_cache and eager and prefill and 128"
+
+# LM head
+run_tracy_case \
+    "lm_head decode seq1 (trace+pcache)" \
+    "DS_LM_HEAD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py::test_ds_lm_head" \
+    "program_cache and not no_program_cache and trace and decode and seq1 and real_weights"
+run_tracy_case \
+    "lm_head prefill seq128 (eager+pcache)" \
+    "DS_LM_HEAD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py::test_ds_lm_head" \
+    "program_cache and not no_program_cache and eager and prefill and seq128 and real_weights"
+
+# RMS norm
+run_tracy_case \
+    "rms_norm decode seq1 (trace+pcache)" \
+    "DS_RMS_NORM_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py::test_ds_rms_norm" \
+    "program_cache and not no_program_cache and trace and decode and 1 and real_weights"
+run_tracy_case \
+    "rms_norm prefill seq128 (eager+pcache)" \
+    "DS_RMS_NORM_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py::test_ds_rms_norm" \
+    "program_cache and not no_program_cache and eager and prefill and 128 and real_weights"
+
+# Distributed norm
+run_tracy_case \
+    "distributed_norm decode seq1 (trace+pcache)" \
+    "DS_DISTRIBUTED_NORM_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py::test_ds_distributed_norm" \
+    "program_cache and not no_program_cache and trace and decode and 1 and real_weights"
+run_tracy_case \
+    "distributed_norm prefill seq128 (eager+pcache)" \
+    "DS_DISTRIBUTED_NORM_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py::test_ds_distributed_norm" \
+    "program_cache and not no_program_cache and eager and prefill and 128 and real_weights"
+
+# MLP fused ops
+run_tracy_case \
+    "ff1_3 decode seq1 (trace+pcache)" \
+    "DS_FF1_3_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py::test_ds_ff1_3" \
+    "program_cache and not no_program_cache and trace and decode and 1"
+run_tracy_case \
+    "ff1_3 prefill seq128 (eager+pcache)" \
+    "DS_FF1_3_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py::test_ds_ff1_3" \
+    "program_cache and not no_program_cache and eager and prefill and 128"
+
+run_tracy_case \
+    "ff2 decode seq1 (trace+pcache)" \
+    "DS_FF2_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py::test_ds_ff2" \
+    "program_cache and not no_program_cache and trace and decode and 1"
+run_tracy_case \
+    "ff2 prefill seq128 (eager+pcache)" \
+    "DS_FF2_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py::test_ds_ff2" \
+    "program_cache and not no_program_cache and eager and prefill and 128"
+
+run_tracy_case \
+    "mul decode seq1 (trace+pcache)" \
+    "DS_MUL_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py::test_ds_mul" \
+    "program_cache and not no_program_cache and trace and decode and 1"
+run_tracy_case \
+    "mul prefill seq128 (eager+pcache)" \
+    "DS_MUL_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py::test_ds_mul" \
+    "program_cache and not no_program_cache and eager and prefill and 128"
+
+run_tracy_case \
+    "reduce_scatter_post_ff2 decode seq1 (trace+pcache)" \
+    "DS_REDUCE_SCATTER_POST_FF2_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py::test_ds_reduce_scatter_post_ff2" \
+    "program_cache and not no_program_cache and trace and decode and 1"
+run_tracy_case \
+    "reduce_scatter_post_ff2 prefill seq128 (eager+pcache)" \
+    "DS_REDUCE_SCATTER_POST_FF2_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py::test_ds_reduce_scatter_post_ff2" \
+    "program_cache and not no_program_cache and eager and prefill and 128"
+
+run_tracy_case \
+    "all_gather_preff1_3 decode seq1 (trace+pcache)" \
+    "DS_ALL_GATHER_PREFF1_3_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py::test_ds_all_gather_preff1_3" \
+    "program_cache and not no_program_cache and trace and decode and 1"
+run_tracy_case \
+    "all_gather_preff1_3 prefill seq128 (eager+pcache)" \
+    "DS_ALL_GATHER_PREFF1_3_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py::test_ds_all_gather_preff1_3" \
+    "program_cache and not no_program_cache and eager and prefill and 128"
+
+# MoE fused op
+run_tracy_case \
+    "moe decode seq1 (trace+pcache)" \
+    "DS_MOE_FORWARD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py::test_ds_moe_forward" \
+    "test_ds_moe_forward and decode and 1 and real_weights and trace and program_cache and not no_program_cache"
+run_tracy_case \
+    "moe prefill seq128 (eager+pcache)" \
+    "DS_MOE_FORWARD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py::test_ds_moe_forward" \
+    "test_ds_moe_forward and prefill and 128 and real_weights and eager and program_cache and not no_program_cache"
+
+# MLA fused op
+run_tracy_case \
+    "mla decode seq1 (trace+pcache)" \
+    "DS_MLA_FORWARD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py::test_ds_mla_forward" \
+    "test_ds_mla_forward and decode and 1 and real_weights and trace and program_cache and not no_program_cache"
+run_tracy_case \
+    "mla prefill seq128 (eager+pcache)" \
+    "DS_MLA_FORWARD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py::test_ds_mla_forward" \
+    "test_ds_mla_forward and prefill and 128 and real_weights and eager and program_cache and not no_program_cache"
+
+echo ""
+echo "=============================================="
+echo "All direct Tracy fused-op perf cases completed"
+echo "=============================================="

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_device_perf_tracy.sh
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_device_perf_tracy.sh
@@ -154,6 +154,30 @@ run_tracy_case \
     "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py::test_ds_all_gather_preff1_3" \
     "program_cache and not no_program_cache and eager and prefill and 128"
 
+# MoE fused op
+run_tracy_case \
+    "moe decode seq1 (trace+pcache)" \
+    "DS_MOE_FORWARD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py::test_ds_moe_forward" \
+    "test_ds_moe_forward and decode and 1 and real_weights and trace and program_cache and not no_program_cache"
+run_tracy_case \
+    "moe prefill seq128 (eager+pcache)" \
+    "DS_MOE_FORWARD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_ds_moe.py::test_ds_moe_forward" \
+    "test_ds_moe_forward and prefill and 128 and real_weights and eager and program_cache and not no_program_cache"
+
+# MLA fused op
+run_tracy_case \
+    "mla decode seq1 (trace+pcache)" \
+    "DS_MLA_FORWARD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py::test_ds_mla_forward" \
+    "test_ds_mla_forward and decode and 1 and real_weights and trace and program_cache and not no_program_cache"
+run_tracy_case \
+    "mla prefill seq128 (eager+pcache)" \
+    "DS_MLA_FORWARD_DEVICE_PERF" \
+    "models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_mla.py::test_ds_mla_forward" \
+    "test_ds_mla_forward and prefill and 128 and real_weights and eager and program_cache and not no_program_cache"
+
 echo ""
 echo "=============================================="
 echo "All direct Tracy fused-op perf cases completed"

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -188,6 +188,7 @@ def run_test_forward_pass_mla2d(
     state_dict,
     decode_position_ids: int | None = None,
     perf_mode=False,
+    trace_mode=False,
     num_iters=20,
 ):
     # Check params
@@ -285,15 +286,42 @@ def run_test_forward_pass_mla2d(
     # Forward pass
     logger.info("Running TTNN forward pass")
     if perf_mode:
-        if mode == "prefill":
-            tt_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
-            tt_output.deallocate()
-        else:
-            for _ in range(num_iters):
-                tt_output = MLA2D.forward_decode(
+        if trace_mode:
+            # Prime compile/runtime state before capture. Without this, first decode pass can
+            # trigger host->device writes that are forbidden during trace capture.
+            if mode == "prefill":
+                warmup_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
+            else:
+                warmup_output = MLA2D.forward_decode(
                     tt_input, position_ids_tensor, run_config, tt_rope_tensors, tt_page_table
                 )
+            ttnn.synchronize_device(mesh_device)
+            warmup_output.deallocate()
+
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            if mode == "prefill":
+                traced_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
+            else:
+                traced_output = MLA2D.forward_decode(
+                    tt_input, position_ids_tensor, run_config, tt_rope_tensors, tt_page_table
+                )
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            for _ in range(num_iters):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            ttnn.release_trace(mesh_device, trace_id)
+            traced_output.deallocate()
+        else:
+            if mode == "prefill":
+                tt_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
                 tt_output.deallocate()
+            else:
+                for _ in range(num_iters):
+                    tt_output = MLA2D.forward_decode(
+                        tt_input, position_ids_tensor, run_config, tt_rope_tensors, tt_page_table
+                    )
+                    tt_output.deallocate()
     else:
         if mode == "prefill":
             tt_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -188,6 +188,7 @@ def run_test_forward_pass_mla2d(
     state_dict,
     decode_position_ids: int | None = None,
     perf_mode=False,
+    trace_mode=False,
     num_iters=20,
 ):
     configured_row_width = batch_size_per_row
@@ -276,15 +277,42 @@ def run_test_forward_pass_mla2d(
     # Forward pass
     logger.info("Running TTNN forward pass")
     if perf_mode:
-        if mode == "prefill":
-            tt_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
-            tt_output.deallocate()
-        else:
-            for _ in range(num_iters):
-                tt_output = MLA2D.forward_decode(
+        if trace_mode:
+            # Prime compile/runtime state before capture. Without this, first decode pass can
+            # trigger host->device writes that are forbidden during trace capture.
+            if mode == "prefill":
+                warmup_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
+            else:
+                warmup_output = MLA2D.forward_decode(
                     tt_input, position_ids_tensor, run_config, tt_rope_tensors, tt_page_table
                 )
+            ttnn.synchronize_device(mesh_device)
+            warmup_output.deallocate()
+
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            if mode == "prefill":
+                traced_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
+            else:
+                traced_output = MLA2D.forward_decode(
+                    tt_input, position_ids_tensor, run_config, tt_rope_tensors, tt_page_table
+                )
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            for _ in range(num_iters):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            ttnn.release_trace(mesh_device, trace_id)
+            traced_output.deallocate()
+        else:
+            if mode == "prefill":
+                tt_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
                 tt_output.deallocate()
+            else:
+                for _ in range(num_iters):
+                    tt_output = MLA2D.forward_decode(
+                        tt_input, position_ids_tensor, run_config, tt_rope_tensors, tt_page_table
+                    )
+                    tt_output.deallocate()
     else:
         if mode == "prefill":
             tt_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -81,7 +81,7 @@ def generate_reference_io(
         moe_state_dict = {
             name: tensor
             for name, tensor in sub_state_dict(checkpoint_state_dict, module_path + ".").items()
-            if not name.startswith("shared_experts.")
+            if not name.startswith("shared_experts.") and not name.endswith(".weight_scale_inv")
         }
         if not moe_state_dict:
             pytest.skip(f"Checkpoint does not contain routed MoE weights under '{module_path}'")


### PR DESCRIPTION
### Summary
We want to further address the instability caused by consecutive tracy runs in ci for op tests. To this end, we stagger runs by adding sleep time in between them.
Additionally, further test cases for MLA and MOE are added.
This solution has been consecutively running on local machine, and is passing on ci from the runs that was done.

### CI Status
[![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml)