### PR TITLE
deepseek_v3: Fix multihost weight-cache validation, harden cache publish, and sync before lazy loads

### DIFF
--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -89,6 +89,11 @@ def create_run_config(  # type: ignore
 
 
 def create_run_config(model_config, weight_config, *model_states, cached_ttnn_weights=None):
+    # Multihost: align ranks before any lazy ``load_weight`` / ``ttnn.load_tensor`` I/O so no rank reads
+    # weight files while another is still finishing cache publication in ``get_weight_config``.
+    if ttnn.using_distributed_env():
+        ttnn.distributed_context_barrier()
+
     # The states are merged to create a single unified model state.
     unified_model_state = functools.reduce(
         lambda cfg1, cfg2: _merge_config_containers(
@@ -389,6 +394,11 @@ def is_op_config(obj: Any) -> bool:
 def load_weight(saved_weight: SavedWeight, device: ttnn.Device) -> ttnn.Tensor:
     """
     Load a weight tensor from a SavedWeight object to a given mesh device.
+
+    On multihost meshes, ``ttnn.load_tensor`` opens the path on every MPI rank; cache directories must
+    therefore live on storage visible to all ranks. Callers should finish writing the weight cache
+    (including ``config.json``) and synchronize ranks (see ``get_weight_config`` / ``create_run_config``)
+    before the first ``load_weight`` for that cache.
     """
     # Load tensor directly to device to properly handle sharded layouts
     tensor = ttnn.load_tensor(

--- a/models/demos/deepseek_v3/utils/weight_config.py
+++ b/models/demos/deepseek_v3/utils/weight_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import os
 import shutil
 from contextlib import contextmanager
 from pathlib import Path
@@ -18,6 +19,42 @@ import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
 from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
 from models.demos.deepseek_v3.utils.run_config import WeightConfig
+
+
+def _multihost_non_writer_should_skip_weight_file_existence_check() -> bool:
+    """See ``validate_weight_config_paths`` — multihost tensor dumps are flushed from global rank 0 only."""
+    if not ttnn.using_distributed_env():
+        return False
+    return int(ttnn.distributed_context_get_rank()) != 0
+
+
+def _write_weight_config_json_atomically(config_path: Path, weight_config: Any) -> None:
+    """Publish ``config.json`` via temp file + ``os.replace`` so readers never see a truncated file (POSIX/NFS)."""
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = config_path.with_name(f".{config_path.name}.write_lock")
+    tmp_path = config_path.with_name(f".{config_path.name}.{os.getpid()}.tmp")
+    payload = json.dumps(weight_config, cls=WeightConfigEncoder).encode("utf-8")
+    with locked_file(lock_path, "w", exclusive=True):
+        try:
+            with tmp_path.open("wb") as tf:
+                tf.write(payload)
+                tf.flush()
+                os.fsync(tf.fileno())
+            os.replace(tmp_path, config_path)
+            try:
+                dfd = os.open(str(config_path.parent), os.O_RDONLY)
+                try:
+                    os.fsync(dfd)
+                finally:
+                    os.close(dfd)
+            except OSError:
+                pass
+        finally:
+            if tmp_path.exists():
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
 
 
 @contextmanager
@@ -183,13 +220,20 @@ def get_weight_config(
 
     weight_config = ModuleClass.convert_weights(hf_config, state_dicts, weight_cache_path, mesh_device)
 
+    if ttnn.using_distributed_env():
+        ttnn.distributed_context_barrier()
+
     # Validate the converted weight config
     validate_weight_config_paths(weight_cache_path, weight_config)
 
-    # Save config with relative paths for portability
-    # Use exclusive lock to prevent concurrent writes and corruption
-    with locked_file(config_path, "w", exclusive=True) as f:
-        json.dump(weight_config, f, cls=WeightConfigEncoder)
+    # Publish config with relative paths. On multihost, only global rank 0 writes disk (same as tensor dumps);
+    # other ranks keep ``weight_config`` in memory and synchronize on a barrier before returning.
+    if not ttnn.using_distributed_env():
+        _write_weight_config_json_atomically(config_path, weight_config)
+    else:
+        if int(ttnn.distributed_context_get_rank()) == 0:
+            _write_weight_config_json_atomically(config_path, weight_config)
+        ttnn.distributed_context_barrier()
 
     # Return normalized config with absolute paths for runtime use
     normalized_config = normalize_weight_config_paths(weight_cache_path, weight_config)
@@ -239,8 +283,8 @@ def validate_weight_config_paths(root_path: Path, weight_config: WeightConfig, p
                     f"Expected '{TENSOR_CACHE_EXTENSION}'. Path: {entry.path}"
                 )
 
-            # Validate file exists
-            if not effective_path.exists():
+            # Validate file exists (multihost: only rank 0 performs dump_tensor disk I/O for mesh tensors)
+            if not effective_path.exists() and not _multihost_non_writer_should_skip_weight_file_existence_check():
                 raise ValueError(
                     f"SavedWeight at '{current_prefix}' references missing file. "
                     f"Resolved path: {effective_path} (original: {entry.path})"


### PR DESCRIPTION
### Summary
Fixes incorrect “missing weight file” validation on multihost (MPI) runs when building DeepSeek V3 weight caches, and hardens cache publication so other ranks do not depend on misleading local filesystem checks or redundant JSON writes. Adds atomic config.json publish (rank 0 only in distributed mode), MPI barriers around conversion / publish / lazy load entry, and documentation for multihost load_weight / ttnn.load_tensor expectations.

### Root cause: why validation failed and jobs looked “hung”
How tensor files are written
ttnn.dump_tensor → dump_tensor_flatbuffer (ttnn/core/tensor/serialization.cpp) writes each .tensorbin from global MPI rank 0 (after gathering shards), then barriers the world so every rank stays in step for that dump.

Non–rank-0 hosts do not necessarily see those bytes at the same path when the cache lives on node-local storage or before shared FS visibility lines up.

What Python did wrong
validate_weight_config_paths used Path.exists() on every rank. On multihost, ranks ≠ 0 often saw “missing” w3.input_tensor_b.tensorbin even though conversion was correct → ValueError on some ranks only.

Why that showed up as “hangs”
Distributed execution relies on collectives and barriers. If one rank throws or diverges (e.g. fails validation) while others are still in or about to enter matching device / host / MPI synchronization, the job can block indefinitely on the next collective — often reported as a specific mesh coordinate “stuck.”

So the main bug was validating a property that is not meaningful on non-writer ranks, not random corruption of tensor files.

### Secondary issues addressed
Partial / torn config.json on shared storage
Writing config.json by truncating and streaming into the final name can let readers see incomplete JSON. On NFS, directory/file metadata can also lag briefly.

Mitigation: write a temp file, fsync, then os.replace into config.json (same parent), with optional directory fsync — readers see either the old full file or the new full file, not a half-written manifest.

Lazy load ordering
create_run_config eventually calls load_weight → ttnn.load_tensor, which opens paths on every rank. Barriers after conversion and after config.json publication align ranks before returning from get_weight_config and before merging run configs, so ranks do not drift ahead while another rank is still finishing disk publication.

Design: who writes config.json?
Multihost: only global MPI rank 0 writes config.json (aligned with rank-0-only tensor serialization in C++). Other ranks keep weight_config in memory and wait on distributed_context_barrier() after rank 0’s write so everyone agrees the manifest is on disk before continuing.

Single-host / non-distributed: unchanged — the single process writes config.json as before.

This removes redundant per-rank JSON writes and lock traffic while keeping correctness.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kp/fix_nfs_race_weight_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kp/fix_nfs_race_weight_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kp/fix_nfs_race_weight_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kp/fix_nfs_race_weight_config) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kp/fix_nfs_race_weight_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kp/fix_nfs_race_weight_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kp/fix_nfs_race_weight_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kp/fix_nfs_race_weight_config) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kp/fix_nfs_race_weight_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kp/fix_nfs_race_weight_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kp/fix_nfs_race_weight_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kp/fix_nfs_race_weight_config) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kp/fix_nfs_race_weight_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kp/fix_nfs_race_weight_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kp/fix_nfs_race_weight_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kp/fix_nfs_race_weight_config) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kp/fix_nfs_race_weight_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kp/fix_nfs_race_weight_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kp/fix_nfs_race_weight_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kp/fix_nfs_race_weight_config) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kp/fix_nfs_race_weight_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kp/fix_nfs_race_weight_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kp/fix_nfs_race_weight_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kp/fix_nfs_race_weight_config) |