### PR TITLE
Fix the Quasar mock device tests (again)

### DIFF
--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -293,13 +293,6 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 // representative of every device in the mesh.
 
 void ValidateNodeBounds(const ProgramSpec& spec) {
-    if (is_gen2_arch()) {
-        // These checks break the Quasar mock device.
-        // Disable for now.
-        // TODO: re-enable with a PR that adds core_descriptor YAMLs
-        //       to the tests build :(
-        return;
-    }
 
     MetalEnvImpl& env_impl = MetalEnvAccessor(MetalContext::instance().get_env()).impl();
 

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -59,3 +59,18 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal/soc_descriptors
     COMPONENT metalium-validation
 )
+
+# Install core descriptor YAML files for mock device testing.
+# These are required by get_core_descriptor_file(), which looks for files in:
+# get_root_dir() + "/tt_metal/core_descriptors/"
+# Production core descriptors (BH/WH) are already installed via JITAPI_FILES.
+# These simulation/versim variants are only needed for mock device tests.
+install(
+    FILES
+        ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml
+        ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/quasar_simulation_1x3_arch.yaml
+        ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/quasar_simulation_8x4_arch.yaml
+        ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/wormhole_b0_versim_1x1_arch.yaml
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal/core_descriptors
+    COMPONENT metalium-validation
+)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40981

### PR Type
Test infra

### Problem description
I'm using the Quasar mock device for API unit testing. 

In order for the unit tests to pass in CI, some fictional mock device YAML files need to be added to the `metalium_validation` package.

This is the exact same problem (and same fix) as in https://github.com/tenstorrent/tt-metal/pull/41345; just that new code began exercising another mock device path, necessitating yet more YAMLs. 

### What's changed
 - Add some fictional core_descriptor YAML files to the metalium_validation CMake (not the main package)
 - Re-enable the code I bypassed to circumvent this issue

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-quasar-mock-device-again)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-quasar-mock-device-again) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-quasar-mock-device-again)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-quasar-mock-device-again) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-quasar-mock-device-again)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-quasar-mock-device-again) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-quasar-mock-device-again)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-quasar-mock-device-again) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-quasar-mock-device-again)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-quasar-mock-device-again) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-quasar-mock-device-again)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-quasar-mock-device-again) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-quasar-mock-device-again) |