### PR TITLE
Migrate remaining conv-team kernels to Device 2.0 experimental API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/circular_buffer.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
@@ -17,27 +17,27 @@ void kernel_main() {
     constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
     constexpr auto src_args = TensorAccessorArgs<9>();
 
-    experimental::CircularBuffer cb_in0(cb_id_in0);
-
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     const auto s_in = TensorAccessor(src_args, src_addr);
+
+    experimental::Noc noc;
+    experimental::CB cb_in0(cb_id_in0);
 
     uint32_t src_index = get_arg_val<uint32_t>(1);
     uint32_t curr_src_row_index = get_arg_val<uint32_t>(2);
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         uint32_t curr_src_offset = src_index;
         cb_in0.reserve_back(1);
-        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+        uint32_t l1_offset = 0;
         for (uint32_t i = 0; i < stride_h; i++) {
             for (uint32_t j = 0; j < stride_w; j++) {
-                uint64_t src_noc_addr = get_noc_addr(curr_src_offset, s_in);
-                noc_async_read(src_noc_addr, l1_write_addr, stick_nbytes);
+                noc.async_read(s_in, cb_in0, stick_nbytes, {.page_id = curr_src_offset}, {.offset_bytes = l1_offset});
                 curr_src_offset++;
-                l1_write_addr += aligned_stick_nbytes_dram;
+                l1_offset += aligned_stick_nbytes_dram;
             }
             curr_src_offset += input_width - stride_w;
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
         cb_in0.push_back(1);
 
         curr_src_row_index += stride_w;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp
@@ -5,10 +5,8 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/circular_buffer.h"
-#include "experimental/noc.h"
-#include "experimental/tensor.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     constexpr uint32_t tiles_per_channel_dim = get_compile_time_arg_val(0);
@@ -21,12 +19,12 @@ void kernel_main() {
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
-    experimental::CircularBuffer cb_in0(cb_id_in0);
-    experimental::Noc noc;
-
     // Initialize interleaved address generator for DRAM access
     constexpr auto src_args = TensorAccessorArgs<3>();
     const auto s = TensorAccessor(src_args, src_addr);
+
+    experimental::Noc noc;
+    experimental::CB cb_in0(cb_id_in0);
 
     // Process each block of data
     uint32_t end_block_id = start_block_id + num_blocks;
@@ -34,13 +32,14 @@ void kernel_main() {
         // Reserve space in the circular buffer for a row of tiles
         for (uint32_t j = 0; j < tiles_per_width_dim; ++j) {
             cb_in0.reserve_back(tiles_per_channel_dim);
+            uint32_t l1_offset = 0;
 
             // Read each tile in the current row
             for (uint32_t k = 0; k < tiles_per_channel_dim; ++k) {
                 // Calculate tile index and read from DRAM to L1
                 uint32_t tile_index = tiles_per_width_dim * tiles_per_channel_dim * i + tiles_per_channel_dim * j + k;
-                noc.async_read<experimental::Noc::TxnIdMode::DISABLED, tile_bytes>(
-                    s, cb_in0, tile_bytes, {.page_id = tile_index}, {.offset_bytes = k * tile_bytes});
+                noc.async_read(s, cb_in0, tile_bytes, {.page_id = tile_index}, {.offset_bytes = l1_offset});
+                l1_offset += tile_bytes;
             }
 
             noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -5,8 +5,8 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/circular_buffer.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 using namespace tt::data_movement::common;
 void kernel_main() {
@@ -21,13 +21,15 @@ void kernel_main() {
     constexpr bool is_l1_aligned = get_compile_time_arg_val(8);
     constexpr auto dst_args = TensorAccessorArgs<9>();
 
-    experimental::CircularBuffer cb_in0(cb_id_in0);
-    experimental::CircularBuffer cb_in1(cb_id_in1);
-
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     constexpr uint32_t patch_size = stride_h * stride_w;
     const auto s_out = TensorAccessor(dst_args, dst_addr);
     uint32_t dst_index = get_arg_val<uint32_t>(1);
+
+    experimental::Noc noc;
+    experimental::CB cb_in0(cb_id_in0);
+    experimental::CB cb_in1(cb_id_in1);
+
     uint32_t intermed_l1_scratch = cb_in1.get_write_ptr();
     // Datatypes will be multiple of 2 bytes only so it is safe to use uint16_t pointer
     volatile tt_l1_ptr uint16_t* patch_data = (volatile uint16_t*)intermed_l1_scratch;
@@ -43,14 +45,23 @@ void kernel_main() {
                 l1_addr += aligned_stick_nbytes_dram;
             }
         }
-        uint64_t dst_noc_addr = get_noc_addr(dst_index, s_out);
         if constexpr (!is_l1_aligned) {
-            noc_async_write((uint32_t)patch_data, dst_noc_addr, stick_nbytes * patch_size);
+            noc.async_write(
+                experimental::CoreLocalMem<uint32_t>(intermed_l1_scratch),
+                s_out,
+                stick_nbytes * patch_size,
+                {},
+                {.page_id = dst_index});
         } else {
             // If L1 aligned, write directly from the circular buffer
-            noc_async_write(l1_addr, dst_noc_addr, stick_nbytes * patch_size);
+            noc.async_write(
+                experimental::CoreLocalMem<uint32_t>(l1_addr),
+                s_out,
+                stick_nbytes * patch_size,
+                {},
+                {.page_id = dst_index});
         }
-        noc_async_write_barrier();
+        noc.async_write_barrier();
         cb_in0.pop_front(1);
         dst_index++;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp
@@ -46,20 +46,16 @@ void kernel_main() {
             }
         }
         if constexpr (!is_l1_aligned) {
+            // Scratch buffer (cb_in1) is populated at its WRITE_PTR; no push_back has advanced it yet.
             noc.async_write(
-                experimental::CoreLocalMem<uint32_t>(intermed_l1_scratch),
+                experimental::use<experimental::CB::AddrSelector::WRITE_PTR>(cb_in1),
                 s_out,
                 stick_nbytes * patch_size,
                 {},
                 {.page_id = dst_index});
         } else {
             // If L1 aligned, write directly from the circular buffer
-            noc.async_write(
-                experimental::CoreLocalMem<uint32_t>(l1_addr),
-                s_out,
-                stick_nbytes * patch_size,
-                {},
-                {.page_id = dst_index});
+            noc.async_write(cb_in0, s_out, stick_nbytes * patch_size, {}, {.page_id = dst_index});
         }
         noc.async_write_barrier();
         cb_in0.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -4,9 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/circular_buffer.h"
 #include "tt-metalium/constants.hpp"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     constexpr uint32_t input_width = get_compile_time_arg_val(0);            // Width of input tensor
@@ -20,8 +20,6 @@ void kernel_main() {
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(8);            // Input circular buffer ID
     constexpr auto dst_args = TensorAccessorArgs<9>();
 
-    experimental::CircularBuffer input_cb(input_cb_id);
-
     // Runtime arguments - Processing parameters
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);        // Base destination address in DRAM
     const uint32_t start_block_id = get_arg_val<uint32_t>(1);  // Starting block ID for processing
@@ -34,6 +32,9 @@ void kernel_main() {
     constexpr uint32_t patch_size = stride_height * stride_width;  // Total elements per patch
     // Initialize DRAM address generator for interleaved memory access
     const auto dst = TensorAccessor(dst_args, dst_addr);
+
+    experimental::Noc noc;
+    experimental::CB input_cb(input_cb_id);
 
     // Processing loop bounds and state variables
     const uint32_t end_block_id = start_block_id + num_blocks;
@@ -56,8 +57,12 @@ void kernel_main() {
                 (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
 
             for (uint32_t stick_idx = 0; stick_idx < width_limit; stick_idx++) {
-                const uint64_t dst_noc_addr = get_noc_addr(output_stick_idx, dst);
-                noc_async_write(l1_read_addr, dst_noc_addr, stick_nbytes);
+                noc.async_write(
+                    experimental::CoreLocalMem<uint32_t>(l1_read_addr),
+                    dst,
+                    stick_nbytes,
+                    {},
+                    {.page_id = output_stick_idx});
 
                 // Update pointers and indices
                 l1_read_addr += aligned_stick_nbytes;
@@ -75,7 +80,7 @@ void kernel_main() {
             remaining_width -= tt::constants::TILE_HEIGHT;
 
             // Ensure all writes complete before moving to next set of tiles_per_channel_dim tiles
-            noc_async_write_barrier();
+            noc.async_write_barrier();
             input_cb.pop_front(tiles_per_channel_dim);
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp
@@ -51,21 +51,17 @@ void kernel_main() {
         // Process each tile in the width dimension
         for (uint32_t tile_idx = 0; tile_idx < tiles_per_width_dim; tile_idx++) {
             input_cb.wait_front(tiles_per_channel_dim);
-            uint32_t l1_read_addr = input_cb.get_read_ptr();
+            auto src = experimental::use<experimental::CB::AddrSelector::WRITE_PTR>(input_cb);
+            uint32_t src_offset = 0;
 
             const uint32_t width_limit =
                 (remaining_width < tt::constants::TILE_HEIGHT) ? remaining_width : tt::constants::TILE_HEIGHT;
 
             for (uint32_t stick_idx = 0; stick_idx < width_limit; stick_idx++) {
-                noc.async_write(
-                    experimental::CoreLocalMem<uint32_t>(l1_read_addr),
-                    dst,
-                    stick_nbytes,
-                    {},
-                    {.page_id = output_stick_idx});
+                noc.async_write(src, dst, stick_nbytes, {.offset_bytes = src_offset}, {.page_id = output_stick_idx});
 
                 // Update pointers and indices
-                l1_read_addr += aligned_stick_nbytes;
+                src_offset += aligned_stick_nbytes;
                 output_stick_idx++;
                 stride_width_idx++;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
@@ -4,7 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/circular_buffer.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     constexpr uint32_t src_cb = get_compile_time_arg_val(0);
@@ -22,9 +22,6 @@ void kernel_main() {
     constexpr uint32_t element_size = get_compile_time_arg_val(12);
     constexpr uint32_t is_reader = get_compile_time_arg_val(13);
 
-    experimental::CircularBuffer cb_src(src_cb);
-    experimental::CircularBuffer cb_dst(dst_cb);
-
     constexpr uint32_t dst_row_size = num_dst_cols * aligned_dst_pixel_size;
     constexpr uint32_t cols_per_core = num_dst_cols / 2;
     constexpr uint32_t process_cols = cols_per_core + ((num_dst_cols % 2) & is_reader);
@@ -35,17 +32,20 @@ void kernel_main() {
     constexpr uint32_t elements_per_pixel = pixel_size / element_size;
     constexpr uint32_t elements_per_aligned_pixel = aligned_pixel_size / element_size;
 
-    uint64_t src_noc_addr = get_noc_addr(cb_src.get_read_ptr());
-    const uint32_t dst_addr_base = cb_dst.get_write_ptr();
-    uint32_t src_addr_base = cb_src.get_read_ptr();
+    experimental::Noc noc;
+    experimental::CB src_cb_obj(src_cb);
+    experimental::CB dst_cb_obj(dst_cb);
+
+    const uint32_t dst_addr_base = dst_cb_obj.get_write_ptr();
+    uint32_t src_addr_base = src_cb_obj.get_read_ptr();
 
     if constexpr (is_aligned) {
-        noc_async_read_one_packet_set_state(src_noc_addr, aligned_chunk_size);
+        experimental::set_read_state<aligned_chunk_size>(noc, src_addr_base);
     }
 
     // Process each destination row
     for (uint32_t row = 0; row < num_dst_rows; ++row) {
-        uint64_t src_col_offset = core_col_offset;
+        uint32_t src_col_offset = core_col_offset;
         uint32_t dst_addr = dst_addr_base + (row * dst_row_size) + core_dst_offset;
 
         // Process columns assigned to this core
@@ -56,8 +56,7 @@ void kernel_main() {
                 const uint32_t h_offset = h * aligned_row_size;
                 if constexpr (is_aligned) {
                     // Fast path: aligned NOC read
-                    noc_async_read_one_packet_with_state<true>(
-                        src_noc_addr + src_col_offset + h_offset, dst_pixel_addr);
+                    experimental::read_with_state(noc, dst_pixel_addr, src_addr_base + src_col_offset + h_offset);
                     dst_pixel_addr += aligned_chunk_size;
                 } else {
                     // Slow path: element-wise copy for unaligned data
@@ -82,9 +81,8 @@ void kernel_main() {
             dst_addr += aligned_dst_pixel_size * 2;
         }
         // Move to next row
-        src_noc_addr += dst_row_offset;
         src_addr_base += dst_row_offset;
     }
 
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/reader_convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/reader_convert_to_chw.cpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     const uint32_t total_tiles = get_arg_val<uint32_t>(0);
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
-    cb_push_back(cb_in, total_tiles);
+    experimental::CB cb(cb_in);
+    cb.push_back(total_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
 constexpr uint32_t TILE_SIZE = 32;
 constexpr uint32_t ELEMENT_SIZE_BYTES = 2;
 constexpr uint32_t STICK_SIZE = TILE_SIZE * ELEMENT_SIZE_BYTES;
@@ -18,42 +20,46 @@ void kernel_main() {
     constexpr uint32_t cb_out = get_compile_time_arg_val(1);
     constexpr uint32_t C = get_compile_time_arg_val(2);
 
-    cb_reserve_back(cb_out, 1);
-    const uint32_t base_l1_write_addr = get_write_ptr(cb_out);
-    noc_async_read_one_packet_set_state(get_noc_addr(get_read_ptr(cb_in_transpose)), STICK_SIZE);
+    experimental::Noc noc;
+    experimental::CB cb_transpose(cb_in_transpose);
+    experimental::CB cb_out_obj(cb_out);
+
+    cb_out_obj.reserve_back(1);
+    const uint32_t base_l1_write_addr = cb_out_obj.get_write_ptr();
+    experimental::set_read_state<STICK_SIZE>(noc, cb_transpose.get_read_ptr());
 
     const uint32_t channel_size = total_tiles * STICK_SIZE;
 
     int tile_index = 0;
     for (uint32_t i = 0; i < num_batches; i++) {
-        cb_wait_front(cb_in_transpose, BATCH_SIZE);
-        uint64_t l1_read_addr_tile = get_noc_addr(get_read_ptr(cb_in_transpose));
+        cb_transpose.wait_front(BATCH_SIZE);
+        uint32_t l1_read_addr_tile = cb_transpose.get_read_ptr();
         for (uint32_t b = 0; b < BATCH_SIZE; b++) {
-            uint64_t l1_read_addr = l1_read_addr_tile;
+            uint32_t l1_read_addr = l1_read_addr_tile;
             for (uint32_t j = 0; j < C; j++) {
                 const uint32_t l1_write_addr = base_l1_write_addr + (j * channel_size) + (tile_index * STICK_SIZE);
-                noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+                experimental::read_with_state(noc, l1_write_addr, l1_read_addr);
                 l1_read_addr += STICK_SIZE;
             }
             tile_index++;
             l1_read_addr_tile += in_transpose_tile_size;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_in_transpose, BATCH_SIZE);
+        noc.async_read_barrier();
+        cb_transpose.pop_front(BATCH_SIZE);
     }
 
     for (uint32_t i = 0; i < leftover; i++) {
-        cb_wait_front(cb_in_transpose, 1);
-        uint64_t l1_read_addr = get_noc_addr(get_read_ptr(cb_in_transpose));
+        cb_transpose.wait_front(1);
+        uint32_t l1_read_addr = cb_transpose.get_read_ptr();
         for (uint32_t j = 0; j < C; j++) {
             const uint32_t l1_write_addr = base_l1_write_addr + (j * channel_size) + (tile_index * STICK_SIZE);
-            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+            experimental::read_with_state(noc, l1_write_addr, l1_read_addr);
             l1_read_addr += STICK_SIZE;
         }
         tile_index++;
-        noc_async_read_barrier();
-        cb_pop_front(cb_in_transpose, 1);
+        noc.async_read_barrier();
+        cb_transpose.pop_front(1);
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_out, 1);
+    noc.async_read_barrier();
+    cb_out_obj.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
@@ -3,19 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 constexpr uint32_t TILE_SIZE = 32;
 
 template <uint32_t StickSize, uint32_t PaddedStickSize, uint32_t NumSticks>
-FORCE_INLINE void copy_padded_sticks(uint32_t l1_read_addr, uint32_t& l1_write_addr) {
-    noc_async_read_one_packet_set_state(get_noc_addr(l1_read_addr), StickSize);
+FORCE_INLINE void copy_padded_sticks(experimental::Noc noc, uint32_t l1_read_addr, uint32_t& l1_write_addr) {
+    experimental::set_read_state<StickSize>(noc, l1_read_addr);
     for (uint32_t row = 0; row < NumSticks; row++) {
-        noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+        experimental::read_with_state(noc, l1_write_addr, l1_read_addr);
         l1_read_addr += PaddedStickSize;
         l1_write_addr += StickSize;
     }
 }
-
 
 void kernel_main() {
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
@@ -45,13 +45,19 @@ void kernel_main() {
     constexpr uint32_t tile_size_stick_bytes = TILE_SIZE * element_size_bytes;
     constexpr uint32_t initial_l1_write_addr_offset = initial_l1_write_stick_offset * channel_size;
 
-    const uint32_t base_l1_write_addr = get_write_ptr(cb_out) + initial_l1_write_addr_offset;
+    experimental::Noc noc;
+    experimental::CB cb_in_obj(cb_in);
+    experimental::CB cb_in_batch_obj(cb_in_batch);
+    experimental::CB cb_in_transpose_obj(cb_in_transpose);
+    experimental::CB cb_out_obj(cb_out);
+
+    const uint32_t base_l1_write_addr = cb_out_obj.get_write_ptr() + initial_l1_write_addr_offset;
     uint32_t l1_output_write_addr = base_l1_write_addr;
 
     // Process each blocked transfer group
     for (uint32_t block_id = 0; block_id < num_blocks && block_id < input_num_blocks; block_id++) {
         if constexpr (is_reader) {
-            cb_reserve_back(cb_in_batch, input_block_size_sticks_per_core);
+            cb_in_batch_obj.reserve_back(input_block_size_sticks_per_core);
 
             // Process all transfers in this group
             const uint32_t group_size = args[args_idx++];
@@ -68,26 +74,26 @@ void kernel_main() {
                     // For DRAM, use bank_id to compute NOC address from bank_id
                     src_addr_base = get_noc_addr_from_bank_id<true>(bank_id, dram_base_read_addr);
                 } else {
-                    src_addr_base = get_noc_addr(src_x, src_y, get_read_ptr(cb_in));
+                    src_addr_base = get_noc_addr(src_x, src_y, cb_in_obj.get_read_ptr());
                 }
 
                 // dst_offset_bytes is already relative to block buffer start (includes channel * block_size + column)
-                const uint32_t dst_addr = get_write_ptr(cb_in_batch) + dst_offset_bytes;
+                const uint32_t dst_addr = cb_in_batch_obj.get_write_ptr() + dst_offset_bytes;
                 noc_async_read(src_addr_base + src_offset_bytes, dst_addr, transfer_size_bytes);
             }
 
-            noc_async_read_barrier();
-            cb_push_back(cb_in_batch, input_block_size_sticks_per_core);
+            noc.async_read_barrier();
+            cb_in_batch_obj.push_back(input_block_size_sticks_per_core);
         }
 
         for (uint32_t i = 0; i < num_full_tiles; i++) {
-            cb_wait_front(cb_in_transpose, 1);
+            cb_in_transpose_obj.wait_front(1);
 
-            const uint32_t l1_read_addr = get_read_ptr(cb_in_transpose);
+            const uint32_t l1_read_addr = cb_in_transpose_obj.get_read_ptr();
 
-            copy_padded_sticks<channel_size, tile_size_stick_bytes, TILE_SIZE>(l1_read_addr, l1_output_write_addr);
-            noc_async_read_barrier();
-            cb_pop_front(cb_in_transpose, 1);
+            copy_padded_sticks<channel_size, tile_size_stick_bytes, TILE_SIZE>(noc, l1_read_addr, l1_output_write_addr);
+            noc.async_read_barrier();
+            cb_in_transpose_obj.pop_front(1);
 
             // Stride by a number of sticks when splitting writers across cores
             l1_output_write_addr += l1_write_output_addr_stride;

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
@@ -69,17 +69,23 @@ void kernel_main() {
                 uint32_t transfer_size_bytes = args[args_idx++];
                 uint32_t bank_id = args[args_idx++];
 
-                uint64_t src_addr_base = 0;
-                if constexpr (is_input_in_dram) {
-                    // For DRAM, use bank_id to compute NOC address from bank_id
-                    src_addr_base = get_noc_addr_from_bank_id<true>(bank_id, dram_base_read_addr);
-                } else {
-                    src_addr_base = get_noc_addr(src_x, src_y, cb_in_obj.get_read_ptr());
-                }
-
                 // dst_offset_bytes is already relative to block buffer start (includes channel * block_size + column)
-                const uint32_t dst_addr = cb_in_batch_obj.get_write_ptr() + dst_offset_bytes;
-                noc_async_read(src_addr_base + src_offset_bytes, dst_addr, transfer_size_bytes);
+                if constexpr (is_input_in_dram) {
+                    // DRAM bank-id path stays on legacy noc_async_read: get_noc_addr_from_bank_id returns a packed
+                    // uint64_t NOC address, and experimental::Noc::async_read does not expose a clean way to
+                    // decompose it back into UnicastEndpoint {noc_x, noc_y, addr} fields.
+                    const uint64_t src_addr_base = get_noc_addr_from_bank_id<true>(bank_id, dram_base_read_addr);
+                    const uint32_t dst_addr = cb_in_batch_obj.get_write_ptr() + dst_offset_bytes;
+                    noc_async_read(src_addr_base + src_offset_bytes, dst_addr, transfer_size_bytes);
+                } else {
+                    experimental::UnicastEndpoint src_ep;
+                    noc.async_read(
+                        src_ep,
+                        cb_in_batch_obj,
+                        transfer_size_bytes,
+                        {.noc_x = src_x, .noc_y = src_y, .addr = cb_in_obj.get_read_ptr() + src_offset_bytes},
+                        {.offset_bytes = dst_offset_bytes});
+                }
             }
 
             noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -7,6 +7,7 @@
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // Pre-zero CB pages via NOC DMA from MEM_ZEROS so tile-alignment padding is zero.
+// Uses MEM_ZEROS_SIZE-aligned transactions (same pattern as zero_out_tiles in conv_reader_common.hpp).
 // padded_page_bytes must be a multiple of 16 to guarantee remainder alignment.
 template <uint32_t padded_page_bytes, typename Dst>
 FORCE_INLINE void pre_zero_pages(experimental::Noc noc, const Dst& dst, uint32_t offset, uint32_t num_pages) {
@@ -27,6 +28,7 @@ FORCE_INLINE void pre_zero_pages(experimental::Noc noc, const Dst& dst, uint32_t
 }
 
 inline int32_t clampIndex(int32_t idx, int32_t lower_bound, int32_t upper_bound) {
+    // If we're doing replicate padding, clamp idx into [lower_bound, upper_bound].
     if (idx < lower_bound) {
         return lower_bound;
     }
@@ -38,6 +40,7 @@ inline int32_t clampIndex(int32_t idx, int32_t lower_bound, int32_t upper_bound)
 
 template <uint32_t in_row_size_bytes, typename Dst>
 inline void zeroPad(experimental::Noc noc, const Dst& dst, uint32_t offset) {
+    // Zero-fill from MEM_ZEROS
     constexpr uint32_t num_full_reads = in_row_size_bytes / MEM_ZEROS_SIZE;
     constexpr uint32_t partial_read_size = in_row_size_bytes % MEM_ZEROS_SIZE;
 
@@ -66,6 +69,7 @@ FORCE_INLINE void read_input_row(
     if constexpr (Reader::DSpec::tensor_shape_static) {
         if constexpr ((reader.dspec().rank() > 1) && (reader.dspec().tensor_shape()[1] > 1)) {
             // Width/block sharded RowMajor tensors may split a logical row across multiple pages.
+            // Height-sharded inputs keep a single page per row and should use the direct path below.
             constexpr uint32_t width_in_pages = reader.dspec().tensor_shape()[1];
             const uint32_t col_page_idx = c_in_offset_bytes / in_row_size_bytes;
             const uint32_t in_offset_bytes = c_in_offset_bytes - (col_page_idx * in_row_size_bytes);
@@ -89,6 +93,8 @@ FORCE_INLINE void read_input_row(
         {.offset_bytes = dst_offset});
 }
 
+// Manages chunked CB writes: reserves TILE_HEIGHT pages, tracks patches written,
+// pushes when full, and flushes remaining at the end of a block.
 template <uint32_t cb_id, uint32_t padded_page_bytes, uint32_t patch_pad_bytes>
 struct ChunkWriter {
     static constexpr uint32_t chunk_max = 32;  // TILE_HEIGHT

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -4,29 +4,33 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 // Pre-zero CB pages via NOC DMA from MEM_ZEROS so tile-alignment padding is zero.
-// Uses MEM_ZEROS_SIZE-aligned transactions (same pattern as zero_out_tiles in conv_reader_common.hpp).
 // padded_page_bytes must be a multiple of 16 to guarantee remainder alignment.
 template <uint32_t padded_page_bytes>
-FORCE_INLINE void pre_zero_pages(uint32_t write_addr, uint32_t num_pages) {
+FORCE_INLINE void pre_zero_pages(experimental::Noc noc, uint32_t write_addr, uint32_t num_pages) {
     static_assert(padded_page_bytes % 16 == 0, "CB page size must be 16-byte aligned for NOC transactions");
-    const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     uint32_t total = num_pages * padded_page_bytes;
-    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    experimental::set_read_state<MEM_ZEROS_SIZE>(noc, MEM_ZEROS_BASE);
     while (total >= MEM_ZEROS_SIZE) {
-        noc_async_read_one_packet_with_state<true>(zeros_noc_addr, write_addr);
+        experimental::read_with_state(noc, write_addr, MEM_ZEROS_BASE);
         write_addr += MEM_ZEROS_SIZE;
         total -= MEM_ZEROS_SIZE;
     }
     if (total > 0) {
-        noc_async_read(zeros_noc_addr, write_addr, total);
+        experimental::UnicastEndpoint self_ep;
+        noc.async_read(
+            self_ep,
+            experimental::CoreLocalMem<uint32_t>(write_addr),
+            total,
+            experimental::local_addr(MEM_ZEROS_BASE, noc.get_noc_id()),
+            {});
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
 inline int32_t clampIndex(int32_t idx, int32_t lower_bound, int32_t upper_bound) {
-    // If we're doing replicate padding, clamp idx into [lower_bound, upper_bound].
     if (idx < lower_bound) {
         return lower_bound;
     }
@@ -37,82 +41,98 @@ inline int32_t clampIndex(int32_t idx, int32_t lower_bound, int32_t upper_bound)
 }
 
 template <uint32_t in_row_size_bytes>
-inline void zeroPad(uint32_t cb_write_addr) {
-    // Zero-fill from MEM_ZEROS
+inline void zeroPad(experimental::Noc noc, uint32_t cb_write_addr) {
     constexpr uint32_t num_full_reads = in_row_size_bytes / MEM_ZEROS_SIZE;
     constexpr uint32_t partial_read_size = in_row_size_bytes % MEM_ZEROS_SIZE;
-    const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+
+    experimental::UnicastEndpoint self_ep;
+    const auto zeros_src = experimental::local_addr(MEM_ZEROS_BASE, noc.get_noc_id());
 
     for (uint32_t i = 0; i < num_full_reads; ++i) {
-        noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
+        noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(cb_write_addr), MEM_ZEROS_SIZE, zeros_src, {});
         cb_write_addr += MEM_ZEROS_SIZE;
     }
     if (partial_read_size > 0) {
-        noc_async_read(zeros_noc_addr, cb_write_addr, partial_read_size);
+        noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(cb_write_addr), partial_read_size, zeros_src, {});
     }
 }
 
 template <typename Reader>
-FORCE_INLINE uint64_t
-get_input_noc_addr(const Reader& reader, uint32_t in_page_idx, uint32_t c_in_offset_bytes, uint32_t in_row_size_bytes) {
+FORCE_INLINE void read_input_row(
+    experimental::Noc noc,
+    const Reader& reader,
+    uint32_t page_idx,
+    uint32_t c_in_offset_bytes,
+    uint32_t in_row_size_bytes,
+    uint32_t dst_addr,
+    uint32_t size_bytes) {
     if constexpr (Reader::DSpec::tensor_shape_static) {
         if constexpr ((reader.dspec().rank() > 1) && (reader.dspec().tensor_shape()[1] > 1)) {
             // Width/block sharded RowMajor tensors may split a logical row across multiple pages.
-            // Height-sharded inputs keep a single page per row and should use the direct path below.
             constexpr uint32_t width_in_pages = reader.dspec().tensor_shape()[1];
             const uint32_t col_page_idx = c_in_offset_bytes / in_row_size_bytes;
             const uint32_t in_offset_bytes = c_in_offset_bytes - (col_page_idx * in_row_size_bytes);
             ASSERT(col_page_idx < width_in_pages);
-
-            const uint32_t in_page_id = in_page_idx * width_in_pages + col_page_idx;
-            return reader.get_noc_addr(in_page_id, in_offset_bytes);
+            const uint32_t in_page_id = page_idx * width_in_pages + col_page_idx;
+            noc.async_read(
+                reader,
+                experimental::CoreLocalMem<uint32_t>(dst_addr),
+                size_bytes,
+                {.page_id = in_page_id, .offset_bytes = in_offset_bytes},
+                {});
+            return;
         }
     }
 
-    return reader.get_noc_addr(in_page_idx, c_in_offset_bytes);
+    noc.async_read(
+        reader,
+        experimental::CoreLocalMem<uint32_t>(dst_addr),
+        size_bytes,
+        {.page_id = page_idx, .offset_bytes = c_in_offset_bytes},
+        {});
 }
 
-// Manages chunked CB writes: reserves TILE_HEIGHT pages, tracks patches written,
-// pushes when full, and flushes remaining at the end of a block.
 template <uint32_t cb_id, uint32_t padded_page_bytes, uint32_t patch_pad_bytes>
 struct ChunkWriter {
-    static constexpr uint32_t chunk_max = 32;  // TILE_HEIGHT
+    static constexpr uint32_t chunk_max = 32;
     uint32_t remaining;
     uint32_t chunk_size;
     uint32_t in_chunk;
     uint32_t write_addr;
+    experimental::Noc noc;
+    experimental::CB cb;
+
+    ChunkWriter(experimental::Noc n) : noc(n), cb(cb_id) {}
 
     void init(uint32_t total_patches) {
         remaining = total_patches;
         in_chunk = 0;
         chunk_size = remaining < chunk_max ? remaining : chunk_max;
-        cb_reserve_back(cb_id, chunk_size);
-        write_addr = get_write_ptr(cb_id);
+        cb.reserve_back(chunk_size);
+        write_addr = cb.get_write_ptr();
         if constexpr (patch_pad_bytes > 0) {
-            pre_zero_pages<padded_page_bytes>(write_addr, chunk_size);
+            pre_zero_pages<padded_page_bytes>(noc, write_addr, chunk_size);
         }
     }
 
-    // Call after writing one patch to write_addr.
-    // Returns true when a chunk was pushed and a new one reserved — caller must restore NOC packet state.
     bool advance() {
         if constexpr (patch_pad_bytes > 0) {
             write_addr += patch_pad_bytes;
         }
         in_chunk++;
         if (in_chunk == chunk_size) {
-            noc_async_read_barrier();
-            cb_push_back(cb_id, chunk_size);
+            noc.async_read_barrier();
+            cb.push_back(chunk_size);
             remaining -= chunk_size;
             in_chunk = 0;
             if (remaining > 0) {
                 chunk_size = remaining < chunk_max ? remaining : chunk_max;
-                cb_reserve_back(cb_id, chunk_size);
-                write_addr = get_write_ptr(cb_id);
+                cb.reserve_back(chunk_size);
+                write_addr = cb.get_write_ptr();
                 if constexpr (patch_pad_bytes > 0) {
-                    pre_zero_pages<padded_page_bytes>(write_addr, chunk_size);
+                    pre_zero_pages<padded_page_bytes>(noc, write_addr, chunk_size);
                 }
-                return true;  // pushed and re-reserved — caller may need to restore NOC state
+                return true;
             }
         }
         return false;
@@ -121,23 +141,20 @@ struct ChunkWriter {
     void flush() {
         if (remaining > 0) {
             if (in_chunk > 0) {
-                noc_async_read_barrier();
-                cb_push_back(cb_id, chunk_size);
+                noc.async_read_barrier();
+                cb.push_back(chunk_size);
                 remaining -= chunk_size;
             }
             while (remaining > 0) {
                 const uint32_t cur = remaining < chunk_max ? remaining : chunk_max;
-                cb_reserve_back(cb_id, cur);
-                cb_push_back(cb_id, cur);
+                cb.reserve_back(cur);
+                cb.push_back(cur);
                 remaining -= cur;
             }
         }
     }
 };
 
-// Copy one (t, h) row of patches from the L1 shard into the vol2col CB.
-// Iterates over w positions in [w_block, w_block_end), extracting kT×kH×kW patches
-// via one_packet NOC reads.  Calls chunk.advance() after each patch.
 template <
     uint32_t kT,
     uint32_t kH,
@@ -150,15 +167,15 @@ template <
     uint32_t padded_page_bytes,
     uint32_t patch_pad_bytes>
 void vol2col_shard_to_cb(
+    experimental::Noc noc,
     uint32_t shard_l1_base,
-    uint64_t shard_noc_base,
     uint32_t t_base,
     uint32_t h_base,
     uint32_t w_block,
     uint32_t w_block_end,
     ChunkWriter<cb_id, padded_page_bytes, patch_pad_bytes>& chunk) {
     constexpr uint32_t kW_bytes = kW * C_in_block_bytes;
-    noc_async_read_one_packet_set_state(shard_noc_base, kW_bytes);
+    experimental::set_read_state<kW_bytes>(noc, shard_l1_base);
     for (uint32_t w = w_block; w < w_block_end; w++) {
         const uint32_t w_base = (w - w_block) * stride_w;
         for (uint32_t kt = 0; kt < kT; kt++) {
@@ -167,41 +184,42 @@ void vol2col_shard_to_cb(
                 const uint32_t h_local = h_base + kh;
                 const uint32_t shard_offset =
                     (t_local * H_shard_max_W_shard_max + h_local * W_shard_max + w_base) * C_in_block_bytes;
-                noc_async_read_one_packet_with_state(shard_l1_base + shard_offset, chunk.write_addr);
+                experimental::read_with_state(noc, chunk.write_addr, shard_l1_base + shard_offset);
                 chunk.write_addr += kW_bytes;
             }
         }
         if (chunk.advance()) {
-            noc_async_read_one_packet_set_state(shard_noc_base, kW_bytes);
+            experimental::set_read_state<kW_bytes>(noc, shard_l1_base);
         }
     }
 }
 
-// Shift retained columns to the start of each shard row for sliding-window W reuse.
-// With stride_w, adjacent w_blocks overlap by max(0, kW - stride_w) columns, not kW-1.
-// After the shift, only (W_shard_cur - overlap) new columns need to be gathered from DRAM.
 template <
     uint32_t C_in_block_bytes,
     uint32_t H_shard_max_W_shard_max,
     uint32_t W_shard_max,
     uint32_t kW,
     uint32_t stride_w>
-void shift_retained_w_columns(uint32_t shard_l1_base, uint32_t T_shard_cur, uint32_t h_rows_gathered) {
+void shift_retained_w_columns(
+    experimental::Noc noc, uint32_t shard_l1_base, uint32_t T_shard_cur, uint32_t h_rows_gathered) {
     constexpr uint32_t overlap_w = kW > stride_w ? kW - stride_w : 0;
     constexpr uint32_t shift_bytes = overlap_w * C_in_block_bytes;
     constexpr uint32_t src_off = (W_shard_max - overlap_w) * C_in_block_bytes;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t t_local = 0; t_local < T_shard_cur; t_local++) {
         for (uint32_t h_local = 0; h_local < h_rows_gathered; h_local++) {
             const uint32_t row_base = (t_local * H_shard_max_W_shard_max + h_local * W_shard_max) * C_in_block_bytes;
-            noc_async_read(get_noc_addr(shard_l1_base + row_base + src_off), shard_l1_base + row_base, shift_bytes);
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(shard_l1_base + row_base),
+                shift_bytes,
+                experimental::local_addr(shard_l1_base + row_base + src_off, noc.get_noc_id()),
+                {});
         }
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
-// Gather rows from DRAM into the L1 shard buffer.
-// When check_padding=false, all positions are known to be in-bounds — skip per-position
-// boundary checks and clamp/zeroPad logic (~3-6 RISC-V cycles saved per position).
 template <
     uint32_t C_in_block_bytes,
     bool is_padding_zeros,
@@ -215,6 +233,7 @@ template <
     bool check_padding,
     typename Reader>
 void gather_rows_to_shard(
+    experimental::Noc noc,
     const Reader& in_reader,
     uint32_t shard_l1_base,
     uint32_t batch_page_base,
@@ -247,42 +266,46 @@ void gather_rows_to_shard(
                     const bool in_padding = t_outside || h_outside || w_outside;
                     if (in_padding) {
                         if constexpr (is_padding_zeros) {
-                            zeroPad<C_in_block_bytes>(shard_addr);
+                            zeroPad<C_in_block_bytes>(noc, shard_addr);
                         } else {
                             const int32_t w_clamped = clampIndex(w_in, 0, static_cast<int32_t>(W_in) - 1);
                             const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_clamped) * H_in_W_in +
                                                       static_cast<uint32_t>(h_clamped) * W_in +
                                                       static_cast<uint32_t>(w_clamped);
-                            noc_async_read(
-                                get_input_noc_addr(in_reader, page_idx, c_in_offset_bytes, in_row_size_bytes),
+                            read_input_row(
+                                noc,
+                                in_reader,
+                                page_idx,
+                                c_in_offset_bytes,
+                                in_row_size_bytes,
                                 shard_addr,
                                 C_in_block_bytes);
                         }
                     } else {
                         const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_in) * H_in_W_in +
                                                   static_cast<uint32_t>(h_in) * W_in + static_cast<uint32_t>(w_in);
-                        noc_async_read(
-                            get_input_noc_addr(in_reader, page_idx, c_in_offset_bytes, in_row_size_bytes),
+                        read_input_row(
+                            noc,
+                            in_reader,
+                            page_idx,
+                            c_in_offset_bytes,
+                            in_row_size_bytes,
                             shard_addr,
                             C_in_block_bytes);
                     }
                 } else {
-                    // Fast path: no padding checks
                     const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_in) * H_in_W_in +
                                               static_cast<uint32_t>(h_in) * W_in + static_cast<uint32_t>(w_in);
-                    noc_async_read(
-                        get_input_noc_addr(in_reader, page_idx, c_in_offset_bytes, in_row_size_bytes),
-                        shard_addr,
-                        C_in_block_bytes);
+                    read_input_row(
+                        noc, in_reader, page_idx, c_in_offset_bytes, in_row_size_bytes, shard_addr, C_in_block_bytes);
                 }
                 shard_offset += C_in_block_bytes;
             }
         }
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
-// Dispatch to fast or slow gather based on runtime bounds check.
 #define GATHER_ROWS(all_in_bounds, ...)  \
     do {                                 \
         if (all_in_bounds)               \
@@ -343,17 +366,14 @@ void kernel_main() {
     constexpr uint32_t dilation_t = get_compile_time_arg_val(28);
     constexpr uint32_t dilation_h = get_compile_time_arg_val(29);
     constexpr uint32_t dilation_w = get_compile_time_arg_val(30);
-    // L1 prefetch buffer parameters
     constexpr uint32_t cb_input_shard = get_compile_time_arg_val(31);
     constexpr uint32_t T_shard_max = get_compile_time_arg_val(32);
     constexpr uint32_t H_shard_max = get_compile_time_arg_val(33);
     constexpr uint32_t W_shard_max = get_compile_time_arg_val(34);
 
-    // Padding bytes to append after each patch row to reach tile-aligned CB page width
     constexpr uint32_t patch_pad_bytes = get_compile_time_arg_val(35);
     constexpr uint32_t padded_page_bytes = kT * kH * kW * C_in_block_bytes + patch_pad_bytes;
 
-    // Load input/output addresses and range parameters
     uint32_t argidx = 0;
     const uint32_t in_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t c_in_block_start = get_arg_val<uint32_t>(argidx++);
@@ -367,44 +387,37 @@ void kernel_main() {
     const uint32_t w_out_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
 
-    // Tensor accessor for input tensor
     constexpr auto in_args = TensorAccessorArgs<36>();
     const auto in_reader = TensorAccessor(in_args, in_addr);
+
+    experimental::Noc noc;
 
     constexpr uint32_t num_patches = T_block_size * H_block_size * W_block_size;
     constexpr uint32_t H_in_W_in = H_in * W_in;
     constexpr uint32_t T_in_H_in_W_in = T_in * H_in * W_in;
 
-    // L1 prefetch: enabled when the host allocated a shard buffer (T_shard_max > 0).
-    // The host decides based on kernel size, dilation, and L1 budget.
     constexpr bool use_l1_prefetch = (T_shard_max > 0);
     constexpr uint32_t H_shard_max_W_shard_max = H_shard_max * W_shard_max;
 
-    // Reserve shard buffer once (used as scratch space, not streaming CB)
     uint32_t shard_l1_base = 0;
-    uint64_t shard_noc_base = 0;
     if constexpr (use_l1_prefetch) {
         constexpr uint32_t shard_total = T_shard_max * H_shard_max_W_shard_max;
-        cb_reserve_back(cb_input_shard, shard_total);
-        shard_l1_base = get_write_ptr(cb_input_shard);
-        shard_noc_base = get_noc_addr(shard_l1_base);
+        experimental::CB cb_shard(cb_input_shard);
+        cb_shard.reserve_back(shard_total);
+        shard_l1_base = cb_shard.get_write_ptr();
     }
 
-    // Process each batch element
     for (uint32_t batch_idx = 0; batch_idx < N; batch_idx++) {
         const uint32_t batch_page_base = batch_idx * T_in_H_in_W_in;
         for (uint32_t c_in_block = c_in_block_start; c_in_block < c_in_block_end; c_in_block++) {
             const uint32_t c_in_offset_bytes = c_in_block * C_in_block_bytes;
-            // Iterate only over assigned C_out blocks
             for (uint32_t c_out_block = c_out_block_start; c_out_block < c_out_block_end; c_out_block++) {
-                // 3D blocking loops over assigned ranges:
                 for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_block_size) {
                     const uint32_t t_block_end = std::min(t_block + T_block_size, t_out_end);
 
                     for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_block_size) {
                         const uint32_t h_block_end = std::min(h_block + H_block_size, h_out_end);
 
-                        // H rows persist across w_blocks for sliding window W reuse.
                         uint32_t h_rows_gathered = 0;
                         const int32_t t_shard_start =
                             static_cast<int32_t>(t_block * stride_t) - static_cast<int32_t>(padding_t);
@@ -415,7 +428,6 @@ void kernel_main() {
                         constexpr uint32_t kW_bytes = kW * C_in_block_bytes;
                         static_assert(kW_bytes <= NOC_MAX_BURST_SIZE, "kW_bytes exceeds NOC_MAX_BURST_SIZE");
 
-                        // Precompute T/H bounds for shard_all_in_bounds (W is per-w_block).
                         const bool th_in_bounds =
                             t_shard_start >= 0 &&
                             (t_shard_start + static_cast<int32_t>(T_shard_cur) - 1) < static_cast<int32_t>(T_in) &&
@@ -432,17 +444,10 @@ void kernel_main() {
                                                                  (w_shard_start + static_cast<int32_t>(W_shard_cur) -
                                                                   1) < static_cast<int32_t>(W_in);
 
-                                // --- SLIDING WINDOW W + H-ROW INTERLEAVED GATHER ---
-                                // For w_block > first: shift retained kW-1 columns to shard start,
-                                // then gather only W_block new columns for existing h-rows.
-                                // H rows persist across w_blocks — no re-gather for retained rows.
                                 const bool is_first_w = (w_block == w_out_start);
 
-                                // W overlap between adjacent w_blocks: kW - stride_w columns.
-                                // No overlap when stride_w >= kW (each block reads entirely new data).
                                 constexpr uint32_t overlap_w = kW > stride_w ? kW - stride_w : 0;
 
-                                // Reset h_rows when no W overlap to retain or on first w_block
                                 if (is_first_w || overlap_w == 0) {
                                     h_rows_gathered = 0;
                                 }
@@ -453,12 +458,12 @@ void kernel_main() {
                                         H_shard_max_W_shard_max,
                                         W_shard_max,
                                         kW,
-                                        stride_w>(shard_l1_base, T_shard_cur, h_rows_gathered);
+                                        stride_w>(noc, shard_l1_base, T_shard_cur, h_rows_gathered);
 
-                                    // Gather new W columns for existing h-rows
                                     const uint32_t new_w_cols = W_shard_cur - overlap_w;
                                     GATHER_ROWS(
                                         shard_all_in_bounds,
+                                        noc,
                                         in_reader,
                                         shard_l1_base,
                                         batch_page_base,
@@ -473,7 +478,7 @@ void kernel_main() {
                                         new_w_cols);
                                 }
 
-                                ChunkWriter<cb_vol2col, padded_page_bytes, patch_pad_bytes> chunk;
+                                ChunkWriter<cb_vol2col, padded_page_bytes, patch_pad_bytes> chunk(noc);
                                 chunk.init(num_patches);
 
                                 for (uint32_t t = t_block; t < t_block_end; t++) {
@@ -481,11 +486,11 @@ void kernel_main() {
                                     for (uint32_t h = h_block; h < h_block_end; h++) {
                                         const uint32_t h_base = (h - h_block) * stride_h;
 
-                                        // Gather shard rows needed for this output h (incremental)
                                         const uint32_t h_needed = h_base + kH;
                                         if (h_needed > h_rows_gathered) {
                                             GATHER_ROWS(
                                                 shard_all_in_bounds,
+                                                noc,
                                                 in_reader,
                                                 shard_l1_base,
                                                 batch_page_base,
@@ -501,7 +506,6 @@ void kernel_main() {
                                             h_rows_gathered = h_needed;
                                         }
 
-                                        // Vol2col for this (t, h) across all w
                                         vol2col_shard_to_cb<
                                             kT,
                                             kH,
@@ -513,16 +517,12 @@ void kernel_main() {
                                             cb_vol2col,
                                             padded_page_bytes,
                                             patch_pad_bytes>(
-                                            shard_l1_base, shard_noc_base, t_base, h_base, w_block, w_block_end, chunk);
+                                            noc, shard_l1_base, t_base, h_base, w_block, w_block_end, chunk);
                                     }
                                 }
                                 chunk.flush();
 
                             } else {
-                                // ============================================================
-                                // DIRECT READER (for 1x1x1 or dilated kernels, no spatial reuse)
-                                // Push patches in TILE_HEIGHT-sized chunks to keep cb_vol2col small.
-                                // ============================================================
                                 const uint32_t t_block_s_start = t_block * stride_t;
                                 const uint32_t t_block_s_end = t_block_end * stride_t;
                                 const uint32_t h_block_s_start = h_block * stride_h;
@@ -530,7 +530,7 @@ void kernel_main() {
                                 const uint32_t w_block_s_start = w_block * stride_w;
                                 const uint32_t w_block_s_end = w_block_end * stride_w;
 
-                                ChunkWriter<cb_vol2col, padded_page_bytes, patch_pad_bytes> chunk;
+                                ChunkWriter<cb_vol2col, padded_page_bytes, patch_pad_bytes> chunk(noc);
                                 chunk.init(num_patches);
 
                                 for (uint32_t t = t_block_s_start; t < t_block_s_end; t += stride_t) {
@@ -560,7 +560,7 @@ void kernel_main() {
 
                                                         if constexpr (is_padding_zeros) {
                                                             if (in_padding) {
-                                                                zeroPad<C_in_block_bytes>(chunk.write_addr);
+                                                                zeroPad<C_in_block_bytes>(noc, chunk.write_addr);
                                                                 chunk.write_addr += C_in_block_bytes;
                                                                 continue;
                                                             }
@@ -570,9 +570,14 @@ void kernel_main() {
                                                             batch_page_base + static_cast<uint32_t>(t_idx) * H_in_W_in +
                                                             static_cast<uint32_t>(h_idx) * W_in +
                                                             static_cast<uint32_t>(w_idx);
-                                                        const uint64_t noc_addr = get_input_noc_addr(
-                                                            in_reader, page_idx, c_in_offset_bytes, in_row_size_bytes);
-                                                        noc_async_read(noc_addr, chunk.write_addr, C_in_block_bytes);
+                                                        read_input_row(
+                                                            noc,
+                                                            in_reader,
+                                                            page_idx,
+                                                            c_in_offset_bytes,
+                                                            in_row_size_bytes,
+                                                            chunk.write_addr,
+                                                            C_in_block_bytes);
                                                         chunk.write_addr += C_in_block_bytes;
                                                     }
                                                 }
@@ -584,11 +589,8 @@ void kernel_main() {
                                 }
                                 chunk.flush();
                             }
-                            // End of w_block
                         }
-                        // End of h_block
                     }
-                    // End of t_block
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -8,24 +8,20 @@
 
 // Pre-zero CB pages via NOC DMA from MEM_ZEROS so tile-alignment padding is zero.
 // padded_page_bytes must be a multiple of 16 to guarantee remainder alignment.
-template <uint32_t padded_page_bytes>
-FORCE_INLINE void pre_zero_pages(experimental::Noc noc, uint32_t write_addr, uint32_t num_pages) {
+template <uint32_t padded_page_bytes, typename Dst>
+FORCE_INLINE void pre_zero_pages(experimental::Noc noc, const Dst& dst, uint32_t offset, uint32_t num_pages) {
     static_assert(padded_page_bytes % 16 == 0, "CB page size must be 16-byte aligned for NOC transactions");
     uint32_t total = num_pages * padded_page_bytes;
     experimental::set_read_state<MEM_ZEROS_SIZE>(noc, MEM_ZEROS_BASE);
     while (total >= MEM_ZEROS_SIZE) {
-        experimental::read_with_state(noc, write_addr, MEM_ZEROS_BASE);
-        write_addr += MEM_ZEROS_SIZE;
+        experimental::read_with_state(noc, dst, MEM_ZEROS_BASE, {.offset_bytes = offset});
+        offset += MEM_ZEROS_SIZE;
         total -= MEM_ZEROS_SIZE;
     }
     if (total > 0) {
         experimental::UnicastEndpoint self_ep;
         noc.async_read(
-            self_ep,
-            experimental::CoreLocalMem<uint32_t>(write_addr),
-            total,
-            experimental::local_addr(MEM_ZEROS_BASE, noc.get_noc_id()),
-            {});
+            self_ep, dst, total, experimental::local_addr(MEM_ZEROS_BASE, noc.get_noc_id()), {.offset_bytes = offset});
     }
     noc.async_read_barrier();
 }
@@ -40,8 +36,8 @@ inline int32_t clampIndex(int32_t idx, int32_t lower_bound, int32_t upper_bound)
     return idx;
 }
 
-template <uint32_t in_row_size_bytes>
-inline void zeroPad(experimental::Noc noc, uint32_t cb_write_addr) {
+template <uint32_t in_row_size_bytes, typename Dst>
+inline void zeroPad(experimental::Noc noc, const Dst& dst, uint32_t offset) {
     constexpr uint32_t num_full_reads = in_row_size_bytes / MEM_ZEROS_SIZE;
     constexpr uint32_t partial_read_size = in_row_size_bytes % MEM_ZEROS_SIZE;
 
@@ -49,22 +45,23 @@ inline void zeroPad(experimental::Noc noc, uint32_t cb_write_addr) {
     const auto zeros_src = experimental::local_addr(MEM_ZEROS_BASE, noc.get_noc_id());
 
     for (uint32_t i = 0; i < num_full_reads; ++i) {
-        noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(cb_write_addr), MEM_ZEROS_SIZE, zeros_src, {});
-        cb_write_addr += MEM_ZEROS_SIZE;
+        noc.async_read(self_ep, dst, MEM_ZEROS_SIZE, zeros_src, {.offset_bytes = offset});
+        offset += MEM_ZEROS_SIZE;
     }
     if (partial_read_size > 0) {
-        noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(cb_write_addr), partial_read_size, zeros_src, {});
+        noc.async_read(self_ep, dst, partial_read_size, zeros_src, {.offset_bytes = offset});
     }
 }
 
-template <typename Reader>
+template <typename Reader, typename Dst>
 FORCE_INLINE void read_input_row(
     experimental::Noc noc,
     const Reader& reader,
     uint32_t page_idx,
     uint32_t c_in_offset_bytes,
     uint32_t in_row_size_bytes,
-    uint32_t dst_addr,
+    const Dst& dst,
+    uint32_t dst_offset,
     uint32_t size_bytes) {
     if constexpr (Reader::DSpec::tensor_shape_static) {
         if constexpr ((reader.dspec().rank() > 1) && (reader.dspec().tensor_shape()[1] > 1)) {
@@ -76,29 +73,29 @@ FORCE_INLINE void read_input_row(
             const uint32_t in_page_id = page_idx * width_in_pages + col_page_idx;
             noc.async_read(
                 reader,
-                experimental::CoreLocalMem<uint32_t>(dst_addr),
+                dst,
                 size_bytes,
                 {.page_id = in_page_id, .offset_bytes = in_offset_bytes},
-                {});
+                {.offset_bytes = dst_offset});
             return;
         }
     }
 
     noc.async_read(
         reader,
-        experimental::CoreLocalMem<uint32_t>(dst_addr),
+        dst,
         size_bytes,
         {.page_id = page_idx, .offset_bytes = c_in_offset_bytes},
-        {});
+        {.offset_bytes = dst_offset});
 }
 
 template <uint32_t cb_id, uint32_t padded_page_bytes, uint32_t patch_pad_bytes>
 struct ChunkWriter {
-    static constexpr uint32_t chunk_max = 32;
+    static constexpr uint32_t chunk_max = 32;  // TILE_HEIGHT
     uint32_t remaining;
     uint32_t chunk_size;
     uint32_t in_chunk;
-    uint32_t write_addr;
+    uint32_t write_offset;
     experimental::Noc noc;
     experimental::CB cb;
 
@@ -109,15 +106,17 @@ struct ChunkWriter {
         in_chunk = 0;
         chunk_size = remaining < chunk_max ? remaining : chunk_max;
         cb.reserve_back(chunk_size);
-        write_addr = cb.get_write_ptr();
+        write_offset = 0;
         if constexpr (patch_pad_bytes > 0) {
-            pre_zero_pages<padded_page_bytes>(noc, write_addr, chunk_size);
+            pre_zero_pages<padded_page_bytes>(noc, cb, 0, chunk_size);
         }
     }
 
+    // Call after writing one patch to write_offset.
+    // Returns true when a chunk was pushed and a new one reserved — caller must restore NOC packet state.
     bool advance() {
         if constexpr (patch_pad_bytes > 0) {
-            write_addr += patch_pad_bytes;
+            write_offset += patch_pad_bytes;
         }
         in_chunk++;
         if (in_chunk == chunk_size) {
@@ -128,11 +127,11 @@ struct ChunkWriter {
             if (remaining > 0) {
                 chunk_size = remaining < chunk_max ? remaining : chunk_max;
                 cb.reserve_back(chunk_size);
-                write_addr = cb.get_write_ptr();
+                write_offset = 0;
                 if constexpr (patch_pad_bytes > 0) {
-                    pre_zero_pages<padded_page_bytes>(noc, write_addr, chunk_size);
+                    pre_zero_pages<padded_page_bytes>(noc, cb, 0, chunk_size);
                 }
-                return true;
+                return true;  // pushed and re-reserved — caller may need to restore NOC state
             }
         }
         return false;
@@ -155,6 +154,9 @@ struct ChunkWriter {
     }
 };
 
+// Copy one (t, h) row of patches from the L1 shard into the vol2col CB.
+// Iterates over w positions in [w_block, w_block_end), extracting kT×kH×kW patches
+// via one_packet NOC reads.  Calls chunk.advance() after each patch.
 template <
     uint32_t kT,
     uint32_t kH,
@@ -184,8 +186,9 @@ void vol2col_shard_to_cb(
                 const uint32_t h_local = h_base + kh;
                 const uint32_t shard_offset =
                     (t_local * H_shard_max_W_shard_max + h_local * W_shard_max + w_base) * C_in_block_bytes;
-                experimental::read_with_state(noc, chunk.write_addr, shard_l1_base + shard_offset);
-                chunk.write_addr += kW_bytes;
+                experimental::read_with_state(
+                    noc, chunk.cb, shard_l1_base + shard_offset, {.offset_bytes = chunk.write_offset});
+                chunk.write_offset += kW_bytes;
             }
         }
         if (chunk.advance()) {
@@ -194,32 +197,40 @@ void vol2col_shard_to_cb(
     }
 }
 
+// Shift retained columns to the start of each shard row for sliding-window W reuse.
+// With stride_w, adjacent w_blocks overlap by max(0, kW - stride_w) columns, not kW-1.
+// After the shift, only (W_shard_cur - overlap) new columns need to be gathered from DRAM.
 template <
     uint32_t C_in_block_bytes,
     uint32_t H_shard_max_W_shard_max,
     uint32_t W_shard_max,
     uint32_t kW,
-    uint32_t stride_w>
+    uint32_t stride_w,
+    typename ShardCB>
 void shift_retained_w_columns(
-    experimental::Noc noc, uint32_t shard_l1_base, uint32_t T_shard_cur, uint32_t h_rows_gathered) {
+    experimental::Noc noc, const ShardCB& shard_cb, uint32_t T_shard_cur, uint32_t h_rows_gathered) {
     constexpr uint32_t overlap_w = kW > stride_w ? kW - stride_w : 0;
     constexpr uint32_t shift_bytes = overlap_w * C_in_block_bytes;
     constexpr uint32_t src_off = (W_shard_max - overlap_w) * C_in_block_bytes;
     experimental::UnicastEndpoint self_ep;
+    const uint32_t shard_l1_base = shard_cb.get_write_ptr();
     for (uint32_t t_local = 0; t_local < T_shard_cur; t_local++) {
         for (uint32_t h_local = 0; h_local < h_rows_gathered; h_local++) {
             const uint32_t row_base = (t_local * H_shard_max_W_shard_max + h_local * W_shard_max) * C_in_block_bytes;
             noc.async_read(
                 self_ep,
-                experimental::CoreLocalMem<uint32_t>(shard_l1_base + row_base),
+                shard_cb,
                 shift_bytes,
                 experimental::local_addr(shard_l1_base + row_base + src_off, noc.get_noc_id()),
-                {});
+                {.offset_bytes = row_base});
         }
     }
     noc.async_read_barrier();
 }
 
+// Gather rows from DRAM into the L1 shard buffer.
+// When check_padding=false, all positions are known to be in-bounds — skip per-position
+// boundary checks and clamp/zeroPad logic (~3-6 RISC-V cycles saved per position).
 template <
     uint32_t C_in_block_bytes,
     bool is_padding_zeros,
@@ -231,11 +242,12 @@ template <
     uint32_t H_in_W_in,
     uint32_t in_row_size_bytes,
     bool check_padding,
-    typename Reader>
+    typename Reader,
+    typename ShardCB>
 void gather_rows_to_shard(
     experimental::Noc noc,
     const Reader& in_reader,
-    uint32_t shard_l1_base,
+    const ShardCB& shard_cb,
     uint32_t batch_page_base,
     uint32_t c_in_offset_bytes,
     int32_t t_shard_start,
@@ -260,13 +272,12 @@ void gather_rows_to_shard(
                 (t_local * H_shard_max_W_shard_max + h_local * W_shard_max + w_col_start) * C_in_block_bytes;
             for (uint32_t w_idx = 0; w_idx < w_count; w_idx++) {
                 const int32_t w_in = w_shard_start + static_cast<int32_t>(w_col_start + w_idx);
-                const uint32_t shard_addr = shard_l1_base + shard_offset;
                 if constexpr (check_padding) {
                     const bool w_outside = (w_in < 0 || w_in >= static_cast<int32_t>(W_in));
                     const bool in_padding = t_outside || h_outside || w_outside;
                     if (in_padding) {
                         if constexpr (is_padding_zeros) {
-                            zeroPad<C_in_block_bytes>(noc, shard_addr);
+                            zeroPad<C_in_block_bytes>(noc, shard_cb, shard_offset);
                         } else {
                             const int32_t w_clamped = clampIndex(w_in, 0, static_cast<int32_t>(W_in) - 1);
                             const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_clamped) * H_in_W_in +
@@ -278,7 +289,8 @@ void gather_rows_to_shard(
                                 page_idx,
                                 c_in_offset_bytes,
                                 in_row_size_bytes,
-                                shard_addr,
+                                shard_cb,
+                                shard_offset,
                                 C_in_block_bytes);
                         }
                     } else {
@@ -290,14 +302,23 @@ void gather_rows_to_shard(
                             page_idx,
                             c_in_offset_bytes,
                             in_row_size_bytes,
-                            shard_addr,
+                            shard_cb,
+                            shard_offset,
                             C_in_block_bytes);
                     }
                 } else {
+                    // Fast path: no padding checks
                     const uint32_t page_idx = batch_page_base + static_cast<uint32_t>(t_in) * H_in_W_in +
                                               static_cast<uint32_t>(h_in) * W_in + static_cast<uint32_t>(w_in);
                     read_input_row(
-                        noc, in_reader, page_idx, c_in_offset_bytes, in_row_size_bytes, shard_addr, C_in_block_bytes);
+                        noc,
+                        in_reader,
+                        page_idx,
+                        c_in_offset_bytes,
+                        in_row_size_bytes,
+                        shard_cb,
+                        shard_offset,
+                        C_in_block_bytes);
                 }
                 shard_offset += C_in_block_bytes;
             }
@@ -306,6 +327,7 @@ void gather_rows_to_shard(
     noc.async_read_barrier();
 }
 
+// Dispatch to fast or slow gather based on runtime bounds check.
 #define GATHER_ROWS(all_in_bounds, ...)  \
     do {                                 \
         if (all_in_bounds)               \
@@ -366,14 +388,17 @@ void kernel_main() {
     constexpr uint32_t dilation_t = get_compile_time_arg_val(28);
     constexpr uint32_t dilation_h = get_compile_time_arg_val(29);
     constexpr uint32_t dilation_w = get_compile_time_arg_val(30);
+    // L1 prefetch buffer parameters
     constexpr uint32_t cb_input_shard = get_compile_time_arg_val(31);
     constexpr uint32_t T_shard_max = get_compile_time_arg_val(32);
     constexpr uint32_t H_shard_max = get_compile_time_arg_val(33);
     constexpr uint32_t W_shard_max = get_compile_time_arg_val(34);
 
+    // Padding bytes to append after each patch row to reach tile-aligned CB page width
     constexpr uint32_t patch_pad_bytes = get_compile_time_arg_val(35);
     constexpr uint32_t padded_page_bytes = kT * kH * kW * C_in_block_bytes + patch_pad_bytes;
 
+    // Load input/output addresses and range parameters
     uint32_t argidx = 0;
     const uint32_t in_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t c_in_block_start = get_arg_val<uint32_t>(argidx++);
@@ -387,6 +412,7 @@ void kernel_main() {
     const uint32_t w_out_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
 
+    // Tensor accessor for input tensor
     constexpr auto in_args = TensorAccessorArgs<36>();
     const auto in_reader = TensorAccessor(in_args, in_addr);
 
@@ -396,28 +422,35 @@ void kernel_main() {
     constexpr uint32_t H_in_W_in = H_in * W_in;
     constexpr uint32_t T_in_H_in_W_in = T_in * H_in * W_in;
 
+    // L1 prefetch: enabled when the host allocated a shard buffer (T_shard_max > 0).
+    // The host decides based on kernel size, dilation, and L1 budget.
     constexpr bool use_l1_prefetch = (T_shard_max > 0);
     constexpr uint32_t H_shard_max_W_shard_max = H_shard_max * W_shard_max;
 
+    // Reserve shard buffer once (used as scratch space, not streaming CB)
+    experimental::CB shard_cb(cb_input_shard);
     uint32_t shard_l1_base = 0;
     if constexpr (use_l1_prefetch) {
         constexpr uint32_t shard_total = T_shard_max * H_shard_max_W_shard_max;
-        experimental::CB cb_shard(cb_input_shard);
-        cb_shard.reserve_back(shard_total);
-        shard_l1_base = cb_shard.get_write_ptr();
+        shard_cb.reserve_back(shard_total);
+        shard_l1_base = shard_cb.get_write_ptr();
     }
 
+    // Process each batch element
     for (uint32_t batch_idx = 0; batch_idx < N; batch_idx++) {
         const uint32_t batch_page_base = batch_idx * T_in_H_in_W_in;
         for (uint32_t c_in_block = c_in_block_start; c_in_block < c_in_block_end; c_in_block++) {
             const uint32_t c_in_offset_bytes = c_in_block * C_in_block_bytes;
+            // Iterate only over assigned C_out blocks
             for (uint32_t c_out_block = c_out_block_start; c_out_block < c_out_block_end; c_out_block++) {
+                // 3D blocking loops over assigned ranges:
                 for (uint32_t t_block = t_out_start; t_block < t_out_end; t_block += T_block_size) {
                     const uint32_t t_block_end = std::min(t_block + T_block_size, t_out_end);
 
                     for (uint32_t h_block = h_out_start; h_block < h_out_end; h_block += H_block_size) {
                         const uint32_t h_block_end = std::min(h_block + H_block_size, h_out_end);
 
+                        // H rows persist across w_blocks for sliding window W reuse.
                         uint32_t h_rows_gathered = 0;
                         const int32_t t_shard_start =
                             static_cast<int32_t>(t_block * stride_t) - static_cast<int32_t>(padding_t);
@@ -428,6 +461,7 @@ void kernel_main() {
                         constexpr uint32_t kW_bytes = kW * C_in_block_bytes;
                         static_assert(kW_bytes <= NOC_MAX_BURST_SIZE, "kW_bytes exceeds NOC_MAX_BURST_SIZE");
 
+                        // Precompute T/H bounds for shard_all_in_bounds (W is per-w_block).
                         const bool th_in_bounds =
                             t_shard_start >= 0 &&
                             (t_shard_start + static_cast<int32_t>(T_shard_cur) - 1) < static_cast<int32_t>(T_in) &&
@@ -444,10 +478,17 @@ void kernel_main() {
                                                                  (w_shard_start + static_cast<int32_t>(W_shard_cur) -
                                                                   1) < static_cast<int32_t>(W_in);
 
+                                // --- SLIDING WINDOW W + H-ROW INTERLEAVED GATHER ---
+                                // For w_block > first: shift retained kW-1 columns to shard start,
+                                // then gather only W_block new columns for existing h-rows.
+                                // H rows persist across w_blocks — no re-gather for retained rows.
                                 const bool is_first_w = (w_block == w_out_start);
 
+                                // W overlap between adjacent w_blocks: kW - stride_w columns.
+                                // No overlap when stride_w >= kW (each block reads entirely new data).
                                 constexpr uint32_t overlap_w = kW > stride_w ? kW - stride_w : 0;
 
+                                // Reset h_rows when no W overlap to retain or on first w_block
                                 if (is_first_w || overlap_w == 0) {
                                     h_rows_gathered = 0;
                                 }
@@ -458,14 +499,15 @@ void kernel_main() {
                                         H_shard_max_W_shard_max,
                                         W_shard_max,
                                         kW,
-                                        stride_w>(noc, shard_l1_base, T_shard_cur, h_rows_gathered);
+                                        stride_w>(noc, shard_cb, T_shard_cur, h_rows_gathered);
 
+                                    // Gather new W columns for existing h-rows
                                     const uint32_t new_w_cols = W_shard_cur - overlap_w;
                                     GATHER_ROWS(
                                         shard_all_in_bounds,
                                         noc,
                                         in_reader,
-                                        shard_l1_base,
+                                        shard_cb,
                                         batch_page_base,
                                         c_in_offset_bytes,
                                         t_shard_start,
@@ -486,13 +528,14 @@ void kernel_main() {
                                     for (uint32_t h = h_block; h < h_block_end; h++) {
                                         const uint32_t h_base = (h - h_block) * stride_h;
 
+                                        // Gather shard rows needed for this output h (incremental)
                                         const uint32_t h_needed = h_base + kH;
                                         if (h_needed > h_rows_gathered) {
                                             GATHER_ROWS(
                                                 shard_all_in_bounds,
                                                 noc,
                                                 in_reader,
-                                                shard_l1_base,
+                                                shard_cb,
                                                 batch_page_base,
                                                 c_in_offset_bytes,
                                                 t_shard_start,
@@ -506,6 +549,7 @@ void kernel_main() {
                                             h_rows_gathered = h_needed;
                                         }
 
+                                        // Vol2col for this (t, h) across all w
                                         vol2col_shard_to_cb<
                                             kT,
                                             kH,
@@ -523,6 +567,10 @@ void kernel_main() {
                                 chunk.flush();
 
                             } else {
+                                // ============================================================
+                                // DIRECT READER (for 1x1x1 or dilated kernels, no spatial reuse)
+                                // Push patches in TILE_HEIGHT-sized chunks to keep cb_vol2col small.
+                                // ============================================================
                                 const uint32_t t_block_s_start = t_block * stride_t;
                                 const uint32_t t_block_s_end = t_block_end * stride_t;
                                 const uint32_t h_block_s_start = h_block * stride_h;
@@ -560,8 +608,9 @@ void kernel_main() {
 
                                                         if constexpr (is_padding_zeros) {
                                                             if (in_padding) {
-                                                                zeroPad<C_in_block_bytes>(noc, chunk.write_addr);
-                                                                chunk.write_addr += C_in_block_bytes;
+                                                                zeroPad<C_in_block_bytes>(
+                                                                    noc, chunk.cb, chunk.write_offset);
+                                                                chunk.write_offset += C_in_block_bytes;
                                                                 continue;
                                                             }
                                                         }
@@ -576,9 +625,10 @@ void kernel_main() {
                                                             page_idx,
                                                             c_in_offset_bytes,
                                                             in_row_size_bytes,
-                                                            chunk.write_addr,
+                                                            chunk.cb,
+                                                            chunk.write_offset,
                                                             C_in_block_bytes);
-                                                        chunk.write_addr += C_in_block_bytes;
+                                                        chunk.write_offset += C_in_block_bytes;
                                                     }
                                                 }
                                             }
@@ -589,8 +639,11 @@ void kernel_main() {
                                 }
                                 chunk.flush();
                             }
+                            // End of w_block
                         }
+                        // End of h_block
                     }
+                    // End of t_block
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
     constexpr uint32_t cb_matmul_result_rm = get_compile_time_arg_val(0);
@@ -25,9 +27,9 @@ void kernel_main() {
     constexpr uint32_t matmul_K_t = get_compile_time_arg_val(15);
     constexpr uint32_t matmul_N_t = get_compile_time_arg_val(16);
     constexpr uint32_t num_patches_tile_padded = get_compile_time_arg_val(17);
-    constexpr uint32_t C_out_block_bytes = get_compile_time_arg_val(19);  // padded to tile width
+    constexpr uint32_t C_out_block_bytes = get_compile_time_arg_val(19);
     constexpr bool use_bias = get_compile_time_arg_val(20) == 1;
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(21));
+    constexpr uint32_t semaphore_id = get_compile_time_arg_val(21);
     constexpr uint32_t cb_zero_tiled = get_compile_time_arg_val(22);
 
     uint32_t argidx = 0;
@@ -47,17 +49,22 @@ void kernel_main() {
     const uint32_t is_reducer = get_arg_val<uint32_t>(argidx++);
     const uint32_t num_workers = get_arg_val<uint32_t>(argidx++);
 
-    volatile tt_l1_ptr uint32_t* local_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+    experimental::Noc noc;
+    experimental::CB cb_out(cb_matmul_result_rm);
+    experimental::CB cb_weight(cb_weight_tiled);
+    experimental::CB cb_bias(cb_bias_tiled);
+    experimental::CB cb_interm(cb_matmul_interm_tiled);
+    experimental::CB cb_reduction(cb_reduction_tiled);
+    experimental::CB cb_ack(cb_worker_ack_back);
+    experimental::Semaphore<> sem(semaphore_id);
 
     // Reducer coordinates and worker core coordinates are only present when num_workers > 0
-    uint64_t reducer_semaphore_noc_addr = 0;
+    uint32_t reducer_core_x = 0, reducer_core_y = 0;
     tt_l1_ptr uint32_t* worker_core_xs = nullptr;
     tt_l1_ptr uint32_t* worker_core_ys = nullptr;
     if (num_workers > 0) {
-        const uint32_t reducer_core_x = get_arg_val<uint32_t>(argidx++);
-        const uint32_t reducer_core_y = get_arg_val<uint32_t>(argidx++);
-        reducer_semaphore_noc_addr = get_noc_addr(reducer_core_x, reducer_core_y, semaphore_addr);
+        reducer_core_x = get_arg_val<uint32_t>(argidx++);
+        reducer_core_y = get_arg_val<uint32_t>(argidx++);
         worker_core_xs = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
         argidx += num_workers;
         worker_core_ys = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
@@ -83,21 +90,28 @@ void kernel_main() {
     // The if constexpr discards this branch, but WH's compiler still evaluates get_tile_size.
     constexpr uint32_t cb_zero_safe = cb_zero_tiled < 32 ? cb_zero_tiled : 0;
     if constexpr (cb_zero_tiled < 32) {
-        cb_reserve_back(cb_zero_tiled, 1);
+        experimental::CB cb_zero(cb_zero_tiled);
+        cb_zero.reserve_back(1);
         constexpr uint32_t zero_tile_bytes = get_tile_size(cb_zero_safe);
-        uint32_t zero_addr = get_write_ptr(cb_zero_tiled);
-        uint64_t zeros_noc = get_noc_addr(MEM_ZEROS_BASE);
+        uint32_t zero_addr = cb_zero.get_write_ptr();
         uint32_t remaining = zero_tile_bytes;
+        experimental::set_read_state<MEM_ZEROS_SIZE>(noc, MEM_ZEROS_BASE);
         while (remaining >= MEM_ZEROS_SIZE) {
-            noc_async_read(zeros_noc, zero_addr, MEM_ZEROS_SIZE);
+            experimental::read_with_state(noc, zero_addr, MEM_ZEROS_BASE);
             zero_addr += MEM_ZEROS_SIZE;
             remaining -= MEM_ZEROS_SIZE;
         }
         if (remaining > 0) {
-            noc_async_read(zeros_noc, zero_addr, remaining);
+            experimental::UnicastEndpoint self_ep;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(zero_addr),
+                remaining,
+                experimental::local_addr(MEM_ZEROS_BASE, noc.get_noc_id()),
+                {});
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_zero_tiled, 1);
+        noc.async_read_barrier();
+        cb_zero.push_back(1);
     }
 
     // Process each batch element
@@ -109,30 +123,35 @@ void kernel_main() {
                 const uint32_t c_out_offset_t = c_out_block * matmul_N_t;
 
                 // Read weights and bias for this block
-                cb_reserve_back(cb_weight_tiled, weight_tiles);
-                uint32_t weight_write_ptr = get_write_ptr(cb_weight_tiled);
+                cb_weight.reserve_back(weight_tiles);
+                uint32_t weight_write_offset = 0;
 
                 for (uint32_t row = c_in_offset_t; row < c_in_offset_t + matmul_K_t; row++) {
                     for (uint32_t col = c_out_offset_t; col < c_out_offset_t + matmul_N_t; col++) {
                         uint32_t weight_idx = row * C_out_t + col;
-                        noc_async_read_tile(weight_idx, weight_reader, weight_write_ptr);
-                        weight_write_ptr += tile_bytes;
+                        noc.async_read(
+                            weight_reader,
+                            cb_weight,
+                            tile_bytes,
+                            {.page_id = weight_idx},
+                            {.offset_bytes = weight_write_offset});
+                        weight_write_offset += tile_bytes;
                     }
                 }
-                noc_async_read_barrier();
-                cb_push_back(cb_weight_tiled, weight_tiles);
+                noc.async_read_barrier();
+                cb_weight.push_back(weight_tiles);
 
                 if constexpr (use_bias) {
                     if (is_reducer) {
-                        cb_reserve_back(cb_bias_tiled, matmul_N_t);
-                        uint32_t bias_write_ptr = get_write_ptr(cb_bias_tiled);
+                        cb_bias.reserve_back(matmul_N_t);
+                        uint32_t bias_write_offset = 0;
                         for (uint32_t i = c_out_offset_t; i < c_out_offset_t + matmul_N_t; i++) {
-                            uint32_t bias_idx = i;
-                            noc_async_read_tile(bias_idx, bias_reader, bias_write_ptr);
-                            bias_write_ptr += tile_bytes;
+                            noc.async_read(
+                                bias_reader, cb_bias, tile_bytes, {.page_id = i}, {.offset_bytes = bias_write_offset});
+                            bias_write_offset += tile_bytes;
                         }
-                        noc_async_read_barrier();
-                        cb_push_back(cb_bias_tiled, matmul_N_t);
+                        noc.async_read_barrier();
+                        cb_bias.push_back(matmul_N_t);
                     }
                 }
 
@@ -149,68 +168,76 @@ void kernel_main() {
                             if (!is_reducer) {
                                 // I'm a worker.
                                 // Wait for compute to finish
-                                cb_wait_front(cb_reduction_tiled, output_tiles);
+                                cb_reduction.wait_front(output_tiles);
 
                                 // Reset our semaphore
-                                *local_semaphore_addr_ptr = 0;
+                                sem.set(0);
 
                                 // Signal to reducer that we have data ready
-                                noc_semaphore_inc(reducer_semaphore_noc_addr, 1);
+                                sem.up(noc, reducer_core_x, reducer_core_y, 1);
 
                                 // Wait for reducer to ack that it has read our data
-                                noc_semaphore_wait(local_semaphore_addr_ptr, 1);
+                                sem.wait(1);
 
                                 // Handshake with compute so it can continue
-                                cb_pop_front(cb_reduction_tiled, output_tiles);
-                                cb_reserve_back(cb_worker_ack_back, 1);
-                                cb_push_back(cb_worker_ack_back, 1);
+                                cb_reduction.pop_front(output_tiles);
+                                cb_ack.reserve_back(1);
+                                cb_ack.push_back(1);
                             } else {
                                 // I'm a reducer.
                                 // Wait for all workers to finish
-                                noc_semaphore_wait(local_semaphore_addr_ptr, num_workers);
+                                sem.wait(num_workers);
 
                                 // Reset our semaphore
-                                *local_semaphore_addr_ptr = 0;
+                                sem.set(0);
 
-                                const uint32_t worker_output_read_ptr = get_read_ptr(cb_matmul_interm_tiled);
+                                const uint32_t worker_output_read_ptr = cb_interm.get_read_ptr();
                                 for (uint32_t worker_idx = 0; worker_idx < num_workers; worker_idx++) {
                                     // Read data from worker into reduction buffer
                                     // Stall if compute has not cleared buffer
-                                    cb_reserve_back(cb_reduction_tiled, output_tiles);
-                                    uint32_t reduction_write_ptr = get_write_ptr(cb_reduction_tiled);
-                                    uint64_t worker_output_read_addr = get_noc_addr(
-                                        worker_core_xs[worker_idx], worker_core_ys[worker_idx], worker_output_read_ptr);
+                                    cb_reduction.reserve_back(output_tiles);
+                                    uint32_t reduction_offset = 0;
+                                    const uint16_t worker_x = worker_core_xs[worker_idx];
+                                    const uint16_t worker_y = worker_core_ys[worker_idx];
                                     for (uint32_t tile = 0; tile < output_tiles; tile++) {
-                                        noc_async_read(
-                                            worker_output_read_addr, reduction_write_ptr, partials_tile_bytes);
-                                        worker_output_read_addr += partials_tile_bytes;
-                                        reduction_write_ptr += partials_tile_bytes;
+                                        experimental::UnicastEndpoint ep;
+                                        noc.async_read(
+                                            ep,
+                                            cb_reduction,
+                                            partials_tile_bytes,
+                                            {.noc_x = worker_x,
+                                             .noc_y = worker_y,
+                                             .addr = worker_output_read_ptr + tile * partials_tile_bytes},
+                                            {.offset_bytes = reduction_offset});
+                                        reduction_offset += partials_tile_bytes;
                                     }
-                                    noc_async_read_barrier();
-                                    cb_push_back(cb_reduction_tiled, output_tiles);
+                                    noc.async_read_barrier();
+                                    cb_reduction.push_back(output_tiles);
 
-                                    const uint64_t worker_semaphore_noc_addr = get_noc_addr(
-                                        worker_core_xs[worker_idx], worker_core_ys[worker_idx], semaphore_addr);
-                                    noc_semaphore_inc(worker_semaphore_noc_addr, 1);
+                                    sem.up(noc, worker_x, worker_y, 1);
                                 }
 
-                                cb_wait_front(cb_matmul_result_rm, output_tiles);
-                                uint32_t cb_read_ptr = get_read_ptr(cb_matmul_result_rm);
+                                cb_out.wait_front(output_tiles);
+                                uint32_t cb_read_ptr = cb_out.get_read_ptr();
 
                                 for (uint32_t t = t_block; t < t_block_end; ++t) {
                                     for (uint32_t h = h_block; h < h_block_end; ++h) {
                                         for (uint32_t w = w_block; w < w_block_end; ++w) {
                                             uint32_t out_page_idx =
                                                 batch_idx * T_out_H_out_W_out + t * H_out * W_out + h * W_out + w;
-                                            uint64_t dst_addr = out_writer.get_noc_addr(out_page_idx);
-                                            dst_addr += c_out_block * C_out_block_bytes;
-                                            noc_async_write(cb_read_ptr, dst_addr, C_out_block_bytes);
+                                            noc.async_write(
+                                                experimental::CoreLocalMem<uint32_t>(cb_read_ptr),
+                                                out_writer,
+                                                C_out_block_bytes,
+                                                {},
+                                                {.page_id = out_page_idx,
+                                                 .offset_bytes = c_out_block * C_out_block_bytes});
                                             cb_read_ptr += C_out_block_bytes;
                                         }
                                     }
                                 }
-                                noc_async_write_barrier();
-                                cb_pop_front(cb_matmul_result_rm, output_tiles);
+                                noc.async_write_barrier();
+                                cb_out.pop_front(output_tiles);
                             }
                         }
                     }
@@ -218,5 +245,5 @@ void kernel_main() {
             }
         }
     }
-    noc_async_atomic_barrier();
+    noc.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -93,22 +93,22 @@ void kernel_main() {
         experimental::CB cb_zero(cb_zero_tiled);
         cb_zero.reserve_back(1);
         constexpr uint32_t zero_tile_bytes = get_tile_size(cb_zero_safe);
-        uint32_t zero_addr = cb_zero.get_write_ptr();
+        uint32_t zero_offset = 0;
         uint32_t remaining = zero_tile_bytes;
         experimental::set_read_state<MEM_ZEROS_SIZE>(noc, MEM_ZEROS_BASE);
         while (remaining >= MEM_ZEROS_SIZE) {
-            experimental::read_with_state(noc, zero_addr, MEM_ZEROS_BASE);
-            zero_addr += MEM_ZEROS_SIZE;
+            experimental::read_with_state(noc, cb_zero, MEM_ZEROS_BASE, {.offset_bytes = zero_offset});
+            zero_offset += MEM_ZEROS_SIZE;
             remaining -= MEM_ZEROS_SIZE;
         }
         if (remaining > 0) {
             experimental::UnicastEndpoint self_ep;
             noc.async_read(
                 self_ep,
-                experimental::CoreLocalMem<uint32_t>(zero_addr),
+                cb_zero,
                 remaining,
                 experimental::local_addr(MEM_ZEROS_BASE, noc.get_noc_id()),
-                {});
+                {.offset_bytes = zero_offset});
         }
         noc.async_read_barrier();
         cb_zero.push_back(1);
@@ -218,7 +218,7 @@ void kernel_main() {
                                 }
 
                                 cb_out.wait_front(output_tiles);
-                                uint32_t cb_read_ptr = cb_out.get_read_ptr();
+                                uint32_t cb_read_offset = 0;
 
                                 for (uint32_t t = t_block; t < t_block_end; ++t) {
                                     for (uint32_t h = h_block; h < h_block_end; ++h) {
@@ -226,13 +226,13 @@ void kernel_main() {
                                             uint32_t out_page_idx =
                                                 batch_idx * T_out_H_out_W_out + t * H_out * W_out + h * W_out + w;
                                             noc.async_write(
-                                                experimental::CoreLocalMem<uint32_t>(cb_read_ptr),
+                                                cb_out,
                                                 out_writer,
                                                 C_out_block_bytes,
-                                                {},
+                                                {.offset_bytes = cb_read_offset},
                                                 {.page_id = out_page_idx,
                                                  .offset_bytes = c_out_block * C_out_block_bytes});
-                                            cb_read_ptr += C_out_block_bytes;
+                                            cb_read_offset += C_out_block_bytes;
                                         }
                                     }
                                 }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -42,6 +43,10 @@ void kernel_main() {
     // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
     // program cache hits.
     const auto s0 = TensorAccessor(src_args, src_addr - misalignment, padded_stick_size);
+
+    experimental::Noc noc;
+    experimental::CB cb_in0(cb_id_in0);
+    experimental::CB cb_non_aligned(cb_id_non_aligned);
 
 #ifdef DEBUG
     DPRINT << "src_addr: " << src_addr << ", padded_stick_size: " << padded_stick_size
@@ -93,20 +98,23 @@ void kernel_main() {
     DEVICE_PRINT("Out CB Page size: {}\n", get_local_cb_interface(cb_id_in0).fifo_page_size);
 #endif
     if constexpr (is_non_aligned) {
+        // TRID-based pipelined async-read from src->scratch->dst.
+        // The ncrisc_noc_read_with_transaction_id_flushed polling pattern is kept as legacy —
+        // experimental::Noc does not yet expose per-TRID completion polling.
         enum SlotState : uint8_t { IDLE = 0, SRC_PENDING = 1, SCRATCH_READY = 2, SCRATCH_PENDING = 3 };
         constexpr uint32_t trid_base = 1;
 
         uint32_t scratch_write_addrs[num_trids];
-        cb_reserve_back(cb_id_non_aligned, num_trids);
-        uint32_t scratch_write_addr_base = get_write_ptr(cb_id_non_aligned);
+        cb_non_aligned.reserve_back(num_trids);
+        uint32_t scratch_write_addr_base = cb_non_aligned.get_write_ptr();
         uint32_t scratch_cb_page_size = get_local_cb_interface(cb_id_non_aligned).fifo_page_size;
         for (uint32_t i = 0; i < num_trids; i++) {
             scratch_write_addrs[i] = scratch_write_addr_base + i * scratch_cb_page_size;
         }
 
         for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
-            cb_reserve_back(cb_id_in0, num_read_per_barrier);
-            uint32_t src_buffer_l1_addr_base = get_write_ptr(cb_id_in0);
+            cb_in0.reserve_back(num_read_per_barrier);
+            uint32_t src_buffer_l1_addr_base = cb_in0.get_write_ptr();
 
             SlotState slot_states[num_trids];
             uint32_t dest_write_addrs[num_trids];
@@ -170,18 +178,17 @@ void kernel_main() {
                     }
                 }
             }
-            cb_push_back(cb_id_in0, num_read_per_barrier);
+            cb_in0.push_back(num_read_per_barrier);
         }
     } else {
         for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
-            cb_reserve_back(cb_id_in0, num_read_per_barrier);
-            uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
+            cb_in0.reserve_back(num_read_per_barrier);
+            uint32_t l1_offset = 0;
 
             for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
                 sticks_read++;
-                uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-                noc_async_read(src_noc_addr, src_buffer_l1_addr, unpadded_stick_size);
-                src_buffer_l1_addr += stick_size_offset;
+                noc.async_read(s0, cb_in0, unpadded_stick_size, {.page_id = src_stick_id}, {.offset_bytes = l1_offset});
+                l1_offset += stick_size_offset;
                 src_stick_id++;
                 for (uint32_t j = 0; j < num_dims; j++) {
                     id_per_dim[j]++;
@@ -193,8 +200,8 @@ void kernel_main() {
                     }
                 }
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in0, num_read_per_barrier);
+            noc.async_read_barrier();
+            cb_in0.push_back(num_read_per_barrier);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     constexpr uint32_t num_tiles_per_row = get_compile_time_arg_val(0);
@@ -31,6 +32,9 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<1>();
     const auto s0 = TensorAccessor(src_args, src_addr);
     const uint32_t extra_tiles_per_row = num_tiles_per_row - num_tiles_per_row_this_core;
+
+    experimental::Noc noc;
+    experimental::CB cb_in0(cb_id_in0);
 
 #ifdef DEBUG
     DPRINT << "src_addr: " << src_addr << ", num_dims: " << num_dims << ", start_id: " << start_id
@@ -69,12 +73,12 @@ void kernel_main() {
     DEVICE_PRINT(
         "num_tiles_per_row_this_core: {} extra_tiles_per_row: {}\n", num_tiles_per_row_this_core, extra_tiles_per_row);
 #endif
-    const uint32_t base_src_buffer_l1_addr = get_write_ptr(cb_id_in0);
-    const uint64_t base_noc_addr = get_noc_addr(0, s0);
+    const uint32_t base_src_buffer_l1_addr = cb_in0.get_write_ptr();
     uint32_t num_tiles_pushed = 0;
     while (tiles_read < num_tiles_per_core) {
-        cb_reserve_back(cb_id_in0, num_tiles_per_barrier);
-        uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
+        cb_in0.reserve_back(num_tiles_per_barrier);
+        uint32_t src_buffer_l1_addr = cb_in0.get_write_ptr();
+        uint32_t l1_offset = 0;
 #ifdef DEBUG
         DPRINT << "Src Buffer L1 Addr: " << src_buffer_l1_addr << ENDL();
         DEVICE_PRINT("Src Buffer L1 Addr: {}\n", src_buffer_l1_addr);
@@ -97,27 +101,26 @@ void kernel_main() {
                     id_per_dim[3],
                     tiles_read);
 #endif
-                src_buffer_l1_addr += tile_size;
+                l1_offset += tile_size;
                 src_stick_id++;
 
             } else {
-                uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-                noc_async_read(src_noc_addr, src_buffer_l1_addr, tile_size);
+                noc.async_read(s0, cb_in0, tile_size, {.page_id = src_stick_id}, {.offset_bytes = l1_offset});
 #ifdef DEBUG
-                DPRINT << "src_stick_id: " << src_stick_id << ", src_buffer_l1_addr: " << src_buffer_l1_addr
+                DPRINT << "src_stick_id: " << src_stick_id << ", src_buffer_l1_addr: " << src_buffer_l1_addr + l1_offset
                        << ", tiles_read: " << tiles_read << "id " << id_per_dim[0] << "," << id_per_dim[1] << ","
                        << id_per_dim[2] << "," << id_per_dim[3] << ENDL();
                 DEVICE_PRINT(
                     "src_stick_id: {}, src_buffer_l1_addr: {}, tiles_read: {}, id {} {} {} {}\n",
                     src_stick_id,
-                    src_buffer_l1_addr,
+                    src_buffer_l1_addr + l1_offset,
                     tiles_read,
                     id_per_dim[0],
                     id_per_dim[1],
                     id_per_dim[2],
                     id_per_dim[3]);
 #endif
-                src_buffer_l1_addr += tile_size;
+                l1_offset += tile_size;
                 src_stick_id++;
             }
 
@@ -131,8 +134,8 @@ void kernel_main() {
                 }
             }
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, num_tiles_per_barrier);
+        noc.async_read_barrier();
+        cb_in0.push_back(num_tiles_per_barrier);
         num_tiles_pushed += num_tiles_per_barrier;
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
@@ -73,15 +73,13 @@ void kernel_main() {
     DEVICE_PRINT(
         "num_tiles_per_row_this_core: {} extra_tiles_per_row: {}\n", num_tiles_per_row_this_core, extra_tiles_per_row);
 #endif
-    const uint32_t base_src_buffer_l1_addr = cb_in0.get_write_ptr();
     uint32_t num_tiles_pushed = 0;
     while (tiles_read < num_tiles_per_core) {
         cb_in0.reserve_back(num_tiles_per_barrier);
-        uint32_t src_buffer_l1_addr = cb_in0.get_write_ptr();
         uint32_t l1_offset = 0;
 #ifdef DEBUG
-        DPRINT << "Src Buffer L1 Addr: " << src_buffer_l1_addr << ENDL();
-        DEVICE_PRINT("Src Buffer L1 Addr: {}\n", src_buffer_l1_addr);
+        DPRINT << "Src Buffer L1 Addr: " << cb_in0.get_write_ptr() << ENDL();
+        DEVICE_PRINT("Src Buffer L1 Addr: {}\n", cb_in0.get_write_ptr());
         DPRINT << "Tiles read " << tiles_read << ", Num tiles pushed: " << num_tiles_pushed << ENDL();
         DEVICE_PRINT("Tiles read {} Num tiles pushed: {}\n", tiles_read, num_tiles_pushed);
 #endif
@@ -107,13 +105,14 @@ void kernel_main() {
             } else {
                 noc.async_read(s0, cb_in0, tile_size, {.page_id = src_stick_id}, {.offset_bytes = l1_offset});
 #ifdef DEBUG
-                DPRINT << "src_stick_id: " << src_stick_id << ", src_buffer_l1_addr: " << src_buffer_l1_addr + l1_offset
+                DPRINT << "src_stick_id: " << src_stick_id
+                       << ", src_buffer_l1_addr: " << cb_in0.get_write_ptr() + l1_offset
                        << ", tiles_read: " << tiles_read << "id " << id_per_dim[0] << "," << id_per_dim[1] << ","
                        << id_per_dim[2] << "," << id_per_dim[3] << ENDL();
                 DEVICE_PRINT(
                     "src_stick_id: {}, src_buffer_l1_addr: {}, tiles_read: {}, id {} {} {} {}\n",
                     src_stick_id,
-                    src_buffer_l1_addr + l1_offset,
+                    cb_in0.get_write_ptr() + l1_offset,
                     tiles_read,
                     id_per_dim[0],
                     id_per_dim[1],

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_rm.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 void kernel_main() {
     const uint32_t num_units = get_arg_val<uint32_t>(0);
     const uint32_t num_elements_per_row = get_arg_val<uint32_t>(1);
@@ -13,8 +14,12 @@ void kernel_main() {
     constexpr uint32_t cb_temp_pad = get_compile_time_arg_val(1);
     constexpr uint32_t output_elem_size = get_compile_time_arg_val(2);
 
-    const uint32_t pad_addr = get_read_ptr(cb_temp_pad);
-    const uint32_t out_addr = get_read_ptr(cb_id_out);
+    experimental::Noc noc;
+    experimental::CB cb_out_obj(cb_id_out);
+    experimental::CB cb_temp_pad_obj(cb_temp_pad);
+
+    const uint32_t pad_addr = cb_temp_pad_obj.get_read_ptr();
+    const uint32_t out_addr = cb_out_obj.get_read_ptr();
     if (pad_size_bytes == 0) {
         return;  // No padding needed, exit early
     }
@@ -49,13 +54,13 @@ void kernel_main() {
     }
 
     uint32_t write_addr = out_addr + unpadded_row_size_bytes;
-    uint64_t pad_noc_addr = get_noc_addr(pad_addr + unpadded_row_size_bytes);
-
-    noc_async_read_one_packet_set_state(pad_noc_addr, pad_size_bytes);
+    // pad_size_bytes is runtime; issue each read as a single-packet UnicastEndpoint NOC transfer
+    experimental::UnicastEndpoint self_ep;
+    const auto pad_src = experimental::local_addr(pad_addr + unpadded_row_size_bytes, noc.get_noc_id());
 
     for (uint32_t i = 0; i < num_units; ++i) {
-        noc_async_read_one_packet_with_state<true>(pad_noc_addr, write_addr);
+        noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(write_addr), pad_size_bytes, pad_src, {});
         write_addr += padded_row_size_bytes;
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_rm.cpp
@@ -53,14 +53,14 @@ void kernel_main() {
         }
     }
 
-    uint32_t write_addr = out_addr + unpadded_row_size_bytes;
     // pad_size_bytes is runtime; issue each read as a single-packet UnicastEndpoint NOC transfer
     experimental::UnicastEndpoint self_ep;
     const auto pad_src = experimental::local_addr(pad_addr + unpadded_row_size_bytes, noc.get_noc_id());
 
+    uint32_t write_offset = unpadded_row_size_bytes;
     for (uint32_t i = 0; i < num_units; ++i) {
-        noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(write_addr), pad_size_bytes, pad_src, {});
-        write_addr += padded_row_size_bytes;
+        noc.async_read(self_ep, cb_out_obj, pad_size_bytes, pad_src, {.offset_bytes = write_offset});
+        write_offset += padded_row_size_bytes;
     }
     noc.async_read_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
@@ -49,11 +49,9 @@ void kernel_main() {
     experimental::CB cb_out(cb_out_id);
     experimental::CB cb_padding(cb_padding_id);
 
-    const uint32_t base_write_addr = cb_out.get_write_ptr();
-    uint32_t write_addr = base_write_addr;
+    uint32_t write_offset = 0;
     uint32_t rows_remaining = num_sticks_this_core;
     uint32_t tiles_read = 0;
-    uint32_t read_addr = cb_untilized.get_read_ptr();
     uint32_t block_row_size = read_size / tt::constants::TILE_HEIGHT;
     const uint32_t pad_addr = cb_padding.get_read_ptr();
     const uint32_t output_row_size_elems = output_row_size_bytes / output_elem_size;
@@ -146,8 +144,8 @@ void kernel_main() {
             output_coord[1],
             output_coord[2],
             output_coord[3]);
-        DPRINT << "Write Addr " << write_addr << ", Offset " << write_addr - base_write_addr << ENDL();
-        DEVICE_PRINT("Write Addr {} Offset {}\n", write_addr, write_addr - base_write_addr);
+        DPRINT << "Write Offset " << write_offset << ENDL();
+        DEVICE_PRINT("Write Offset {}\n", write_offset);
 
 #endif
 
@@ -156,26 +154,26 @@ void kernel_main() {
 
         if constexpr (is_non_aligned) {
             uint32_t current_src_l1 = noc_read_src_base;
-            uint32_t current_write_addr = write_addr;
+            uint32_t current_write_offset = write_offset;
             for (uint32_t row = 0; row < read_rows_size; row++) {
                 noc.async_read(
                     self_ep,
-                    experimental::CoreLocalMem<uint32_t>(current_write_addr),
+                    cb_out,
                     output_row_size_bytes,
                     experimental::local_addr(current_src_l1 + misalignment, noc.get_noc_id()),
-                    {});
+                    {.offset_bytes = current_write_offset});
                 current_src_l1 += block_row_size;
-                current_write_addr += output_row_size_bytes;
+                current_write_offset += output_row_size_bytes;
             }
         } else {
             noc.async_read(
                 self_ep,
-                experimental::CoreLocalMem<uint32_t>(write_addr),
+                cb_out,
                 read_rows_size * block_row_size,
                 experimental::local_addr(noc_read_src_base, noc.get_noc_id()),
-                {});
+                {.offset_bytes = write_offset});
         }
-        uint32_t pad_write_addr = write_addr + output_row_size_bytes - padded_channels_bytes;
+        uint32_t pad_write_offset = write_offset + output_row_size_bytes - padded_channels_bytes;
         if (padded_channels_elems > 0) {
 #ifdef DEBUG
             volatile tt_l1_ptr uint16_t* pad_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
@@ -188,23 +186,23 @@ void kernel_main() {
             }
             DPRINT << ENDL();
             DEVICE_PRINT("\n");
-            DPRINT << "Pad Write Addr : " << pad_write_addr << ENDL();
-            DEVICE_PRINT("Pad Write Addr : {}\n", pad_write_addr);
+            DPRINT << "Pad Write Offset : " << pad_write_offset << ENDL();
+            DEVICE_PRINT("Pad Write Offset : {}\n", pad_write_offset);
 #endif
             const auto pad_src = experimental::local_addr(pad_src_l1_addr, noc.get_noc_id());
             for (uint32_t row_index = 0; row_index < read_rows_size; row_index++) {
                 noc.async_read(
                     self_ep,
-                    experimental::CoreLocalMem<uint32_t>(pad_write_addr),
+                    cb_out,
                     padded_channels_elems * output_elem_size,
                     pad_src,
-                    {});
-                pad_write_addr += output_row_size_bytes;
+                    {.offset_bytes = pad_write_offset});
+                pad_write_offset += output_row_size_bytes;
             }
         }
         noc.async_read_barrier();
 
-        write_addr += read_rows_size * output_row_size_bytes;
+        write_offset += read_rows_size * output_row_size_bytes;
         cb_untilized.pop_front(num_tiles_per_read);
         tiles_read += num_tiles_per_read;
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
@@ -9,6 +9,8 @@
 #include "api/debug/dprint.h"
 #include "ckernel_defs.h"
 #include "tt-metalium/constants.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
 uint32_t round_down(uint32_t value, uint32_t multiple) {
     if (value % multiple != 0) {
         value -= (value % multiple);
@@ -42,13 +44,18 @@ void kernel_main() {
 
     const volatile tt_l1_ptr uint32_t* const output_end = (tt_l1_ptr uint32_t*)(output_end_addr);
 
-    const uint32_t base_write_addr = get_write_ptr(cb_out_id);
+    experimental::Noc noc;
+    experimental::CB cb_untilized(cb_untilized_id);
+    experimental::CB cb_out(cb_out_id);
+    experimental::CB cb_padding(cb_padding_id);
+
+    const uint32_t base_write_addr = cb_out.get_write_ptr();
     uint32_t write_addr = base_write_addr;
     uint32_t rows_remaining = num_sticks_this_core;
     uint32_t tiles_read = 0;
-    uint32_t read_addr = get_read_ptr(cb_untilized_id);
+    uint32_t read_addr = cb_untilized.get_read_ptr();
     uint32_t block_row_size = read_size / tt::constants::TILE_HEIGHT;
-    const uint32_t pad_addr = get_read_ptr(cb_padding_id);
+    const uint32_t pad_addr = cb_padding.get_read_ptr();
     const uint32_t output_row_size_elems = output_row_size_bytes / output_elem_size;
 
     const uint32_t padded_channels_bytes = padded_channels_elems * output_elem_size;
@@ -67,7 +74,7 @@ void kernel_main() {
         }
     }
 
-    uint64_t pad_noc_addr = get_noc_addr(pad_addr + output_row_size_bytes - padded_channels_bytes);
+    const uint32_t pad_src_l1_addr = pad_addr + output_row_size_bytes - padded_channels_bytes;
 
 #ifdef DEBUG
     DPRINT << "total_num_tiles: " << total_num_tiles << ", num_tiles_per_read: " << num_tiles_per_read
@@ -82,10 +89,13 @@ void kernel_main() {
         block_row_size);
     DPRINT << "untilized CB ID: " << cb_untilized_id << " Out CB ID: " << cb_out_id << ENDL();
     DEVICE_PRINT("untilized CB ID: {} Out CB ID: {}\n", cb_untilized_id, cb_out_id);
-    DPRINT << "pad_addr : " << pad_addr << ", pad_noc_addr : " << pad_noc_addr
+    DPRINT << "pad_addr : " << pad_addr << ", pad_src_l1_addr : " << pad_src_l1_addr
            << ", padded_channels_elems: " << padded_channels_elems << ENDL();
     DEVICE_PRINT(
-        "pad_addr : {} pad_noc_addr : {} padded_channels_elems: {}\n", pad_addr, pad_noc_addr, padded_channels_elems);
+        "pad_addr : {} pad_src_l1_addr : {} padded_channels_elems: {}\n",
+        pad_addr,
+        pad_src_l1_addr,
+        padded_channels_elems);
     DPRINT << "Unaligned " << is_non_aligned << ENDL();
     DEVICE_PRINT("Unaligned {}\n", is_non_aligned);
     DPRINT << "Output Row Size Elems " << output_row_size_elems << " Bytes: " << output_row_size_bytes
@@ -99,6 +109,7 @@ void kernel_main() {
 
     const uint32_t output_end_width_in_input = output_end[1] + output_start_in_input[1];
     uint32_t row_count = 0;
+    experimental::UnicastEndpoint self_ep;
     while (tiles_read < total_num_tiles && rows_remaining > 0) {
         uint32_t width_start_in_input = output_start_in_input[1] + output_coord[1];
         uint32_t width_tile_start_in_input = round_down(width_start_in_input, ckernel::TILE_HEIGHT);
@@ -140,20 +151,29 @@ void kernel_main() {
 
 #endif
 
-        cb_wait_front(cb_untilized_id, num_tiles_per_read);
-        uint64_t noc_read_addr = get_noc_addr(get_read_ptr(cb_untilized_id));
+        cb_untilized.wait_front(num_tiles_per_read);
+        const uint32_t noc_read_src_base = cb_untilized.get_read_ptr() + read_start_offset * block_row_size;
 
-        noc_read_addr += read_start_offset * block_row_size;
         if constexpr (is_non_aligned) {
-            uint64_t current_noc_read_addr = noc_read_addr;
+            uint32_t current_src_l1 = noc_read_src_base;
             uint32_t current_write_addr = write_addr;
             for (uint32_t row = 0; row < read_rows_size; row++) {
-                noc_async_read(current_noc_read_addr + misalignment, current_write_addr, output_row_size_bytes);
-                current_noc_read_addr += block_row_size;
+                noc.async_read(
+                    self_ep,
+                    experimental::CoreLocalMem<uint32_t>(current_write_addr),
+                    output_row_size_bytes,
+                    experimental::local_addr(current_src_l1 + misalignment, noc.get_noc_id()),
+                    {});
+                current_src_l1 += block_row_size;
                 current_write_addr += output_row_size_bytes;
             }
         } else {
-            noc_async_read(noc_read_addr, write_addr, read_rows_size * block_row_size);
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(write_addr),
+                read_rows_size * block_row_size,
+                experimental::local_addr(noc_read_src_base, noc.get_noc_id()),
+                {});
         }
         uint32_t pad_write_addr = write_addr + output_row_size_bytes - padded_channels_bytes;
         if (padded_channels_elems > 0) {
@@ -171,15 +191,21 @@ void kernel_main() {
             DPRINT << "Pad Write Addr : " << pad_write_addr << ENDL();
             DEVICE_PRINT("Pad Write Addr : {}\n", pad_write_addr);
 #endif
+            const auto pad_src = experimental::local_addr(pad_src_l1_addr, noc.get_noc_id());
             for (uint32_t row_index = 0; row_index < read_rows_size; row_index++) {
-                noc_async_read(pad_noc_addr, pad_write_addr, padded_channels_elems * output_elem_size);
+                noc.async_read(
+                    self_ep,
+                    experimental::CoreLocalMem<uint32_t>(pad_write_addr),
+                    padded_channels_elems * output_elem_size,
+                    pad_src,
+                    {});
                 pad_write_addr += output_row_size_bytes;
             }
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         write_addr += read_rows_size * output_row_size_bytes;
-        cb_pop_front(cb_untilized_id, num_tiles_per_read);
+        cb_untilized.pop_front(num_tiles_per_read);
         tiles_read += num_tiles_per_read;
 
         // output_coord keeps track of the current position in the output tensor
@@ -194,5 +220,5 @@ void kernel_main() {
             }
         }
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
@@ -31,22 +31,22 @@ void kernel_main() {
     uint32_t sticks_read = 0;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
         cb_in0.reserve_back(num_read_per_barrier);
-        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+        uint32_t l1_offset = 0;
 
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
-            noc.async_read(
-                s0, experimental::CoreLocalMem<uint32_t>(l1_write_addr), stick_size, {.page_id = i_stick}, {});
+            noc.async_read(s0, cb_in0, stick_size, {.page_id = i_stick}, {.offset_bytes = l1_offset});
 #ifdef LAST_DIM
             // align data if slicing on last dim
             noc.async_read_barrier();
+            const uint32_t l1_write_addr = cb_in0.get_write_ptr() + l1_offset;
             tt::data_movement::common::tt_memmove<false, false, false, 0>(
                 l1_write_addr + page_offset,  // destination (shifted right)
                 l1_write_addr,                // source (original location)
                 stick_size                    // total bytes to move
             );
 #endif
-            l1_write_addr += stick_size_offset;
+            l1_offset += stick_size_offset;
             i_stick += 1;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -23,19 +24,22 @@ void kernel_main() {
     // program cache hits.
     const auto s0 = TensorAccessor(src_args, src_addr, stick_size);
 
+    experimental::Noc noc;
+    experimental::CB cb_in0(cb_id_in0);
+
     uint32_t i_stick = start_id;
     uint32_t sticks_read = 0;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
-        cb_reserve_back(cb_id_in0, num_read_per_barrier);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        cb_in0.reserve_back(num_read_per_barrier);
+        uint32_t l1_write_addr = cb_in0.get_write_ptr();
 
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
-            uint64_t src_noc_addr = get_noc_addr(i_stick, s0);
-            noc_async_read(src_noc_addr, l1_write_addr, stick_size);
+            noc.async_read(
+                s0, experimental::CoreLocalMem<uint32_t>(l1_write_addr), stick_size, {.page_id = i_stick}, {});
 #ifdef LAST_DIM
             // align data if slicing on last dim
-            noc_async_read_barrier();
+            noc.async_read_barrier();
             tt::data_movement::common::tt_memmove<false, false, false, 0>(
                 l1_write_addr + page_offset,  // destination (shifted right)
                 l1_write_addr,                // source (original location)
@@ -45,7 +49,7 @@ void kernel_main() {
             l1_write_addr += stick_size_offset;
             i_stick += 1;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, num_read_per_barrier);
+        noc.async_read_barrier();
+        cb_in0.push_back(num_read_per_barrier);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -57,25 +58,37 @@ void kernel_main() {
     // program cache hits.
     const auto s0 = TensorAccessor(dst_args, dst_addr, output_stick_size);
     const uint32_t noc_write_size = std::min(output_stick_size, input_stick_size);
+
+    experimental::Noc noc;
+    experimental::CB cb_out0(cb_id_out0);
+
     uint32_t dst_stick_id = start_id;
     uint32_t sticks_read = 0;
 #ifdef DEBUG
-    uint32_t base_src_l1_addr = get_read_ptr(cb_id_out0);
+    uint32_t base_src_l1_addr = cb_out0.get_read_ptr();
 #endif
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
-        cb_wait_front(cb_id_out0, num_read_per_barrier);
-        uint32_t src_buffer_l1_addr = get_read_ptr(cb_id_out0);
+        cb_out0.wait_front(num_read_per_barrier);
+        uint32_t src_buffer_l1_addr = cb_out0.get_read_ptr();
 
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
 #ifdef UNPAD_INPUT_WIDTH
             if ((id_per_dim[0] + padding_width_ntiles + 1) <= num_unpadded_sticks[0]) {
-                uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, s0);
-                noc_async_write(src_buffer_l1_addr, dst_noc_addr, noc_write_size);
+                noc.async_write(
+                    experimental::CoreLocalMem<uint32_t>(src_buffer_l1_addr),
+                    s0,
+                    noc_write_size,
+                    {},
+                    {.page_id = dst_stick_id});
             }
 #else
-            uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, s0);
-            noc_async_write(src_buffer_l1_addr + page_offset, dst_noc_addr, noc_write_size);
+            noc.async_write(
+                experimental::CoreLocalMem<uint32_t>(src_buffer_l1_addr),
+                s0,
+                noc_write_size,
+                {.offset_bytes = page_offset},
+                {.page_id = dst_stick_id});
 #endif
 #ifdef DEBUG
             DPRINT << "SRC L1 : " << src_buffer_l1_addr - base_src_l1_addr << " Dst Stick ID " << dst_stick_id
@@ -103,7 +116,7 @@ void kernel_main() {
                 }
             }
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, num_read_per_barrier);
+        noc.async_write_barrier();
+        cb_out0.pop_front(num_read_per_barrier);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -64,39 +64,27 @@ void kernel_main() {
 
     uint32_t dst_stick_id = start_id;
     uint32_t sticks_read = 0;
-#ifdef DEBUG
-    uint32_t base_src_l1_addr = cb_out0.get_read_ptr();
-#endif
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
         cb_out0.wait_front(num_read_per_barrier);
-        uint32_t src_buffer_l1_addr = cb_out0.get_read_ptr();
+        uint32_t src_offset = 0;
 
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
 #ifdef UNPAD_INPUT_WIDTH
             if ((id_per_dim[0] + padding_width_ntiles + 1) <= num_unpadded_sticks[0]) {
-                noc.async_write(
-                    experimental::CoreLocalMem<uint32_t>(src_buffer_l1_addr),
-                    s0,
-                    noc_write_size,
-                    {},
-                    {.page_id = dst_stick_id});
+                noc.async_write(cb_out0, s0, noc_write_size, {.offset_bytes = src_offset}, {.page_id = dst_stick_id});
             }
 #else
             noc.async_write(
-                experimental::CoreLocalMem<uint32_t>(src_buffer_l1_addr),
-                s0,
-                noc_write_size,
-                {.offset_bytes = page_offset},
-                {.page_id = dst_stick_id});
+                cb_out0, s0, noc_write_size, {.offset_bytes = src_offset + page_offset}, {.page_id = dst_stick_id});
 #endif
 #ifdef DEBUG
-            DPRINT << "SRC L1 : " << src_buffer_l1_addr - base_src_l1_addr << " Dst Stick ID " << dst_stick_id
-                   << " sticks_read: " << sticks_read << " Coord " << id_per_dim[0] << ", " << id_per_dim[1] << ", "
-                   << id_per_dim[2] << ", " << id_per_dim[3] << ENDL();
+            DPRINT << "SRC L1 : " << src_offset << " Dst Stick ID " << dst_stick_id << " sticks_read: " << sticks_read
+                   << " Coord " << id_per_dim[0] << ", " << id_per_dim[1] << ", " << id_per_dim[2] << ", "
+                   << id_per_dim[3] << ENDL();
             DEVICE_PRINT(
                 "SRC L1 : {} Dst Stick ID {} sticks_read: {} Coord {}, {}, {}, {}\n",
-                src_buffer_l1_addr - base_src_l1_addr,
+                src_offset,
                 dst_stick_id,
                 sticks_read,
                 id_per_dim[0],
@@ -104,7 +92,7 @@ void kernel_main() {
                 id_per_dim[2],
                 id_per_dim[3]);
 #endif
-            src_buffer_l1_addr += stick_size_offset;
+            src_offset += stick_size_offset;
             dst_stick_id++;
             for (uint32_t j = 0; j < num_dims; j++) {
                 id_per_dim[j]++;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -85,22 +86,31 @@ void kernel_main() {
     // program cache hits.
     const auto s0 = TensorAccessor(dst_args, dst_addr, output_stick_size);
     const uint32_t noc_write_size = std::min(output_stick_size, input_stick_size);
+
+    experimental::Noc noc;
+    experimental::CB cb_in(cb_id_in);
+    experimental::CB cb_out(cb_id_out);
+
     uint32_t dst_stick_id = start_id;
     uint32_t src_stick_id = start_id;
     uint32_t sticks_read = 0;
     uint32_t sticks_written = 0;
 #ifdef DEBUG
-    uint32_t base_src_l1_addr = get_read_ptr(cb_id_in);
+    uint32_t base_src_l1_addr = cb_in.get_read_ptr();
 #endif
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_written < num_sticks_per_core; ++iter) {
 #ifdef LAST_DIM_STRIDED
         // read output rows in batches if striding on last dim
-        cb_reserve_back(cb_id_out, num_read_per_barrier);
+        cb_out.reserve_back(num_read_per_barrier);
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
-            uint32_t l1_write_addr = get_write_ptr(cb_id_out);
-            uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-            noc_async_read(src_noc_addr, l1_write_addr, output_stick_size);
+            uint32_t l1_write_addr = cb_out.get_write_ptr();
+            noc.async_read(
+                s0,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                output_stick_size,
+                {.page_id = src_stick_id},
+                {});
             l1_write_addr += output_stick_size;
             src_stick_id += rev_stride[1];
             for (uint32_t j = 0; j < num_dims; j++) {
@@ -113,20 +123,19 @@ void kernel_main() {
                 }
             }
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_id_out, num_read_per_barrier);
+        noc.async_read_barrier();
+        cb_out.push_back(num_read_per_barrier);
 #endif
 
         // begin writing
-        cb_wait_front(cb_id_in, num_read_per_barrier);
+        cb_in.wait_front(num_read_per_barrier);
 #ifdef LAST_DIM_STRIDED
-        cb_wait_front(cb_id_out, num_read_per_barrier);
-        uint32_t output_l1_addr = get_read_ptr(cb_id_out);
+        cb_out.wait_front(num_read_per_barrier);
+        uint32_t output_l1_addr = cb_out.get_read_ptr();
 #endif
-        uint32_t src_buffer_l1_addr = get_read_ptr(cb_id_in);
+        uint32_t src_buffer_l1_addr = cb_in.get_read_ptr();
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_written < num_sticks_per_core; ++i) {
             sticks_written++;
-            uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, s0);
 #ifdef LAST_DIM_STRIDED
             // fill the read output row with the input with stride
             volatile tt_l1_ptr uint8_t* out_stick =
@@ -141,10 +150,20 @@ void kernel_main() {
                 }
                 out_index += rev_stride[0];
             }
-            noc_async_write(output_l1_addr, dst_noc_addr, output_stick_size);
+            noc.async_write(
+                experimental::CoreLocalMem<uint32_t>(output_l1_addr),
+                s0,
+                output_stick_size,
+                {},
+                {.page_id = dst_stick_id});
             output_l1_addr += output_stick_size;
 #else
-            noc_async_write(src_buffer_l1_addr + alignment_offset, dst_noc_addr + page_begins_offset, noc_write_size);
+            noc.async_write(
+                experimental::CoreLocalMem<uint32_t>(src_buffer_l1_addr + alignment_offset),
+                s0,
+                noc_write_size,
+                {},
+                {.page_id = dst_stick_id, .offset_bytes = page_begins_offset});
 #endif
 #ifdef DEBUG
             DPRINT << "SRC L1 : " << src_buffer_l1_addr - base_src_l1_addr << " Dst Stick ID " << dst_stick_id
@@ -173,7 +192,7 @@ void kernel_main() {
                 }
             }
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_in, num_read_per_barrier);
+        noc.async_write_barrier();
+        cb_in.pop_front(num_read_per_barrier);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
@@ -95,23 +95,13 @@ void kernel_main() {
     uint32_t src_stick_id = start_id;
     uint32_t sticks_read = 0;
     uint32_t sticks_written = 0;
-#ifdef DEBUG
-    uint32_t base_src_l1_addr = cb_in.get_read_ptr();
-#endif
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_written < num_sticks_per_core; ++iter) {
 #ifdef LAST_DIM_STRIDED
         // read output rows in batches if striding on last dim
         cb_out.reserve_back(num_read_per_barrier);
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
-            uint32_t l1_write_addr = cb_out.get_write_ptr();
-            noc.async_read(
-                s0,
-                experimental::CoreLocalMem<uint32_t>(l1_write_addr),
-                output_stick_size,
-                {.page_id = src_stick_id},
-                {});
-            l1_write_addr += output_stick_size;
+            noc.async_read(s0, cb_out, output_stick_size, {.page_id = src_stick_id}, {});
             src_stick_id += rev_stride[1];
             for (uint32_t j = 0; j < num_dims; j++) {
                 id_per_dim[j]++;
@@ -131,17 +121,17 @@ void kernel_main() {
         cb_in.wait_front(num_read_per_barrier);
 #ifdef LAST_DIM_STRIDED
         cb_out.wait_front(num_read_per_barrier);
-        uint32_t output_l1_addr = cb_out.get_read_ptr();
+        uint32_t output_offset = 0;
 #endif
-        uint32_t src_buffer_l1_addr = cb_in.get_read_ptr();
+        uint32_t src_offset = 0;
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_written < num_sticks_per_core; ++i) {
             sticks_written++;
 #ifdef LAST_DIM_STRIDED
             // fill the read output row with the input with stride
-            volatile tt_l1_ptr uint8_t* out_stick =
-                reinterpret_cast<volatile tt_l1_ptr uint8_t*>(output_l1_addr + page_begins_offset);
+            volatile tt_l1_ptr uint8_t* out_stick = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(
+                cb_out.get_read_ptr() + output_offset + page_begins_offset);
             volatile tt_l1_ptr uint8_t* in_stick =
-                reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_buffer_l1_addr + alignment_offset);
+                reinterpret_cast<volatile tt_l1_ptr uint8_t*>(cb_in.get_read_ptr() + src_offset + alignment_offset);
             uint32_t out_index = 0;
             for (uint32_t j = 0; j < input_stick_size / element_size; j++) {
                 // general writing for all data types byte by byte
@@ -150,29 +140,21 @@ void kernel_main() {
                 }
                 out_index += rev_stride[0];
             }
-            noc.async_write(
-                experimental::CoreLocalMem<uint32_t>(output_l1_addr),
-                s0,
-                output_stick_size,
-                {},
-                {.page_id = dst_stick_id});
-            output_l1_addr += output_stick_size;
+            noc.async_write(cb_out, s0, output_stick_size, {.offset_bytes = output_offset}, {.page_id = dst_stick_id});
+            output_offset += output_stick_size;
 #else
             noc.async_write(
-                experimental::CoreLocalMem<uint32_t>(src_buffer_l1_addr + alignment_offset),
+                cb_in,
                 s0,
                 noc_write_size,
-                {},
+                {.offset_bytes = src_offset + alignment_offset},
                 {.page_id = dst_stick_id, .offset_bytes = page_begins_offset});
 #endif
 #ifdef DEBUG
-            DPRINT << "SRC L1 : " << src_buffer_l1_addr - base_src_l1_addr << " Dst Stick ID " << dst_stick_id
+            DPRINT << "SRC L1 : " << src_offset << " Dst Stick ID " << dst_stick_id
                    << " sticks_written: " << sticks_written << " Coord ";
             DEVICE_PRINT(
-                "SRC L1 : {} Dst Stick ID {} sticks_written: {} Coord ",
-                src_buffer_l1_addr - base_src_l1_addr,
-                dst_stick_id,
-                sticks_written);
+                "SRC L1 : {} Dst Stick ID {} sticks_written: {} Coord ", src_offset, dst_stick_id, sticks_written);
             for (uint32_t j = 0; j < num_dims; j++) {
                 DPRINT << ", " << id_per_dim[j];
                 DEVICE_PRINT(", {} ", id_per_dim[j]);
@@ -180,7 +162,7 @@ void kernel_main() {
             DPRINT << ENDL();
             DEVICE_PRINT("\n");
 #endif
-            src_buffer_l1_addr += stick_size_offset;
+            src_offset += stick_size_offset;
             dst_stick_id += rev_stride[1];
             for (uint32_t j = 0; j < num_dims; j++) {
                 id_per_dim[j]++;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 #define ENABLE_DEBUG 0
 
@@ -25,51 +26,61 @@ FORCE_INLINE void fill_with_val(uint32_t begin_addr) {
 }
 
 template <uint32_t StickNBytes, uint32_t MaxChunkSize>
-FORCE_INLINE void copy_padding_small_sticks(uint64_t padding_l1_addr, uint64_t dst_addr, uint16_t nsticks) {
+FORCE_INLINE void copy_padding_small_sticks(
+    experimental::Noc noc, uint32_t padding_l1_addr, uint32_t dst_addr, uint16_t nsticks) {
     static_assert(MaxChunkSize >= StickNBytes, "This function assumes max chunk size > stick size");
 
     constexpr uint32_t sticks_per_batch = MaxChunkSize / StickNBytes;
     constexpr uint32_t batch_size_bytes = sticks_per_batch * StickNBytes;
+    static_assert(batch_size_bytes <= NOC_MAX_BURST_SIZE, "batch_size_bytes must be single-packet");
 
     if constexpr (sticks_per_batch > 1) {
         const uint16_t num_full_batches = nsticks / sticks_per_batch;
         const uint16_t remaining_sticks = nsticks % sticks_per_batch;
 
-        uint64_t current_dst = dst_addr;
+        uint32_t current_dst = dst_addr;
+
+        experimental::set_read_state<batch_size_bytes>(noc, padding_l1_addr);
         for (uint16_t batch = 0; batch < num_full_batches; ++batch) {
-            noc_async_read(padding_l1_addr, current_dst, batch_size_bytes);
+            experimental::read_with_state(noc, current_dst, padding_l1_addr);
             current_dst += batch_size_bytes;
         }
 
-        for (uint16_t k = 0; k < remaining_sticks; ++k) {
-            noc_async_read(padding_l1_addr, current_dst, StickNBytes);
-            current_dst += StickNBytes;
+        if (remaining_sticks > 0) {
+            experimental::set_read_state<StickNBytes>(noc, padding_l1_addr);
+            for (uint16_t k = 0; k < remaining_sticks; ++k) {
+                experimental::read_with_state(noc, current_dst, padding_l1_addr);
+                current_dst += StickNBytes;
+            }
         }
     } else {
-        noc_async_read_one_packet_set_state(padding_l1_addr, StickNBytes);
-        uint64_t current_dst = dst_addr;
+        experimental::set_read_state<StickNBytes>(noc, padding_l1_addr);
+        uint32_t current_dst = dst_addr;
         for (uint16_t k = 0; k < nsticks; ++k) {
-            noc_async_read_one_packet_with_state(padding_l1_addr, current_dst);
+            experimental::read_with_state(noc, current_dst, padding_l1_addr);
             current_dst += StickNBytes;
         }
     }
 }
 
 template <uint32_t StickNBytes, uint32_t MaxChunkSize>
-FORCE_INLINE void copy_padding_large_sticks(uint64_t padding_l1_addr, uint64_t dst_addr, uint16_t nsticks) {
+FORCE_INLINE void copy_padding_large_sticks(
+    experimental::Noc noc, uint32_t padding_l1_addr, uint32_t dst_addr, uint16_t nsticks) {
     constexpr uint32_t num_full_chunks = StickNBytes / MaxChunkSize;
     constexpr uint32_t remainder_bytes = StickNBytes % MaxChunkSize;
     constexpr uint32_t remainder_offset = num_full_chunks * MaxChunkSize;
+    static_assert(MaxChunkSize <= NOC_MAX_BURST_SIZE, "MaxChunkSize must be single-packet");
+    static_assert(remainder_bytes <= NOC_MAX_BURST_SIZE, "remainder must be single-packet");
 
     // Copy all full chunks for all sticks
     if constexpr (num_full_chunks > 0) {
-        noc_async_read_one_packet_set_state(padding_l1_addr, MaxChunkSize);
+        experimental::set_read_state<MaxChunkSize>(noc, padding_l1_addr);
 
-        uint64_t stick_base_addr = dst_addr;
+        uint32_t stick_base_addr = dst_addr;
         for (uint16_t stick = 0; stick < nsticks; ++stick) {
-            uint64_t chunk_addr = stick_base_addr;
+            uint32_t chunk_addr = stick_base_addr;
             for (uint32_t chunk = 0; chunk < num_full_chunks; ++chunk) {
-                noc_async_read_one_packet_with_state(padding_l1_addr, chunk_addr);
+                experimental::read_with_state(noc, chunk_addr, padding_l1_addr);
                 chunk_addr += MaxChunkSize;
             }
             stick_base_addr += StickNBytes;
@@ -78,22 +89,23 @@ FORCE_INLINE void copy_padding_large_sticks(uint64_t padding_l1_addr, uint64_t d
 
     // Copy all remainder chunks for all sticks
     if constexpr (remainder_bytes > 0) {
-        noc_async_read_one_packet_set_state(padding_l1_addr, remainder_bytes);
+        experimental::set_read_state<remainder_bytes>(noc, padding_l1_addr);
 
-        uint64_t remainder_base_addr = dst_addr + remainder_offset;
+        uint32_t remainder_base_addr = dst_addr + remainder_offset;
         for (uint16_t stick = 0; stick < nsticks; ++stick) {
-            noc_async_read_one_packet_with_state(padding_l1_addr, remainder_base_addr);
+            experimental::read_with_state(noc, remainder_base_addr, padding_l1_addr);
             remainder_base_addr += StickNBytes;
         }
     }
 }
 
 template <uint32_t PaddingConfigCBId, uint32_t OutCBId, uint32_t StickNBytes, uint32_t MaxChunkSize>
-FORCE_INLINE void copy_padding(uint64_t padding_l1_addr) {
-    const uint32_t padding_config_l1_addr = get_read_ptr(PaddingConfigCBId);
+FORCE_INLINE void copy_padding(
+    experimental::Noc noc, experimental::CB padding_config_cb, experimental::CB out_cb, uint32_t padding_l1_addr) {
+    const uint32_t padding_config_l1_addr = padding_config_cb.get_read_ptr();
     volatile tt_l1_ptr uint16_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(padding_config_l1_addr);
 
-    const uint64_t dst_base_addr = get_write_ptr(OutCBId);
+    const uint32_t dst_base_addr = out_cb.get_write_ptr();
 
     uint16_t nsticks = 1;
     constexpr uint32_t stick_stride = StickNBytes;
@@ -101,61 +113,63 @@ FORCE_INLINE void copy_padding(uint64_t padding_l1_addr) {
         uint16_t dst_local_idx = config_data[j + 0];
         nsticks = config_data[j + 1];
 
-        const uint64_t dst_addr = dst_base_addr + (static_cast<uint64_t>(dst_local_idx) * stick_stride);
+        const uint32_t dst_addr = dst_base_addr + (static_cast<uint32_t>(dst_local_idx) * stick_stride);
         if constexpr (StickNBytes <= MaxChunkSize) {
-            copy_padding_small_sticks<StickNBytes, MaxChunkSize>(padding_l1_addr, dst_addr, nsticks);
+            copy_padding_small_sticks<StickNBytes, MaxChunkSize>(noc, padding_l1_addr, dst_addr, nsticks);
         } else {
-            copy_padding_large_sticks<StickNBytes, MaxChunkSize>(padding_l1_addr, dst_addr, nsticks);
+            copy_padding_large_sticks<StickNBytes, MaxChunkSize>(noc, padding_l1_addr, dst_addr, nsticks);
         }
     }
 }
 
 template <bool IsBlockSharded, bool IsWidthSharded, bool IsColumnMajor>
-static inline uint64_t get_remote_core_l1_noc_addr(
+static inline void resolve_destination_coords(
     uint16_t destination_noc_x,
     uint16_t destination_noc_y,
     uint16_t my_noc_x,
     uint16_t my_noc_y,
-    uint32_t out_base_l1_addr) {
+    uint16_t& out_noc_x,
+    uint16_t& out_noc_y) {
     static_assert(!(IsBlockSharded && IsWidthSharded), "Cannot be block and width sharding");
-    uint16_t noc_x;
     if constexpr ((IsBlockSharded && !IsColumnMajor) || IsWidthSharded) {
-        noc_x = my_noc_x;
+        out_noc_x = my_noc_x;
     } else {
-        noc_x = destination_noc_x;
+        out_noc_x = destination_noc_x;
     }
-    uint16_t noc_y;
     if constexpr ((IsBlockSharded && IsColumnMajor) || IsWidthSharded) {
-        noc_y = my_noc_y;
+        out_noc_y = my_noc_y;
     } else {
-        noc_y = destination_noc_y;
+        out_noc_y = destination_noc_y;
     }
-    return get_noc_addr(noc_x, noc_y, out_base_l1_addr);
 }
 
 template <uint32_t StickSizeBytes, bool EnableBlocking, uint32_t BlockHeightSticks>
 static inline void write_stick_async(
+    experimental::Noc noc,
     uint32_t in_base_l1_addr,
-    uint64_t out_base_l1_addr,
+    uint32_t out_base_l1_addr,
+    uint16_t dst_noc_x,
+    uint16_t dst_noc_y,
     uint16_t src_offset_id,
     uint16_t dst_offset_id,
     uint16_t transfer_size) {
+    uint32_t src_offset;
     if constexpr (EnableBlocking) {
-        const uint32_t src_offset = (src_offset_id % BlockHeightSticks) *
-                                    StickSizeBytes;  // Convert from global stick offset to local block stick offset
-        const uint32_t dst_offset = dst_offset_id * StickSizeBytes;
-        const uint32_t size = transfer_size * StickSizeBytes;
-        const uint32_t src_addr = in_base_l1_addr + src_offset;
-        const uint64_t dst_addr = out_base_l1_addr + dst_offset;
-        noc_async_write(src_addr, dst_addr, size);
+        src_offset = (src_offset_id % BlockHeightSticks) * StickSizeBytes;
     } else {
-        const uint32_t src_offset = src_offset_id * StickSizeBytes;
-        const uint32_t dst_offset = dst_offset_id * StickSizeBytes;
-        const uint32_t size = transfer_size * StickSizeBytes;
-        const uint32_t src_addr = in_base_l1_addr + src_offset;
-        const uint64_t dst_addr = out_base_l1_addr + dst_offset;
-        noc_async_write(src_addr, dst_addr, size);
+        src_offset = src_offset_id * StickSizeBytes;
     }
+    const uint32_t dst_offset = dst_offset_id * StickSizeBytes;
+    const uint32_t size = transfer_size * StickSizeBytes;
+    const uint32_t src_addr = in_base_l1_addr + src_offset;
+    const uint32_t dst_addr = out_base_l1_addr + dst_offset;
+
+    noc.async_write(
+        experimental::CoreLocalMem<uint32_t>(src_addr),
+        experimental::UnicastEndpoint{},
+        size,
+        {},
+        {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = dst_addr});
 }
 
 template <
@@ -170,7 +184,13 @@ template <
     bool IsBlockSharded,
     bool IsWidthSharded,
     bool IsColumnMajor>
-static inline void run_halo_gather(const tt_l1_ptr uint16_t* config, uint32_t my_noc_x, uint32_t my_noc_y) {
+static inline void run_halo_gather(
+    experimental::Noc noc,
+    experimental::CB in_cb,
+    experimental::CB out_cb,
+    const tt_l1_ptr uint16_t* config,
+    uint16_t my_noc_x,
+    uint16_t my_noc_y) {
     static_assert(BlockStride >= 1, "Blocks stride must be at least 1");
 
     constexpr uint32_t block_size_height_tiles = BlockSizeHeight / TILE_SIZE;
@@ -183,15 +203,14 @@ static inline void run_halo_gather(const tt_l1_ptr uint16_t* config, uint32_t my
         return;
     }
 
-    uint32_t in_base_l1_addr = get_read_ptr(InputCBIndex);
-    const uint32_t out_base_l1_addr = get_write_ptr(OutputCBIndex);
+    uint32_t in_base_l1_addr = in_cb.get_read_ptr();
+    const uint32_t out_base_l1_addr = out_cb.get_write_ptr();
 
     // Assume input is already ready when !EnableBlocking (like when using RM)
     if constexpr (EnableBlocking) {
-        cb_wait_front(InputCBIndex, total_tiles_in_single_block);
+        in_cb.wait_front(total_tiles_in_single_block);
     }
 
-    uint64_t out_l1_addr = 0;
     uint16_t block_id = BlockStartOffset;
     uint16_t block_boundary_offset = BlockSizeHeight + (BlockSizeHeight * BlockStartOffset);
     while (number_of_segments_remaining) {
@@ -200,8 +219,9 @@ static inline void run_halo_gather(const tt_l1_ptr uint16_t* config, uint32_t my
         const uint16_t destination_noc_y = config[current_config_index++];
         uint16_t transfers_remaining = config[current_config_index++];
 
-        out_l1_addr = get_remote_core_l1_noc_addr<IsBlockSharded, IsWidthSharded, IsColumnMajor>(
-            destination_noc_x, destination_noc_y, my_noc_x, my_noc_y, out_base_l1_addr);
+        uint16_t dst_noc_x, dst_noc_y;
+        resolve_destination_coords<IsBlockSharded, IsWidthSharded, IsColumnMajor>(
+            destination_noc_x, destination_noc_y, my_noc_x, my_noc_y, dst_noc_x, dst_noc_y);
 
         // Perform all transfers in this route
         while (transfers_remaining > 0) {
@@ -212,26 +232,26 @@ static inline void run_halo_gather(const tt_l1_ptr uint16_t* config, uint32_t my
                 // Pop blocks until we have the right one - this works because transfers are globally ordered by
                 // ascending block IDs
                 while (src_offset >= block_boundary_offset) {
-                    noc_async_write_barrier();
-                    cb_pop_front(InputCBIndex, total_tiles_in_single_block);
-                    cb_wait_front(InputCBIndex, total_tiles_in_single_block);
+                    noc.async_write_barrier();
+                    in_cb.pop_front(total_tiles_in_single_block);
+                    in_cb.wait_front(total_tiles_in_single_block);
                     block_boundary_offset +=
                         BlockSizeHeight *
                         BlockStride;  // When block stride > 1 we are expecting the input CB to skip
                                       // BlockStride number of blocks (like when splitting work across cores)
                     block_id += BlockStride;
-                    in_base_l1_addr = get_read_ptr(InputCBIndex);  // Ensure base address is at front of input CB
+                    in_base_l1_addr = in_cb.get_read_ptr();  // Ensure base address is at front of input CB
                 }
             }
             write_stick_async<StickSizeBytes, EnableBlocking, BlockSizeHeight>(
-                in_base_l1_addr, out_l1_addr, src_offset, dst_offset, transfer_size);
+                noc, in_base_l1_addr, out_base_l1_addr, dst_noc_x, dst_noc_y, src_offset, dst_offset, transfer_size);
             transfers_remaining--;
         }
         number_of_segments_remaining--;
     }
 
     if constexpr (EnableBlocking) {
-        cb_pop_front(InputCBIndex, total_tiles_in_single_block);
+        in_cb.pop_front(total_tiles_in_single_block);
     }
 }
 
@@ -260,6 +280,14 @@ void kernel_main() {
     constexpr uint32_t elem_nbytes = sizeof(uint16_t);
     constexpr bool enable_blocking = !skip_untilize;
 
+    experimental::Noc noc;
+    experimental::CB padding_config_cb(padding_config_cb_id);
+    experimental::CB gather_config_cb(gather_config_cb_id);
+    experimental::CB src_cb(src_cb_id);
+    experimental::CB in_cb(in_cb_id);
+    experimental::CB out_cb(out_cb_id);
+    experimental::CB pad_cb(pad_cb_id);
+
 #ifdef CONFIG_TENSOR_IN_DRAM
     constexpr uint32_t padding_config_dram_addr = get_compile_time_arg_val(18);
     constexpr uint32_t padding_config_page_size = get_compile_time_arg_val(19);
@@ -275,46 +303,45 @@ void kernel_main() {
 
     uint32_t config_read_index = get_arg_val<uint32_t>(0);
 
-    uint64_t padding_src_noc_addr = get_noc_addr(config_read_index, padding_config_accessor);
-    uint64_t gather_src_noc_addr = get_noc_addr(config_read_index, gather_config_accessor);
-
-    noc_async_read(padding_src_noc_addr, get_write_ptr(padding_config_cb_id), padding_config_page_size);
-    noc_async_read(gather_src_noc_addr, get_write_ptr(gather_config_cb_id), gather_config_page_size);
-    noc_async_read_barrier();
+    noc.async_read(
+        padding_config_accessor, padding_config_cb, padding_config_page_size, {.page_id = config_read_index}, {});
+    noc.async_read(
+        gather_config_accessor, gather_config_cb, gather_config_page_size, {.page_id = config_read_index}, {});
+    noc.async_read_barrier();
 #endif
 
-    const uint16_t my_noc_x = NOC_X(my_x[noc_index]);
-    const uint16_t my_noc_y = NOC_Y(my_y[noc_index]);
+    const uint16_t my_noc_x = my_x[noc.get_noc_id()];
+    const uint16_t my_noc_y = my_y[noc.get_noc_id()];
 
     // Only one of the cores should push the input
     if constexpr (block_start_offset == 0) {
-        cb_reserve_back(src_cb_id, in_nsticks);
-        cb_push_back(src_cb_id, in_nsticks);
+        src_cb.reserve_back(in_nsticks);
+        src_cb.push_back(in_nsticks);
     }
 
     if constexpr (padding_config_cb_id != 0) {
         if constexpr (pad_val_u32 == 0) {
             // Use MEM_ZEROS_BASE if we are zero padded
-            const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, MEM_ZEROS_BASE);
             constexpr uint32_t padding_region_size = MEM_ZEROS_SIZE;
-            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(padding_l1_addr);
+            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(
+                noc, padding_config_cb, out_cb, MEM_ZEROS_BASE);
         } else {
             constexpr uint16_t pad_val = static_cast<uint16_t>(pad_val_u32);
             constexpr uint32_t num_elements_to_fill = aligned_stick_nbytes / elem_nbytes;
-            fill_with_val<num_elements_to_fill, pad_val>(get_write_ptr(pad_cb_id));
+            fill_with_val<num_elements_to_fill, pad_val>(pad_cb.get_write_ptr());
 
-            const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, get_read_ptr(pad_cb_id));
             // MaxChunkSize must be in bytes and >= StickNBytes to avoid misaligned NOC transactions
             constexpr uint32_t padding_region_size = aligned_stick_nbytes;
-            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(padding_l1_addr);
+            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(
+                noc, padding_config_cb, out_cb, pad_cb.get_read_ptr());
         }
     }
 
     if constexpr (skip_untilize) {
-        cb_wait_front(src_cb_id, in_nsticks);
+        src_cb.wait_front(in_nsticks);
     }
 
-    const uint32_t config_data_l1_addr = get_read_ptr(gather_config_cb_id);
+    const uint32_t config_data_l1_addr = gather_config_cb.get_read_ptr();
     const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
     run_halo_gather<
         in_cb_id,
@@ -327,8 +354,8 @@ void kernel_main() {
         enable_blocking,
         is_block_sharded,
         is_width_sharded,
-        is_col_major>(config_data, my_noc_x, my_noc_y);
+        is_col_major>(noc, in_cb, out_cb, config_data, my_noc_x, my_noc_y);
 
-    noc_async_read_barrier();
-    noc_async_write_barrier();
+    noc.async_read_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -143,10 +143,10 @@ static inline void resolve_destination_coords(
     }
 }
 
-template <uint32_t StickSizeBytes, bool EnableBlocking, uint32_t BlockHeightSticks>
+template <uint32_t StickSizeBytes, bool EnableBlocking, uint32_t BlockHeightSticks, typename Src>
 static inline void write_stick_async(
     experimental::Noc noc,
-    uint32_t in_base_l1_addr,
+    const Src& in_src,
     uint32_t out_base_l1_addr,
     uint16_t dst_noc_x,
     uint16_t dst_noc_y,
@@ -161,14 +161,13 @@ static inline void write_stick_async(
     }
     const uint32_t dst_offset = dst_offset_id * StickSizeBytes;
     const uint32_t size = transfer_size * StickSizeBytes;
-    const uint32_t src_addr = in_base_l1_addr + src_offset;
     const uint32_t dst_addr = out_base_l1_addr + dst_offset;
 
     noc.async_write(
-        experimental::CoreLocalMem<uint32_t>(src_addr),
+        in_src,
         experimental::UnicastEndpoint{},
         size,
-        {},
+        {.offset_bytes = src_offset},
         {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = dst_addr});
 }
 
@@ -203,8 +202,8 @@ static inline void run_halo_gather(
         return;
     }
 
-    uint32_t in_base_l1_addr = in_cb.get_read_ptr();
     const uint32_t out_base_l1_addr = out_cb.get_write_ptr();
+    auto in_src = experimental::use<experimental::CB::AddrSelector::READ_PTR>(in_cb);
 
     // Assume input is already ready when !EnableBlocking (like when using RM)
     if constexpr (EnableBlocking) {
@@ -240,11 +239,11 @@ static inline void run_halo_gather(
                         BlockStride;  // When block stride > 1 we are expecting the input CB to skip
                                       // BlockStride number of blocks (like when splitting work across cores)
                     block_id += BlockStride;
-                    in_base_l1_addr = in_cb.get_read_ptr();  // Ensure base address is at front of input CB
+                    // in_src tracks the CB's read_ptr dynamically via AddrSelector::READ_PTR
                 }
             }
             write_stick_async<StickSizeBytes, EnableBlocking, BlockSizeHeight>(
-                noc, in_base_l1_addr, out_base_l1_addr, dst_noc_x, dst_noc_y, src_offset, dst_offset, transfer_size);
+                noc, in_src, out_base_l1_addr, dst_noc_x, dst_noc_y, src_offset, dst_offset, transfer_size);
             transfers_remaining--;
         }
         number_of_segments_remaining--;


### PR DESCRIPTION
## Summary

- Extends #41653 to the remaining dataflow kernels owned by `@tenstorrent/metalium-developers-convolutions` per `.github/CODEOWNERS`
- Migrates 18 kernels across `sliding_window/halo`, `data_movement/fold`, `experimental/conv3d`, `experimental/cnn` (convert_to_chw/hwc), `experimental/slice_write`, `experimental/padded_slice` to `experimental::{Noc, CB, Semaphore, UnicastEndpoint}` + the shared `pool/device/kernels/experimental_device_api.hpp` helper
- Follow-up commit replaces `CoreLocalMem<uint32_t>(cb.get_*_ptr() + offset)` wraps with `CB` object + `{.offset_bytes = offset}` idiom (incl. `experimental::use<CB::AddrSelector::{READ,WRITE}_PTR>` where the source/dest semantics require a specific pointer)

## Notes

- `conv3d/compute.cpp` uses no dataflow API; left unchanged.
- `padded_slice_reader_rm` non-aligned TRID pipeline kept on legacy `noc_async_read_set_trid` / `ncrisc_noc_read_with_transaction_id_flushed` — `experimental::Noc` does not yet expose per-TRID completion polling. Aligned path migrated.
- `writer_convert_to_hwc` DRAM bank-id path kept on legacy `noc_async_read` (bank-id → `UnicastEndpoint` decomposition has no clean equivalent). CBs, barriers, and the remote-L1 path migrated.

## Test plan

Verified locally (`scripts/run_safe_pytest.sh --dev`):

- [x] `tests/ttnn/unit_tests/operations/conv` + `tests/ttnn/unit_tests/operations/pool` + `tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_for_conv.py` — 2345 passed, 2299 skipped
- [x] `tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py` — 16 passed
- [x] `tests/ttnn/unit_tests/operations/conv/data_movement/test_convert_to_chw.py` + `tests/ttnn/unit_tests/operations/data_movement/test_convert_to_hwc.py` — 372 passed
- [x] `tests/ttnn/unit_tests/operations/conv/test_conv3d.py` — 10 passed
- [x] `tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py` — 126 passed

CI:
- [ ] Sanity tests
- [ ] Blackhole post-commit
- [ ] Device perf regressions
- [ ] L2 nightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/conv_team_dm2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/conv_team_dm2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/conv_team_dm2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/conv_team_dm2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/conv_team_dm2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/conv_team_dm2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/conv_team_dm2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/conv_team_dm2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/conv_team_dm2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/conv_team_dm2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/conv_team_dm2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/conv_team_dm2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/conv_team_dm2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/conv_team_dm2_migration)