### PR TITLE
Ign/layernorm padding fix

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -11,6 +11,7 @@ import ttnn
 
 from loguru import logger
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_allclose_and_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 TEST_PADDING_VALUE = -42
 
@@ -480,45 +481,37 @@ def test_layernorm_pre_all_gather_residual_pcc(device, inp_shape):
     run_layernorm_pre_all_gather_residual_pcc(device, inp_shape)
 
 
-def test_pre_allgather_ignores_implicit_tile_padding(device):
+@pytest.mark.parametrize(
+    "inp_shape",
+    [(1, 1, 37, 72)],
+)
+def test_pre_allgather_ignores_implicit_tile_padding(device, inp_shape):
     """layer_norm_pre_all_gather stats match for ttnn.ones vs torch2tt_tensor."""
-    inp_shape = (1, 1, 37, 72)
-    dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
 
     tt_from_torch = torch2tt_tensor(
         torch.ones(inp_shape, dtype=torch.bfloat16),
         tt_dtype=ttnn.bfloat16,
         tt_device=device,
         tt_layout=ttnn.TILE_LAYOUT,
-        tt_memory_config=dram_memcfg,
     )
     tt_ones = ttnn.ones(
         shape=inp_shape,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
-        memory_config=dram_memcfg,
     )
 
     stats_from_torch = ttnn.layer_norm_pre_all_gather(
         tt_from_torch,
         dtype=ttnn.bfloat16,
-        memory_config=dram_memcfg,
     )
     stats_from_ones = ttnn.layer_norm_pre_all_gather(
         tt_ones,
         dtype=ttnn.bfloat16,
-        memory_config=dram_memcfg,
     )
 
     out_from_torch = tt2torch_tensor(stats_from_torch)
     out_from_ones = tt2torch_tensor(stats_from_ones)
 
-    passing, output_str = comp_allclose_and_pcc(
-        out_from_torch,
-        out_from_ones,
-        rtol=1e-3,
-        atol=1e-3,
-        pcc=0.99,
-    )
-    assert passing, output_str
+    # test for equivalance
+    assert_equal(out_from_torch, out_from_ones)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -465,8 +465,6 @@ def test_layernorm_part_1_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
 )
 def test_layernorm_pre_post_gamma_only_pcc(use_pre_all_gather, device):
     """layer_norm_post_all_gather with gamma and no bias; PCC vs torch reference."""
-    if use_pre_all_gather:
-        pytest.skip("Skipping test with use_pre_all_gather=True due to implicit padding issue #42135")
     run_layernorm_pre_post_gamma_only_pcc(device, use_pre_all_gather)
 
 
@@ -476,8 +474,6 @@ def test_layernorm_pre_post_gamma_only_pcc(use_pre_all_gather, device):
 )
 def test_layernorm_pre_all_gather_residual_pcc(device, inp_shape):
     """layer_norm_pre_all_gather with residual_input_tensor; PCC vs torch reference."""
-    if inp_shape == (1, 1, 24, 38):
-        pytest.skip("Skipping shape (1,1,24,38) due to implicit padding issue #42148")
     run_layernorm_pre_all_gather_residual_pcc(device, inp_shape)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -478,3 +478,47 @@ def test_layernorm_pre_all_gather_residual_pcc(device, inp_shape):
     if inp_shape == (1, 1, 24, 38):
         pytest.skip("Skipping shape (1,1,24,38) due to implicit padding issue #42148")
     run_layernorm_pre_all_gather_residual_pcc(device, inp_shape)
+
+
+def test_pre_allgather_ignores_implicit_tile_padding(device):
+    """layer_norm_pre_all_gather stats match for ttnn.ones vs torch2tt_tensor."""
+    inp_shape = (1, 1, 37, 72)
+    dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
+
+    tt_from_torch = torch2tt_tensor(
+        torch.ones(inp_shape, dtype=torch.bfloat16),
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+    tt_ones = ttnn.ones(
+        shape=inp_shape,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=dram_memcfg,
+    )
+
+    stats_from_torch = ttnn.layer_norm_pre_all_gather(
+        tt_from_torch,
+        dtype=ttnn.bfloat16,
+        memory_config=dram_memcfg,
+    )
+    stats_from_ones = ttnn.layer_norm_pre_all_gather(
+        tt_ones,
+        dtype=ttnn.bfloat16,
+        memory_config=dram_memcfg,
+    )
+
+    out_from_torch = tt2torch_tensor(stats_from_torch)
+    out_from_ones = tt2torch_tensor(stats_from_ones)
+
+    passing, output_str = comp_allclose_and_pcc(
+        out_from_torch,
+        out_from_ones,
+        rtol=1e-3,
+        atol=1e-3,
+        pcc=0.99,
+    )
+    assert passing, output_str

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
@@ -103,7 +103,7 @@ Tensor layer_norm_pre_all_gather(
     const LayerNormProgramConfig& program_config,
     const std::optional<bool>& use_2d_core_grid) {
     using OperationType = LayerNormPreAllGatherDeviceOperation;
-    auto padded_input = ttnn::fill_implicit_tile_padding(input, 0.0f);
+    auto input_padded = ttnn::fill_implicit_tile_padding(input, 0.0f);
     return ttnn::device_operation::detail::launch<OperationType>(
         OperationType::operation_attributes_t{
             .norm_type = norm_type,
@@ -113,7 +113,7 @@ Tensor layer_norm_pre_all_gather(
             .use_2d_core_grid = use_2d_core_grid,
         },
         OperationType::tensor_args_t{
-            .input = padded_input,
+            .input = input_padded,
             .recip_tensor = recip_tensor,
         });
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "layernorm_pre_all_gather_device_operation.hpp"
+#include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
 #include "ttnn/device_operation.hpp"
@@ -102,6 +103,7 @@ Tensor layer_norm_pre_all_gather(
     const LayerNormProgramConfig& program_config,
     const std::optional<bool>& use_2d_core_grid) {
     using OperationType = LayerNormPreAllGatherDeviceOperation;
+    auto padded_input = ttnn::fill_implicit_tile_padding(input, 0.0f);
     return ttnn::device_operation::detail::launch<OperationType>(
         OperationType::operation_attributes_t{
             .norm_type = norm_type,
@@ -111,7 +113,7 @@ Tensor layer_norm_pre_all_gather(
             .use_2d_core_grid = use_2d_core_grid,
         },
         OperationType::tensor_args_t{
-            .input = input,
+            .input = padded_input,
             .recip_tensor = recip_tensor,
         });
 }


### PR DESCRIPTION
### Ticket
Parent : #31983

Sub-issues:
- #41465
- #42135



### Problem description
 - ttnn::layer_norm_pre_all_gather assumes inputs are zero-padded, but this is not enforced.
  The kernel (```layernorm_pre_allgather.cpp```) computes sum(x) and sum(x²) over the full padded tile width, so when tensors are created using ttnn.ones, non-zero padding values are included in the computation, leading to incorrect statistics.                

- When implicit tile padding is enabled with a non-zero value (e.g., TEST_PADDING_VALUE = -42), tests **test_layernorm_pre_post_gamma_only_pcc** and **test_layernorm_pre_all_gather_residual_pcc** produce incorrect results. (path: tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py)
The operation incorrectly includes padded elements in its statistics computation, leading to significant numerical errors (low PCC, high ATOL/RTOL). When padding is disabled, the same test passes, confirming that padding handling is the root cause.



### What's changed
- Added implicit tile padding initialized to zero in the kernel (```layernorm_pre_all_gather_device_operation.cpp```) to ensure padded regions always hold 0 and do not contribute to the computation results.
- Added a new test to verify consistent behavior between: ttnn.ones(...) and torch2tt_tensor(torch.ones(...))
- Removed previously skipped tests:
   test_layernorm_pre_post_gamma_only_pcc  and test_pre_allgather_ignores_implicit_tile_padding
   (now passing with implicit padding handling, including irregular shapes)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/layernorm_padding_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/layernorm_padding_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/layernorm_padding_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/layernorm_padding_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/layernorm_padding_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/layernorm_padding_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/layernorm_padding_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/layernorm_padding_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/layernorm_padding_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/layernorm_padding_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/layernorm_padding_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/layernorm_padding_fix)