### PR TITLE
[llk] Add Bf16 comparison ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_bf16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_bf16.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""BF16 SFPU tensor-tensor binary comparisons (eq/ne/lt/gt/le/ge) on Blackhole and Wormhole."""
+
+import struct
+
+import pytest
+import torch
+import ttnn
+
+pytestmark = pytest.mark.use_module_device
+
+
+# BF16 special values via round-trip through float32 bit patterns.
+# BF16 uses the top 16 bits of IEEE-754 float32, so build values via int→float32→bfloat16.
+def _bf16_from_bits(bits16: int) -> float:
+    """Expand a 16-bit BF16 bit pattern to float32 (zero-pad lower 16 mantissa bits)."""
+    packed = struct.pack(">I", bits16 << 16)
+    return struct.unpack(">f", packed)[0]
+
+
+_SPECIAL_BF16_GRID = torch.tensor(
+    [
+        _bf16_from_bits(0x0000),  # +0.0
+        _bf16_from_bits(0x8000),  # -0.0
+        _bf16_from_bits(0x3F80),  # +1.0
+        _bf16_from_bits(0xBF80),  # -1.0
+        _bf16_from_bits(0x45CD),  # ~6576.0 — an arbitrary finite
+        _bf16_from_bits(0x7F80),  # +inf
+        _bf16_from_bits(0xFF80),  # -inf
+        _bf16_from_bits(0x7FC0),  # quiet NaN
+    ],
+    dtype=torch.float32,
+).to(torch.bfloat16)
+
+
+def _bool_mask(tt: torch.Tensor) -> torch.Tensor:
+    """Normalize device output (float/bool/int) to a boolean mask for comparison with torch.*."""
+    if tt.dtype == torch.bool:
+        return tt
+    if tt.is_floating_point():
+        return tt != 0.0
+    return tt != 0
+
+
+def _assert_matches_torch(ttnn_op, torch_a: torch.Tensor, torch_b: torch.Tensor, device, mem_cfg=None):
+    golden_fn = ttnn.get_golden_function(ttnn_op)
+    golden = golden_fn(torch_a, torch_b)
+    assert golden.dtype == torch.bool
+
+    ta = ttnn.from_torch(torch_a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(torch_b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    kwargs = {}
+    if mem_cfg is not None:
+        kwargs["memory_config"] = mem_cfg
+    out = ttnn_op(ta, tb, **kwargs)
+    out_t = ttnn.to_torch(out)
+    assert torch.equal(_bool_mask(out_t), golden), f"mismatch for {ttnn_op.__name__}"
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        torch.Size([64, 64]),
+        torch.Size([1, 1, 32, 32]),
+        torch.Size([1, 3, 320, 384]),
+    ),
+)
+@pytest.mark.parametrize(
+    "mem_cfg",
+    (
+        None,
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+    ),
+)
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_bf16_tensor_tensor_random(input_shapes, mem_cfg, ttnn_op, device):
+    torch.manual_seed(0)
+    a = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-1000.0, 1000.0)
+    b = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-1000.0, 1000.0)
+    _assert_matches_torch(ttnn_op, a, b, device, mem_cfg=mem_cfg)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_bf16_broadcast_rhs_singleton(ttnn_op, device):
+    """RHS broadcasts from a scalar-shaped tensor (1,1,1)."""
+    torch.manual_seed(1)
+    a = torch.empty((2, 64, 64), dtype=torch.bfloat16).uniform_(-50.0, 50.0)
+    b = torch.tensor([[[3.25]]], dtype=torch.bfloat16)
+    _assert_matches_torch(ttnn_op, a, b, device)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_bf16_special_floats(ttnn_op, device):
+    """All pairs from `_SPECIAL_BF16_GRID` (Cartesian product): zeros, finites, ±inf ties, NaN/unordered."""
+    pairs = torch.cartesian_prod(_SPECIAL_BF16_GRID, _SPECIAL_BF16_GRID)
+    a = pairs[:, 0].unsqueeze(0).expand(32, -1)
+    b = pairs[:, 1].unsqueeze(0).expand(32, -1)
+    _assert_matches_torch(ttnn_op, a, b, device)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_bf16_adjacent_ulps(ttnn_op, device):
+    """Nearest BF16 neighbors (1 ULP apart) — exercises the border of the 7-bit mantissa."""
+    # BF16 ULP at 1.0 is 2^-7 = 0.0078125; just below 1.0 is 0.99609375 (0x3F7F).
+    one = torch.tensor(_bf16_from_bits(0x3F80), dtype=torch.bfloat16)  # 1.0
+    one_up = torch.tensor(_bf16_from_bits(0x3F81), dtype=torch.bfloat16)  # 1.0 + 1 ULP
+    one_dn = torch.tensor(_bf16_from_bits(0x3F7F), dtype=torch.bfloat16)  # 1.0 - 1 ULP
+    m_one = torch.tensor(_bf16_from_bits(0xBF80), dtype=torch.bfloat16)  # -1.0
+    m_one_up = torch.tensor(_bf16_from_bits(0xBF7F), dtype=torch.bfloat16)  # -1.0 + 1 ULP
+    m_one_dn = torch.tensor(_bf16_from_bits(0xBF81), dtype=torch.bfloat16)  # -1.0 - 1 ULP
+
+    vals_a = torch.stack([one, one_up, one_dn, m_one, m_one_dn, m_one])
+    vals_b = torch.stack([one_up, one, one, m_one_dn, m_one, m_one_up])
+    a = vals_a.unsqueeze(0).expand(32, -1)
+    b = vals_b.unsqueeze(0).expand(32, -1)
+    _assert_matches_torch(ttnn_op, a, b, device)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_bf16_exact_equal_tile(ttnn_op, device):
+    """Two identical tiles (all elements pairwise equal)."""
+    torch.manual_seed(2)
+    a = torch.empty((128, 128), dtype=torch.bfloat16).uniform_(-10.0, 10.0)
+    same = torch.cat([a, a], dim=0)
+    _assert_matches_torch(ttnn_op, same[:128], same[128:], device)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -203,7 +203,7 @@ template <
     int ITERATIONS,
     SfpuType RELATIONAL_OP,
     std::enable_if_t<is_fp32_compare_v<RELATIONAL_OP>, int> = 0>
-inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+inline void calculate_binary_comp_float(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     constexpr uint dst_tile_size_sfpi = 32;
 
 #pragma GCC unroll 8

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -107,15 +107,15 @@ inline void llk_math_eltwise_binary_sfpu_gt_uint16(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_eq_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_eq_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::eq, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_eq_fp32(
+inline void llk_math_eltwise_binary_sfpu_eq_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::eq>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::eq>,
         dst_index0,
         dst_index1,
         odst,
@@ -123,15 +123,15 @@ inline void llk_math_eltwise_binary_sfpu_eq_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_ne_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::ne, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ne_fp32(
+inline void llk_math_eltwise_binary_sfpu_ne_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ne>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::ne>,
         dst_index0,
         dst_index1,
         odst,
@@ -139,15 +139,15 @@ inline void llk_math_eltwise_binary_sfpu_ne_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_lt_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_lt_fp32(
+inline void llk_math_eltwise_binary_sfpu_lt_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::lt>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
         dst_index1,
         odst,
@@ -155,15 +155,15 @@ inline void llk_math_eltwise_binary_sfpu_lt_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_gt_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_gt_fp32(
+inline void llk_math_eltwise_binary_sfpu_gt_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::gt>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
         dst_index1,
         odst,
@@ -171,15 +171,15 @@ inline void llk_math_eltwise_binary_sfpu_gt_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_le_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_le_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_le_fp32(
+inline void llk_math_eltwise_binary_sfpu_le_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::le>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::le>,
         dst_index0,
         dst_index1,
         odst,
@@ -187,15 +187,15 @@ inline void llk_math_eltwise_binary_sfpu_le_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_ge_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ge_fp32(
+inline void llk_math_eltwise_binary_sfpu_ge_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ge>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::ge>,
         dst_index0,
         dst_index1,
         odst,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -203,7 +203,7 @@ template <
     int ITERATIONS,
     SfpuType RELATIONAL_OP,
     std::enable_if_t<is_fp32_compare_v<RELATIONAL_OP>, int> = 0>
-inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+inline void calculate_binary_comp_float(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     constexpr uint dst_tile_size_sfpi = 32;
 
 #pragma GCC unroll 8

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -107,15 +107,15 @@ inline void llk_math_eltwise_binary_sfpu_gt_uint16(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_eq_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_eq_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::eq, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_eq_fp32(
+inline void llk_math_eltwise_binary_sfpu_eq_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::eq>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::eq>,
         dst_index0,
         dst_index1,
         odst,
@@ -123,15 +123,15 @@ inline void llk_math_eltwise_binary_sfpu_eq_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_ne_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::ne, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ne_fp32(
+inline void llk_math_eltwise_binary_sfpu_ne_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ne>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::ne>,
         dst_index0,
         dst_index1,
         odst,
@@ -139,15 +139,15 @@ inline void llk_math_eltwise_binary_sfpu_ne_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_lt_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_lt_fp32(
+inline void llk_math_eltwise_binary_sfpu_lt_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::lt>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::lt>,
         dst_index0,
         dst_index1,
         odst,
@@ -155,15 +155,15 @@ inline void llk_math_eltwise_binary_sfpu_lt_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_gt_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_gt_fp32(
+inline void llk_math_eltwise_binary_sfpu_gt_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::gt>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::gt>,
         dst_index0,
         dst_index1,
         odst,
@@ -171,15 +171,15 @@ inline void llk_math_eltwise_binary_sfpu_gt_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_le_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_le_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_le_fp32(
+inline void llk_math_eltwise_binary_sfpu_le_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::le>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::le>,
         dst_index0,
         dst_index1,
         odst,
@@ -187,15 +187,15 @@ inline void llk_math_eltwise_binary_sfpu_le_fp32(
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() {
+inline void llk_math_eltwise_binary_sfpu_ge_float_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_ge_fp32(
+inline void llk_math_eltwise_binary_sfpu_ge_float(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ge>,
+        ckernel::sfpu::calculate_binary_comp_float<APPROXIMATE, 8, SfpuType::ge>,
         dst_index0,
         dst_index1,
         odst,

--- a/tt_metal/hw/inc/api/compute/eltwise_binary_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary_sfpu.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -57,27 +57,27 @@ ALWI void power_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 }
 
 ALWI void eq_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_eq_fp32<APPROX>(idst0, idst1, odst)));
+    MATH((llk_math_eltwise_binary_sfpu_eq_float<APPROX>(idst0, idst1, odst)));
 }
 
 ALWI void ne_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_ne_fp32<APPROX>(idst0, idst1, odst)));
+    MATH((llk_math_eltwise_binary_sfpu_ne_float<APPROX>(idst0, idst1, odst)));
 }
 
 ALWI void lt_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_lt_fp32<APPROX>(idst0, idst1, odst)));
+    MATH((llk_math_eltwise_binary_sfpu_lt_float<APPROX>(idst0, idst1, odst)));
 }
 
 ALWI void gt_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_gt_fp32<APPROX>(idst0, idst1, odst)));
+    MATH((llk_math_eltwise_binary_sfpu_gt_float<APPROX>(idst0, idst1, odst)));
 }
 
 ALWI void le_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_le_fp32<APPROX>(idst0, idst1, odst)));
+    MATH((llk_math_eltwise_binary_sfpu_le_float<APPROX>(idst0, idst1, odst)));
 }
 
 ALWI void ge_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_ge_fp32<APPROX>(idst0, idst1, odst)));
+    MATH((llk_math_eltwise_binary_sfpu_ge_float<APPROX>(idst0, idst1, odst)));
 }
 
 /**
@@ -97,16 +97,16 @@ ALWI void rsub_binary_tile_init() {
 
 ALWI void power_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_pow_init<APPROX>())); }
 
-ALWI void eq_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_eq_fp32_init<APPROX>())); }
+ALWI void eq_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_eq_float_init<APPROX>())); }
 
-ALWI void ne_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ne_fp32_init<APPROX>())); }
+ALWI void ne_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ne_float_init<APPROX>())); }
 
-ALWI void lt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_fp32_init<APPROX>())); }
+ALWI void lt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_float_init<APPROX>())); }
 
-ALWI void gt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_fp32_init<APPROX>())); }
+ALWI void gt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_float_init<APPROX>())); }
 
-ALWI void le_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_le_fp32_init<APPROX>())); }
+ALWI void le_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_le_float_init<APPROX>())); }
 
-ALWI void ge_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ge_fp32_init<APPROX>())); }
+ALWI void ge_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ge_float_init<APPROX>())); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -19,13 +19,13 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
     switch (val) {
         case ADD:
         case SUB:
-        case EQ:
-        case NE:
         case LOGICAL_AND:
         case LOGICAL_OR:
         case LOGICAL_XOR:
         case SQUARED_DIFFERENCE:
         case RSUB: return a == b && (a == FLOAT32 || a == INT32 || a == UINT32 || a == UINT16);
+        case EQ:
+        case NE: return a == b && (a == FLOAT32 || a == BFLOAT16 || a == INT32 || a == UINT32 || a == UINT16);
         case MUL:
             return !fast_and_approximate_mode || (a == b && (a == FLOAT32 || a == INT32 || a == UINT32 || a == UINT16));
         case DIV: return !fast_and_approximate_mode || (a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32);
@@ -35,9 +35,9 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case BIAS_GELU:
         case HYPOT: return (a == FLOAT32 && b == FLOAT32);
         case GT:
-        case LT: return ((a == b) && (a == INT32 || a == FLOAT32 || a == UINT16));
+        case LT: return ((a == b) && (a == FLOAT32 || a == BFLOAT16 || a == INT32 || a == UINT16));
         case GE:
-        case LE: return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32));
+        case LE: return ((a == b) && (a == FLOAT32 || a == BFLOAT16 || a == INT32));
         case LCM:
         case GCD: return (a == INT32 && b == INT32);
         case LEFT_SHIFT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -176,42 +176,46 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
             }
             break;
         case BinaryOpType::LT:
-            if ((is_sfpu_op() && dtype == DataType::FLOAT32) || dtype == DataType::INT32 || dtype == DataType::UINT16) {
+            if (is_sfpu_op() && (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16 ||
+                                 dtype == DataType::INT32 || dtype == DataType::UINT16)) {
                 binary_op = SfpuBinaryOp::LT;
             } else {
                 postprocess = unary::UnaryOpType::LTZ;
             }
             break;
         case BinaryOpType::GT:
-            if ((is_sfpu_op() && dtype == DataType::FLOAT32) || dtype == DataType::INT32 || dtype == DataType::UINT16) {
+            if (is_sfpu_op() && (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16 ||
+                                 dtype == DataType::INT32 || dtype == DataType::UINT16)) {
                 binary_op = SfpuBinaryOp::GT;
             } else {
                 postprocess = unary::UnaryOpType::GTZ;
             }
             break;
         case BinaryOpType::GE:
-            if ((is_sfpu_op() && dtype == DataType::FLOAT32) || dtype == DataType::INT32) {
+            if (is_sfpu_op() &&
+                (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16 || dtype == DataType::INT32)) {
                 binary_op = SfpuBinaryOp::GE;
             } else {
                 postprocess = unary::UnaryOpType::GEZ;
             }
             break;
         case BinaryOpType::LE:
-            if ((is_sfpu_op() && dtype == DataType::FLOAT32) || dtype == DataType::INT32) {
+            if (is_sfpu_op() &&
+                (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16 || dtype == DataType::INT32)) {
                 binary_op = SfpuBinaryOp::LE;
             } else {
                 postprocess = unary::UnaryOpType::LEZ;
             }
             break;
         case BinaryOpType::EQ:
-            if (is_sfpu_op() && dtype == DataType::FLOAT32) {
+            if (is_sfpu_op() && (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16)) {
                 binary_op = SfpuBinaryOp::EQ;
             } else {
                 postprocess = unary::UnaryOpType::EQZ;
             }
             break;
         case BinaryOpType::NE:
-            if (is_sfpu_op() && dtype == DataType::FLOAT32) {
+            if (is_sfpu_op() && (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16)) {
                 binary_op = SfpuBinaryOp::NE;
             } else {
                 postprocess = unary::UnaryOpType::NEZ;
@@ -500,41 +504,39 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
         case ATAN2: return {"atan2_binary_tile_init();", "atan2_binary_tile"};
         case LT:
-            if (dtype == DataType::FLOAT32) {
+            if (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16) {
                 return {"lt_binary_tile_init();", "lt_binary_tile"};
-            }
-            else if (dtype == DataType::UINT16) {
+            } else if (dtype == DataType::UINT16) {
                 return {"lt_uint16_tile_init();", "lt_uint16_tile"};
             }
             return {"lt_int32_tile_init();", "lt_int32_tile"};
         case GT:
-            if (dtype == DataType::FLOAT32) {
+            if (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16) {
                 return {"gt_binary_tile_init();", "gt_binary_tile"};
-            }
-            else if (dtype == DataType::UINT16) {
+            } else if (dtype == DataType::UINT16) {
                 return {"gt_uint16_tile_init();", "gt_uint16_tile"};
             }
             return {"gt_int32_tile_init();", "gt_int32_tile"};
         case GE:
-            if (dtype == DataType::FLOAT32) {
+            if (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16) {
                 return {"ge_binary_tile_init();", "ge_binary_tile"};
             }
             return {"ge_int32_tile_init();", "ge_int32_tile"};
         case LE:
-            if (dtype == DataType::FLOAT32) {
+            if (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16) {
                 return {"le_binary_tile_init();", "le_binary_tile"};
             }
             return {"le_int32_tile_init();", "le_int32_tile"};
         case EQ:
-            if (dtype == DataType::FLOAT32) {
+            if (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16) {
                 return {"eq_binary_tile_init();", "eq_binary_tile"};
             }
-            TT_THROW("SFPU EQ binary tile is only defined for Float32");
+            TT_THROW("SFPU EQ binary tile is only defined for float types");
         case NE:
-            if (dtype == DataType::FLOAT32) {
+            if (dtype == DataType::FLOAT32 || dtype == DataType::BFLOAT16) {
                 return {"ne_binary_tile_init();", "ne_binary_tile"};
             }
-            TT_THROW("SFPU NE binary tile is only defined for Float32");
+            TT_THROW("SFPU NE binary tile is only defined for float types");
         case WHERE: {
             const char* data_format = (dtype == DataType::INT32)     ? "Int32"
                                       : (dtype == DataType::UINT32)  ? "UInt32"


### PR DESCRIPTION
### Summary
[llk] Rework Bf16 comparison ops.
Current Bf16 comparison operations use subtract + GTZ, which behaves incorrectly with special values like NaN.
Reuse existing FP32 code, because BF16 is binary identical to upper 16 bits of FP32.
Rename `_fp32` to `_float` functions to emphasize their input data types.

### Performance
Wormhole_b0, EQ and GT ops, 32x32 tensor. Shapes: L1 interleaved, height sharded, block sharded.
<img width="1800" height="750" alt="eq_gt_kernel_compare_32x32" src="https://github.com/user-attachments/assets/88f321a2-aa0f-42ca-b952-0d83f52a0f99" />

Wormhole_b0, EQ and GT ops, 1024x1024 tensor. Shapes: L1 interleaved, height sharded, block sharded.
<img width="1800" height="750" alt="eq_gt_kernel_compare_1024x1024" src="https://github.com/user-attachments/assets/9e9f6569-cf63-43b6-a26d-07d844d198df" />

### Extra CI checks
- [ ] [![Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml?query=branch%3Avlad%2Fbf16-comparison-ops)
- [x] [![Model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml?query=branch%3Avlad%2Fbf16-comparison-ops)
- [ ] [![Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch%3Avlad%2Fbf16-comparison-ops)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/bf16-comparison-ops) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/bf16-comparison-ops) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/bf16-comparison-ops) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/bf16-comparison-ops) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/bf16-comparison-ops) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/bf16-comparison-ops) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/bf16-comparison-ops) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/bf16-comparison-ops) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/bf16-comparison-ops) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/bf16-comparison-ops) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/bf16-comparison-ops) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/bf16-comparison-ops) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/bf16-comparison-ops) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/bf16-comparison-ops) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/bf16-comparison-ops) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/bf16-comparison-ops) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/bf16-comparison-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/bf16-comparison-ops) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/bf16-comparison-ops) |