### PR TITLE
Fix SDPA softplus kernel build after #42115 template change

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1112,7 +1112,7 @@ void calculate_softplus_first_column(uint param0, uint param1, uint param2) {
     float beta_reciprocal = ckernel::sfpu::Converter::as_float(param1);
     float threshold = ckernel::sfpu::Converter::as_float(param2);
     for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
-        ckernel::sfpu::calculate_softplus_body<APPROX>(beta, beta_reciprocal, threshold);
+        ckernel::sfpu::calculate_softplus_body<APPROX, DST_ACCUM_MODE>(beta, beta_reciprocal, threshold);
         sfpi::dst_reg += 2;
     }
 }


### PR DESCRIPTION
#42115 added `is_fp32_dest_acc_en` as a second template parameter to `calculate_softplus_body` but missed the call site in SDPA's `compute_common.hpp`, causing a runtime kernel compilation failure.

## Test plan

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/fix-sdpa-softplus-template)](https://github.com/tenstorrent/tt-metal/actions/runs/24497385115)
- [ ] [![Nightly tt-metal L2 tests (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/fix-sdpa-softplus-template)](https://github.com/tenstorrent/tt-metal/actions/runs/24497386245)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/fix-sdpa-softplus-template)](https://github.com/tenstorrent/tt-metal/actions/runs/24497386905)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
