### PR TITLE
Migrate randn op to ProgramDescriptor framework (#42193)

### DIFF
--- a/ttnn/cpp/ttnn/operations/randn/device/randn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/randn/device/randn_device_operation.hpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::randn {
 
@@ -25,33 +26,16 @@ struct RandnDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    struct ProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle compute_kernel_id{};
-            tt::tt_metal::KernelHandle writer_kernel_id{};
-            std::vector<CoreCoord> cores;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-    };
-
-    using program_factory_t = std::variant<ProgramFactory>;
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output);
 
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/randn/device/randn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/randn/device/randn_program_factory.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #include <cstring>
 
 #include <tt-metalium/constants.hpp>
@@ -18,7 +19,12 @@ std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max(
 
 auto get_random_seed(std::mt19937& rng) -> uint32_t { return distribution(rng); }
 
-RandnDeviceOperation::ProgramFactory::cached_program_t RandnDeviceOperation::ProgramFactory::create(
+static constexpr const char* WRITER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/randn/device/kernels/writer_standard_normal.cpp";
+static constexpr const char* COMPUTE_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/randn/device/kernels/compute_standard_normal.cpp";
+
+ProgramDescriptor RandnDeviceOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
     [[maybe_unused]] const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
@@ -29,111 +35,85 @@ RandnDeviceOperation::ProgramFactory::cached_program_t RandnDeviceOperation::Pro
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    uint32_t num_cores_x = grid.x;
-    uint32_t num_cores_y = grid.y;
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y);
-
-    Program program = Program();
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    const auto num_cores_total = cores.size();
 
     DataType output_dtype = output.dtype();
     auto out_data_format = datatype_to_dataformat_converter(output_dtype);
     const uint32_t dtype_tile_size = tile_size(out_data_format);
 
     constexpr uint32_t in_out_num_tiles = 2;
-
     constexpr uint32_t dst_cb_id = CBIndex::c_0;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(in_out_num_tiles * dtype_tile_size, {{dst_cb_id, out_data_format}})
-            .set_page_size(dst_cb_id, dtype_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
-
-    const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/randn/device/kernels/";
-    std::vector<uint32_t> writer_compile_time_args{dst_cb_id};
-    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-    const std::string writer_file_path = kernels_dir_path + "writer_standard_normal.cpp";
-    const std::vector<uint32_t> compute_compile_time_args{dst_cb_id};
-    const std::string compute_file_path = kernels_dir_path + "compute_standard_normal.cpp";
-
-    KernelHandle writer_kernel_id = tt_metal::CreateKernel(
-        program, writer_file_path, all_cores, WriterDataMovementConfig(writer_compile_time_args));
-
-    std::map<std::string, std::string> compute_defines;
-    switch (output_dtype) {
-        case DataType::BFLOAT16: compute_defines["OUTPUT_DTYPE_BFLOAT16"] = "1"; break;
-        default: break;
-    }
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
-    KernelHandle compute_kernel_id = CreateKernel(
-        program,
-        compute_file_path,
-        all_cores,
-        ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                       // generated number out of range [from, to)
-            .dst_full_sync_en = dst_full_sync_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = compute_defines,
-        });
 
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in_out_num_tiles * dtype_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = dst_cb_id,
+            .data_format = out_data_format,
+            .page_size = dtype_tile_size,
+        }}},
+    });
+
+    // Writer kernel
+    KernelDescriptor::CompileTimeArgs writer_ct_args;
+    writer_ct_args.reserve(8);
+    writer_ct_args.push_back(dst_cb_id);
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = WRITER_KERNEL_PATH;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.runtime_args.reserve(num_cores_total);
+
+    // Compute kernel
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = std::move(all_cores);
+    compute_desc.compile_time_args = {dst_cb_id};
+    if (output_dtype == DataType::BFLOAT16) {
+        compute_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1");
+    }
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
+                                   // generated number out of range [from, to)
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+    };
+    compute_desc.runtime_args.reserve(num_cores_total);
+
+    // Runtime args
     std::mt19937 rng = operation_attributes.seed.has_value() ? std::mt19937(*operation_attributes.seed)
                                                              : std::mt19937(std::time(nullptr));
 
+    const uint32_t output_addr = output.buffer()->address();
     uint32_t tile_offset = 0;
-    for (auto core : cores) {
-        uint32_t units_per_core;
-        if (core_group_1.contains(core)) {
-            units_per_core = units_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            units_per_core = units_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
+    for (const auto& core : cores) {
+        uint32_t units_per_core = core_group_1.contains(core) ? units_per_core_group_1 : units_per_core_group_2;
 
-        uint32_t seed = get_random_seed(rng);
+        compute_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{get_random_seed(rng), units_per_core});
 
-        std::vector<uint32_t> compute_runtime_args = {seed, units_per_core};
-        SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
-
-        std::vector<uint32_t> writer_runtime_args = {output.buffer()->address(), tile_offset, units_per_core};
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        writer_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset, units_per_core});
 
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.compute_kernel_id = compute_kernel_id, .writer_kernel_id = writer_kernel_id, .cores = cores}};
-}
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void RandnDeviceOperation::ProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& operation_attributes,
-    [[maybe_unused]] const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& compute_kernel_id = cached_program.shared_variables.compute_kernel_id;
-    auto& cores = cached_program.shared_variables.cores;
-
-    const uint32_t output_addr = output.buffer()->address();
-
-    std::mt19937 rng = operation_attributes.seed.has_value() ? std::mt19937(*operation_attributes.seed)
-                                                             : std::mt19937(std::time(nullptr));
-
-    for (auto core : cores) {
-        {
-            auto& runtime_args = GetRuntimeArgs(program, compute_kernel_id, core);
-            runtime_args[0] = get_random_seed(rng);
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output_addr;
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::randn


### PR DESCRIPTION
## Summary

Migrate the `randn` operation from the legacy `ProgramFactory` + `override_runtime_arguments` pattern to the declarative `ProgramDescriptor`-based `create_descriptor` approach.

Closes #42400

## Notes for reviewers

- Only 2 files changed: `randn_device_operation.hpp` and `randn_program_factory.cpp` — no public API changes, no kernel changes, no nanobind changes.
- The `ProgramFactory` struct with `shared_variables_t` (kernel handles + cached cores) and `override_runtime_arguments` is removed entirely. Replaced by a single `create_descriptor` that returns a `ProgramDescriptor`.
- The `compute_program_hash` is unchanged — it uses the same hash as before (attributes minus seed), so existing program cache entries will still hit correctly.
- All 80 nightly randn tests pass (`tests/ttnn/nightly/unit_tests/operations/rand/test_randn.py`), covering shapes, dtypes, layouts, memory configs, sharding strategies, compute kernel options, and program cache behavior.

## Test plan

- [x] All 80 nightly randn tests pass
- [x] Program cache callback test passes (verifies cache hit behavior)
- [x] Sharded L1 tests pass (HEIGHT, WIDTH, BLOCK strategies)
- [x] Compute kernel config tests pass

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-randn-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-randn-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-randn-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-randn-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-randn-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-randn-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-randn-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-randn-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-randn-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-randn-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-randn-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-randn-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-randn-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-randn-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-randn-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-randn-to-program-descriptor)