### PR TITLE
AI-friendliness enhancements for Metal 2.0 host APIs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -34,8 +34,7 @@ inline KernelSpec MakeMinimalDMKernel(
     const std::string& name, const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes, uint8_t num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
-        .source = MINIMAL_KERNEL_SOURCE,
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .target_nodes = nodes,
         .num_threads = num_threads,
         .config_spec =
@@ -52,8 +51,7 @@ inline KernelSpec MakeMinimalGen1DMKernel(
     tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0) {
     return KernelSpec{
         .unique_id = name,
-        .source = MINIMAL_KERNEL_SOURCE,
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .target_nodes = nodes,
         .num_threads = 1,
         .config_spec =
@@ -71,8 +69,7 @@ inline KernelSpec MakeMinimalComputeKernel(
     const std::string& name, const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes, uint8_t num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
-        .source = MINIMAL_KERNEL_SOURCE,
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .target_nodes = nodes,
         .num_threads = num_threads,
         .config_spec = ComputeConfiguration{},

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -949,8 +949,7 @@ TEST_F(ProgramSpecTestQuasar, SourceCodeKernelSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Change to inline source code
-    spec.kernels[0].source = "void kernel_main() {}";
-    spec.kernels[0].source_type = KernelSpec::SourceType::SOURCE_CODE;
+    spec.kernels[0].source = KernelSpec::SourceCode{"void kernel_main() {}"};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1233,8 +1232,7 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
     // Demonstrates constructing KernelSpec with designated initializers
     KernelSpec dm_kernel{
         .unique_id = "my_dm_kernel",
-        .source = "void kernel_main() {}",
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{"void kernel_main() {}"},
         .target_nodes = NodeCoord{0, 0},
         .num_threads = 2,
         .config_spec =
@@ -1249,8 +1247,7 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
 
     KernelSpec compute_kernel{
         .unique_id = "my_compute_kernel",
-        .source = "void kernel_main() {}",
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{"void kernel_main() {}"},
         .target_nodes = NodeRange{{0, 0}, {1, 1}},
         .num_threads = 4,
         .compiler_options =
@@ -1333,8 +1330,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
             {
                 KernelSpec{
                     .unique_id = "producer",
-                    .source = "void kernel_main() {}",
-                    .source_type = KernelSpec::SourceType::SOURCE_CODE,
+                    .source = KernelSpec::SourceCode{"void kernel_main() {}"},
                     .target_nodes = NodeCoord{0, 0},
                     .dfb_bindings =
                         {
@@ -1352,8 +1348,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                 },
                 KernelSpec{
                     .unique_id = "consumer",
-                    .source = "void kernel_main() {}",
-                    .source_type = KernelSpec::SourceType::SOURCE_CODE,
+                    .source = KernelSpec::SourceCode{"void kernel_main() {}"},
                     .target_nodes = NodeCoord{0, 0},
                     .dfb_bindings =
                         {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -16,7 +16,14 @@
 
 namespace tt::tt_metal::experimental::metal2_host_api {
 
+// A name identifying a DataflowBufferSpec within a ProgramSpec.
+//
+// Convention: define names as `constexpr const char*` constants so cross-references
+// fail at compile time on typos:
+//   constexpr const char* INPUT_DFB = "input_dfb";
+//   DataflowBufferSpec{.unique_id = INPUT_DFB, ...};
 using DFBSpecName = std::string;
+
 enum class DFBAccessPattern { STRIDED, BLOCKED, CONTIGUOUS };
 
 struct DataflowBufferSpec {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -100,12 +100,10 @@ struct KernelSpec {
     struct CompilerOptions {
         using IncludePaths = std::vector<std::string>;
         using Defines = std::vector<std::pair<std::string, std::string>>;
-        using Macros = std::vector<std::string>;
         using OptLevel = tt::tt_metal::KernelBuildOptLevel;
 
         IncludePaths include_paths;         // -I <path>
         Defines defines;                    // -D <name>=<value>
-        Macros macros;                      // -M <macro>
         OptLevel opt_level = OptLevel::O2;  // -O<level>
         // Can add more options here as needed
     };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -71,10 +72,12 @@ struct KernelSpec {
     // Kernel identifier: used to reference this kernel within the ProgramSpec
     KernelSpecName unique_id;
 
-    // Kernel source
-    std::string source;
-    enum class SourceType { FILE_PATH, SOURCE_CODE };
-    SourceType source_type = SourceType::FILE_PATH;
+    // Kernel source: either a path to a source file, or the source code itself.
+    // (Wrapper types disambiguate the string-constructible variant alternatives, 
+    // ensuring compile-time enforcement.)
+    struct SourceFilePath { std::filesystem::path path; };
+    struct SourceCode     { std::string code; };
+    std::variant<SourceFilePath, SourceCode> source;
 
     // Target nodes
     // The logical coordinates for the set of device nodes on which the kernel will run

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -54,7 +54,13 @@ struct DataMovementConfiguration {
     std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
 };
 
-using KernelSpecID = uint32_t;
+
+// A name identifying a KernelSpec within a ProgramSpec.
+//
+// Convention: define names as `constexpr const char*` constants so cross-references
+// fail at compile time on typos:
+//   constexpr const char* READER_KERNEL = "reader";
+//   KernelSpec{.unique_id = READER_KERNEL, ...};
 using KernelSpecName = std::string;
 
 struct KernelSpec {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -17,8 +17,18 @@
 
 namespace tt::tt_metal::experimental::metal2_host_api {
 
-using WorkerSpecName = std::string;
+// A name identifying a ProgramSpec within a MeshWorkload.
+// (Not yet in use; relevant once the MeshWorkload factory API lands.)
+//
+// Convention: define names as `constexpr const char*` constants so cross-references
+// fail at compile time on typos:
+//   constexpr const char* MATMUL_PROGRAM = "matmul";
+//   ProgramSpec{.program_id = MATMUL_PROGRAM, ...};
 using ProgramSpecName = std::string;
+
+// A name identifying a WorkerSpec within a ProgramSpec.
+// Convention: define names as `constexpr const char*` constants (see above).
+using WorkerSpecName = std::string;
 
 //------------------------------------------------
 // ProgramSpec & WorkerSpec

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -14,6 +14,12 @@
 
 namespace tt::tt_metal::experimental::metal2_host_api {
 
+// A name identifying a SemaphoreSpec within a ProgramSpec.
+//
+// Convention: define names as `constexpr const char*` constants so cross-references
+// fail at compile time on typos:
+//   constexpr const char* DONE_FLAG = "done_flag";
+//   SemaphoreSpec{.unique_id = DONE_FLAG, ...};
 using SemaphoreSpecName = std::string;
 
 struct SemaphoreSpec {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -382,10 +382,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.compiler_options.include_paths.empty(),
             "KernelSpec '{}' specifies include_paths -- this feature is not yet implemented. (Coming soon!)",
             kernel.unique_id);
-        TT_FATAL(
-            kernel.compiler_options.macros.empty(),
-            "KernelSpec '{}' specifies macros -- this feature is not yet implemented.",
-            kernel.unique_id);
     }
 
     // Validate no per-node thread maps are used (not yet implemented)

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1083,10 +1083,14 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
 // ----------------------------------------------------------------------------
 
 KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
-    KernelSource::SourceType source_type = (kernel_spec.source_type == KernelSpec::SourceType::FILE_PATH)
-                                               ? KernelSource::SourceType::FILE_PATH
-                                               : KernelSource::SourceType::SOURCE_CODE;
-    return KernelSource(kernel_spec.source, source_type);
+    // Source file path
+    if (auto* p = std::get_if<KernelSpec::SourceFilePath>(&kernel_spec.source)) {
+        return KernelSource(p->path.string(), KernelSource::SourceType::FILE_PATH);
+    }
+    else { // Source code
+        const auto& c = std::get<KernelSpec::SourceCode>(kernel_spec.source);
+        return KernelSource(c.code, KernelSource::SourceType::SOURCE_CODE);
+    }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

1. Naming convention comments on the five *Name type aliases (full comment on four, abbreviated on WorkerSpecName given its proximity to ProgramSpecName)
2.  SourceType enum → tagged variant (SourceFilePath / SourceCode), with all 11 call sites in program_spec.cpp, test_helpers.hpp, and test_program_spec.cpp migrated
3. Removed Macros from CompilerOptions and its not-yet-implemented check in program_spec.cpp

4. **(TODO)** Make WorkerSpec optional. Make names based on node grid.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/claudes-api-feedback)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/claudes-api-feedback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/claudes-api-feedback)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/claudes-api-feedback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/claudes-api-feedback)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/claudes-api-feedback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/claudes-api-feedback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/claudes-api-feedback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/claudes-api-feedback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/claudes-api-feedback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/claudes-api-feedback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/claudes-api-feedback)