### PR TITLE
#42177: fix group_norm to pass llk cb asserts

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -312,7 +312,7 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
     uint32_t in0_CB_size = a.buffer()->aligned_size_per_bank();  // use buffer size to handle both RM and Tile
     uint32_t in_CB_size = in0_block_tiles * in_single_tile_size;
     // in2 - scaler
-    uint32_t in2_CB_size = single_tile_size * (use_welford ? 2 : 1);
+    uint32_t in2_CB_size = single_tile_size * (use_welford ? 3 : 1);
     // in3 - eps
     uint32_t in3_CB_size = single_tile_size;
     // gamma

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -219,6 +219,12 @@ void kernel_main() {
                     tile_regs_acquire();
                     for (uint32_t w = 0; w < subblock_w; ++w) {
                         uint32_t index = w + index_subblock_w_offset + index_h_offset;
+                        // When the last group spans fewer than block_w tiles, the index can
+                        // exceed the CB tile count. Clamp it so the read stays in bounds;
+                        // the input mask guarantees the result from the clamped tile is zeroed.
+                        if (index >= per_core_MN) {
+                            index = per_core_MN - 1;
+                        }
                         uint32_t index_mask = w + index_subblock_w_offset;
 #ifdef TILIZE_IN
                         mul_tiles(cb_in_id, cb_input_mask_id, index, index_mask, w);


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #42177 

New CB bounds LLK asserts are catching errors in group norm

Add fixes to increase CB size and reduce amount computed over

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

No need for tests since these will be part of Sanity with llk assert runs.

Verified locally these pass with the new llk asserts.