### PR TITLE
Bug fix for >4D tensors in AllBroadcast and Broadcast

### DIFF
--- a/tests/nightly/t3000/ccl/test_broadcast_op.py
+++ b/tests/nightly/t3000/ccl/test_broadcast_op.py
@@ -309,6 +309,15 @@ def run_broadcast_impl(
             ttnn.bfloat16,
             ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
         ),
+        (
+            4,
+            1,
+            1,
+            [1, 16, 1, 16, 512],
+            ttnn.ROW_MAJOR_LAYOUT,
+            ttnn.bfloat16,
+            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ),
     ],
     ids=[
         "2-dev-DRAM",
@@ -320,6 +329,7 @@ def run_broadcast_impl(
         "8-dev-DRAM-2",
         "2-dev-L1-2",
         "4-dev-DRAM-3",
+        "4-dev-DRAM-5D",
     ],
 )
 @pytest.mark.parametrize("num_iters", [3])

--- a/tests/nightly/t3000/ccl/test_new_all_broadcast.py
+++ b/tests/nightly/t3000/ccl/test_new_all_broadcast.py
@@ -271,6 +271,14 @@ def run_all_broadcast_impl(
             ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
         ),
         (4, 1, [2, 2, 2, 16, 16], ttnn.TILE_LAYOUT, ttnn.bfloat16, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1)),
+        (
+            4,
+            1,
+            [1, 16, 1, 16, 512],
+            ttnn.ROW_MAJOR_LAYOUT,
+            ttnn.bfloat16,
+            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+        ),
     ],
 )
 @pytest.mark.parametrize("num_iters", [3])

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -106,12 +106,11 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
     uint32_t row_size = input_tensor.logical_shape()[-1] * input_tensor.element_size();
     uint32_t page_size = input_tensor.buffer()->aligned_page_size();
 
-    uint32_t num_rows = input_tensor.logical_shape().size() > 2
-                            ? input_tensor.logical_shape()[-2] * input_tensor.logical_shape()[-3]
-                            : input_tensor.logical_shape()[-2];
-    if (input_tensor.logical_shape().size() == 4) {
-        num_rows *= input_tensor.logical_shape()[0];
-    }
+    uint32_t num_rows = std::accumulate(
+        input_tensor.logical_shape().cbegin(),
+        input_tensor.logical_shape().cend() - 1,
+        1u,
+        std::multiplies<uint32_t>());
 
     // L1 Scratch CB Creation
     DataType dtype = input_tensor.dtype();

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
@@ -108,12 +108,11 @@ BroadcastProgramFactory::cached_program_t BroadcastProgramFactory::create_at(
     uint32_t row_size = input_tensor.logical_shape()[-1] * input_tensor.element_size();
     uint32_t page_size = input_tensor.buffer()->aligned_page_size();
 
-    uint32_t num_rows = input_tensor.logical_shape().size() > 2
-                            ? input_tensor.logical_shape()[-2] * input_tensor.logical_shape()[-3]
-                            : input_tensor.logical_shape()[-2];
-    if (input_tensor.logical_shape().size() == 4) {
-        num_rows *= input_tensor.logical_shape()[0];
-    }
+    uint32_t num_rows = std::accumulate(
+        input_tensor.logical_shape().cbegin(),
+        input_tensor.logical_shape().cend() - 1,
+        1u,
+        std::multiplies<uint32_t>());
 
     // L1 Scratch CB Creation
     DataType dtype = input_tensor.dtype();


### PR DESCRIPTION
### Summary
PR https://github.com/tenstorrent/tt-metal/pull/41878 caused failures in Galaxy CCL CI tests (https://github.com/tenstorrent/tt-metal/actions/runs/24430422290/job/71374037922).

Root-cause is a bug in AllBroadcast where `num_rows` is hardcoded to assume a 4D tensor. PR https://github.com/tenstorrent/tt-metal/pull/41878 exposed this because it causes AllReduce to pass a 5D tensor to AllBroadcast.

Broadcast op also shares the same bug.

I've fixed both ops in this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-ab) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-ab) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-ab) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:scardoza/fix-ab) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:scardoza/fix-ab) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:scardoza/fix-ab) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-ab) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-ab) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-ab) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-ab) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-ab) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-ab) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-ab) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-ab) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-ab) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-ab) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-ab) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-ab) |