### PR TITLE
fix wh tests by inc kernel size space

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -8,7 +8,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
-from models.common.utility_functions import is_wormhole_b0
+from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
     reorder_tensor_chunks,
@@ -484,7 +484,11 @@ def run_ring_joint_sdpa(
     "device_params, all_gather_topology",
     [
         (
-            {"trace_region_size": 1000000, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            {
+                "trace_region_size": 1000000,
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
+            },
             ttnn.Topology.Linear,
         ),
     ],
@@ -851,11 +855,17 @@ def run_ring_joint_sdpa_perf(
     "device_params, all_gather_topology",
     [
         (
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
+            },
             ttnn.Topology.Linear,
         ),
         (
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
+            },
             ttnn.Topology.Ring,
         ),
     ],

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 from loguru import logger
 from transformers.cache_utils import DynamicCache
+from ttnn.device import is_blackhole
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
@@ -129,9 +130,11 @@ def run_mla_inference(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
         },
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
         },
     ],
     ids=["line", "ring"],


### PR DESCRIPTION
Fix WH T3K mla tests that fail due to kernel size overflow. 
Increase kernel size if not blackhole.

https://github.com/tenstorrent/tt-metal/actions/runs/24549598843 ✅
https://github.com/tenstorrent/tt-metal/actions/runs/24549590003 ✅

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-fix-wh-mla-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-fix-wh-mla-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-fix-wh-mla-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-fix-wh-mla-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-fix-wh-mla-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-fix-wh-mla-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-fix-wh-mla-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-fix-wh-mla-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-fix-wh-mla-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-fix-wh-mla-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-fix-wh-mla-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-fix-wh-mla-tests)