### PR TITLE
[fuser] refactor: operand management

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -230,8 +230,8 @@ class OperandRegistry:
             l1_address=address,
             is_output=False,
             sfpu=sfpu,
+            const_value=const_value,
         )
-        operand.const_value = const_value
         self.operands[name] = operand
         return operand
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -18,35 +18,27 @@ from ttexalens.tt_exalens_lib import read_from_device, write_to_device
 @dataclass
 class Operand:
     name: str
-    dimensions: Optional[Tuple[int, int]] = None
-    data_format: Optional[DataFormat] = None
-    tile_shape: Optional[TileShape] = None
+    dimensions: Tuple[int, int]
+    data_format: DataFormat
+    tile_shape: TileShape = construct_tile_shape(
+        (DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM)
+    )
     l1_address: Optional[int] = None
     is_output: bool = False
     sfpu: bool = True
     _data: Optional[torch.Tensor] = None
     _raw_data: Optional[torch.Tensor] = None
     _master_golden: Optional[torch.Tensor] = None
+    _const_value: Optional[float] = None
     l1_golden: Optional[torch.Tensor] = None
-    _tile_count: Optional[int] = None
+    tile_count: Optional[int] = None
     tile_count_x: Optional[int] = None
     tile_count_y: Optional[int] = None
 
     def __post_init__(self):
-        if not self.is_output and (self.dimensions is None or self.data_format is None):
-            raise ValueError(
-                f"Input operand '{self.name}' must have dimensions and data_format"
-            )
-
-        if self.tile_shape is None:
-            self.tile_shape = construct_tile_shape(
-                (DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM)
-            )
-
-        if self.dimensions is not None:
-            self.tile_count_x = self.dimensions[1] // self.tile_shape.total_col_dim()
-            self.tile_count_y = self.dimensions[0] // self.tile_shape.total_row_dim()
-            self._tile_count = self.tile_count_x * self.tile_count_y
+        self.tile_count_x = self.dimensions[1] // self.tile_shape.total_col_dim()
+        self.tile_count_y = self.dimensions[0] // self.tile_shape.total_row_dim()
+        self.tile_count = self.tile_count_x * self.tile_count_y
 
     def is_input(self) -> bool:
         return not self.is_output
@@ -55,10 +47,7 @@ class Operand:
         if self._data is not None:
             return
 
-        if self.dimensions is None or self.data_format is None:
-            raise ValueError(
-                f"Cannot generate data for operand '{self.name}' without dimensions and format"
-            )
+        const_value = const_value if const_value is not None else self._const_value
 
         height, width = self.dimensions[0], self.dimensions[1]
         tile_rows = self.tile_shape.total_row_dim()
@@ -100,6 +89,7 @@ class Operand:
         self._tile_count = tile_count
 
     def set_data(self, raw_data: torch.Tensor):
+        self._const_value = None
         self._raw_data = raw_data
 
         if self.data_format != DataFormat.Bfp8_b:
@@ -132,19 +122,6 @@ class Operand:
         if self.is_input():
             return self.raw_data
         return self._master_golden
-
-    @property
-    def tile_count(self) -> Optional[int]:
-        if self._tile_count is None:
-            if self.dimensions is not None:
-                tile_rows = self.tile_shape.total_row_dim()
-                tile_cols = self.tile_shape.total_col_dim()
-                self._tile_count = (self.dimensions[0] // tile_rows) * (
-                    self.dimensions[1] // tile_cols
-                )
-            elif self.is_input():
-                self.generate_data()
-        return self._tile_count
 
     def __str__(self) -> str:
         return f"{self.name}, {self.dimensions}, {self.data_format}, L1 Addr: {hex(self.l1_address)}"
@@ -277,6 +254,7 @@ class OperandRegistry:
         data_format: DataFormat,
         address: int = None,
         sfpu: bool = True,
+        const_value: Optional[float] = None,
     ) -> Operand:
         if name in self.operands:
             raise ValueError(f"Operand '{name}' already exists")
@@ -289,6 +267,7 @@ class OperandRegistry:
             is_output=False,
             sfpu=sfpu,
         )
+        operand._const_value = const_value
         self.operands[name] = operand
         return operand
 
@@ -344,32 +323,42 @@ class OperandRegistry:
         src_b_const_value: Optional[float] = None,
     ) -> OperandMapping:
         if src_a not in self.operands:
-            self.add_input(src_a, dimensions=src_a_dims, data_format=input_format)
+            self.add_input(
+                src_a,
+                dimensions=src_a_dims,
+                data_format=input_format,
+                const_value=src_a_const_value,
+            )
         else:
             existing = self.operands[src_a]
             if list(existing.dimensions) != list(src_a_dims):
                 raise ValueError(
                     f"Operand '{src_a}' already exists with dimensions {existing.dimensions}, got {src_a_dims}"
                 )
+            if src_a_tensor is None:
+                self.operands[src_a]._const_value = src_a_const_value
 
         if src_b not in self.operands:
-            self.add_input(src_b, dimensions=src_b_dims, data_format=input_format)
+            self.add_input(
+                src_b,
+                dimensions=src_b_dims,
+                data_format=input_format,
+                const_value=src_b_const_value,
+            )
         else:
             existing = self.operands[src_b]
             if list(existing.dimensions) != list(src_b_dims):
                 raise ValueError(
                     f"Operand '{src_b}' already exists with dimensions {existing.dimensions}, got {src_b_dims}"
                 )
+            if src_b_tensor is None:
+                self.operands[src_b]._const_value = src_b_const_value
 
         if src_a_tensor is not None:
             self.operands[src_a].set_data(src_a_tensor)
-        else:
-            self.operands[src_a].generate_data(const_value=src_a_const_value)
 
         if src_b_tensor is not None:
             self.operands[src_b].set_data(src_b_tensor)
-        else:
-            self.operands[src_b].generate_data(const_value=src_b_const_value)
 
         mapping = OperandMapping(
             src_a=src_a,
@@ -386,7 +375,9 @@ class OperandRegistry:
     DEFAULT_L1_END_ADDRESS = 0x00169FFF
 
     def allocate_l1_addresses(
-        self, start_address: int = DEFAULT_L1_START_ADDRESS, end_address: int = DEFAULT_L1_END_ADDRESS
+        self,
+        start_address: int = DEFAULT_L1_START_ADDRESS,
+        end_address: int = DEFAULT_L1_END_ADDRESS,
     ) -> None:
         """
         Allocate L1 addresses for all operands.
@@ -408,8 +399,9 @@ class OperandRegistry:
                 operand.l1_address = current_address
                 current_address += operand.calculate_l1_size()
                 if current_address > end_address:
-                    raise ValueError("There is not enought space on device for all operands")
-
+                    raise ValueError(
+                        "There is not enough space on device for all operands"
+                    )
 
     def write_inputs_to_l1(self, location: str = "0,0") -> None:
         """Write all input operands to L1 memory."""

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -3,14 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 from helpers.llk_params import DataFormat, format_dict
 from helpers.stimuli_generator import generate_random_face
 from helpers.tile_constants import DEFAULT_TILE_C_DIM, DEFAULT_TILE_R_DIM
 from helpers.tile_shape import TileShape, construct_tile_shape
-from helpers.tilize_untilize import tilize_block
+from helpers.tilize_untilize import tilize_block, untilize_block
+from helpers.unpack import unpack_res_tiles
+from ttexalens.tt_exalens_lib import read_from_device, write_to_device
 
 
 @dataclass
@@ -146,6 +148,70 @@ class Operand:
 
     def __str__(self) -> str:
         return f"{self.name}, {self.dimensions}, {self.data_format}, L1 Addr: {hex(self.l1_address)}"
+
+    def calculate_l1_size(self) -> int:
+        """Calculate the size in L1 memory for this operand."""
+        tile_elements = self.tile_shape.total_tile_size()
+        return self.data_format.num_bytes_per_tile(tile_elements) * self.tile_count
+
+    def pack_for_l1(self) -> List[Tuple[int, List]]:
+        """Pack operand data for writing to L1 memory.
+
+        Returns:
+            List of (address, packed_data) tuples, one per tile.
+        """
+        from helpers.pack import (
+            pack_bfp8_b,
+            pack_bfp16,
+            pack_fp8_e4m3,
+            pack_fp16,
+            pack_fp32,
+            pack_int8,
+            pack_int16,
+            pack_int32,
+            pack_uint8,
+            pack_uint16,
+            pack_uint32,
+        )
+
+        packers = {
+            DataFormat.Float16: pack_fp16,
+            DataFormat.Float16_b: pack_bfp16,
+            DataFormat.Float32: pack_fp32,
+            DataFormat.Bfp8_b: pack_bfp8_b,
+            DataFormat.Int32: pack_int32,
+            DataFormat.UInt32: pack_uint32,
+            DataFormat.Int16: pack_int16,
+            DataFormat.UInt16: pack_uint16,
+            DataFormat.Fp8_e4m3: pack_fp8_e4m3,
+            DataFormat.Int8: pack_int8,
+            DataFormat.UInt8: pack_uint8,
+        }
+
+        pack_function = packers.get(self.data_format)
+        if not pack_function:
+            raise ValueError(f"Unsupported data format: {self.data_format.name}")
+
+        tile_elements = self.tile_shape.total_tile_size()
+        tile_size = self.data_format.num_bytes_per_tile(tile_elements)
+        buffer = self.data.flatten()
+        packed_tiles = []
+
+        for i in range(self.tile_count):
+            start_idx = tile_elements * i
+            tile_data = buffer[start_idx : start_idx + tile_elements]
+
+            if self.data_format == DataFormat.Bfp8_b:
+                packed = pack_function(
+                    tile_data, num_faces=self.tile_shape.total_num_faces()
+                )
+            else:
+                packed = pack_function(tile_data)
+
+            addr = self.l1_address + i * tile_size
+            packed_tiles.append((addr, packed))
+
+        return packed_tiles
 
 
 class OperandMapping:
@@ -315,3 +381,78 @@ class OperandRegistry:
         mapping.create_output_operand(self, output_format, output_dims)
 
         return mapping
+
+    DEFAULT_L1_START_ADDRESS = 0x21000
+
+    def allocate_l1_addresses(
+        self, start_address: int = DEFAULT_L1_START_ADDRESS
+    ) -> None:
+        """
+        Allocate L1 addresses for all operands.
+
+        Addresses are allocated sequentially:
+        1. All input operands
+        2. All output operands
+        """
+
+        current_address = start_address
+
+        for operand in self.get_all_inputs():
+            if operand.l1_address is None:
+                operand.l1_address = current_address
+                current_address += operand.calculate_l1_size()
+
+        for operand in self.get_all_outputs():
+            if operand.l1_address is None:
+                operand.l1_address = current_address
+                current_address += operand.calculate_l1_size()
+
+    def write_inputs_to_l1(self, location: str = "0,0") -> None:
+        """Write all input operands to L1 memory."""
+
+        for operand in self.get_all_inputs():
+            for addr, packed_data in operand.pack_for_l1():
+                write_to_device(location, addr, packed_data)
+
+    def read_outputs_from_l1(self, location: str = "0,0") -> None:
+        """Read output operands from L1 memory."""
+
+        for output in self.get_all_outputs():
+            if output.l1_address is None:
+                raise ValueError(
+                    f"Output operand '{output.name}' does not have an L1 address."
+                )
+
+            output_dimensions = output.dimensions
+            output_format = output.data_format
+            tile_cnt = output.tile_count
+            tile_elements = output.tile_shape.total_tile_size()
+
+            read_bytes_cnt = output_format.num_bytes_per_tile(tile_elements) * tile_cnt
+            read_data = read_from_device(
+                location, output.l1_address, num_bytes=read_bytes_cnt
+            )
+
+            res_from_l1 = unpack_res_tiles(
+                read_data,
+                output_format,
+                tile_count=tile_cnt,
+                sfpu=False,
+                num_faces=output.tile_shape.total_num_faces(),
+                face_r_dim=output.tile_shape.face_r_dim,
+            )
+
+            torch_format = format_dict[output_format]
+            tilized_tensor = torch.tensor(res_from_l1, dtype=torch_format)
+
+            if output_format != DataFormat.Bfp8_b and output_dimensions is not None:
+                raw_tensor = untilize_block(
+                    tilized_tensor,
+                    stimuli_format=output_format,
+                    dimensions=output_dimensions,
+                )
+            else:
+                raw_tensor = tilized_tensor
+
+            output._data = tilized_tensor
+            output._raw_data = raw_tensor

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -238,9 +238,9 @@ class OperandRegistry:
     def add_output(
         self,
         name: str,
+        dimensions: Tuple[int, int],
+        data_format: DataFormat,
         address: int = None,
-        dimensions: Optional[Tuple[int, int]] = None,
-        data_format: Optional[DataFormat] = None,
     ) -> Operand:
         if name in self.operands:
             raise ValueError(f"Output operand '{name}' already exists")

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -26,10 +26,9 @@ class Operand:
     l1_address: Optional[int] = None
     is_output: bool = False
     sfpu: bool = True
-    _data: Optional[torch.Tensor] = None
     _raw_data: Optional[torch.Tensor] = None
     _master_golden: Optional[torch.Tensor] = None
-    _const_value: Optional[float] = None
+    const_value: Optional[float] = None
     l1_golden: Optional[torch.Tensor] = None
     tile_count: Optional[int] = None
     tile_count_x: Optional[int] = None
@@ -43,25 +42,17 @@ class Operand:
     def is_input(self) -> bool:
         return not self.is_output
 
-    def generate_data(self, const_value=None):
-        if self._data is not None:
-            return
-
-        const_value = const_value if const_value is not None else self._const_value
-
+    def generate_data(self):
         height, width = self.dimensions[0], self.dimensions[1]
-        tile_rows = self.tile_shape.total_row_dim()
-        tile_cols = self.tile_shape.total_col_dim()
-        tile_count = (height // tile_rows) * (width // tile_cols)
 
-        faces_needed = tile_count * self.tile_shape.total_num_faces()
+        faces_needed = self.tile_count * self.tile_shape.total_num_faces()
         faces_data = []
 
         for _ in range(faces_needed):
             face = generate_random_face(
                 stimuli_format=self.data_format,
-                const_value=const_value,
-                const_face=const_value is not None,
+                const_value=self.const_value,
+                const_face=self.const_value is not None,
                 sfpu=self.sfpu,
                 face_r_dim=self.tile_shape.face_r_dim,
                 negative_values=False,
@@ -77,39 +68,10 @@ class Operand:
             height, width
         )
 
-        if self.data_format != DataFormat.Bfp8_b:
-            tilized_data = tilize_block(
-                raw_data, dimensions=self.dimensions, stimuli_format=self.data_format
-            )
-        else:
-            tilized_data = raw_data
-
         self._raw_data = raw_data
-        self._data = tilized_data
-        self._tile_count = tile_count
 
     def set_data(self, raw_data: torch.Tensor):
-        self._const_value = None
         self._raw_data = raw_data
-
-        if self.data_format != DataFormat.Bfp8_b:
-            tilized_data = tilize_block(
-                raw_data, dimensions=self.dimensions, stimuli_format=self.data_format
-            )
-        else:
-            tilized_data = raw_data
-
-        self._data = tilized_data
-
-    @property
-    def data(self) -> Optional[torch.Tensor]:
-        if self._data is None and self.is_input():
-            self.generate_data()
-        return self._data
-
-    @data.setter
-    def data(self, value: torch.Tensor):
-        self._data = value
 
     @property
     def raw_data(self) -> Optional[torch.Tensor]:
@@ -171,7 +133,16 @@ class Operand:
 
         tile_elements = self.tile_shape.total_tile_size()
         tile_size = self.data_format.num_bytes_per_tile(tile_elements)
-        buffer = self.data.flatten()
+
+        if self.data_format != DataFormat.Bfp8_b:
+            buffer = tilize_block(
+                self.raw_data,
+                dimensions=self.dimensions,
+                stimuli_format=self.data_format,
+            ).flatten()
+        else:
+            buffer = self.raw_data.flatten()
+
         packed_tiles = []
 
         for i in range(self.tile_count):
@@ -235,13 +206,6 @@ class OperandMapping:
 
         return (M, N)
 
-    def get_output_tile_count(self, operand_registry: "OperandRegistry") -> int:
-        dims = self.resolve_output_dimensions(operand_registry)
-        output_op = operand_registry.get(self.output)
-        tile_rows = output_op.tile_shape.total_row_dim()
-        tile_cols = output_op.tile_shape.total_col_dim()
-        return (dims[0] // tile_rows) * (dims[1] // tile_cols)
-
 
 class OperandRegistry:
     def __init__(self):
@@ -267,7 +231,7 @@ class OperandRegistry:
             is_output=False,
             sfpu=sfpu,
         )
-        operand._const_value = const_value
+        operand.const_value = const_value
         self.operands[name] = operand
         return operand
 
@@ -302,11 +266,6 @@ class OperandRegistry:
     def get_all_outputs(self) -> list[Operand]:
         return [op for op in self.operands.values() if op.is_output]
 
-    def update_data(self, name: str, data: torch.Tensor):
-        if name not in self.operands:
-            raise KeyError(f"Operand '{name}' not found")
-        self.operands[name].data = data
-
     def create_mapping(
         self,
         src_a: str,
@@ -335,8 +294,6 @@ class OperandRegistry:
                 raise ValueError(
                     f"Operand '{src_a}' already exists with dimensions {existing.dimensions}, got {src_a_dims}"
                 )
-            if src_a_tensor is None:
-                self.operands[src_a]._const_value = src_a_const_value
 
         if src_b not in self.operands:
             self.add_input(
@@ -351,8 +308,6 @@ class OperandRegistry:
                 raise ValueError(
                     f"Operand '{src_b}' already exists with dimensions {existing.dimensions}, got {src_b_dims}"
                 )
-            if src_b_tensor is None:
-                self.operands[src_b]._const_value = src_b_const_value
 
         if src_a_tensor is not None:
             self.operands[src_a].set_data(src_a_tensor)
@@ -450,5 +405,4 @@ class OperandRegistry:
             else:
                 raw_tensor = tilized_tensor
 
-            output._data = tilized_tensor
             output._raw_data = raw_tensor

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -342,6 +342,15 @@ class OperandRegistry:
         2. All output operands
         """
 
+        if (
+            start_address < self.DEFAULT_L1_START_ADDRESS
+            or start_address > self.DEFAULT_L1_END_ADDRESS
+        ):
+            raise ValueError(
+                f"Start L1 address for operands must be between "
+                f"{self.DEFAULT_L1_START_ADDRESS} and {self.DEFAULT_L1_END_ADDRESS}"
+            )
+
         current_address = start_address
 
         for operand in self.get_all_inputs():

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -382,10 +382,11 @@ class OperandRegistry:
 
         return mapping
 
-    DEFAULT_L1_START_ADDRESS = 0x21000
+    DEFAULT_L1_START_ADDRESS = 0x00021000
+    DEFAULT_L1_END_ADDRESS = 0x00169FFF
 
     def allocate_l1_addresses(
-        self, start_address: int = DEFAULT_L1_START_ADDRESS
+        self, start_address: int = DEFAULT_L1_START_ADDRESS, end_address: int = DEFAULT_L1_END_ADDRESS
     ) -> None:
         """
         Allocate L1 addresses for all operands.
@@ -406,6 +407,9 @@ class OperandRegistry:
             if operand.l1_address is None:
                 operand.l1_address = current_address
                 current_address += operand.calculate_l1_size()
+                if current_address > end_address:
+                    raise ValueError("There is not enought space on device for all operands")
+
 
     def write_inputs_to_l1(self, location: str = "0,0") -> None:
         """Write all input operands to L1 memory."""

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -50,7 +50,7 @@ class FuserConfig(TestConfig):
         self.operand_registry = operand_registry
 
         if self.global_config.architecture is None:
-            self.global_config.architecture = get_chip_architecture()
+            self.global_config.architecture = self.CHIP_ARCH
 
         for operation in self.pipeline:
             if is_format_combination_outlier(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -107,6 +107,8 @@ class FuserConfig(TestConfig):
         self.build_elfs()
 
     def run_perf_test(self, worker_id: str, run_count: int = 2):
+        """Run performance tests for different isolation levels (L1, unpack, math, pack, congestion) and collect profiling data."""
+
         from .fused_generator import FUSED_TESTS_DIR
 
         self.global_config.profiler_enabled = True
@@ -180,6 +182,8 @@ class FuserConfig(TestConfig):
             perf_report.dump_csv(f"{csv_prefix}.{worker_id}.post.csv")
 
     def run_regular_test(self):
+        """Run functional test: generate, build, write inputs to L1, execute kernel, read outputs and verify against golden."""
+
         from .fused_generator import FUSED_TESTS_DIR
         from .fused_golden import FusedGolden
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -10,10 +10,6 @@ import pandas as pd
 import pytest
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.data_format_inference import data_formats, is_format_combination_outlier
-from helpers.device import (
-    collect_pipeline_results,
-    write_pipeline_operands_to_l1,
-)
 from helpers.llk_params import DestAccumulation, DestSync, PerfRunType
 from helpers.logger import logger
 from helpers.perf import PerfReport
@@ -21,6 +17,7 @@ from helpers.profiler import Profiler, ProfilerData
 from helpers.test_config import BuildMode, ProfilerBuild, StimuliMode, TestConfig
 from ttexalens.tt_exalens_lib import read_words_from_device
 
+from .fused_operand import OperandRegistry
 from .fused_operation import FusedOperation
 
 
@@ -39,6 +36,11 @@ class GlobalConfig:
 class FuserConfig:
     pipeline: List[FusedOperation]
     global_config: GlobalConfig
+
+    @property
+    def registry(self) -> OperandRegistry:
+        """Get the OperandRegistry from the first operation in the pipeline."""
+        return self.pipeline[0].operand_mapping.operand_registry
 
     def __post_init__(self):
         if self.global_config.architecture is None:
@@ -132,7 +134,7 @@ class FuserConfig:
             test_config = self.create_test_config(cpp_path, profiler_enabled=True)
             test_config.generate_variant_hash()
 
-            write_pipeline_operands_to_l1(self.pipeline, TestConfig.TENSIX_LOCATION)
+            self.registry.allocate_l1_addresses()
 
             if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
                 self.generate_and_build_test(cpp_path, test_config)
@@ -190,7 +192,7 @@ class FuserConfig:
         test_config = self.create_test_config(cpp_path, profiler_enabled=False)
         test_config.generate_variant_hash()
 
-        write_pipeline_operands_to_l1(self.pipeline, TestConfig.TENSIX_LOCATION)
+        self.registry.allocate_l1_addresses()
 
         if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
             self.generate_and_build_test(cpp_path, test_config)
@@ -198,8 +200,10 @@ class FuserConfig:
         if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
             pytest.skip(TestConfig.SKIP_JUST_FOR_COMPILE_MARKER)
 
+        self.registry.write_inputs_to_l1(TestConfig.TENSIX_LOCATION)
+
         test_config.run_elf_files()
         test_config.wait_for_tensix_operations_finished()
-        collect_pipeline_results(self.pipeline, TestConfig.TENSIX_LOCATION)
+        self.registry.read_outputs_from_l1(TestConfig.TENSIX_LOCATION)
         golden = FusedGolden()
         assert golden.check_pipeline(self)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -4,6 +4,7 @@
 
 from dataclasses import dataclass
 from functools import reduce
+from hashlib import sha256
 from typing import List
 
 import pandas as pd
@@ -99,6 +100,29 @@ class FuserConfig(TestConfig):
                     f"Block size ({operation.block_size}) is bigger than dest capacity ({dest_capacity})"
                 )
 
+    def generate_variant_hash(self):
+        NON_COMPILATION_ARGUMENTS = [
+            "run_configs",
+            "variant_id",
+            "runtime_arguments_struct",
+            "runtime_format",
+            "passed_templates",
+            "passed_runtimes",
+            "current_run_type",
+            "temp_elfs",
+            "pipeline",
+            "global_config",
+            "operand_registry",
+        ]
+
+        temp_str = [
+            str(value)
+            for field_name, value in self.__dict__.items()
+            if field_name not in NON_COMPILATION_ARGUMENTS
+        ]
+
+        self.variant_id = sha256(str(" | ".join(temp_str)).encode()).hexdigest()
+
     def generate_and_build_test(self):
         from .fused_generator import FusedKernelGenerator
 
@@ -137,10 +161,10 @@ class FuserConfig(TestConfig):
 
             self.operand_registry.allocate_l1_addresses()
 
-            if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
+            if self.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
                 self.generate_and_build_test()
 
-            if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
+            if self.BUILD_MODE == BuildMode.PRODUCE:
                 continue
 
             logger.info("Running perf test for run type: {}", run_type.name)
@@ -151,11 +175,11 @@ class FuserConfig(TestConfig):
                 meta = Profiler._get_meta(self.test_name, self.variant_id)
                 buffer_data = [
                     read_words_from_device(
-                        TestConfig.TENSIX_LOCATION,
+                        self.TENSIX_LOCATION,
                         addr,
-                        word_count=TestConfig.THREAD_PERFORMANCE_DATA_BUFFER_LENGTH,
+                        word_count=self.THREAD_PERFORMANCE_DATA_BUFFER_LENGTH,
                     )
-                    for addr in TestConfig.THREAD_PERFORMANCE_DATA_BUFFER
+                    for addr in self.THREAD_PERFORMANCE_DATA_BUFFER
                 ]
                 profiler_data = Profiler._parse_buffers(buffer_data, meta)
                 profiler_data.df["run_index"] = run_index
@@ -164,7 +188,7 @@ class FuserConfig(TestConfig):
             get_stats = Profiler.STATS_FUNCTION[run_type]
             all_results.append(get_stats(ProfilerData.concat(runs)))
 
-        if TestConfig.BUILD_MODE != BuildMode.PRODUCE and all_results:
+        if self.BUILD_MODE != BuildMode.PRODUCE and all_results:
             results = reduce(
                 lambda left, right: pd.merge(
                     left, right, on="marker", how="outer", validate="1:1"
@@ -187,8 +211,8 @@ class FuserConfig(TestConfig):
         from .fused_generator import FUSED_TESTS_DIR
         from .fused_golden import FusedGolden
 
-        if TestConfig.STIMULI_MODE == StimuliMode.GENERATE_ONLY:
-            pytest.skip(TestConfig.SKIP_JUST_FOR_STIMULI_MARKER)
+        if self.STIMULI_MODE == StimuliMode.GENERATE_ONLY:
+            pytest.skip(self.SKIP_JUST_FOR_STIMULI_MARKER)
 
         self.test_name = FUSED_TESTS_DIR / f"{self.global_config.test_name}.cpp"
 
@@ -196,16 +220,16 @@ class FuserConfig(TestConfig):
 
         self.operand_registry.allocate_l1_addresses()
 
-        if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
+        if self.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
             self.generate_and_build_test()
 
-        if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
-            pytest.skip(TestConfig.SKIP_JUST_FOR_COMPILE_MARKER)
+        if self.BUILD_MODE == BuildMode.PRODUCE:
+            pytest.skip(self.SKIP_JUST_FOR_COMPILE_MARKER)
 
-        self.operand_registry.write_inputs_to_l1(TestConfig.TENSIX_LOCATION)
+        self.operand_registry.write_inputs_to_l1(self.TENSIX_LOCATION)
 
         self.run_elf_files()
         self.wait_for_tensix_operations_finished()
-        self.operand_registry.read_outputs_from_l1(TestConfig.TENSIX_LOCATION)
+        self.operand_registry.read_outputs_from_l1(self.TENSIX_LOCATION)
         golden = FusedGolden()
         assert golden.check_pipeline(self)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -32,17 +32,28 @@ class GlobalConfig:
     loop_factor: int = 16
 
 
-@dataclass
-class FuserConfig:
+class FuserConfig(TestConfig):
     pipeline: List[FusedOperation]
     global_config: GlobalConfig
+    operand_registry: OperandRegistry
 
-    @property
-    def registry(self) -> OperandRegistry:
-        """Get the OperandRegistry from the first operation in the pipeline."""
-        return self.pipeline[0].operand_mapping.operand_registry
+    def __init__(
+        self,
+        pipeline: List[FusedOperation],
+        global_config: GlobalConfig,
+        operand_registry: OperandRegistry,
+    ):
+        profiler_build = (
+            ProfilerBuild.Yes if global_config.profiler_enabled else ProfilerBuild.No
+        )
+        super().__init__(
+            test_name="", profiler_build=profiler_build, skip_build_header=True
+        )
 
-    def __post_init__(self):
+        self.pipeline = pipeline
+        self.global_config = global_config
+        self.operand_registry = operand_registry
+
         if self.global_config.architecture is None:
             self.global_config.architecture = get_chip_architecture()
 
@@ -93,19 +104,12 @@ class FuserConfig:
                     f"Block size ({operation.block_size}) is bigger than dest capacity ({dest_capacity})"
                 )
 
-    def create_test_config(self, cpp_path, profiler_enabled: bool) -> TestConfig:
-        return TestConfig(
-            test_name=cpp_path,
-            profiler_build=ProfilerBuild.Yes if profiler_enabled else ProfilerBuild.No,
-            skip_build_header=True,
-        )
-
-    def generate_and_build_test(self, cpp_path, test_config: TestConfig):
+    def generate_and_build_test(self):
         from .fused_generator import FusedKernelGenerator
 
         code_generator = FusedKernelGenerator(self)
-        code_generator.write_kernel(cpp_path, self.global_config.regenerate_cpp)
-        test_config.build_elfs()
+        code_generator.write_kernel(self.test_name, self.global_config.regenerate_cpp)
+        self.build_elfs()
 
     def run_perf_test(self, worker_id: str, run_count: int = 2):
         from .fused_generator import FUSED_TESTS_DIR
@@ -127,27 +131,26 @@ class FuserConfig:
             runs = []
             self.global_config.perf_run_type = run_type
 
-            cpp_path = (
+            self.test_name = (
                 FUSED_TESTS_DIR / f"{self.global_config.test_name}_{run_type.name}.cpp"
             )
 
-            test_config = self.create_test_config(cpp_path, profiler_enabled=True)
-            test_config.generate_variant_hash()
+            self.generate_variant_hash()
 
-            self.registry.allocate_l1_addresses()
+            self.operand_registry.allocate_l1_addresses()
 
             if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
-                self.generate_and_build_test(cpp_path, test_config)
+                self.generate_and_build_test()
 
             if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
                 continue
 
             logger.info("Running perf test for run type: {}", run_type.name)
             for run_index in range(run_count):
-                test_config.run_elf_files()
-                test_config.wait_for_tensix_operations_finished()
+                self.run_elf_files()
+                self.wait_for_tensix_operations_finished()
 
-                meta = Profiler._get_meta(test_config.test_name, test_config.variant_id)
+                meta = Profiler._get_meta(self.test_name, self.variant_id)
                 buffer_data = [
                     read_words_from_device(
                         TestConfig.TENSIX_LOCATION,
@@ -187,23 +190,22 @@ class FuserConfig:
         if TestConfig.STIMULI_MODE == StimuliMode.GENERATE_ONLY:
             pytest.skip(TestConfig.SKIP_JUST_FOR_STIMULI_MARKER)
 
-        cpp_path = FUSED_TESTS_DIR / f"{self.global_config.test_name}.cpp"
+        self.test_name = FUSED_TESTS_DIR / f"{self.global_config.test_name}.cpp"
 
-        test_config = self.create_test_config(cpp_path, profiler_enabled=False)
-        test_config.generate_variant_hash()
+        self.generate_variant_hash()
 
-        self.registry.allocate_l1_addresses()
+        self.operand_registry.allocate_l1_addresses()
 
         if TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]:
-            self.generate_and_build_test(cpp_path, test_config)
+            self.generate_and_build_test()
 
         if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
             pytest.skip(TestConfig.SKIP_JUST_FOR_COMPILE_MARKER)
 
-        self.registry.write_inputs_to_l1(TestConfig.TENSIX_LOCATION)
+        self.operand_registry.write_inputs_to_l1(TestConfig.TENSIX_LOCATION)
 
-        test_config.run_elf_files()
-        test_config.wait_for_tensix_operations_finished()
-        self.registry.read_outputs_from_l1(TestConfig.TENSIX_LOCATION)
+        self.run_elf_files()
+        self.wait_for_tensix_operations_finished()
+        self.operand_registry.read_outputs_from_l1(TestConfig.TENSIX_LOCATION)
         golden = FusedGolden()
         assert golden.check_pipeline(self)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -43,12 +43,7 @@ class FuserConfig(TestConfig):
         global_config: GlobalConfig,
         operand_registry: OperandRegistry,
     ):
-        profiler_build = (
-            ProfilerBuild.Yes if global_config.profiler_enabled else ProfilerBuild.No
-        )
-        super().__init__(
-            test_name="", profiler_build=profiler_build, skip_build_header=True
-        )
+        super().__init__(test_name="", skip_build_header=True)
 
         self.pipeline = pipeline
         self.global_config = global_config
@@ -115,6 +110,7 @@ class FuserConfig(TestConfig):
         from .fused_generator import FUSED_TESTS_DIR
 
         self.global_config.profiler_enabled = True
+        self.profiler_build = ProfilerBuild.Yes
 
         run_types = [
             PerfRunType.L1_TO_L1,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
@@ -86,6 +86,7 @@ class FuserConfigSchema(BaseModel):
                 test_name=test_name,
                 loop_factor=self.loop_factor,
             ),
+            operand_registry=operands,
         )
 
     @classmethod

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device.py
@@ -6,10 +6,7 @@ import os
 import time
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import List
 
-import torch
-from fuser.fused_operation import FusedOperation
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate
@@ -25,31 +22,11 @@ from ttexalens.tt_exalens_lib import (
     parse_elf,
     read_from_device,
     read_word_from_device,
-    write_to_device,
     write_words_to_device,
 )
 
-from .llk_params import (
-    BriscCmd,
-    DataFormat,
-    format_dict,
-)
+from .llk_params import BriscCmd
 from .logger import logger
-from .pack import (
-    pack_bfp8_b,
-    pack_bfp16,
-    pack_fp8_e4m3,
-    pack_fp16,
-    pack_fp32,
-    pack_int8,
-    pack_int16,
-    pack_int32,
-    pack_uint8,
-    pack_uint16,
-    pack_uint32,
-)
-from .tilize_untilize import untilize_block
-from .unpack import unpack_res_tiles
 
 
 class _UninitializedMailboxes:
@@ -388,118 +365,3 @@ def _send_arc_message(message_type: str, device_id: int):
         args=[0, 0],
         timeout=datetime.timedelta(seconds=10),
     )
-
-
-def write_pipeline_operands_to_l1(
-    pipeline: List[FusedOperation],
-    location: str = "0,0",
-):
-    TILE_ELEMENTS = 1024
-    current_address = 0x21000
-
-    def calculate_size(data_format: DataFormat, tile_count: int) -> int:
-        return data_format.num_bytes_per_tile(TILE_ELEMENTS) * tile_count
-
-    def write_operand_data(operand, location):
-        packers = {
-            DataFormat.Float16: pack_fp16,
-            DataFormat.Float16_b: pack_bfp16,
-            DataFormat.Float32: pack_fp32,
-            DataFormat.Bfp8_b: pack_bfp8_b,
-            DataFormat.Int32: pack_int32,
-            DataFormat.UInt32: pack_uint32,
-            DataFormat.Int16: pack_int16,
-            DataFormat.UInt16: pack_uint16,
-            DataFormat.Fp8_e4m3: pack_fp8_e4m3,
-            DataFormat.Int8: pack_int8,
-            DataFormat.UInt8: pack_uint8,
-        }
-
-        pack_function = packers.get(operand.data_format)
-        if not pack_function:
-            raise ValueError(f"Unsupported data format: {operand.data_format.name}")
-
-        tile_size = calculate_size(operand.data_format, 1)
-        buffer = operand.data.flatten()
-
-        for i in range(operand.tile_count):
-            start_idx = TILE_ELEMENTS * i
-            tile_data = buffer[start_idx : start_idx + TILE_ELEMENTS]
-
-            if pack_function == pack_bfp8_b:
-                packed_data = pack_function(tile_data, num_faces=4)
-            else:
-                packed_data = pack_function(tile_data)
-
-            addr = operand.l1_address + i * tile_size
-            write_to_device(location, addr, packed_data)
-
-    for operation in pipeline:
-        src_a = operation.src_a
-        src_b = operation.src_b
-        output = operation.output
-        if src_a.is_input() and src_a.l1_address is None:
-            src_a.l1_address = current_address
-            current_address += calculate_size(src_a.data_format, src_a.tile_count)
-            write_operand_data(src_a, location)
-
-        if src_b.is_input() and src_b.l1_address is None:
-            src_b.l1_address = current_address
-            current_address += calculate_size(src_b.data_format, src_b.tile_count)
-            write_operand_data(src_b, location)
-
-        if output.l1_address is None:
-            output_tile_count = output.tile_count
-            output.l1_address = current_address
-            current_address += calculate_size(output.data_format, output_tile_count)
-
-
-def collect_pipeline_results(
-    pipeline: List[FusedOperation],
-    location: str = "0,0",
-):
-    TILE_ELEMENTS = 1024
-
-    for operation in pipeline:
-        output_operand = operation.output
-        output_name = output_operand.name
-
-        if output_operand.l1_address is None:
-            raise ValueError(
-                f"Output operand '{output_name}' does not have an L1 address. "
-            )
-
-        output_dimensions = operation.output.dimensions
-        output_format = output_operand.data_format
-        tile_cnt = operation.output.tile_count
-
-        read_bytes_cnt = (
-            output_operand.data_format.num_bytes_per_tile(TILE_ELEMENTS) * tile_cnt
-        )
-        read_data = read_from_device(
-            location, output_operand.l1_address, num_bytes=read_bytes_cnt
-        )
-
-        res_from_L1 = unpack_res_tiles(
-            read_data,
-            output_format,
-            tile_count=tile_cnt,
-            sfpu=False,
-            num_faces=operation.num_faces,
-            face_r_dim=operation.face_r_dim,
-        )
-
-        torch_format = format_dict[output_format]
-        tilized_tensor = torch.tensor(res_from_L1, dtype=torch_format)
-
-        if output_format != DataFormat.Bfp8_b and output_dimensions is not None:
-            raw_tensor = untilize_block(
-                tilized_tensor,
-                stimuli_format=output_format,
-                dimensions=output_dimensions,
-            )
-        else:
-            raw_tensor = tilized_tensor
-
-        output_operand._data = tilized_tensor
-        output_operand._raw_data = raw_tensor

--- a/tt_metal/tt-llk/tests/python_tests/test_sdpa_reinits.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sdpa_reinits.py
@@ -5,10 +5,6 @@
 import pytest
 import torch
 from conftest import skip_for_coverage, skip_for_wormhole
-from helpers.device import (
-    read_from_device,
-    write_to_device,
-)
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     BroadcastGolden,
@@ -39,6 +35,7 @@ from helpers.test_variant_parameters import (
 from helpers.tilize_untilize import tilize_block, untilize_block
 from helpers.unpack import unpack_res_tiles
 from helpers.utils import passed_test
+from ttexalens.tt_exalens_lib import read_from_device, write_to_device
 
 
 @skip_for_coverage


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Fixes: https://github.com/tenstorrent/tt-llk/issues/1589

Moved read and write operands logic from `device.py` to `fused_operand.py`.
Split `write_pipeline_operands_to_l1` into two functions `allocate_l1_addresses` and `write_inputs_to_l1`.
Removed `FusedOperand.data` field since we no longer need it and simplified stimuli generation.
`FuserConfig` class now inherits `TestConfig`

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fuser_alloc_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=markoradosavljevic/fuser_alloc_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=markoradosavljevic/fuser_alloc_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=markoradosavljevic/fuser_alloc_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=markoradosavljevic/fuser_alloc_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=markoradosavljevic/fuser_alloc_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fuser_alloc_refactor) |