### PR TITLE
#38930: add extra checks on cb accesses

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -21,6 +21,10 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     DeviceZoneScopedSumN2("CB-COMPUTE-RESERVE-BACK");
     std::uint32_t output = operand;
 
+    LLK_ASSERT(
+        static_cast<std::uint32_t>(num_tiles) <= get_local_cb_interface(output).fifo_num_pages,
+        "cb_reserve_back: num_tiles exceeds CB size (would deadlock)");
+
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
     volatile tt_reg_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -21,6 +21,10 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     DeviceZoneScopedSumN2("CB-COMPUTE-RESERVE-BACK");
     std::uint32_t output = operand;
 
+    LLK_ASSERT(
+        cb_access_divides_size_evenly(output, (std::uint32_t)num_tiles),
+        "cb_reserve_back: tile count must evenly divide CB size");
+
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
     volatile tt_reg_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
 
@@ -72,6 +76,11 @@ inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num
 template <bool push_blocks = false, bool brisc_pack = false>
 inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
     std::uint32_t output = operand;
+
+    LLK_ASSERT(
+        cb_access_divides_size_evenly(output, (std::uint32_t)num_tiles),
+        "cb_push_back: tile count must evenly divide CB size");
+
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
 
     get_local_cb_interface(output).fifo_wr_ptr += num_words;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -21,10 +21,6 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     DeviceZoneScopedSumN2("CB-COMPUTE-RESERVE-BACK");
     std::uint32_t output = operand;
 
-    LLK_ASSERT(
-        cb_access_divides_size_evenly(output, (std::uint32_t)num_tiles),
-        "cb_reserve_back: tile count must evenly divide CB size");
-
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
     volatile tt_reg_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -21,10 +21,6 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     DeviceZoneScopedSumN2("CB-COMPUTE-RESERVE-BACK");
     std::uint32_t output = operand;
 
-    LLK_ASSERT(
-        static_cast<std::uint32_t>(num_tiles) <= get_local_cb_interface(output).fifo_num_pages,
-        "cb_reserve_back: num_tiles exceeds CB size (would deadlock)");
-
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
     volatile tt_reg_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -73,10 +73,6 @@ template <bool push_blocks = false, bool brisc_pack = false>
 inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
     std::uint32_t output = operand;
 
-    LLK_ASSERT(
-        cb_access_divides_size_evenly(output, (std::uint32_t)num_tiles),
-        "cb_push_back: tile count must evenly divide CB size");
-
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
 
     get_local_cb_interface(output).fifo_wr_ptr += num_words;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -73,17 +73,20 @@ template <bool push_blocks = false, bool brisc_pack = false>
 inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
     std::uint32_t output = operand;
 
-    std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
+    auto& cb = get_local_cb_interface(output);
+    std::uint32_t num_words = num_tiles * cb.fifo_page_size;
 
-    get_local_cb_interface(output).fifo_wr_ptr += num_words;
-    get_local_cb_interface(output).fifo_wr_tile_ptr = 0;
+    LLK_ASSERT(cb.fifo_wr_ptr < cb.fifo_limit, "CB push_back: fifo_wr_ptr already at or past fifo_limit");
 
-    LLK_ASSERT(
-        get_local_cb_interface(output).fifo_wr_ptr <= get_local_cb_interface(output).fifo_limit,
-        "CB push_back: fifo_wr_ptr exceeds fifo_limit");
+    std::uint32_t remaining = cb.fifo_limit - cb.fifo_wr_ptr;
 
-    if (get_local_cb_interface(output).fifo_wr_ptr >= get_local_cb_interface(output).fifo_limit) {
-        get_local_cb_interface(output).fifo_wr_ptr -= get_local_cb_interface(output).fifo_size;
+    LLK_ASSERT(remaining >= num_words, "CB push_back: fifo_wr_ptr would exceed fifo_limit");
+
+    cb.fifo_wr_ptr += (num_words <= remaining) ? num_words : remaining;
+    cb.fifo_wr_tile_ptr = 0;
+
+    if (cb.fifo_wr_ptr >= cb.fifo_limit) {
+        cb.fifo_wr_ptr -= cb.fifo_size;
     }
 
     llk_push_to_brisc(operand, num_tiles, num_words);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -82,7 +82,7 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
 
     LLK_ASSERT(remaining >= num_words, "CB push_back: fifo_wr_ptr would exceed fifo_limit");
 
-    cb.fifo_wr_ptr += (num_words <= remaining) ? num_words : remaining;
+    cb.fifo_wr_ptr += num_words;
     cb.fifo_wr_tile_ptr = 0;
 
     if (cb.fifo_wr_ptr >= cb.fifo_limit) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -19,10 +19,6 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     DeviceZoneScopedSumN1("CB-COMPUTE-WAIT-FRONT");
     std::uint32_t input = operand;
 
-    LLK_ASSERT(
-        static_cast<std::uint32_t>(num_tiles) <= get_local_cb_interface(input).fifo_num_pages,
-        "cb_wait_front: num_tiles exceeds CB size (would deadlock)");
-
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -19,11 +19,6 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     DeviceZoneScopedSumN1("CB-COMPUTE-WAIT-FRONT");
     std::uint32_t input = operand;
 
-    LLK_ASSERT(
-        cb_wait_front_validate(input, (std::uint32_t)num_tiles),
-        "cb_wait_front: successive calls must request strictly increasing num_tiles "
-        "with a constant step size between calls (until cb_pop_front resets the sequence)");
-
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
 
@@ -40,10 +35,6 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
-
-#ifdef ENABLE_LLK_ASSERT
-    cb_wait_front_validate(input, /*num_tiles=*/0, /*reset=*/true);
-#endif
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
         (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -21,7 +21,7 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 
     LLK_ASSERT(
         cb_wait_front_validate(input, (std::uint32_t)num_tiles),
-        "cb_wait_front: cumulative count, step consistency, or divisibility constraint violated");
+        "cb_wait_front: monotonicity or step consistency violated");
 
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
@@ -40,7 +40,9 @@ inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
 
-    LLK_ASSERT(cb_wait_front_validate(input, 0, true), "");
+#ifdef ENABLE_LLK_ASSERT
+    cb_wait_front_validate(input, /*num_tiles=*/0, /*reset=*/true);
+#endif
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
         (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
@@ -50,14 +52,18 @@ inline void llk_pop_tiles(
     TT_SETDMAREG(0, get_local_cb_interface(input).tiles_acked, 0, LO_16(4));
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
-    get_local_cb_interface(input).fifo_rd_ptr += num_words;
+    auto& cb = get_local_cb_interface(input);
 
-    LLK_ASSERT(
-        get_local_cb_interface(input).fifo_rd_ptr <= get_local_cb_interface(input).fifo_limit,
-        "CB pop_front: fifo_rd_ptr exceeds fifo_limit");
+    LLK_ASSERT(cb.fifo_rd_ptr < cb.fifo_limit, "CB pop_front: fifo_rd_ptr already at or past fifo_limit");
 
-    if (get_local_cb_interface(input).fifo_rd_ptr >= get_local_cb_interface(input).fifo_limit) {
-        get_local_cb_interface(input).fifo_rd_ptr -= get_local_cb_interface(input).fifo_size;
+    std::uint32_t remaining = cb.fifo_limit - cb.fifo_rd_ptr;
+
+    LLK_ASSERT(remaining >= num_words, "CB pop_front: fifo_rd_ptr would exceed fifo_limit");
+
+    cb.fifo_rd_ptr += (num_words <= remaining) ? num_words : remaining;
+
+    if (cb.fifo_rd_ptr >= cb.fifo_limit) {
+        cb.fifo_rd_ptr -= cb.fifo_size;
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -52,7 +52,7 @@ inline void llk_pop_tiles(
 
     LLK_ASSERT(remaining >= num_words, "CB pop_front: fifo_rd_ptr would exceed fifo_limit");
 
-    cb.fifo_rd_ptr += (num_words <= remaining) ? num_words : remaining;
+    cb.fifo_rd_ptr += num_words;
 
     if (cb.fifo_rd_ptr >= cb.fifo_limit) {
         cb.fifo_rd_ptr -= cb.fifo_size;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -18,6 +18,11 @@ using namespace ckernel;
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     DeviceZoneScopedSumN1("CB-COMPUTE-WAIT-FRONT");
     std::uint32_t input = operand;
+
+    LLK_ASSERT(
+        cb_wait_front_validate(input, (std::uint32_t)num_tiles),
+        "cb_wait_front: cumulative count, step consistency, or divisibility constraint violated");
+
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
 
@@ -34,6 +39,12 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
+
+    LLK_ASSERT(
+        cb_access_divides_size_evenly(input, (std::uint32_t)num_tiles),
+        "cb_pop_front: tile count must evenly divide CB size");
+    LLK_ASSERT(cb_wait_front_validate(input, 0, true), "");
+
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
         (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -40,9 +40,6 @@ inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
 
-    LLK_ASSERT(
-        cb_access_divides_size_evenly(input, (std::uint32_t)num_tiles),
-        "cb_pop_front: tile count must evenly divide CB size");
     LLK_ASSERT(cb_wait_front_validate(input, 0, true), "");
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -19,6 +19,10 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     DeviceZoneScopedSumN1("CB-COMPUTE-WAIT-FRONT");
     std::uint32_t input = operand;
 
+    LLK_ASSERT(
+        static_cast<std::uint32_t>(num_tiles) <= get_local_cb_interface(input).fifo_num_pages,
+        "cb_wait_front: num_tiles exceeds CB size (would deadlock)");
+
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -21,7 +21,8 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 
     LLK_ASSERT(
         cb_wait_front_validate(input, (std::uint32_t)num_tiles),
-        "cb_wait_front: monotonicity or step consistency violated");
+        "cb_wait_front: successive calls must request strictly increasing num_tiles "
+        "with a constant step size between calls (until cb_pop_front resets the sequence)");
 
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -21,6 +21,10 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     DeviceZoneScopedSumN2("CB-COMPUTE-RESERVE-BACK");
     std::uint32_t output = operand;
 
+    LLK_ASSERT(
+        static_cast<std::uint32_t>(num_tiles) <= get_local_cb_interface(output).fifo_num_pages,
+        "cb_reserve_back: num_tiles exceeds CB size (would deadlock)");
+
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
     volatile tt_reg_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -21,6 +21,10 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     DeviceZoneScopedSumN2("CB-COMPUTE-RESERVE-BACK");
     std::uint32_t output = operand;
 
+    LLK_ASSERT(
+        cb_access_divides_size_evenly(output, (std::uint32_t)num_tiles),
+        "cb_reserve_back: tile count must evenly divide CB size");
+
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
     volatile tt_reg_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
 
@@ -72,6 +76,11 @@ inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num
 template <bool push_blocks = false, bool brisc_pack = false>
 inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
     std::uint32_t output = operand;
+
+    LLK_ASSERT(
+        cb_access_divides_size_evenly(output, (std::uint32_t)num_tiles),
+        "cb_push_back: tile count must evenly divide CB size");
+
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
 
     get_local_cb_interface(output).fifo_wr_ptr += num_words;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -21,10 +21,6 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     DeviceZoneScopedSumN2("CB-COMPUTE-RESERVE-BACK");
     std::uint32_t output = operand;
 
-    LLK_ASSERT(
-        cb_access_divides_size_evenly(output, (std::uint32_t)num_tiles),
-        "cb_reserve_back: tile count must evenly divide CB size");
-
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
     volatile tt_reg_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -21,10 +21,6 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
     DeviceZoneScopedSumN2("CB-COMPUTE-RESERVE-BACK");
     std::uint32_t output = operand;
 
-    LLK_ASSERT(
-        static_cast<std::uint32_t>(num_tiles) <= get_local_cb_interface(output).fifo_num_pages,
-        "cb_reserve_back: num_tiles exceeds CB size (would deadlock)");
-
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
     volatile tt_reg_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -73,10 +73,6 @@ template <bool push_blocks = false, bool brisc_pack = false>
 inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
     std::uint32_t output = operand;
 
-    LLK_ASSERT(
-        cb_access_divides_size_evenly(output, (std::uint32_t)num_tiles),
-        "cb_push_back: tile count must evenly divide CB size");
-
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
 
     get_local_cb_interface(output).fifo_wr_ptr += num_words;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -73,17 +73,20 @@ template <bool push_blocks = false, bool brisc_pack = false>
 inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
     std::uint32_t output = operand;
 
-    std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
+    auto& cb = get_local_cb_interface(output);
+    std::uint32_t num_words = num_tiles * cb.fifo_page_size;
 
-    get_local_cb_interface(output).fifo_wr_ptr += num_words;
-    get_local_cb_interface(output).fifo_wr_tile_ptr = 0;
+    LLK_ASSERT(cb.fifo_wr_ptr < cb.fifo_limit, "CB push_back: fifo_wr_ptr already at or past fifo_limit");
 
-    LLK_ASSERT(
-        get_local_cb_interface(output).fifo_wr_ptr <= get_local_cb_interface(output).fifo_limit,
-        "CB push_back: fifo_wr_ptr exceeds fifo_limit");
+    std::uint32_t remaining = cb.fifo_limit - cb.fifo_wr_ptr;
 
-    if (get_local_cb_interface(output).fifo_wr_ptr >= get_local_cb_interface(output).fifo_limit) {
-        get_local_cb_interface(output).fifo_wr_ptr -= get_local_cb_interface(output).fifo_size;
+    LLK_ASSERT(remaining >= num_words, "CB push_back: fifo_wr_ptr would exceed fifo_limit");
+
+    cb.fifo_wr_ptr += (num_words <= remaining) ? num_words : remaining;
+    cb.fifo_wr_tile_ptr = 0;
+
+    if (cb.fifo_wr_ptr >= cb.fifo_limit) {
+        cb.fifo_wr_ptr -= cb.fifo_size;
     }
 
     llk_push_to_brisc(operand, num_tiles, num_words);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -82,7 +82,7 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
 
     LLK_ASSERT(remaining >= num_words, "CB push_back: fifo_wr_ptr would exceed fifo_limit");
 
-    cb.fifo_wr_ptr += (num_words <= remaining) ? num_words : remaining;
+    cb.fifo_wr_ptr += num_words;
     cb.fifo_wr_tile_ptr = 0;
 
     if (cb.fifo_wr_ptr >= cb.fifo_limit) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -68,6 +68,10 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     DeviceZoneScopedSumN1("CB-COMPUTE-WAIT-FRONT");
     std::uint32_t input = operand;
 
+    LLK_ASSERT(
+        static_cast<std::uint32_t>(num_tiles) <= get_local_cb_interface(input).fifo_num_pages,
+        "cb_wait_front: num_tiles exceeds CB size (would deadlock)");
+
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -67,6 +67,11 @@ inline __attribute__((__always_inline__)) void apply_mm_stagger(int operand) {
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     DeviceZoneScopedSumN1("CB-COMPUTE-WAIT-FRONT");
     std::uint32_t input = operand;
+
+    LLK_ASSERT(
+        cb_wait_front_validate(input, (std::uint32_t)num_tiles),
+        "cb_wait_front: cumulative count, step consistency, or divisibility constraint violated");
+
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
 
@@ -85,6 +90,12 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
+
+    LLK_ASSERT(
+        cb_access_divides_size_evenly(input, (std::uint32_t)num_tiles),
+        "cb_pop_front: tile count must evenly divide CB size");
+    LLK_ASSERT(cb_wait_front_validate(input, 0, true), "");
+
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
         (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -70,7 +70,8 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 
     LLK_ASSERT(
         cb_wait_front_validate(input, (std::uint32_t)num_tiles),
-        "cb_wait_front: monotonicity or step consistency violated");
+        "cb_wait_front: successive calls must request strictly increasing num_tiles "
+        "with a constant step size between calls (until cb_pop_front resets the sequence)");
 
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -70,7 +70,7 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 
     LLK_ASSERT(
         cb_wait_front_validate(input, (std::uint32_t)num_tiles),
-        "cb_wait_front: cumulative count, step consistency, or divisibility constraint violated");
+        "cb_wait_front: monotonicity or step consistency violated");
 
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
@@ -91,7 +91,9 @@ inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
 
-    LLK_ASSERT(cb_wait_front_validate(input, 0, true), "");
+#ifdef ENABLE_LLK_ASSERT
+    cb_wait_front_validate(input, /*num_tiles=*/0, /*reset=*/true);
+#endif
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
         (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
@@ -101,14 +103,18 @@ inline void llk_pop_tiles(
     TT_SETDMAREG(0, get_local_cb_interface(input).tiles_acked, 0, LO_16(4));
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
-    get_local_cb_interface(input).fifo_rd_ptr += num_words;
+    auto& cb = get_local_cb_interface(input);
 
-    LLK_ASSERT(
-        get_local_cb_interface(input).fifo_rd_ptr <= get_local_cb_interface(input).fifo_limit,
-        "CB pop_front: fifo_rd_ptr exceeds fifo_limit");
+    LLK_ASSERT(cb.fifo_rd_ptr < cb.fifo_limit, "CB pop_front: fifo_rd_ptr already at or past fifo_limit");
 
-    if (get_local_cb_interface(input).fifo_rd_ptr >= get_local_cb_interface(input).fifo_limit) {
-        get_local_cb_interface(input).fifo_rd_ptr -= get_local_cb_interface(input).fifo_size;
+    std::uint32_t remaining = cb.fifo_limit - cb.fifo_rd_ptr;
+
+    LLK_ASSERT(remaining >= num_words, "CB pop_front: fifo_rd_ptr would exceed fifo_limit");
+
+    cb.fifo_rd_ptr += (num_words <= remaining) ? num_words : remaining;
+
+    if (cb.fifo_rd_ptr >= cb.fifo_limit) {
+        cb.fifo_rd_ptr -= cb.fifo_size;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -91,9 +91,6 @@ inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
 
-    LLK_ASSERT(
-        cb_access_divides_size_evenly(input, (std::uint32_t)num_tiles),
-        "cb_pop_front: tile count must evenly divide CB size");
     LLK_ASSERT(cb_wait_front_validate(input, 0, true), "");
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -68,10 +68,6 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     DeviceZoneScopedSumN1("CB-COMPUTE-WAIT-FRONT");
     std::uint32_t input = operand;
 
-    LLK_ASSERT(
-        static_cast<std::uint32_t>(num_tiles) <= get_local_cb_interface(input).fifo_num_pages,
-        "cb_wait_front: num_tiles exceeds CB size (would deadlock)");
-
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -103,7 +103,7 @@ inline void llk_pop_tiles(
 
     LLK_ASSERT(remaining >= num_words, "CB pop_front: fifo_rd_ptr would exceed fifo_limit");
 
-    cb.fifo_rd_ptr += (num_words <= remaining) ? num_words : remaining;
+    cb.fifo_rd_ptr += num_words;
 
     if (cb.fifo_rd_ptr >= cb.fifo_limit) {
         cb.fifo_rd_ptr -= cb.fifo_size;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -68,11 +68,6 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     DeviceZoneScopedSumN1("CB-COMPUTE-WAIT-FRONT");
     std::uint32_t input = operand;
 
-    LLK_ASSERT(
-        cb_wait_front_validate(input, (std::uint32_t)num_tiles),
-        "cb_wait_front: successive calls must request strictly increasing num_tiles "
-        "with a constant step size between calls (until cb_pop_front resets the sequence)");
-
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
 
@@ -91,10 +86,6 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
-
-#ifdef ENABLE_LLK_ASSERT
-    cb_wait_front_validate(input, /*num_tiles=*/0, /*reset=*/true);
-#endif
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
         (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);

--- a/tt_metal/hw/inc/api/compute/cb_api.h
+++ b/tt_metal/hw/inc/api/compute/cb_api.h
@@ -26,12 +26,16 @@ namespace ckernel {
  * cb_wait_front(8) followed by a cb_pop_front(32) would produce incorrect behavior. Instead 4 calls of cb_wait_front()
  * waiting on 8, 16, 24, 32 tiles should be issued.
  *
- * Important note: number of tiles used in all cb_* calls must evenly divide the cb size and must be the same number in
- * all cb_wait_front calls in the same kernel. Example 1: cb_wait_front(32), cb_wait_front(40), cb_pop_front(32+8) tiles
- * on a CB of size 64 would produce incorrect behavior. Example 2: cb_wait_front(3) on a cb of size 32 would also
- * produce incorrect behavior. These limitations are due to performance optimizations in the CB implementation.
+ * Important note: within a single cumulative wait sequence (between cb_pop_front calls), the step size between
+ * consecutive cb_wait_front calls should be consistent. Example: cb_wait_front(8), cb_wait_front(16),
+ * cb_wait_front(24), cb_pop_front(24) is correct (consistent step of 8). Different step sizes may be used in
+ * separate wait/pop sequences on the same CB.
  *
- * Important note: CB total size must be an even multiple of the argument passed to this call.
+ * Important note: the total number of tiles passed to cb_pop_front/cb_push_back calls within one complete cycle of
+ * the CB must sum to exactly the CB size (fifo_num_pages) so that the internal pointer wraps correctly. Individual
+ * pop or push amounts do not need to evenly divide the CB size. Example: on a CB of size 12, cb_pop_front(5)
+ * followed by cb_pop_front(7) is correct (total 12 = CB size). Out-of-bounds pointer advancement is detected at
+ * runtime when watcher or lightweight kernel asserts are enabled.
  *
  * Return value: None
  *
@@ -78,9 +82,8 @@ ALWI void cb_pop_front(uint32_t cbid, uint32_t ntiles) { UNPACK((llk_pop_tiles(c
 // clang-format off
 /**
  * A blocking call that waits for the specified number of tiles to be free in the specified circular buffer. This call
- * is used by the producer to wait for the consumer to consume (ie. free up) the specified number of tiles.
- *
- * CB total size must be an even multiple of the argument passed to this call.
+ * is used by the producer to wait for the consumer to consume (ie. free up) the specified number of tiles. This is a
+ * polling operation that does not advance any CB pointer.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/compute/cb_api.h
+++ b/tt_metal/hw/inc/api/compute/cb_api.h
@@ -26,16 +26,12 @@ namespace ckernel {
  * cb_wait_front(8) followed by a cb_pop_front(32) would produce incorrect behavior. Instead 4 calls of cb_wait_front()
  * waiting on 8, 16, 24, 32 tiles should be issued.
  *
- * Important note: within a single cumulative wait sequence (between cb_pop_front calls), the step size between
- * consecutive cb_wait_front calls should be consistent. Example: cb_wait_front(8), cb_wait_front(16),
- * cb_wait_front(24), cb_pop_front(24) is correct (consistent step of 8). Different step sizes may be used in
- * separate wait/pop sequences on the same CB.
- *
  * Important note: the total number of tiles passed to cb_pop_front/cb_push_back calls within one complete cycle of
  * the CB must sum to exactly the CB size (fifo_num_pages) so that the internal pointer wraps correctly. Individual
  * pop or push amounts do not need to evenly divide the CB size. Example: on a CB of size 12, cb_pop_front(5)
- * followed by cb_pop_front(7) is correct (total 12 = CB size). Out-of-bounds pointer advancement is detected at
- * runtime when watcher or lightweight kernel asserts are enabled.
+ * followed by cb_pop_front(7) is correct (total 12 = CB size). However, cb_pop_front(7) followed by
+ * cb_pop_front(7) on the same CB is incorrect (total 14 != 12). Out-of-bounds pointer advancement is detected
+ * at runtime when watcher or lightweight kernel asserts are enabled.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -197,7 +197,6 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
 // clang-format on
 FORCE_INLINE
 void cb_push_back(const int32_t operand, const int32_t num_pages) {
-    ASSERT(cb_access_divides_size_evenly(operand, (uint32_t)num_pages));
     uint32_t num_words = num_pages * get_local_cb_interface(operand).fifo_page_size;
 
     volatile tt_reg_ptr uint32_t* pages_received_ptr = get_cb_tiles_received_ptr(operand);
@@ -240,7 +239,6 @@ void cb_push_back(const int32_t operand, const int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_pop_front(int32_t operand, int32_t num_pages) {
-    ASSERT(cb_access_divides_size_evenly(operand, (uint32_t)num_pages));
 #if ASSERT_ENABLED
     cb_wait_front_validate(operand, 0, true);
 #endif

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -391,7 +391,6 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
-    ASSERT(cb_access_divides_size_evenly(operand, (uint32_t)num_pages));
     uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -402,9 +402,7 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
-    ASSERT(
-        static_cast<uint32_t>(num_pages) <= get_local_cb_interface(operand).fifo_num_pages,
-        "cb_reserve_back: num_pages exceeds CB size (would deadlock)");
+    ASSERT(static_cast<uint32_t>(num_pages) <= get_local_cb_interface(operand).fifo_num_pages);
     uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
@@ -475,9 +473,7 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
-    ASSERT(
-        static_cast<uint32_t>(num_pages) <= get_local_cb_interface(operand).fifo_num_pages,
-        "cb_wait_front: num_pages exceeds CB size (would deadlock)");
+    ASSERT(static_cast<uint32_t>(num_pages) <= get_local_cb_interface(operand).fifo_num_pages);
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
     uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -192,8 +192,9 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
  * internal write pointer wraps correctly. Individual push amounts do not need
  * to evenly divide the CB size. Example: on a CB of size 12,
  * cb_push_back(5) followed by cb_push_back(7) is correct (total 12 = CB
- * size). Out-of-bounds pointer advancement is detected at runtime when
- * watcher or lightweight kernel asserts are enabled.
+ * size). However, cb_push_back(7) followed by cb_push_back(7) on the same
+ * CB is incorrect (total 14 != 12). Out-of-bounds pointer advancement is
+ * detected at runtime when watcher or lightweight kernel asserts are enabled.
  *
  * Return value: None
  *
@@ -242,8 +243,9 @@ void cb_push_back(const int32_t operand, const int32_t num_pages) {
  * internal read pointer wraps correctly. Individual pop amounts do not need
  * to evenly divide the CB size. Example: on a CB of size 12,
  * cb_pop_front(5) followed by cb_pop_front(7) is correct (total 12 = CB
- * size). Out-of-bounds pointer advancement is detected at runtime when
- * watcher or lightweight kernel asserts are enabled.
+ * size). However, cb_pop_front(7) followed by cb_pop_front(7) on the same
+ * CB is incorrect (total 14 != 12). Out-of-bounds pointer advancement is
+ * detected at runtime when watcher or lightweight kernel asserts are enabled.
  *
  * Return value: None
  *
@@ -255,9 +257,6 @@ void cb_push_back(const int32_t operand, const int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_pop_front(int32_t operand, int32_t num_pages) {
-#if ASSERT_ENABLED
-    cb_wait_front_validate(operand, /*num_tiles=*/0, /*reset=*/true);
-#endif
     volatile tt_reg_ptr uint32_t* pages_acked_ptr = get_cb_tiles_acked_ptr(operand);
     pages_acked_ptr[0] += num_pages;
 
@@ -456,16 +455,12 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
  * 4 calls of cb_wait_front(8) followed by a cb_pop_front(32) would produce incorrect behavior. Instead 4 calls of
  * cb_wait_front() waiting on 8, 16, 24, 32 tiles should be issued.
  *
- * Important note: within a single cumulative wait sequence (between cb_pop_front calls), the step size between
- * consecutive cb_wait_front calls should be consistent. Example: cb_wait_front(8), cb_wait_front(16),
- * cb_wait_front(24), cb_pop_front(24) is correct (consistent step of 8). Different step sizes may be used in
- * separate wait/pop sequences on the same CB.
- *
  * Important note: the total number of tiles passed to cb_pop_front/cb_push_back calls within one complete cycle of
  * the CB must sum to exactly the CB size (fifo_num_pages) so that the internal pointer wraps correctly. Individual
  * pop or push amounts do not need to evenly divide the CB size. Example: on a CB of size 12, cb_pop_front(5)
- * followed by cb_pop_front(7) is correct (total 12 = CB size). Out-of-bounds pointer advancement is detected at
- * runtime when watcher or lightweight kernel asserts are enabled.
+ * followed by cb_pop_front(7) is correct (total 12 = CB size). However, cb_pop_front(7) followed by
+ * cb_pop_front(7) on the same CB is incorrect (total 14 != 12). Out-of-bounds pointer advancement is detected
+ * at runtime when watcher or lightweight kernel asserts are enabled.
  *
  * Return value: None
  *
@@ -477,7 +472,6 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
-    ASSERT(cb_wait_front_validate(operand, (uint32_t)num_pages));
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
     uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -402,6 +402,9 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
+    ASSERT(
+        static_cast<uint32_t>(num_pages) <= get_local_cb_interface(operand).fifo_num_pages,
+        "cb_reserve_back: num_pages exceeds CB size (would deadlock)");
     uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
@@ -472,6 +475,9 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
+    ASSERT(
+        static_cast<uint32_t>(num_pages) <= get_local_cb_interface(operand).fifo_num_pages,
+        "cb_wait_front: num_pages exceeds CB size (would deadlock)");
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
     uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -402,7 +402,6 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
-    ASSERT(static_cast<uint32_t>(num_pages) <= get_local_cb_interface(operand).fifo_num_pages);
     uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
@@ -473,7 +472,6 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
-    ASSERT(static_cast<uint32_t>(num_pages) <= get_local_cb_interface(operand).fifo_num_pages);
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
     uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -187,6 +187,14 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
  * writes of sub-tiles 2) modify tiles (or sub-tiles) by random access of the
  * valid section of the CB
  *
+ * Important note: the total number of tiles pushed within one complete cycle
+ * of the CB must sum to exactly the CB size (fifo_num_pages) so that the
+ * internal write pointer wraps correctly. Individual push amounts do not need
+ * to evenly divide the CB size. Example: on a CB of size 12,
+ * cb_push_back(5) followed by cb_push_back(7) is correct (total 12 = CB
+ * size). Out-of-bounds pointer advancement is detected at runtime when
+ * watcher or lightweight kernel asserts are enabled.
+ *
  * Return value: None
  *
  * | Argument  | Description                           | Type     | Valid Range                                                                                       | Required |
@@ -228,6 +236,14 @@ void cb_push_back(const int32_t operand, const int32_t num_pages) {
  * CB via multiple reads of sub-tiles 2) access the tiles (or their sub-tiles)
  * that are visible to the consumer by random access of the valid section of
  * the CB
+ *
+ * Important note: the total number of tiles popped within one complete cycle
+ * of the CB must sum to exactly the CB size (fifo_num_pages) so that the
+ * internal read pointer wraps correctly. Individual pop amounts do not need
+ * to evenly divide the CB size. Example: on a CB of size 12,
+ * cb_pop_front(5) followed by cb_pop_front(7) is correct (total 12 = CB
+ * size). Out-of-bounds pointer advancement is detected at runtime when
+ * watcher or lightweight kernel asserts are enabled.
  *
  * Return value: None
  *
@@ -346,8 +362,7 @@ inline void wait_for_sync_register_value(uintptr_t addr, int32_t val) {
 /**
  * A non-blocking call that checks if the specified number of pages are available for reservation at the back of the
  * circular buffer. This call is used by the producer to see if the consumer has freed up the desired space (in pages).
- *
- * CB total size must be an even multiple of the argument passed to this call.
+ * This is a polling operation that does not advance any CB pointer.
  *
  * Return value: true if the specified number of pages are available
  *
@@ -375,9 +390,8 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
 // clang-format off
 /**
  * A blocking call that waits for the specified number of tiles to be free in the specified circular buffer. This call
- * is used by the producer to wait for the consumer to consume (ie. free up) the specified number of tiles.
- *
- * CB total size must be an even multiple of the argument passed to this call.
+ * is used by the producer to wait for the consumer to consume (ie. free up) the specified number of tiles. This is a
+ * polling operation that does not advance any CB pointer.
  *
  * Return value: None
  *
@@ -412,20 +426,11 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
 // clang-format off
 /**
  * A non-blocking call that tells the caller if the specified number of pages are available in the specified circular
- * buffer (CB). This call is used by the consumer of the CB to see if the producers has fill the CB with at least the
- * specified number of tiles. Important note: in case multiple calls of cb_wait_front(n) are issued without a paired
- * cb_pop_front() call, n is expected to be incremented by the user to be equal to a cumulative total of tiles. Example:
- * 4 calls of cb_wait_front(8) followed by a cb_pop_front(32) would produce incorrect behavior. Instead 4 calls of
- * cb_wait_front() waiting on 8, 16, 24, 32 tiles should be issued.
+ * buffer (CB). This call is used by the consumer of the CB to see if the producer has filled the CB with at least the
+ * specified number of tiles. This is a polling operation that does not advance any CB pointer. See cb_wait_front for
+ * the blocking variant and cumulative wait semantics.
  *
- * Important note: number of tiles used in all cb_* calls must evenly divide the cb size and must be the same number in
- * all cb_wait_front calls in the same kernel. Example 1: cb_wait_front(32), cb_wait_front(40), cb_pop_front(32+8) tiles
- * on a CB of size 64 would produce incorrect behavior. Example 2: cb_wait_front(3) on a cb of size 32 would also
- * produce incorrect behavior. These limitations are due to performance optimizations in the CB implementation.
- *
- * Important note: CB total size must be an even multiple of the argument passed to this call.
- *
- * Return value: None
+ * Return value: true if the specified number of pages are available
  *
  * | Argument  | Description                           | Type     | Valid Range                                                                                       | Required |
  * |-----------|---------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
@@ -451,12 +456,16 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
  * 4 calls of cb_wait_front(8) followed by a cb_pop_front(32) would produce incorrect behavior. Instead 4 calls of
  * cb_wait_front() waiting on 8, 16, 24, 32 tiles should be issued.
  *
- * Important note: number of tiles used in all cb_* calls must evenly divide the cb size and must be the same number in
- * all cb_wait_front calls in the same kernel. Example 1: cb_wait_front(32), cb_wait_front(40), cb_pop_front(32+8) tiles
- * on a CB of size 64 would produce incorrect behavior. Example 2: cb_wait_front(3) on a cb of size 32 would also
- * produce incorrect behavior. These limitations are due to performance optimizations in the CB implementation.
+ * Important note: within a single cumulative wait sequence (between cb_pop_front calls), the step size between
+ * consecutive cb_wait_front calls should be consistent. Example: cb_wait_front(8), cb_wait_front(16),
+ * cb_wait_front(24), cb_pop_front(24) is correct (consistent step of 8). Different step sizes may be used in
+ * separate wait/pop sequences on the same CB.
  *
- * Important note: CB total size must be an even multiple of the argument passed to this call.
+ * Important note: the total number of tiles passed to cb_pop_front/cb_push_back calls within one complete cycle of
+ * the CB must sum to exactly the CB size (fifo_num_pages) so that the internal pointer wraps correctly. Individual
+ * pop or push amounts do not need to evenly divide the CB size. Example: on a CB of size 12, cb_pop_front(5)
+ * followed by cb_pop_front(7) is correct (total 12 = CB size). Out-of-bounds pointer advancement is detected at
+ * runtime when watcher or lightweight kernel asserts are enabled.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -256,7 +256,7 @@ void cb_push_back(const int32_t operand, const int32_t num_pages) {
 FORCE_INLINE
 void cb_pop_front(int32_t operand, int32_t num_pages) {
 #if ASSERT_ENABLED
-    cb_wait_front_validate(operand, 0, true);
+    cb_wait_front_validate(operand, /*num_tiles=*/0, /*reset=*/true);
 #endif
     volatile tt_reg_ptr uint32_t* pages_acked_ptr = get_cb_tiles_acked_ptr(operand);
     pages_acked_ptr[0] += num_pages;

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -197,6 +197,7 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
 // clang-format on
 FORCE_INLINE
 void cb_push_back(const int32_t operand, const int32_t num_pages) {
+    ASSERT(cb_access_divides_size_evenly(operand, (uint32_t)num_pages));
     uint32_t num_words = num_pages * get_local_cb_interface(operand).fifo_page_size;
 
     volatile tt_reg_ptr uint32_t* pages_received_ptr = get_cb_tiles_received_ptr(operand);
@@ -239,6 +240,10 @@ void cb_push_back(const int32_t operand, const int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_pop_front(int32_t operand, int32_t num_pages) {
+    ASSERT(cb_access_divides_size_evenly(operand, (uint32_t)num_pages));
+#if ASSERT_ENABLED
+    cb_wait_front_validate(operand, 0, true);
+#endif
     volatile tt_reg_ptr uint32_t* pages_acked_ptr = get_cb_tiles_acked_ptr(operand);
     pages_acked_ptr[0] += num_pages;
 
@@ -386,6 +391,7 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
+    ASSERT(cb_access_divides_size_evenly(operand, (uint32_t)num_pages));
     uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
@@ -465,6 +471,7 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
+    ASSERT(cb_wait_front_validate(operand, (uint32_t)num_pages));
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
     uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -114,6 +114,20 @@ __attribute__((noinline)) inline bool cb_access_within_bounds(
     return cb.fifo_rd_ptr + (start_tile_index + num_tiles) * cb.fifo_page_size <= cb.fifo_limit;
 }
 
+// Validates the calling pattern of cb_wait_front for a given circular buffer.
+//
+// Between cb_pop_front calls (which reset the sequence), successive
+// cb_wait_front calls must request a strictly increasing num_tiles with a
+// constant step size.  For example, the sequence 8 -> 16 -> 24 (step = 8) is
+// valid, while 8 -> 16 -> 20 (step changes from 8 to 4) is not.
+//
+// Returns false if any of these conditions are violated:
+//   - num_tiles exceeds UINT16_MAX
+//   - the step between the current and previous num_tiles differs from the
+//     established step size
+//
+// Call with reset=true (done by cb_pop_front / llk_pop_tiles) to clear the
+// tracked state for cb_id and start a new sequence.
 __attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uint32_t num_tiles, bool reset = false) {
     static uint16_t last_count[NUM_CIRCULAR_BUFFERS] = {};
     static uint16_t step_size[NUM_CIRCULAR_BUFFERS] = {};

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -114,13 +114,6 @@ __attribute__((noinline)) inline bool cb_access_within_bounds(
     return cb.fifo_rd_ptr + (start_tile_index + num_tiles) * cb.fifo_page_size <= cb.fifo_limit;
 }
 
-__attribute__((noinline)) inline bool cb_access_divides_size_evenly(uint32_t cb_id, uint32_t num_tiles) {
-    if (num_tiles == 0) {
-        return true;
-    }
-    return get_local_cb_interface(cb_id).fifo_num_pages % num_tiles == 0;
-}
-
 __attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uint32_t num_tiles, bool reset = false) {
     static uint16_t last_count[NUM_CIRCULAR_BUFFERS] = {};
     static uint16_t step_size[NUM_CIRCULAR_BUFFERS] = {};

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -115,7 +115,10 @@ __attribute__((noinline)) inline bool cb_access_within_bounds(
 }
 
 __attribute__((noinline)) inline bool cb_access_divides_size_evenly(uint32_t cb_id, uint32_t num_tiles) {
-    return num_tiles > 0 && get_local_cb_interface(cb_id).fifo_num_pages % num_tiles == 0;
+    if (num_tiles == 0) {
+        return true;
+    }
+    return get_local_cb_interface(cb_id).fifo_num_pages % num_tiles == 0;
 }
 
 __attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uint32_t num_tiles, bool reset = false) {
@@ -124,6 +127,10 @@ __attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uin
 
     if (reset) {
         last_count[cb_id] = 0;
+        return true;
+    }
+
+    if (num_tiles == 0) {
         return true;
     }
 

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -114,56 +114,6 @@ __attribute__((noinline)) inline bool cb_access_within_bounds(
     return cb.fifo_rd_ptr + (start_tile_index + num_tiles) * cb.fifo_page_size <= cb.fifo_limit;
 }
 
-// Validates the calling pattern of cb_wait_front for a given circular buffer.
-//
-// Between cb_pop_front calls (which reset the sequence), successive
-// cb_wait_front calls must request a strictly increasing num_tiles with a
-// constant step size.  For example, the sequence 8 -> 16 -> 24 (step = 8) is
-// valid, while 8 -> 16 -> 20 (step changes from 8 to 4) is not.
-//
-// Returns false if any of these conditions are violated:
-//   - num_tiles exceeds UINT16_MAX
-//   - the step between the current and previous num_tiles differs from the
-//     established step size
-//
-// Call with reset=true (done by cb_pop_front / llk_pop_tiles) to clear the
-// tracked state for cb_id and start a new sequence.
-__attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uint32_t num_tiles, bool reset = false) {
-    static uint16_t last_count[NUM_CIRCULAR_BUFFERS] = {};
-    static uint16_t step_size[NUM_CIRCULAR_BUFFERS] = {};
-
-    if (reset) {
-        last_count[cb_id] = 0;
-        step_size[cb_id] = 0;
-        return true;
-    }
-
-    if (num_tiles == 0) {
-        return true;
-    }
-
-    if (num_tiles > UINT16_MAX) {
-        return false;
-    }
-
-    uint16_t num_tiles16 = (uint16_t)num_tiles;
-    uint16_t prev = last_count[cb_id];
-
-    if (prev > 0 && num_tiles16 <= prev) {
-        prev = 0;
-        step_size[cb_id] = 0;
-    }
-
-    uint16_t step = num_tiles16 - prev;
-    if (step_size[cb_id] > 0 && step != step_size[cb_id]) {
-        return false;
-    }
-
-    last_count[cb_id] = num_tiles16;
-    step_size[cb_id] = step;
-    return true;
-}
-
 #if defined(COMPILE_FOR_TRISC)
 constexpr uint32_t cb_addr_shift = CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT;
 #else

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -127,6 +127,7 @@ __attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uin
 
     if (reset) {
         last_count[cb_id] = 0;
+        step_size[cb_id] = 0;
         return true;
     }
 

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -144,9 +144,6 @@ __attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uin
     if (step_size[cb_id] > 0 && step != step_size[cb_id]) {
         return false;
     }
-    if (!cb_access_divides_size_evenly(cb_id, (uint32_t)step)) {
-        return false;
-    }
 
     last_count[cb_id] = (uint16_t)num_tiles;
     step_size[cb_id] = step;

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -128,19 +128,24 @@ __attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uin
         return true;
     }
 
+    if (num_tiles > UINT16_MAX) {
+        return false;
+    }
+
+    uint16_t num_tiles16 = (uint16_t)num_tiles;
     uint16_t prev = last_count[cb_id];
 
-    if (prev > 0 && (uint16_t)num_tiles <= prev) {
+    if (prev > 0 && num_tiles16 <= prev) {
         prev = 0;
         step_size[cb_id] = 0;
     }
 
-    uint16_t step = (uint16_t)num_tiles - prev;
+    uint16_t step = num_tiles16 - prev;
     if (step_size[cb_id] > 0 && step != step_size[cb_id]) {
         return false;
     }
 
-    last_count[cb_id] = (uint16_t)num_tiles;
+    last_count[cb_id] = num_tiles16;
     step_size[cb_id] = step;
     return true;
 }

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -129,11 +129,13 @@ __attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uin
     }
 
     uint16_t prev = last_count[cb_id];
-    uint16_t step = (uint16_t)num_tiles - prev;
 
     if (prev > 0 && (uint16_t)num_tiles <= prev) {
-        return false;
+        prev = 0;
+        step_size[cb_id] = 0;
     }
+
+    uint16_t step = (uint16_t)num_tiles - prev;
     if (step_size[cb_id] > 0 && step != step_size[cb_id]) {
         return false;
     }

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -108,9 +108,41 @@ FORCE_INLINE RemoteReceiverCBInterface& get_remote_receiver_cb_interface(uint32_
     return cb_interface[cb_id].remote_receiver_cb_interface;
 }
 
-__attribute__((noinline)) bool cb_access_within_bounds(uint32_t cb_id, uint32_t start_tile_index, uint32_t num_tiles) {
+__attribute__((noinline)) inline bool cb_access_within_bounds(
+    uint32_t cb_id, uint32_t start_tile_index, uint32_t num_tiles) {
     const auto& cb = get_local_cb_interface(cb_id);
     return cb.fifo_rd_ptr + (start_tile_index + num_tiles) * cb.fifo_page_size <= cb.fifo_limit;
+}
+
+__attribute__((noinline)) inline bool cb_access_divides_size_evenly(uint32_t cb_id, uint32_t num_tiles) {
+    return num_tiles > 0 && get_local_cb_interface(cb_id).fifo_num_pages % num_tiles == 0;
+}
+
+__attribute__((noinline)) inline bool cb_wait_front_validate(uint32_t cb_id, uint32_t num_tiles, bool reset = false) {
+    static uint16_t last_count[NUM_CIRCULAR_BUFFERS] = {};
+    static uint16_t step_size[NUM_CIRCULAR_BUFFERS] = {};
+
+    if (reset) {
+        last_count[cb_id] = 0;
+        return true;
+    }
+
+    uint16_t prev = last_count[cb_id];
+    uint16_t step = (uint16_t)num_tiles - prev;
+
+    if (prev > 0 && (uint16_t)num_tiles <= prev) {
+        return false;
+    }
+    if (step_size[cb_id] > 0 && step != step_size[cb_id]) {
+        return false;
+    }
+    if (!cb_access_divides_size_evenly(cb_id, (uint32_t)step)) {
+        return false;
+    }
+
+    last_count[cb_id] = (uint16_t)num_tiles;
+    step_size[cb_id] = step;
+    return true;
 }
 
 #if defined(COMPILE_FOR_TRISC)


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #38930 

We do not have asserts to ensure that the documented requirements (see https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_wait_front.html#cb-wait-front) for CB accesses are respected.

This PR adds checks for the requirements.

While testing via matmul pytests, a lot of false positives were found. According to AI, he step-level divisibility check is overly strict even conceptually — what matters for correct wrapping is that the total tiles popped per CB cycle equals fifo_num_pages, not that each individual pop divides it. Padded matmul kernels legitimately use variable-sized wait/pop amounts (regular subblocks vs. padding).

Based on this experience, the documentation has been updated.

Also fixes a missing inline for a no inline function required because of C++ linker rules.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Needed to use static variables. This assert code would not be portable to Quasar, which is okay because Quasar does not have CBs.

Running
- Sanity with lightweight and llk asserts https://github.com/tenstorrent/tt-metal/actions/runs/24521453797
- BHPC with llk asserts https://github.com/tenstorrent/tt-metal/actions/runs/24521470485

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-38930_cb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-38930_cb_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38930_cb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38930_cb_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38930_cb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38930_cb_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-38930_cb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-38930_cb_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38930_cb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38930_cb_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38930_cb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38930_cb_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38930_cb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38930_cb_check)