### PR TITLE
Fix permute kernel BRISC compile failure with sharded TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
@@ -261,7 +261,7 @@ void kernel_main() {
                     uint32_t output_tile_offset_bytes = base_output_face_line_offset_bytes + face_w_offset_bytes;
 
                     // Build final output address
-                    uint64_t write_noc_base_addr = get_noc_addr(output_tile_idx, s, output_tile_offset_bytes);
+                    uint64_t write_noc_base_addr = s.get_noc_addr(output_tile_idx, output_tile_offset_bytes);
 
                     // Build final input read address
                     uint32_t final_addr = base_l1_read_addr + face_h_offset_bytes + face_w_offset_bytes +
@@ -319,7 +319,7 @@ void kernel_main() {
                     for (uint8_t sub_tile_line = sub_tile_line_start; sub_tile_line < FACE_HEIGHT; ++sub_tile_line) {
                         uint32_t offset = (face_offset + (sub_tile_line * FACE_WIDTH)) * element_size;
 
-                        uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
+                        uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
 
                         // Perform asynchronous write
                         noc_async_write(l1_read_ptr, write_noc_base_addr, SUBTILE_LINE_BYTES);


### PR DESCRIPTION
## Summary
- Fix BRISC compile failure in `writer_permute_interleaved_tiled_row_invariant.cpp` when `ttnn.permute` outputs to HEIGHT_SHARDED L1 memory
- Replace free function `get_noc_addr(id, accessor, offset)` with member function `accessor.get_noc_addr(id, offset)` on lines 264 and 322, matching the pattern used by other correctly migrated kernels (e.g. `writer_pad_tiled.cpp`)

## Root Cause
The free `get_noc_addr` template in `dataflow_api_addrgen.h:430` uses SFINAE (`decltype(addrgen.get_noc_addr())* resolver = nullptr`) which requires a zero-argument `get_noc_addr()` method. The sharded (non-interleaved) TensorAccessor primary template does NOT have one (it doesn't inherit from `InterleavedAddrGen`), so SFINAE excludes the template and no overload matches.

## Repro
```python
import torch, ttnn

device = ttnn.open_device(device_id=0)
input_tensor = ttnn.from_torch(
    torch.zeros(32, 1, 1, 128, dtype=torch.bfloat16),
    dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device,
)
# permutation [2, 0, 1, 3] -> MultiCoreTileRowInvariant kernel
# HEIGHT_SHARDED L1 output -> sharded TensorAccessor -> SFINAE failure
result = ttnn.permute(
    input_tensor, [2, 0, 1, 3],
    memory_config=ttnn.MemoryConfig(
        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1,
        ttnn.ShardSpec(
            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))]),
            [32, 128], ttnn.ShardOrientation.ROW_MAJOR,
        ),
    ),
    pad_value=0.0,
)
ttnn.close_device(device)
```

### Error
```
brisc compile failure:
error: no matching function for call to 'get_noc_addr(uint32_t&, const TensorAccessor<...DistributionSpec...>&, uint32_t&)'
  264 |  uint64_t write_noc_base_addr = get_noc_addr(output_tile_idx, s, output_tile_offset_bytes);
      |                                 ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: candidate: 'template<class AddrGen> uint64_t get_noc_addr(uint32_t, const AddrGen&, uint32_t, uint8_t, decltype(addrgen.get_noc_addr())*)'
note: template argument deduction/substitution failed:
note: no matching function for call to 'TensorAccessor<...>::get_noc_addr() const'
  435 |     decltype(addrgen.get_noc_addr())* resolver = nullptr
```