### PR TITLE
Improve Wan2.2 D2H on single and multi-host

### DIFF
--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -37,6 +37,7 @@ from ...utils.tensor import (
     bf16_tensor,
     fast_device_to_host,
     float32_tensor,
+    float_to_uint8,
     local_device_to_torch,
     typed_tensor_2dshard,
 )
@@ -1010,31 +1011,22 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             self._prepare_vae()
             tt_video_BCTHW, new_logical_h = self.tt_vae(tt_latents_BTHWC, logical_h, t_chunk_size=self.vae_t_chunk_size)
 
-            # On-device post-processing: [-1,1] → [0,1], optionally → uint8.
-            # VAE output is ROW_MAJOR; arithmetic ops require TILE_LAYOUT.
-            if output_type in ("np", "uint8"):
-                tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.TILE_LAYOUT)
-                tt_video_BCTHW = ttnn.add(tt_video_BCTHW, 1.0)
-                tt_video_BCTHW = ttnn.multiply(tt_video_BCTHW, 0.5)
-                tt_video_BCTHW = ttnn.clamp(tt_video_BCTHW, min=0.0, max=1.0)
-                if output_type == "uint8":
-                    tt_video_BCTHW = ttnn.multiply(tt_video_BCTHW, 255.0)
-                    tt_video_BCTHW = ttnn.clamp(tt_video_BCTHW, min=0.0, max=255.0)
-                    tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
-                    tt_video_BCTHW = ttnn.typecast(tt_video_BCTHW, ttnn.uint8)
-                else:
-                    tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
-
             concat_dims = [None, None]
             concat_dims[self.vae_parallel_config.height_parallel.mesh_axis] = 3
             concat_dims[self.vae_parallel_config.width_parallel.mesh_axis] = 4
             d2h_permute = (0, 2, 3, 4, 1) if output_type in ("np", "uint8") else None
+
+            if output_type == "uint8":
+                pre_fn = float_to_uint8
+            else:
+                pre_fn = None
 
             video_torch = fast_device_to_host(
                 tt_video_BCTHW,
                 self.mesh_device,
                 concat_dims,
                 ccl_manager=self.vae_ccl_manager,
+                pre_transfer_fn=pre_fn,
                 permute=d2h_permute,
             )
 

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -38,6 +38,7 @@ from ...utils.tensor import (
     fast_device_to_host,
     float32_tensor,
     float_to_uint8,
+    float_to_unit_range,
     local_device_to_torch,
     typed_tensor_2dshard,
 )
@@ -1018,6 +1019,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
             if output_type == "uint8":
                 pre_fn = float_to_uint8
+            elif output_type == "np":
+                pre_fn = float_to_unit_range
             else:
                 pre_fn = None
 

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -1010,28 +1010,45 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             self._prepare_vae()
             tt_video_BCTHW, new_logical_h = self.tt_vae(tt_latents_BTHWC, logical_h, t_chunk_size=self.vae_t_chunk_size)
 
-            # On-device post-processing for np output: [-1,1] → [0,1]
+            # On-device post-processing: [-1,1] → [0,1], optionally → uint8.
             # VAE output is ROW_MAJOR; arithmetic ops require TILE_LAYOUT.
-            if output_type == "np":
+            if output_type in ("np", "uint8"):
                 tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.TILE_LAYOUT)
                 tt_video_BCTHW = ttnn.add(tt_video_BCTHW, 1.0)
                 tt_video_BCTHW = ttnn.multiply(tt_video_BCTHW, 0.5)
                 tt_video_BCTHW = ttnn.clamp(tt_video_BCTHW, min=0.0, max=1.0)
-                tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
+                if output_type == "uint8":
+                    tt_video_BCTHW = ttnn.multiply(tt_video_BCTHW, 255.0)
+                    tt_video_BCTHW = ttnn.clamp(tt_video_BCTHW, min=0.0, max=255.0)
+                    tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
+                    tt_video_BCTHW = ttnn.typecast(tt_video_BCTHW, ttnn.uint8)
+                else:
+                    tt_video_BCTHW = ttnn.to_layout(tt_video_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
 
             concat_dims = [None, None]
             concat_dims[self.vae_parallel_config.height_parallel.mesh_axis] = 3
             concat_dims[self.vae_parallel_config.width_parallel.mesh_axis] = 4
+            d2h_permute = (0, 2, 3, 4, 1) if output_type in ("np", "uint8") else None
+
             video_torch = fast_device_to_host(
                 tt_video_BCTHW,
                 self.mesh_device,
                 concat_dims,
                 ccl_manager=self.vae_ccl_manager,
+                permute=d2h_permute,
             )
-            video_torch = video_torch[:, :, :, :new_logical_h, :]
 
-            if output_type == "np":
-                video = video_torch.permute(0, 2, 3, 4, 1).float().numpy()
+            if d2h_permute is not None:
+                # Output is (B, T, H, W, C) — trim height in dim 2.
+                video_torch = video_torch[:, :, :new_logical_h, :, :]
+            else:
+                # Output is (B, C, T, H, W) — trim height in dim 3.
+                video_torch = video_torch[:, :, :, :new_logical_h, :]
+
+            if output_type == "uint8":
+                video = video_torch.numpy()
+            elif output_type == "np":
+                video = video_torch.float().numpy()
             else:
                 video = self.video_processor.postprocess_video(video_torch, output_type=output_type)
         else:

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import statistics
+import subprocess
 
 import numpy as np
 import pytest
 import torch
-from diffusers.utils import export_to_video
 from loguru import logger
 from PIL import Image
 
@@ -20,6 +20,67 @@ from models.tt_dit.pipelines.wan.pipeline_wan_i2v import WanPipelineI2V
 from ....utils.test import line_params, ring_params, ring_params_8k
 
 DEVICE_PARAMS = {"trace_region_size": 120000000}
+
+
+def export_to_video_simple(frames, output_video_path, fps=16, crf=25):
+    """Encode frames to video via ffmpeg subprocess.
+
+    Accepts either float32 [0,1] or uint8 [0,255] frames with shape (T, H, W, 3).
+    """
+    from imageio_ffmpeg import get_ffmpeg_exe
+
+    frames = np.asarray(frames)
+    if frames.ndim != 4 or frames.shape[-1] != 3:
+        raise ValueError(f"Expected frames with shape (T, H, W, 3), got {frames.shape}")
+
+    t, h, w, c = frames.shape
+
+    cmd = [
+        get_ffmpeg_exe(),
+        "-y",
+        "-f",
+        "rawvideo",
+        "-vcodec",
+        "rawvideo",
+        "-s",
+        f"{w}x{h}",
+        "-pix_fmt",
+        "rgb24",
+        "-r",
+        f"{fps:.2f}",
+        "-i",
+        "-",
+        "-an",
+        "-vcodec",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        str(crf),
+        "-v",
+        "warning",
+        output_video_path,
+    ]
+
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    try:
+        for frame in frames:
+            if frame.dtype != np.uint8:
+                frame = (frame * 255).clip(0, 255).astype(np.uint8)
+            p.stdin.write(frame.tobytes())
+        p.stdin.close()
+        stderr = p.stderr.read().decode("utf-8", errors="ignore")
+        rc = p.wait()
+    except Exception:
+        p.kill()
+        p.wait()
+        raise
+
+    if rc != 0:
+        raise RuntimeError(f"ffmpeg failed with return code {rc}:\n{stderr}")
+
+    return output_video_path
 
 
 def t2v_metrics(mesh_device, height):
@@ -260,6 +321,7 @@ def test_pipeline_performance(
                     profiler_iteration=i,
                     seed=42,
                     traced=traced,
+                    output_type="uint8",
                 )
                 ttnn.synchronize_device(mesh_device)
         logger.info(f"  Run {i+1} completed in {benchmark_profiler.get_duration('run', i):.2f}s")
@@ -278,22 +340,22 @@ def test_pipeline_performance(
 
     # Basic validation
     if isinstance(frames, np.ndarray):
-        print(f"  Video data range: [{frames.min():.3f}, {frames.max():.3f}]")
+        print(f"  Video dtype:      {frames.dtype}")
+        print(f"  Video data range: [{frames.min()}, {frames.max()}]")
     elif isinstance(frames, torch.Tensor):
-        print(f"  Video data range: [{frames.min().item():.3f}, {frames.max().item():.3f}]")
+        print(f"  Video dtype:      {frames.dtype}")
+        print(f"  Video data range: [{frames.min().item()}, {frames.max().item()}]")
 
-    # Save video using diffusers utility
+    # Save video
     # Remove batch dimension
     frames = frames[0]
-    try:
-        if not is_ci_env:
-            if int(ttnn.distributed_context_get_rank()) == 0:
-                export_to_video(frames, f"wan_output_video_{model_type}{'_traced' if traced else ''}.mp4", fps=16)
-                print(f"✓ Saved video to: wan_output_video_{model_type}{'_traced' if traced else ''}.mp4")
-            else:
-                print(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")
-    except AttributeError as e:
-        logger.info(f"AttributeError: {e}")
+    if not is_ci_env:
+        if int(ttnn.distributed_context_get_rank()) == 0:
+            output_path = f"wan_output_video_{model_type}{'_traced' if traced else ''}.mp4"
+            export_to_video_simple(frames, output_path, fps=16)
+            print(f"✓ Saved video to: {output_path}")
+        else:
+            print(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")
 
     # Calculate statistics
     text_encoder_times = [benchmark_profiler.get_duration("encoder", i) for i in range(num_perf_runs)]

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import statistics
-import subprocess
 
 import numpy as np
 import pytest
@@ -16,71 +15,11 @@ from models.common.utility_functions import is_blackhole
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
 from models.tt_dit.pipelines.wan.pipeline_wan_i2v import WanPipelineI2V
+from models.tt_dit.utils.video import export_to_video
 
 from ....utils.test import line_params, ring_params, ring_params_8k
 
 DEVICE_PARAMS = {"trace_region_size": 120000000}
-
-
-def export_to_video_simple(frames, output_video_path, fps=16, crf=25):
-    """Encode frames to video via ffmpeg subprocess.
-
-    Accepts either float32 [0,1] or uint8 [0,255] frames with shape (T, H, W, 3).
-    """
-    from imageio_ffmpeg import get_ffmpeg_exe
-
-    frames = np.asarray(frames)
-    if frames.ndim != 4 or frames.shape[-1] != 3:
-        raise ValueError(f"Expected frames with shape (T, H, W, 3), got {frames.shape}")
-
-    t, h, w, c = frames.shape
-
-    cmd = [
-        get_ffmpeg_exe(),
-        "-y",
-        "-f",
-        "rawvideo",
-        "-vcodec",
-        "rawvideo",
-        "-s",
-        f"{w}x{h}",
-        "-pix_fmt",
-        "rgb24",
-        "-r",
-        f"{fps:.2f}",
-        "-i",
-        "-",
-        "-an",
-        "-vcodec",
-        "libx264",
-        "-pix_fmt",
-        "yuv420p",
-        "-crf",
-        str(crf),
-        "-v",
-        "warning",
-        output_video_path,
-    ]
-
-    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-    try:
-        for frame in frames:
-            if frame.dtype != np.uint8:
-                frame = (frame * 255).clip(0, 255).astype(np.uint8)
-            p.stdin.write(frame.tobytes())
-        p.stdin.close()
-        stderr = p.stderr.read().decode("utf-8", errors="ignore")
-        rc = p.wait()
-    except Exception:
-        p.kill()
-        p.wait()
-        raise
-
-    if rc != 0:
-        raise RuntimeError(f"ffmpeg failed with return code {rc}:\n{stderr}")
-
-    return output_video_path
 
 
 def t2v_metrics(mesh_device, height):
@@ -352,7 +291,7 @@ def test_pipeline_performance(
     if not is_ci_env:
         if int(ttnn.distributed_context_get_rank()) == 0:
             output_path = f"wan_output_video_{model_type}{'_traced' if traced else ''}.mp4"
-            export_to_video_simple(frames, output_path, fps=16)
+            export_to_video(frames, output_path, fps=16)
             print(f"✓ Saved video to: {output_path}")
         else:
             print(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -8,7 +8,6 @@ import os
 import numpy as np
 import pytest
 import torch
-from diffusers.utils import export_to_video
 from loguru import logger
 
 import ttnn
@@ -107,6 +106,7 @@ def test_pipeline_inference(
                 seed=seed,
                 guidance_scale=4.0,
                 guidance_scale_2=3.0,
+                output_type="uint8",
             )
 
         if hasattr(result, "frames"):
@@ -126,14 +126,13 @@ def test_pipeline_inference(
         # Remove batch dimension
         frames = frames[0]
         output_filename = f"wan_t2v_{width}x{height}_{number}.mp4"
-        try:
-            if int(ttnn.distributed_context_get_rank()) == 0:
-                export_to_video(frames, output_filename, fps=16)
-                logger.info(f"Saved video to: {output_filename}")
-            else:
-                logger.info(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")
-        except AttributeError as e:
-            logger.info(f"AttributeError: {e}")
+        if int(ttnn.distributed_context_get_rank()) == 0:
+            from models.tt_dit.utils.video import export_to_video
+
+            export_to_video(frames, output_filename, fps=16)
+            logger.info(f"Saved video to: {output_filename}")
+        else:
+            logger.info(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")
 
     if no_prompt:
         run(prompt=prompt, number=0, seed=42)

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
@@ -9,7 +9,6 @@ import numpy as np
 import PIL
 import pytest
 import torch
-from diffusers.utils import export_to_video
 from loguru import logger
 
 import ttnn
@@ -110,6 +109,7 @@ def test_pipeline_inference(
                 seed=seed,
                 guidance_scale=guidance_scale,
                 guidance_scale_2=guidance_scale_2,
+                output_type="uint8",
             )
 
         if hasattr(result, "frames"):
@@ -129,11 +129,10 @@ def test_pipeline_inference(
         # Remove batch dimension
         frames = frames[0]
         output_filename = f"wan_i2v_{width}x{height}_{number}.mp4"
-        try:
-            export_to_video(frames, output_filename, fps=16)
-            logger.info(f"Saved video to: {output_filename}")
-        except AttributeError as e:
-            logger.info(f"AttributeError: {e}")
+        from models.tt_dit.utils.video import export_to_video
+
+        export_to_video(frames, output_filename, fps=16)
+        logger.info(f"Saved video to: {output_filename}")
 
     if no_prompt:
         run(prompt=prompt, number=0, seed=42)

--- a/models/tt_dit/tests/models/wan2_2/test_stability_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_stability_wan.py
@@ -7,7 +7,6 @@ import time
 
 import pytest
 import torch
-from diffusers.utils import export_to_video
 
 import ttnn
 from models.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
@@ -109,6 +108,7 @@ def test_stability(
                     num_inference_steps=num_inference_steps,
                     guidance_scale=3.0,
                     guidance_scale_2=4.0,
+                    output_type="uint8",
                 )
 
             # Check output
@@ -120,13 +120,15 @@ def test_stability(
             print("✓ Inference completed successfully")
             print(f"  Output shape: {frames.shape if hasattr(frames, 'shape') else 'Unknown'}")
 
-            # Save video using diffusers utility
+            # Save video
             # Remove batch dimension
             frames_to_save = frames[0]
             out_path = os.path.join(
                 "wan_outputs",
                 f"wan_stability_prompt_{prompt_idx}_iter{iteration}.mp4",
             )
+            from models.tt_dit.utils.video import export_to_video
+
             export_to_video(frames_to_save, out_path, fps=16)
             print(f"✓ Saved video to: {out_path}")
 

--- a/models/tt_dit/tests/unit/test_fast_device_to_host.py
+++ b/models/tt_dit/tests/unit/test_fast_device_to_host.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for fast_device_to_host with Wan 2.2 VAE output shape.
+
+VAE output shape: BCTHW = (1, 3, 81, 720, 1280)
+  - H (dim 3) fractured on TP axis (mesh axis 0, size 4)
+  - W (dim 4) fractured on SP axis (mesh axis 1, size 32)
+  - Per-device shard: (1, 3, 81, 180, 40)
+
+Run with:
+    pytest models/tt_dit/tests/unit/test_fast_device_to_host.py -k "bh_4x32" --timeout=300
+"""
+
+import time
+
+import pytest
+import torch
+
+import ttnn
+
+from ...parallel.manager import CCLManager
+from ...utils.tensor import fast_device_to_host, typed_tensor_2dshard
+from ...utils.test import line_params, ring_params
+
+# Wan 2.2 VAE output — BCTHW
+B, C, T, H, W = 1, 3, 81, 720, 1280
+TP_AXIS = 0  # mesh axis for height
+SP_AXIS = 1  # mesh axis for width
+H_DIM = 3  # BCTHW dimension for height
+W_DIM = 4  # BCTHW dimension for width
+
+
+def _make_reference_tensor() -> torch.Tensor:
+    """Create a deterministic reference tensor with the Wan VAE output shape."""
+    gen = torch.Generator().manual_seed(42)
+    return torch.randn(B, C, T, H, W, generator=gen, dtype=torch.bfloat16)
+
+
+def _shard_to_device(ref: torch.Tensor, mesh_device: ttnn.MeshDevice) -> ttnn.Tensor:
+    """Shard a BCTHW tensor: H on TP axis (0), W on SP axis (1)."""
+    return typed_tensor_2dshard(
+        ref,
+        mesh_device,
+        shard_mapping={TP_AXIS: H_DIM, SP_AXIS: W_DIM},
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+    )
+
+
+def _make_concat_dims() -> list[int | None]:
+    dims: list[int | None] = [None, None]
+    dims[TP_AXIS] = H_DIM
+    dims[SP_AXIS] = W_DIM
+    return dims
+
+
+def _make_ccl_manager(mesh_device: ttnn.MeshDevice, num_links: int, topology: ttnn.Topology) -> CCLManager | None:
+    return CCLManager(mesh_device, num_links=num_links, topology=topology)
+
+
+# ---------------------------------------------------------------------------
+# Test parametrization
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "mesh_device, num_links, device_params, topology",
+    [[(4, 32), 2, ring_params, ttnn.Topology.Ring], [(4, 8), 2, line_params, ttnn.Topology.Linear]],
+    ids=["bh_4x32", "bh_4x8"],
+    indirect=["mesh_device", "device_params"],
+)
+class TestFastDeviceToHost:
+    def test_correctness(self, mesh_device, num_links, device_params, topology):
+        """Round-trip: shard to device -> fast_device_to_host -> compare to reference."""
+        ref = _make_reference_tensor()
+        tt_tensor = _shard_to_device(ref, mesh_device)
+        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+        concat_dims = _make_concat_dims()
+
+        result = fast_device_to_host(tt_tensor, mesh_device, concat_dims, ccl_manager=ccl_manager)
+
+        rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
+        # In single-host or root=None (default), all ranks get the result.
+        assert result is not None, f"Rank {rank} got None from fast_device_to_host"
+        assert result.shape == ref.shape, f"Shape mismatch: {result.shape} vs {ref.shape}"
+        torch.testing.assert_close(result, ref, rtol=0, atol=0)
+
+    def test_slow_perf(self, mesh_device, num_links, device_params, topology):
+        """Measure average D2H time over 10 iterations."""
+        n_iters = 10
+
+        ref = _make_reference_tensor()
+        tt_tensor = _shard_to_device(ref, mesh_device)
+        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+        concat_dims = _make_concat_dims()
+
+        # Warmup
+        ccl_manager.device_to_host(tt_tensor, concat_dims)
+
+        # Sync + barrier before measurement
+        ttnn.synchronize_device(mesh_device)
+        if ttnn.using_distributed_env():
+            ttnn.distributed_context_barrier()
+
+        start = time.perf_counter()
+        for _ in range(n_iters):
+            ccl_manager.device_to_host(tt_tensor, concat_dims)
+        # Sync + barrier before measurement
+        ttnn.synchronize_device(mesh_device)
+        if ttnn.using_distributed_env():
+            ttnn.distributed_context_barrier()
+        end = time.perf_counter()
+
+        avg_s = (end - start) / n_iters
+        tensor_bytes = B * C * T * H * W * 2  # bfloat16 = 2 bytes
+        throughput_gbs = (tensor_bytes / avg_s) / 1e9
+
+        rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
+        if rank == 0:
+            print(f"\n--- ccl_manager.device_to_host performance (root=0) ---")
+            print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
+            print(f"  Tensor shape:  ({B}, {C}, {T}, {H}, {W}) bfloat16")
+            print(f"  Tensor size:   {tensor_bytes / 1e6:.1f} MB")
+            print(f"  Iterations:    {n_iters}")
+            print(f"  Average time:  {avg_s * 1000:.1f} ms")
+            print(f"  Throughput:    {throughput_gbs:.2f} GB/s")
+
+    def test_performance(self, mesh_device, num_links, device_params, topology):
+        """Measure average D2H time over 10 iterations."""
+        n_iters = 10
+
+        ref = _make_reference_tensor()
+        tt_tensor = _shard_to_device(ref, mesh_device)
+        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+        concat_dims = _make_concat_dims()
+
+        # Warmup
+        fast_device_to_host(tt_tensor, mesh_device, concat_dims, ccl_manager=ccl_manager)
+
+        # Sync + barrier before measurement
+        ttnn.synchronize_device(mesh_device)
+        if ttnn.using_distributed_env():
+            ttnn.distributed_context_barrier()
+
+        start = time.perf_counter()
+        for _ in range(n_iters):
+            video = fast_device_to_host(tt_tensor, mesh_device, concat_dims, ccl_manager=ccl_manager)
+            video = video.permute(0, 2, 3, 4, 1).float()
+        # Sync + barrier before measurement
+        ttnn.synchronize_device(mesh_device)
+        if ttnn.using_distributed_env():
+            ttnn.distributed_context_barrier()
+        end = time.perf_counter()
+
+        avg_s = (end - start) / n_iters
+        tensor_bytes = B * C * T * H * W * 4  # float32 = 4 bytes (full pipeline output)
+        throughput_gbs = (tensor_bytes / avg_s) / 1e9
+
+        rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
+        if rank == 0:
+            print(f"\n--- fast_device_to_host + permute + float performance (root=0) ---")
+            print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
+            print(f"  Output shape:  (1, {T}, {H}, {W}, {C}) float32 (BTHWC)")
+            print(f"  Output size:   {tensor_bytes / 1e6:.1f} MB")
+            print(f"  Iterations:    {n_iters}")
+            print(f"  Average time:  {avg_s * 1000:.1f} ms")
+            print(f"  Throughput:    {throughput_gbs:.2f} GB/s")
+
+    def test_fused_correctness(self, mesh_device, num_links, device_params, topology):
+        """Round-trip with fused permute + dtype conversion."""
+        import torch
+
+        ref = _make_reference_tensor()
+        tt_tensor = _shard_to_device(ref, mesh_device)
+        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+        concat_dims = _make_concat_dims()
+
+        result = fast_device_to_host(
+            tt_tensor,
+            mesh_device,
+            concat_dims,
+            ccl_manager=ccl_manager,
+            permute=(0, 2, 3, 4, 1),
+            dtype=torch.float32,
+        )
+
+        expected = ref.permute(0, 2, 3, 4, 1).float()
+        assert result.shape == expected.shape, f"Shape mismatch: {result.shape} vs {expected.shape}"
+        assert result.dtype == torch.float32
+        torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+    def test_fused_performance(self, mesh_device, num_links, device_params, topology):
+        """Measure fused permute+dtype D2H time over 10 iterations."""
+        import torch
+
+        n_iters = 10
+        ref = _make_reference_tensor()
+        tt_tensor = _shard_to_device(ref, mesh_device)
+        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+        concat_dims = _make_concat_dims()
+
+        # Warmup
+        fast_device_to_host(
+            tt_tensor,
+            mesh_device,
+            concat_dims,
+            ccl_manager=ccl_manager,
+            permute=(0, 2, 3, 4, 1),
+            dtype=torch.float32,
+        )
+
+        ttnn.synchronize_device(mesh_device)
+        if ttnn.using_distributed_env():
+            ttnn.distributed_context_barrier()
+
+        start = time.perf_counter()
+        for _ in range(n_iters):
+            fast_device_to_host(
+                tt_tensor,
+                mesh_device,
+                concat_dims,
+                ccl_manager=ccl_manager,
+                permute=(0, 2, 3, 4, 1),
+                dtype=torch.float32,
+            )
+        ttnn.synchronize_device(mesh_device)
+        if ttnn.using_distributed_env():
+            ttnn.distributed_context_barrier()
+        end = time.perf_counter()
+
+        avg_s = (end - start) / n_iters
+        tensor_bytes = B * C * T * H * W * 4  # float32 = 4 bytes
+        throughput_gbs = (tensor_bytes / avg_s) / 1e9
+
+        rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
+        if rank == 0:
+            print(f"\n--- fast_device_to_host FUSED performance (root=0) ---")
+            print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
+            print(f"  Output shape:  (1, {T}, {H}, {W}, {C}) float32 (BTHWC)")
+            print(f"  Output size:   {tensor_bytes / 1e6:.1f} MB")
+            print(f"  Iterations:    {n_iters}")
+            print(f"  Average time:  {avg_s * 1000:.1f} ms")
+            print(f"  Throughput:    {throughput_gbs:.2f} GB/s")
+
+    def test_uint8_accuracy(self, mesh_device, num_links, device_params, topology):
+        """Compare on-device uint8 conversion against host float32 path.
+
+        Runs twice with different input tensors to verify program cache reuse
+        (override_runtime_arguments must correctly update buffer addresses).
+        """
+        import torch
+
+        concat_dims = _make_concat_dims()
+        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+
+        for iteration, seed in enumerate([42, 123]):
+            gen = torch.Generator().manual_seed(seed)
+            ref = torch.rand(B, C, T, H, W, generator=gen, dtype=torch.bfloat16)
+            tt_tensor = _shard_to_device(ref, mesh_device)
+
+            # --- Host reference path: bf16 → float32 → ×255 → uint8 ---
+            host_uint8 = (ref.float() * 255).clamp(0, 255).to(torch.uint8)
+
+            # --- Device path: bf16 → ×255 → clamp → typecast(uint8) → D2H ---
+            tt_tile = ttnn.to_layout(tt_tensor, ttnn.TILE_LAYOUT)
+            tt_scaled = ttnn.multiply(tt_tile, 255.0)
+            tt_clamped = ttnn.clamp(tt_scaled, min=0.0, max=255.0)
+            tt_clamped = ttnn.to_layout(tt_clamped, ttnn.ROW_MAJOR_LAYOUT)
+            tt_uint8 = ttnn.typecast(tt_clamped, ttnn.uint8)
+
+            device_uint8 = fast_device_to_host(tt_uint8, mesh_device, concat_dims, ccl_manager=ccl_manager)
+
+            diff = (device_uint8.int() - host_uint8.int()).abs()
+            max_err = diff.max().item()
+            mean_err = diff.float().mean().item()
+            pct_exact = (diff == 0).float().mean().item() * 100
+
+            label = "fresh" if iteration == 0 else "cached"
+            print(f"\n--- uint8 accuracy, iter {iteration} ({label}) ---")
+            print(f"  Max error:     {max_err}")
+            print(f"  Mean error:    {mean_err:.4f}")
+            print(f"  Exact match:   {pct_exact:.1f}%")
+            assert max_err <= 1, f"Max uint8 error {max_err} > 1 on iter {iteration} ({label})"
+
+    def test_uint8_performance(self, mesh_device, num_links, device_params, topology):
+        """Measure on-device uint8 conversion + D2H + permute."""
+        import torch
+
+        n_iters = 10
+        gen = torch.Generator().manual_seed(42)
+        ref = torch.rand(B, C, T, H, W, generator=gen, dtype=torch.bfloat16)
+        tt_tensor = _shard_to_device(ref, mesh_device)
+        concat_dims = _make_concat_dims()
+        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+
+        def _convert_and_transfer():
+            tt_tile = ttnn.to_layout(tt_tensor, ttnn.TILE_LAYOUT)
+            tt_scaled = ttnn.multiply(tt_tile, 255.0)
+            tt_clamped = ttnn.clamp(tt_scaled, min=0.0, max=255.0)
+            tt_clamped = ttnn.to_layout(tt_clamped, ttnn.ROW_MAJOR_LAYOUT)
+            tt_uint8 = ttnn.typecast(tt_clamped, ttnn.uint8)
+            return fast_device_to_host(
+                tt_uint8,
+                mesh_device,
+                concat_dims,
+                ccl_manager=ccl_manager,
+                permute=(0, 2, 3, 4, 1),
+            )
+
+        # Warmup
+        _convert_and_transfer()
+
+        ttnn.synchronize_device(mesh_device)
+        start = time.perf_counter()
+        for _ in range(n_iters):
+            _convert_and_transfer()
+        ttnn.synchronize_device(mesh_device)
+        end = time.perf_counter()
+
+        avg_s = (end - start) / n_iters
+        tensor_bytes = B * C * T * H * W  # uint8 = 1 byte
+        throughput_gbs = (tensor_bytes / avg_s) / 1e9
+
+        rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
+        if rank == 0:
+            print(f"\n--- on-device uint8 + D2H + permute performance (root=0) ---")
+            print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
+            print(f"  Output shape:  (1, {T}, {H}, {W}, {C}) uint8 (BTHWC)")
+            print(f"  Output size:   {tensor_bytes / 1e6:.1f} MB")
+            print(f"  Iterations:    {n_iters}")
+            print(f"  Average time:  {avg_s * 1000:.1f} ms")
+            print(f"  Throughput:    {throughput_gbs:.2f} GB/s")

--- a/models/tt_dit/tests/unit/test_fast_device_to_host.py
+++ b/models/tt_dit/tests/unit/test_fast_device_to_host.py
@@ -294,13 +294,13 @@ class TestFastDeviceToHost:
         ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
 
         def _convert_and_transfer():
-            tt_tile = ttnn.to_layout(tt_tensor, ttnn.TILE_LAYOUT)
-            tt_scaled = ttnn.multiply(tt_tile, 255.0)
-            tt_clamped = ttnn.clamp(tt_scaled, min=0.0, max=255.0)
-            tt_clamped = ttnn.to_layout(tt_clamped, ttnn.ROW_MAJOR_LAYOUT)
-            tt_uint8 = ttnn.typecast(tt_clamped, ttnn.uint8)
+            # tt_tile = ttnn.to_layout(tt_tensor, ttnn.TILE_LAYOUT)
+            # tt_scaled = ttnn.multiply(tt_tile, 255.0)
+            # tt_clamped = ttnn.clamp(tt_scaled, min=0.0, max=255.0)
+            # tt_clamped = ttnn.to_layout(tt_clamped, ttnn.ROW_MAJOR_LAYOUT)
+            # tt_uint8 = ttnn.typecast(tt_clamped, ttnn.uint8)
             return fast_device_to_host(
-                tt_uint8,
+                tt_tensor,
                 mesh_device,
                 concat_dims,
                 ccl_manager=ccl_manager,

--- a/models/tt_dit/tests/unit/test_fast_device_to_host.py
+++ b/models/tt_dit/tests/unit/test_fast_device_to_host.py
@@ -21,7 +21,7 @@ import torch
 import ttnn
 
 from ...parallel.manager import CCLManager
-from ...utils.tensor import fast_device_to_host, typed_tensor_2dshard
+from ...utils.tensor import fast_device_to_host, float_to_uint8, typed_tensor_2dshard
 from ...utils.test import line_params, ring_params
 
 # Wan 2.2 VAE output — BCTHW
@@ -85,46 +85,6 @@ class TestFastDeviceToHost:
         assert result.shape == ref.shape, f"Shape mismatch: {result.shape} vs {ref.shape}"
         torch.testing.assert_close(result, ref, rtol=0, atol=0)
 
-    def test_slow_perf(self, mesh_device, num_links, device_params, topology):
-        """Measure average D2H time over 10 iterations."""
-        n_iters = 10
-
-        ref = _make_reference_tensor()
-        tt_tensor = _shard_to_device(ref, mesh_device)
-        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
-        concat_dims = _make_concat_dims()
-
-        # Warmup
-        ccl_manager.device_to_host(tt_tensor, concat_dims)
-
-        # Sync + barrier before measurement
-        ttnn.synchronize_device(mesh_device)
-        if ttnn.using_distributed_env():
-            ttnn.distributed_context_barrier()
-
-        start = time.perf_counter()
-        for _ in range(n_iters):
-            ccl_manager.device_to_host(tt_tensor, concat_dims)
-        # Sync + barrier before measurement
-        ttnn.synchronize_device(mesh_device)
-        if ttnn.using_distributed_env():
-            ttnn.distributed_context_barrier()
-        end = time.perf_counter()
-
-        avg_s = (end - start) / n_iters
-        tensor_bytes = B * C * T * H * W * 2  # bfloat16 = 2 bytes
-        throughput_gbs = (tensor_bytes / avg_s) / 1e9
-
-        rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
-        if rank == 0:
-            print(f"\n--- ccl_manager.device_to_host performance (root=0) ---")
-            print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
-            print(f"  Tensor shape:  ({B}, {C}, {T}, {H}, {W}) bfloat16")
-            print(f"  Tensor size:   {tensor_bytes / 1e6:.1f} MB")
-            print(f"  Iterations:    {n_iters}")
-            print(f"  Average time:  {avg_s * 1000:.1f} ms")
-            print(f"  Throughput:    {throughput_gbs:.2f} GB/s")
-
     def test_performance(self, mesh_device, num_links, device_params, topology):
         """Measure average D2H time over 10 iterations."""
         n_iters = 10
@@ -153,88 +113,12 @@ class TestFastDeviceToHost:
         end = time.perf_counter()
 
         avg_s = (end - start) / n_iters
-        tensor_bytes = B * C * T * H * W * 4  # float32 = 4 bytes (full pipeline output)
+        tensor_bytes = B * C * T * H * W * 2  # float32 = 4 bytes (full pipeline output)
         throughput_gbs = (tensor_bytes / avg_s) / 1e9
 
         rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
         if rank == 0:
             print(f"\n--- fast_device_to_host + permute + float performance (root=0) ---")
-            print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
-            print(f"  Output shape:  (1, {T}, {H}, {W}, {C}) float32 (BTHWC)")
-            print(f"  Output size:   {tensor_bytes / 1e6:.1f} MB")
-            print(f"  Iterations:    {n_iters}")
-            print(f"  Average time:  {avg_s * 1000:.1f} ms")
-            print(f"  Throughput:    {throughput_gbs:.2f} GB/s")
-
-    def test_fused_correctness(self, mesh_device, num_links, device_params, topology):
-        """Round-trip with fused permute + dtype conversion."""
-        import torch
-
-        ref = _make_reference_tensor()
-        tt_tensor = _shard_to_device(ref, mesh_device)
-        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
-        concat_dims = _make_concat_dims()
-
-        result = fast_device_to_host(
-            tt_tensor,
-            mesh_device,
-            concat_dims,
-            ccl_manager=ccl_manager,
-            permute=(0, 2, 3, 4, 1),
-            dtype=torch.float32,
-        )
-
-        expected = ref.permute(0, 2, 3, 4, 1).float()
-        assert result.shape == expected.shape, f"Shape mismatch: {result.shape} vs {expected.shape}"
-        assert result.dtype == torch.float32
-        torch.testing.assert_close(result, expected, rtol=0, atol=0)
-
-    def test_fused_performance(self, mesh_device, num_links, device_params, topology):
-        """Measure fused permute+dtype D2H time over 10 iterations."""
-        import torch
-
-        n_iters = 10
-        ref = _make_reference_tensor()
-        tt_tensor = _shard_to_device(ref, mesh_device)
-        ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
-        concat_dims = _make_concat_dims()
-
-        # Warmup
-        fast_device_to_host(
-            tt_tensor,
-            mesh_device,
-            concat_dims,
-            ccl_manager=ccl_manager,
-            permute=(0, 2, 3, 4, 1),
-            dtype=torch.float32,
-        )
-
-        ttnn.synchronize_device(mesh_device)
-        if ttnn.using_distributed_env():
-            ttnn.distributed_context_barrier()
-
-        start = time.perf_counter()
-        for _ in range(n_iters):
-            fast_device_to_host(
-                tt_tensor,
-                mesh_device,
-                concat_dims,
-                ccl_manager=ccl_manager,
-                permute=(0, 2, 3, 4, 1),
-                dtype=torch.float32,
-            )
-        ttnn.synchronize_device(mesh_device)
-        if ttnn.using_distributed_env():
-            ttnn.distributed_context_barrier()
-        end = time.perf_counter()
-
-        avg_s = (end - start) / n_iters
-        tensor_bytes = B * C * T * H * W * 4  # float32 = 4 bytes
-        throughput_gbs = (tensor_bytes / avg_s) / 1e9
-
-        rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
-        if rank == 0:
-            print(f"\n--- fast_device_to_host FUSED performance (root=0) ---")
             print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
             print(f"  Output shape:  (1, {T}, {H}, {W}, {C}) float32 (BTHWC)")
             print(f"  Output size:   {tensor_bytes / 1e6:.1f} MB")
@@ -259,16 +143,17 @@ class TestFastDeviceToHost:
             tt_tensor = _shard_to_device(ref, mesh_device)
 
             # --- Host reference path: bf16 → float32 → ×255 → uint8 ---
-            host_uint8 = (ref.float() * 255).clamp(0, 255).to(torch.uint8)
+            host_uint8 = (ref.float() * 255).clamp(0, 255).to(torch.uint8).permute(0, 2, 3, 4, 1)
 
-            # --- Device path: bf16 → ×255 → clamp → typecast(uint8) → D2H ---
-            tt_tile = ttnn.to_layout(tt_tensor, ttnn.TILE_LAYOUT)
-            tt_scaled = ttnn.multiply(tt_tile, 255.0)
-            tt_clamped = ttnn.clamp(tt_scaled, min=0.0, max=255.0)
-            tt_clamped = ttnn.to_layout(tt_clamped, ttnn.ROW_MAJOR_LAYOUT)
-            tt_uint8 = ttnn.typecast(tt_clamped, ttnn.uint8)
-
-            device_uint8 = fast_device_to_host(tt_uint8, mesh_device, concat_dims, ccl_manager=ccl_manager)
+            # --- Device path: pre_transfer_fn handles bf16 → uint8 on device ---
+            device_uint8 = fast_device_to_host(
+                tt_tensor,
+                mesh_device,
+                concat_dims,
+                ccl_manager=ccl_manager,
+                pre_transfer_fn=float_to_uint8,
+                permute=(0, 2, 3, 4, 1),
+            )
 
             diff = (device_uint8.int() - host_uint8.int()).abs()
             max_err = diff.max().item()
@@ -294,16 +179,12 @@ class TestFastDeviceToHost:
         ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
 
         def _convert_and_transfer():
-            # tt_tile = ttnn.to_layout(tt_tensor, ttnn.TILE_LAYOUT)
-            # tt_scaled = ttnn.multiply(tt_tile, 255.0)
-            # tt_clamped = ttnn.clamp(tt_scaled, min=0.0, max=255.0)
-            # tt_clamped = ttnn.to_layout(tt_clamped, ttnn.ROW_MAJOR_LAYOUT)
-            # tt_uint8 = ttnn.typecast(tt_clamped, ttnn.uint8)
             return fast_device_to_host(
                 tt_tensor,
                 mesh_device,
                 concat_dims,
                 ccl_manager=ccl_manager,
+                pre_transfer_fn=float_to_uint8,
                 permute=(0, 2, 3, 4, 1),
             )
 

--- a/models/tt_dit/tests/unit/test_fast_device_to_host.py
+++ b/models/tt_dit/tests/unit/test_fast_device_to_host.py
@@ -2,12 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for fast_device_to_host with Wan 2.2 VAE output shape.
+"""Tests for fast_device_to_host with Wan 2.2 VAE output shapes.
 
-VAE output shape: BCTHW = (1, 3, 81, 720, 1280)
-  - H (dim 3) fractured on TP axis (mesh axis 0, size 4)
-  - W (dim 4) fractured on SP axis (mesh axis 1, size 32)
-  - Per-device shard: (1, 3, 81, 180, 40)
+Parametrized resolutions:
+  720p: BCTHW = (1, 3, 81, 720, 1280)
+  480p: BCTHW = (1, 3, 81, 480, 832)
+
+Sharding: H (dim 3) on TP axis (mesh axis 0), W (dim 4) on SP axis (mesh axis 1).
 
 Run with:
     pytest models/tt_dit/tests/unit/test_fast_device_to_host.py -k "bh_4x32" --timeout=300
@@ -24,15 +25,15 @@ from ...parallel.manager import CCLManager
 from ...utils.tensor import fast_device_to_host, float_to_uint8, typed_tensor_2dshard
 from ...utils.test import line_params, ring_params
 
-# Wan 2.2 VAE output — BCTHW
-B, C, T, H, W = 1, 3, 81, 720, 1280
+# Wan 2.2 VAE output — BCTHW (H and W are parametrized per-test)
+B, C, T = 1, 3, 81
 TP_AXIS = 0  # mesh axis for height
 SP_AXIS = 1  # mesh axis for width
 H_DIM = 3  # BCTHW dimension for height
 W_DIM = 4  # BCTHW dimension for width
 
 
-def _make_reference_tensor() -> torch.Tensor:
+def _make_reference_tensor(H: int, W: int) -> torch.Tensor:
     """Create a deterministic reference tensor with the Wan VAE output shape."""
     gen = torch.Generator().manual_seed(42)
     return torch.randn(B, C, T, H, W, generator=gen, dtype=torch.bfloat16)
@@ -69,10 +70,15 @@ def _make_ccl_manager(mesh_device: ttnn.MeshDevice, num_links: int, topology: tt
     ids=["bh_4x32", "bh_4x8"],
     indirect=["mesh_device", "device_params"],
 )
+@pytest.mark.parametrize(
+    "height, width",
+    [(720, 1280), (480, 832)],
+    ids=["720p", "480p"],
+)
 class TestFastDeviceToHost:
-    def test_correctness(self, mesh_device, num_links, device_params, topology):
+    def test_correctness(self, mesh_device, num_links, device_params, topology, height, width):
         """Round-trip: shard to device -> fast_device_to_host -> compare to reference."""
-        ref = _make_reference_tensor()
+        ref = _make_reference_tensor(height, width)
         tt_tensor = _shard_to_device(ref, mesh_device)
         ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
         concat_dims = _make_concat_dims()
@@ -80,16 +86,15 @@ class TestFastDeviceToHost:
         result = fast_device_to_host(tt_tensor, mesh_device, concat_dims, ccl_manager=ccl_manager)
 
         rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
-        # In single-host or root=None (default), all ranks get the result.
         assert result is not None, f"Rank {rank} got None from fast_device_to_host"
         assert result.shape == ref.shape, f"Shape mismatch: {result.shape} vs {ref.shape}"
         torch.testing.assert_close(result, ref, rtol=0, atol=0)
 
-    def test_performance(self, mesh_device, num_links, device_params, topology):
+    def test_performance(self, mesh_device, num_links, device_params, topology, height, width):
         """Measure average D2H time over 10 iterations."""
         n_iters = 10
 
-        ref = _make_reference_tensor()
+        ref = _make_reference_tensor(height, width)
         tt_tensor = _shard_to_device(ref, mesh_device)
         ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
         concat_dims = _make_concat_dims()
@@ -113,20 +118,20 @@ class TestFastDeviceToHost:
         end = time.perf_counter()
 
         avg_s = (end - start) / n_iters
-        tensor_bytes = B * C * T * H * W * 2  # float32 = 4 bytes (full pipeline output)
+        tensor_bytes = B * C * T * height * width * 2
         throughput_gbs = (tensor_bytes / avg_s) / 1e9
 
         rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
         if rank == 0:
             print(f"\n--- fast_device_to_host + permute + float performance (root=0) ---")
             print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
-            print(f"  Output shape:  (1, {T}, {H}, {W}, {C}) float32 (BTHWC)")
+            print(f"  Output shape:  (1, {T}, {height}, {width}, {C}) float32 (BTHWC)")
             print(f"  Output size:   {tensor_bytes / 1e6:.1f} MB")
             print(f"  Iterations:    {n_iters}")
             print(f"  Average time:  {avg_s * 1000:.1f} ms")
             print(f"  Throughput:    {throughput_gbs:.2f} GB/s")
 
-    def test_uint8_accuracy(self, mesh_device, num_links, device_params, topology):
+    def test_uint8_accuracy(self, mesh_device, num_links, device_params, topology, height, width):
         """Compare on-device uint8 conversion against host float32 path.
 
         Runs twice with different input tensors to verify program cache reuse
@@ -139,11 +144,11 @@ class TestFastDeviceToHost:
 
         for iteration, seed in enumerate([42, 123]):
             gen = torch.Generator().manual_seed(seed)
-            ref = torch.rand(B, C, T, H, W, generator=gen, dtype=torch.bfloat16)
+            ref = torch.rand(B, C, T, height, width, generator=gen, dtype=torch.bfloat16) * 2.0 - 1.0
             tt_tensor = _shard_to_device(ref, mesh_device)
 
             # --- Host reference path: bf16 → float32 → ×255 → uint8 ---
-            host_uint8 = (ref.float() * 255).clamp(0, 255).to(torch.uint8).permute(0, 2, 3, 4, 1)
+            host_uint8 = ((ref.float() + 1.0) * 0.5 * 255.0).clamp(0, 255).to(torch.uint8).permute(0, 2, 3, 4, 1)
 
             # --- Device path: pre_transfer_fn handles bf16 → uint8 on device ---
             device_uint8 = fast_device_to_host(
@@ -167,13 +172,13 @@ class TestFastDeviceToHost:
             print(f"  Exact match:   {pct_exact:.1f}%")
             assert max_err <= 1, f"Max uint8 error {max_err} > 1 on iter {iteration} ({label})"
 
-    def test_uint8_performance(self, mesh_device, num_links, device_params, topology):
+    def test_uint8_performance(self, mesh_device, num_links, device_params, topology, height, width):
         """Measure on-device uint8 conversion + D2H + permute."""
         import torch
 
         n_iters = 10
         gen = torch.Generator().manual_seed(42)
-        ref = torch.rand(B, C, T, H, W, generator=gen, dtype=torch.bfloat16)
+        ref = torch.rand(B, C, T, height, width, generator=gen, dtype=torch.bfloat16)
         tt_tensor = _shard_to_device(ref, mesh_device)
         concat_dims = _make_concat_dims()
         ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
@@ -199,14 +204,14 @@ class TestFastDeviceToHost:
         end = time.perf_counter()
 
         avg_s = (end - start) / n_iters
-        tensor_bytes = B * C * T * H * W  # uint8 = 1 byte
+        tensor_bytes = B * C * T * height * width
         throughput_gbs = (tensor_bytes / avg_s) / 1e9
 
         rank = int(ttnn.distributed_context_get_rank()) if ttnn.using_distributed_env() else 0
         if rank == 0:
             print(f"\n--- on-device uint8 + D2H + permute performance (root=0) ---")
             print(f"  Mesh shape:    {tuple(mesh_device.shape)}")
-            print(f"  Output shape:  (1, {T}, {H}, {W}, {C}) uint8 (BTHWC)")
+            print(f"  Output shape:  (1, {T}, {height}, {width}, {C}) uint8 (BTHWC)")
             print(f"  Output size:   {tensor_bytes / 1e6:.1f} MB")
             print(f"  Iterations:    {n_iters}")
             print(f"  Average time:  {avg_s * 1000:.1f} ms")

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -298,6 +298,98 @@ def _to_torch_zero_copy(t: ttnn.Tensor) -> torch.Tensor:
         return ttnn.to_torch(t)
 
 
+def _get_inter_host_axis(mesh_device: ttnn.MeshDevice, view, mesh_shape: tuple[int, ...]) -> int:
+    """Return the mesh axis that spans multiple hosts (0 or 1).
+
+    In a 2D mesh, one axis typically spans hosts (inter-host) while the other
+    is fully local to each host (intra-host).  Finds a local coordinate first,
+    then checks whether varying each axis stays local.
+    """
+    from ttnn._ttnn.multi_device import MeshCoordinate
+
+    # Find any coordinate that is local to this host.
+    ref_r, ref_c = 0, 0
+    for r in range(mesh_shape[0]):
+        for c in range(mesh_shape[1]):
+            if view.is_local(MeshCoordinate(r, c)):
+                ref_r, ref_c = r, c
+                break
+        else:
+            continue
+        break
+
+    # Check axis 0: vary row while keeping the local column fixed.
+    if mesh_shape[0] > 1:
+        if not all(view.is_local(MeshCoordinate(r, ref_c)) for r in range(mesh_shape[0])):
+            return 0
+    # Check axis 1: vary column while keeping the local row fixed.
+    if mesh_shape[1] > 1:
+        if not all(view.is_local(MeshCoordinate(ref_r, c)) for c in range(mesh_shape[1])):
+            return 1
+    # Both axes are fully local — shouldn't happen in a true distributed env.
+    return 0
+
+
+def _reassemble_2d(
+    mesh_coords: list,
+    shards: list[torch.Tensor],
+    shard_shape: list[int],
+    mesh_shape: tuple[int, ...],
+    concat_dims: list[int | None],
+    permute: tuple[int, ...] | None = None,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """Reassemble per-device shards into a single tensor for a 2D mesh.
+
+    For the common case where both axes are concatenated, writes each shard
+    directly into a pre-allocated output buffer.  When *permute* and/or *dtype*
+    are given the permutation and type conversion are fused into the scatter
+    write, halving total memory traffic.
+    """
+    d0, d1 = concat_dims
+
+    if d0 is not None and d1 is not None:
+        s0, s1 = shard_shape[d0], shard_shape[d1]
+        full_shape = list(shard_shape)
+        full_shape[d0] *= mesh_shape[0]
+        full_shape[d1] *= mesh_shape[1]
+        ndim = len(full_shape)
+
+        if permute is not None:
+            out_shape = [full_shape[p] for p in permute]
+            out_dtype = dtype if dtype is not None else shards[0].dtype
+            perm_list = list(permute)
+            d0_out = perm_list.index(d0)
+            d1_out = perm_list.index(d1)
+
+            out = torch.empty(out_shape, dtype=out_dtype)
+            for coord, shard in zip(mesh_coords, shards):
+                r, c = int(coord[0]), int(coord[1])
+                slices = [slice(None)] * ndim
+                slices[d0_out] = slice(r * s0, (r + 1) * s0)
+                slices[d1_out] = slice(c * s1, (c + 1) * s1)
+                out[tuple(slices)] = shard.permute(*permute).contiguous()
+            return out
+
+        out_dtype = dtype if dtype is not None else shards[0].dtype
+        out = torch.empty(full_shape, dtype=out_dtype)
+        for coord, shard in zip(mesh_coords, shards):
+            r, c = int(coord[0]), int(coord[1])
+            slices = [slice(None)] * ndim
+            slices[d0] = slice(r * s0, (r + 1) * s0)
+            slices[d1] = slice(c * s1, (c + 1) * s1)
+            out[tuple(slices)] = shard
+        return out
+
+    if d0 is not None:
+        by_pos = sorted(zip(mesh_coords, shards), key=lambda x: int(x[0][0]))
+        return torch.cat([s for _, s in by_pos], dim=d0)
+    if d1 is not None:
+        by_pos = sorted(zip(mesh_coords, shards), key=lambda x: int(x[0][1]))
+        return torch.cat([s for _, s in by_pos], dim=d1)
+    return shards[0]
+
+
 def fast_device_to_host(
     tt_tensor: ttnn.Tensor,
     mesh_device: ttnn.MeshDevice,

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -298,6 +298,26 @@ def _to_torch_zero_copy(t: ttnn.Tensor) -> torch.Tensor:
         return ttnn.to_torch(t)
 
 
+_TTNN_TO_TORCH_DTYPE = {
+    ttnn.bfloat16: torch.bfloat16,
+    ttnn.float32: torch.float32,
+    ttnn.uint8: torch.uint8,
+    ttnn.uint16: torch.int16,
+    ttnn.int32: torch.int32,
+}
+
+
+def _host_buffer_to_torch(buf, padded_shape: list[int], tt_dtype: ttnn.DataType) -> torch.Tensor:
+    """Zero-copy conversion of a HostBuffer to a torch tensor.
+
+    Uses the DLPack protocol to get a uint8 view of the raw buffer memory,
+    then reinterprets it as the correct dtype and reshapes.
+    """
+    torch_dtype = _TTNN_TO_TORCH_DTYPE[tt_dtype]
+    raw = torch.from_dlpack(buf)
+    return raw.view(torch_dtype).reshape(padded_shape)
+
+
 def _get_inter_host_axis(mesh_device: ttnn.MeshDevice, view, mesh_shape: tuple[int, ...]) -> int:
     """Return the mesh axis that spans multiple hosts (0 or 1).
 
@@ -451,53 +471,79 @@ def fast_device_to_host(
         inter_host_axis = _get_inter_host_axis(mesh_device, view, mesh_shape)
         intra_host_axis = 1 - inter_host_axis
 
-        # Step 1: On-device all_gather for inter-host axis only.
+        # Step 1: On-device all_gather + repeat + mesh_partition.
+        # All_gather replicates the inter-host axis.  Repeat + mesh_partition
+        # then re-shard it so every local device holds *unique* data,
+        # maximising PCIe bandwidth during the DMA read.
         gathered_tensor = tt_tensor
-        if concat_dims[inter_host_axis] is not None and mesh_shape[inter_host_axis] > 1:
+        inter_dim = concat_dims[inter_host_axis]
+        if inter_dim is not None and mesh_shape[inter_host_axis] > 1:
             gathered_tensor = ttnn.to_layout(gathered_tensor, ttnn.TILE_LAYOUT)
             gathered_tensor = ccl_manager.all_gather(
                 gathered_tensor,
-                dim=concat_dims[inter_host_axis],
+                dim=inter_dim,
                 mesh_axis=inter_host_axis,
                 use_hyperparams=True,
                 use_persistent_buffer=True,
             )
-            gathered_tensor = ttnn.to_layout(gathered_tensor, ttnn.ROW_MAJOR_LAYOUT)
+            n_hosts = int(ttnn.distributed_context_get_size())
+            if n_hosts > 1:
+                repeat_dims = [1] * len(gathered_tensor.shape)
+                repeat_dims[inter_dim] = n_hosts
+                gathered_tensor = ttnn.repeat(gathered_tensor, repeat_dims)
+                gathered_tensor = ttnn.mesh_partition(gathered_tensor, dim=inter_dim, cluster_axis=inter_host_axis)
+            tt_scaled = ttnn.multiply(gathered_tensor, 255.0)
+            tt_clamped = ttnn.clamp(tt_scaled, min=0.0, max=255.0)
+            tt_clamped = ttnn.to_layout(tt_clamped, ttnn.ROW_MAJOR_LAYOUT)
+            gathered_tensor = ttnn.typecast(tt_clamped, ttnn.uint8)
 
         # Step 2: Only root rank (if specified) does D2H.
         if root is not None and rank != root:
             return None
 
-        # Step 3: Fast DMA on local shards + host-side concat for intra-host axis.
-        # After the inter-host all_gather, the gathered axis is replicated so
-        # many local devices hold identical data.  Only read one device per
-        # unique intra-host-axis position to avoid redundant DMA.
-        mesh_coords = list(gathered_tensor.tensor_topology().mesh_coords())
-        device_tensors = ttnn.get_device_tensors(gathered_tensor)
-
-        seen_intra_positions: set[int] = set()
-        unique_pairs: list[tuple] = []
-        for c, dt in zip(mesh_coords, device_tensors):
-            if not view.is_local(c):
-                continue
-            intra_pos = int(c[intra_host_axis])
-            if intra_pos in seen_intra_positions:
-                continue
-            seen_intra_positions.add(intra_pos)
-            unique_pairs.append((c, dt))
-
-        local_host_tensors = [dt.cpu(blocking=False) for _, dt in unique_pairs]
+        # Step 3: DMA all local shards and reassemble on host.
+        # Single .cpu() on the mesh tensor batches all local DMA reads into
+        # one C++ dispatch — the reader thread pool processes all device
+        # completion queues in parallel.
+        host_tensor = gathered_tensor.cpu(blocking=False)
         ttnn.synchronize_device(mesh_device)
 
-        logical_shape = list(local_host_tensors[0].shape)
+        # Extract local shard buffers via get_shard (zero-copy, no MPI).
+        host_mesh_coords = list(host_tensor.tensor_topology().mesh_coords())
+        distributed_buf = host_tensor.host_buffer()
+        tt_dtype = host_tensor.dtype
+        padded_shape = list(host_tensor.padded_shape)
+        logical_shape = list(host_tensor.shape)
         trim = tuple(slice(0, d) for d in logical_shape)
-        shards = [_to_torch_zero_copy(s)[trim] for s in local_host_tensors]
 
-        if concat_dims[intra_host_axis] is not None and len(shards) > 1:
-            local_coords = [c for c, _ in unique_pairs]
-            by_intra = sorted(zip(local_coords, shards), key=lambda x: int(x[0][intra_host_axis]))
-            return torch.cat([s for _, s in by_intra], dim=concat_dims[intra_host_axis])
-        return shards[0]
+        local_coords_and_bufs = []
+        for c in host_mesh_coords:
+            if not view.is_local(c):
+                continue
+            buf = distributed_buf.get_shard(c)
+            if buf is not None:
+                local_coords_and_bufs.append((c, buf))
+
+        shards = [_host_buffer_to_torch(buf, padded_shape, tt_dtype)[trim] for _, buf in local_coords_and_bufs]
+
+        # Build local mesh shape and 0-based coordinates for _reassemble_2d.
+        local_inter_positions = sorted({int(c[inter_host_axis]) for c, _ in local_coords_and_bufs})
+        local_intra_positions = sorted({int(c[intra_host_axis]) for c, _ in local_coords_and_bufs})
+        local_mesh_shape = [0, 0]
+        local_mesh_shape[inter_host_axis] = len(local_inter_positions)
+        local_mesh_shape[intra_host_axis] = len(local_intra_positions)
+        local_mesh_shape = tuple(local_mesh_shape)
+
+        inter_remap = {pos: i for i, pos in enumerate(local_inter_positions)}
+        intra_remap = {pos: i for i, pos in enumerate(local_intra_positions)}
+        local_coords = []
+        for c, _ in local_coords_and_bufs:
+            coord = [0, 0]
+            coord[inter_host_axis] = inter_remap[int(c[inter_host_axis])]
+            coord[intra_host_axis] = intra_remap[int(c[intra_host_axis])]
+            local_coords.append(tuple(coord))
+
+        return _reassemble_2d(local_coords, shards, logical_shape, local_mesh_shape, concat_dims, permute, dtype)
 
     # --- Single-host: async DMA on all devices + host-side concat -----------
 

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -318,6 +318,16 @@ def _host_buffer_to_torch(buf, padded_shape: list[int], tt_dtype: ttnn.DataType)
     return raw.view(torch_dtype).reshape(padded_shape)
 
 
+def float_to_unit_range(t: ttnn.Tensor) -> ttnn.Tensor:
+    """On-device denormalization: map from [-1.0, 1.0] to [0.0, 1.0]."""
+    t = ttnn.to_layout(t, ttnn.TILE_LAYOUT)
+    t = ttnn.add(t, 1.0)
+    t = ttnn.multiply(t, 0.5)
+    t = ttnn.clamp(t, min=0.0, max=1.0)
+    t = ttnn.to_layout(t, ttnn.ROW_MAJOR_LAYOUT)
+    return t
+
+
 def float_to_uint8(t: ttnn.Tensor) -> ttnn.Tensor:
     """On-device float-to-uint8: map from [-1.0, 1.0] to [0, 255]"""
     t = ttnn.to_layout(t, ttnn.TILE_LAYOUT)

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -12,7 +12,7 @@ import torch
 import ttnn
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from types import EllipsisType
 
 
@@ -318,6 +318,15 @@ def _host_buffer_to_torch(buf, padded_shape: list[int], tt_dtype: ttnn.DataType)
     return raw.view(torch_dtype).reshape(padded_shape)
 
 
+def float_to_uint8(t: ttnn.Tensor) -> ttnn.Tensor:
+    """On-device float-to-uint8: multiply by 255, clamp [0, 255], typecast."""
+    t = ttnn.to_layout(t, ttnn.TILE_LAYOUT)
+    t = ttnn.multiply(t, 255.0)
+    t = ttnn.clamp(t, min=0.0, max=255.0)
+    t = ttnn.to_layout(t, ttnn.ROW_MAJOR_LAYOUT)
+    return ttnn.typecast(t, ttnn.uint8)
+
+
 def _get_inter_host_axis(mesh_device: ttnn.MeshDevice, view, mesh_shape: tuple[int, ...]) -> int:
     """Return the mesh axis that spans multiple hosts (0 or 1).
 
@@ -417,6 +426,7 @@ def fast_device_to_host(
     ccl_manager=None,
     root: int | None = None,
     *,
+    pre_transfer_fn: Callable[[ttnn.Tensor], ttnn.Tensor] | None = None,
     permute: tuple[int, ...] | None = None,
     dtype: torch.dtype | None = None,
 ) -> torch.Tensor | None:
@@ -442,6 +452,10 @@ def fast_device_to_host(
         root: If set, only the host with this MPI rank performs the D2H
             transfer and returns the assembled tensor; all other ranks return
             ``None``.  If ``None`` (default), all ranks perform D2H.
+        pre_transfer_fn: Optional on-device transformation applied just before
+            the DMA read.  For multi-host, runs after ``mesh_partition``; for
+            single-host, runs right before ``.cpu()``.  Typical use is
+            ``float_to_uint8`` to shrink data before the PCIe transfer.
         permute: If set, each shard is permuted before being written into the
             output.  Fuses the permutation into the scatter write so that no
             intermediate tensor in the original layout is ever materialised.
@@ -492,10 +506,12 @@ def fast_device_to_host(
                 repeat_dims[inter_dim] = n_hosts
                 gathered_tensor = ttnn.repeat(gathered_tensor, repeat_dims)
                 gathered_tensor = ttnn.mesh_partition(gathered_tensor, dim=inter_dim, cluster_axis=inter_host_axis)
-            tt_scaled = ttnn.multiply(gathered_tensor, 255.0)
-            tt_clamped = ttnn.clamp(tt_scaled, min=0.0, max=255.0)
-            tt_clamped = ttnn.to_layout(tt_clamped, ttnn.ROW_MAJOR_LAYOUT)
-            gathered_tensor = ttnn.typecast(tt_clamped, ttnn.uint8)
+            if pre_transfer_fn is not None:
+                gathered_tensor = pre_transfer_fn(gathered_tensor)
+            else:
+                gathered_tensor = ttnn.to_layout(gathered_tensor, ttnn.ROW_MAJOR_LAYOUT)
+        elif pre_transfer_fn is not None:
+            gathered_tensor = pre_transfer_fn(gathered_tensor)
 
         # Step 2: Only root rank (if specified) does D2H.
         if root is not None and rank != root:
@@ -549,6 +565,9 @@ def fast_device_to_host(
 
     # Grab mesh coordinates from the device tensor before DMA.
     mesh_coords = list(tt_tensor.tensor_topology().mesh_coords())
+
+    if pre_transfer_fn is not None:
+        tt_tensor = pre_transfer_fn(tt_tensor)
 
     # Single .cpu() on the mesh tensor batches all DMA reads into one C++
     # dispatch — host buffers are allocated in parallel and the reader thread

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -319,9 +319,10 @@ def _host_buffer_to_torch(buf, padded_shape: list[int], tt_dtype: ttnn.DataType)
 
 
 def float_to_uint8(t: ttnn.Tensor) -> ttnn.Tensor:
-    """On-device float-to-uint8: multiply by 255, clamp [0, 255], typecast."""
+    """On-device float-to-uint8: map from [-1.0, 1.0] to [0, 255]"""
     t = ttnn.to_layout(t, ttnn.TILE_LAYOUT)
-    t = ttnn.multiply(t, 255.0)
+    t = ttnn.add(t, 1.0)  # shift to [0, 2.0]
+    t = ttnn.multiply(t, 0.5 * 255.0)  # scale to [0, 1.0] then [0, 255]
     t = ttnn.clamp(t, min=0.0, max=255.0)
     t = ttnn.to_layout(t, ttnn.ROW_MAJOR_LAYOUT)
     return ttnn.typecast(t, ttnn.uint8)

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
+import torch
+
 import ttnn
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from types import EllipsisType
-
-    import torch
 
 
 def typed_tensor(
@@ -395,16 +395,21 @@ def fast_device_to_host(
     mesh_device: ttnn.MeshDevice,
     concat_dims: list[int | None],
     ccl_manager=None,
-) -> torch.Tensor:
+    root: int | None = None,
+    *,
+    permute: tuple[int, ...] | None = None,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor | None:
     """Fast D2H transfer using async DMA and zero-copy to_torch.
 
     On a single-host system, this avoids the on-device all_gather by reading
     all per-device shards concurrently with async DMA, converting to PyTorch
     with zero-copy when possible, and concatenating on host.
 
-    On a multi-host (distributed) system, each host can only access its local
-    devices, so this falls back to on-device all_gather via *ccl_manager*
-    followed by a local-device read.
+    On a multi-host (distributed) system, this uses a hybrid approach: an
+    on-device all_gather for the inter-host axis only, then fast async DMA +
+    zero-copy for local shards with host-side concatenation for the intra-host
+    axis.
 
     Args:
         tt_tensor: Multi-device ttnn tensor on ``mesh_device``.
@@ -414,18 +419,15 @@ def fast_device_to_host(
             along dim 3 for mesh axis 0 and dim 4 for mesh axis 1.
         ccl_manager: Optional :class:`CCLManager` instance.  Required for
             multi-host environments where only local devices are accessible.
+        root: If set, only the host with this MPI rank performs the D2H
+            transfer and returns the assembled tensor; all other ranks return
+            ``None``.  If ``None`` (default), all ranks perform D2H.
+        permute: If set, each shard is permuted before being written into the
+            output.  Fuses the permutation into the scatter write so that no
+            intermediate tensor in the original layout is ever materialised.
+        dtype: Output dtype.  When combined with ``permute``, the dtype
+            conversion is fused into the scatter write (single-pass copy).
     """
-    # Multi-host: can only access local devices, must all_gather on device first.
-    if ttnn.using_distributed_env():
-        if ccl_manager is None:
-            msg = "fast_device_to_host requires ccl_manager in a distributed " "(multi-host) environment"
-            raise ValueError(msg)
-        return ccl_manager.device_to_host(tt_tensor, concat_dims)
-
-    from concurrent.futures import ThreadPoolExecutor
-
-    import torch
-
     mesh_shape = tuple(mesh_device.shape)
 
     if len(mesh_shape) != 2:
@@ -437,76 +439,86 @@ def fast_device_to_host(
             f"concat_dims must have exactly 2 elements for a 2D mesh, got {len(concat_dims)}: {concat_dims}"
         )
 
-    # Get mesh coordinates before issuing DMA — topology is on the original
-    # device tensor and maps each shard index to its (row, col) mesh position.
-    mesh_coords = list(tt_tensor.tensor_topology().mesh_coords())
-    device_tensors = ttnn.get_device_tensors(tt_tensor)
+    # --- Multi-host: hybrid on-device collective + fast local DMA -----------
+    if ttnn.using_distributed_env():
+        if ccl_manager is None:
+            msg = "fast_device_to_host requires ccl_manager in a distributed (multi-host) environment"
+            raise ValueError(msg)
 
-    # Async DMA: issue all transfers then sync once
-    host_tensors = [dt.cpu(blocking=False) for dt in device_tensors]
+        view = mesh_device.get_view()
+        rank = int(ttnn.distributed_context_get_rank())
+
+        inter_host_axis = _get_inter_host_axis(mesh_device, view, mesh_shape)
+        intra_host_axis = 1 - inter_host_axis
+
+        # Step 1: On-device all_gather for inter-host axis only.
+        gathered_tensor = tt_tensor
+        if concat_dims[inter_host_axis] is not None and mesh_shape[inter_host_axis] > 1:
+            gathered_tensor = ttnn.to_layout(gathered_tensor, ttnn.TILE_LAYOUT)
+            gathered_tensor = ccl_manager.all_gather(
+                gathered_tensor,
+                dim=concat_dims[inter_host_axis],
+                mesh_axis=inter_host_axis,
+                use_hyperparams=True,
+                use_persistent_buffer=True,
+            )
+            gathered_tensor = ttnn.to_layout(gathered_tensor, ttnn.ROW_MAJOR_LAYOUT)
+
+        # Step 2: Only root rank (if specified) does D2H.
+        if root is not None and rank != root:
+            return None
+
+        # Step 3: Fast DMA on local shards + host-side concat for intra-host axis.
+        # After the inter-host all_gather, the gathered axis is replicated so
+        # many local devices hold identical data.  Only read one device per
+        # unique intra-host-axis position to avoid redundant DMA.
+        mesh_coords = list(gathered_tensor.tensor_topology().mesh_coords())
+        device_tensors = ttnn.get_device_tensors(gathered_tensor)
+
+        seen_intra_positions: set[int] = set()
+        unique_pairs: list[tuple] = []
+        for c, dt in zip(mesh_coords, device_tensors):
+            if not view.is_local(c):
+                continue
+            intra_pos = int(c[intra_host_axis])
+            if intra_pos in seen_intra_positions:
+                continue
+            seen_intra_positions.add(intra_pos)
+            unique_pairs.append((c, dt))
+
+        local_host_tensors = [dt.cpu(blocking=False) for _, dt in unique_pairs]
+        ttnn.synchronize_device(mesh_device)
+
+        logical_shape = list(local_host_tensors[0].shape)
+        trim = tuple(slice(0, d) for d in logical_shape)
+        shards = [_to_torch_zero_copy(s)[trim] for s in local_host_tensors]
+
+        if concat_dims[intra_host_axis] is not None and len(shards) > 1:
+            local_coords = [c for c, _ in unique_pairs]
+            by_intra = sorted(zip(local_coords, shards), key=lambda x: int(x[0][intra_host_axis]))
+            return torch.cat([s for _, s in by_intra], dim=concat_dims[intra_host_axis])
+        return shards[0]
+
+    # --- Single-host: async DMA on all devices + host-side concat -----------
+
+    # Grab mesh coordinates from the device tensor before DMA.
+    mesh_coords = list(tt_tensor.tensor_topology().mesh_coords())
+
+    # Single .cpu() on the mesh tensor batches all DMA reads into one C++
+    # dispatch — host buffers are allocated in parallel and the reader thread
+    # pool processes all completion-queue reads concurrently.
+    host_tensor = tt_tensor.cpu(blocking=False)
     ttnn.synchronize_device(mesh_device)
 
-    # Zero-copy to_torch when available, otherwise standard to_torch
-    with ThreadPoolExecutor(max_workers=len(host_tensors)) as pool:
-        shards = list(pool.map(_to_torch_zero_copy, host_tensors))
+    # Extract per-shard host tensors (single-host: just wraps each shard).
+    host_shard_tensors = ttnn.get_device_tensors(host_tensor)
 
-    # Trim physical (tile-padded) shape to logical shape — view, no copy
-    logical_shape = list(host_tensors[0].shape)
-    shards = [s[tuple(slice(0, d) for d in logical_shape)] for s in shards]
+    # Zero-copy to_torch, trimmed to logical (un-padded) shape.
+    logical_shape = list(host_shard_tensors[0].shape)
+    trim = tuple(slice(0, d) for d in logical_shape)
+    shards = [_to_torch_zero_copy(s)[trim] for s in host_shard_tensors]
 
-    # Validate that topology coordinates and device tensors are consistent.
-    n_coords, n_shards = len(mesh_coords), len(shards)
-    expected = mesh_shape[0] * mesh_shape[1]
-    if n_coords != n_shards:
-        raise ValueError(
-            f"mesh_coords length ({n_coords}) != device shards length ({n_shards}); "
-            "tensor_topology and get_device_tensors are out of sync"
-        )
-    if n_shards != expected:
-        raise ValueError(f"Expected {expected} shards for mesh shape {mesh_shape}, got {n_shards}")
-
-    # Build coord→shard mapping using explicit mesh coordinates rather than
-    # assuming get_device_tensors() returns shards in row-major order.
-    shards_by_coord = {(int(c[0]), int(c[1])): s for c, s in zip(mesh_coords, shards)}
-
-    if len(shards_by_coord) != n_shards:
-        raise ValueError(
-            f"Duplicate mesh coordinates detected: {n_shards} shards but only "
-            f"{len(shards_by_coord)} unique coordinates"
-        )
-
-    # Validate: if a mesh axis is not gathered (concat_dims[axis] is None)
-    # and has more than one device, the tensor must be replicated along that
-    # axis — otherwise we'd silently drop unique shards.
-    placements = list(tt_tensor.tensor_topology().placements())
-    for axis in range(len(concat_dims)):
-        if concat_dims[axis] is None and mesh_shape[axis] > 1:
-            if not isinstance(placements[axis], ttnn.PlacementReplicate):
-                msg = (
-                    f"concat_dims[{axis}] is None (no gather) but mesh axis {axis} "
-                    f"(size {mesh_shape[axis]}) is not replicated — this would drop shards."
-                )
-                raise ValueError(msg)
-
-    # Reassemble from 2D mesh using explicit coordinate lookup.
-    if concat_dims[0] is not None and concat_dims[1] is not None:
-        rows = []
-        for r in range(mesh_shape[0]):
-            row_shards = [shards_by_coord[(r, c)] for c in range(mesh_shape[1])]
-            rows.append(torch.cat(row_shards, dim=concat_dims[1]))
-        return torch.cat(rows, dim=concat_dims[0])
-    elif concat_dims[0] is not None:
-        return torch.cat(
-            [shards_by_coord[(r, 0)] for r in range(mesh_shape[0])],
-            dim=concat_dims[0],
-        )
-    elif concat_dims[1] is not None:
-        return torch.cat(
-            [shards_by_coord[(0, c)] for c in range(mesh_shape[1])],
-            dim=concat_dims[1],
-        )
-    else:
-        return shards[0]
+    return _reassemble_2d(mesh_coords, shards, logical_shape, mesh_shape, concat_dims, permute, dtype)
 
 
 def upsample(

--- a/models/tt_dit/utils/video.py
+++ b/models/tt_dit/utils/video.py
@@ -9,10 +9,16 @@ import subprocess
 import numpy as np
 
 
-def export_to_video(frames, output_video_path: str, fps: int = 16, crf: int = 25) -> str:
+def export_to_video(
+    frames, output_video_path: str, fps: int = 16, crf: int = 25, preset: str | None = "ultrafast"
+) -> str:
     """Encode frames to video via ffmpeg subprocess.
 
     Accepts either float32 [0,1] or uint8 [0,255] frames with shape (T, H, W, 3).
+    ``preset`` is passed directly as the libx264 ``-preset`` flag (e.g.
+    "ultrafast", "veryfast", "medium", "slow").  When *None* ffmpeg uses its
+    built-in default ("medium"). We default to "ultrafast" for faster encoding,
+    at expense of filesize.
     """
     from imageio_ffmpeg import get_ffmpeg_exe
 
@@ -44,6 +50,10 @@ def export_to_video(frames, output_video_path: str, fps: int = 16, crf: int = 25
         "yuv420p",
         "-crf",
         str(crf),
+    ]
+    if preset is not None:
+        cmd += ["-preset", preset]
+    cmd += [
         "-v",
         "warning",
         output_video_path,

--- a/models/tt_dit/utils/video.py
+++ b/models/tt_dit/utils/video.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+
+import numpy as np
+
+
+def export_to_video(frames, output_video_path: str, fps: int = 16, crf: int = 25) -> str:
+    """Encode frames to video via ffmpeg subprocess.
+
+    Accepts either float32 [0,1] or uint8 [0,255] frames with shape (T, H, W, 3).
+    """
+    from imageio_ffmpeg import get_ffmpeg_exe
+
+    frames = np.asarray(frames)
+    if frames.ndim != 4 or frames.shape[-1] != 3:
+        raise ValueError(f"Expected frames with shape (T, H, W, 3), got {frames.shape}")
+
+    t, h, w, c = frames.shape
+
+    cmd = [
+        get_ffmpeg_exe(),
+        "-y",
+        "-f",
+        "rawvideo",
+        "-vcodec",
+        "rawvideo",
+        "-s",
+        f"{w}x{h}",
+        "-pix_fmt",
+        "rgb24",
+        "-r",
+        f"{fps:.2f}",
+        "-i",
+        "-",
+        "-an",
+        "-vcodec",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        str(crf),
+        "-v",
+        "warning",
+        output_video_path,
+    ]
+
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    try:
+        for frame in frames:
+            if frame.dtype != np.uint8:
+                frame = (frame * 255).clip(0, 255).astype(np.uint8)
+            p.stdin.write(frame.tobytes())
+        p.stdin.close()
+        stderr = p.stderr.read().decode("utf-8", errors="ignore")
+        rc = p.wait()
+    except Exception:
+        p.kill()
+        p.wait()
+        raise
+
+    if rc != 0:
+        raise RuntimeError(f"ffmpeg failed with return code {rc}:\n{stderr}")
+
+    return output_video_path

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -692,7 +692,14 @@ void py_module(nb::module_& mod) {
 
     auto py_distributed_host_buffer = static_cast<nb::class_<DistributedHostBuffer>>(mod.attr("DistributedHostBuffer"));
     py_distributed_host_buffer.def("is_local", &DistributedHostBuffer::is_local, nb::arg("coord"))
-        .def("shape", &DistributedHostBuffer::shape, nb::rv_policy::reference_internal);
+        .def("shape", &DistributedHostBuffer::shape, nb::rv_policy::reference_internal)
+        .def(
+            "get_shard",
+            &DistributedHostBuffer::get_shard,
+            nb::arg("coord"),
+            R"doc(
+            Returns the HostBuffer shard at the given coordinate, or None if not local/populated.
+        )doc");
 
     auto py_tensor_topology = static_cast<nb::class_<TensorTopology>>(mod.attr("TensorTopology"));
     py_tensor_topology

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -722,7 +722,14 @@ void py_module(nb::module_& mod) {
 
     auto py_distributed_host_buffer = static_cast<nb::class_<DistributedHostBuffer>>(mod.attr("DistributedHostBuffer"));
     py_distributed_host_buffer.def("is_local", &DistributedHostBuffer::is_local, nb::arg("coord"))
-        .def("shape", &DistributedHostBuffer::shape, nb::rv_policy::reference_internal);
+        .def("shape", &DistributedHostBuffer::shape, nb::rv_policy::reference_internal)
+        .def(
+            "get_shard",
+            &DistributedHostBuffer::get_shard,
+            nb::arg("coord"),
+            R"doc(
+            Returns the HostBuffer shard at the given coordinate, or None if not local/populated.
+        )doc");
 
     auto py_tensor_topology = static_cast<nb::class_<TensorTopology>>(mod.attr("TensorTopology"));
     py_tensor_topology


### PR DESCRIPTION
### Summary
There were a few opportunities to improve D2H in Wan pipeline
- `torch.cat` memory allocations
- reading bf16 to host before conversion to uint8
- loading individual device shards to host buffers from python
On multi-host, it was even worse since we weren't taking advantage of 32 chips worth of PCIe bandwidth.

This PR makes a few improvements
- do uint8 conversion on device (requires https://github.com/tenstorrent/tt-metal/pull/42191 and https://github.com/tenstorrent/tt-metal/pull/42192 bugfixes)
- send device shards to cpu in single python call
- for multi-host, add binding to get specific shards from distributed host buffer. this is necessary because `get_device_tensors` on a distributed host buffer on multi-host causes a host all-gather, which is unnecessary and expensive in this use case

This saves 100ms e2e on 1xGLX and 500ms e2e on 4xGLX.

New perf results fast D2H

  | bf16 | uint8 |  
-- | -- | -- | --
1x | 169ms | 65ms |  
4x | 235ms | 111ms |  


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/wan_uint8_d2h)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/wan_uint8_d2h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=cglagovich/wan_uint8_d2h)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cglagovich/wan_uint8_d2h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/wan_uint8_d2h)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/wan_uint8_d2h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/wan_uint8_d2h)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/wan_uint8_d2h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/wan_uint8_d2h)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/wan_uint8_d2h)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/wan_uint8_d2h)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/wan_uint8_d2h)