### PR TITLE
relax update_cache_device_operation requirements for deepseek prefill

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -267,12 +267,11 @@ class TestUpdateCacheFP32:
         ((8, 4), 1024, 128, "HEIGHT_SHARDED"),  # 128/32 = 4 shards across 8 banks → ≤1 shard/bank → HEIGHT_SHARDED
     ],
 )
-@pytest.mark.parametrize("num_heads", [128])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("op_type", ["fill", "fill_cache_for_user", "update"])
 class TestUpdateCacheWithKVPE:
     def test_kvpe_cache_op(
-        self, op_type, mesh_shape, seq_len, expected_seq_len_local, expected_layout, num_heads, input_dtype, device
+        self, op_type, mesh_shape, seq_len, expected_seq_len_local, expected_layout, input_dtype, device
     ):
         """Test fill/update cache operations with KVPE cache created by init_kvpe_cache.
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -258,3 +258,101 @@ class TestUpdateCacheFP32:
         logger.info(output_cache)
         logger.info(output_update)
         assert eq_cache and eq_update
+
+
+@pytest.mark.parametrize(
+    "mesh_shape,seq_len,expected_seq_len_local,expected_layout",
+    [
+        ((2, 4), 1024, 512, "ND_SHARDED"),  # 512/32 = 16 shards across 8 banks → 2 shards/bank → ND_SHARDED
+        ((8, 4), 1024, 128, "HEIGHT_SHARDED"),  # 128/32 = 4 shards across 8 banks → ≤1 shard/bank → HEIGHT_SHARDED
+    ],
+)
+@pytest.mark.parametrize("num_heads", [128])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("op_type", ["fill", "fill_cache_for_user", "update"])
+class TestUpdateCacheWithKVPE:
+    def test_kvpe_cache_op(
+        self, op_type, mesh_shape, seq_len, expected_seq_len_local, expected_layout, num_heads, input_dtype, device
+    ):
+        """Test fill/update cache operations with KVPE cache created by init_kvpe_cache.
+
+        Uses ND_SHARDED cache with ROUND_ROBIN_1D across 8 DRAM banks.
+        The cache layout behavior depends on mesh size:
+        - 2x4 mesh (seq_len=1024, seq_len_local=512): 512/32 = 16 shards → 2 shards/bank → ND_SHARDED
+        - 8x4 mesh (seq_len=1024, seq_len_local=128): 128/32 = 4 shards → ≤1 shard/bank → HEIGHT_SHARDED
+        """
+
+        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+
+        kvpe_cache_head_dim = 32
+        sp_axis = 0
+        num_kvpe_cache_layers = 2
+        mesh_device = device
+
+        # Initialize KVPE cache using the utility function
+        # This creates cache with shape [num_layers, 1, seq_len_local, kvpe_cache_head_dim]
+        # with ND_SHARDED memory config using ROUND_ROBIN_1D across 8 DRAM banks
+        tt_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=kvpe_cache_head_dim,
+            mesh_device=mesh_device,
+            seq_len=seq_len,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=num_kvpe_cache_layers,
+        )
+
+        if expected_layout == "ND_SHARDED":
+            expected_layout_enum = ttnn.TensorMemoryLayout.ND_SHARDED
+        elif expected_layout == "HEIGHT_SHARDED":
+            expected_layout_enum = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+        else:
+            raise ValueError(f"Unexpected expected_layout value: {expected_layout}")
+        assert tt_cache.memory_config().memory_layout == expected_layout_enum, (
+            f"Expected cache layout to be {expected_layout_enum}, " f"but got {tt_cache.memory_config().memory_layout}"
+        )
+        assert tt_cache.shape[-2] == expected_seq_len_local, (
+            f"Expected local sequence length to be {expected_seq_len_local}, " f"but got {tt_cache.shape[-2]}"
+        )
+
+        logger.info(f"Cache memory config: {tt_cache.memory_config()}")
+        logger.info(f"Cache shape: {tt_cache.shape}")
+        logger.info(f"Expected layout: {expected_layout}")
+        logger.info(f"Operation type: {op_type}")
+
+        seq_len_local = seq_len // mesh_shape[sp_axis]
+
+        if op_type == "fill":
+            input_shape = [1, 1, seq_len_local, kvpe_cache_head_dim]
+            x = torch.randn(input_shape).bfloat16()
+            tt_x = ttnn.from_torch(x, dtype=input_dtype, device=device, layout=ttnn.TILE_LAYOUT)
+            ttnn.fill_cache(tt_cache, tt_x, batch_idx=0)
+            tt_got_back = tt_cache.to_torch().float()
+            eq, output = comp_pcc(x.float(), tt_got_back[0, :, :, :])
+
+        elif op_type == "fill_cache_for_user":
+            user_idx = 1
+            input_shape = [1, 1, seq_len_local, kvpe_cache_head_dim]
+            user = torch.randn(input_shape).bfloat16()
+            tt_user = ttnn.from_torch(user, dtype=input_dtype, device=device, layout=ttnn.TILE_LAYOUT)
+            ttnn.kv_cache.fill_cache_for_user_(tt_cache, tt_user, user_idx)
+
+            tt_got_back = tt_cache.to_torch().float()
+            eq, output = comp_pcc(user.float(), tt_got_back[user_idx, :, :, :])
+            eq_z, output_z = comp_pcc(torch.zeros_like(user).float(), tt_got_back[0, :, :, :])
+            eq = eq and eq_z
+            output = f"User match: {output}, Zero match: {output_z}"
+        elif op_type == "update":
+            batch_offset = 0
+            update_idx = 2
+            cache_entry = torch.randn([1, 1, 1, kvpe_cache_head_dim]).bfloat16()
+            tt_cache_entry = ttnn.from_torch(cache_entry, dtype=input_dtype, device=device, layout=ttnn.TILE_LAYOUT)
+            ttnn.update_cache(tt_cache, tt_cache_entry, update_idx=update_idx, batch_offset=batch_offset)
+
+            tt_got_back = tt_cache.to_torch().float()
+            eq, output = comp_pcc(cache_entry.float(), tt_got_back[batch_offset, :, update_idx, :])
+
+        else:
+            raise ValueError(f"Unexpected op_type value: {op_type}")
+
+        logger.info(output)
+        assert eq, output

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -56,10 +56,16 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
         "Input tensor height ({}) must equal cache tensor height ({})",
         input_tensor.padded_shape()[1],
         cache_tensor.padded_shape()[1]);
+
     TT_FATAL(
         cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED ||
-            cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED,
-        "Cache tensor memory layout must be INTERLEAVED or ND_SHARDED but got {}",
+            cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED ||
+            (cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+             cache_tensor.memory_config().created_with_nd_shard_spec() &&
+             cache_tensor.memory_config()
+                 .is_dram()),  // ND_SHARDED layout can collapse to HEIGHT_SHARDED when each bank holds single shard
+        "Cache tensor memory layout must be INTERLEAVED, ND_SHARDED, or HEIGHT_SHARDED (created from ND shard spec) "
+        "but got {}",
         cache_tensor.memory_config().memory_layout());
     if (args.op_type == UpdateCacheOpType::FILL) {
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion


### PR DESCRIPTION
ND_SHARDED tensor can collapse to HEIGHT_SHARDED when each bank holds 1 shard. 
KV cache op can work with HEIGHT_SHARDED DRAM tensor created this way. 
Enabled and added regression test. 

It might work with regular HEIGHT_SHARDED DRAM tensor; that goes beyond my needs today.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-update-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-update-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-update-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-update-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-update-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-update-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-update-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-update-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-update-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-update-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-update-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-update-kv-cache)