### PR TITLE
SDXL: Fix OOM in CI for N150

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -46,9 +46,34 @@ jobs:
           # ----- Catalogs -----
           # Stable set (default path; optional per-model timeout)
           # SDXL model requires test run over 30min to successfully execute pcc test on the entire UNet loop
-          # Temporarily filtered to only SDXL for testing OOM fix
           STABLE='[
-            {"model":"stable_diffusion_xl_base","timeout": 120}
+            {"model":"bge_m3"},
+            {"model":"common_models"},
+            {"model":"functional_unet"},
+            {"model":"ttt-llama3.2-1B"},
+            {"model":"qwen25_vl-3B"},
+            {"model":"resnet50"},
+            {"model":"whisper"},
+            {"model":"openpdn_mnist"},
+            {"model":"vit"},
+            {"model":"sentence_bert"},
+            {"model":"swin_s"},
+            {"model":"swin_v2"},
+            {"model":"mobilenetv2"},
+            {"model":"mobilenetv3"},
+            {"model":"segformer"},
+            {"model":"vgg_unet"},
+            {"model":"vanilla_unet"},
+            {"model":"efficientnetb0"},
+            {"model":"efficientdetd0"},
+            {"model":"vovnet"},
+            {"model":"ssd512"},
+            {"model":"yunet"},
+            {"model":"retinanet"},
+            {"model":"ufld_v2"},
+            {"model":"ttt-mistral-7B-v0.3"},
+            {"model":"stable_diffusion_xl_base","timeout": 120},
+            {"model":"stable_diffusion","timeout":45}
           ]'
 
           # Stable set (CIv2)
@@ -145,7 +170,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: tt-metal-ci-vm-168  # Hardcoded for testing, was: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
+    runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -46,34 +46,9 @@ jobs:
           # ----- Catalogs -----
           # Stable set (default path; optional per-model timeout)
           # SDXL model requires test run over 30min to successfully execute pcc test on the entire UNet loop
+          # Temporarily filtered to only SDXL for testing OOM fix
           STABLE='[
-            {"model":"bge_m3"},
-            {"model":"common_models"},
-            {"model":"functional_unet"},
-            {"model":"ttt-llama3.2-1B"},
-            {"model":"qwen25_vl-3B"},
-            {"model":"resnet50"},
-            {"model":"whisper"},
-            {"model":"openpdn_mnist"},
-            {"model":"vit"},
-            {"model":"sentence_bert"},
-            {"model":"swin_s"},
-            {"model":"swin_v2"},
-            {"model":"mobilenetv2"},
-            {"model":"mobilenetv3"},
-            {"model":"segformer"},
-            {"model":"vgg_unet"},
-            {"model":"vanilla_unet"},
-            {"model":"efficientnetb0"},
-            {"model":"efficientdetd0"},
-            {"model":"vovnet"},
-            {"model":"ssd512"},
-            {"model":"yunet"},
-            {"model":"retinanet"},
-            {"model":"ufld_v2"},
-            {"model":"ttt-mistral-7B-v0.3"},
-            {"model":"stable_diffusion_xl_base","timeout": 120},
-            {"model":"stable_diffusion","timeout":45}
+            {"model":"stable_diffusion_xl_base","timeout": 120}
           ]'
 
           # Stable set (CIv2)
@@ -170,7 +145,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
+    runs-on: tt-metal-ci-vm-168  # Hardcoded for testing, was: ["cloud-virtual-machine", "${{ inputs.extra-tag }}", "${{ matrix.card }}"]
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -213,6 +213,13 @@ jobs:
               $PYTEST_CMD tests/nightly/single_card/tt_transformers -k ${{ matrix.test-config.model }}
             elif [[ "${{ matrix.test-config.model }}" == *"qwen25_vl"* ]]; then
               $PYTEST_CMD tests/nightly/single_card/qwen25_vl -k ${{ matrix.test-config.model }}
+            elif [[ "${{ matrix.test-config.model }}" == "stable_diffusion_xl_base" ]]; then
+              # Split into separate pytest invocations to avoid host OOM from accumulated memory
+              # across 311 tests in a single process (LoRA tests load ~15GB per test case).
+              $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base/lora
+              $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base/refiner
+              $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base/vae
+              $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base --ignore=tests/nightly/single_card/stable_diffusion_xl_base/lora --ignore=tests/nightly/single_card/stable_diffusion_xl_base/refiner --ignore=tests/nightly/single_card/stable_diffusion_xl_base/vae
             else
               $PYTEST_CMD tests/nightly/single_card/${{ matrix.test-config.model }}
             fi
@@ -403,7 +410,15 @@ jobs:
         env:
           PYTEST_CMD: ${{ inputs.enable-ops-recording && 'python -m tracy -r -p --dump-device-data-mid-run -m pytest' || 'pytest' }}
         run: |
-          $PYTEST_CMD tests/nightly/single_card/${{ matrix.test-config.model }}
+          if [[ "${{ matrix.test-config.model }}" == "stable_diffusion_xl_base" ]]; then
+            # Split into separate pytest invocations to avoid host OOM from accumulated memory
+            $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base/lora
+            $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base/refiner
+            $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base/vae
+            $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base --ignore=tests/nightly/single_card/stable_diffusion_xl_base/lora --ignore=tests/nightly/single_card/stable_diffusion_xl_base/refiner --ignore=tests/nightly/single_card/stable_diffusion_xl_base/vae
+          else
+            $PYTEST_CMD tests/nightly/single_card/${{ matrix.test-config.model }}
+          fi
       - name: Prepare Tracy reports
         if: ${{ !cancelled() && inputs.enable-ops-recording }}
         uses: ./docker-job/.github/actions/prepare-tracy-reports


### PR DESCRIPTION
### Summary
Before (current): One pytest process collects all 311 tests in `tests/nightly/single_card/stable_diffusion_xl_base`, runs them sequentially in the same process. At some point we encounter `bash: line 25:    40 Killed                  $PYTEST_CMD tests/nightly/single_card/stable_diffusion_xl_base` which is probably related to OOM issue.

Failing `(Single-card) Frequent model and ttnn tests`: 
https://github.com/tenstorrent/tt-metal/actions/runs/24383084263/job/71211282124#step:8:6545 (tt-metal-ci-vm-168)
https://github.com/tenstorrent/tt-metal/actions/runs/24371949934/job/71177995309#step:8:6542  (tt-metal-ci-vm-232)
https://github.com/tenstorrent/tt-metal/actions/runs/24327991672/job/71028004729#step:8:6538  (tt-metal-ci-vm-14)
https://github.com/tenstorrent/tt-metal/actions/runs/24293730213/job/70935394490#step:8:6619   (tt-metal-ci-vm-109)                                                  
                                                            
 After (with the change): Four separate pytest processes, each collecting a subset of tests:                                                                                                          
  1. lora/ - 41 tests
  2. refiner/ - 112                                                                                                            
  3. vae/ - 70
  4. base tests - 88
  In total, still 311 tests collected but run in 4 different processes.                                                                                                                      
                                                            
 When a process exits, the OS reclaims 100% of its memory. Each batch starts fresh.        
                                                                                                                                                                                              
 This doesn't fix the underlying memory behavior but it limits how much any single process can accumulate.

Passing `(Single-card) Frequent model and ttnn tests`:
https://github.com/tenstorrent/tt-metal/actions/runs/24447974628/job/71430687555   (tt-metal-ci-vm-232)
https://github.com/tenstorrent/tt-metal/actions/runs/24453297915/job/71448674531    (tt-metal-ci-vm-98)
https://github.com/tenstorrent/tt-metal/actions/runs/24459546799/job/71471451789  (tt-metal-ci-vm-168)

### Notes for reviewers
We might have some memory leak regarding outputs/weights or caching issue that is hard to find. At first I thought this is related to some specific runners so that is why I marked each test's runner. We can see 168 and 232 in both failing and passing tests, which means that it is probably not related to the runners themselves. The same tests for BH pass because half of them are skipped since we do not support 512x512 resolution on BH.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml?query=branch:nmilicevic/sdxl-ci-oom-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=nmilicevic/sdxl-ci-oom-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml?query=branch:nmilicevic/sdxl-ci-oom-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml?query=branch:nmilicevic/sdxl-ci-oom-fix) |
