### PR TITLE
Migrate uniform op to ProgramDescriptor framework

### DIFF
--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::uniform {
 
@@ -26,28 +27,11 @@ struct UniformDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    struct ProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle compute_kernel_id{};
-            tt::tt_metal::KernelHandle writer_kernel_id{};
-            std::vector<CoreCoord> cores;
-        };
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output);
 
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-    };
-
-    using program_factory_t = std::variant<ProgramFactory>;
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -20,7 +20,11 @@ std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max(
 
 auto get_random_seed() -> uint32_t { return distribution(rng); }
 
-UniformDeviceOperation::ProgramFactory::cached_program_t UniformDeviceOperation::ProgramFactory::create(
+static constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp";
+static constexpr const char* COMPUTE_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/uniform/device/kernels/compute_uniform.cpp";
+
+ProgramDescriptor UniformDeviceOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output) {
@@ -31,11 +35,8 @@ UniformDeviceOperation::ProgramFactory::cached_program_t UniformDeviceOperation:
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    uint32_t num_cores_x = grid.x;
-    uint32_t num_cores_y = grid.y;
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y);
-
-    Program program = Program();
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    const auto num_cores_total = cores.size();
 
     DataType output_dtype = output.dtype();
     auto out_data_format = datatype_to_dataformat_converter(output_dtype);
@@ -46,50 +47,82 @@ UniformDeviceOperation::ProgramFactory::cached_program_t UniformDeviceOperation:
     constexpr uint32_t intermed_num_tiles = 2;
 
     constexpr uint32_t intermed_cb_id = CBIndex::c_24;
-    CircularBufferConfig cb_intermed_config =
-        CircularBufferConfig(intermed_num_tiles * intermed_tile_size, {{intermed_cb_id, tt::DataFormat::Float32}})
-            .set_page_size(intermed_cb_id, intermed_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed_config);
-
     constexpr uint32_t dst_cb_id = CBIndex::c_0;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(in_out_num_tiles * dtype_tile_size, {{dst_cb_id, out_data_format}})
-            .set_page_size(dst_cb_id, dtype_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
-    const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/uniform/device/kernels/";
-    std::vector<uint32_t> writer_compile_time_args{intermed_cb_id, dst_cb_id};
-    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-    const std::string writer_file_path = kernels_dir_path + "writer_uniform.cpp";
-    const std::vector<uint32_t> compute_compile_time_args{intermed_cb_id};
-    const std::string compute_file_path = kernels_dir_path + "compute_uniform.cpp";
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
-    std::map<std::string, std::string> writer_defines;
+    ProgramDescriptor desc;
+
+    // Intermediate CB (Float32)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed_num_tiles * intermed_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = intermed_cb_id,
+            .data_format = tt::DataFormat::Float32,
+            .page_size = intermed_tile_size,
+        }}},
+    });
+
+    // Output CB
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in_out_num_tiles * dtype_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = dst_cb_id,
+            .data_format = out_data_format,
+            .page_size = dtype_tile_size,
+        }}},
+    });
+
+    // Writer kernel
+    KernelDescriptor::Defines writer_defines;
     switch (output_dtype) {
-        case DataType::BFLOAT16: writer_defines["OUTPUT_DTYPE_BFLOAT16"] = "1"; break;
-        case DataType::FLOAT32: writer_defines["OUTPUT_DTYPE_FLOAT32"] = "1"; break;
+        case DataType::BFLOAT16: writer_defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
+        case DataType::FLOAT32: writer_defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
         default: break;
     }
 
-    KernelHandle writer_kernel_id = tt_metal::CreateKernel(
-        program, writer_file_path, all_cores, WriterDataMovementConfig(writer_compile_time_args, writer_defines));
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
-    KernelHandle compute_kernel_id = CreateKernel(
-        program,
-        compute_file_path,
-        all_cores,
-        ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                       // generated number out of range [from, to)
-            .dst_full_sync_en = dst_full_sync_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_compile_time_args,
-        });
+    KernelDescriptor::CompileTimeArgs writer_ct_args{intermed_cb_id, dst_cb_id};
+    TensorAccessorArgs(output.buffer()).append_to(writer_ct_args);
 
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = WRITER_KERNEL_PATH;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.runtime_args.reserve(num_cores_total);
+
+    // Compute kernel
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = std::move(all_cores);
+    compute_desc.compile_time_args = {intermed_cb_id};
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
+                                   // generated number out of range [from, to)
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+    };
+    compute_desc.runtime_args.reserve(num_cores_total);
+
+    // Runtime args per core
+    const float eps = 1e-6;
+    union {
+        float f;
+        uint32_t u;
+    } f2u_from{}, f2u_to{};
+    f2u_from.f = operation_attributes.from;
+    f2u_to.f = operation_attributes.to - eps;  // -eps make sure that generated number is < operation_attributes.to
+
+    const uint32_t output_addr = output.buffer()->address();
     uint32_t tile_offset = 0;
-    for (int i = 0; i < cores.size(); ++i) {
+    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
         const auto& core = cores[i];
         uint32_t units_per_core;
         if (core_group_1.contains(core)) {
@@ -100,53 +133,22 @@ UniformDeviceOperation::ProgramFactory::cached_program_t UniformDeviceOperation:
             TT_THROW("Core not in specified core ranges");
         }
 
-        const float eps = 1e-6;
-        union {
-            float f;
-            uint32_t u;
-        } f2u_from{}, f2u_to{};
-        f2u_from.f = operation_attributes.from;
-        f2u_to.f = operation_attributes.to - eps;  // -eps make sure that generated number is < operation_attributes.to
-
         // Each core has its own seed to increase the number of generated random numbers
         uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
 
-        std::vector<uint32_t> compute_runtime_args = {seed, f2u_from.u, f2u_to.u, tile_offset, units_per_core};
-        SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        compute_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{seed, f2u_from.u, f2u_to.u, tile_offset, units_per_core});
 
-        std::vector<uint32_t> writer_runtime_args = {output.buffer()->address(), tile_offset, units_per_core};
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        writer_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset, units_per_core});
 
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.compute_kernel_id = compute_kernel_id, .writer_kernel_id = writer_kernel_id, .cores = cores}};
-}
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void UniformDeviceOperation::ProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& compute_kernel_id = cached_program.shared_variables.compute_kernel_id;
-    auto& cores = cached_program.shared_variables.cores;
-
-    const uint32_t output_addr = output.buffer()->address();
-
-    for (int i = 0; i < cores.size(); ++i) {
-        {
-            auto& runtime_args = GetRuntimeArgs(program, compute_kernel_id, cores[i]);
-            runtime_args[0] = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, cores[i]);
-            runtime_args[0] = output_addr;
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::uniform

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -2,6 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
+#include <ctime>
+#include <limits>
+#include <random>
 #include <string>
 
 #include <tt-metalium/constants.hpp>
@@ -15,10 +19,12 @@ namespace ttnn::operations::uniform {
 using namespace tt;
 using namespace tt::tt_metal;
 
+namespace {
 std::mt19937 rng(std::time(nullptr));
-std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max());
+std::uniform_int_distribution<int32_t> distribution(1, std::numeric_limits<int32_t>::max());
 
-auto get_random_seed() -> uint32_t { return distribution(rng); }
+uint32_t get_random_seed() { return distribution(rng); }
+}  // namespace
 
 static constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp";
 static constexpr const char* COMPUTE_KERNEL_PATH =
@@ -112,13 +118,10 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     compute_desc.runtime_args.reserve(num_cores_total);
 
     // Runtime args per core
-    const float eps = 1e-6;
-    union {
-        float f;
-        uint32_t u;
-    } f2u_from{}, f2u_to{};
-    f2u_from.f = operation_attributes.from;
-    f2u_to.f = operation_attributes.to - eps;  // -eps make sure that generated number is < operation_attributes.to
+    const float eps = 1e-6f;
+    const uint32_t f2u_from = std::bit_cast<uint32_t>(operation_attributes.from);
+    // -eps make sure that generated number is < operation_attributes.to
+    const uint32_t f2u_to = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
     const uint32_t output_addr = output.buffer()->address();
     uint32_t tile_offset = 0;
@@ -137,7 +140,7 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
         uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
 
         compute_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{seed, f2u_from.u, f2u_to.u, tile_offset, units_per_core});
+            core, KernelDescriptor::CoreRuntimeArgs{seed, f2u_from, f2u_to, tile_offset, units_per_core});
 
         writer_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset, units_per_core});


### PR DESCRIPTION
## Summary

Migrate the `uniform` operation from the legacy `ProgramFactory` + `override_runtime_arguments` pattern to the declarative `ProgramDescriptor`-based `create_descriptor` approach.

Closes #42402

## Notes for reviewers

- 2 files changed: `uniform_device_operation.hpp` and `uniform_program_factory.cpp`. No public API changes.
- 2 kernels (compute + writer), 2 CBs. Same structure as randn.
- Custom `compute_program_hash` preserved (excludes seed from hash for cache hits).
- All comments preserved including `fp32_dest_acc_en` precision comment and `-eps` comment.
- Performance: 7.8 us/call (baseline 6.3 us, +24% overhead — within microsecond range). (host side)
- All 100 nightly tests pass.

## Test plan

- [x] All 100 nightly uniform tests pass
- [x] bfloat16 and float32 dtypes tested
- [x] Various shapes, ranges, seeds tested
- [x] Compute kernel config options tested
- [x] Performance within acceptable range

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-uniform-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-uniform-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-uniform-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-uniform-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-uniform-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-uniform-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-uniform-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-uniform-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-uniform-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-uniform-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-uniform-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-uniform-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-uniform-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-uniform-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-uniform-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-uniform-to-program-descriptor)