### PR TITLE
Optimize and fix D2D kernels for Deepseek

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange.cpp
@@ -20,18 +20,6 @@ constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(7);
 constexpr bool use_fabric_on_receiver = get_compile_time_arg_val(8);
 constexpr bool use_fabric_on_sender = get_compile_time_arg_val(9);
 
-FORCE_INLINE bool socket_wait_for_pages_with_termination(
-    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
-    constexpr uint32_t termination_value = 1;
-    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == termination_value) {
-            return false;
-        }
-    }
-    return true;
-}
-
 FORCE_INLINE void write_data_to_local_core_with_ack(
     SocketSenderInterface& sender_socket, uint32_t l1_read_addr, uint64_t dst_addr, uint32_t page_size) {
     noc_async_write(l1_read_addr, dst_addr, page_size);
@@ -190,9 +178,12 @@ void kernel_main() {
     }
 
     while (true) {
-        socket_reserve_pages(sender_socket, 1);
-        if (!socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
+        invalidate_l1_cache();
+        if (termination_semaphore[0] == 1) {
             break;
+        }
+        socket_reserve_pages(sender_socket, 1);
+        while (!socket_wait_for_pages(receiver_socket, 1)) {
         }
 
         auto l1_read_addr = receiver_socket.read_ptr;

--- a/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange_multiple_upstreams.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange_multiple_upstreams.cpp
@@ -97,7 +97,7 @@ FORCE_INLINE void send_worker_data_over_fabric(
     uint64_t dst = dst_addr;
     if constexpr (partial_packet_size > 0) {
         for (uint32_t i = 0; i < num_whole_fabric_packets_per_link; ++i) {
-            write_data_to_remote_core_with_ack<false>(
+            write_data_to_remote_core_with_ack(
                 fabric_connection, packet_header_addr, src, dst, downstream_bytes_sent_noc_addr, whole_packet_size);
             src += whole_packet_size;
             dst += whole_packet_size;
@@ -106,7 +106,7 @@ FORCE_INLINE void send_worker_data_over_fabric(
             fabric_connection, packet_header_addr, src, dst, downstream_bytes_sent_noc_addr, partial_packet_size);
     } else if constexpr (num_whole_fabric_packets_per_link > 0) {
         for (uint32_t i = 0; i < num_whole_fabric_packets_per_link - 1; ++i) {
-            write_data_to_remote_core_with_ack<false>(
+            write_data_to_remote_core_with_ack(
                 fabric_connection, packet_header_addr, src, dst, downstream_bytes_sent_noc_addr, whole_packet_size);
             src += whole_packet_size;
             dst += whole_packet_size;
@@ -135,14 +135,12 @@ FORCE_INLINE bool process_upstream_sockets(
     uint32_t remaining = num_sockets_this_risc;
     uint32_t worker_idx = 0;
     uint32_t processed_mask = 0;
-
+    invalidate_l1_cache();
+    if (termination_semaphore[0] == 1) {
+        return true;
+    }
     while (remaining > 0) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == 1) {
-            return true;
-        }
-
-        if (!(processed_mask & (1 << worker_idx)) && socket_wait_for_pages(receiver_sockets[worker_idx], 1, 1000)) {
+        if (!(processed_mask & (1 << worker_idx)) && socket_wait_for_pages(receiver_sockets[worker_idx], 1, 1)) {
             uint32_t l1_read_addr = receiver_sockets[worker_idx].read_ptr;
             uint64_t dst_addr = dst_addr_base + (socket_start_idx + worker_idx) * upstream_page_size;
 

--- a/tt_metal/hw/inc/api/socket_api.h
+++ b/tt_metal/hw/inc/api/socket_api.h
@@ -284,10 +284,10 @@ bool socket_wait_for_pages(
     do {
         invalidate_l1_cache();
         bytes_recv = *bytes_sent_ptr - socket.bytes_acked;
-        iter_count++;
         if (early_exit_iter_count && iter_count >= early_exit_iter_count) {
             return false;
         }
+        iter_count++;
     } while (bytes_recv < num_bytes);
     return true;
 #endif


### PR DESCRIPTION
### Summary

- Move termination signalling before the start of a new loop/iteration for both D2D kernels
- Always flush in `send_worker_data_over_fabric` for `d2d_exchange_multiple_upstreams.cpp`
- Reduce timeout in `d2d_exchange_multiple_upstreams.cpp` as waiting for 1000 cycles on a socket that hasn't acked could be blocking processing other sockets that are ready
- Fix bug in `socket_wait_for_pages` always returns false when setting the timeout to 1 since the increment happens before the timeout check

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/d2d) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/d2d) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/d2d) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/d2d) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/d2d) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/d2d) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/d2d) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/d2d) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/d2d) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/d2d) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/d2d) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/d2d) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/d2d) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/d2d) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/d2d) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/d2d) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/d2d) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/d2d) |