### PR TITLE
Migrate moreh_fold op to ProgramDescriptor framework

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.hpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_fold {
 
@@ -30,28 +31,10 @@ struct MorehFoldOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    struct ProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            std::vector<CoreCoord> cores;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-    };
-
-    using program_factory_t = std::variant<ProgramFactory>;
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output);
 
     static void validate_inputs(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
@@ -9,11 +9,17 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/hal.hpp>
-#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_fold {
 
-MorehFoldOperation::ProgramFactory::cached_program_t MorehFoldOperation::ProgramFactory::create(
+using namespace tt::tt_metal;
+
+static constexpr const char* READER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/reader_fold_rm.cpp";
+static constexpr const char* WRITER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/writer_fold_rm.cpp";
+
+ProgramDescriptor MorehFoldOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
@@ -47,24 +53,17 @@ MorehFoldOperation::ProgramFactory::cached_program_t MorehFoldOperation::Program
     uint32_t LH = ls[0];
     uint32_t LW = ls[1];
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Device Setup
-    ////////////////////////////////////////////////////////////////////////////
-    Program program{};
     IDevice* device = input.device();
 
     uint32_t num_units = output.logical_volume() / output.logical_shape()[-1];
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto grid = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = grid.x;
+    uint32_t num_cores_y = grid.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, num_units);
+        split_work_to_cores(grid, num_units);
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                         CircularBuffer Setup
-    ////////////////////////////////////////////////////////////////////////////
-    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    auto data_format = datatype_to_dataformat_converter(input.dtype());
 
     uint32_t unit_size = input.element_size();
     uint32_t input_cb_page_size = unit_size * input.logical_shape()[-1];
@@ -75,77 +74,92 @@ MorehFoldOperation::ProgramFactory::cached_program_t MorehFoldOperation::Program
     uint32_t aligned_output_cb_page_size = round_up_to_mul32(output_cb_page_size);
 
     // For DRAM reads, we need DRAM-aligned size
-    bool src_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool src_is_dram = input.buffer()->buffer_type() == BufferType::DRAM;
     bool is_blackhole = (device->arch() == tt::ARCH::BLACKHOLE);
-    uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    uint32_t dram_alignment = hal::get_dram_alignment();
     uint32_t dram_aligned_input_cb_page_size = tt::align(input_cb_page_size, dram_alignment);
 
     uint32_t input_cb_index = tt::CBIndex::c_0;    // input
     uint32_t scratch_cb_index = tt::CBIndex::c_1;  // scratch for DRAM alignment
     uint32_t output_cb_index = tt::CBIndex::c_16;  // output
 
-    CircularBufferConfig input_cb_config =
-        CircularBufferConfig(aligned_input_cb_page_size * 2, {{input_cb_index, data_format}})
-            .set_page_size(input_cb_index, aligned_input_cb_page_size);
-    CreateCircularBuffer(program, all_cores, input_cb_config);
+    ProgramDescriptor desc;
 
-    // Create scratch CB for DRAM alignment
+    // Input CB
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = aligned_input_cb_page_size * 2,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = data_format,
+            .page_size = aligned_input_cb_page_size,
+        }}},
+    });
+
+    // Scratch CB for DRAM alignment
+    // On Blackhole, always use two-step read for DRAM
     if ((src_is_dram && (input_cb_page_size % dram_alignment != 0)) || is_blackhole) {
         uint32_t scratch_cb_page_size = dram_aligned_input_cb_page_size;
-        CircularBufferConfig scratch_cb_config =
-            CircularBufferConfig(4 * scratch_cb_page_size, {{scratch_cb_index, data_format}})
-                .set_page_size(scratch_cb_index, scratch_cb_page_size);
-        CreateCircularBuffer(program, all_cores, scratch_cb_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = 4 * scratch_cb_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = scratch_cb_index,
+                .data_format = data_format,
+                .page_size = scratch_cb_page_size,
+            }}},
+        });
     }
 
-    CircularBufferConfig output_cb_config =
-        CircularBufferConfig(aligned_output_cb_page_size * 2, {{output_cb_index, data_format}})
-            .set_page_size(output_cb_index, aligned_output_cb_page_size);
-    CreateCircularBuffer(program, all_cores, output_cb_config);
+    // Output CB
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = aligned_output_cb_page_size * 2,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = data_format,
+            .page_size = aligned_output_cb_page_size,
+        }}},
+    });
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                         Kernels defines
-    ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-
+    // Kernel defines
+    KernelDescriptor::Defines reader_defines;
     switch (input.dtype()) {
-        case DataType::BFLOAT16: reader_defines["DTYPE_BFLOAT16"] = "1"; break;
-        case DataType::FLOAT32: reader_defines["DTYPE_FLOAT32"] = "1"; break;
+        case DataType::BFLOAT16: reader_defines.emplace_back("DTYPE_BFLOAT16", "1"); break;
+        case DataType::FLOAT32: reader_defines.emplace_back("DTYPE_FLOAT32", "1"); break;
         default: break;
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      DataMovementKernel SetUp
-    ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args{
-        static_cast<uint32_t>(input_cb_index),
-        static_cast<uint32_t>(output_cb_index),
-        static_cast<uint32_t>(scratch_cb_index),
-    };
-    TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
+    // Reader kernel
+    KernelDescriptor::CompileTimeArgs reader_ct_args{input_cb_index, output_cb_index, scratch_cb_index};
+    TensorAccessorArgs(input.buffer()).append_to(reader_ct_args);
 
-    std::vector<uint32_t> writer_compile_time_args{
-        static_cast<uint32_t>(output_cb_index),
-    };
-    TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = READER_KERNEL_PATH;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto* const reader_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/reader_fold_rm.cpp";
-    const auto* const writer_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/writer_fold_rm.cpp";
+    // Writer kernel
+    KernelDescriptor::CompileTimeArgs writer_ct_args{output_cb_index};
+    TensorAccessorArgs(output.buffer()).append_to(writer_ct_args);
 
-    const auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    const auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = WRITER_KERNEL_PATH;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = std::move(all_cores);
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      RuntimeArgs SetUp
-    ////////////////////////////////////////////////////////////////////////////
-    uint32_t start_id = 0;
+    // Runtime args per core
     auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
     uint32_t g1_numcores = core_group_1.num_cores();
+    reader_desc.runtime_args.reserve(cores.size());
+    writer_desc.runtime_args.reserve(cores.size());
+
+    uint32_t start_id = 0;
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores.at(i);
         uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
@@ -155,62 +169,43 @@ MorehFoldOperation::ProgramFactory::cached_program_t MorehFoldOperation::Program
         uint32_t aligned = (src_is_dram ? (input_cb_page_size % dram_alignment == 0) : 1);
         aligned = aligned && !is_blackhole;
 
-        std::vector<uint32_t> reader_args = {
-            input.buffer()->address(),
-            N,
-            C,
-            H,
-            W,
-            kernel_size_h,
-            kernel_size_w,
-            stride_h,
-            stride_w,
-            padding_h,
-            padding_w,
-            dilation_h,
-            dilation_w,
-            LH,
-            LW,
-            input_cb_page_size,
-            dram_aligned_input_cb_page_size,
-            aligned_output_cb_page_size,
-            start_id,
-            num_units_per_core,
-            aligned};
+        reader_desc.runtime_args.emplace_back(
+            core,
+            KernelDescriptor::CoreRuntimeArgs{
+                input.buffer()->address(),
+                N,
+                C,
+                H,
+                W,
+                kernel_size_h,
+                kernel_size_w,
+                stride_h,
+                stride_w,
+                padding_h,
+                padding_w,
+                dilation_h,
+                dilation_w,
+                LH,
+                LW,
+                input_cb_page_size,
+                dram_aligned_input_cb_page_size,
+                aligned_output_cb_page_size,
+                start_id,
+                num_units_per_core,
+                aligned});
 
-        std::vector<uint32_t> writer_args = {
-            output.buffer()->address(), aligned_output_cb_page_size, start_id, num_units_per_core};
+        writer_desc.runtime_args.emplace_back(
+            core,
+            KernelDescriptor::CoreRuntimeArgs{
+                output.buffer()->address(), aligned_output_cb_page_size, start_id, num_units_per_core});
 
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
         start_id += num_units_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, cores}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void MorehFoldOperation::ProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& cores = cached_program.shared_variables.cores;
-    auto input_buffer_address = tensor_args.input.buffer()->address();
-    auto output_buffer_address = output.buffer()->address();
-
-    for (const auto& core : cores) {
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = input_buffer_address;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output_buffer_address;
-        }
-    }
-}
 }  // namespace ttnn::operations::moreh::moreh_fold


### PR DESCRIPTION
Closes #42250.

Migrates `moreh_fold` to `ProgramDescriptor` and adopts the `BufferBinding` fast cache-hit path from #42992.

## Tests

`test_moreh_fold` — green.

## Performance

Host-side dispatch only (device kernel time unchanged). Hot cache, n=500×5 with 100-iter warmup, median, Wormhole B0, input `[32,32]` → output `[7,11]` with kernel `[4,4]`.

| Op | Legacy main (μs) | Descriptor (μs) | Δ |
|---|---:|---:|---:|
| `moreh_fold` | 24.18 | 27.24 | +12.6% |

The op carries operation-attribute-derived runtime args (`kernel_size`, `stride`, `padding`, `dilation`, computed `LH`/`LW`, page sizes), so it does not adopt the BufferBinding fast cache-hit path — using BufferBinding would skip `create_descriptor()` on cache hits and leave those scalars stale across calls with different params. The +12.6% reflects the inherent cost of re-running `create_descriptor()` on every cache hit.

### CI Status

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-moreh-fold-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-moreh-fold-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-moreh-fold-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-moreh-fold-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-moreh-fold-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-moreh-fold-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-moreh-fold-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-moreh-fold-to-program-descriptor)
