### PR TITLE
Decouple `create_decoder_block_tensors` from weight preparation

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -37,8 +37,6 @@ from models.demos.deepseek_v3_b1.weights.prepare import (
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3MoELayerWeights,
     create_gate_indices_tensor,
-    prepare_dense_layer_weights,
-    prepare_moe_layer_weights,
 )
 
 
@@ -49,25 +47,28 @@ def create_decoder_block_tensors(
     sender_row,
     sender_col,
     position_id,
-    state_dict,
-    layer_idx,
     max_seq_len,
     reduce_root_coord=ttnn.MeshCoordinate(1, 1),
     *,
+    weights: DeepSeekV3MoELayerWeights | DeepSeekV3DenseLayerWeights,
     is_moe: bool = True,
-    num_routed_experts: int = 0,
-    preloaded_weights=None,
     validate_debug_tensors: bool = False,
     torch_input=None,
 ):
     """Create all tensors required by DecoderBlock.op().
 
+    ``weights`` must be built on ``submesh`` (e.g. via
+    ``prepare_moe_layer_weights`` / ``prepare_dense_layer_weights`` from
+    ``weights/prepare.py``).
+
     Returns a dict with all attention + FFN + shared expert + reduce tensors.
     Intermediate torch CPU tensors (torch_input, torch_kv_cache, etc.) are
     included so that callers (e.g. golden-reference builders) can reuse them.
     """
-    if preloaded_weights is None and state_dict is None:
-        raise ValueError("Either state_dict or preloaded_weights must be provided")
+    if is_moe and not isinstance(weights, DeepSeekV3MoELayerWeights):
+        raise TypeError(f"is_moe=True requires DeepSeekV3MoELayerWeights, got {type(weights).__name__}")
+    if not is_moe and not isinstance(weights, DeepSeekV3DenseLayerWeights):
+        raise TypeError(f"is_moe=False requires DeepSeekV3DenseLayerWeights, got {type(weights).__name__}")
     torch.manual_seed(0)
     num_devices = mesh_rows * mesh_cols
     device_grid_size = submesh.compute_with_storage_grid_size()
@@ -88,7 +89,7 @@ def create_decoder_block_tensors(
 
     _RopeConfig.max_seq_len = max_seq_len
 
-    # ── Constants for runtime tensors ──
+    # Constants for runtime tensors
     QNOPE_HEAD_DIM = 128
     QROPE_HEAD_DIM = _RopeConfig.qk_rope_head_dim
     QNOPE_OUT_DIM = 512
@@ -132,7 +133,7 @@ def create_decoder_block_tensors(
         }
     )
 
-    # ── SDPA KV cache buffer ──
+    # SDPA KV cache buffer
     kv_cache_num_cores_x = device_grid_size.x
     kv_cache_num_cores_y = device_grid_size.y
     kv_cache_num_cores = kv_cache_num_cores_x * kv_cache_num_cores_y
@@ -155,7 +156,7 @@ def create_decoder_block_tensors(
         mesh_mapper=mesh_mapper,
     )
 
-    # ── SDPA output intermediate buffer ──
+    # SDPA output intermediate buffer
     sdpa_out_interm_num_cores = device_grid_size.x * device_grid_size.y
     sdpa_out_interm_num_slots = 5  # MoE needs 36864 bytes/shard; 5 slots × 17 tiles × 512 = 43520
     sdpa_out_interm_shard_height = sdpa_out_interm_num_slots * 8
@@ -183,24 +184,7 @@ def create_decoder_block_tensors(
     if torch_input is None:
         torch_input = torch.randn(shape, dtype=torch.bfloat16)
 
-    # ══════════════════════════════════════════════════════════════════════════
-    # All weights via prepare_* functions or preloaded
-    # ══════════════════════════════════════════════════════════════════════════
-    if preloaded_weights is not None:
-        layer = preloaded_weights
-    else:
-        if is_moe:
-            layer = prepare_moe_layer_weights(
-                submesh,
-                state_dict,
-                layer_idx,
-                num_routed_experts=num_routed_experts,
-                move_to_device=True,
-            )
-        else:
-            layer = prepare_dense_layer_weights(submesh, state_dict, layer_idx, move_to_device=True)
-
-    # ── FFN final output config (DRAM streaming matmul output grid) ──
+    # FFN final output config (DRAM streaming matmul output grid)
     gate_proj_noc = ttnn.NOC.NOC_0
     gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(submesh, gate_proj_noc)
     gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in gate_proj_worker_cores])
@@ -221,7 +205,7 @@ def create_decoder_block_tensors(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, final_output_shard_spec
     )
 
-    # ── MoE-only: gate indices and output buffers ──
+    # MoE-only gate indices and output buffers
     if is_moe:
         input_core = ttnn.CoreCoord(device_grid_size.x - 1, RoutedExpert.INPUT_CORE_Y)
         input_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(input_core, input_core)])
@@ -273,9 +257,7 @@ def create_decoder_block_tensors(
                 mesh_mapper=mesh_mapper,
             )
 
-    # ══════════════════════════════════════════════════════════════════════════
     # Attention input/intermediate/output mesh tensors
-    # ══════════════════════════════════════════════════════════════════════════
     sender_coord = ttnn.MeshCoordinate(sender_row, sender_col)
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(mcast_core, mcast_core)}), shape, ttnn.ShardOrientation.ROW_MAJOR
@@ -300,7 +282,7 @@ def create_decoder_block_tensors(
         mesh_mapper=ttnn.ShardTensorToMesh(submesh, dim=0),
     )
 
-    # ── RoPE TTNN tensors ──
+    # RoPE TTNN tensors
     qrope_dram_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
     position_ids = torch.tensor([position_id])
 
@@ -346,7 +328,7 @@ def create_decoder_block_tensors(
         mesh_mapper=mesh_mapper,
     )
 
-    # ── Trans mat ──
+    # Rotation transform matrix tensor
     qrope_grid = ttnn.CoreRange(
         ttnn.CoreCoord(QNOPE_GRID_COLS, 0), ttnn.CoreCoord(QNOPE_GRID_COLS + QROPE_GRID_COLS - 1, matmul2_grid_y - 1)
     )
@@ -365,7 +347,7 @@ def create_decoder_block_tensors(
         mesh_mapper=mesh_mapper,
     )
 
-    # ── Position IDs ──
+    # Position IDs
     pos_core_grid = ttnn.CoreRangeSet(
         [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
     )
@@ -383,7 +365,7 @@ def create_decoder_block_tensors(
         mesh_mapper=mesh_mapper,
     )
 
-    # ── KV Cache (ND sharded DRAM) ──
+    # KV cache (ND sharded DRAM)
     program_config = FlashMLADecode.ProgramConfig(k_chunk_size=128, exp_approx_mode=False)
     grid = program_config.grid
     kv_nd_shard_spec = ttnn.NdShardSpec(
@@ -418,7 +400,7 @@ def create_decoder_block_tensors(
             mesh_mapper=kv_cache_2d_mesh_mapper,
         )
 
-    # ── KV cache clone for standalone AttentionBlock.op sanity check ──
+    # KV cache clone for standalone AttentionBlock validation
     ttnn_kv_cache_attn_ref = None
     if validate_debug_tensors:
         if position_id == 0:
@@ -440,7 +422,7 @@ def create_decoder_block_tensors(
                 mesh_mapper=kv_cache_2d_mesh_mapper,
             )
 
-    # ── SDPA output tensor ──
+    # SDPA output tensor
     s1_cores, _ = FlashMLADecode.ProgramConfig.grid.BLOCKS[0]
     sdpa_input_output_grid_crs = ttnn.CoreRangeSet(
         [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in s1_cores]
@@ -466,13 +448,13 @@ def create_decoder_block_tensors(
             tile=sdpa_tile,
         )
 
-    # ── Post-SDPA tensors ──
+    # Post-SDPA tensors
     a_tile = ttnn.Tile([M, 32])
     shard_mesh_mapper = ttnn.ShardTensorToMesh(submesh, dim=0)
     gather_core = ttnn.CoreCoord(12, 9)
     gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
 
-    # ── Attention block output / MoE residual input (overlapped with sdpa_kv_cache_buffer) ──
+    # Attention block output / MoE residual input (overlapped with sdpa_kv_cache_buffer)
     # These are temporally disjoint: the kv cache on core (12,9) is done after SDPA,
     # so the attention output and MoE residual input can reuse that L1 region.
     output_shard_spec = ttnn.ShardSpec(gather_core_grid, (M, output_size), ttnn.ShardOrientation.ROW_MAJOR)
@@ -499,7 +481,7 @@ def create_decoder_block_tensors(
             mesh_mapper=shard_mesh_mapper,
         )
 
-    # ── SDPA worker/forwarder tensors ──
+    # SDPA worker/forwarder tensors
     sdpa_output_cores = FlashMLADecode.ProgramConfig.grid.output_cores(0, NUM_SDPA_WORKERS)
     sdpa_worker_grid = ttnn.CoreRangeSet(
         [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in sdpa_output_cores]
@@ -554,9 +536,7 @@ def create_decoder_block_tensors(
         mesh_mapper=shard_mesh_mapper,
     )
 
-    # ══════════════════════════════════════════════════════════════════════════
     # Reduce-to-one tensors
-    # ══════════════════════════════════════════════════════════════════════════
     reduce_mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)], submesh.shape)
     reduce_mesh_mapper = ttnn.create_mesh_mapper(submesh, reduce_mesh_mapper_config)
     tile_1x32 = ttnn.Tile([1, 32])
@@ -601,7 +581,7 @@ def create_decoder_block_tensors(
         mesh_mapper=reduce_mesh_mapper,
     )
 
-    # ── Standalone MoE ref reduce tensors (MoE only) ──
+    # Standalone MoE reference reduce tensors (MoE only)
     if is_moe:
         moe_ref_reduce_intermediate = None
         moe_ref_reduce_output = None
@@ -628,23 +608,23 @@ def create_decoder_block_tensors(
     sender_core_from_residual = attn_output.memory_config().shard_spec.grid.bounding_box().end
     mcast_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), sender_core_from_residual)])
 
-    # ── Routed weight tensors differ between MoE (list) and dense (single tensor) ──
-    routed_gate = layer.routed_gate_proj[0] if is_moe else layer.routed_gate_proj
-    routed_up = layer.routed_up_proj[0] if is_moe else layer.routed_up_proj
-    routed_down = layer.routed_down_proj[0] if is_moe else layer.routed_down_proj
+    # Routed weight tensors differ between MoE (list) and dense (single tensor)
+    routed_gate = weights.routed_gate_proj[0] if is_moe else weights.routed_gate_proj
+    routed_up = weights.routed_up_proj[0] if is_moe else weights.routed_up_proj
+    routed_down = weights.routed_down_proj[0] if is_moe else weights.routed_down_proj
 
     result = {
         # Attention weights (from prepare_*_layer_weights)
-        "gamma_overlapped": layer.attn_norm,
-        "matmul_weights_overlapped": layer.q_a_proj,
-        "rmsnorm2_gamma_overlapped": layer.q_norm,
-        "matmul2_weights_overlapped": layer.q_b_proj,
-        "matmul3_weights_overlapped": layer.kv_b1_proj,
-        "dkv_matmul_weights_overlapped": layer.kv_a_proj,
-        "dkv_rmsnorm_gamma_overlapped": layer.kv_norm,
-        "kv_b2_overlapped": layer.kv_b2_proj,
-        "o_proj_overlapped": layer.o_proj,
-        "ffn_norm_overlapped": layer.ffn_norm,
+        "gamma_overlapped": weights.attn_norm,
+        "matmul_weights_overlapped": weights.q_a_proj,
+        "rmsnorm2_gamma_overlapped": weights.q_norm,
+        "matmul2_weights_overlapped": weights.q_b_proj,
+        "matmul3_weights_overlapped": weights.kv_b1_proj,
+        "dkv_matmul_weights_overlapped": weights.kv_a_proj,
+        "dkv_rmsnorm_gamma_overlapped": weights.kv_norm,
+        "kv_b2_overlapped": weights.kv_b2_proj,
+        "o_proj_overlapped": weights.o_proj,
+        "ffn_norm_overlapped": weights.ffn_norm,
         # Attention activation/buffer tensors
         "input_tensor_mesh": input_tensor_mesh,
         "ttnn_qrope_sin": ttnn_qrope_sin,
@@ -676,9 +656,9 @@ def create_decoder_block_tensors(
         "final_output_mem_config": final_output_mem_config,
         "final_output_total_width": final_output_total_width,
         # Shared expert weights
-        "shared_gate_weights_overlapped": layer.shared_gate_proj,
-        "shared_up_weights_overlapped": layer.shared_up_proj,
-        "shared_down_weights_tensor": layer.shared_down_proj,
+        "shared_gate_weights_overlapped": weights.shared_gate_proj,
+        "shared_up_weights_overlapped": weights.shared_up_proj,
+        "shared_down_weights_tensor": weights.shared_down_proj,
         "shared_k_parallel": SharedExpert.K_PARALLEL,
         "shared_n_parallel": SharedExpert.N_PARALLEL,
         # Reduce-to-one
@@ -699,8 +679,8 @@ def create_decoder_block_tensors(
     if is_moe:
         result.update(
             {
-                "gate_mm_overlapped": layer.gate_mm,
-                "ttnn_gate_bias": layer.gate_bias,
+                "gate_mm_overlapped": weights.gate_mm,
+                "ttnn_gate_bias": weights.gate_bias,
                 "ttnn_gate_indices": ttnn_gate_indices,
                 "gate_output_scores_tensor": gate_output_scores_tensor,
                 "gate_output_indices_tensor": gate_output_indices_tensor,
@@ -720,9 +700,8 @@ class DecoderStage(StageKind):
 
     def __init__(
         self,
-        state_dict: dict[str, torch.Tensor] | None,
         *,
-        weights: DeepSeekV3MoELayerWeights | DeepSeekV3DenseLayerWeights | None,
+        weights: DeepSeekV3MoELayerWeights | DeepSeekV3DenseLayerWeights,
         layer_idx: int,
         position_id: int,
         max_seq_len: int,
@@ -733,11 +712,15 @@ class DecoderStage(StageKind):
         use_hardcoded_expert_index: bool,
         enable_routing: bool,
     ) -> None:
-        if state_dict is None and weights is None:
-            raise ValueError("Either state_dict or weights must be provided")
-        if state_dict is not None and weights is not None:
-            raise ValueError("Provide state_dict or weights, not both")
-        self._state_dict = state_dict
+        if not isinstance(weights, (DeepSeekV3MoELayerWeights, DeepSeekV3DenseLayerWeights)):
+            raise ValueError(
+                f"Invalid weights type: {type(weights)}, expected DeepSeekV3MoELayerWeights or DeepSeekV3DenseLayerWeights"
+            )
+        if is_moe and not isinstance(weights, DeepSeekV3MoELayerWeights):
+            raise ValueError(f"MoE weights must be a DeepSeekV3MoELayerWeights, got {type(weights)}")
+        if not is_moe and not isinstance(weights, DeepSeekV3DenseLayerWeights):
+            raise ValueError(f"Dense weights must be a DeepSeekV3DenseLayerWeights, got {type(weights)}")
+
         self._weights = weights
         self._layer_idx = layer_idx
         self._position_id = position_id
@@ -890,12 +873,9 @@ class DecoderStage(StageKind):
                 sender_coord[0],
                 sender_coord[1],
                 self._position_id,
-                self._state_dict,
-                self._layer_idx,
                 self._max_seq_len,
                 reduce_root_coord=reduce_root_coord,
-                num_routed_experts=self._num_routed_experts,
-                preloaded_weights=self._weights,
+                weights=self._weights,
             )
         else:
             d = create_decoder_block_tensors(
@@ -905,12 +885,10 @@ class DecoderStage(StageKind):
                 sender_coord[0],
                 sender_coord[1],
                 self._position_id,
-                self._state_dict,
-                self._layer_idx,
                 self._max_seq_len,
                 reduce_root_coord=reduce_root_coord,
+                weights=self._weights,
                 is_moe=False,
-                preloaded_weights=self._weights,
             )
         ttnn.synchronize_device(mesh_device)
 
@@ -941,18 +919,14 @@ class DecoderStage(StageKind):
 class MoEDecoderStage(DecoderStage):
     """Decoder stage: bcast + fused attention + MoE + reduce-to-one.
 
-    Accepts weights in two forms (mutually exclusive):
-    - ``weights``: a pre-loaded :class:`DeepSeekV3MoELayerWeights` (production path via
-      ``WeightProvider.load_moe_layer``).
-    - ``state_dict``: a raw HF-format state dict (test path; requires ``layer_idx`` and
-      ``num_routed_experts`` for weight processing).
+    Requires ``weights`` as a pre-loaded :class:`DeepSeekV3MoELayerWeights`
+    (typically from ``WeightProvider.load_moe_layer``).
     """
 
     def __init__(
         self,
-        state_dict: dict[str, torch.Tensor] | None = None,
         *,
-        weights: DeepSeekV3MoELayerWeights | None = None,
+        weights: DeepSeekV3MoELayerWeights,
         layer_idx: int = 4,
         num_routed_experts: int = 256,
         position_id: int = 0,
@@ -963,7 +937,6 @@ class MoEDecoderStage(DecoderStage):
         is_torus: bool = True,
     ) -> None:
         super().__init__(
-            state_dict,
             weights=weights,
             layer_idx=layer_idx,
             position_id=position_id,
@@ -980,17 +953,14 @@ class MoEDecoderStage(DecoderStage):
 class DenseDecoderStage(DecoderStage):
     """Dense decoder stage: bcast + fused attention + dense MLP + reduce-to-one.
 
-    Accepts weights in two forms (mutually exclusive):
-    - ``weights``: a pre-loaded :class:`DeepSeekV3DenseLayerWeights` (production path via
-      ``WeightProvider.load_dense_layer``).
-    - ``state_dict``: a raw HF-format state dict (test path; requires ``layer_idx``).
+    Requires ``weights`` as a pre-loaded :class:`DeepSeekV3DenseLayerWeights`
+    (typically from ``WeightProvider.load_dense_layer``).
     """
 
     def __init__(
         self,
-        state_dict: dict[str, torch.Tensor] | None = None,
         *,
-        weights: DeepSeekV3DenseLayerWeights | None = None,
+        weights: DeepSeekV3DenseLayerWeights,
         layer_idx: int = 0,
         position_id: int = 0,
         max_seq_len: int = 32 * 1024,
@@ -998,7 +968,6 @@ class DenseDecoderStage(DecoderStage):
         is_torus: bool = True,
     ) -> None:
         super().__init__(
-            state_dict,
             weights=weights,
             layer_idx=layer_idx,
             position_id=position_id,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -29,7 +29,11 @@ from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
     ROUTED_EXPERT_LAYER_IDX,
     extract_routed_expert_output,
 )
-from models.demos.deepseek_v3_b1.weights.prepare import get_layer_raw_tensors
+from models.demos.deepseek_v3_b1.weights.prepare import (
+    get_layer_raw_tensors,
+    prepare_dense_layer_weights,
+    prepare_moe_layer_weights,
+)
 
 
 def _decode_expert_upload_mode(expert_upload_mode: str) -> tuple[int, int | None]:
@@ -360,6 +364,15 @@ def test_decoder(
             state_dict, ROUTED_EXPERT_LAYER_IDX, rigged_group_count
         )
 
+    logger.info("Preparing layer weights on device...")
+    layer_weights = prepare_moe_layer_weights(
+        submesh,
+        state_dict,
+        ROUTED_EXPERT_LAYER_IDX,
+        num_routed_experts=effective_num_routed_experts,
+        move_to_device=True,
+    )
+
     logger.info("Creating decoder block tensors...")
     d = create_decoder_block_tensors(
         submesh,
@@ -368,11 +381,9 @@ def test_decoder(
         sender_row,
         sender_col,
         position_id,
-        state_dict,
-        layer_idx=ROUTED_EXPERT_LAYER_IDX,
         max_seq_len=max_seq_len,
+        weights=layer_weights,
         is_moe=True,
-        num_routed_experts=effective_num_routed_experts,
         validate_debug_tensors=validate_standalone_mla or validate_standalone_moe,
         torch_input=torch_input,
     )
@@ -846,6 +857,9 @@ def test_decoder_mlp(
         seed=RoutedExpert.SEED,
     )
 
+    logger.info("Preparing dense layer weights on device...")
+    layer_weights = prepare_dense_layer_weights(submesh, state_dict, DENSE_LAYER_IDX, move_to_device=True)
+
     logger.info("Creating dense decoder block tensors...")
     d = create_decoder_block_tensors(
         submesh,
@@ -854,9 +868,8 @@ def test_decoder_mlp(
         sender_row,
         sender_col,
         position_id,
-        state_dict,
-        layer_idx=DENSE_LAYER_IDX,
         max_seq_len=max_seq_len,
+        weights=layer_weights,
         is_moe=False,
     )
 


### PR DESCRIPTION
### Summary

This change refactors the decoder stage to require pre-built weight objects instead of accepting raw state dictionaries, simplifying the interface and improving type safety.

### What's Changed

* The `create_decoder_block_tensors` function and `DecoderStage` class now require `weights` objects (`DeepSeekV3MoELayerWeights` or `DeepSeekV3DenseLayerWeights`) instead of accepting `state_dict` and preparing weights internally. This removes ambiguity, enforces type safety, and delegates weight preparation to the caller. [[1]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011L39-L40) [[2]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011L51-R71) [[3]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011L702-R704) [[4]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011L715-R723) [[5]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011L872-R878)
* All references to layer weights in the tensor dictionary are updated to use the new `weights` parameter instead of the previously ambiguous `layer` variable, reflecting the refactored API. [[1]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011L610-R627) [[2]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011L658-R661) [[3]](diffhunk://#diff-35d6e562e7ea9c9573f17dd3379fb68ad74f55b3f9e78acd63128644503fa011L681-R683)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/refactor-state-dict-weights-in-stage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/refactor-state-dict-weights-in-stage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/refactor-state-dict-weights-in-stage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/refactor-state-dict-weights-in-stage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/refactor-state-dict-weights-in-stage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/refactor-state-dict-weights-in-stage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/refactor-state-dict-weights-in-stage) |