### PR TITLE
#40182: Named rounding modes [CLEANUP]

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -495,8 +495,8 @@ inline void calculate_sine() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0] * FRAC_1_PI;
-        vInt whole_v = float_to_int16(v, 0);
-        v -= int32_to_float(whole_v, 0);
+        vInt whole_v = float_to_int16(v, RoundMode::NearestEven);
+        v -= int32_to_float(whole_v, RoundMode::NearestEven);
         v = sfpu_sinpi<APPROXIMATION_MODE>(v);
 
         v_if(whole_v & 1) { v = -v; }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_rsqrt.h
@@ -25,7 +25,7 @@ inline void calculate_add_rsqrt(uint32_t param0) {
         if constexpr (fp32_dest_acc_en) {
             sfpi::dst_reg[0] = y;
         } else {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(y, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(y, RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -88,7 +88,7 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        r = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, 0));
+        r = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven));
     }
 
     r = sfpi::setsgn(r, y);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
@@ -98,7 +98,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_fmod_(sfpi::vFloat in0, sfpi::vFloat in1) 
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
     }
 
     return result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -61,7 +61,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vInt exp = sfpi::exexp(base);
     v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
     v_endif;
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(exp, 0);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(exp, sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
@@ -102,8 +102,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
-    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, 0);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, sfpi::RoundMode::NearestEven);
 
     d2 = d1 * d2;
     zif = _float_to_int32_positive_(d2 * d3);
@@ -115,9 +115,9 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
 
     // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
     // Check valid base range
-    sfpi::vInt pow_int =
-        sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+    sfpi::vInt pow_int = sfpi::float_to_int16(
+        pow, sfpi::RoundMode::NearestEven);  // int16 should be plenty, since large powers will approach 0/Inf
+    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
 
     // Division by 0 when base is 0 and pow is negative => set to NaN
     v_if((absbase == 0.f) && pow < 0.f) {
@@ -144,7 +144,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
     }
 
     return y;
@@ -192,7 +192,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
     // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), 0);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2)
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
@@ -218,9 +218,9 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     v_if(base < 0.0f) {  // negative base
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
-        sfpi::vInt pow_int =
-            sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+        sfpi::vInt pow_int = sfpi::float_to_int16(
+            pow, sfpi::RoundMode::NearestEven);  // int16 should be plenty, since large powers will approach 0/Inf
+        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
 
         // If pow is odd integer then result is negative
         // If power is even, then result is positive

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -24,8 +24,8 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
 
     // Convert to float for reciprocal computation
     // Handle 2^31 edge case where sign-magnitude conversion yields negative
-    sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
-    sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
+    sfpi::vFloat a_f = sfpi::int32_to_float(a, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat b_f = sfpi::int32_to_float(b, sfpi::RoundMode::NearestEven);
     v_if(a_f < 0.0f) { a_f = TWO_POW_31; }
     v_endif;
     v_if(b_f < 0.0f) { b_f = TWO_POW_31; }
@@ -50,8 +50,8 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     sfpi::vInt r = a - qb;
 
     // Compute correction for approximation error: correction = |r| / b
-    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
-    sfpi::vInt correction = sfpi::float_to_uint16(r_f * inv_b_f, 0);
+    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), sfpi::RoundMode::NearestEven);
+    sfpi::vInt correction = sfpi::float_to_uint16(r_f * inv_b_f, sfpi::RoundMode::NearestEven);
 
     // Compute correction * b (full 32-bit result from 24-bit multiplies)
     sfpi::vInt tmp_lo = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 0);
@@ -153,7 +153,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat 
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
     }
 
     return result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -17,7 +17,7 @@ inline void cast_fp32_to_fp16a() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         // vFloat val = dst_reg[0];
-        // dst_reg[0] = float_to_fp16a(val, 0);
+        // dst_reg[0] = float_to_fp16a(val, sfpi::RoundMode::NearestEven);
         TTI_SFPLOAD(0, 0, 3, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
         TTI_SFPSTORE(0, 1, 3, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -37,7 +37,7 @@ inline void calculate_cube_root() {
         // f = (0x548c2b4b - i * 1.0/3.0) / 256.0 + 2^23
         //   = (0x548c2b4b/256.0 - i * 1.0/3.0/256.0) + 2^23
 
-        sfpi::vFloat f = sfpi::int32_to_float(sfpi::reinterpret<sfpi::vInt>(x), 0);
+        sfpi::vFloat f = sfpi::int32_to_float(sfpi::reinterpret<sfpi::vInt>(x), sfpi::RoundMode::NearestEven);
 
         f = f * negative_third_256 + magic;
 
@@ -64,7 +64,7 @@ inline void calculate_cube_root() {
             d = sfpi::setsgn(d, a);
             y = d * (t * t);
 
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -30,7 +30,7 @@ inline void calculate_celu(uint32_t param0, uint32_t param1) {
 
             sfpi::vFloat result = alpha * (exp_val - sfpi::vConst1);
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
             sfpi::dst_reg[0] = result;
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -37,8 +37,8 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
             v_else { pos_in1 = in1; }
             v_endif;
 
-            sfpi::vFloat float_in0 = sfpi::int32_to_float(pos_in0, 0);
-            sfpi::vFloat float_in1 = sfpi::int32_to_float(pos_in1, 0);
+            sfpi::vFloat float_in0 = sfpi::int32_to_float(pos_in0, sfpi::RoundMode::NearestEven);
+            sfpi::vFloat float_in1 = sfpi::int32_to_float(pos_in1, sfpi::RoundMode::NearestEven);
             result = float_in0 * _sfpu_reciprocal_<2>(float_in1);
             result = sfpi::setsgn(result, in0 ^ in1);
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -29,7 +29,7 @@ sfpi_inline void calculate_div_int32_body(
     sfpi::vInt b = sfpi::abs(b_orig);
 
     // Convert to floats, but check for the edge case mentioned above.
-    sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
+    sfpi::vFloat b_f = sfpi::int32_to_float(b, sfpi::RoundMode::NearestEven);
     v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
     v_endif;
 
@@ -43,7 +43,7 @@ sfpi_inline void calculate_div_int32_body(
     e = e * e + e;
     sfpi::vInt a = sfpi::abs(a_orig);
     inv_b_f = e * inv_b_f + inv_b_f;
-    sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
+    sfpi::vFloat a_f = sfpi::int32_to_float(a, sfpi::RoundMode::NearestEven);
     v_if(a_f < 0.0f) { a_f = 2147483648.0f; }
     v_endif;
 
@@ -70,12 +70,12 @@ sfpi_inline void calculate_div_int32_body(
 
     // Compute remainder.
     sfpi::vInt r = a - qb;
-    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
+    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), sfpi::RoundMode::NearestEven);
 
     // Compute correction value in float32.
     sfpi::vFloat correction_f = r_f * inv_b_f;
     sfpi::vInt b1 = b >> 23;
-    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
+    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, sfpi::RoundMode::NearestEven);
 
     // Compute tmp = correction * b.
     b1 = __builtin_rvtt_sfpmul24(correction.get(), b1.get(), 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
     }
     return y;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -222,7 +222,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
         sfpi::vInt exponential_part = sfpi::exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));
         sfpi::vInt fractional_part = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
 
-        sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, 0);
+        sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
         frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
         sfpi::vFloat exp_val = sfpi::setexp(frac, exponential_part);
 
@@ -281,7 +281,7 @@ inline void calculate_gelu() {
             sfpi::vFloat in = sfpi::dst_reg[0];
             sfpi::vFloat result = calculate_gelu_piecewise(in);
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;
@@ -447,7 +447,7 @@ inline void calculate_gelu_derivative_polynomial() {
         sfpi::vFloat val = sfpi::dst_reg[0];
         sfpi::vFloat result = calculate_gelu_derivative_simple<APPROXIMATION_MODE>(val);
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -43,7 +43,7 @@ inline void calculate_lgamma_stirling() {
         // reflection adjustment for inputs < 0.5 are done in calculate_lgamma_adjusted.
 
         if constexpr (!is_fp32_dest_acc_en) {
-            res = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(res, 0));
+            res = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(res, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = res;
@@ -76,7 +76,7 @@ inline void calculate_lgamma_adjusted(
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         } else {
             sfpi::vInt exp = sfpi::exexp(in);
             sfpi::vInt man = sfpi::exman9(in);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -38,7 +38,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
     v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
     v_endif;
 
-    sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+    sfpi::vFloat expf = sfpi::int32_to_float(exp, sfpi::RoundMode::NearestEven);
     sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat result = expf * vConstLn2 + series_result;  // exp correction: ln(1+x) + exp*ln(2)
 
@@ -67,7 +67,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
     }
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
     }
 
     return result;
@@ -160,7 +160,7 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
         v_endif;
 
         // Convert to float - int32_to_float handles sign-magnitude format correctly
-        sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+        sfpi::vFloat expf = sfpi::int32_to_float(exp, sfpi::RoundMode::NearestEven);
 
         // Step 5: Combine: ln(x) = exp×ln(2) + ln(m)
         result = expf * sfpi::vConstFloatPrgm2 + ln_m;  // log(x) = log2(x) / log(2)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -97,7 +97,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + 0x1.274p-3f;
             r = r * m + -0x1.55p-3f;
             r = r * m + 0x1.998p-3f;
-            e_float = sfpi::int32_to_float(abs_e, 0);
+            e_float = sfpi::int32_to_float(abs_e, sfpi::RoundMode::NearestEven);
             r = r * m + sfpi::vConstFloatPrgm1;
             s = m * m;
             r = r * m + sfpi::vConstFloatPrgm2;
@@ -106,7 +106,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
 
             m = m + t;
-            e_float = sfpi::int32_to_float(abs_e, 0);
+            e_float = sfpi::int32_to_float(abs_e, sfpi::RoundMode::NearestEven);
             r = neg_quarter * m + sfpi::vConstFloatPrgm1;
             s = m * m;
             r = r * m + sfpi::vConstFloatPrgm2;
@@ -139,7 +139,7 @@ inline void calculate_log1p() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat result = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -90,7 +90,7 @@ inline sfpi::vFloat piecewise_log_expand(sfpi::vFloat poly_result, sfpi::vInt e_
 #endif
     v_if(e_int < 0) { e_int = sfpi::setsgn(~e_int + 1, 1); }
     v_endif;
-    return sfpi::int32_to_float(e_int, 0) * EXPAND_C + poly_result;
+    return sfpi::int32_to_float(e_int, sfpi::RoundMode::NearestEven) * EXPAND_C + poly_result;
 }
 #endif
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -120,7 +120,7 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
         sfpi::vFloat result = sum * scale;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -24,7 +24,7 @@ inline void calculate_rdiv(const uint value) {
                 recip = _sfpu_reciprocal_<2>(in);
             } else {
                 recip = _sfpu_reciprocal_<1>(in);
-                recip = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(recip, 0));
+                recip = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(recip, sfpi::RoundMode::NearestEven));
             }
         }
         sfpi::vFloat result = recip * val;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -46,7 +46,7 @@ inline void calculate_sigmoid() {
             sfpi::vFloat val = sfpi::dst_reg[0];
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
 
             sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -19,7 +19,7 @@ inline void calculate_silu() {
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -147,7 +147,7 @@ inline void calculate_tanh() {
                 result = _sfpu_tanh_fp32_accurate_<is_fp32_dest_acc_en>(val);
             } else {
                 result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
 
             sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -206,7 +206,7 @@ inline void calculate_tanh_derivative_sech2() {
 
         // Explicit RNE rounding for BF16 output — SFPSTORE truncates toward zero by default.
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -130,7 +130,7 @@ inline void calculate_tangent() {
         if constexpr (is_fp32_dest_acc_en) {
             sfpi::dst_reg[0] = a;
         } else {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(a, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(a, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }
@@ -202,7 +202,7 @@ inline void calculate_sine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg++;
@@ -288,7 +288,7 @@ inline void calculate_cosine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg++;
@@ -356,7 +356,7 @@ inline void calculate_atan() {
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;
@@ -435,7 +435,7 @@ inline void calculate_asin_acos_impl() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -65,7 +65,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
     // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), 0);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
@@ -106,8 +106,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
-    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, 0);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, sfpi::RoundMode::NearestEven);
 
     d2 = d1 * d2;
     zif = _float_to_int32_positive_(d2 * d3);
@@ -129,9 +129,9 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     v_if(base < 0.0f) {
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
-        sfpi::vInt pow_int =
-            sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+        sfpi::vInt pow_int = sfpi::float_to_int16(
+            pow, sfpi::RoundMode::NearestEven);  // int16 should be plenty, since large powers will approach 0/Inf
+        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
 
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
@@ -150,7 +150,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
     // rather than 81 (which would have been correct).
     // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-    y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+    y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
 
     return y;
 }
@@ -224,7 +224,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
     // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), 0);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2)
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
@@ -244,9 +244,9 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     v_if(base < 0.0f) {  // negative base
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
-        sfpi::vInt pow_int =
-            sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+        sfpi::vInt pow_int = sfpi::float_to_int16(
+            pow, sfpi::RoundMode::NearestEven);  // int16 should be plenty, since large powers will approach 0/Inf
+        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
 
         // If pow is odd integer then result is negative
         // If power is even, then result is positive

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_selu.h
@@ -29,7 +29,7 @@ inline void calculate_selu(uint scale, uint alpha) {
             sfpi::vFloat result = minus_mul * alpha_value * scale_value;
 
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
             sfpi::dst_reg[0] = result;
         }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -93,7 +93,7 @@ template <bool is_fp32_dest_acc_en>
 sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloat addend) {
     sfpi::vFloat result = mul_a * mul_b + addend;
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
     }
     sfpi::dst_reg[0] = result;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -88,7 +88,7 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        r = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, 0));
+        r = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven));
     }
 
     r = sfpi::setsgn(r, y);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
@@ -104,7 +104,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_fmod_(sfpi::vFloat in0, sfpi::vFloat in1) 
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
     }
 
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -61,7 +61,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vInt exp = sfpi::exexp(base);
     v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
     v_endif;
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(exp, 0);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(exp, sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
@@ -102,8 +102,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
-    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, 0);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, sfpi::RoundMode::NearestEven);
 
     d2 = d1 * d2;
     zif = _float_to_int32_positive_(d2 * d3);
@@ -115,9 +115,9 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
 
     // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
     // Check valid base range
-    sfpi::vInt pow_int =
-        sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+    sfpi::vInt pow_int = sfpi::float_to_int16(
+        pow, sfpi::RoundMode::NearestEven);  // int16 should be plenty, since large powers will approach 0/Inf
+    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
 
     // Division by 0 when base is 0 and pow is negative => set to NaN
     v_if((absbase == 0.f) && pow < 0.f) {
@@ -144,7 +144,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
     }
 
     return y;
@@ -192,7 +192,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
     // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), 0);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2)
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
@@ -218,9 +218,9 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     v_if(base < 0.0f) {  // negative base
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
-        sfpi::vInt pow_int =
-            sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+        sfpi::vInt pow_int = sfpi::float_to_int16(
+            pow, sfpi::RoundMode::NearestEven);  // int16 should be plenty, since large powers will approach 0/Inf
+        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
 
         // If pow is odd integer then result is negative
         // If power is even, then result is positive

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -23,7 +23,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
 
     // Convert to float for reciprocal computation
     // Handle edge case: if conversion results in negative
-    sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
+    sfpi::vFloat b_f = sfpi::int32_to_float(b, sfpi::RoundMode::NearestEven);
     v_if(b_f < 0.0f) { b_f = TWO_POW_31; }
     v_endif;
 
@@ -44,7 +44,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     sfpi::vUInt a = sfpi::abs(a_signed);
     inv_b_f = e * inv_b_f + inv_b_f;
 
-    sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
+    sfpi::vFloat a_f = sfpi::int32_to_float(a, sfpi::RoundMode::NearestEven);
     v_if(a_f < 0.0f) { a_f = TWO_POW_31; }
     v_endif;
 
@@ -63,10 +63,10 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
 
     // Split q and b into 11-bit chunks to compute q * b
     sfpi::vUInt MASK_11 = 0x7ff;
-    sfpi::vFloat q1 = int32_to_float(q & MASK_11, 0);
-    sfpi::vFloat q2 = int32_to_float(q >> 11, 0);
-    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, 0);
-    sfpi::vFloat b0 = int32_to_float(b & MASK_11, 0);
+    sfpi::vFloat q1 = int32_to_float(q & MASK_11, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat q2 = int32_to_float(q >> 11, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat b0 = int32_to_float(b & MASK_11, sfpi::RoundMode::NearestEven);
 
     // hi = q2 * b0 + q1 * b1 (high part)
     // lo = q1 * b0 (low part)
@@ -82,18 +82,18 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     sfpi::vInt r = a - qb;
 
     // Use abs(r) for correction computation
-    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
+    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), sfpi::RoundMode::NearestEven);
 
     // Compute correction: r / b in float32
     sfpi::vFloat correction_f = r_f * inv_b_f;
-    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
-    correction_f = sfpi::int32_to_float(correction, 0);
+    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, sfpi::RoundMode::NearestEven);
+    correction_f = sfpi::int32_to_float(correction, sfpi::RoundMode::NearestEven);
 
     // Recompute b chunks for correction multiplication to reduce register pressure
     b = sfpi::abs(b_signed);
-    b0 = int32_to_float(b & MASK_11, 0);
-    b1 = int32_to_float((b >> 11) & MASK_11, 0);
-    sfpi::vFloat b2 = sfpi::int32_to_float(b >> 22, 0);
+    b0 = int32_to_float(b & MASK_11, sfpi::RoundMode::NearestEven);
+    b1 = int32_to_float((b >> 11) & MASK_11, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat b2 = sfpi::int32_to_float(b >> 22, sfpi::RoundMode::NearestEven);
 
     // tmp = correction * (b2<<22 + b1<<11 + b0)
     sfpi::vFloat low = correction_f * b0 + MANTISSA_ALIGNMENT_OFFSET;
@@ -205,7 +205,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat 
     v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
     }
 
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -17,7 +17,7 @@ inline void cast_fp32_to_fp16a() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         // vFloat val = dst_reg[0];
-        // dst_reg[0] = float_to_fp16a(val, 0);
+        // dst_reg[0] = float_to_fp16a(val, sfpi::RoundMode::NearestEven);
         TTI_SFPLOAD(0, 0, 3, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
         TTI_SFPSTORE(0, 1, 3, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -37,7 +37,7 @@ inline void calculate_cube_root() {
         // f = (0x548c2b4b - i * 1.0/3.0) / 256.0 + 2^23
         //   = (0x548c2b4b/256.0 - i * 1.0/3.0/256.0) + 2^23
 
-        sfpi::vFloat f = sfpi::int32_to_float(sfpi::reinterpret<sfpi::vInt>(x), 0);
+        sfpi::vFloat f = sfpi::int32_to_float(sfpi::reinterpret<sfpi::vInt>(x), sfpi::RoundMode::NearestEven);
 
         f = f * negative_third_256 + magic;
 
@@ -64,7 +64,7 @@ inline void calculate_cube_root() {
             d = sfpi::setsgn(d, a);
             y = d * (t * t);
 
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -30,7 +30,7 @@ inline void calculate_celu(uint32_t param0, uint32_t param1) {
 
             sfpi::vFloat result = alpha * (exp_val - sfpi::vConst1);
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
             sfpi::dst_reg[0] = result;
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -22,8 +22,8 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
 
         v_if(in0 != 0 && in0 == in1) { result = sfpi::vConst1; }
         v_else {
-            sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
-            sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
+            sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, sfpi::RoundMode::NearestEven);
+            sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, sfpi::RoundMode::NearestEven);
             result = float_in0 * _sfpu_reciprocal_<2>(float_in1);
         }
         v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -36,7 +36,7 @@ sfpi_inline void calculate_div_int32_body(
     b = sfpi::abs(b);
 
     // Convert to floats, but check for the edge case mentioned above.
-    sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
+    sfpi::vFloat b_f = sfpi::int32_to_float(b, sfpi::RoundMode::NearestEven);
     v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
     v_endif;
 
@@ -72,7 +72,7 @@ sfpi_inline void calculate_div_int32_body(
 
     // Final step of Halley's Method
     inv_b_f = e * inv_b_f + inv_b_f;
-    sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
+    sfpi::vFloat a_f = sfpi::int32_to_float(a, sfpi::RoundMode::NearestEven);
 
     // Apply scale
     inv_b_f = inv_b_f * scale;
@@ -93,10 +93,10 @@ sfpi_inline void calculate_div_int32_body(
     // Now q2 = q>>22, q1 = q>>11
     // And so qb = (q2<<22 + q1<<11) * (b2<<22 + b1<<11 + b0)
     //           = (q2<<22 * b0) + (q1<<11 * b1<<11) + (q1<<11 * b0)
-    sfpi::vFloat q1 = int32_to_float(q & MASK_11, 0);
-    sfpi::vFloat q2 = int32_to_float(q >> 11, 0);
-    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, 0);
-    sfpi::vFloat b0 = int32_to_float(b & MASK_11, 0);
+    sfpi::vFloat q1 = int32_to_float(q & MASK_11, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat q2 = int32_to_float(q >> 11, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat b0 = int32_to_float(b & MASK_11, sfpi::RoundMode::NearestEven);
     q = q << 11;
 
     sfpi::vFloat MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;
@@ -113,13 +113,13 @@ sfpi_inline void calculate_div_int32_body(
         sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get(), 4, sfpi::SFPLOAD_ADDR_MODE_NOINC);
     a = sfpi::abs(a);
     sfpi::vInt r = a - qb;
-    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
+    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), sfpi::RoundMode::NearestEven);
 
     // Compute correction value in float32.
     sfpi::vFloat correction_f = r_f * inv_b_f;
-    sfpi::vFloat b2 = sfpi::int32_to_float(b >> 22, 0);
-    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
-    correction_f = sfpi::int32_to_float(correction, 0);
+    sfpi::vFloat b2 = sfpi::int32_to_float(b >> 22, sfpi::RoundMode::NearestEven);
+    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, sfpi::RoundMode::NearestEven);
+    correction_f = sfpi::int32_to_float(correction, sfpi::RoundMode::NearestEven);
 
     // correction should fit into 11 bits, thus:
     // tmp = correction * (b2<<22 + b1<<11 + b0)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
     }
     return y;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -222,7 +222,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
         sfpi::vInt exponential_part = sfpi::exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));
         sfpi::vInt fractional_part = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
 
-        sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, 0);
+        sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
         frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
         sfpi::vFloat exp_val = sfpi::setexp(frac, exponential_part);
 
@@ -281,7 +281,7 @@ inline void calculate_gelu() {
             sfpi::vFloat in = sfpi::dst_reg[0];
             sfpi::vFloat result = calculate_gelu_piecewise(in);
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;
@@ -447,7 +447,7 @@ inline void calculate_gelu_derivative_polynomial() {
         sfpi::vFloat val = sfpi::dst_reg[0];
         sfpi::vFloat result = calculate_gelu_derivative_simple<APPROXIMATION_MODE>(val);
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -43,7 +43,7 @@ inline void calculate_lgamma_stirling() {
         // reflection adjustment for inputs < 0.5 are done in calculate_lgamma_adjusted.
 
         if constexpr (!is_fp32_dest_acc_en) {
-            res = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(res, 0));
+            res = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(res, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
@@ -146,7 +146,7 @@ inline void calculate_lgamma_adjusted(
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         } else {
             sfpi::vInt exp = sfpi::exexp(in);
             sfpi::vInt man = sfpi::exman9(in);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -38,7 +38,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
     v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
     v_endif;
 
-    sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+    sfpi::vFloat expf = sfpi::int32_to_float(exp, sfpi::RoundMode::NearestEven);
     sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat result = expf * vConstLn2 + series_result;  // exp correction: ln(1+x) + exp*ln(2)
 
@@ -67,7 +67,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
     }
 
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
     }
 
     return result;
@@ -162,7 +162,7 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
         v_endif;
 
         // Convert to float - int32_to_float handles sign-magnitude format correctly
-        sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+        sfpi::vFloat expf = sfpi::int32_to_float(exp, sfpi::RoundMode::NearestEven);
 
         // Step 5: Combine: ln(x) = exp×ln(2) + ln(m)
         constexpr float LN2 = 0.69314718246459961f;  // log(2)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -97,7 +97,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + 0x1.274p-3f;
             r = r * m + -0x1.55p-3f;
             r = r * m + 0x1.998p-3f;
-            e_float = sfpi::int32_to_float(abs_e, 0);
+            e_float = sfpi::int32_to_float(abs_e, sfpi::RoundMode::NearestEven);
             r = r * m + sfpi::vConstFloatPrgm1;
             s = m * m;
             r = r * m + sfpi::vConstFloatPrgm2;
@@ -106,7 +106,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
 
             m = m + t;
-            e_float = sfpi::int32_to_float(abs_e, 0);
+            e_float = sfpi::int32_to_float(abs_e, sfpi::RoundMode::NearestEven);
             r = neg_quarter * m + sfpi::vConstFloatPrgm1;
             s = m * m;
             r = r * m + sfpi::vConstFloatPrgm2;
@@ -139,7 +139,7 @@ inline void calculate_log1p() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat result = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -90,7 +90,7 @@ inline sfpi::vFloat piecewise_log_expand(sfpi::vFloat poly_result, sfpi::vInt e_
 #endif
     v_if(e_int < 0) { e_int = sfpi::setsgn(~e_int + 1, 1); }
     v_endif;
-    return sfpi::int32_to_float(e_int, 0) * EXPAND_C + poly_result;
+    return sfpi::int32_to_float(e_int, sfpi::RoundMode::NearestEven) * EXPAND_C + poly_result;
 }
 #endif
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -120,7 +120,7 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
         sfpi::vFloat result = sum * scale;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -24,7 +24,7 @@ inline void calculate_rdiv(const uint value) {
                 recip = _sfpu_reciprocal_<2>(in);
             } else {
                 recip = _sfpu_reciprocal_<1>(in);
-                recip = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(recip, 0));
+                recip = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(recip, sfpi::RoundMode::NearestEven));
             }
         }
         sfpi::vFloat result = recip * val;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -48,7 +48,7 @@ inline void calculate_sigmoid() {
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
 
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
 
             sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -19,7 +19,7 @@ inline void calculate_silu() {
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -145,7 +145,7 @@ inline void calculate_tanh() {
                 result = _sfpu_tanh_fp32_accurate_<is_fp32_dest_acc_en>(val);
             } else {
                 result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
 
             sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -206,7 +206,7 @@ inline void calculate_tanh_derivative_sech2() {
 
         // Explicit RNE rounding for BF16 output — SFPSTORE truncates toward zero by default.
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -150,7 +150,7 @@ inline void calculate_tangent() {
         if constexpr (is_fp32_dest_acc_en) {
             sfpi::dst_reg[0] = a;
         } else {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(a, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(a, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }
@@ -222,7 +222,7 @@ inline void calculate_sine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg++;
@@ -308,7 +308,7 @@ inline void calculate_cosine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(r, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg++;
@@ -376,7 +376,7 @@ inline void calculate_atan() {
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;
@@ -455,7 +455,7 @@ inline void calculate_asin_acos_impl() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -67,7 +67,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
     // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), 0);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
@@ -108,8 +108,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
 
     // Compute formula in Horner form
     sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
-    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, 0);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, sfpi::RoundMode::NearestEven);
 
     d2 = d1 * d2;
     zif = _float_to_int32_positive_(d2 * d3);
@@ -131,9 +131,9 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     v_if(base < 0.0f) {
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
-        sfpi::vInt pow_int =
-            sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+        sfpi::vInt pow_int = sfpi::float_to_int16(
+            pow, sfpi::RoundMode::NearestEven);  // int16 should be plenty, since large powers will approach 0/Inf
+        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
 
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
@@ -152,7 +152,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
     // rather than 81 (which would have been correct).
     // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-    y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+    y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
 
     return y;
 }
@@ -226,7 +226,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vInt exp_sign = sfpi::vInt(0) - sign_bit;    // 0 or 0xFFFFFFFF (arithmetic right shift equivalent)
     sfpi::vInt exp_abs = (exp ^ exp_sign) - exp_sign;  // Take two's complement if negative exponent
     // setsgn reads sign from bit 31, so use exp_sign directly (0 or 0xFFFFFFFF) not (exp_sign & 1)
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), 0);
+    sfpi::vFloat exp_f32 = sfpi::int32_to_float(sfpi::setsgn(exp_abs, exp_sign), sfpi::RoundMode::NearestEven);
 
     // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2)
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
@@ -246,9 +246,9 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     v_if(base < 0.0f) {  // negative base
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
-        sfpi::vInt pow_int =
-            sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+        sfpi::vInt pow_int = sfpi::float_to_int16(
+            pow, sfpi::RoundMode::NearestEven);  // int16 should be plenty, since large powers will approach 0/Inf
+        sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
 
         // If pow is odd integer then result is negative
         // If power is even, then result is positive

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_selu.h
@@ -29,7 +29,7 @@ inline void calculate_selu(uint scale, uint alpha) {
             sfpi::vFloat result = minus_mul * alpha_value * scale_value;
 
             if constexpr (!is_fp32_dest_acc_en) {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
             sfpi::dst_reg[0] = result;
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -90,7 +90,7 @@ template <bool is_fp32_dest_acc_en>
 sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloat addend) {
     sfpi::vFloat result = mul_a * mul_b + addend;
     if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
     }
     sfpi::dst_reg[0] = result;
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -22,8 +22,8 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
     sfpi::vFloat original_base = base;
 
     // Check for integer power
-    sfpi::vInt pow_int       = sfpi::float_to_int16(pow, 0); // int16 should be plenty, since large powers will approach 0/Inf
-    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+    sfpi::vInt pow_int       = sfpi::float_to_int16(pow, sfpi::RoundMode::NearestEven); // int16 should be plenty, since large powers will approach 0/Inf
+    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
     v_if (pow_rounded == pow)
     {
         // if pow is integer, set base to positive
@@ -44,7 +44,7 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
         exp = sfpi::setsgn(~exp + 1, 1);
     }
     v_endif;
-    sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+    sfpi::vFloat expf = sfpi::int32_to_float(exp, sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     sfpi::vFloat vConstLn2  = 0.692871f;
@@ -78,8 +78,8 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
             // if pow is odd integer, set result to negative
             // Check if odd by dividing by 2 and comparing with floor
             sfpi::vFloat half_pow         = pow_rounded * 0.5f;
-            sfpi::vInt half_pow_int       = sfpi::float_to_int16(half_pow, 0);
-            sfpi::vFloat half_pow_floored = sfpi::int32_to_float(half_pow_int, 0);
+            sfpi::vInt half_pow_int       = sfpi::float_to_int16(half_pow, sfpi::RoundMode::NearestEven);
+            sfpi::vFloat half_pow_floored = sfpi::int32_to_float(half_pow_int, sfpi::RoundMode::NearestEven);
             v_if (half_pow != half_pow_floored)
             {
                 result = sfpi::setsgn(result, 1);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -20,7 +20,7 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         // sfpi::vFloat val = sfpi::dst_reg[0];
-        // sfpi::dst_reg[0] = float_to_fp16a(val, 0);
+        // sfpi::dst_reg[0] = float_to_fp16a(val, sfpi::RoundMode::NearestEven);
         TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
         TTI_SFPSTORE(0, 1, ADDR_MOD_7, 0);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -28,7 +28,7 @@ inline void _calculate_elu_(std::uint32_t slope)
             sfpi::vFloat result = s * v_exp;
             if constexpr (!is_fp32_dest_acc_en)
             {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
             sfpi::dst_reg[0] = result;
         }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -85,7 +85,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val)
     sfpi::vInt exponential_part = exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z)); // Extract exponent ( = 2**(integer part of val/ln2))
     sfpi::vInt fractional_part  = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));   // Extract mantissa ( = leftover part, in [0; 1])
 
-    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, 0);
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
 
     // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 2^23]
     // This uses a 2nd degree polynomial adjustment of the fractional part
@@ -100,7 +100,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val)
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
     }
 
     return y;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -30,7 +30,7 @@ inline void _calculate_exp2_()
         else
         {
             result = _sfpu_exp_21f_bf16_<true>(v);
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -53,7 +53,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     }
     v_endif;
 
-    sfpi::vFloat expf      = int32_to_float(exp, 0);
+    sfpi::vFloat expf      = int32_to_float(exp, sfpi::RoundMode::NearestEven);
     sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
@@ -89,7 +89,7 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
         exp = sfpi::setsgn(~exp + 1, 1);
     }
     v_endif;
-    sfpi::vFloat expf = int32_to_float(exp, 0);
+    sfpi::vFloat expf = int32_to_float(exp, sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     sfpi::vFloat vConstLn2  = 0.692871f;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -116,7 +116,7 @@ inline void _calculate_rsqrt_compat_(const int iterations)
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }
@@ -152,7 +152,7 @@ inline void _calculate_reciprocal_compat_(const int iterations)
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -126,7 +126,7 @@ inline void _calculate_sqrt_internal_(const int iterations)
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -87,8 +87,8 @@ inline void _calculate_sine_(const int iterations)
     {
         sfpi::vFloat v             = sfpi::dst_reg[0];
         v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
-        sfpi::vInt whole_v         = sfpi::float_to_int16(v, 0);
-        sfpi::vFloat whole_v_float = sfpi::int32_to_float(whole_v, 0);
+        sfpi::vInt whole_v         = sfpi::float_to_int16(v, sfpi::RoundMode::NearestEven);
+        sfpi::vFloat whole_v_float = sfpi::int32_to_float(whole_v, sfpi::RoundMode::NearestEven);
         v                          = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_sine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -114,8 +114,8 @@ inline void _calculate_cosine_(const int iterations)
     {
         sfpi::vFloat v             = sfpi::dst_reg[0];
         v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
-        sfpi::vInt whole_v         = sfpi::float_to_int16(v, 0);
-        sfpi::vFloat whole_v_float = sfpi::int32_to_float(whole_v, 0);
+        sfpi::vInt whole_v         = sfpi::float_to_int16(v, sfpi::RoundMode::NearestEven);
+        sfpi::vFloat whole_v_float = sfpi::int32_to_float(whole_v, sfpi::RoundMode::NearestEven);
         v                          = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_cosine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -214,7 +214,7 @@ inline void _calculate_atanh_()
             }
             else
             {
-                den = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
+                den = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, sfpi::RoundMode::NearestEven));
             }
             num              = num * den;
             den              = _calculate_log_body_no_init_(num);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
@@ -22,8 +22,8 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
     sfpi::vFloat original_base = base;
 
     // Check for integer power
-    sfpi::vInt pow_int       = float_to_int16(pow, 0); // int16 should be plenty, since large powers will approach 0/Inf
-    sfpi::vFloat pow_rounded = int32_to_float(pow_int, 0);
+    sfpi::vInt pow_int       = float_to_int16(pow, sfpi::RoundMode::NearestEven); // int16 should be plenty, since large powers will approach 0/Inf
+    sfpi::vFloat pow_rounded = int32_to_float(pow_int, sfpi::RoundMode::NearestEven);
     v_if (pow_rounded == pow)
     {
         // if pow is integer, set base to positive
@@ -44,7 +44,7 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
         exp = sfpi::setsgn(~exp + 1, 1);
     }
     v_endif;
-    sfpi::vFloat expf = int32_to_float(exp, 0);
+    sfpi::vFloat expf = int32_to_float(exp, sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     sfpi::vFloat vConstLn2  = 0.692871f;
@@ -78,8 +78,8 @@ sfpi_inline sfpi::vFloat _calculate_sfpu_binary_power_(sfpi::vFloat base, sfpi::
             // if pow is odd integer, set result to negative
             // Check if odd by dividing by 2 and comparing with floor
             sfpi::vFloat half_pow         = pow_rounded * 0.5f;
-            sfpi::vInt half_pow_int       = sfpi::float_to_int16(half_pow, 0);
-            sfpi::vFloat half_pow_floored = sfpi::int32_to_float(half_pow_int, 0);
+            sfpi::vInt half_pow_int       = sfpi::float_to_int16(half_pow, sfpi::RoundMode::NearestEven);
+            sfpi::vFloat half_pow_floored = sfpi::int32_to_float(half_pow_int, sfpi::RoundMode::NearestEven);
             v_if (half_pow != half_pow_floored)
             {
                 result = sfpi::setsgn(result, 1);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -19,7 +19,7 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         // sfpi::vFloat val = sfpi::dst_reg[0];
-        // sfpi::dst_reg[0] = float_to_fp16a(val, 0);
+        // sfpi::dst_reg[0] = float_to_fp16a(val, sfpi::RoundMode::NearestEven);
         TTI_SFPLOAD(0, 0, 3, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
         TTI_SFPSTORE(0, 1, 3, 0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -28,7 +28,7 @@ inline void _calculate_elu_(std::uint32_t slope)
             sfpi::vFloat result = s * v_exp;
             if constexpr (!is_fp32_dest_acc_en)
             {
-                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
             }
             sfpi::dst_reg[0] = result;
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -82,7 +82,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val)
     sfpi::vInt exponential_part = exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z)); // Extract exponent ( = 2**(integer part of val/ln2))
     sfpi::vInt fractional_part  = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));   // Extract mantissa ( = leftover part, in [0; 1])
 
-    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, 0);
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
 
     // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 2^23]
     // This uses a 2nd degree polynomial adjustment of the fractional part
@@ -97,7 +97,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val)
         // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
         // rather than 81 (which would have been correct).
         // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, sfpi::RoundMode::NearestEven));
     }
 
     return y;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -30,7 +30,7 @@ inline void _calculate_exp2_()
         else
         {
             result = _sfpu_exp_21f_bf16_<true>(v);
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, sfpi::RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[0] = result;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -53,7 +53,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     }
     v_endif;
 
-    sfpi::vFloat expf      = int32_to_float(exp, 0);
+    sfpi::vFloat expf      = int32_to_float(exp, sfpi::RoundMode::NearestEven);
     sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
@@ -89,7 +89,7 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
         exp = sfpi::setsgn(~exp + 1, 1);
     }
     v_endif;
-    sfpi::vFloat expf = int32_to_float(exp, 0);
+    sfpi::vFloat expf = int32_to_float(exp, sfpi::RoundMode::NearestEven);
 
     // De-normalize to original range
     sfpi::vFloat vConstLn2  = 0.692871f;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -96,7 +96,7 @@ inline void _calculate_reciprocal_internal_(const int iterations)
             else
             {
                 sfpi::vFloat out = _sfpu_reciprocal_<1>(in);
-                sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+                sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, sfpi::RoundMode::NearestEven));
             }
         }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -116,7 +116,7 @@ inline void _calculate_rsqrt_compat_(const int iterations)
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }
@@ -152,7 +152,7 @@ inline void _calculate_reciprocal_compat_(const int iterations)
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -125,7 +125,7 @@ inline void _calculate_sqrt_internal_(const int iterations)
         }
         else
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
+            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, sfpi::RoundMode::NearestEven));
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -87,8 +87,8 @@ inline void _calculate_sine_(const int iterations)
     {
         sfpi::vFloat v             = sfpi::dst_reg[0];
         v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
-        sfpi::vInt whole_v         = float_to_int16(v, 0);
-        sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
+        sfpi::vInt whole_v         = float_to_int16(v, sfpi::RoundMode::NearestEven);
+        sfpi::vFloat whole_v_float = int32_to_float(whole_v, sfpi::RoundMode::NearestEven);
         v                          = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_sine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -114,8 +114,8 @@ inline void _calculate_cosine_(const int iterations)
     {
         sfpi::vFloat v             = sfpi::dst_reg[0];
         v                          = 0.318309886183791f * v; // *1/pi to get number of pi rads.
-        sfpi::vInt whole_v         = float_to_int16(v, 0);
-        sfpi::vFloat whole_v_float = int32_to_float(whole_v, 0);
+        sfpi::vInt whole_v         = float_to_int16(v, sfpi::RoundMode::NearestEven);
+        sfpi::vFloat whole_v_float = int32_to_float(whole_v, sfpi::RoundMode::NearestEven);
         v                          = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
         v       = _sfpu_cosine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -214,7 +214,7 @@ inline void _calculate_atanh_()
             }
             else
             {
-                den = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, 0));
+                den = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(tmp, sfpi::RoundMode::NearestEven));
             }
             num              = num * den;
             den              = _calculate_log_body_no_init_(num);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -101,7 +101,7 @@ inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, c
 
         // Round to bf16 if not in fp32 dest accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, RoundMode::NearestEven));
         }
 
         sfpi::dst_reg[out_tile_idx * dst_tile_size] = result;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -236,7 +236,7 @@ void calculate_recip_first_column() {
             if constexpr (DST_ACCUM_MODE || APPROX) {
                 sfpi::dst_reg[0] = out;
             } else {
-                sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+                sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, RoundMode::NearestEven));
             }
             sfpi::dst_reg += 2;
         }
@@ -251,7 +251,7 @@ void calculate_recip_first_column() {
                     sfpi::dst_reg[0] = ckernel::sfpu::_sfpu_reciprocal_<2>(in);
                 } else {
                     sfpi::vFloat out = ckernel::sfpu::_sfpu_reciprocal_<1>(in);
-                    sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, 0));
+                    sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vFloat>(float_to_fp16b(out, RoundMode::NearestEven));
                 }
             }
 


### PR DESCRIPTION
### Summary
0 & 1 are not good names for the rounding mode to use, particularly as we now have 3 options in some circumstances.

### Notes for reviewers
this is a mechanical change using grep, cut, uniq, xargs & sed.  The sfpi library currently uses a namespace/unscoped enum but at a future time we should be able to switch to a scoped enum so that integer literals will not compile.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/round-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/round-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/round-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/round-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/round-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/round-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/round-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/round-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/round-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/round-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/round-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/round-40182)