### PR TITLE
#42174: fix up matmul CB usage to avoid CB llk asserts

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -532,6 +532,7 @@ create_program_batch_sharded(
                 {"cb_in0_intermediate", tt::CBIndex::c_8},
                 {"cb_in1_intermediate", tt::CBIndex::c_9},
                 {"cb_in0_transposed", tt::CBIndex::c_10},
+                {"bias_ntiles", per_core_N},
             }});
 
     // Set runtime args - each core only gets SetRuntimeArgs called ONCE per kernel

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -711,6 +711,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 {"cb_in0_intermediate", tt::CBIndex::c_8},
                 {"cb_in1_intermediate", tt::CBIndex::c_9},
                 {"cb_in0_transposed", tt::CBIndex::c_10},
+                {"bias_ntiles", in1_per_core_w},
             }});
 
     // Create circular buffers
@@ -1582,6 +1583,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
                 {"cb_in0_intermediate", tt::CBIndex::c_8},
                 {"cb_in1_intermediate", tt::CBIndex::c_9},
                 {"cb_in0_transposed", tt::CBIndex::c_10},
+                {"bias_ntiles", in1_per_core_w},
             }});
 
     // Create circular buffers

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -870,6 +870,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
                 {"cb_in0_intermediate", tt::CBIndex::c_8},
                 {"cb_in1_intermediate", tt::CBIndex::c_9},
                 {"cb_in0_transposed", tt::CBIndex::c_10},
+                {"bias_ntiles", in1_per_core_w},
             }});
 
     // Create circular buffers

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -220,8 +220,10 @@ create_program_dram_sharded(
     uint32_t in2_CB_tiles = in2_block_tiles;
     uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
 
-    uint32_t in3_block_tiles = per_core_N_in1_sender;
-    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    // Bias CB must be sized to per_core_N_compute (the padded value) because
+    // the compute kernel iterates in1_num_subblocks * out_subblock_w tiles when
+    // adding bias, which equals per_core_N_compute after subblock-width padding.
+    uint32_t in3_CB_tiles = per_core_N_compute;
     uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
 
     // get the max page size based on num tiles
@@ -229,9 +231,10 @@ create_program_dram_sharded(
     get_max_page_size_and_num_pages(
         device, in1_block_tiles, in1_single_tile_size, in1_buffer_page_size, in1_buffer_num_pages);
 
+    // DRAM read uses per_core_N_in1_sender (actual data tiles), not the padded CB size
     uint32_t bias_buffer_page_size, bias_buffer_num_pages;
     get_max_page_size_and_num_pages(
-        device, in3_block_tiles, bias_single_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
+        device, per_core_N_in1_sender, bias_single_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
 
     uint32_t num_worker_cores = num_dram_banks;
 
@@ -334,7 +337,7 @@ create_program_dram_sharded(
         (std::uint32_t)in1_buffer_page_size,
         (std::uint32_t)in1_buffer_num_pages,
         // in1 block args
-        (std::uint32_t)per_core_N_in1_sender,                // in1_block_w
+        (std::uint32_t)per_core_N_compute,                   // in1_block_w (padded, used only for bias CB)
         (std::uint32_t)per_core_N_in1_sender * in0_block_w,  // in1_block_num_tiles
         // in0/in1 common args
         (std::uint32_t)num_blocks,                                    // num_blocks
@@ -474,6 +477,7 @@ create_program_dram_sharded(
                 {"cb_in0_intermediate", tt::CBIndex::c_8},
                 {"cb_in1_intermediate", tt::CBIndex::c_9},
                 {"cb_in0_transposed", tt::CBIndex::c_10},
+                {"bias_ntiles", per_core_N_compute},
             }});
 
     log_debug(LogOp, "in1_single_tile_size: {}", in1_single_tile_size);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -446,6 +446,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         {"cb_in0_intermediate", tt::CBIndex::c_8},
         {"cb_in1_intermediate", tt::CBIndex::c_9},
         {"cb_in0_transposed", tt::CBIndex::c_10},
+        {"bias_ntiles", in1_per_core_w},
     };
 
     // Compute kernel compile time args (group 1)

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -195,6 +195,7 @@ void kernel_main() {
 
 #ifdef FUSE_BIAS
     constexpr uint32_t bias_cb_id = get_named_compile_time_arg_val("cb_bias");
+    constexpr uint32_t bias_ntiles = get_named_compile_time_arg_val("bias_ntiles");
     constexpr uint32_t mm_out_cb_id = mm_partials_cb_id;
     experimental::CircularBuffer bias_cb(bias_cb_id);
 #else
@@ -231,7 +232,6 @@ void kernel_main() {
         for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
             for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                 bool enable_reload = false;
-                uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
 
 #ifdef PACK_RELU
                 // for each batch we start with relu disabled so that intermediate results are not relu'd
@@ -275,6 +275,10 @@ void kernel_main() {
 
                     in0_cb.wait_front(in0_block_num_tiles);
                     in1_cb.wait_front(in1_block_num_tiles);
+
+                    if (block == 0 && !last_out) {
+                        out_cb.reserve_back(out_block_num_tiles);
+                    }
 
                     int in0_index_subblock_offset = 0;
                     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
@@ -358,13 +362,6 @@ void kernel_main() {
 
                             } else {
                                 tile_regs_commit();
-                                // Wait for tiles in output buffer to be written out since interm and output share
-                                // memory
-                                if (block == 0) {
-                                    out_cb.reserve_back(out_num_tiles_to_wait);
-                                    out_num_tiles_to_wait += out_subblock_num_tiles;
-                                }
-                                // Move partial result to interm buffer
                                 mm_partials_cb.reserve_back(out_subblock_num_tiles);
                                 tile_regs_wait();
 
@@ -395,18 +392,24 @@ void kernel_main() {
 #ifdef PACKER_L1_ACC
 #ifdef FUSE_BIAS
                     if (block < num_blocks_inner_dim - 1) {
-                        // Wait for l1 accumulation to populate interm buffer,
-                        // then pop to update fifo rd pointer
-                        mm_partials_cb.wait_front(out_block_num_tiles);
-                        mm_partials_cb.pop_front(out_block_num_tiles);
+                        // Wait/pop in subblock-sized steps so the step size
+                        // matches the bias section's wait_front(out_subblock_num_tiles),
+                        // satisfying the CB API requirement that all wait_front
+                        // increments on a given CB are identical.
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                            mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            mm_partials_cb.pop_front(out_subblock_num_tiles);
+                        }
                     }
                     // never reload when with bias, bias uses interm buffer
                     enable_reload = false;
 #else
                     // Last iteration does spill and reload to output buffer
                     if (block < num_blocks_inner_dim - 2) {
-                        mm_partials_cb.wait_front(out_block_num_tiles);
-                        mm_partials_cb.pop_front(out_block_num_tiles);
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                            mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            mm_partials_cb.pop_front(out_subblock_num_tiles);
+                        }
                     }
                     if (block == num_blocks_inner_dim - 2) {
                         enable_reload = true;
@@ -436,8 +439,11 @@ void kernel_main() {
 
                 reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
                 add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
-                // reconfigure unpacker df for src B
-                bias_cb.wait_front(in1_block_w);
+                // Reader only pushes bias once when num_blocks_w_dim == 1;
+                // the tiles stay in the CB for reuse across bh/batch iterations.
+                if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
+                    bias_cb.wait_front(bias_ntiles);
+                }
                 for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                     int in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
@@ -479,7 +485,7 @@ void kernel_main() {
                     }
                 }
                 if constexpr (num_blocks_w_dim > 1) {
-                    bias_cb.pop_front(in1_block_w);
+                    bias_cb.pop_front(bias_ntiles);
                 }
 #endif  // FUSE_BIAS
                 if constexpr (untilize_out) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -535,6 +535,7 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
                 {"cb_in0_intermediate", tt::CBIndex::c_8},
                 {"cb_in1_intermediate", tt::CBIndex::c_9},
                 {"cb_in0_transposed", tt::CBIndex::c_10},
+                {"bias_ntiles", in1_per_core_w},
             }});
 
     // Create circular buffers


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #42174 

Fix CB API violations in bmm_large_block_zm_fused_bias_activation compute kernel

Four categories of fixes to satisfy circular buffer API constraints (tile counts must evenly divide CB size, wait_front step sizes must be consistent, and tile counts must increase cumulatively between pop_front calls):

Bias CB: introduce bias_ntiles named compile-time arg. The kernel previously used in1_block_w for bias wait_front/pop_front, but in the DRAM-sharded factory in1_block_w was overloaded and could differ from the actual bias CB size. All 6 factories now pass bias_ntiles to decouple bias tile count from weight stride.

Bias CB: guard wait_front for single-bw configurations. When num_blocks_w_dim == 1, the reader pushes bias tiles only once (b == 0 && bh == 0) and the compute kernel reuses them across bh/batch iterations without popping. The wait_front call is now similarly guarded to avoid a duplicate call with the same tile count.

mm_partials_cb: use subblock-sized wait_front/pop_front in PACKER_L1_ACC accumulation paths. Both the FUSE_BIAS and non-FUSE_BIAS L1-accumulation paths previously called mm_partials_cb.wait_front(out_block_num_tiles), but reload_from_cb_to_dst and the bias section use out_subblock_num_tiles, causing a step-size mismatch. Replaced with a loop of subblock-sized calls.

Output CB: replace cumulative reserve_back with a single call. The per-subblock out_cb.reserve_back(out_num_tiles_to_wait) pattern used progressively increasing tile counts that could fail the divisibility check. Replaced with a single reserve_back(out_block_num_tiles) before the subblock loop on block 0.

DRAM-sharded factory (matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp): Sized the bias CB to per_core_N_compute (padded for subblock alignment) instead of per_core_N_in1_sender, while keeping the DRAM read size at per_core_N_in1_sender to avoid out-of-bounds reads.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

These issues were found when adding in more llk asserts related to CBs. No need to add new tests because existing tests run with llk asserts will catch these errrors.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42174_mm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-42174_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42174_mm) | [#2925](https://github.com/tenstorrent/tt-metal/actions/runs/24485929409) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42174_mm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-42174_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42174_mm) | [#17563](https://github.com/tenstorrent/tt-metal/actions/runs/24485935442) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42174_mm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-42174_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42174_mm) | [#5254](https://github.com/tenstorrent/tt-metal/actions/runs/24485942485) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42174_mm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-42174_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42174_mm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42174_mm) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42174_mm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-42174_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42174_mm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42174_mm) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42174_mm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-42174_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42174_mm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42174_mm) |