### PR TITLE
Disable pytest-level timeouts in ttsim testing

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -170,17 +170,18 @@ jobs:
           set -euo pipefail
           pip3 install -q PyYAML
           python3 - "${{ env.TTNN_TESTS_YAML }}" "$GITHUB_OUTPUT" << 'PY'
-          import json, sys, yaml
+          import json, re, sys, yaml
           path, out_path = sys.argv[1], sys.argv[2]
           with open(path) as f:
               tests = yaml.safe_load(f)
           # TTSim runs all tests on ubuntu-latest; ignore skus and timeouts from YAML, use fixed timeout.
-          TTSIM_TIMEOUT_MINUTES = 30
+          TTSIM_TIMEOUT_MINUTES = 40
           entries = []
           for t in tests:
               if not t.get("ttsim") or not t.get("cmd"):
                   continue
-              entries.append({"name": t.get("name", "Unnamed Test"), "cmd": t.get("cmd", ""), "timeout": TTSIM_TIMEOUT_MINUTES})
+              cmd = re.sub(r'\s+--timeout\s+\d+', '', t['cmd'])
+              entries.append({"name": t.get("name", "Unnamed Test"), "cmd": cmd, "timeout": TTSIM_TIMEOUT_MINUTES})
           if not entries:
               raise SystemExit("No TTSim-compatible TTNN tests found (ttsim: true)")
           with open(out_path, "a") as f:
@@ -280,15 +281,15 @@ jobs:
 
       - name: Run TTNN Pytests - ${{ matrix.test-group.name }}
         run: |
-          # Run pytest with parallel execution and skip list.
+          # Run pytest with parallel execution, pytest-level timeouts disabled (more harm than good on sim), and skip list.
           # If a worker crashes, pytest-xdist only reports "worker crashed"
           # which is useless for debugging. Re-run the failures serially to
           # get actionable output.
-          if ${{ matrix.test-group.cmd }} -n 4 ${{ steps.skip-list.outputs.skip_args }}; then
+          if ${{ matrix.test-group.cmd }} -p no:timeout -n 4 ${{ steps.skip-list.outputs.skip_args }}; then
             exit 0
           fi
           echo "::warning::Parallel run failed. Re-running failed tests serially for clear diagnostics..."
-          ${{ matrix.test-group.cmd }} --lf --lfnf=all --tb=long -v ${{ steps.skip-list.outputs.skip_args }} || true
+          ${{ matrix.test-group.cmd }} -p no:timeout --lf --lfnf=all --tb=long -v ${{ steps.skip-list.outputs.skip_args }} || true
           exit 1
 
   ttsim-cpp-unit-tests:

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -111,21 +111,15 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/reduce/test_intimg.py
 
 blackhole:
-  # pytest-timeout timeouts
-  - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_oob
-  - tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
-  - tests/ttnn/unit_tests/operations/matmul/test_linear.py
-  - tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
-  - tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
-  - tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
-
   # Job-level timeouts
   - tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+  - tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
   - tests/ttnn/unit_tests/operations/fused/test_softmax.py
   - tests/ttnn/unit_tests/operations/matmul/test_matmul.py
   - tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
   - tests/ttnn/unit_tests/operations/pool/test_mpwi.py
   - tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+  - tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
   - tests/ttnn/unit_tests/operations/reduce/test_topk.py
 
   # MOVD2B failures


### PR DESCRIPTION
### Summary
Remove the pytest timeouts on ttsim, as they are too aggressive in some cases and not useful.
Also increase the ttnn sanity tests budget to 40 minutes, the same as the ttnn silicon-based tests.
Enable some additional test coverage that can now be run.

### Notes for reviewers
n/a

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/ttsim-pytest-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [#2880](https://github.com/tenstorrent/tt-metal/actions/runs/24471912027) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/ttsim-pytest-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/ttsim-pytest-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/ttsim-pytest-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/ttsim-pytest-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/ttsim-pytest-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/ttsim-pytest-timeouts) |