### PR TITLE
Migrate moreh_abs_pow op to ProgramDescriptor framework

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
@@ -10,29 +10,7 @@
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/device_operation.hpp"
-
-#define MOREH_ABS_POW_FACTORY_H(name)                                                       \
-    struct name {                                                                           \
-        struct shared_variables_t {                                                         \
-            tt::tt_metal::KernelHandle reader_kernels_id;                                   \
-            tt::tt_metal::KernelHandle writer_kernels_id;                                   \
-            std::size_t num_cores_to_be_used;                                               \
-            std::size_t num_cores_y;                                                        \
-        };                                                                                  \
-                                                                                            \
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>; \
-                                                                                            \
-        static cached_program_t create(                                                     \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output_tensor);                                          \
-                                                                                            \
-        static void override_runtime_arguments(                                             \
-            cached_program_t& cached_program,                                               \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output_tensor);                                          \
-    };
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_abs_pow {
 
@@ -53,9 +31,11 @@ struct MorehAbsPowOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    MOREH_ABS_POW_FACTORY_H(MorehAbsPowFactory)
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output);
 
-    using program_factory_t = std::variant<MorehAbsPowFactory>;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
@@ -4,21 +4,30 @@
 
 #include "moreh_abs_pow_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
-#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::moreh::moreh_abs_pow {
-MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation::MorehAbsPowFactory::create(
+
+using namespace tt::tt_metal;
+
+static constexpr const char* READER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/reader_moreh_abs_pow.cpp";
+static constexpr const char* WRITER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/writer_moreh_abs_pow.cpp";
+static constexpr const char* COMPUTE_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp";
+
+ProgramDescriptor MorehAbsPowOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     const auto& input = tensor_args.input;
     const auto p = operation_attributes.p;
+
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     auto* device = input.device();
-    auto program = CreateProgram();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -37,6 +46,7 @@ MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation:
     const auto origin_w = input.logical_shape()[input_rank - 1];
 
     auto [floored_p, decimal, p_is_negative] = get_floored_p_and_decimal_and_p_is_negative(p);
+
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -53,13 +63,15 @@ MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation:
          core_group_1,
          core_group_2,
          num_units_per_core_group_1,
-         num_units_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid, num_units);
+         num_units_per_core_group_2] = split_work_to_cores(grid, num_units);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const auto cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : cb_data_format;
+    const uint32_t cb_tile_size = tile_size(cb_data_format);
+    const uint32_t intermed_tile_size = tile_size(intermed_data_format);
 
     const uint32_t in0_t{1};  // input
     const uint32_t in1_t{1};  // one
@@ -73,67 +85,141 @@ MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation:
     const uint32_t im2_t{1};  // exp(log(|x|) * decimal)
     const uint32_t im3_t{1};  // |x|^p
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CB::c_in0, in0_t},    // input
-            {tt::CB::c_in1, in1_t},    // one
-            {tt::CB::c_in2, in2_t},    // recip_p_decimal
-            {tt::CB::c_in3, in3_t},    // mask_w
-            {tt::CB::c_out0, out0_t},  // output
-            {tt::CB::c_intermed0, im0_t, intermed_data_format},
-            {tt::CB::c_intermed1, im1_t, intermed_data_format},
-            {tt::CB::c_intermed2, im2_t, intermed_data_format},
-            {tt::CB::c_intermed3, im3_t, intermed_data_format},
-        });
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_1,
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in2_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_2,
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in3_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_16,
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im0_t * intermed_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_24,
+            .data_format = intermed_data_format,
+            .page_size = intermed_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im1_t * intermed_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_25,
+            .data_format = intermed_data_format,
+            .page_size = intermed_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im2_t * intermed_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_26,
+            .data_format = intermed_data_format,
+            .page_size = intermed_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im3_t * intermed_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_27,
+            .data_format = intermed_data_format,
+            .page_size = intermed_tile_size,
+        }}},
+    });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto* const reader_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/"
-        "reader_moreh_abs_pow.cpp";
-    const auto* const writer_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/"
-        "writer_moreh_abs_pow.cpp";
-
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args;
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_ct_args);
-    std::vector<uint32_t> writer_ct_args = {};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = READER_KERNEL_PATH;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.runtime_args.reserve(num_cores_to_be_used);
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args;
     TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = WRITER_KERNEL_PATH;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.runtime_args.reserve(num_cores_to_be_used);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> compute_defines{};
+    ComputeConfigDescriptor compute_config{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    const auto* const compute_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/"
-        "moreh_abs_pow_kernel.cpp";
+    // Compute kernel for core_group_1
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = COMPUTE_KERNEL_PATH;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_units_per_core_group_1};
+    compute_desc_1.config = compute_config;
 
-    const auto compute_kernels_id_1 = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_units_per_core_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
-
-    KernelHandle compute_kernels_id_2{0};
-    if (!core_group_2.ranges().empty()) {
-        compute_kernels_id_2 = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_units_per_core_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+    // Compute kernel for core_group_2 (may be empty)
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = COMPUTE_KERNEL_PATH;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_units_per_core_group_2};
+        compute_desc_2.config = compute_config;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -143,68 +229,57 @@ MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation:
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_units_per_core;
-        KernelHandle compute_kernel_id;
         if (core_group_1.contains(core)) {
             num_units_per_core = num_units_per_core_group_1;
-            compute_kernel_id = compute_kernels_id_1;
         } else if (core_group_2.contains(core)) {
             num_units_per_core = num_units_per_core_group_2;
-            compute_kernel_id = compute_kernels_id_2;
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
 
         // reader
-        const std::vector<uint32_t> reader_runtime_args{
-            input.buffer()->address(),
-            static_cast<uint32_t>(is_dram(input)),
-            *reinterpret_cast<uint32_t*>(&decimal),
-            num_units_per_core,
-            Wt,
-            tile_offset,
-            origin_w};
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        reader_desc.runtime_args.emplace_back(
+            core,
+            KernelDescriptor::CoreRuntimeArgs{
+                input.buffer()->address(),
+                static_cast<uint32_t>(is_dram(input)),
+                *reinterpret_cast<uint32_t*>(&decimal),
+                num_units_per_core,
+                Wt,
+                tile_offset,
+                origin_w});
 
         // writer
-        const std::vector<uint32_t> writer_runtime_args{
-            output.buffer()->address(), static_cast<uint32_t>(is_dram(output)), num_units_per_core, Wt, tile_offset};
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
+        writer_desc.runtime_args.emplace_back(
+            core,
+            KernelDescriptor::CoreRuntimeArgs{
+                output.buffer()->address(),
+                static_cast<uint32_t>(is_dram(output)),
+                num_units_per_core,
+                Wt,
+                tile_offset});
 
-        // compute
-        const std::vector<uint32_t> compute_runtime_args{
+        // compute — runtime args go to the correct kernel descriptor
+        KernelDescriptor::CoreRuntimeArgs compute_rt{
             num_units_per_core, Wt, origin_w, floored_p, static_cast<uint32_t>(p_is_negative)};
-        SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+
+        if (core_group_1.contains(core)) {
+            compute_desc_1.runtime_args.emplace_back(core, std::move(compute_rt));
+        } else {
+            compute_desc_2.runtime_args.emplace_back(core, std::move(compute_rt));
+        }
 
         tile_offset += num_units_per_core * Wt;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehAbsPowOperation::MorehAbsPowFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernels_id = cached_program.shared_variables.reader_kernels_id;
-    auto& writer_kernels_id = cached_program.shared_variables.writer_kernels_id;
-    auto& num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    for (uint32_t icore = 0; icore < num_cores_to_be_used; icore++) {
-        CoreCoord core = {icore / num_cores_y, icore % num_cores_y};
-        // readers
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernels_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-
-        // writer
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernels_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_abs_pow

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_abs_pow_device_operation.hpp"
+#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <bit>
 
 namespace ttnn::operations::moreh::moreh_abs_pow {
 
@@ -243,7 +246,7 @@ ProgramDescriptor MorehAbsPowOperation::create_descriptor(
             KernelDescriptor::CoreRuntimeArgs{
                 input.buffer()->address(),
                 static_cast<uint32_t>(is_dram(input)),
-                *reinterpret_cast<uint32_t*>(&decimal),
+                std::bit_cast<uint32_t>(decimal),
                 num_units_per_core,
                 Wt,
                 tile_offset,


### PR DESCRIPTION
## Summary

Migrate the `moreh_abs_pow` operation from the legacy `ProgramFactory` + `override_runtime_arguments` pattern to the declarative `ProgramDescriptor`-based `create_descriptor` approach.

Closes #42243

## Notes for reviewers

- 2 files changed: `moreh_abs_pow_device_operation.hpp` and `moreh_abs_pow_program_factory.cpp`. No public API changes.
- Removed the `MOREH_ABS_POW_FACTORY_H` macro — the factory is now a direct `create_descriptor` method.
- **First migration with dual compute kernels**: two `KernelDescriptor` entries for compute (one per core group), each with its own compile-time args (`num_units_per_core_group_1` vs `num_units_per_core_group_2`). Runtime args are routed to the correct kernel descriptor based on which core group the core belongs to.
- All section comments preserved from original code.
- Performance: 25.5 us/call (baseline 19.3 us, +32% overhead — within microsecond range).
- 466 moreh_norm tests pass (moreh_abs_pow is tested as part of moreh_norm).

## Test plan

- [x] 466 moreh_norm nightly tests pass (exercises moreh_abs_pow)
- [x] Benchmark: 1000 calls completed successfully
- [x] Performance within acceptable range (<50% overhead, microsecond scale)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-moreh-abs-pow-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-moreh-abs-pow-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-moreh-abs-pow-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-moreh-abs-pow-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-moreh-abs-pow-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-moreh-abs-pow-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-moreh-abs-pow-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-moreh-abs-pow-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-moreh-abs-pow-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-moreh-abs-pow-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-moreh-abs-pow-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-moreh-abs-pow-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-moreh-abs-pow-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-moreh-abs-pow-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-moreh-abs-pow-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-moreh-abs-pow-to-program-descriptor)