### PR TITLE
Bugfix: Fix mistral vision

### DIFF
--- a/models/tt_transformers/tests/multimodal/mistral_24b/test_conv2d.py
+++ b/models/tt_transformers/tests/multimodal/mistral_24b/test_conv2d.py
@@ -20,7 +20,8 @@ from models.tt_transformers.tt.multimodal.mistral_24b.vision_conv2d import TtMis
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"),
+            ttnn._ttnn.multi_device.SystemMeshDescriptor().shape().mesh_size(),
         )
     ],
     indirect=True,

--- a/models/tt_transformers/tests/multimodal/mistral_24b/test_vision_rms.py
+++ b/models/tt_transformers/tests/multimodal/mistral_24b/test_vision_rms.py
@@ -76,6 +76,7 @@ def test_rmsnorm_inference(seq_len, batch_size, reset_seeds, device):
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device=device),
     )
 
+    mode = "prefill"
     tt_output = tt_model(tt_input, mode=mode)
 
     tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(device, dim=-1))[

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1112,7 +1112,7 @@ void calculate_softplus_first_column(uint param0, uint param1, uint param2) {
     float beta_reciprocal = ckernel::sfpu::Converter::as_float(param1);
     float threshold = ckernel::sfpu::Converter::as_float(param2);
     for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
-        ckernel::sfpu::calculate_softplus_body<APPROX>(beta, beta_reciprocal, threshold);
+        ckernel::sfpu::calculate_softplus_body<APPROX, DST_ACCUM_MODE>(beta, beta_reciprocal, threshold);
         sfpi::dst_reg += 2;
     }
 }


### PR DESCRIPTION
## Problem

Three separate failures blocked T3K Mistral vision tests from passing:

### 1. `test_rmsnorm_inference` — `NameError: name 'mode' is not defined`

`test_rmsnorm_inference` calls `tt_model(tt_input, mode=mode)` but `mode` was never assigned in the test function.

See: https://github.com/tenstorrent/tt-metal/actions/runs/24299089187/job/70949678365

### 2. `test_conv2d_inference[wormhole_b0-6]` — mesh size mismatch

`test_conv2d.py` parametrized on `len(ttnn.get_device_ids())` which returns the count of physical PCIe devices (6 on this machine). The system mesh only exposes 4 devices (`MeshShape([2,2])`), so requesting a 6-device config caused the test to fail.

See: https://github.com/tenstorrent/tt-metal/actions/runs/24477790659/job/71535746000

### 3. `test_vision_attention` — `calculate_softplus_body` template compile error

The LLK updated `calculate_softplus_body` to require two template parameters:
```cpp
template<bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
```
`compute_common.hpp` was only passing one (`<APPROX>`), causing a trisc1 compile failure.

See: https://github.com/tenstorrent/tt-metal/actions/runs/24477790659/job/71535902066

---

## Fix

### 1. `mode` undefined — `ec54fdf780`
Define `mode = "prefill"` before the call, matching the value used in production in `vision_pixtral_image_block.py` — vision RMSNorm always runs in prefill context.

### 2. Mesh size mismatch — `4218e97f7e`
Replace `len(ttnn.get_device_ids())` with `ttnn._ttnn.multi_device.SystemMeshDescriptor().shape().mesh_size()` — the same API `conftest.py` uses — so the parametrize range never exceeds the actual system mesh capacity.

### 3. `calculate_softplus_body` template — `cf3d6c6e9c`
Pass `DST_ACCUM_MODE` as the second template argument, following the existing pattern in `compute_common.hpp` (e.g. line 837: `ckernel_sfpu_exp_accurate<true, DST_ACCUM_MODE>`).

---

## Validation
- [x] t3k unit tests passed: https://github.com/tenstorrent/tt-metal/actions/runs/24479242860/job/71540458058

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-fix-t3k-mistral-vision)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-fix-t3k-mistral-vision)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-fix-t3k-mistral-vision)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-fix-t3k-mistral-vision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-fix-t3k-mistral-vision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-fix-t3k-mistral-vision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-fix-t3k-mistral-vision) |
