### PR TITLE
#41777: post_combine_reduce support more than one 32-token chunk per core

### DIFF
--- a/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_moe_post_combine_reduce.py
+++ b/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_moe_post_combine_reduce.py
@@ -17,7 +17,6 @@ import pytest
 import torch
 import ttnn
 from loguru import logger
-from models.common.utility_functions import run_for_blackhole
 
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 
@@ -94,7 +93,6 @@ def assert_pcc(result, expected, threshold=PCC_THRESHOLD, label=""):
 # ============================================================================
 
 
-@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
 def test_structured_data(device):
     """Constant-per-tile activations with sequential weights [1..8].
     This pattern is easy to verify manually and catches tile ordering bugs."""
@@ -136,7 +134,6 @@ def test_structured_data(device):
 # ============================================================================
 
 
-@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
 def test_random_data(device):
     """Random activations and weights, compared to PyTorch reference."""
     torch.manual_seed(42)
@@ -153,7 +150,6 @@ def test_random_data(device):
     assert_pcc(result, ref, label="random")
 
 
-@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
 def test_vs_old_implementation(device):
     """Fused kernel vs old implementation (to_layout + mul + sum) with random data."""
     torch.manual_seed(42)
@@ -180,7 +176,6 @@ def test_vs_old_implementation(device):
 # ============================================================================
 
 
-@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
 @pytest.mark.parametrize("k_active", [6, 4, 2, 1])
 def test_sparse_weights(device, k_active):
     """Fused kernel with sparse weights (k_active out of 8 experts non-zero per token)."""
@@ -248,7 +243,6 @@ def test_skip_nonlocal_experts(device):
 # ============================================================================
 
 
-@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
 def test_output_layout(device):
     """Verify output is TILE layout with correct shape."""
     torch.manual_seed(42)
@@ -263,3 +257,54 @@ def test_output_layout(device):
     )
     assert result_tt.layout == ttnn.TILE_LAYOUT, f"Expected TILE_LAYOUT, got {result_tt.layout}"
     assert list(result_tt.shape) == [1, NUM_TOKENS, EMB_DIM], f"Wrong shape: {result_tt.shape}"
+
+
+# ============================================================================
+# Multi-chunk-per-core tests: num_tokens / 32 > num_cores, so some cores must
+# process more than one 32-token chunk. Covers issue #41777.
+# ============================================================================
+
+
+@pytest.mark.parametrize("num_tokens", [4096, 6400, 8192])
+def test_multi_chunk_structured(device, num_tokens):
+    """Structured data with >100 chunks so some cores get 2+ chunks each."""
+    tile_width = 1024
+    num_tiles = EMB_DIM // tile_width
+
+    tile_values = 0.1 * torch.arange(
+        1,
+        num_tokens * NUM_EXPERTS * num_tiles + 1,
+        dtype=torch.float32,
+    )
+    combine = (
+        tile_values.view(1, num_tokens, NUM_EXPERTS, num_tiles, 1)
+        .expand(1, num_tokens, NUM_EXPERTS, num_tiles, tile_width)
+        .reshape(1, num_tokens, NUM_EXPERTS, EMB_DIM)
+        .to(torch.bfloat16)
+    )
+
+    weights = (
+        torch.arange(1, NUM_EXPERTS + 1, dtype=torch.float32)
+        .view(1, 1, NUM_EXPERTS, 1)
+        .expand(1, num_tokens, NUM_EXPERTS, 1)
+        .to(torch.bfloat16)
+    )
+
+    ref = pytorch_reference(combine, weights)
+    result = ttnn.to_torch(new_implementation(to_device(combine, device), to_device(weights, device)))
+    assert_pcc(result, ref, threshold=0.998, label=f"multi_chunk_structured_{num_tokens}")
+
+
+@pytest.mark.parametrize("num_tokens", [4096, 6400, 8192])
+def test_multi_chunk_random(device, num_tokens):
+    """Random data with >100 chunks so some cores get 2+ chunks each."""
+    torch.manual_seed(42)
+    combine = torch.randn(1, num_tokens, NUM_EXPERTS, EMB_DIM, dtype=torch.bfloat16)
+    weights = torch.randn(1, num_tokens, NUM_EXPERTS, 1, dtype=torch.bfloat16)
+
+    ref = pytorch_reference(combine, weights)
+    result = ttnn.to_torch(new_implementation(to_device(combine, device), to_device(weights, device)))
+    assert_pcc(result, ref, label=f"multi_chunk_random_{num_tokens}")
+
+
+# ============================================================================

--- a/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_moe_post_combine_reduce.py
+++ b/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_moe_post_combine_reduce.py
@@ -201,7 +201,6 @@ def test_sparse_weights(device, k_active):
 # ============================================================================
 
 
-@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
 def test_skip_nonlocal_experts(device):
     """Verify that marking experts as non-local (-1 in dispatch table) produces
     the same result when those experts' combine_output is zero (as in real MoE)."""
@@ -291,7 +290,7 @@ def test_multi_chunk_structured(device, num_tokens):
     )
 
     ref = pytorch_reference(combine, weights)
-    result = ttnn.to_torch(new_implementation(to_device(combine, device), to_device(weights, device)))
+    result = ttnn.to_torch(new_implementation(to_device(combine, device), to_device(weights, device), None, None))
     assert_pcc(result, ref, threshold=0.998, label=f"multi_chunk_structured_{num_tokens}")
 
 
@@ -303,7 +302,7 @@ def test_multi_chunk_random(device, num_tokens):
     weights = torch.randn(1, num_tokens, NUM_EXPERTS, 1, dtype=torch.bfloat16)
 
     ref = pytorch_reference(combine, weights)
-    result = ttnn.to_torch(new_implementation(to_device(combine, device), to_device(weights, device)))
+    result = ttnn.to_torch(new_implementation(to_device(combine, device), to_device(weights, device), None, None))
     assert_pcc(result, ref, label=f"multi_chunk_random_{num_tokens}")
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
@@ -18,11 +18,10 @@ constexpr uint32_t cb_rowmajor = tt::CBIndex::c_17;
 
 constexpr uint32_t num_experts = get_compile_time_arg_val(0);
 constexpr uint32_t emb_dim_cb_tiles = get_compile_time_arg_val(1);
-// The following two CT args are only meaningful when use_dispatch_table_skip
-// is true; they carry zeros from the program factory otherwise.
+// dispatch_table_num_pages is only meaningful when use_dispatch_table_skip
+// is true; it carries zero from the program factory otherwise.
 constexpr uint32_t dispatch_table_num_pages = get_compile_time_arg_val(2);
-constexpr uint32_t indices_pages_per_core = get_compile_time_arg_val(3);
-constexpr bool use_dispatch_table_skip = get_compile_time_arg_val(4) != 0;
+constexpr bool use_dispatch_table_skip = get_compile_time_arg_val(3) != 0;
 
 void kernel_main() {
     constexpr uint32_t TOKENS_PER_CHUNK = 32;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
@@ -38,8 +38,6 @@ void kernel_main() {
 
     binary_op_init_common(cb_combine_input, cb_weights, cb_output);
 
-    using namespace compute_kernel_lib::tilize_config;
-
     for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
         cb_reserve_back(cb_rowmajor, total_token_tiles);
 
@@ -116,18 +114,6 @@ void kernel_main() {
         }
         cb_push_back(cb_rowmajor, total_token_tiles);
 
-        // Avoid redundant tilize init/uninit on every chunk: init once on the first,
-        // skip both on middle chunks, uninit once on the last.
-        const bool is_first = (chunk == 0);
-        const bool is_last_chunk = (chunk == num_chunks - 1);
-        if (num_chunks == 1) {
-            compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output, InitUninitMode::InitAndUninit>(1);
-        } else if (is_first) {
-            compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output, InitUninitMode::InitOnly>(1);
-        } else if (is_last_chunk) {
-            compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output, InitUninitMode::UninitOnly>(1);
-        } else {
-            compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output, InitUninitMode::Neither>(1);
-        }
+        compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output>(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
@@ -30,14 +30,18 @@ void kernel_main() {
     constexpr uint32_t total_token_tiles = TOKENS_PER_CHUNK * emb_dim_cb_tiles;
 
     if constexpr (use_dispatch_table_skip) {
-        // Wait for writer to finish pre-loading scratch data (all chunks' indices)
+        // Wait for writer to finish pre-loading dispatch table (loaded once for all chunks)
         cb_wait_front(cb_dispatch_table, dispatch_table_num_pages);
-        cb_wait_front(cb_indices, num_chunks * TOKENS_PER_CHUNK);
     }
 
     binary_op_init_common(cb_combine_input, cb_weights, cb_output);
 
     for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
+        if constexpr (use_dispatch_table_skip) {
+            // Wait for writer to load this chunk's indices (one chunk at a time)
+            cb_wait_front(cb_indices, TOKENS_PER_CHUNK);
+        }
+
         cb_reserve_back(cb_rowmajor, total_token_tiles);
 
         // Process one expert at a time: both input (c_0) and weight (c_1) are streamed
@@ -58,9 +62,7 @@ void kernel_main() {
                 bool skip_expert = false;
                 bool must_zero_init = false;
                 if constexpr (use_dispatch_table_skip) {
-                    // Absolute index into the pre-loaded indices CB for this token
-                    uint32_t token_cb_idx = chunk * TOKENS_PER_CHUNK + i;
-                    uint32_t expert_id = read_tile_value(cb_indices, token_cb_idx, expert_idx);
+                    uint32_t expert_id = read_tile_value(cb_indices, i, expert_idx);
                     // Check dispatch table: -1 (0xFFFFFFFF) means non-local
                     uint32_t chip_id = read_tile_value(cb_dispatch_table, 0, expert_id);
                     bool is_local = (chip_id != 0xFFFFFFFF);
@@ -111,6 +113,12 @@ void kernel_main() {
             }
             pack_reconfig_l1_acc(0);
         }
+
+        if constexpr (use_dispatch_table_skip) {
+            // Release this chunk's indices so writer can load the next chunk's
+            cb_pop_front(cb_indices, TOKENS_PER_CHUNK);
+        }
+
         cb_push_back(cb_rowmajor, total_token_tiles);
 
         compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output>(1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
@@ -25,92 +25,109 @@ constexpr uint32_t indices_pages_per_core = get_compile_time_arg_val(3);
 constexpr bool use_dispatch_table_skip = get_compile_time_arg_val(4) != 0;
 
 void kernel_main() {
-    constexpr uint32_t TOKENS_PER_CORE = 32;
+    constexpr uint32_t TOKENS_PER_CHUNK = 32;
     uint32_t token_start_idx = get_arg_val<uint32_t>(0);
-    constexpr uint32_t total_token_tiles = TOKENS_PER_CORE * emb_dim_cb_tiles;
+    uint32_t num_chunks = get_arg_val<uint32_t>(1);
+    constexpr uint32_t total_token_tiles = TOKENS_PER_CHUNK * emb_dim_cb_tiles;
 
     if constexpr (use_dispatch_table_skip) {
-        // Wait for writer to finish loading scratch data
+        // Wait for writer to finish pre-loading scratch data (all chunks' indices)
         cb_wait_front(cb_dispatch_table, dispatch_table_num_pages);
-        cb_wait_front(cb_indices, indices_pages_per_core);
+        cb_wait_front(cb_indices, num_chunks * TOKENS_PER_CHUNK);
     }
 
     binary_op_init_common(cb_combine_input, cb_weights, cb_output);
 
-    cb_reserve_back(cb_rowmajor, total_token_tiles);
+    using namespace compute_kernel_lib::tilize_config;
 
-    // Process one expert at a time: both input (c_0) and weight (c_1) are streamed
-    // one expert at a time by reader and writer respectively.
-    for (uint32_t i = 0; i < TOKENS_PER_CORE; ++i) {
-        mul_tiles_bcast_scalar_init_short(cb_combine_input, cb_weights);
+    for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
+        cb_reserve_back(cb_rowmajor, total_token_tiles);
 
-        // first_active tracks whether we've picked the accumulator-initializing
-        // expert yet: the DeepSeek path looks for a locally-mapped expert via
-        // the dispatch table; the GPT-OSS path looks for a non-zero routing
-        // weight. A single pass skips inactive experts; if none qualified,
-        // the last expert is forced through to initialise the accumulator.
-        bool first_active = true;
-        for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
-            cb_wait_front(cb_combine_input, emb_dim_cb_tiles);
-            cb_wait_front(cb_weights, 1);
+        // Process one expert at a time: both input (c_0) and weight (c_1) are streamed
+        // one expert at a time by reader and writer respectively.
+        for (uint32_t i = 0; i < TOKENS_PER_CHUNK; ++i) {
+            mul_tiles_bcast_scalar_init_short(cb_combine_input, cb_weights);
 
-            bool skip_expert = false;
-            bool must_zero_init = false;
-            if constexpr (use_dispatch_table_skip) {
-                // Look up global expert ID from indices CB
-                uint32_t expert_id = read_tile_value(cb_indices, i, expert_idx);
-                // Check dispatch table: -1 (0xFFFFFFFF) means non-local
-                uint32_t chip_id = read_tile_value(cb_dispatch_table, 0, expert_id);
-                bool is_local = (chip_id != 0xFFFFFFFF);
+            // first_active tracks whether we've picked the accumulator-initializing
+            // expert yet: the DeepSeek path looks for a locally-mapped expert via
+            // the dispatch table; the GPT-OSS path looks for a non-zero routing
+            // weight. A single pass skips inactive experts; if none qualified,
+            // the last expert is forced through to initialise the accumulator.
+            bool first_active = true;
+            for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
+                cb_wait_front(cb_combine_input, emb_dim_cb_tiles);
+                cb_wait_front(cb_weights, 1);
 
-                // On the last expert, if none were local, we must process it to
-                // initialize the accumulator. Writer guarantees the weight is zero
-                // for this case, so multiply produces zeros.
-                bool is_last = (expert_idx == num_experts - 1);
-                must_zero_init = is_last && first_active;
-                skip_expert = !is_local && !must_zero_init;
-            } else {
-                // Read weight value — if zero, skip (but always process at least one
-                // expert so the accumulator gets initialized with valid data)
-                uint32_t weight_val = read_tile_value(cb_weights, 0, 0);
-                skip_expert = (weight_val == 0) && !first_active;
-            }
+                bool skip_expert = false;
+                bool must_zero_init = false;
+                if constexpr (use_dispatch_table_skip) {
+                    // Absolute index into the pre-loaded indices CB for this token
+                    uint32_t token_cb_idx = chunk * TOKENS_PER_CHUNK + i;
+                    uint32_t expert_id = read_tile_value(cb_indices, token_cb_idx, expert_idx);
+                    // Check dispatch table: -1 (0xFFFFFFFF) means non-local
+                    uint32_t chip_id = read_tile_value(cb_dispatch_table, 0, expert_id);
+                    bool is_local = (chip_id != 0xFFFFFFFF);
 
-            if (skip_expert) {
+                    // On the last expert, if none were local, we must process it to
+                    // initialize the accumulator. Writer guarantees the weight is zero
+                    // for this case, so multiply produces zeros.
+                    bool is_last = (expert_idx == num_experts - 1);
+                    must_zero_init = is_last && first_active;
+                    skip_expert = !is_local && !must_zero_init;
+                } else {
+                    // Read weight value — if zero, skip (but always process at least one
+                    // expert so the accumulator gets initialized with valid data)
+                    uint32_t weight_val = read_tile_value(cb_weights, 0, 0);
+                    skip_expert = (weight_val == 0) && !first_active;
+                }
+
+                if (skip_expert) {
+                    cb_pop_front(cb_combine_input, emb_dim_cb_tiles);
+                    cb_pop_front(cb_weights, 1);
+                    continue;
+                }
+
+                if (!first_active) {
+                    pack_reconfig_l1_acc(1);  // accumulate
+                } else {
+                    pack_reconfig_l1_acc(0);  // overwrite
+                    first_active = false;
+                }
+
+                tile_regs_acquire();
+
+                for (uint32_t j = 0; j < emb_dim_cb_tiles; j++) {
+                    mul_tiles_bcast<BroadcastType::SCALAR>(cb_combine_input, cb_weights, j, 0, j);
+                }
+
+                tile_regs_commit();
+                tile_regs_wait();
+
+                for (uint32_t j = 0; j < emb_dim_cb_tiles; j++) {
+                    pack_tile<true>(j, cb_rowmajor, i * emb_dim_cb_tiles + j);
+                }
+
+                tile_regs_release();
+
                 cb_pop_front(cb_combine_input, emb_dim_cb_tiles);
                 cb_pop_front(cb_weights, 1);
-                continue;
             }
-
-            if (!first_active) {
-                pack_reconfig_l1_acc(1);  // accumulate
-            } else {
-                pack_reconfig_l1_acc(0);  // overwrite
-                first_active = false;
-            }
-
-            tile_regs_acquire();
-
-            for (uint32_t j = 0; j < emb_dim_cb_tiles; j++) {
-                mul_tiles_bcast<BroadcastType::SCALAR>(cb_combine_input, cb_weights, j, 0, j);
-            }
-
-            tile_regs_commit();
-            tile_regs_wait();
-
-            for (uint32_t j = 0; j < emb_dim_cb_tiles; j++) {
-                pack_tile<true>(j, cb_rowmajor, i * emb_dim_cb_tiles + j);
-            }
-
-            tile_regs_release();
-
-            cb_pop_front(cb_combine_input, emb_dim_cb_tiles);
-            cb_pop_front(cb_weights, 1);
+            pack_reconfig_l1_acc(0);
         }
-        pack_reconfig_l1_acc(0);
-    }
-    cb_push_back(cb_rowmajor, total_token_tiles);
+        cb_push_back(cb_rowmajor, total_token_tiles);
 
-    // Tilize all 32 tokens' row-major scratch into the output CB as one block.
-    compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output>(1);
+        // Avoid redundant tilize init/uninit on every chunk: init once on the first,
+        // skip both on middle chunks, uninit once on the last.
+        const bool is_first = (chunk == 0);
+        const bool is_last_chunk = (chunk == num_chunks - 1);
+        if (num_chunks == 1) {
+            compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output, InitUninitMode::InitAndUninit>(1);
+        } else if (is_first) {
+            compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output, InitUninitMode::InitOnly>(1);
+        } else if (is_last_chunk) {
+            compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output, InitUninitMode::UninitOnly>(1);
+        } else {
+            compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output, InitUninitMode::Neither>(1);
+        }
+    }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_reader.cpp
@@ -16,26 +16,30 @@ constexpr uint32_t emb_dim_cb_tiles = get_compile_time_arg_val(1);
 constexpr uint32_t emb_dim_bytes = get_compile_time_arg_val(2);
 constexpr auto combine_accessor_args = TensorAccessorArgs<3>();
 
-constexpr uint32_t TOKENS_PER_CORE = 32;
+constexpr uint32_t TOKENS_PER_CHUNK = 32;
 
 void kernel_main() {
     uint32_t combine_addr = get_arg_val<uint32_t>(0);
     uint32_t token_start_idx = get_arg_val<uint32_t>(1);
+    uint32_t num_chunks = get_arg_val<uint32_t>(2);
 
     const auto combine_addrg = TensorAccessor(combine_accessor_args, combine_addr);
 
-    for (uint32_t token_idx = 0; token_idx < TOKENS_PER_CORE; ++token_idx) {
-        uint32_t global_token_idx = token_start_idx + token_idx;
+    for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
+        for (uint32_t token_idx = 0; token_idx < TOKENS_PER_CHUNK; ++token_idx) {
+            uint32_t global_token_idx = token_start_idx + token_idx;
 
-        for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
-            cb_reserve_back(cb_combine_input, emb_dim_cb_tiles);
-            uint32_t cb_write_addr = get_write_ptr(cb_combine_input);
+            for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
+                cb_reserve_back(cb_combine_input, emb_dim_cb_tiles);
+                uint32_t cb_write_addr = get_write_ptr(cb_combine_input);
 
-            uint32_t expert_page_idx = global_token_idx * num_experts + expert_idx;
-            uint64_t noc_addr = combine_addrg.get_noc_addr(expert_page_idx);
-            noc_async_read(noc_addr, cb_write_addr, emb_dim_bytes);
-            noc_async_read_barrier();
-            cb_push_back(cb_combine_input, emb_dim_cb_tiles);
+                uint32_t expert_page_idx = global_token_idx * num_experts + expert_idx;
+                uint64_t noc_addr = combine_addrg.get_noc_addr(expert_page_idx);
+                noc_async_read(noc_addr, cb_write_addr, emb_dim_bytes);
+                noc_async_read_barrier();
+                cb_push_back(cb_combine_input, emb_dim_cb_tiles);
+            }
         }
+        token_start_idx += TOKENS_PER_CHUNK;
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
@@ -36,25 +36,28 @@ constexpr auto indices_accessor_args =
 constexpr bool use_dispatch_table_skip =
     get_compile_time_arg_val(indices_accessor_args.next_compile_time_args_offset()) != 0;
 
-constexpr uint32_t TOKENS_PER_CORE = 32;
+constexpr uint32_t TOKENS_PER_CHUNK = 32;
 
 void kernel_main() {
     // Runtime arg layout: weight_addr, output_addr,
     //   (if dispatch_table_skip: dispatch_table_addr, indices_addr),
-    //   token_start_idx.
+    //   token_start_idx, num_chunks.
     uint32_t weight_addr = get_arg_val<uint32_t>(0);
     uint32_t output_addr = get_arg_val<uint32_t>(1);
     uint32_t dispatch_table_addr;
     uint32_t indices_addr;
     uint32_t token_start_idx;
+    uint32_t num_chunks;
     if constexpr (use_dispatch_table_skip) {
         dispatch_table_addr = get_arg_val<uint32_t>(2);
         indices_addr = get_arg_val<uint32_t>(3);
         token_start_idx = get_arg_val<uint32_t>(4);
+        num_chunks = get_arg_val<uint32_t>(5);
     } else {
         dispatch_table_addr = 0;
         indices_addr = 0;
         token_start_idx = get_arg_val<uint32_t>(2);
+        num_chunks = get_arg_val<uint32_t>(3);
     }
 
     constexpr uint32_t weight_tile_size = get_tile_size(cb_weights);
@@ -63,8 +66,6 @@ void kernel_main() {
     const auto weight_addrg = TensorAccessor(weight_accessor_args, weight_addr);
     const auto output_addrg = TensorAccessor(output_accessor_args, output_addr);
 
-    // Set to the dispatch_table CB L1 address when skipping — used as a scratch
-    // pointer for the per-token has_local test below.
     uint32_t dispatch_table_write_addr = 0;
     uint32_t indices_write_addr = 0;
 
@@ -73,7 +74,7 @@ void kernel_main() {
             TensorAccessor(dispatch_table_accessor_args, dispatch_table_addr, dispatch_table_page_size);
         const auto indices_addrg = TensorAccessor(indices_accessor_args, indices_addr, indices_page_size);
 
-        // Pre-load dispatch table into CB (c_2) — read once, used by compute
+        // Pre-load dispatch table into CB (c_2) — read once, used by compute for all chunks
         cb_reserve_back(cb_dispatch_table, dispatch_table_num_pages);
         dispatch_table_write_addr = get_write_ptr(cb_dispatch_table);
         for (uint32_t i = 0; i < dispatch_table_num_pages; i++) {
@@ -83,81 +84,90 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb_dispatch_table, dispatch_table_num_pages);
 
-        // Pre-load indices for this core's tokens into CB (c_3) — read once, used by compute
-        cb_reserve_back(cb_indices, indices_pages_per_core);
+        // Pre-load indices for ALL of this core's tokens (all chunks) into CB (c_3)
+        uint32_t total_tokens_this_core = num_chunks * TOKENS_PER_CHUNK;
+        cb_reserve_back(cb_indices, total_tokens_this_core);
         indices_write_addr = get_write_ptr(cb_indices);
-        for (uint32_t i = 0; i < indices_pages_per_core; i++) {
+        for (uint32_t i = 0; i < total_tokens_this_core; i++) {
             uint32_t page_idx = token_start_idx + i;
             noc_async_read_page(page_idx, indices_addrg, indices_write_addr + i * indices_aligned_page_size);
         }
         noc_async_read_barrier();
-        cb_push_back(cb_indices, indices_pages_per_core);
+        cb_push_back(cb_indices, total_tokens_this_core);
     }
 
-    // Phase 1: Stream one weight per expert per token (matching expert-by-expert compute).
-    for (uint32_t token_idx = 0; token_idx < TOKENS_PER_CORE; ++token_idx) {
-        uint32_t global_token_idx = token_start_idx + token_idx;
+    constexpr uint32_t cb_output_tiles = emb_dim_cb_tiles * TOKENS_PER_CHUNK;
 
-        bool has_local = true;
-        if constexpr (use_dispatch_table_skip) {
-            // Access dispatch table and indices from L1 (data still valid after cb_push_back)
-            int32_t* dispatch_table = (int32_t*)dispatch_table_write_addr;
-            int32_t* token_indices = (int32_t*)(indices_write_addr + token_idx * indices_aligned_page_size);
-            has_local = false;
-            for (uint32_t k = 0; k < num_experts; ++k) {
-                int32_t expert_id = token_indices[k];
-                if (dispatch_table[expert_id] != -1) {
-                    has_local = true;
-                    break;
+    uint32_t token_cb_offset = 0;  // tracks position within the pre-loaded indices CB
+    for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
+        // Phase 1: Stream one weight per expert per token for this chunk
+        for (uint32_t token_idx = 0; token_idx < TOKENS_PER_CHUNK; ++token_idx) {
+            uint32_t global_token_idx = token_start_idx + token_idx;
+
+            bool has_local = true;
+            if constexpr (use_dispatch_table_skip) {
+                // Access dispatch table and indices from L1 (data still valid after cb_push_back)
+                int32_t* dispatch_table = (int32_t*)dispatch_table_write_addr;
+                uint32_t token_cb_idx = token_cb_offset + token_idx;
+                int32_t* token_indices = (int32_t*)(indices_write_addr + token_cb_idx * indices_aligned_page_size);
+                has_local = false;
+                for (uint32_t k = 0; k < num_experts; ++k) {
+                    int32_t expert_id = token_indices[k];
+                    if (dispatch_table[expert_id] != -1) {
+                        has_local = true;
+                        break;
+                    }
                 }
             }
-        }
 
-        for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
-            cb_reserve_back(cb_weights, 1);
-            uint32_t cb_write_addr = get_write_ptr(cb_weights);
+            for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
+                cb_reserve_back(cb_weights, 1);
+                uint32_t cb_write_addr = get_write_ptr(cb_weights);
 
-            if constexpr (use_dispatch_table_skip) {
-                bool is_last = (expert_idx == num_experts - 1);
-                if (!has_local && is_last) {
-                    // No local experts for this token — zero the weight tile so compute's
-                    // must_zero_init multiply produces zeros regardless of combine_output.
-                    volatile uint32_t* ptr = (volatile uint32_t*)cb_write_addr;
-                    for (uint32_t w = 0; w < weight_tile_size / sizeof(uint32_t); w++) {
-                        ptr[w] = 0;
+                if constexpr (use_dispatch_table_skip) {
+                    bool is_last = (expert_idx == num_experts - 1);
+                    if (!has_local && is_last) {
+                        // No local experts for this token — zero the weight tile so compute's
+                        // must_zero_init multiply produces zeros regardless of combine_output.
+                        volatile uint32_t* ptr = (volatile uint32_t*)cb_write_addr;
+                        for (uint32_t w = 0; w < weight_tile_size / sizeof(uint32_t); w++) {
+                            ptr[w] = 0;
+                        }
+                    } else {
+                        uint32_t weight_page_idx = global_token_idx * num_experts + expert_idx;
+                        noc_async_read_page(weight_page_idx, weight_addrg, cb_write_addr);
+                        noc_async_read_barrier();
                     }
                 } else {
                     uint32_t weight_page_idx = global_token_idx * num_experts + expert_idx;
                     noc_async_read_page(weight_page_idx, weight_addrg, cb_write_addr);
                     noc_async_read_barrier();
                 }
-            } else {
-                uint32_t weight_page_idx = global_token_idx * num_experts + expert_idx;
-                noc_async_read_page(weight_page_idx, weight_addrg, cb_write_addr);
-                noc_async_read_barrier();
+                cb_push_back(cb_weights, 1);
             }
-            cb_push_back(cb_weights, 1);
         }
+        token_cb_offset += TOKENS_PER_CHUNK;
+
+        // Phase 2: Write output tiles after compute finishes this chunk.
+        // The output CB holds TOKENS_PER_CHUNK * emb_dim_cb_tiles tile-sized pages
+        // (including padding when emb_dim is not 1024-aligned); only the first
+        // emb_dim_out_tiles of them hold real data for this 32-token block.
+        cb_wait_front(cb_output, cb_output_tiles);
+
+        uint32_t cb_read_addr = get_read_ptr(cb_output);
+
+        uint32_t tile_row = token_start_idx / TOKENS_PER_CHUNK;
+        uint32_t start_tile_idx = tile_row * emb_dim_out_tiles;
+
+        for (uint32_t tile_idx = 0; tile_idx < emb_dim_out_tiles; ++tile_idx) {
+            noc_async_write_page(start_tile_idx + tile_idx, output_addrg, cb_read_addr);
+            cb_read_addr += output_tile_size;
+        }
+
+        noc_async_write_barrier();
+
+        cb_pop_front(cb_output, cb_output_tiles);
+
+        token_start_idx += TOKENS_PER_CHUNK;
     }
-
-    // Phase 2: Write output tiles after compute finishes.
-    // The output CB holds TOKENS_PER_CORE * emb_dim_cb_tiles tile-sized pages
-    // (including padding when emb_dim is not 1024-aligned); only the first
-    // emb_dim_out_tiles of them hold real data for this 32-token block.
-    constexpr uint32_t cb_output_tiles = emb_dim_cb_tiles * TOKENS_PER_CORE;
-    cb_wait_front(cb_output, cb_output_tiles);
-
-    uint32_t cb_read_addr = get_read_ptr(cb_output);
-
-    uint32_t tile_row = token_start_idx / TOKENS_PER_CORE;
-    uint32_t start_tile_idx = tile_row * emb_dim_out_tiles;
-
-    for (uint32_t tile_idx = 0; tile_idx < emb_dim_out_tiles; ++tile_idx) {
-        noc_async_write_page(start_tile_idx + tile_idx, output_addrg, cb_read_addr);
-        cb_read_addr += output_tile_size;
-    }
-
-    noc_async_write_barrier();
-
-    cb_pop_front(cb_output, cb_output_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
@@ -66,12 +66,10 @@ void kernel_main() {
     const auto output_addrg = TensorAccessor(output_accessor_args, output_addr);
 
     uint32_t dispatch_table_write_addr = 0;
-    uint32_t indices_write_addr = 0;
 
     if constexpr (use_dispatch_table_skip) {
         const auto dispatch_table_addrg =
             TensorAccessor(dispatch_table_accessor_args, dispatch_table_addr, dispatch_table_page_size);
-        const auto indices_addrg = TensorAccessor(indices_accessor_args, indices_addr, indices_page_size);
 
         // Pre-load dispatch table into CB (c_2) — read once, used by compute for all chunks
         cb_reserve_back(cb_dispatch_table, dispatch_table_num_pages);
@@ -82,37 +80,36 @@ void kernel_main() {
         }
         noc_async_read_barrier();
         cb_push_back(cb_dispatch_table, dispatch_table_num_pages);
-
-        // Pre-load indices for ALL of this core's tokens (all chunks) into CB (c_3)
-        uint32_t total_tokens_this_core = num_chunks * TOKENS_PER_CHUNK;
-        cb_reserve_back(cb_indices, total_tokens_this_core);
-        indices_write_addr = get_write_ptr(cb_indices);
-        for (uint32_t i = 0; i < total_tokens_this_core; i++) {
-            uint32_t page_idx = token_start_idx + i;
-            noc_async_read_page(page_idx, indices_addrg, indices_write_addr + i * indices_aligned_page_size);
-        }
-        noc_async_read_barrier();
-        cb_push_back(cb_indices, total_tokens_this_core);
     }
 
     constexpr uint32_t cb_output_tiles = emb_dim_cb_tiles * TOKENS_PER_CHUNK;
 
-    uint32_t token_cb_offset = 0;  // tracks position within the pre-loaded indices CB
     for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
+        // Load indices for this chunk into CB (c_3) — one chunk at a time to save L1
+        uint32_t indices_write_addr = 0;
+        if constexpr (use_dispatch_table_skip) {
+            const auto indices_addrg = TensorAccessor(indices_accessor_args, indices_addr, indices_page_size);
+            cb_reserve_back(cb_indices, TOKENS_PER_CHUNK);
+            indices_write_addr = get_write_ptr(cb_indices);
+            for (uint32_t i = 0; i < TOKENS_PER_CHUNK; i++) {
+                noc_async_read_page(
+                    token_start_idx + i, indices_addrg, indices_write_addr + i * indices_aligned_page_size);
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_indices, TOKENS_PER_CHUNK);
+        }
+
         // Phase 1: Stream one weight per expert per token for this chunk
         for (uint32_t token_idx = 0; token_idx < TOKENS_PER_CHUNK; ++token_idx) {
             uint32_t global_token_idx = token_start_idx + token_idx;
 
             bool has_local = true;
             if constexpr (use_dispatch_table_skip) {
-                // Access dispatch table and indices from L1 (data still valid after cb_push_back)
                 int32_t* dispatch_table = (int32_t*)dispatch_table_write_addr;
-                uint32_t token_cb_idx = token_cb_offset + token_idx;
-                int32_t* token_indices = (int32_t*)(indices_write_addr + token_cb_idx * indices_aligned_page_size);
+                int32_t* token_indices = (int32_t*)(indices_write_addr + token_idx * indices_aligned_page_size);
                 has_local = false;
                 for (uint32_t k = 0; k < num_experts; ++k) {
-                    int32_t expert_id = token_indices[k];
-                    if (dispatch_table[expert_id] != -1) {
+                    if (dispatch_table[token_indices[k]] != -1) {
                         has_local = true;
                         break;
                     }
@@ -145,7 +142,6 @@ void kernel_main() {
                 cb_push_back(cb_weights, 1);
             }
         }
-        token_cb_offset += TOKENS_PER_CHUNK;
 
         // Phase 2: Write output tiles after compute finishes this chunk.
         // The output CB holds TOKENS_PER_CHUNK * emb_dim_cb_tiles tile-sized pages

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
@@ -23,11 +23,10 @@ constexpr uint32_t emb_dim_out_tiles = get_compile_time_arg_val(2);
 constexpr uint32_t dispatch_table_num_pages = get_compile_time_arg_val(3);
 constexpr uint32_t dispatch_table_page_size = get_compile_time_arg_val(4);
 constexpr uint32_t dispatch_table_aligned_page_size = get_compile_time_arg_val(5);
-constexpr uint32_t indices_pages_per_core = get_compile_time_arg_val(6);
-constexpr uint32_t indices_page_size = get_compile_time_arg_val(7);
-constexpr uint32_t indices_aligned_page_size = get_compile_time_arg_val(8);
+constexpr uint32_t indices_page_size = get_compile_time_arg_val(6);
+constexpr uint32_t indices_aligned_page_size = get_compile_time_arg_val(7);
 
-constexpr auto weight_accessor_args = TensorAccessorArgs<9>();
+constexpr auto weight_accessor_args = TensorAccessorArgs<8>();
 constexpr auto output_accessor_args = TensorAccessorArgs<weight_accessor_args.next_compile_time_args_offset()>();
 constexpr auto dispatch_table_accessor_args =
     TensorAccessorArgs<output_accessor_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
@@ -74,6 +74,7 @@ CreatedProgram create_at(
         emb_dim_cb_tiles);
 
     constexpr uint32_t TOKENS_PER_CHUNK = 32;
+    TT_FATAL(num_tokens > 0, "post_combine_reduce: num_tokens must be > 0, got {}", num_tokens);
     TT_FATAL(
         num_tokens % TOKENS_PER_CHUNK == 0,
         "Number of tokens {} must be divisible by {} for hardware tilization",
@@ -86,7 +87,6 @@ CreatedProgram create_at(
     uint32_t num_cores_total = num_cores_x * num_cores_y;
 
     const uint32_t total_chunks = num_tokens / TOKENS_PER_CHUNK;
-    TT_FATAL(total_chunks > 0, "post_combine_reduce: num_tokens must be > 0, got {}", num_tokens);
     const uint32_t num_cores = std::min(total_chunks, num_cores_total);
     const uint32_t base_chunks_per_core = total_chunks / num_cores;
     const uint32_t extra_chunks = total_chunks % num_cores;
@@ -149,8 +149,7 @@ CreatedProgram create_at(
         // Sized for the maximum any core will handle: base+1 chunks when extra_chunks > 0.
         indices_page_size_val = get_page_size(indices);
         indices_aligned_page_size = get_aligned_page_size(indices);
-        uint32_t max_chunks_per_core = base_chunks_per_core + (extra_chunks > 0 ? 1 : 0);
-        indices_pages_per_core = max_chunks_per_core * TOKENS_PER_CHUNK;
+        indices_pages_per_core = (base_chunks_per_core + (extra_chunks > 0 ? 1 : 0)) * TOKENS_PER_CHUNK;
         uint32_t indices_cb_size = indices_pages_per_core * indices_aligned_page_size;
         tt::tt_metal::CircularBufferConfig cb_indices_config =
             tt::tt_metal::CircularBufferConfig(indices_cb_size, {{tt::CBIndex::c_3, indices_cb_data_format}})

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
@@ -188,13 +188,12 @@ CreatedProgram create_at(
     tt::tt_metal::TensorAccessorArgs(combine_buffer).append_to(reader_compile_time_args);
 
     // Compute compile-time args. The skip-mode toggle is appended last so the
-    // DeepSeek-only args (dispatch_table / indices page counts) retain stable
-    // positions across both modes (they are zero in the GPT-OSS path).
+    // DeepSeek-only arg (dispatch_table page count) retains a stable position
+    // across both modes (it is zero in the GPT-OSS path).
     std::vector<uint32_t> compute_compile_time_args = {
         num_experts,
         emb_dim_cb_tiles,
         dispatch_table_num_pages,
-        indices_pages_per_core,
         static_cast<uint32_t>(use_dispatch_table_skip ? 1 : 0),
     };
 
@@ -210,7 +209,6 @@ CreatedProgram create_at(
         dispatch_table_num_pages,
         dispatch_table_page_size_val,
         dispatch_table_aligned_page_size,
-        indices_pages_per_core,
         indices_page_size_val,
         indices_aligned_page_size,
     };

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
@@ -145,11 +145,10 @@ CreatedProgram create_at(
                 .set_page_size(tt::CBIndex::c_2, dispatch_table_aligned_page_size);
         tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_dispatch_table_config);
 
-        // c_3: Indices scratch — loaded once for ALL of this core's tokens (all chunks).
-        // Sized for the maximum any core will handle: base+1 chunks when extra_chunks > 0.
+        // c_3: Indices scratch — loaded one chunk at a time (reused per chunk).
         indices_page_size_val = get_page_size(indices);
         indices_aligned_page_size = get_aligned_page_size(indices);
-        indices_pages_per_core = (base_chunks_per_core + (extra_chunks > 0 ? 1 : 0)) * TOKENS_PER_CHUNK;
+        indices_pages_per_core = TOKENS_PER_CHUNK;
         uint32_t indices_cb_size = indices_pages_per_core * indices_aligned_page_size;
         tt::tt_metal::CircularBufferConfig cb_indices_config =
             tt::tt_metal::CircularBufferConfig(indices_cb_size, {{tt::CBIndex::c_3, indices_cb_data_format}})

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_program_factory.cpp
@@ -73,28 +73,23 @@ CreatedProgram create_at(
         "Embedding dimension tiles {} must fit in 8 DST registers for batching",
         emb_dim_cb_tiles);
 
-    constexpr uint32_t REQUIRED_TOKENS_PER_CORE = 32;
+    constexpr uint32_t TOKENS_PER_CHUNK = 32;
     TT_FATAL(
-        num_tokens % REQUIRED_TOKENS_PER_CORE == 0,
+        num_tokens % TOKENS_PER_CHUNK == 0,
         "Number of tokens {} must be divisible by {} for hardware tilization",
         num_tokens,
-        REQUIRED_TOKENS_PER_CORE);
+        TOKENS_PER_CHUNK);
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;
 
-    uint32_t num_cores_needed = num_tokens / REQUIRED_TOKENS_PER_CORE;
-    TT_FATAL(
-        num_cores_needed <= num_cores_total,
-        "Need {} cores ({} tokens / {} tokens per core) but only {} cores available",
-        num_cores_needed,
-        num_tokens,
-        REQUIRED_TOKENS_PER_CORE,
-        num_cores_total);
-
-    uint32_t num_cores = num_cores_needed;
+    const uint32_t total_chunks = num_tokens / TOKENS_PER_CHUNK;
+    TT_FATAL(total_chunks > 0, "post_combine_reduce: num_tokens must be > 0, got {}", num_tokens);
+    const uint32_t num_cores = std::min(total_chunks, num_cores_total);
+    const uint32_t base_chunks_per_core = total_chunks / num_cores;
+    const uint32_t extra_chunks = total_chunks % num_cores;
 
     constexpr bool row_major = true;
 
@@ -150,11 +145,12 @@ CreatedProgram create_at(
                 .set_page_size(tt::CBIndex::c_2, dispatch_table_aligned_page_size);
         tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_dispatch_table_config);
 
-        // c_3: Indices scratch — loaded once by writer, read by compute.
-        // Each core handles TOKENS_PER_CORE tokens, each with num_experts index entries.
+        // c_3: Indices scratch — loaded once for ALL of this core's tokens (all chunks).
+        // Sized for the maximum any core will handle: base+1 chunks when extra_chunks > 0.
         indices_page_size_val = get_page_size(indices);
         indices_aligned_page_size = get_aligned_page_size(indices);
-        indices_pages_per_core = REQUIRED_TOKENS_PER_CORE;  // one page per token
+        uint32_t max_chunks_per_core = base_chunks_per_core + (extra_chunks > 0 ? 1 : 0);
+        indices_pages_per_core = max_chunks_per_core * TOKENS_PER_CHUNK;
         uint32_t indices_cb_size = indices_pages_per_core * indices_aligned_page_size;
         tt::tt_metal::CircularBufferConfig cb_indices_config =
             tt::tt_metal::CircularBufferConfig(indices_cb_size, {{tt::CBIndex::c_3, indices_cb_data_format}})
@@ -162,15 +158,15 @@ CreatedProgram create_at(
         tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_indices_config);
     }
 
-    // c_16: Output
-    uint32_t output_cb_size = REQUIRED_TOKENS_PER_CORE * emb_dim_cb_tiles * tile_size;
+    // c_16: Output — one chunk at a time (compute produces TOKENS_PER_CHUNK tiles per iteration)
+    uint32_t output_cb_size = TOKENS_PER_CHUNK * emb_dim_cb_tiles * tile_size;
     tt::tt_metal::CircularBufferConfig cb_output_config =
         tt::tt_metal::CircularBufferConfig(output_cb_size, {{tt::CBIndex::c_16, output_cb_data_format}})
             .set_page_size(tt::CBIndex::c_16, tile_size);
     auto cb_output_handle = tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_output_config);
 
-    // c_17: Row-major scratch for tilize
-    uint32_t rowmajor_cb_size = 32 * emb_dim_cb_tiles * tile_size;
+    // c_17: Row-major scratch for tilize — one chunk at a time
+    uint32_t rowmajor_cb_size = TOKENS_PER_CHUNK * emb_dim_cb_tiles * tile_size;
     tt::tt_metal::CircularBufferConfig cb_rowmajor_config =
         tt::tt_metal::CircularBufferConfig(rowmajor_cb_size, {{tt::CBIndex::c_17, output_cb_data_format}})
             .set_page_size(tt::CBIndex::c_17, tile_size);
@@ -252,23 +248,27 @@ CreatedProgram create_at(
         core_range_set,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
-    // Each core processes exactly 32 tokens (validated above)
+    // Distribute chunks of 32 tokens across cores. The first `extra_chunks` cores
+    // get (base_chunks_per_core + 1) chunks; the remaining get base_chunks_per_core.
     uint32_t token_start = 0;
     for (uint32_t i = 0; i < num_cores; ++i) {
         const CoreCoord& core = cores[i];
+        const uint32_t chunks_this_core = base_chunks_per_core + (i < extra_chunks ? 1 : 0);
 
         std::vector<uint32_t> reader_runtime_args = {
             combine_buffer->address(),
             token_start,
+            chunks_this_core,
         };
 
         std::vector<uint32_t> compute_runtime_args = {
             token_start,
+            chunks_this_core,
         };
 
         // Writer runtime args: weight_addr, output_addr,
         //   (deepseek only: dispatch_table_addr, indices_addr),
-        //   token_start. override_runtime_arguments mirrors this layout.
+        //   token_start, chunks_this_core. override_runtime_arguments mirrors this layout.
         std::vector<uint32_t> writer_runtime_args = {
             weight_buffer->address(),
             output_buffer->address(),
@@ -278,12 +278,13 @@ CreatedProgram create_at(
             writer_runtime_args.push_back(indices_buffer->address());
         }
         writer_runtime_args.push_back(token_start);
+        writer_runtime_args.push_back(chunks_this_core);
 
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
         tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
 
-        token_start += REQUIRED_TOKENS_PER_CORE;
+        token_start += chunks_this_core * TOKENS_PER_CHUNK;
     }
 
     return CreatedProgram{


### PR DESCRIPTION
## Summary
- Previously each core was hard-coded to process exactly 32 tokens, which capped the op at num_cores_total * 32 tokens (e.g. ~3200 on BH) and prevented scaling to 128K sequence lengths.
-  Wrap the reader/compute/writer kernels in an outer loop over N 32-token chunks and distribute chunks across all available cores in the program factory; the first `extra_chunks` cores get one extra chunk when total_chunks is not divisible by num_cores.

### Checklist

- [ ] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=jjovicic/post-combine-reduce-multichunk)](https://github.com/tenstorrent/tt-metal/actions/runs/25320956225)
- [ ] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=jjovicic/post-combine-reduce-multichunk)](https://github.com/tenstorrent/tt-metal/actions/runs/25320964583)
- [ ] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=jjovicic/post-combine-reduce-multichunk)](https://github.com/tenstorrent/tt-metal/actions/runs/25323345618)
- [ ] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=jjovicic/post-combine-reduce-multichunk)](https://github.com/tenstorrent/tt-metal/actions/runs/25320987570)