### PR TITLE
#41702: Port sharded and move kernels to device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -36,6 +37,8 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<1>();
     constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
+    experimental::CircularBuffer cb(cb_id);
+
     // if controller core then this local address will be incremented by remote cores,
     // otherwise controller core will set this to signal that write to dst can be done once controller core sees
     // control_value locally
@@ -49,14 +52,14 @@ void kernel_main() {
     const auto dst_addrgen = TensorAccessor(dst_args, dst_addr);
 
     // read a ublock of tiles from src to CB
-    cb_reserve_back(cb_id, num_tiles);
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    cb.reserve_back(num_tiles);
+    uint32_t l1_write_addr = cb.get_write_ptr();
     for (uint32_t i = start_id; i < start_id + num_tiles; i += ublock_size_tiles) {
         noc_async_read_tile(i, src_addrgen, l1_write_addr);
         noc_async_read_barrier();
         l1_write_addr += tile_bytes;
     }
-    cb_push_back(cb_id, num_tiles);
+    cb.push_back(num_tiles);
 
     if (is_controller) {
         noc_semaphore_wait(semaphore_addr_ptr, control_value);
@@ -81,12 +84,12 @@ void kernel_main() {
         noc_semaphore_wait(semaphore_addr_ptr, control_value);
     }
 
-    cb_wait_front(cb_id, num_tiles);
-    uint32_t l1_read_addr = get_read_ptr(cb_id);
+    cb.wait_front(num_tiles);
+    uint32_t l1_read_addr = cb.get_read_ptr();
     for (uint32_t i = start_id; i < start_id + num_tiles; i += ublock_size_tiles) {
         noc_async_write_tile(i, dst_addrgen, l1_read_addr);
         noc_async_write_barrier();
         l1_read_addr += tile_bytes;
     }
-    cb_pop_front(cb_id, num_tiles);
+    cb.pop_front(num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -38,6 +39,8 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<2>();
     constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
+    experimental::CircularBuffer cb(cb_id);
+
     const auto src_addrgen = TensorAccessor(src_args, src_addr);
     const auto dst_addrgen = TensorAccessor(dst_args, dst_addr);
 
@@ -47,15 +50,15 @@ void kernel_main() {
     volatile uint32_t* semaphore_addr_ptr = reinterpret_cast<volatile uint32_t*>(semaphore_addr);
 
     // read a ublock of tiles from src to CB
-    cb_reserve_back(cb_id, num_pages);
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    cb.reserve_back(num_pages);
+    uint32_t l1_write_addr = cb.get_write_ptr();
     for (uint32_t i = start_id; i < start_id + num_pages; ++i) {
         uint64_t src_noc_addr = src_addrgen.get_noc_addr(i);
         noc_async_read(src_noc_addr, l1_write_addr, page_size);
         noc_async_read_barrier();
         l1_write_addr += aligned_page_size;
     }
-    cb_push_back(cb_id, num_pages);
+    cb.push_back(num_pages);
 
     if (is_controller) {
         noc_semaphore_wait(semaphore_addr_ptr, control_value);
@@ -80,13 +83,13 @@ void kernel_main() {
         noc_semaphore_wait(semaphore_addr_ptr, control_value);
     }
 
-    cb_wait_front(cb_id, num_pages);
-    uint32_t l1_read_addr = get_read_ptr(cb_id);
+    cb.wait_front(num_pages);
+    uint32_t l1_read_addr = cb.get_read_ptr();
     for (uint32_t i = start_id; i < start_id + num_pages; ++i) {
         uint64_t dst_noc_addr = dst_addrgen.get_noc_addr(i);
         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
         noc_async_write_barrier();
         l1_read_addr += aligned_page_size;
     }
-    cb_pop_front(cb_id, num_pages);
+    cb.pop_front(num_pages);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp
@@ -7,9 +7,13 @@
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t per_core_tile_cnt = get_arg_val<uint32_t>(0);
+
+    experimental::CircularBuffer cb_in(tt::CBIndex::c_0);
+    experimental::CircularBuffer cb_out(tt::CBIndex::c_16);
 
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     copy_tile_init(tt::CBIndex::c_0);
@@ -17,14 +21,14 @@ void kernel_main() {
         acquire_dst();
 
         // Pop tile after tile, copy to DST and pack
-        cb_wait_front(tt::CBIndex::c_0, 1);
-        cb_reserve_back(tt::CBIndex::c_16, 1);
+        cb_in.wait_front(1);
+        cb_out.reserve_back(1);
         copy_tile(tt::CBIndex::c_0, 0, 0);
 
         pack_tile(0, tt::CBIndex::c_16);
 
-        cb_pop_front(tt::CBIndex::c_0, 1);
-        cb_push_back(tt::CBIndex::c_16, 1);
+        cb_in.pop_front(1);
+        cb_out.push_back(1);
 
         release_dst();
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 void kernel_main() {
@@ -18,18 +19,20 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_compile_time_arg_val(3);
     const uint32_t tile_size_bytes = get_tile_size(cb_id_in0);
 
+    experimental::CircularBuffer cb_in(cb_id_in0);
+
     constexpr auto src_args = TensorAccessorArgs<4>();
     const auto accessor_src = TensorAccessor(src_args, src_addr);
     for (uint32_t shard_id = start_shard_id; shard_id < num_shards; shard_id += num_cores) {
         auto shard_pages = accessor_src.shard_pages(shard_id);
         for (auto page_iter = shard_pages.begin(); page_iter != shard_pages.end();
              page_iter += num_tiles_per_input_block) {
-            cb_reserve_back(cb_id_in0, num_tiles_per_input_block);
+            cb_in.reserve_back(num_tiles_per_input_block);
             uint64_t noc_read_addr = page_iter->noc_addr();
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            uint32_t l1_write_addr = cb_in.get_write_ptr();
             noc_async_read(noc_read_addr, l1_write_addr, tile_size_bytes * num_tiles_per_input_block);
             noc_async_read_barrier();
-            cb_push_back(cb_id_in0, num_tiles_per_input_block);
+            cb_in.push_back(num_tiles_per_input_block);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
 #include "experimental/circular_buffer.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded.cpp
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     const uint32_t num_units = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
 
-    cb_reserve_back(cb_id_in0, num_units);
-    cb_push_back(cb_id_in0, num_units);
+    experimental::CircularBuffer cb_in(cb_id_in0);
+
+    cb_in.reserve_back(num_units);
+    cb_in.push_back(num_units);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
 #include "tensix_types.h"
 
 // #include "api/debug/dprint.h"
@@ -32,27 +35,29 @@ void kernel_main() {
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in(cb_id_in0);
     const auto s = TensorAccessor(src_args, src_addr);
 
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_readers>();
     uint32_t barrier_count = 0;
     uint32_t curr_tile_id = start_id;
-    cb_reserve_back(cb_id_in0, block_num_tiles);
-    uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+    uint32_t l1_offset = 0;
+    cb_in.reserve_back(block_num_tiles);
     for (uint32_t h = 0; h < block_height_tiles; h++) {
         uint32_t tile_id = curr_tile_id;
         for (uint32_t w = 0; w < block_width_tiles; w++) {
-            noc_async_read_tile(tile_id, s, l1_write_addr);
+            noc.async_read(s, cb_in, tile_bytes, {.page_id = tile_id}, {.offset_bytes = l1_offset});
             tile_id++;
-            l1_write_addr += tile_bytes;
+            l1_offset += tile_bytes;
             if (++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
+                noc.async_read_barrier();
                 barrier_count = 0;
             }
         }
-        l1_write_addr += padded_offset_bytes;
+        l1_offset += padded_offset_bytes;
         curr_tile_id += input_width_offset_tiles;
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_id_in0, block_num_tiles);
+    noc.async_read_barrier();
+    cb_in.push_back(block_num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
 
@@ -22,10 +23,13 @@ void kernel_main() {
     constexpr uint32_t num_trids = get_compile_time_arg_val(2);
     constexpr auto src_args = TensorAccessorArgs<3>();
 
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+
     const auto s0 = TensorAccessor(src_args, src_addr + aligned_input_width_offset_bytes);
     uint32_t stick_id = start_id;
-    cb_reserve_back(cb_id_in0, block_height);
-    uint32_t dest_write_addr = get_write_ptr(cb_id_in0);
+    cb_in0.reserve_back(block_height);
+    uint32_t dest_write_addr = cb_in0.get_write_ptr();
     if (aligned) {
         for (uint32_t h = 0; h < block_height; ++h) {
             uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
@@ -44,8 +48,8 @@ void kernel_main() {
 
         constexpr uint32_t trid_base = 1;
 
-        cb_reserve_back(cb_id_in1, num_trids);
-        uint32_t scratch_write_addr_base = get_write_ptr(cb_id_in1);
+        cb_in1.reserve_back(num_trids);
+        uint32_t scratch_write_addr_base = cb_in1.get_write_ptr();
         uint32_t scratch_cb_page_size = get_local_cb_interface(cb_id_in1).fifo_page_size;
         SlotState slot_states[num_trids];
         uint32_t dest_write_addrs[num_trids];
@@ -103,5 +107,5 @@ void kernel_main() {
 
     }
     noc_async_read_set_trid(0);
-    cb_push_back(cb_id_in0, block_height);
+    cb_in0.push_back(block_height);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_writer.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t shard_cb_id = get_compile_time_arg_val(0);
@@ -18,7 +19,8 @@ void kernel_main() {
     uint32_t args_idx = 0;
     tt_l1_ptr uint32_t* args = (tt_l1_ptr uint32_t*)(get_arg_addr(5));
 
-    uint32_t base_l1_read_addr = get_read_ptr(shard_cb_id);
+    experimental::CircularBuffer shard_cb(shard_cb_id);
+    uint32_t base_l1_read_addr = shard_cb.get_read_ptr();
 
     for (uint32_t i = 0; i < num_segments; ++i) {
         uint32_t write_size = args[args_idx++];

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
 
@@ -24,7 +25,8 @@ void kernel_main() {
     tt_l1_ptr uint32_t* args = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
     uint32_t args_idx = 0;
 
-    uint32_t l1_read_addr = get_read_ptr(shard_cb_id) + read_offset;
+    experimental::CircularBuffer shard_cb(shard_cb_id);
+    uint32_t l1_read_addr = shard_cb.get_read_ptr() + read_offset;
     for (uint32_t i = 0; i < num_writes; ++i) {
         uint32_t bank_id = args[args_idx++];
         uint32_t addr = dst_addr + args[args_idx++];

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
 #include "experimental/circular_buffer.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     const uint32_t num_units = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
 
-    cb_wait_front(cb_id_out, num_units);
+    experimental::CircularBuffer cb_out(cb_id_out);
+
+    cb_out.wait_front(num_units);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_interleaved_start_id.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -24,21 +27,24 @@ void kernel_main() {
 
     const auto s = TensorAccessor(dst_args, dst_addr);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out(cb_id_out);
+
     const uint32_t padded_width_diff = (block_width_tiles - unpadded_block_width_tiles) * tile_bytes;
 
     uint32_t row_start_tile_id = start_id;
-    cb_wait_front(cb_id_out, block_num_tiles);
-    uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+    cb_out.wait_front(block_num_tiles);
+    uint32_t l1_read_offset = 0;
     for (uint32_t h = 0; h < unpadded_block_height_tiles; h++) {
         uint32_t tile_id = row_start_tile_id;
         for (uint32_t w = 0; w < unpadded_block_width_tiles; w++) {
-            noc_async_write_tile(tile_id, s, l1_read_addr);
+            noc.async_write(cb_out, s, tile_bytes, {.offset_bytes = l1_read_offset}, {.page_id = tile_id});
             tile_id++;
-            l1_read_addr += tile_bytes;
+            l1_read_offset += tile_bytes;
         }
-        l1_read_addr += padded_width_diff;
+        l1_read_offset += padded_width_diff;
         row_start_tile_id += output_width_tiles;
     }
-    noc_async_write_barrier();
-    cb_pop_front(cb_id_out, block_num_tiles);
+    noc.async_write_barrier();
+    cb_out.pop_front(block_num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 void kernel_main() {
@@ -36,9 +37,11 @@ void kernel_main() {
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(8));
     experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 
+    experimental::CircularBuffer cb_out(cb_id_out);
+
     uint32_t row_start_tile_id = start_id_base + start_id_offset;
-    cb_wait_front(cb_id_out, block_width_padded_num_tiles);
-    uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+    cb_out.wait_front(block_width_padded_num_tiles);
+    uint32_t l1_read_addr = cb_out.get_read_ptr();
     for (uint32_t h = 0; h < block_height_tiles; h++) {
         uint32_t tile_id = row_start_tile_id;
         for (uint32_t w = 0; w < block_width_tiles; w++) {
@@ -51,5 +54,5 @@ void kernel_main() {
         row_start_tile_id += output_width_tiles;
     }
     noc_async_write_barrier();
-    cb_pop_front(cb_id_out, block_width_padded_num_tiles);
+    cb_out.pop_front(block_width_padded_num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 void kernel_main() {
@@ -31,9 +32,11 @@ void kernel_main() {
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(6));
     experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 
+    experimental::CircularBuffer cb_out(cb_id_out0);
+
     uint32_t stick_id = start_id;
-    cb_wait_front(cb_id_out0, block_height);
-    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+    cb_out.wait_front(block_height);
+    uint32_t l1_read_addr = cb_out.get_read_ptr();
     for (uint32_t h = 0; h < block_height; ++h) {
         uint64_t dst_noc_addr = get_noc_addr(stick_id, s);
         noc_async_write(l1_read_addr, dst_noc_addr, block_width_bytes);
@@ -41,5 +44,5 @@ void kernel_main() {
         l1_read_addr += padded_block_width_bytes;
     }
     noc_async_write_barrier();
-    cb_pop_front(cb_id_out0, block_height);
+    cb_out.pop_front(block_height);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -18,9 +19,11 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(dst_args, dst_addr + input_width_offset_bytes);
 
+    experimental::CircularBuffer cb_out(cb_id_out0);
+
     uint32_t stick_id = start_id;
-    cb_wait_front(cb_id_out0, block_height);
-    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+    cb_out.wait_front(block_height);
+    uint32_t l1_read_addr = cb_out.get_read_ptr();
     for (uint32_t h = 0; h < block_height; ++h) {
         uint64_t dst_noc_addr = get_noc_addr(stick_id, s0);
         noc_async_write(l1_read_addr, dst_noc_addr, block_width_bytes);
@@ -28,5 +31,5 @@ void kernel_main() {
         l1_read_addr += padded_block_width_bytes;
     }
     noc_async_write_barrier();
-    cb_pop_front(cb_id_out0, block_height);
+    cb_out.pop_front(block_height);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
@@ -4,6 +4,8 @@
 
 #include <cstdint>
 #include "api/tensor/tensor_accessor.h"
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 // Simple kernel that copies [start_page, end_page) pages from src to dst.
 void kernel_main() {
@@ -21,13 +23,15 @@ void kernel_main() {
 
     auto accessor_src = TensorAccessor(args_src, bank_base_address_src);
 
+    experimental::CircularBuffer cb(cb_id);
+
     constexpr uint32_t one_tile = 1;
-    uint32_t cb_addr = get_write_ptr(cb_id);
+    uint32_t cb_addr = cb.get_write_ptr();
     auto pages = accessor_src.pages(start_page, end_page);
     for (const auto& page : pages) {
-        cb_reserve_back(cb_id, one_tile);
+        cb.reserve_back(one_tile);
         noc_async_read(page.noc_addr(), cb_addr, page_size);
         noc_async_read_barrier();
-        cb_push_back(cb_id, one_tile);
+        cb.push_back(one_tile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
@@ -26,10 +26,10 @@ void kernel_main() {
     experimental::CircularBuffer cb(cb_id);
 
     constexpr uint32_t one_tile = 1;
-    uint32_t cb_addr = cb.get_write_ptr();
     auto pages = accessor_src.pages(start_page, end_page);
     for (const auto& page : pages) {
         cb.reserve_back(one_tile);
+        uint32_t cb_addr = cb.get_write_ptr();
         noc_async_read(page.noc_addr(), cb_addr, page_size);
         noc_async_read_barrier();
         cb.push_back(one_tile);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
@@ -26,10 +26,10 @@ void kernel_main() {
     experimental::CircularBuffer cb(cb_id);
 
     constexpr uint32_t one_tile = 1;
-    uint32_t cb_addr = cb.get_write_ptr();
     auto pages = accessor_dst.pages(start_page, end_page);
     for (const auto& page : pages) {
         cb.wait_front(one_tile);
+        uint32_t cb_addr = cb.get_read_ptr();
         noc_async_write(cb_addr, page.noc_addr(), page_size);
         noc_async_write_barrier();
         cb.pop_front(one_tile);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
@@ -4,6 +4,8 @@
 
 #include <cstdint>
 #include "api/tensor/tensor_accessor.h"
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 // Simple kernel that copies [start_page, end_page) pages from dst to dst.
 void kernel_main() {
@@ -21,13 +23,15 @@ void kernel_main() {
 
     auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst);
 
+    experimental::CircularBuffer cb(cb_id);
+
     constexpr uint32_t one_tile = 1;
-    uint32_t cb_addr = get_write_ptr(cb_id);
+    uint32_t cb_addr = cb.get_write_ptr();
     auto pages = accessor_dst.pages(start_page, end_page);
     for (const auto& page : pages) {
-        cb_wait_front(cb_id, one_tile);
+        cb.wait_front(one_tile);
         noc_async_write(cb_addr, page.noc_addr(), page_size);
         noc_async_write_barrier();
-        cb_pop_front(cb_id, one_tile);
+        cb.pop_front(one_tile);
     }
 }


### PR DESCRIPTION
## Summary
- Migrates 16 kernel files in `ttnn/cpp/ttnn/operations/data_movement/` (sharded and move operations)
- Uses experimental::Noc, experimental::CircularBuffer APIs
- 2 full migrations + 14 partial migrations (CB experimental, NOC legacy for explicit coords/semaphores)

### Migration details:

**Full migration (CB + NOC experimental):**
- `reader_unary_sharded_blocks_interleaved_start_id.cpp`
- `writer_unary_sharded_blocks_interleaved_start_id.cpp`

**Partial migration (CB experimental, NOC legacy):**
- Sharded: 12 kernels using `get_noc_addr()` with explicit NOC coords
- Move: 2 kernels using semaphores and multicast operations

**No migration needed:**
- 5 kernels with no CB protocol operations (reshard readers, nd_reshard_copy_local_shards)
- 1 kernel with non-standard CB usage (reader_unary_local_l1_copy_backwards)

## Test plan

Rebased onto latest main (2026-04-22). Ran the diagnostic grep from the migration plan's Known Issues to confirm no variable declarations were silently dropped by the rebase — clean.

Local test results (all pass on rebuilt binary):

| Test file | Result |
|---|---|
| `tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py` | 90 passed, 16 skipped |
| `tests/ttnn/unit_tests/operations/data_movement/test_sharded_to_interleaved_oob.py` | 1 passed |
| `tests/ttnn/unit_tests/operations/data_movement/test_core.py -k reshard` | 24 passed |
| `tests/tt_eager/python_api_testing/unit_testing/misc/test_move.py` | 136 passed, 128 skipped |
| `tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py` | 34 passed |
| `tests/tt_eager/python_api_testing/unit_testing/misc/test_nd_reshard.py` | 109 passed, 8 skipped |
| `tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py` | 32 passed, 32 skipped |

**Total: 426 tests passed, 0 failures** across sharded / move / reshard unit tests.

- [x] Build passes (`./build_metal.sh`)
- [x] `test_interleaved_to_sharded.py` passes (PR test plan)
- [x] Additional sharded / move / reshard suites pass (see table above)
- [x] Sanity tests pipeline re-launched on rebased branch
- [x] Blackhole post-commit pipeline re-launched on rebased branch

Part of #41702

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

Sanity tests and blackhole post-commit are clean, except for unrelated failures.

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=device-2.0-migration/sharded-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:device-2.0-migration/sharded-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=device-2.0-migration/sharded-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:device-2.0-migration/sharded-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=device-2.0-migration/sharded-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:device-2.0-migration/sharded-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=device-2.0-migration/sharded-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:device-2.0-migration/sharded-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=device-2.0-migration/sharded-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:device-2.0-migration/sharded-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=device-2.0-migration/sharded-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:device-2.0-migration/sharded-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=device-2.0-migration/sharded-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:device-2.0-migration/sharded-ops)