### PR TITLE
Fix wrong result size recalculation in narrow op

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_narrow.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_narrow.py
@@ -16,8 +16,8 @@ from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc, tt_dtype
 @pytest.mark.parametrize(
     "input_shape, dim, start, length, memory_config, layout",
     [
-        ((64, 32, 17, 32), 0, 24, 16, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.TILE_LAYOUT),
-        ((1, 32, 24, 16), 1, 5, 8, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.ROW_MAJOR_LAYOUT),
+        ((256, 32, 17, 32), 0, 168, 16, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.TILE_LAYOUT),
+        ((1, 32, 168, 16), 1, 5, 8, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.ROW_MAJOR_LAYOUT),
         (
             (1, 8, 64, 128),
             1,
@@ -194,3 +194,27 @@ def test_narrow_mesh(input_shape, dim, start, length, memory_config, layout, mes
         ttnn_output, mesh_composer=ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(dims=[0, 1]))
     )
     assert_equal(torch_result, output)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.bfloat8_b],
+)
+@pytest.mark.parametrize(
+    "input_shape, dim, start, length, memory_config, layout",
+    [((14336, 7168), 0, 0, 96, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.TILE_LAYOUT)],
+)
+def test_narrow_regression(input_shape, dim, start, length, memory_config, layout, dtype, device):
+    torch_input_tensor = torch.randn(input_shape, dtype=tt_dtype_to_torch_dtype[dtype])
+    torch_result = torch.narrow(torch_input_tensor, dim, start, length)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=layout, dtype=dtype, device=device, memory_config=memory_config
+    )
+    ttnn_output = ttnn.narrow(input_tensor, dim, start, length)
+
+    assert layout == ttnn_output.layout
+    assert memory_config.buffer_type == ttnn_output.memory_config().buffer_type
+    assert memory_config.memory_layout == ttnn_output.memory_config().memory_layout
+    output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_result, output, 0.99)

--- a/tests/ttnn/unit_tests/base_functionality/test_narrow.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_narrow.py
@@ -194,3 +194,27 @@ def test_narrow_mesh(input_shape, dim, start, length, memory_config, layout, mes
         ttnn_output, mesh_composer=ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(dims=[0, 1]))
     )
     assert_equal(torch_result, output)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.bfloat8_b],
+)
+@pytest.mark.parametrize(
+    "input_shape, dim, start, length, memory_config, layout",
+    [((14336, 7168), 0, 0, 96, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.TILE_LAYOUT)],
+)
+def test_narrow_regression(input_shape, dim, start, length, memory_config, layout, dtype, device):
+    torch_input_tensor = torch.randn(input_shape, dtype=tt_dtype_to_torch_dtype[dtype])
+    torch_result = torch.narrow(torch_input_tensor, dim, start, length)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=layout, dtype=dtype, device=device, memory_config=memory_config
+    )
+    ttnn_output = ttnn.narrow(input_tensor, dim, start, length)
+
+    assert layout == ttnn_output.layout
+    assert memory_config.buffer_type == ttnn_output.memory_config().buffer_type
+    assert memory_config.memory_layout == ttnn_output.memory_config().memory_layout
+    output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_result, output, 0.99)

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
@@ -9,7 +9,7 @@ namespace ttnn {
 
 ttnn::Tensor narrow(
     const ttnn::Tensor& input_tensor, const int32_t narrow_dim, const int32_t narrow_start, const uint32_t length) {
-    auto input_tensor_shape = input_tensor.padded_shape();
+    const auto& input_tensor_shape = input_tensor.padded_shape();
     uint32_t dim = input_tensor_shape.get_normalized_index(narrow_dim);
     uint32_t start = operations::data_movement::wrap_index(narrow_start, input_tensor_shape[dim]);
 
@@ -75,8 +75,7 @@ ttnn::Tensor narrow(
 
     tt::tt_metal::distributed::ReplicatedBufferConfig replicated_config =
         std::get<tt::tt_metal::distributed::ReplicatedBufferConfig>(storage.get_mesh_buffer().global_config());
-    uint32_t reduction_factor = input_tensor_shape[dim] / length;
-    replicated_config.size /= reduction_factor;
+    replicated_config.size = replicated_config.size / input_tensor_shape[dim] * length;
     tt::tt_metal::distributed::MeshBufferConfig narrowed_global_config = replicated_config;
 
     // Handle INTERLEAVED DRAM buffers
@@ -252,9 +251,10 @@ ttnn::Tensor narrow(
         // Update tensor shape in pages
         auto narrowed_pages_shape = tensor_pages_shape;
         if (narrow_width) {
-            narrowed_pages_shape[1] /= reduction_factor;
+            narrowed_pages_shape[1] = length / page_shape[1];
         } else {
-            narrowed_pages_shape[0] /= reduction_factor;
+            narrowed_pages_shape[0] =
+                static_cast<uint32_t>(static_cast<uint64_t>(tensor_pages_shape[0]) * length / input_tensor_shape[dim]);
         }
 
         // Create new shard specifications

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
@@ -9,7 +9,7 @@ namespace ttnn {
 
 ttnn::Tensor narrow(
     const ttnn::Tensor& input_tensor, const int32_t narrow_dim, const int32_t narrow_start, const uint32_t length) {
-    auto input_tensor_shape = input_tensor.padded_shape();
+    const auto input_tensor_shape = input_tensor.padded_shape();
     uint32_t dim = input_tensor_shape.get_normalized_index(narrow_dim);
     uint32_t start = operations::data_movement::wrap_index(narrow_start, input_tensor_shape[dim]);
 
@@ -75,8 +75,7 @@ ttnn::Tensor narrow(
 
     tt::tt_metal::distributed::ReplicatedBufferConfig replicated_config =
         std::get<tt::tt_metal::distributed::ReplicatedBufferConfig>(storage.get_mesh_buffer().global_config());
-    uint32_t reduction_factor = input_tensor_shape[dim] / length;
-    replicated_config.size /= reduction_factor;
+    replicated_config.size = replicated_config.size / input_tensor_shape[dim] * length;
     tt::tt_metal::distributed::MeshBufferConfig narrowed_global_config = replicated_config;
 
     // Handle INTERLEAVED DRAM buffers
@@ -252,9 +251,11 @@ ttnn::Tensor narrow(
         // Update tensor shape in pages
         auto narrowed_pages_shape = tensor_pages_shape;
         if (narrow_width) {
-            narrowed_pages_shape[1] /= reduction_factor;
+            narrowed_pages_shape[1] =
+                tensor_pages_shape[1] * page_shape[1] / input_tensor_shape[dim] * length / page_shape[1];
         } else {
-            narrowed_pages_shape[0] /= reduction_factor;
+            narrowed_pages_shape[0] =
+                tensor_pages_shape[0] * page_shape[0] / input_tensor_shape[dim] * length / page_shape[0];
         }
 
         // Create new shard specifications


### PR DESCRIPTION
### Summary
Narrow had wrong formula to calculate output size.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=itaraban/fix-narrow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:itaraban/fix-narrow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=itaraban/fix-narrow)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:itaraban/fix-narrow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=itaraban/fix-narrow)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:itaraban/fix-narrow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=itaraban/fix-narrow)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:itaraban/fix-narrow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=itaraban/fix-narrow)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:itaraban/fix-narrow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=itaraban/fix-narrow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:itaraban/fix-narrow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=itaraban/fix-narrow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:itaraban/fix-narrow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=itaraban/fix-narrow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:itaraban/fix-narrow)