### PR TITLE
Fix segfault in test_blitz_decode_weights.py

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -86,24 +86,30 @@ def _create_output_device_tensor(
     tile=None,
     mesh_mapper=None,
 ):
-    """Allocate a zeroed output tensor on device."""
-    num_cores = core_range_set.num_cores()
-    shard = _shard_shape(height, width, num_cores, sharding)
+    """Allocate an uninitialized output tensor on device.
+
+    Uses ``allocate_tensor_on_device`` (alloc-only) rather than
+    ``from_torch(torch.zeros(...))``. The latter host-materializes zeros
+    and dispatches a tilize program, which allocates a ROW_MAJOR staging
+    buffer the same size as the output plus non-globally-allocated CBs.
+    For BFLOAT16 that combined footprint, on top of the already-live
+    fused overlap tensor, pushes L1 past its waterline and clashes with
+    the statically reserved CB region. The allocated buffer is
+    immediately overwritten by ``CopyToOutput.op``, so its initial
+    contents don't matter.
+    """
+    shard = _shard_shape(height, width, core_range_set.num_cores(), sharding)
     shard_spec = ttnn.ShardSpec(core_range_set, shard, ttnn.ShardOrientation.ROW_MAJOR)
-    mem_config = ttnn.MemoryConfig(sharding, ttnn.BufferType.L1, shard_spec)
-    kwargs = {}
-    if tile is not None:
-        kwargs["tile"] = tile
-    if mesh_mapper is not None:
-        kwargs["mesh_mapper"] = mesh_mapper
-    return ttnn.from_torch(
-        torch.zeros(height, width, dtype=torch.bfloat16),
+    tensor_spec = ttnn.TensorSpec(
+        ttnn.Shape([height, width]),
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=mem_config,
-        **kwargs,
+        memory_layout=sharding,
+        shard_spec=shard_spec,
+        buffer_type=ttnn.BufferType.L1,
+        tile=tile,
     )
+    return ttnn.allocate_tensor_on_device(tensor_spec, device)
 
 
 def _get_roundtrip_reference(


### PR DESCRIPTION
### Root cause
`_create_output_device_tensor` built the extraction output via `ttnn.from_torch(torch.zeros(...), layout=TILE_LAYOUT, device=...)`. That path:
1. Host-materializes a zeros tensor,
2. Allocates a **ROW_MAJOR staging buffer** on device the same size as the output,
3. Dispatches a **tilize program** with non-globally-allocated CBs.
For `BFLOAT16` the staging buffer + tilize CBs + the already-live ~622 KB fused overlap tensor exceeded the L1 waterline by ~12.8 KB — exactly the clash reported. `BFLOAT8_B` fit because its buffers were roughly half the size.
### Fix
Use `ttnn.allocate_tensor_on_device` (pure allocation, no host materialization, no tilize dispatch). The buffer is immediately overwritten by `CopyToOutput.op`, so initial contents don't matter.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kwerblinskiTT/fix_test_blitz_decode_weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/fix_test_blitz_decode_weights)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kwerblinskiTT/fix_test_blitz_decode_weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinskiTT/fix_test_blitz_decode_weights)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kwerblinskiTT/fix_test_blitz_decode_weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/fix_test_blitz_decode_weights)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kwerblinskiTT/fix_test_blitz_decode_weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/fix_test_blitz_decode_weights)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kwerblinskiTT/fix_test_blitz_decode_weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/fix_test_blitz_decode_weights)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kwerblinskiTT/fix_test_blitz_decode_weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/fix_test_blitz_decode_weights)