### PR TITLE
run_safe_pytest.sh: add simulator mode, --run-all, exit-5 handling

### DIFF
--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -7,12 +7,19 @@
 # Automatically resets the device after hangs, ensuring the next runner
 # always gets a clean device.
 #
-# Usage: scripts/run_safe_pytest.sh [--dev] <test_path> [extra_pytest_args...]
+# Simulator mode (TT_METAL_SIMULATOR set):
+#   Exports TT_METAL_SLOW_DISPATCH_MODE=1 and TT_METAL_DISABLE_SFPLOADMACRO=1.
+#   Skips flock, device resets, and triage (these require real hardware).
+#   No hang protection — sim runs at kHz, so wall-clock timeouts are meaningless.
+#
+# Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]
 #
 # Options:
 #   --dev       Enables polling watcher (NoC sanitizer, waypoints, CB
 #               sanitization), lightweight ebreak asserts, and auto-triage
 #               on hang with full triage + watcher log dump.
+#   --run-all   Run all tests instead of stopping on first failure (-x).
+#               Useful for eval scoring where you need full pass/fail counts.
 #
 # Modes:
 #   default  - Dispatch timeout only. Lean, no debug overhead.
@@ -34,12 +41,25 @@ LOCK_FILE="/tmp/tt-device.lock"
 DIRTY_FLAG="/tmp/tt-device.dirty"
 TRIAGE_LOG="/tmp/safe-pytest-triage-$$.log"
 
+# --- Detect simulator mode ---
+SIM_MODE=false
+if [[ -n "${TT_METAL_SIMULATOR:-}" ]]; then
+    SIM_MODE=true
+    export TT_METAL_SLOW_DISPATCH_MODE=1
+    export TT_METAL_DISABLE_SFPLOADMACRO=1
+fi
+
 # --- Parse flags ---
 DEV_MODE=false
+FAIL_FAST=true
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dev)
             DEV_MODE=true
+            shift
+            ;;
+        --run-all)
+            FAIL_FAST=false
             shift
             ;;
         *)
@@ -51,29 +71,31 @@ done
 # --- Argument validation ---
 if [[ $# -eq 0 ]]; then
     echo "SAFE_PYTEST_ERROR: No test path provided" >&2
-    echo "Usage: scripts/run_safe_pytest.sh [--dev] <test_path> [extra_pytest_args...]" >&2
+    echo "Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]" >&2
     exit 3
 fi
 
 TEST_PATH="$1"
 shift
 
-# --- Acquire flock ---
-exec 9>"$LOCK_FILE"
+# --- Acquire flock (hardware only) ---
+if [[ "$SIM_MODE" == false ]]; then
+    exec 9>"$LOCK_FILE"
 
-echo "SAFE_PYTEST: Waiting for device lock..." >&2
-flock 9
-echo "SAFE_PYTEST: Device lock acquired" >&2
+    echo "SAFE_PYTEST: Waiting for device lock..." >&2
+    flock 9
+    echo "SAFE_PYTEST: Device lock acquired" >&2
 
-# --- Check if device needs reset from previous hang ---
-if [[ -f "$DIRTY_FLAG" ]]; then
-    echo "SAFE_PYTEST: Device marked dirty from previous hang, resetting..." >&2
-    if ! tt-smi -r; then
-        echo "SAFE_PYTEST_ERROR: Device reset (tt-smi -r) failed" >&2
-        exit 3
+    # --- Check if device needs reset from previous hang ---
+    if [[ -f "$DIRTY_FLAG" ]]; then
+        echo "SAFE_PYTEST: Device marked dirty from previous hang, resetting..." >&2
+        if ! tt-smi -r; then
+            echo "SAFE_PYTEST_ERROR: Device reset (tt-smi -r) failed" >&2
+            exit 3
+        fi
+        rm -f "$DIRTY_FLAG"
+        echo "SAFE_PYTEST: Device reset complete" >&2
     fi
-    rm -f "$DIRTY_FLAG"
-    echo "SAFE_PYTEST: Device reset complete" >&2
 fi
 
 # --- Setup environment ---
@@ -86,17 +108,20 @@ else
     echo "SAFE_PYTEST: WARNING: python_env not found; using system Python" >&2
 fi
 
-export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
-
-# Auto-triage: dispatch layer runs tt-triage when timeout fires (both modes).
-# This only executes on actual hang, not on every test — zero overhead for passing tests.
-# Requires tt-exalens: uv pip install -r tools/triage/requirements.txt
-if ! python3 -c "import ttexalens" 2>/dev/null; then
-    echo "SAFE_PYTEST: WARNING: tt-exalens not installed — triage on hang will be unavailable." >&2
-    echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt" >&2
-fi
+# --- Hang detection setup (hardware only) ---
+# On timeout, the dispatch layer runs tt-triage. Fires only on actual hang —
+# zero overhead for passing tests. On sim there is no hang detection because
+# wall-clock timeouts are meaningless at kHz clock speeds.
 rm -f "$TRIAGE_LOG"
-export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress > ${TRIAGE_LOG} 2>&1"
+if [[ "$SIM_MODE" == false ]]; then
+    export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
+    # Requires tt-exalens: uv pip install -r tools/triage/requirements.txt
+    if ! python3 -c "import ttexalens" 2>/dev/null; then
+        echo "SAFE_PYTEST: WARNING: tt-exalens not installed — triage on hang will be unavailable." >&2
+        echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt" >&2
+    fi
+    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress > ${TRIAGE_LOG} 2>&1"
+fi
 
 if [[ "$DEV_MODE" == true ]]; then
     # Lightweight asserts: compiles ASSERT() as ebreak, halting the core at the
@@ -124,22 +149,37 @@ if [[ "$DEV_MODE" == true ]]; then
     export TT_METAL_WATCHER_DISABLE_ASSERT=1
     export TT_METAL_WATCHER_DISABLE_DISPATCH=1
 
-    echo "SAFE_PYTEST: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s" >&2
+    if [[ "$SIM_MODE" == true ]]; then
+        echo "SAFE_PYTEST: [sim+dev] asserts=ebreak llk_asserts=ON watcher=polling (no hang detection on sim)" >&2
+    else
+        echo "SAFE_PYTEST: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s" >&2
+    fi
+elif [[ "$SIM_MODE" == true ]]; then
+    echo "SAFE_PYTEST: [sim] no hang detection" >&2
 else
     echo "SAFE_PYTEST: dispatch_timeout=${DISPATCH_TIMEOUT}s" >&2
 fi
 echo "SAFE_PYTEST: pytest ${TEST_PATH} $*" >&2
 echo "========================================" >&2
 
-# --- Mark device dirty before running tests ---
+# --- Mark device dirty before running tests (hardware only) ---
 # Pessimistic: assume the device will get corrupted. If the script is killed at any
 # point (SIGKILL, OOM, etc.), the flag persists and the next runner will reset.
 # Cleared on clean exit or after a successful inline reset.
-touch "$DIRTY_FLAG"
+if [[ "$SIM_MODE" == false ]]; then
+    touch "$DIRTY_FLAG"
+fi
 
 # --- Run pytest ---
 # -x: stop on first failure (avoids running tests after a hang bricks the device)
-pytest "${TEST_PATH}" -x "$@"
+# --run-all: skip -x to get full pass/fail counts (for eval scoring)
+PYTEST_CMD=(pytest "${TEST_PATH}")
+if [[ "$FAIL_FAST" == true ]]; then
+    PYTEST_CMD+=(-x)
+fi
+PYTEST_CMD+=("$@")
+
+"${PYTEST_CMD[@]}"
 EXIT_CODE=$?
 
 echo "========================================" >&2
@@ -152,15 +192,27 @@ if [[ $EXIT_CODE -eq 0 ]]; then
     exit 0
 fi
 
+# Pytest exit code 5 = no tests collected (typo in path, bad marker filter, etc.)
+if [[ $EXIT_CODE -eq 5 ]]; then
+    rm -f "$DIRTY_FLAG"
+    rm -f "$TRIAGE_LOG"
+    echo "SAFE_PYTEST_ERROR: No tests collected" >&2
+    exit 3
+fi
+
+# Kill any remaining child processes and their descendants.
+for child_pid in $(pgrep -P $$ 2>/dev/null); do
+    pkill -9 -P "$child_pid" 2>/dev/null || true
+    kill -9 "$child_pid" 2>/dev/null || true
+done
+
 # Determine if this was a hang:
 #   Triage log non-empty = dispatch timeout handler ran tt-triage (definitive hang signal)
+# On sim there is no hang detection, so IS_HANG always stays false.
 IS_HANG=false
 if [[ -s "$TRIAGE_LOG" ]]; then
     IS_HANG=true
 fi
-
-# Kill any remaining child processes (pytest may have left orphans)
-pkill -9 -P $$ 2>/dev/null || true
 
 # Only reset device when the failure might have left it dirty.
 # Hangs and crashes corrupt device state. Normal test failures (PCC mismatch,

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -192,19 +192,22 @@ if [[ $EXIT_CODE -eq 0 ]]; then
     exit 0
 fi
 
-# Pytest exit code 5 = no tests collected (typo in path, bad marker filter, etc.)
-if [[ $EXIT_CODE -eq 5 ]]; then
+# Pytest setup errors (no device touched):
+#   4 = usage error (bad args, nonexistent path)
+#   5 = no tests collected (typo in path, bad marker filter, etc.)
+if [[ $EXIT_CODE -eq 4 || $EXIT_CODE -eq 5 ]]; then
     rm -f "$DIRTY_FLAG"
     rm -f "$TRIAGE_LOG"
-    echo "SAFE_PYTEST_ERROR: No tests collected" >&2
+    if [[ $EXIT_CODE -eq 4 ]]; then
+        echo "SAFE_PYTEST_ERROR: Pytest usage error (invalid path or arguments)" >&2
+    else
+        echo "SAFE_PYTEST_ERROR: No tests collected" >&2
+    fi
     exit 3
 fi
 
-# Kill any remaining child processes and their descendants.
-for child_pid in $(pgrep -P $$ 2>/dev/null); do
-    pkill -9 -P "$child_pid" 2>/dev/null || true
-    kill -9 "$child_pid" 2>/dev/null || true
-done
+# Kill any remaining child processes (pytest may have left orphans)
+pkill -9 -P $$ 2>/dev/null || true
 
 # Determine if this was a hang:
 #   Triage log non-empty = dispatch timeout handler ran tt-triage (definitive hang signal)


### PR DESCRIPTION
## Summary
- **Simulator mode**: detect `TT_METAL_SIMULATOR`, export `TT_METAL_SLOW_DISPATCH_MODE=1` and `TT_METAL_DISABLE_SFPLOADMACRO=1`, and skip flock / dirty-flag tracking / device reset / dispatch-timeout triage. No hang protection is added for sim — wall-clock timeouts are meaningless at kHz.
- **`--run-all`** flag drops `-x` from the pytest invocation so full pass/fail counts are reported (eval scoring).
- **Exit code 5** (no tests collected) is mapped to setup-error exit 3 with a dedicated message.
- **Deeper orphan cleanup**: iterate `pgrep -P $$` and recursively kill each child tree instead of a single `pkill -9 -P $$`.

Unchanged: reset policy (still hang-only), triage command/output (no JSON path), log prefix, hardware code paths.

## Test plan
- [ ] Hardware: normal pass — `scripts/run_safe_pytest.sh <passing_test>` still prints `PASS`, resets are not triggered.
- [ ] Hardware: normal failure — exits 1, no reset.
- [ ] Hardware: hang — triage fires, device is reset, exits 2.
- [ ] Hardware: bad path — `scripts/run_safe_pytest.sh does/not/exist` reports "No tests collected" and exits 3.
- [ ] Hardware: `--run-all` — runs every test even after failures, reports aggregate counts.
- [ ] Simulator: `TT_METAL_SIMULATOR=... scripts/run_safe_pytest.sh <test>` — no flock wait, no reset, no triage setup; slow-dispatch/sfploadmacro env is exported.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/run_safe_pytest_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/run_safe_pytest_changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/run_safe_pytest_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/run_safe_pytest_changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/run_safe_pytest_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/run_safe_pytest_changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/run_safe_pytest_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/run_safe_pytest_changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/run_safe_pytest_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/run_safe_pytest_changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/run_safe_pytest_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/run_safe_pytest_changes)