### PR TITLE
Revert "#39648: Fix AllReduce OOM (#41878)"

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_reduce.py
+++ b/tests/nightly/t3000/ccl/test_all_reduce.py
@@ -184,11 +184,11 @@ NUM_ITERS = 2
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
 @pytest.mark.parametrize(
-    "input_shape", [[128, 128], [544, 2880], [8, 8, 128, 128], [8, 128, 128], [8, 8, 8, 8, 128, 128], [8, 8, 8, 16, 16]]
+    "input_shape", [[128, 128], [8, 8, 128, 128], [8, 128, 128], [8, 8, 8, 8, 128, 128], [8, 8, 8, 16, 16]]
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
-@pytest.mark.parametrize("cluster_axis", [1])
+@pytest.mark.parametrize("cluster_axis", [0])
 @pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
 def test_nd(mesh_device, input_shape, cluster_axis, dtype, memory_config, topology):
     tt_input, torch_reference = _get_tensors(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -176,7 +176,7 @@ ttnn::Tensor all_reduce_async(
     uint32_t dim = ttnn::operations::experimental::ccl::detail::finding_scatter_dim(
         input_tensor, ttnn::ccl::get_active_physical_devices(input_tensor).size());
 
-    const auto& initial_shape = input_tensor.logical_shape();
+    auto initial_shape = input_tensor.logical_shape();
     auto composite_dim = (dim == input_tensor.padded_shape().size()) ? 0 : dim;
     bool composite_all_gather =
         composite_common::use_composite_all_gather(input_tensor, composite_dim, out_memory_config);
@@ -201,20 +201,17 @@ ttnn::Tensor all_reduce_async(
         ttnn::operations::experimental::ccl::detail::is_true_2d_mesh(input_tensor, topology);
 
     if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim) || composite_for_2d_mesh) {
-        // All reduce = all gather + local reduce
         log_debug(tt::LogOp, "Using composite all gather + local reduce");
 
-        // Reshape (B, C, H, W) -> (1, B, C, H, W)
-        ttnn::SmallVector<uint32_t> ag_shape_vec(initial_shape.rank() + 1);
-        ag_shape_vec[0] = 1;
-        std::copy(initial_shape.cbegin(), initial_shape.cend(), ag_shape_vec.begin() + 1);
-        auto reshaped_tensor = ttnn::reshape(working_input_tensor, ttnn::Shape(ag_shape_vec));
+        // All reduce = all gather + local reduce
+        composite_dim = 0;
+        auto reshaped_tensor = ttnn::reshape(
+            working_input_tensor,
+            ttnn::Shape({1, initial_shape[0] * initial_shape[1], initial_shape[2], initial_shape[3]}));
         if (interleaved_input_tensor.has_value()) {
             interleaved_input_tensor->deallocate();
         }
 
-        // AllGather (1, B, C, H, W) -> (num_devices, B, C, H, W)
-        composite_dim = 0;
         auto gather_tensor = composite_common::composite_all_gather(
             reshaped_tensor,
             composite_dim,
@@ -224,7 +221,6 @@ ttnn::Tensor all_reduce_async(
             std::nullopt);
         reshaped_tensor.deallocate();
 
-        // Reduce (num_devices, B, C, H, W) -> (1, B, C, H, W)
         bool is_float32 = (input_tensor.dtype() == ttnn::DataType::FLOAT32);
         auto sum_tensor = is_float32
                               ? ttnn::operations::experimental::ccl::local_sum_float32(
@@ -233,7 +229,6 @@ ttnn::Tensor all_reduce_async(
                                     gather_tensor, static_cast<int>(composite_dim), out_memory_config);
         gather_tensor.deallocate();
 
-        // Reshape (1, B, C, H, W) -> (B, C, H, W)
         return ttnn::reshape(sum_tensor, initial_shape);
     }
 
@@ -303,7 +298,7 @@ ttnn::Tensor all_reduce_async(
     const bool input_is_sharded = input_tensor.memory_config().is_sharded();
     uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
     uint32_t dim = ttnn::operations::experimental::ccl::detail::finding_scatter_dim(input_tensor, num_devices);
-    const auto& initial_shape = input_tensor.logical_shape();
+    auto initial_shape = input_tensor.logical_shape();
 
     // Convert sharded tensors to interleaved because the shard specs are not compatible with composite intermediates.
     // Otherwise work directly with input_tensor.
@@ -329,20 +324,20 @@ ttnn::Tensor all_reduce_async(
         ttnn::operations::experimental::ccl::detail::is_true_2d_mesh(input_tensor, topology_);
 
     if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim) || composite_for_2d_mesh) {
-        // All reduce = all gather + local reduce
         log_debug(tt::LogOp, "Using composite all gather + local reduce");
+        // All reduce = all gather + local reduce
+        composite_dim = 0;
 
-        // Reshape (B, C, H, W) -> (1, B, C, H, W)
-        ttnn::SmallVector<uint32_t> ag_shape_vec(initial_shape.rank() + 1);
+        ttnn::SmallVector<uint32_t> ag_shape_vec(initial_shape.rank());
+        std::copy(initial_shape.cbegin() + 2, initial_shape.cend(), ag_shape_vec.begin() + 2);
         ag_shape_vec[0] = 1;
-        std::copy(initial_shape.cbegin(), initial_shape.cend(), ag_shape_vec.begin() + 1);
+        ag_shape_vec[1] = initial_shape[0] * initial_shape[1];
+
         auto reshaped_tensor = ttnn::reshape(working_input_tensor, ttnn::Shape(ag_shape_vec));
         if (interleaved_input_tensor.has_value()) {
             interleaved_input_tensor->deallocate();
         }
 
-        // AllGather (1, B, C, H, W) -> (num_devices, B, C, H, W)
-        composite_dim = 0;
         auto gather_tensor = composite_common::composite_all_gather(
             reshaped_tensor,
             composite_dim,
@@ -352,7 +347,6 @@ ttnn::Tensor all_reduce_async(
             cluster_axis);
         reshaped_tensor.deallocate();
 
-        // Reduce (num_devices, B, C, H, W) -> (1, B, C, H, W)
         bool is_float32 = (input_tensor.dtype() == ttnn::DataType::FLOAT32);
         auto sum_tensor = is_float32
                               ? ttnn::operations::experimental::ccl::local_sum_float32(
@@ -361,7 +355,6 @@ ttnn::Tensor all_reduce_async(
                                     gather_tensor, static_cast<int>(composite_dim), out_memory_config);
         gather_tensor.deallocate();
 
-        // Reshape (1, B, C, H, W) -> (B, C, H, W)
         return ttnn::reshape(sum_tensor, initial_shape);
     }
 


### PR DESCRIPTION
This reverts commit cb25231546ea17684f6a9f7fa3ba27f08342a590.

Commit was causing galaxy e2e pipeline to have multiple PCC failures

https://github.com/tenstorrent/tt-metal/actions/runs/24430422290/job/71374037922

Reverting the PR fixes these locally, running the pipeline below

https://github.com/tenstorrent/tt-metal/actions/runs/24474075258

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jvega/revert_39648_Fix_AllReduce_OOM)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jvega/revert_39648_Fix_AllReduce_OOM)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jvega/revert_39648_Fix_AllReduce_OOM)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jvega/revert_39648_Fix_AllReduce_OOM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jvega/revert_39648_Fix_AllReduce_OOM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jvega/revert_39648_Fix_AllReduce_OOM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jvega/revert_39648_Fix_AllReduce_OOM) |