### PR TITLE
(minor) Rename causal scheme variables for clarity in ring SDPA

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1390,8 +1390,8 @@ void apply_partial_mask_lightweight(
 /**
  * Lightweight causal mask: stamps neginf and diagonal tiles onto QKT using L1 accumulate.
  *
- * For Q tile-row i (0..num_rows-1) processing K chunk starting at k_low_idx:
- *   diag_col = q_low_idx + i - k_low_idx
+ * For Q tile-row i (0..num_rows-1) processing K chunk starting at k_start_tile:
+ *   diag_col = q_start_tile + i - k_start_tile
  *   - diag_col < 0:           entire row above diagonal -> stamp neginf on all num_cols tiles
  *   - 0 <= diag_col < num_cols: diagonal tile at col diag_col, neginf at cols diag_col+1..num_cols-1
  *   - diag_col >= num_cols:     entire row below diagonal -> no mask needed
@@ -1402,15 +1402,15 @@ void apply_causal_mask_lightweight(
     uint32_t neginf_idx,
     uint32_t diag_idx,
     uint32_t out_cb,
-    uint32_t q_low_idx,
-    uint32_t k_low_idx,
+    uint32_t q_start_tile,
+    uint32_t k_start_tile,
     uint32_t num_rows,
     uint32_t num_cols) {
     copy_tile_to_dst_init_short(mask_cb);
     PACK((llk_pack_reconfig_l1_acc(1)));
 
     for (uint32_t row = 0; row < num_rows; row++) {
-        int32_t diag_col = (int32_t)(q_low_idx + row) - (int32_t)k_low_idx;
+        int32_t diag_col = (int32_t)(q_start_tile + row) - (int32_t)k_start_tile;
         uint32_t row_offset = row * num_cols;
 
         if (diag_col < 0) {
@@ -1515,16 +1515,16 @@ struct LightweightMaskContext {
         uint32_t global_n_mask_chunk_id,
         uint32_t local_n_mask_chunk_id,
         uint32_t joint_n_mask_chunk_id,
-        uint32_t q_low_idx = 0) const {
+        uint32_t q_start_tile = 0) const {
         if (is_causal) {
-            uint32_t k_low_idx = k_chunk * Sk_chunk_t;
+            uint32_t k_start_tile = k_chunk * Sk_chunk_t;
             apply_causal_mask_lightweight<dst_size>(
                 cb_mask_in,
                 neginf_tile_idx,
                 causal_diag_tile_idx,
                 cb_qk_im,
-                q_low_idx,
-                k_low_idx,
+                q_start_tile,
+                k_start_tile,
                 Sq_chunk_t,
                 Sk_chunk_t);
         }
@@ -1727,8 +1727,9 @@ void sdpa_inner_loop(
     const uint32_t q_per_core = iter_q_end - iter_q_start;
 
     for (uint32_t q_iter = iter_q_start; q_iter < iter_q_end; ++q_iter) {
-        uint32_t q_low_idx;
-        uint32_t q_high_idx;
+        uint32_t q_start_tile = 0;    // First tile of Q chunk (tile units, both STANDARD and RING)
+        uint32_t q_high_tile = 0;     // STANDARD: upper tile bound for K iteration
+        uint32_t causal_k_limit = 0;  // RING: K-chunk index beyond which all K is above the diagonal
         if constexpr (sdpa_type == STANDARD) {
             uint32_t q_chunk;
 #if defined BALANCED_Q_PARALLEL
@@ -1746,19 +1747,18 @@ void sdpa_inner_loop(
             if constexpr (is_chunked) {
                 q_chunk = chunked_q_chunk_offset + q_chunk;
             }
-            q_low_idx = q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
+            q_start_tile = q_chunk * Sq_chunk_t;
             if (is_causal) {
-                q_high_idx = q_low_idx + Sq_chunk_t;
+                q_high_tile = q_start_tile + Sq_chunk_t;
             } else {
-                q_high_idx = Skt;
+                q_high_tile = Skt;
             }
         } else if (sdpa_type == RING) {
             uint32_t q_chunk = remap_q_index(q_iter, q_num_chunks, use_zigzag_balancing) % q_num_chunks;
 
             if (is_causal) {
-                q_low_idx = q_chunk * Sq_chunk_t;
-                q_high_idx = q_low_idx + Sq_chunk_t;
-                q_high_idx = (q_high_idx + Sk_chunk_t - 1) / Sk_chunk_t;
+                q_start_tile = q_chunk * Sq_chunk_t;
+                causal_k_limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
             }
             if (is_balanced && (q_chunk < q_num_chunks / 2)) {
                 continue;
@@ -1775,8 +1775,8 @@ void sdpa_inner_loop(
 
         uint32_t k_chunk_end;
         if constexpr (sdpa_type == STANDARD) {
-            // loop while k_low < q_high => (k_chunk * Sk_chunk_t) < q_high_idx.
-            k_chunk_end = (q_high_idx + Sk_chunk_t - 1) / Sk_chunk_t;
+            // loop while k_low < q_high => (k_chunk * Sk_chunk_t) < q_high_tile.
+            k_chunk_end = (q_high_tile + Sk_chunk_t - 1) / Sk_chunk_t;
         } else {  // RING or JOINT.
             k_chunk_end = iter_k_chunk_end;
         }
@@ -1796,7 +1796,7 @@ void sdpa_inner_loop(
 
             KV_chunks_processed_in_iter++;
 
-            if (sdpa_type == RING && k_chunk >= q_high_idx && is_causal) {
+            if (sdpa_type == RING && k_chunk >= causal_k_limit && is_causal) {
                 cb_wait_front(cb_k_in, k_chunk_tiles);
                 cb_wait_front(cb_v_in, v_chunk_tiles);
                 cb_pop_front(cb_k_in, k_chunk_tiles);
@@ -1846,7 +1846,7 @@ void sdpa_inner_loop(
                 const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
                 const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
                 // Apply mask if causal overlap, sliding window, or this K chunk has padding
-                apply_mask = (q_low_idx < k_high_idx) || (sliding_window_size > 0) || needs_padding_mask;
+                apply_mask = (q_start_tile < k_high_idx) || (sliding_window_size > 0) || needs_padding_mask;
             } else if constexpr (use_provided_mask) {
                 apply_mask = true;
             } else if constexpr (use_padded_mask) {
@@ -1886,7 +1886,7 @@ void sdpa_inner_loop(
                         global_n_mask_chunk_id,
                         local_n_mask_chunk_id,
                         joint_n_mask_chunk_id,
-                        q_low_idx);
+                        q_start_tile);
                     cb_push_back(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
                 } else {
                     add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
@@ -2444,8 +2444,8 @@ void sdpa_ring(
     const uint32_t cb_prev_out,
     const uint32_t cb_out,
     const LightweightMaskContext& lw_mask,
-    const bool is_causal,
-    const bool is_balanced,
+    const bool is_causal_ring_iter,
+    const bool skip_first_half_q,
     const bool is_last_ring_iter,
     const bool use_zigzag_balancing = false) {
     sdpa_inner_loop<
@@ -2521,8 +2521,8 @@ void sdpa_ring(
         cb_prev_out,
         cb_out,
         lw_mask,
-        is_causal,
-        is_balanced,
+        is_causal_ring_iter,
+        skip_first_half_q,
         use_zigzag_balancing,
         is_last_ring_iter);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -248,13 +248,13 @@ void kernel_main() {
                 q_per_core,
                 lw_mask);
         } else {
-            bool causality = (ring_iter == 0 ? is_causal : false);
+            bool is_causal_ring_iter = (ring_iter == 0 ? is_causal : false);
 
             uint32_t iter_num_kv_chunks = num_kv_chunks;
             if (is_causal && is_balanced && ring_index > ring_id) {
                 iter_num_kv_chunks /= 2;
             }
-            bool balancing = (ring_index >= ring_id ? false : is_balanced);
+            bool skip_first_half_q = (ring_index >= ring_id ? false : is_balanced);
 
             sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, NH, DHt, vDHt, scale_fp32>(
                 qk_in0_block_w,
@@ -307,8 +307,8 @@ void kernel_main() {
                 cb_prev_out,
                 cb_out,
                 lw_mask,
-                causality,
-                balancing,
+                is_causal_ring_iter,
+                skip_first_half_q,
                 is_last_ring_iter,
                 use_zigzag_balancing);
         }


### PR DESCRIPTION
Rename variables in the non-streaming ring SDPA causal masking flow to better reflect their actual meaning and units:

- q_low_idx → q_start_tile: first tile of Q chunk (tile units)
- q_high_idx → causal_k_limit (RING) / q_high_tile (STANDARD): the old name was confusing because it started as tile units then got overwritten to K-chunk units in the RING path. Now split into two variables with clear units.
- causality → is_causal_ring_iter: the per-ring-iteration causal flag (true only on ring_iter 0), distinguished from the compile-time is_causal config flag.
- balancing → skip_first_half_q: this variable gates whether Q chunks in the first half are skipped (already conditional on ring position), not the raw is_balanced config flag.
- sdpa_ring params: is_causal → is_causal_ring_iter, is_balanced → skip_first_half_q (matching the caller semantics).

No functional changes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_sdpa_ring_renaming)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dnijemcevic/causal_sdpa_ring_renaming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dnijemcevic/causal_sdpa_ring_renaming)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dnijemcevic/causal_sdpa_ring_renaming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/causal_sdpa_ring_renaming)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/causal_sdpa_ring_renaming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dnijemcevic/causal_sdpa_ring_renaming)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dnijemcevic/causal_sdpa_ring_renaming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dnijemcevic/causal_sdpa_ring_renaming)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dnijemcevic/causal_sdpa_ring_renaming)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dnijemcevic/causal_sdpa_ring_renaming)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dnijemcevic/causal_sdpa_ring_renaming)