### PR TITLE
Add compile-time guards for fp32 tilize mode consistency

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
@@ -66,6 +66,24 @@ constexpr bool is_fp32_input_format() {
     return format == 0;  // Float32
 }
 
+template <uint32_t input_cb, bool pack_default>
+constexpr bool has_unpack_to_dest_fp32() {
+    // Detects whether the CB was configured with UnpackToDestMode::UnpackToDestFp32 in the
+    // program factory. The JIT folds that host-side enum into unpack_dst_format[]: when set,
+    // a Float32 CB keeps Dest-side format Float32 (0); with Default mode it is downgraded to
+    // Tf32 (4). So comparing unpack_src_format[cb] == unpack_dst_format[cb] is a reliable
+    // compile-time signal on the TRISCs that can see both arrays (UNPACK and MATH; PACK cannot).
+    //
+    // pack_default controls the value returned on PACK (where the check is not observable).
+    // Callers pick it so the surrounding static_assert passes on PACK, deferring enforcement
+    // to UNPACK/MATH.
+#if defined(UCK_CHLKC_PACK)
+    return pack_default;
+#else
+    return unpack_src_format[input_cb] == unpack_dst_format[input_cb];
+#endif
+}
+
 template <uint32_t block_width_tiles, uint32_t input_cb, uint32_t output_cb>
 constexpr bool can_use_fast_tilize() {
     return block_width_tiles < 256 &&
@@ -110,6 +128,33 @@ ALWI void tilize(
                                             is_fp32_input_format<input_cb>();
     constexpr bool use_fast = can_use_fast_tilize<block_width_tiles, input_cb, output_cb>() &&
                               !lossless_fp32_override;
+
+    // Lossless fp32 requires BOTH fp32 Dest AND the input CB configured with UnpackToDestFp32.
+    // Without these, the slow tilize path still round-trips fp32 through tf32 in Dest and the
+    // "lossless" promise is silently broken. Gate with if constexpr so the asserts only fire
+    // when the input is actually fp32 and Lossless mode is requested.
+    if constexpr (lossless_fp32_override) {
+        static_assert(DST_ACCUM_MODE,
+            "Fp32Mode::Lossless requires fp32_dest_acc_en=true in the ComputeConfig: "
+            "Dest must hold fp32, otherwise the slow tilize path still downgrades to tf32.");
+        static_assert(has_unpack_to_dest_fp32<input_cb, /*pack_default=*/true>(),
+            "Fp32Mode::Lossless requires UnpackToDestMode::UnpackToDestFp32 on the input CB. "
+            "Set unpack_to_dest_mode[input_cb] = UnpackToDestMode::UnpackToDestFp32 in the "
+            "program factory; otherwise the unpacker truncates fp32 to tf32 on its way to Dest.");
+    }
+
+    // Conversely, the fast tilize path requires UnpackToDestMode::Default on the input CB.
+    // Combining fast_tilize with UnpackToDestFp32 silently corrupts output (the unpacker
+    // writes 32-bit fp32 payloads into Dest slots that fast_tilize's pack stage reads as
+    // tf32). Only applicable to fp32 inputs — Float16_b is unaffected because its
+    // unpack_dst_format equals its unpack_src_format regardless of UnpackToDestMode.
+    if constexpr (use_fast && is_fp32_input_format<input_cb>()) {
+        static_assert(!has_unpack_to_dest_fp32<input_cb, /*pack_default=*/false>(),
+            "Fast tilize on fp32 input requires UnpackToDestMode::Default on the input CB. "
+            "Combining fast_tilize with UnpackToDestFp32 corrupts output. Either leave "
+            "unpack_to_dest_mode[input_cb] as Default in the program factory, or request "
+            "Fp32Mode::Lossless to force the slow (bit-exact) tilize path.");
+    }
 
     // Determine if we're doing data type reconfiguration
     constexpr bool use_unpack_reconfig =


### PR DESCRIPTION
## Summary
- Enforce that `Fp32Mode::Lossless` requires both `fp32_dest_acc_en=true` and `UnpackToDestMode::UnpackToDestFp32` on the input CB, so the slow tilize path cannot silently downgrade fp32 to tf32 in Dest.
- Reject `fast_tilize` on fp32 input when the input CB is configured with `UnpackToDestFp32`, which otherwise corrupts output (unpacker writes fp32 payloads into Dest slots the pack stage reads as tf32).
- Introduce `has_unpack_to_dest_fp32<>` helper that compile-time inspects `unpack_src_format[cb] == unpack_dst_format[cb]` on UNPACK/MATH, with a caller-supplied default on PACK where the arrays aren't visible.

## Test plan
- [ ] Sanity pipeline passes on this branch
- [ ] Model perf pipeline passes on this branch
- [ ] Spot-check an op using `Fp32Mode::Lossless` to confirm the new `static_assert`s fire only on misconfiguration

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/tilize_helper_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/tilize_helper_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/tilize_helper_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/tilize_helper_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/tilize_helper_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/tilize_helper_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/tilize_helper_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/tilize_helper_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/tilize_helper_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/tilize_helper_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/tilize_helper_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/tilize_helper_asserts)