### PR TITLE
Include demo runtime settings in artifact statistics for High Batch Deepseek

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -800,6 +800,8 @@ def run_demo(
                 os.fsync(checkpoint_fh.fileno())
 
             statistics["tt-metal_commit"] = _resolve_tt_metal_commit()
+            statistics["sample_on_device"] = sample_on_device
+            statistics["enable_trace"] = enable_trace
             return {"generations": results, "statistics": statistics, "model_params": model_params}
         finally:
             if checkpoint_fh is not None:

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -800,8 +800,6 @@ def run_demo(
                 os.fsync(checkpoint_fh.fileno())
 
             statistics["tt-metal_commit"] = _resolve_tt_metal_commit()
-            statistics["sample_on_device"] = sample_on_device
-            statistics["enable_trace"] = enable_trace
             return {"generations": results, "statistics": statistics, "model_params": model_params}
         finally:
             if checkpoint_fh is not None:

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 
@@ -75,6 +76,11 @@ def _assert_perf_targets(results: dict, perf_targets: dict[str, float]) -> None:
             f"{metric_name}={measured:.6f} is outside expected range "
             f"[{lower:.6f}, {upper:.6f}] (expected {expected:.6f} +/- {PERF_MARGIN*100:.1f}%)"
         )
+
+
+def _timestamped_artifact_stem(artifact_name: str) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return f"{artifact_name}_{timestamp}"
 
 
 def _demo_case(
@@ -349,12 +355,15 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
     if case["artifact_name"] is not None and _is_primary_artifact_writer():
         artifact_dir = Path("generated/artifacts")
         artifact_dir.mkdir(parents=True, exist_ok=True)
-        output_file = artifact_dir / f"{case['artifact_name']}.json"
+        output_file = artifact_dir / f"{_timestamped_artifact_stem(case['artifact_name'])}.json"
+        statistics = dict(results.get("statistics", {}))
+        statistics["sample_on_device"] = case["sample_on_device"]
+        statistics["enable_trace"] = case["enable_trace"]
 
         output_data = {
             "prompts": prompts,
             "generations": [],
-            "statistics": results.get("statistics", {}),
+            "statistics": statistics,
         }
 
         for i, gen_result in enumerate(results["generations"]):

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -361,9 +361,10 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
         statistics["enable_trace"] = case["enable_trace"]
 
         output_data = {
-            "prompts": prompts,
+            "prompts": prompts if prompts else [],
             "generations": [],
             "statistics": statistics,
+            "model_params": results.get("model_params", {}),
         }
 
         for i, gen_result in enumerate(results["generations"]):

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -356,14 +356,11 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
         artifact_dir = Path("generated/artifacts")
         artifact_dir.mkdir(parents=True, exist_ok=True)
         output_file = artifact_dir / f"{_timestamped_artifact_stem(case['artifact_name'])}.json"
-        statistics = dict(results.get("statistics", {}))
-        statistics["sample_on_device"] = case["sample_on_device"]
-        statistics["enable_trace"] = case["enable_trace"]
 
         output_data = {
             "prompts": prompts if prompts else [],
             "generations": [],
-            "statistics": statistics,
+            "statistics": results.get("statistics", {}),
             "model_params": results.get("model_params", {}),
         }
 


### PR DESCRIPTION
### Summary
Added timestamped artifact names and persist sample_on_device and enable_trace in statistics so generated JSON captures exact run configuration.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:deepseek-artifact-settings) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=deepseek-artifact-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:deepseek-artifact-settings) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:deepseek-artifact-settings) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:deepseek-artifact-settings) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=deepseek-artifact-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:deepseek-artifact-settings) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:deepseek-artifact-settings) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:deepseek-artifact-settings) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=deepseek-artifact-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:deepseek-artifact-settings) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:deepseek-artifact-settings) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:deepseek-artifact-settings) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=deepseek-artifact-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:deepseek-artifact-settings) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:deepseek-artifact-settings) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:deepseek-artifact-settings) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=deepseek-artifact-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:deepseek-artifact-settings) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:deepseek-artifact-settings) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:deepseek-artifact-settings) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=deepseek-artifact-settings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:deepseek-artifact-settings) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:deepseek-artifact-settings) |