### PR TITLE
MoE  Combine Overlap with Untilize

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -317,6 +317,7 @@ def test_ttnn_combine(
     topology,
     use_predictable_data,
     run_pcc_check,
+    dispatched_buffer_layout,
 ):
     """Test TTNN combine operation in isolation using torch reference inputs."""
     torch.manual_seed(42)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -412,7 +412,7 @@ def test_ttnn_combine(
     tt_dispatched_buffer = ttnn.from_torch(
         dispatched_buffer,
         mesh_mapper=mesh_mapper,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        layout=ttnn.TILE_LAYOUT,
         device=mesh_device,
         dtype=ttnn.bfloat16,
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -301,6 +301,11 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])
+@pytest.mark.parametrize(
+    "dispatched_buffer_layout",
+    [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    ids=["tile", "row_major"],
+)
 def test_ttnn_combine(
     mesh_device,
     seq_len_per_chip,
@@ -412,7 +417,7 @@ def test_ttnn_combine(
     tt_dispatched_buffer = ttnn.from_torch(
         dispatched_buffer,
         mesh_mapper=mesh_mapper,
-        layout=ttnn.TILE_LAYOUT,
+        layout=dispatched_buffer_layout,
         device=mesh_device,
         dtype=ttnn.bfloat16,
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -44,7 +44,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, capacity_factor",
     [
-        (128, 7 * 1024, 16, 4, 2),
+        (1600, 7 * 1024, 32, 4, 2),
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -44,7 +44,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, capacity_factor",
     [
-        (1600, 7 * 1024, 32, 4, 2),
+        (128, 7 * 1024, 16, 4, 2),
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -197,6 +197,11 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])
+@pytest.mark.parametrize(
+    "dispatched_buffer_layout",
+    [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    ids=["tile", "row_major"],
+)
 def test_ttnn_combine(
     mesh_device,
     seq_len_per_chip,
@@ -207,6 +212,7 @@ def test_ttnn_combine(
     num_links,
     topology,
     use_predictable_data,
+    dispatched_buffer_layout,
 ):
     """Test TTNN combine operation in isolation using torch reference inputs."""
     torch.manual_seed(42)
@@ -307,7 +313,7 @@ def test_ttnn_combine(
     tt_dispatched_buffer = ttnn.from_torch(
         dispatched_buffer,
         mesh_mapper=mesh_mapper,
-        layout=ttnn.TILE_LAYOUT,
+        layout=dispatched_buffer_layout,
         device=mesh_device,
         dtype=ttnn.bfloat16,
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -307,7 +307,7 @@ def test_ttnn_combine(
     tt_dispatched_buffer = ttnn.from_torch(
         dispatched_buffer,
         mesh_mapper=mesh_mapper,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        layout=ttnn.TILE_LAYOUT,
         device=mesh_device,
         dtype=ttnn.bfloat16,
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -640,7 +640,9 @@ def test_ttnn_dispatch_combine_overflow(
     )
 
     logger.info("[overflow test] Running combine with overflow data...")
-    tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
+
+    tt_dispatched_buffer_tiled = ttnn.to_layout(tt_dispatched_buffer, layout=ttnn.TILE_LAYOUT)
+    tt_output = tt_combine_module(tt_dispatched_buffer_tiled, tt_metadata, tt_expert_token_counts)
     ttnn.synchronize_device(mesh_device)
     logger.info("[overflow test] Combine completed (did not hang)")
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -433,6 +433,8 @@ def test_ttnn_dispatch_combine(
         init_zeros=True,
     )
 
+    tt_dispatched_buffer = ttnn.to_layout(tt_dispatched_buffer, layout=ttnn.TILE_LAYOUT)
+
     # Run TTNN combine
     logger.debug("Running TTNN combine...")
     tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -226,7 +226,7 @@ def test_ttnn_dispatch_combine(
     num_links,
     topology,
     use_predictable_data,
-    dispatched_buffer_layout=ttnn.TILE_LAYOUT,
+    dispatched_buffer_layout,
 ):
     """Test end-to-end TTNN dispatch→combine round-trip with host reduction."""
     torch.manual_seed(42)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -211,6 +211,11 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])
+@pytest.mark.parametrize(
+    "dispatched_buffer_layout",
+    [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    ids=["tile", "row_major"],
+)
 def test_ttnn_dispatch_combine(
     mesh_device,
     seq_len_per_chip,
@@ -221,6 +226,7 @@ def test_ttnn_dispatch_combine(
     num_links,
     topology,
     use_predictable_data,
+    dispatched_buffer_layout=ttnn.TILE_LAYOUT,
 ):
     """Test end-to-end TTNN dispatch→combine round-trip with host reduction."""
     torch.manual_seed(42)
@@ -433,7 +439,7 @@ def test_ttnn_dispatch_combine(
         init_zeros=True,
     )
 
-    tt_dispatched_buffer = ttnn.to_layout(tt_dispatched_buffer, layout=ttnn.TILE_LAYOUT)
+    tt_dispatched_buffer = ttnn.to_layout(tt_dispatched_buffer, layout=dispatched_buffer_layout)
 
     # Run TTNN combine
     logger.debug("Running TTNN combine...")
@@ -516,10 +522,16 @@ def test_ttnn_dispatch_combine(
     ],
     indirect=["mesh_device", "device_params"],
 )
+@pytest.mark.parametrize(
+    "dispatched_buffer_layout",
+    [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    ids=["tile", "row_major"],
+)
 def test_ttnn_dispatch_combine_overflow(
     mesh_device,
     num_links,
     topology,
+    dispatched_buffer_layout,
 ):
     """Test that dispatch/combine hangs (or corrupts) when token count exceeds max_dispatched_tokens_per_expert.
 
@@ -641,8 +653,8 @@ def test_ttnn_dispatch_combine_overflow(
 
     logger.info("[overflow test] Running combine with overflow data...")
 
-    tt_dispatched_buffer_tiled = ttnn.to_layout(tt_dispatched_buffer, layout=ttnn.TILE_LAYOUT)
-    tt_output = tt_combine_module(tt_dispatched_buffer_tiled, tt_metadata, tt_expert_token_counts)
+    tt_dispatched_buffer = ttnn.to_layout(tt_dispatched_buffer, layout=dispatched_buffer_layout)
+    tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
     ttnn.synchronize_device(mesh_device)
     logger.info("[overflow test] Combine completed (did not hang)")
 
@@ -664,7 +676,12 @@ def test_ttnn_dispatch_combine_overflow(
     ],
     indirect=["mesh_device", "device_params"],
 )
-def test_ttnn_dispatch_combine_top4(mesh_device, num_links, topology):
+@pytest.mark.parametrize(
+    "dispatched_buffer_layout",
+    [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    ids=["tile", "row_major"],
+)
+def test_ttnn_dispatch_combine_top4(mesh_device, num_links, topology, dispatched_buffer_layout):
     """Regression test for num_experts_per_tok > 2 (previously caused hangs due to undersized CB buffering)."""
     test_ttnn_dispatch_combine(
         mesh_device=mesh_device,
@@ -676,4 +693,5 @@ def test_ttnn_dispatch_combine_top4(mesh_device, num_links, topology):
         num_links=num_links,
         topology=topology,
         use_predictable_data=True,
+        dispatched_buffer_layout=dispatched_buffer_layout,
     )

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -452,10 +452,12 @@ class TtMoe(LightweightModule):
         # ========================================
         # Step 4: Combine (enabled)
         # ========================================
-        # Combine expects TILE_LAYOUT input and untilizes it inside of operator
+        # Combine expects ROW_MAJOR or TILE_LAYOUT input
+        expert_outputs_rm = ttnn.to_layout(expert_outputs, ttnn.ROW_MAJOR_LAYOUT)
+        logger.debug(f"[TtMoe.forward] expert_outputs_rm shape: {expert_outputs_rm.shape} {expert_outputs_rm.dtype=}")
 
         combined_output = self.combine_module(
-            expert_outputs,
+            expert_outputs_rm,
             metadata,
             tt_expert_token_counts,
         )

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -452,12 +452,10 @@ class TtMoe(LightweightModule):
         # ========================================
         # Step 4: Combine (enabled)
         # ========================================
-        # Combine expects ROW_MAJOR input
-        expert_outputs_rm = ttnn.to_layout(expert_outputs, ttnn.ROW_MAJOR_LAYOUT)
-        logger.debug(f"[TtMoe.forward] expert_outputs_rm shape: {expert_outputs_rm.shape} {expert_outputs_rm.dtype=}")
+        # Combine expects TILE_LAYOUT input and untilizes it inside of operator
 
         combined_output = self.combine_module(
-            expert_outputs_rm,
+            expert_outputs,
             metadata,
             tt_expert_token_counts,
         )

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -352,12 +352,10 @@ class TtMoe(LightweightModule):
         # ========================================
         # Step 4: Combine (enabled)
         # ========================================
-        # Combine expects ROW_MAJOR input
-        expert_outputs_rm = ttnn.to_layout(expert_outputs, ttnn.ROW_MAJOR_LAYOUT)
-        logger.debug(f"[TtMoe.forward] expert_outputs_rm shape: {expert_outputs_rm.shape} {expert_outputs_rm.dtype=}")
+        # Combine expects TILE_LAYOUT input and untilizes it inside of operator
 
         combined_output = self.combine_module(
-            expert_outputs_rm,
+            expert_outputs,
             metadata,
             tt_expert_token_counts,
         )

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
@@ -15,9 +15,9 @@ namespace ttnn::operations::experimental::deepseek_prefill::combine {
 void CombineDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // Validate layouts
-    TT_FATAL(
-        tensor_args.dispatched_buffer.layout() == tt::tt_metal::Layout::ROW_MAJOR,
-        "Dispatched buffer must be ROW_MAJOR layout");
+    // TT_FATAL(
+    //     tensor_args.dispatched_buffer.layout() == tt::tt_metal::Layout::ROW_MAJOR,
+    //     "Dispatched buffer must be ROW_MAJOR layout");
     TT_FATAL(
         tensor_args.dispatched_metadata.layout() == tt::tt_metal::Layout::ROW_MAJOR,
         "Dispatched metadata must be ROW_MAJOR layout");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
@@ -15,9 +15,9 @@ namespace ttnn::operations::experimental::deepseek_prefill::combine {
 void CombineDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // Validate layouts
-    // TT_FATAL(
-    //     tensor_args.dispatched_buffer.layout() == tt::tt_metal::Layout::ROW_MAJOR,
-    //     "Dispatched buffer must be ROW_MAJOR layout");
+    TT_FATAL(
+        tensor_args.dispatched_buffer.layout() == tt::tt_metal::Layout::TILE,
+        "Dispatched buffer must be TILE_LAYOUT layout");
     TT_FATAL(
         tensor_args.dispatched_metadata.layout() == tt::tt_metal::Layout::ROW_MAJOR,
         "Dispatched metadata must be ROW_MAJOR layout");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
@@ -16,8 +16,9 @@ void CombineDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // Validate layouts
     TT_FATAL(
-        tensor_args.dispatched_buffer.layout() == tt::tt_metal::Layout::TILE,
-        "Dispatched buffer must be TILE_LAYOUT layout");
+        tensor_args.dispatched_buffer.layout() == tt::tt_metal::Layout::TILE ||
+            tensor_args.dispatched_buffer.layout() == tt::tt_metal::Layout::ROW_MAJOR,
+        "Dispatched buffer must be TILE_LAYOUT or ROW_MAJOR layout");
     TT_FATAL(
         tensor_args.dispatched_metadata.layout() == tt::tt_metal::Layout::ROW_MAJOR,
         "Dispatched metadata must be ROW_MAJOR layout");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -604,7 +604,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t output_aligned_page_size = detail::get_aligned_page_size(output_tensor);
         std::vector<uint32_t> zi_compile_time_args = {
             output_aligned_page_size,
-            1,  // num_sender_cores = 1: each idle core signals only its owning sender
+            num_cores,  // num_sender_cores = num_cores: each idle core signals all sender cores
             static_cast<uint32_t>(tt::CBIndex::c_6),
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(zi_compile_time_args);
@@ -639,6 +639,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         auto per_sender_compile_args = reader_compile_time_args_base;
         per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender k_s)
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+        if (init_zeros) {
+            per_sender_compile_args.push_back(
+                num_idle_cores);  // num_total_idle_cores (all idle cores across all senders)
+        }
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
             program,
@@ -691,16 +695,17 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
             uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
 
-            // Each idle core signals only its owning sender (num_sender_cores CT arg = 1)
-            uint32_t owning_sender = idle_sender_map[idle_idx];
+            // Each idle core signals all sender cores
             std::vector<uint32_t> zi_runtime_args = {
                 output_tensor.buffer()->address(),
                 page_start,
                 page_end,
                 zi_done_semaphore_id,
-                sender_noc_coords[owning_sender].first,
-                sender_noc_coords[owning_sender].second,
             };
+            for (const auto& [noc_x, noc_y] : sender_noc_coords) {
+                zi_runtime_args.push_back(noc_x);
+                zi_runtime_args.push_back(noc_y);
+            }
 
             tt::tt_metal::SetRuntimeArgs(program, zero_init_kernel_id, zero_init_cores_vec[idle_idx], zi_runtime_args);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -158,27 +158,50 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t num_cores = effective_num_links;
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    auto sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
-        subdevice_cores.at(0), num_cores, worker_core_range_set, true);
-    std::vector<CoreCoord> sender_cores = corerange_to_cores(sender_core_grid);
-    TT_FATAL(sender_cores.size() == num_cores, "Expected {} sender cores, got {}", num_cores, sender_cores.size());
-
-    // Step 2: Collect idle cores in the SAME physical row as sender_cores[0]
-    uint32_t sender_row_y_phys =
-        (uint32_t)mesh_device->virtual_core_from_logical_core(sender_cores[0], tt::CoreType::WORKER).y;
-    std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
-    std::vector<CoreCoord> same_row_idle;
+    // Interleaved layout: [sender0, idle0_0..idle0_{k0-1}, sender1, idle1_0..idle1_{k1-1}, ...]
+    // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
+    uint32_t sender_row_y = subdevice_cores.at(0).y;
+    std::vector<CoreCoord> all_row_cores;
     for (const auto& core : subdevice_cores) {
-        if (sender_core_set.count(core)) {
-            continue;
+        if (core.y == sender_row_y) {
+            all_row_cores.push_back(core);
         }
-        auto noc = mesh_device->virtual_core_from_logical_core(core, tt::CoreType::WORKER);
-        if ((uint32_t)noc.y == sender_row_y_phys) {
-            same_row_idle.push_back(core);
+    }
+    std::sort(
+        all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) { return a.x < b.x; });
+
+    uint32_t total_row_cores = static_cast<uint32_t>(all_row_cores.size());
+    TT_FATAL(
+        total_row_cores > num_cores,
+        "Same-row has only {} cores for {} senders — need at least one idle core per sender",
+        total_row_cores,
+        num_cores);
+
+    // Divide total_row_cores into num_cores groups: last (total_row_cores % num_cores) groups get +1.
+    // Within each group: first core = sender, remaining = that sender's idle cores.
+    uint32_t base_group_size = total_row_cores / num_cores;
+    uint32_t extra_groups = total_row_cores % num_cores;
+
+    std::vector<CoreCoord> sender_cores;
+    sender_cores.reserve(num_cores);
+    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
+    std::vector<CoreCoord> all_idle_cores;
+    std::vector<uint32_t> idle_sender_map;
+
+    {
+        uint32_t pos = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
+            sender_cores.push_back(all_row_cores[pos++]);
+            for (uint32_t j = 1; j < group_size; j++, pos++) {
+                sender_idle_groups[s].push_back(all_row_cores[pos]);
+                all_idle_cores.push_back(all_row_cores[pos]);
+                idle_sender_map.push_back(s);
+            }
         }
     }
 
-    uint32_t num_idle_cores = static_cast<uint32_t>(same_row_idle.size());
+    uint32_t num_idle_cores = static_cast<uint32_t>(all_idle_cores.size());
     TT_FATAL(
         num_idle_cores >= num_cores,
         "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
@@ -187,24 +210,13 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t K_base = num_idle_cores / num_cores;
     uint32_t K_extra = num_idle_cores % num_cores;
 
-    // sender_idle_groups[s] = dedicated idle cores for sender s (all in same physical row)
-    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
-    std::vector<CoreCoord> all_idle_cores;
-    all_idle_cores.reserve(num_idle_cores);
-    // idle_sender_map[j] = which sender owns flat idle-core index j
-    std::vector<uint32_t> idle_sender_map;
-    idle_sender_map.reserve(num_idle_cores);
-    {
-        uint32_t pos = 0;
-        for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
-            for (uint32_t j = 0; j < k_s; j++, pos++) {
-                sender_idle_groups[s].push_back(same_row_idle[pos]);
-                all_idle_cores.push_back(same_row_idle[pos]);
-                idle_sender_map.push_back(s);
-            }
-        }
+    // Build sender_core_grid from selected sender cores
+    std::set<CoreRange> sender_ranges_set;
+    for (const auto& sc : sender_cores) {
+        sender_ranges_set.insert(CoreRange(sc));
     }
+    auto sender_core_grid = CoreRangeSet(sender_ranges_set);
+    TT_FATAL(sender_cores.size() == num_cores, "Expected {} sender cores, got {}", num_cores, sender_cores.size());
 
     log_debug(
         tt::LogOp,
@@ -535,7 +547,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     {
         uint32_t global_idle_idx = 0;
         for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
                 auto per_core_args = reader_untilize_compile_time_args_base;
                 per_core_args.push_back(j);    // 11: core_id (local to sender s's group)
@@ -623,7 +635,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
         auto per_sender_compile_args = reader_compile_time_args_base;
         per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender k_s)
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -731,6 +731,9 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         zi_compile_time_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // counter page size
         zi_compile_time_args.push_back(read_batch_size);
         zi_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_9));  // cb_metadata_batch_id
+        zi_compile_time_args.push_back(operation_attributes.num_experts_per_tok);  // num_experts_per_tok
+        zi_compile_time_args.push_back(
+            detail::get_aligned_page_size(dispatched_metadata));  // aligned_dispatched_metadata_page_size
 
         std::map<std::string, std::string> zi_defines;
         zi_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -160,9 +160,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
     // Core layout depends on dispatched_buffer layout:
-    //   TILE_LAYOUT: sender in the middle of its idle group to reduce NOC congestion.
-    //     Cores are divided into groups, sender placed at group_size/2:
-    //     [idle0_0..idle0_{m-1}, sender0, idle0_m..idle0_{k0-1}, ..., sender1, ...]
+    //   TILE_LAYOUT: sender placed at the end of its idle group so every idle core sits to the
+    //     sender's left and can write rightward on NOC0 (the +X NOC).
+    //     Cores are divided into groups, sender placed at group_size-1:
+    //     [idle0_0..idle0_{k0-1}, sender0, idle1_0..idle1_{k1-1}, sender1, ...]
     //   ROW_MAJOR: first num_cores cores are senders, remaining are idle (for zero-init only).
     //     [sender0, sender1, idle0, idle1, idle2, ...]
     // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
@@ -190,14 +191,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<uint32_t> idle_sender_map;
 
     if (is_tile_layout) {
-        // TILE_LAYOUT: divide into groups, sender in the middle of each group
+        // TILE_LAYOUT: divide into groups, sender at the end of each group
         uint32_t base_group_size = total_row_cores / num_cores;
         uint32_t extra_groups = total_row_cores % num_cores;
 
         uint32_t pos = 0;
         for (uint32_t s = 0; s < num_cores; s++) {
             uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
-            uint32_t sender_offset = group_size / 2;
+            uint32_t sender_offset = group_size - 1;
 
             for (uint32_t j = 0; j < group_size; j++) {
                 if (j == sender_offset) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -158,17 +158,72 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t num_cores = effective_num_links;
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    auto sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+    // Step 1: Select sender cores using num_cores_to_corerangeset_in_subcoregrids.
+    // This picks the first num_cores from the subdevice in row-major order, keeping
+    // senders physically adjacent and (typically) in the same physical row.
+    CoreRangeSet sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
         subdevice_cores.at(0), num_cores, worker_core_range_set, true);
     std::vector<CoreCoord> sender_cores = corerange_to_cores(sender_core_grid);
+    TT_FATAL(sender_cores.size() == num_cores, "Expected {} sender cores, got {}", num_cores, sender_cores.size());
+
+    // Step 2: Collect idle cores in the SAME physical row as sender_cores[0].
+    // NOC multicast requires a single-row bounding box: if idle cores span multiple
+    // physical rows the box widens to a rectangle that includes non-subdevice cores
+    // (Ethernet tiles, other workers), causing noc_async_write_barrier() to hang
+    // because the hardware waits for ACKs from cores that can't respond properly.
+    uint32_t sender_row_y_phys =
+        (uint32_t)mesh_device->virtual_core_from_logical_core(sender_cores[0], tt::CoreType::WORKER).y;
+    std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
+    std::vector<CoreCoord> same_row_idle;
+    for (const auto& core : subdevice_cores) {
+        if (sender_core_set.count(core)) {
+            continue;
+        }
+        auto noc = mesh_device->virtual_core_from_logical_core(core, tt::CoreType::WORKER);
+        if ((uint32_t)noc.y == sender_row_y_phys) {
+            same_row_idle.push_back(core);
+        }
+    }
+
+    uint32_t num_idle_cores = static_cast<uint32_t>(same_row_idle.size());
+    TT_FATAL(
+        num_idle_cores >= num_cores,
+        "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
+        num_idle_cores,
+        num_cores);
+    uint32_t K_base = num_idle_cores / num_cores;
+    uint32_t K_extra = num_idle_cores % num_cores;
+
+    // sender_idle_groups[s] = dedicated idle cores for sender s (all in same physical row)
+    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
+    std::vector<CoreCoord> all_idle_cores;
+    all_idle_cores.reserve(num_idle_cores);
+    // idle_sender_map[j] = which sender owns flat idle-core index j
+    std::vector<uint32_t> idle_sender_map;
+    idle_sender_map.reserve(num_idle_cores);
+    {
+        uint32_t pos = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            for (uint32_t j = 0; j < k_s; j++, pos++) {
+                sender_idle_groups[s].push_back(same_row_idle[pos]);
+                all_idle_cores.push_back(same_row_idle[pos]);
+                idle_sender_map.push_back(s);
+            }
+        }
+    }
 
     log_debug(
         tt::LogOp,
-        "Combine program: hidden_size: {} num_cores: {} experts_per_core_range: {} cores: {}",
+        "Combine program: hidden_size: {} num_cores: {} experts_per_core_range: {} "
+        "sender_cores: {} num_idle_cores: {} K_base: {} K_extra: {}",
         hidden_size,
         num_cores,
         experts_per_core_range,
-        sender_cores);
+        sender_cores,
+        num_idle_cores,
+        K_base,
+        K_extra);
 
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
@@ -200,9 +255,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
         auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        // Need num_cores extra words (one receive_buf_addr per sender) after the counter data.
-        uint32_t recv_buf_extra_bytes = num_cores * sizeof(uint32_t);
-        uint32_t extra_pages = std::max(1u, tt::div_up(recv_buf_extra_bytes, counter_page_size));
+        // One extra page holds the single receive_buf_addr (uint32) appended after counter data.
+        uint32_t extra_pages = 1;
         uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
         tt::tt_metal::CircularBufferConfig c2_config =
             tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_2, data_format}})
@@ -367,45 +421,39 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t pages_per_core = 0;
     uint32_t remainder_pages = 0;
 
-    // Find idle worker cores in the same row as sender cores — always needed for reader_untilize
-    uint32_t sender_row_y = sender_cores[0].y;
-    std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
-    std::vector<CoreCoord> idle_row_cores;
-    for (const auto& core : subdevice_cores) {
-        if (core.y == sender_row_y && !sender_core_set.contains(core)) {
-            idle_row_cores.push_back(core);
+    // idle_row_cores: all same-row idle cores, ordered by sender group then by x.
+    std::vector<CoreCoord>& idle_row_cores = all_idle_cores;
+
+    // Per-sender multicast bounding boxes and idle NOC coordinates.
+    // Each sender multicasts only to its own dedicated idle group so both senders
+    // can run their multicast in parallel without interfering.
+    struct SenderMcastCfg {
+        uint32_t mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y;
+        std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
+    };
+    std::vector<SenderMcastCfg> sender_mcast_cfgs(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        TT_FATAL(!sender_idle_groups[s].empty(), "Sender {} has no idle cores assigned", s);
+        auto& cfg = sender_mcast_cfgs[s];
+        auto first_noc = mesh_device->virtual_core_from_logical_core(sender_idle_groups[s][0], tt::CoreType::WORKER);
+        cfg.mcast_start_x = cfg.mcast_end_x = first_noc.x;
+        cfg.mcast_start_y = cfg.mcast_end_y = first_noc.y;
+        for (const auto& ic : sender_idle_groups[s]) {
+            auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
+            cfg.mcast_start_x = std::min(cfg.mcast_start_x, (uint32_t)noc.x);
+            cfg.mcast_end_x = std::max(cfg.mcast_end_x, (uint32_t)noc.x);
+            cfg.mcast_start_y = std::min(cfg.mcast_start_y, (uint32_t)noc.y);
+            cfg.mcast_end_y = std::max(cfg.mcast_end_y, (uint32_t)noc.y);
+            cfg.idle_noc_coords.emplace_back((uint32_t)noc.x, (uint32_t)noc.y);
         }
     }
-    uint32_t num_idle_cores = static_cast<uint32_t>(idle_row_cores.size());
-    TT_FATAL(
-        num_idle_cores >= num_cores,
-        "Need at least {} idle cores (one per sender) in sender row {}, found {}; "
-        "subdevice must have more than {} cores per row",
-        num_cores,
-        sender_row_y,
-        num_idle_cores,
-        num_cores);
 
+    // Build idle CoreRangeSet
     std::set<CoreRange> idle_ranges_set;
     for (const auto& core : idle_row_cores) {
         idle_ranges_set.insert(CoreRange(core));
     }
     CoreRangeSet idle_core_grid(idle_ranges_set);
-
-    // Compute NOC coordinates and multicast bounding box for idle cores
-    std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
-    for (const auto& core : idle_row_cores) {
-        auto noc_coord = mesh_device->virtual_core_from_logical_core(core, tt::CoreType::WORKER);
-        idle_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
-    }
-    uint32_t mcast_start_x = idle_noc_coords[0].first, mcast_end_x = idle_noc_coords[0].first;
-    uint32_t mcast_start_y = idle_noc_coords[0].second, mcast_end_y = idle_noc_coords[0].second;
-    for (const auto& [x, y] : idle_noc_coords) {
-        mcast_start_x = std::min(mcast_start_x, x);
-        mcast_end_x = std::max(mcast_end_x, x);
-        mcast_start_y = std::min(mcast_start_y, y);
-        mcast_end_y = std::max(mcast_end_y, y);
-    }
 
     // counter_ready semaphore: created only on sender + idle cores so get_semaphore() returns
     // the same L1 offset on both sides (sender writes to idle's copy, idle waits on its own)
@@ -426,21 +474,16 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
     }
 
-    // c_1 on idle cores: receives the full expert_token_counts multicast from sender.
-    // MUST be allocated BEFORE c_0 so that its L1 data-buffer address matches the sender's
-    // c_1 (dispatched_metadata) address.  The sender uses get_write_ptr(c_1_sender) as the
-    // multicast destination; if c_0 were allocated first here, idle c_1 would land 449 KB
-    // higher in L1 and the multicast would write into the wrong location, leaving the token
-    // counts as all-zeros and causing a hang (idle cores see 0 batches → send only the
-    // sentinel → sender waits on data_ready forever).
-    // Extra pages after the counter data hold one receive_buf_addr per sender core so idle
-    // cores can discover each sender's receive buffer from the multicast payload alone.
+    // c_1 on idle cores: receives the expert_token_counts multicast from the owning sender.
+    // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
+    // The sender uses get_write_ptr(c_1_sender) as the multicast destination; if c_0 were
+    // allocated first here it would consume ~3 MB causing c_1 to wrap and corrupt the mailbox.
+    // One extra page holds the single receive_buf_addr that each sender appends before multicasting.
     {
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
         auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        uint32_t recv_buf_extra_bytes = num_cores * sizeof(uint32_t);
-        uint32_t extra_pages = std::max(1u, tt::div_up(recv_buf_extra_bytes, counter_page_size));
+        uint32_t extra_pages = 1;
         uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
         tt::tt_metal::CircularBufferConfig c1_idle_config =
             tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
@@ -486,12 +529,11 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
     //   0-10: shared base (below)
-    //   11:   core_id (global index 0..num_idle_cores-1, appended per-core)
-    //   12:   num_idle_cores (total, appended per-core)
+    //   11:   core_id   — local index within sender s's idle group (0..k_s-1)
+    //   12:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
     //   13:   aligned_output_page_size
     //   14:   aligned_experts_tok_counter_page_size
-    //   15:   num_senders (= num_cores)
-    //   16+:  TensorAccessorArgs for dispatched_buffer
+    //   15+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
     const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
         static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
         detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -506,31 +548,38 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
     };
 
-    // All idle cores cover the full expert range; the kernel routes each expert to the
-    // correct sender via sender_idx = local_expert / experts_per_sender.
-    // core_id is a global index for round-robin batch assignment across all idle cores.
+    // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
+    // core_id is LOCAL within the sender's group (0..k_s-1) for round-robin batch assignment.
+    // num_idle_cores baked in as k_s so the kernel only considers its own group.
+    // No num_senders arg — each kernel is bound to a single sender.
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     reader_untilize_kernel_ids.reserve(num_idle_cores);
 
-    for (uint32_t j = 0; j < num_idle_cores; j++) {
-        auto per_core_args = reader_untilize_compile_time_args_base;
-        per_core_args.push_back(j);                                                   // 11: core_id (global)
-        per_core_args.push_back(num_idle_cores);                                      // 12: num_idle_cores (total)
-        per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 13
-        per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 14
-        per_core_args.push_back(num_cores);                                           // 15: num_senders
-        tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);  // 16+
+    {
+        uint32_t global_idle_idx = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
+                auto per_core_args = reader_untilize_compile_time_args_base;
+                per_core_args.push_back(j);    // 11: core_id (local to sender s's group)
+                per_core_args.push_back(k_s);  // 12: num_idle_cores (per-sender)
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 13
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 14
+                // 15+: TensorAccessorArgs (no num_senders — single-sender kernel)
+                tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);
 
-        CoreRangeSet single_idle_core({CoreRange(idle_row_cores[j])});
-        reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
-            "reader_untilize.cpp",
-            single_idle_core,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                .compile_args = per_core_args}));
+                CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
+                reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+                    program,
+                    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
+                    "reader_untilize.cpp",
+                    single_idle_core,
+                    tt::tt_metal::DataMovementConfig{
+                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                        .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                        .compile_args = per_core_args}));
+            }
+        }
     }
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
@@ -566,7 +615,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t output_aligned_page_size = detail::get_aligned_page_size(output_tensor);
         std::vector<uint32_t> zi_compile_time_args = {
             output_aligned_page_size,
-            num_cores,
+            1,  // num_sender_cores = 1: each idle core signals only its owning sender
             static_cast<uint32_t>(tt::CBIndex::c_6),
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(zi_compile_time_args);
@@ -591,13 +640,15 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
     // num_idle_cores and cb_untilize_id are appended per-sender below.
 
-    // Create one reader_combine kernel per sender so each can have its own per-sender num_idle_cores
-    // baked in at compile time (avoids a VLA whose size would vary across sender cores).
+    // One reader_combine kernel per sender with k_s (per-sender idle count) baked in as
+    // num_idle_cores.  The VLA idle_start_noc_addrs[num_idle_cores] is sized exactly right
+    // and the sender only round-robins across its own k_s dedicated idle cores.
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
+        uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
         auto per_sender_compile_args = reader_compile_time_args_base;
-        per_sender_compile_args.push_back(num_idle_cores);                            // num_idle_cores (all idle cores)
+        per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender k_s)
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
@@ -650,16 +701,16 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
             uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
 
+            // Each idle core signals only its owning sender (num_sender_cores CT arg = 1)
+            uint32_t owning_sender = idle_sender_map[idle_idx];
             std::vector<uint32_t> zi_runtime_args = {
                 output_tensor.buffer()->address(),
                 page_start,
                 page_end,
                 zi_done_semaphore_id,
+                sender_noc_coords[owning_sender].first,
+                sender_noc_coords[owning_sender].second,
             };
-            for (const auto& [noc_x, noc_y] : sender_noc_coords) {
-                zi_runtime_args.push_back(noc_x);
-                zi_runtime_args.push_back(noc_y);
-            }
 
             tt::tt_metal::SetRuntimeArgs(program, zero_init_kernel_id, zero_init_cores_vec[idle_idx], zi_runtime_args);
         }
@@ -688,17 +739,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             reader_runtime_args.push_back(sender_page_end);
             reader_runtime_args.push_back(zi_done_semaphore_id);
         }
+        // Multicast targets only this sender's dedicated idle group
+        const auto& mcast_cfg = sender_mcast_cfgs[core_idx];
         reader_runtime_args.push_back(counter_ready_semaphore_id);
-        reader_runtime_args.push_back(mcast_start_x);
-        reader_runtime_args.push_back(mcast_start_y);
-        reader_runtime_args.push_back(mcast_end_x);
-        reader_runtime_args.push_back(mcast_end_y);
+        reader_runtime_args.push_back(mcast_cfg.mcast_start_x);
+        reader_runtime_args.push_back(mcast_cfg.mcast_start_y);
+        reader_runtime_args.push_back(mcast_cfg.mcast_end_x);
+        reader_runtime_args.push_back(mcast_cfg.mcast_end_y);
         reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
         reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
-        // Pass NOC coords of ALL idle cores — all idle cores now handle all experts
-        for (uint32_t j = 0; j < num_idle_cores; j++) {
-            reader_runtime_args.push_back(idle_noc_coords[j].first);
-            reader_runtime_args.push_back(idle_noc_coords[j].second);
+        // Pass NOC coords of only this sender's k_s dedicated idle cores
+        for (const auto& [noc_x, noc_y] : mcast_cfg.idle_noc_coords) {
+            reader_runtime_args.push_back(noc_x);
+            reader_runtime_args.push_back(noc_y);
         }
 
         std::vector<uint32_t> writer_runtime_args = {
@@ -754,21 +807,23 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         core_idx++;
     }
 
-    // Set runtime args for idle cores.  All idle cores cover the full expert range; the kernel
-    // determines the owning sender per expert via sender_idx = local_expert / experts_per_sender.
-    // Layout: counter_ready_sem, [data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s]]×num_senders,
-    //         dispatched_buffer_addr, expert_start=0, expert_end=experts_per_chip
+    // Set runtime args for idle cores.  Each idle core is bound to its owning sender s.
+    // Layout: counter_ready_sem, data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s],
+    //         dispatched_buffer_addr, expert_start, expert_end
     for (uint32_t j = 0; j < num_idle_cores; j++) {
-        std::vector<uint32_t> idle_rt_args = {counter_ready_semaphore_id};
-        for (uint32_t s = 0; s < num_cores; s++) {
-            idle_rt_args.push_back(data_ready_semaphore_ids[s]);
-            idle_rt_args.push_back(sender_noc_coords[s].first);
-            idle_rt_args.push_back(sender_noc_coords[s].second);
-            idle_rt_args.push_back(start_semaphore_ids[s]);
-        }
-        idle_rt_args.push_back(dispatched_buffer.buffer()->address());
-        idle_rt_args.push_back(0);                                      // expert_start = 0
-        idle_rt_args.push_back(operation_attributes.experts_per_chip);  // expert_end
+        uint32_t s = idle_sender_map[j];
+        uint32_t expert_start = s * experts_per_core_range;
+        uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+        std::vector<uint32_t> idle_rt_args = {
+            counter_ready_semaphore_id,
+            data_ready_semaphore_ids[s],
+            sender_noc_coords[s].first,
+            sender_noc_coords[s].second,
+            start_semaphore_ids[s],
+            dispatched_buffer.buffer()->address(),
+            expert_start,
+            expert_end,
+        };
         tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
     }
 
@@ -785,7 +840,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
          .zero_init_semaphore_id = zero_init_semaphore_id,
          .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id,
          .counter_ready_semaphore_id = counter_ready_semaphore_id,
-         .num_senders = num_cores,
          .data_ready_semaphore_ids = std::move(data_ready_semaphore_ids),
          .start_semaphore_ids = std::move(start_semaphore_ids)}};
 }
@@ -824,9 +878,9 @@ void CombineProgramFactory::override_runtime_arguments(
         for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
             auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
                 program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-            // dispatched_buffer_addr sits at index 1 + num_senders*4:
-            // index 0 = counter_ready_sem, then num_senders groups of {data_ready_sem, noc_x, noc_y, start_sem}
-            idle_rt_args.at(1 + shared_variables.num_senders * 4) = tensor_args.dispatched_buffer.buffer()->address();
+            // RT layout: [0:counter_ready_sem, 1:data_ready_sem, 2:noc_x, 3:noc_y, 4:start_sem,
+            //             5:dispatched_buffer_addr, 6:expert_start, 7:expert_end]
+            idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -675,6 +675,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .defines = writer_defines});
 
     // Compute kernel on idle cores that untilizes dispatched_buffer data
+    const uint32_t full_ct_dim = static_cast<uint32_t>(hidden_size) / 32u;
+    uint32_t block_ct_dim = 8;
+    while (full_ct_dim % block_ct_dim != 0) {
+        --block_ct_dim;
+    }
+
     tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
@@ -682,12 +688,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         idle_core_grid,
         tt::tt_metal::ComputeConfig{
             .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_signal_id (CB used for signaling on the same core that
-                                                          // data is loaded and ready to be untilized)
-                static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_untilize_id (untilized dispatched_buffer data)
-                static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_in_id (dispatched_buffer data)
-                static_cast<uint32_t>(hidden_size),       // hidden_size
-                static_cast<uint32_t>(read_batch_size),   // read_batch_size
+                static_cast<uint32_t>(
+                    tt::CBIndex::c_3),  // 0: cb_signal_id (CB used for signaling on the same core that
+                                        //    data is loaded and ready to be untilized)
+                static_cast<uint32_t>(tt::CBIndex::c_2),  // 1: cb_untilize_id (untilized dispatched_buffer data)
+                static_cast<uint32_t>(tt::CBIndex::c_0),  // 2: cb_in_id (dispatched_buffer data)
+                read_batch_size,                          // 3: read_batch_size
+                full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
+                block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
             }});
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -230,8 +230,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
         num_idle_cores,
         num_cores);
-    uint32_t K_base = num_idle_cores / num_cores;
-    uint32_t K_extra = num_idle_cores % num_cores;
+    uint32_t idle_cores_per_sender = num_idle_cores / num_cores;
+    uint32_t senders_with_extra_idle = num_idle_cores % num_cores;
 
     // Build sender_core_grid from selected sender cores
     std::set<CoreRange> sender_ranges_set;
@@ -244,14 +244,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     log_debug(
         tt::LogOp,
         "Combine program: hidden_size: {} num_cores: {} experts_per_core_range: {} "
-        "sender_cores: {} num_idle_cores: {} K_base: {} K_extra: {}",
+        "sender_cores: {} num_idle_cores: {} idle_cores_per_sender: {} senders_with_extra_idle: {}",
         hidden_size,
         num_cores,
         experts_per_core_range,
         sender_cores,
         num_idle_cores,
-        K_base,
-        K_extra);
+        idle_cores_per_sender,
+        senders_with_extra_idle);
 
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
@@ -318,7 +318,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         detail::create_tensor_cb(
             program,
             sender_core_grid,
-            output_tensor,
+            output_tensor,  // dispatched_buffer and output_tensor have same page size
             /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_4,
             "output_for_writer");
@@ -465,13 +465,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     };
     std::vector<SenderMcastCfg> sender_mcast_cfgs(num_cores);
     if (is_tile_layout) {
+        // Compute per-sender NOC multicast bounding box (min/max x,y over idle cores)
+        // and collect individual idle core NOC coordinates for semaphore signaling.
         for (uint32_t s = 0; s < num_cores; s++) {
             TT_FATAL(!sender_idle_groups[s].empty(), "Sender {} has no idle cores assigned", s);
             auto& cfg = sender_mcast_cfgs[s];
+
+            // Initialize bounding box from the first idle core in the group
             auto first_noc =
                 mesh_device->virtual_core_from_logical_core(sender_idle_groups[s][0], tt::CoreType::WORKER);
             cfg.mcast_start_x = cfg.mcast_end_x = first_noc.x;
             cfg.mcast_start_y = cfg.mcast_end_y = first_noc.y;
+
+            // Expand bounding box to cover all idle cores and record each core's NOC coords
             for (const auto& ic : sender_idle_groups[s]) {
                 auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
                 cfg.mcast_start_x = std::min(cfg.mcast_start_x, (uint32_t)noc.x);
@@ -513,7 +519,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         }
     }
 
-    // cb_factor reduces CB size to fit L1: Blackhole has more L1, Wormhole needs 4x reduction
+    // cb_factor reduces CB size to fit L1: Wormhole needs 4x reduction
     uint32_t cb_factor;
     {
         const auto arch = mesh_device->arch();
@@ -665,7 +671,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t output_aligned_page_size = detail::get_aligned_page_size(output_tensor);
         std::vector<uint32_t> zi_compile_time_args = {
             output_aligned_page_size,
-            num_cores,  // num_sender_cores = num_cores: each idle core signals all sender cores
+            num_cores,  // num_sender_cores = num_cores: each idle core signals all sender cores that its zero-init
+                        // portion is done and output pages are initializer with 0 for that chip
             static_cast<uint32_t>(tt::CBIndex::c_6),
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(zi_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -234,7 +234,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
 
-    constexpr uint32_t read_batch_size = 32;
+    const uint32_t read_batch_size = is_tile_layout ? dispatched_buffer.tensor_spec().tile().get_height() : 8;
 
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
@@ -297,15 +297,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             program,
             sender_core_grid,
             output_tensor,
-            /*buffering_factor=*/rw_buffering,
-            /*cb_id=*/tt::CBIndex::c_4,
-            "output_for_writer");
-    }
-
-        detail::create_tensor_cb(
-            program,
-            sender_core_grid,
-            dispatched_buffer,
             /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_4,
             "output_for_writer");
@@ -562,12 +553,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     if (is_tile_layout) {
         // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
-        //   0-11: shared base (below, includes cb_factor at index 11)
-        //   12:   core_id   — local index within sender s's idle group (0..k_s-1)
-        //   13:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
-        //   14:   aligned_output_page_size
-        //   15:   aligned_experts_tok_counter_page_size
-        //   16+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
+        //   0-13: shared base (below, includes tile_height/tile_width at 12-13)
+        //   14:   core_id   — local index within sender s's idle group (0..k_s-1)
+        //   15:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
+        //   16:   aligned_output_page_size
+        //   17:   aligned_experts_tok_counter_page_size
+        //   18+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
+        const uint32_t tile_height = dispatched_buffer.tensor_spec().tile().get_height();
+        const uint32_t tile_width = dispatched_buffer.tensor_spec().tile().get_width();
         const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
             static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
             detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -581,6 +574,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
             (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
             cb_factor,                                         // 11: cb_factor
+            tile_height,                                       // 12: tile_height
+            tile_width,                                        // 13: tile_width
         };
 
         // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
@@ -594,11 +589,11 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
                 auto per_core_args = reader_untilize_compile_time_args_base;
-                per_core_args.push_back(j);    // 12: core_id (local to sender s's group)
-                per_core_args.push_back(k_s);  // 13: num_idle_cores (per-sender)
-                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 14
-                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 15
-                // 16+: TensorAccessorArgs (no num_senders — single-sender kernel)
+                per_core_args.push_back(j);    // 14: core_id (local to sender s's group)
+                per_core_args.push_back(k_s);  // 15: num_idle_cores (per-sender)
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 16
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 17
+                // 18+: TensorAccessorArgs (no num_senders — single-sender kernel)
                 tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);
 
                 CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
@@ -670,8 +665,9 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<uint32_t> reader_compile_time_args_base = compile_time_args;
     if (init_zeros) {
         reader_compile_time_args_base.push_back(static_cast<uint32_t>(tt::CBIndex::c_7));  // zi_cb_id
+        reader_compile_time_args_base.push_back(num_idle_cores);  // num_total_idle_cores (both layouts need this)
     }
-    // num_idle_cores and cb_untilize_id are appended per-sender below.
+    // num_idle_cores (per-sender k_s) and cb_untilize_id are appended per-sender below (TILE_LAYOUT only).
 
     // One reader_combine kernel per sender.  For TILE_LAYOUT, k_s (per-sender idle count)
     // is baked in as num_idle_cores so the sender only round-robins across its own dedicated
@@ -684,10 +680,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender)
             per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
-            if (init_zeros) {
-                per_sender_compile_args.push_back(
-                    num_idle_cores);  // num_total_idle_cores (all idle cores across all senders)
-            }
         }
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -160,10 +160,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
     // Core layout depends on dispatched_buffer layout:
-    //   TILE_LAYOUT: sender placed at the end of its idle group so every idle core sits to the
-    //     sender's left and can write rightward on NOC0 (the +X NOC).
-    //     Cores are divided into groups, sender placed at group_size-1:
-    //     [idle0_0..idle0_{k0-1}, sender0, idle1_0..idle1_{k1-1}, sender1, ...]
+    //   TILE_LAYOUT: sender placed at the start of its idle group so every idle core sits to the
+    //     sender's right and can write leftward on NOC1 (the -X NOC, writer default).
+    //     Cores are divided into groups, sender placed at group offset 0:
+    //     [sender0, idle0_0..idle0_{k0-1}, sender1, idle1_0..idle1_{k1-1}, ...]
     //   ROW_MAJOR: first num_cores cores are senders, remaining are idle (for zero-init only).
     //     [sender0, sender1, idle0, idle1, idle2, ...]
     // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
@@ -191,14 +191,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<uint32_t> idle_sender_map;
 
     if (is_tile_layout) {
-        // TILE_LAYOUT: divide into groups, sender at the end of each group
+        // TILE_LAYOUT: divide into groups, sender at the start of each group
         uint32_t base_group_size = total_row_cores / num_cores;
         uint32_t extra_groups = total_row_cores % num_cores;
 
         uint32_t pos = 0;
         for (uint32_t s = 0; s < num_cores; s++) {
             uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
-            uint32_t sender_offset = group_size - 1;
+            uint32_t sender_offset = 0;
 
             for (uint32_t j = 0; j < group_size; j++) {
                 if (j == sender_offset) {
@@ -569,6 +569,16 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                     .set_page_size(tt::CBIndex::c_3, signal_page_size);
             tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
         }
+        // c_8 on idle cores: 1-page stop-signal CB (compute -> zero_init_writer).
+        // Compute pushes 0 per batch (meaning "a batch is ready on c_2") and ROUTE_INFO_SENTINEL
+        // when it exits its own loop, so zero_init_writer knows when to stop its send loop.
+        {
+            uint32_t stop_signal_page_size = l1_alignment;
+            tt::tt_metal::CircularBufferConfig stop_signal_cb_config =
+                tt::tt_metal::CircularBufferConfig(stop_signal_page_size, {{tt::CBIndex::c_8, tt::DataFormat::UInt8}})
+                    .set_page_size(tt::CBIndex::c_8, stop_signal_page_size);
+            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, stop_signal_cb_config);
+        }
     }
 
     // counter_offset mirrors the constexpr calculation in reader_combine.cpp
@@ -678,6 +688,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(zi_compile_time_args);
 
+        // Tile-layout-only compile-time args used by the post-zero-init untilized-data send loop.
+        // In ROW_MAJOR the corresponding #if IS_TILE_LAYOUT block is compiled out, so these
+        // trailing args are ignored — still pushed unconditionally to keep the kernel object stable.
+        zi_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_2));     // cb_untilize_id
+        zi_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_8));     // cb_stop_signal_id
+        zi_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_1));     // cb_experts_tok_counter_id
+        zi_compile_time_args.push_back(detail::get_num_pages(expert_token_counts));  // experts_tok_counter_pages
+        zi_compile_time_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // counter page size
+        zi_compile_time_args.push_back(read_batch_size);
+
+        std::map<std::string, std::string> zi_defines;
+        zi_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
+
         zero_init_kernel_id = tt::tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
@@ -686,7 +709,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             tt::tt_metal::DataMovementConfig{
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-                .compile_args = zi_compile_time_args});
+                .compile_args = zi_compile_time_args,
+                .defines = zi_defines});
 
         zero_init_cores_vec = idle_row_cores;
     }
@@ -756,6 +780,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                     read_batch_size,                          // 3: read_batch_size
                     full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
                     block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
+                    static_cast<uint32_t>(
+                        tt::CBIndex::c_8),  // 6: cb_stop_signal_id (compute -> zero_init_writer per-batch/stop)
                 }});
     }
 
@@ -783,6 +809,17 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             for (const auto& [noc_x, noc_y] : sender_noc_coords) {
                 zi_runtime_args.push_back(noc_x);
                 zi_runtime_args.push_back(noc_y);
+            }
+
+            // TILE_LAYOUT: append owning-sender info so zero_init_writer can run its send loop.
+            // In ROW_MAJOR the trailing args are ignored (kernel compiled with IS_TILE_LAYOUT=0).
+            if (is_tile_layout) {
+                uint32_t s = idle_sender_map[idle_idx];
+                zi_runtime_args.push_back(counter_ready_semaphore_id);
+                zi_runtime_args.push_back(sender_noc_coords[s].first);
+                zi_runtime_args.push_back(sender_noc_coords[s].second);
+                zi_runtime_args.push_back(data_ready_semaphore_ids[s]);
+                zi_runtime_args.push_back(start_semaphore_ids[s]);
             }
 
             tt::tt_metal::SetRuntimeArgs(program, zero_init_kernel_id, zero_init_cores_vec[idle_idx], zi_runtime_args);
@@ -883,9 +920,9 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
 
     // Set runtime args for idle cores (TILE_LAYOUT only — reader_untilize kernel).
-    // Each idle core is bound to its owning sender s.
-    // Layout: counter_ready_sem, data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s],
-    //         dispatched_buffer_addr, expert_start, expert_end
+    // Layout: counter_ready_sem, dispatched_buffer_addr, expert_start, expert_end.
+    // Sender NOC coords and per-sender data_ready/start semaphores are now consumed by
+    // zero_init_writer on the same core (which owns the untilized-data send).
     if (is_tile_layout) {
         for (uint32_t j = 0; j < num_idle_cores; j++) {
             uint32_t s = idle_sender_map[j];
@@ -893,10 +930,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
             std::vector<uint32_t> idle_rt_args = {
                 counter_ready_semaphore_id,
-                data_ready_semaphore_ids[s],
-                sender_noc_coords[s].first,
-                sender_noc_coords[s].second,
-                start_semaphore_ids[s],
                 dispatched_buffer.buffer()->address(),
                 expert_start,
                 expert_end,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -106,6 +106,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     const auto& dispatched_metadata = tensor_args.dispatched_metadata;
     const auto& expert_token_counts = tensor_args.expert_token_counts;
     const auto& output_tensor = tensor_return_value;
+    const bool is_tile_layout = dispatched_buffer.layout() == tt::tt_metal::Layout::TILE;
 
     auto* mesh_device = dispatched_buffer.device();
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
@@ -261,14 +262,25 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, c2_config);
     }
 
-    // c_18: receive buffer for idle-core untilized data written back via NOC
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        output_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_18,
-        "untilized_output");
+    if (is_tile_layout) {
+        // c_18: receive buffer for idle-core untilized data written back via NOC (TILE_LAYOUT only)
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            output_tensor,
+            /*buffering_factor=*/read_batch_size,
+            /*cb_id=*/tt::CBIndex::c_18,
+            "untilized_output");
+    } else {
+        // c_0 on sender cores: dispatched_buffer rows for ROW_MAJOR DMA reads
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            dispatched_buffer,
+            /*buffering_factor=*/read_batch_size,
+            /*cb_id=*/tt::CBIndex::c_0,
+            "dispatched_buffer_sender");
+    }
 
     // c_3: route_info (reader->writer, 4 x uint32_t per entry)
     {
@@ -419,7 +431,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     std::map<std::string, std::string> reader_defines = fabric_defines;
     reader_defines["INIT_ZEROS"] = operation_attributes.init_zeros ? "1" : "0";
-    bool is_tile_layout = dispatched_buffer.layout() == tt::tt_metal::Layout::TILE;
     reader_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
 
     const bool init_zeros = operation_attributes.init_zeros;
@@ -432,7 +443,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     // idle_row_cores: all same-row idle cores, ordered by sender group then by x.
     std::vector<CoreCoord>& idle_row_cores = all_idle_cores;
 
-    // Per-sender multicast bounding boxes and idle NOC coordinates.
+    // Per-sender multicast bounding boxes and idle NOC coordinates (TILE_LAYOUT only).
     // Each sender multicasts only to its own dedicated idle group so both senders
     // can run their multicast in parallel without interfering.
     struct SenderMcastCfg {
@@ -440,19 +451,22 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
     };
     std::vector<SenderMcastCfg> sender_mcast_cfgs(num_cores);
-    for (uint32_t s = 0; s < num_cores; s++) {
-        TT_FATAL(!sender_idle_groups[s].empty(), "Sender {} has no idle cores assigned", s);
-        auto& cfg = sender_mcast_cfgs[s];
-        auto first_noc = mesh_device->virtual_core_from_logical_core(sender_idle_groups[s][0], tt::CoreType::WORKER);
-        cfg.mcast_start_x = cfg.mcast_end_x = first_noc.x;
-        cfg.mcast_start_y = cfg.mcast_end_y = first_noc.y;
-        for (const auto& ic : sender_idle_groups[s]) {
-            auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
-            cfg.mcast_start_x = std::min(cfg.mcast_start_x, (uint32_t)noc.x);
-            cfg.mcast_end_x = std::max(cfg.mcast_end_x, (uint32_t)noc.x);
-            cfg.mcast_start_y = std::min(cfg.mcast_start_y, (uint32_t)noc.y);
-            cfg.mcast_end_y = std::max(cfg.mcast_end_y, (uint32_t)noc.y);
-            cfg.idle_noc_coords.emplace_back((uint32_t)noc.x, (uint32_t)noc.y);
+    if (is_tile_layout) {
+        for (uint32_t s = 0; s < num_cores; s++) {
+            TT_FATAL(!sender_idle_groups[s].empty(), "Sender {} has no idle cores assigned", s);
+            auto& cfg = sender_mcast_cfgs[s];
+            auto first_noc =
+                mesh_device->virtual_core_from_logical_core(sender_idle_groups[s][0], tt::CoreType::WORKER);
+            cfg.mcast_start_x = cfg.mcast_end_x = first_noc.x;
+            cfg.mcast_start_y = cfg.mcast_end_y = first_noc.y;
+            for (const auto& ic : sender_idle_groups[s]) {
+                auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
+                cfg.mcast_start_x = std::min(cfg.mcast_start_x, (uint32_t)noc.x);
+                cfg.mcast_end_x = std::max(cfg.mcast_end_x, (uint32_t)noc.x);
+                cfg.mcast_start_y = std::min(cfg.mcast_start_y, (uint32_t)noc.y);
+                cfg.mcast_end_y = std::max(cfg.mcast_end_y, (uint32_t)noc.y);
+                cfg.idle_noc_coords.emplace_back((uint32_t)noc.x, (uint32_t)noc.y);
+            }
         }
     }
 
@@ -463,39 +477,29 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
     CoreRangeSet idle_core_grid(idle_ranges_set);
 
-    // counter_ready semaphore: created only on sender + idle cores so get_semaphore() returns
-    // the same L1 offset on both sides (sender writes to idle's copy, idle waits on its own)
-    std::set<CoreRange> sender_and_idle_ranges;
-    for (const auto& cr : sender_core_grid.ranges()) {
-        sender_and_idle_ranges.insert(cr);
-    }
-    for (const auto& cr : idle_core_grid.ranges()) {
-        sender_and_idle_ranges.insert(cr);
-    }
-    CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
-    auto counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
-    // One data_ready and one start semaphore per sender so each sender's handshake with idle
-    // cores is independent — idle core routes to the correct pair via sender_idx = expert / experts_per_sender.
+    // TILE_LAYOUT semaphores for sender <-> idle core handshake
+    uint32_t counter_ready_semaphore_id = 0;
     std::vector<uint32_t> data_ready_semaphore_ids, start_semaphore_ids;
-    for (uint32_t s = 0; s < num_cores; s++) {
-        data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
-        start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+    if (is_tile_layout) {
+        // counter_ready semaphore: created only on sender + idle cores so get_semaphore() returns
+        // the same L1 offset on both sides (sender writes to idle's copy, idle waits on its own)
+        std::set<CoreRange> sender_and_idle_ranges;
+        for (const auto& cr : sender_core_grid.ranges()) {
+            sender_and_idle_ranges.insert(cr);
+        }
+        for (const auto& cr : idle_core_grid.ranges()) {
+            sender_and_idle_ranges.insert(cr);
+        }
+        CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
+        counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+        // One data_ready and one start semaphore per sender so each sender's handshake with idle
+        // cores is independent — idle core routes to the correct pair via sender_idx = expert / experts_per_sender.
+        for (uint32_t s = 0; s < num_cores; s++) {
+            data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+            start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+        }
     }
 
-    // c_1 on idle cores: receives the expert_token_counts multicast from the owning sender.
-    // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
-    {
-        uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
-        uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
-        auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        uint32_t extra_pages = 1;
-        uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
-        tt::tt_metal::CircularBufferConfig c1_idle_config =
-            tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
-                .set_page_size(tt::CBIndex::c_1, counter_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
-    }
-    // c_0 on idle cores: dispatched_buffer tiles
     // cb_factor reduces CB size to fit L1: Blackhole has more L1, Wormhole needs 4x reduction
     uint32_t cb_factor;
     {
@@ -506,28 +510,45 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             cb_factor = 4;  // Wormhole_B0 and others
         }
     }
-    detail::create_tensor_cb(
-        program,
-        idle_core_grid,
-        dispatched_buffer,
-        /*buffering_factor=*/hidden_size / (32 * cb_factor),
-        /*cb_id=*/tt::CBIndex::c_0,
-        "dispatched_buffer_idle");
-    // c_2 on idle cores: untilized output rows, one full batch (read_batch_size rows)
-    detail::create_tensor_cb(
-        program,
-        idle_core_grid,
-        output_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_2,
-        "untilize_idle");
-    // c_3 on idle cores: 1-page signal CB (reader->compute, mirrors c_17 on sender cores)
-    {
-        uint32_t signal_page_size = l1_alignment;
-        tt::tt_metal::CircularBufferConfig signal_cb_config =
-            tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_3, signal_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+
+    if (is_tile_layout) {
+        // c_1 on idle cores: receives the expert_token_counts multicast from the owning sender.
+        // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
+        {
+            uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
+            uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
+            auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
+            uint32_t extra_pages = 1;
+            uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
+            tt::tt_metal::CircularBufferConfig c1_idle_config =
+                tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
+                    .set_page_size(tt::CBIndex::c_1, counter_page_size);
+            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
+        }
+        // c_0 on idle cores: dispatched_buffer tiles
+        detail::create_tensor_cb(
+            program,
+            idle_core_grid,
+            dispatched_buffer,
+            /*buffering_factor=*/hidden_size / (32 * cb_factor),
+            /*cb_id=*/tt::CBIndex::c_0,
+            "dispatched_buffer_idle");
+        // c_2 on idle cores: untilized output rows, one full batch (read_batch_size rows)
+        detail::create_tensor_cb(
+            program,
+            idle_core_grid,
+            output_tensor,
+            /*buffering_factor=*/read_batch_size,
+            /*cb_id=*/tt::CBIndex::c_2,
+            "untilize_idle");
+        // c_3 on idle cores: 1-page signal CB (reader->compute, mirrors c_17 on sender cores)
+        {
+            uint32_t signal_page_size = l1_alignment;
+            tt::tt_metal::CircularBufferConfig signal_cb_config =
+                tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
+                    .set_page_size(tt::CBIndex::c_3, signal_page_size);
+            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+        }
     }
 
     // counter_offset mirrors the constexpr calculation in reader_combine.cpp
@@ -537,36 +558,37 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t counter_offset =
         mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
 
-    // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
-    //   0-11: shared base (below, includes cb_factor at index 11)
-    //   12:   core_id   — local index within sender s's idle group (0..k_s-1)
-    //   13:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
-    //   14:   aligned_output_page_size
-    //   15:   aligned_experts_tok_counter_page_size
-    //   16+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
-    const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
-        static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
-        detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
-        operation_attributes.experts_per_chip,             // 2:  experts_per_chip
-        counter_offset,                                    // 3:  counter_offset
-        static_cast<uint32_t>(tt::CBIndex::c_0),           // 4:  cb_dispatched_buffer_id
-        static_cast<uint32_t>(tt::CBIndex::c_2),           // 5:  cb_untilize_id
-        (uint32_t)hidden_size,                             // 6:  hidden_size
-        read_batch_size,                                   // 7:  read_batch_size
-        static_cast<uint32_t>(tt::CBIndex::c_3),           // 8:  cb_signal_id
-        detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
-        (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
-        cb_factor,                                         // 11: cb_factor
-    };
-
-    // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
-    // core_id is LOCAL within the sender's group (0..k_s-1) for round-robin batch assignment.
-    // num_idle_cores baked in as k_s so the kernel only considers its own group.
-    // No num_senders arg — each kernel is bound to a single sender.
+    // reader_untilize + compute kernels only needed for TILE_LAYOUT
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
-    reader_untilize_kernel_ids.reserve(num_idle_cores);
+    if (is_tile_layout) {
+        // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
+        //   0-11: shared base (below, includes cb_factor at index 11)
+        //   12:   core_id   — local index within sender s's idle group (0..k_s-1)
+        //   13:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
+        //   14:   aligned_output_page_size
+        //   15:   aligned_experts_tok_counter_page_size
+        //   16+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
+        const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
+            static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
+            detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
+            operation_attributes.experts_per_chip,             // 2:  experts_per_chip
+            counter_offset,                                    // 3:  counter_offset
+            static_cast<uint32_t>(tt::CBIndex::c_0),           // 4:  cb_dispatched_buffer_id
+            static_cast<uint32_t>(tt::CBIndex::c_2),           // 5:  cb_untilize_id
+            (uint32_t)hidden_size,                             // 6:  hidden_size
+            read_batch_size,                                   // 7:  read_batch_size
+            static_cast<uint32_t>(tt::CBIndex::c_3),           // 8:  cb_signal_id
+            detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
+            (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
+            cb_factor,                                         // 11: cb_factor
+        };
 
-    {
+        // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
+        // core_id is LOCAL within the sender's group (0..k_s-1) for round-robin batch assignment.
+        // num_idle_cores baked in as k_s so the kernel only considers its own group.
+        // No num_senders arg — each kernel is bound to a single sender.
+        reader_untilize_kernel_ids.reserve(num_idle_cores);
+
         uint32_t global_idle_idx = 0;
         for (uint32_t s = 0; s < num_cores; s++) {
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
@@ -651,19 +673,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
     // num_idle_cores and cb_untilize_id are appended per-sender below.
 
-    // One reader_combine kernel per sender with k_s (per-sender idle count) baked in as
-    // num_idle_cores.  The VLA idle_start_noc_addrs[num_idle_cores] is sized exactly right
-    // and the sender only round-robins across its own k_s dedicated idle cores.
+    // One reader_combine kernel per sender.  For TILE_LAYOUT, k_s (per-sender idle count)
+    // is baked in as num_idle_cores so the sender only round-robins across its own dedicated
+    // idle cores.  For ROW_MAJOR, no idle-core args are needed.
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
         auto per_sender_compile_args = reader_compile_time_args_base;
-        per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender k_s)
-        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
-        if (init_zeros) {
-            per_sender_compile_args.push_back(
-                num_idle_cores);  // num_total_idle_cores (all idle cores across all senders)
+        if (is_tile_layout) {
+            uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
+            per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender)
+            per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+            if (init_zeros) {
+                per_sender_compile_args.push_back(
+                    num_idle_cores);  // num_total_idle_cores (all idle cores across all senders)
+            }
         }
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
@@ -687,29 +711,31 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .compile_args = compile_time_args,
             .defines = writer_defines});
 
-    // Compute kernel on idle cores that untilizes dispatched_buffer data
-    const uint32_t full_ct_dim = static_cast<uint32_t>(hidden_size) / 32u;
-    uint32_t block_ct_dim = 8;
-    while (full_ct_dim % block_ct_dim != 0) {
-        --block_ct_dim;
-    }
+    // Compute kernel on idle cores that untilizes dispatched_buffer data (TILE_LAYOUT only)
+    if (is_tile_layout) {
+        const uint32_t full_ct_dim = static_cast<uint32_t>(hidden_size) / 32u;
+        uint32_t block_ct_dim = 8;
+        while (full_ct_dim % block_ct_dim != 0) {
+            --block_ct_dim;
+        }
 
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
-        "untilize_combine.cpp",
-        idle_core_grid,
-        tt::tt_metal::ComputeConfig{
-            .compile_args = {
-                static_cast<uint32_t>(
-                    tt::CBIndex::c_3),  // 0: cb_signal_id (CB used for signaling on the same core that
-                                        //    data is loaded and ready to be untilized)
-                static_cast<uint32_t>(tt::CBIndex::c_2),  // 1: cb_untilize_id (untilized dispatched_buffer data)
-                static_cast<uint32_t>(tt::CBIndex::c_0),  // 2: cb_in_id (dispatched_buffer data)
-                read_batch_size,                          // 3: read_batch_size
-                full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
-                block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
-            }});
+        tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
+            "untilize_combine.cpp",
+            idle_core_grid,
+            tt::tt_metal::ComputeConfig{
+                .compile_args = {
+                    static_cast<uint32_t>(
+                        tt::CBIndex::c_3),  // 0: cb_signal_id (CB used for signaling on the same core that
+                                            //    data is loaded and ready to be untilized)
+                    static_cast<uint32_t>(tt::CBIndex::c_2),  // 1: cb_untilize_id (untilized dispatched_buffer data)
+                    static_cast<uint32_t>(tt::CBIndex::c_0),  // 2: cb_in_id (dispatched_buffer data)
+                    read_batch_size,                          // 3: read_batch_size
+                    full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
+                    block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
+                }});
+    }
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;
@@ -764,19 +790,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             reader_runtime_args.push_back(sender_page_end);
             reader_runtime_args.push_back(zi_done_semaphore_id);
         }
-        // Multicast targets only this sender's dedicated idle group
-        const auto& mcast_cfg = sender_mcast_cfgs[core_idx];
-        reader_runtime_args.push_back(counter_ready_semaphore_id);
-        reader_runtime_args.push_back(mcast_cfg.mcast_start_x);
-        reader_runtime_args.push_back(mcast_cfg.mcast_start_y);
-        reader_runtime_args.push_back(mcast_cfg.mcast_end_x);
-        reader_runtime_args.push_back(mcast_cfg.mcast_end_y);
-        reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
-        reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
-        // Pass NOC coords of only this sender's k_s dedicated idle cores
-        for (const auto& [noc_x, noc_y] : mcast_cfg.idle_noc_coords) {
-            reader_runtime_args.push_back(noc_x);
-            reader_runtime_args.push_back(noc_y);
+        if (is_tile_layout) {
+            // Multicast targets only this sender's dedicated idle group
+            const auto& mcast_cfg = sender_mcast_cfgs[core_idx];
+            reader_runtime_args.push_back(counter_ready_semaphore_id);
+            reader_runtime_args.push_back(mcast_cfg.mcast_start_x);
+            reader_runtime_args.push_back(mcast_cfg.mcast_start_y);
+            reader_runtime_args.push_back(mcast_cfg.mcast_end_x);
+            reader_runtime_args.push_back(mcast_cfg.mcast_end_y);
+            reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
+            reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
+            // Pass NOC coords of only this sender's k_s dedicated idle cores
+            for (const auto& [noc_x, noc_y] : mcast_cfg.idle_noc_coords) {
+                reader_runtime_args.push_back(noc_x);
+                reader_runtime_args.push_back(noc_y);
+            }
         }
 
         std::vector<uint32_t> writer_runtime_args = {
@@ -832,24 +860,27 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         core_idx++;
     }
 
-    // Set runtime args for idle cores.  Each idle core is bound to its owning sender s.
+    // Set runtime args for idle cores (TILE_LAYOUT only — reader_untilize kernel).
+    // Each idle core is bound to its owning sender s.
     // Layout: counter_ready_sem, data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s],
     //         dispatched_buffer_addr, expert_start, expert_end
-    for (uint32_t j = 0; j < num_idle_cores; j++) {
-        uint32_t s = idle_sender_map[j];
-        uint32_t expert_start = s * experts_per_core_range;
-        uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
-        std::vector<uint32_t> idle_rt_args = {
-            counter_ready_semaphore_id,
-            data_ready_semaphore_ids[s],
-            sender_noc_coords[s].first,
-            sender_noc_coords[s].second,
-            start_semaphore_ids[s],
-            dispatched_buffer.buffer()->address(),
-            expert_start,
-            expert_end,
-        };
-        tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
+    if (is_tile_layout) {
+        for (uint32_t j = 0; j < num_idle_cores; j++) {
+            uint32_t s = idle_sender_map[j];
+            uint32_t expert_start = s * experts_per_core_range;
+            uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+            std::vector<uint32_t> idle_rt_args = {
+                counter_ready_semaphore_id,
+                data_ready_semaphore_ids[s],
+                sender_noc_coords[s].first,
+                sender_noc_coords[s].second,
+                start_semaphore_ids[s],
+                dispatched_buffer.buffer()->address(),
+                expert_start,
+                expert_end,
+            };
+            tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
+        }
     }
 
     return {
@@ -900,12 +931,15 @@ void CombineProgramFactory::override_runtime_arguments(
             zi_runtime_args.at(0) = tensor_return_value.buffer()->address();
         }
 
-        for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
-            auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
-                program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-            // RT layout: [0:counter_ready_sem, 1:data_ready_sem, 2:noc_x, 3:noc_y, 4:start_sem,
-            //             5:dispatched_buffer_addr, 6:expert_start, 7:expert_end]
-            idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
+        // Update idle core runtime args only when reader_untilize kernels exist (TILE_LAYOUT)
+        if (!shared_variables.reader_untilize_kernel_ids.empty()) {
+            for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
+                auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
+                    program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
+                // RT layout: [0:counter_ready_sem, 1:data_ready_sem, 2:noc_x, 3:noc_y, 4:start_sem,
+                //             5:dispatched_buffer_addr, 6:expert_start, 7:expert_end]
+                idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
+            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -173,14 +173,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
 
-    constexpr uint32_t read_batch_size = 8;  // matches BH DRAM bank count for full bandwidth utilization
+    constexpr uint32_t read_batch_size = 32;
 
     // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
         program,
         sender_core_grid,
         dispatched_buffer,
-        /*buffering_factor=*/read_batch_size,
+        /*buffering_factor=*/hidden_size / 32,
         /*cb_id=*/tt::CBIndex::c_0,
         "dispatched_buffer_scratch");
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
@@ -200,8 +200,24 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         /*cb_id=*/tt::CBIndex::c_2,
         "expert_token_counts");
 
-    // c_3, c_4: reader→writer CBs for (route_info, output) per remote entry.
-    // The reader pushes both per entry in lockstep, so small buffering (2) suffices.
+    // c_17: 1-page CB on sender cores (for reader->compute signaling)
+    {
+        uint32_t signal_page_size = l1_alignment;
+        tt::tt_metal::CircularBufferConfig signal_cb_config =
+            tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_17, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_17, signal_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, signal_cb_config);
+    }
+    // c_18: same size as c_0 (for compute untilized output)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        output_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_18,
+        "untilized_output");
+
+    // c_3: route_info (reader->writer, 4 x uint32_t per entry)
     {
         constexpr uint32_t rw_buffering = 2;
 
@@ -431,6 +447,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_7));  // zi_cb_id
         reader_compile_time_args.push_back(num_zero_init_cores);                      // num_idle_cores
     }
+    reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_17));  // cb_signal_id
+    reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
 
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -451,6 +469,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
             .compile_args = compile_time_args,
             .defines = writer_defines});
+
+    // Compute kernel on sender cores only (not on zero-init idle cores)
+    [[maybe_unused]] tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
+        "untilize_combine.cpp",
+        sender_core_grid,
+        tt::tt_metal::ComputeConfig{
+            .compile_args = {
+                static_cast<uint32_t>(tt::CBIndex::c_17),  // cb_signal_id
+                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id
+                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+                static_cast<uint32_t>(hidden_size),        // hidden_size
+                static_cast<uint32_t>(read_batch_size),    // read_batch_size
+            }});
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -200,7 +200,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
         auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        uint32_t cb_size = (counter_pages + 1) * counter_page_size;
+        // Need num_cores extra words (one receive_buf_addr per sender) after the counter data.
+        uint32_t recv_buf_extra_bytes = num_cores * sizeof(uint32_t);
+        uint32_t extra_pages = std::max(1u, tt::div_up(recv_buf_extra_bytes, counter_page_size));
+        uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
         tt::tt_metal::CircularBufferConfig c2_config =
             tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_2, data_format}})
                 .set_page_size(tt::CBIndex::c_2, counter_page_size);
@@ -415,8 +418,13 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
     CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
     auto counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
-    auto data_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
-    auto start_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    // One data_ready and one start semaphore per sender so each sender's handshake with idle
+    // cores is independent — idle core routes to the correct pair via sender_idx = expert / experts_per_sender.
+    std::vector<uint32_t> data_ready_semaphore_ids, start_semaphore_ids;
+    for (uint32_t s = 0; s < num_cores; s++) {
+        data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+        start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+    }
 
     // c_1 on idle cores: receives the full expert_token_counts multicast from sender.
     // MUST be allocated BEFORE c_0 so that its L1 data-buffer address matches the sender's
@@ -425,14 +433,15 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     // higher in L1 and the multicast would write into the wrong location, leaving the token
     // counts as all-zeros and causing a hang (idle cores see 0 batches → send only the
     // sentinel → sender waits on data_ready forever).
-    // One extra page larger than the raw counter data so the receive_buf_addr word appended at
-    // the end of the multicast payload lands within the allocated CB region.
-    // Extra space is one full counter_page_size (not l1_alignment) to keep cb_size divisible by page_size.
+    // Extra pages after the counter data hold one receive_buf_addr per sender core so idle
+    // cores can discover each sender's receive buffer from the multicast payload alone.
     {
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
         auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        uint32_t cb_size = (counter_pages + 1) * counter_page_size;
+        uint32_t recv_buf_extra_bytes = num_cores * sizeof(uint32_t);
+        uint32_t extra_pages = std::max(1u, tt::div_up(recv_buf_extra_bytes, counter_page_size));
+        uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
         tt::tt_metal::CircularBufferConfig c1_idle_config =
             tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
                 .set_page_size(tt::CBIndex::c_1, counter_page_size);
@@ -475,16 +484,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t counter_offset =
         mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
 
-    // Base compile-time args shared across all idle cores (indices 0-12).
-    // core_id (13) and num_idle_cores (14) are appended per-core; remaining fixed args follow at
-    // 15-16; TensorAccessorArgs follow at 17+.
-    // Wait — actual layout (matching reader_untilize.cpp):
+    // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
     //   0-10: shared base (below)
-    //   11: core_id          (appended per-core)
-    //   12: num_idle_cores   (appended per-core)
-    //   13: aligned_output_page_size
-    //   14: aligned_experts_tok_counter_page_size
-    //   15+: TensorAccessorArgs for dispatched_buffer
+    //   11:   core_id (global index 0..num_idle_cores-1, appended per-core)
+    //   12:   num_idle_cores (total, appended per-core)
+    //   13:   aligned_output_page_size
+    //   14:   aligned_experts_tok_counter_page_size
+    //   15:   num_senders (= num_cores)
+    //   16+:  TensorAccessorArgs for dispatched_buffer
     const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
         static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
         detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -499,42 +506,31 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
     };
 
-    // Partition idle cores among senders so each sender owns an exclusive slice.
-    // This prevents multiple senders from racing on the same start_semaphore.
-    // Sender s owns idle cores [offset_s, offset_s + k_s).
-    // k_s = K_base + (s < K_extra ? 1 : 0) where K_base = num_idle_cores / num_cores.
-    uint32_t K_base = num_idle_cores / num_cores;
-    uint32_t K_extra = num_idle_cores % num_cores;
-
-    // Create one reader_untilize kernel instance per idle core with per-sender
-    // core_id and num_idle_cores baked in at compile time.
+    // All idle cores cover the full expert range; the kernel routes each expert to the
+    // correct sender via sender_idx = local_expert / experts_per_sender.
+    // core_id is a global index for round-robin batch assignment across all idle cores.
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     reader_untilize_kernel_ids.reserve(num_idle_cores);
 
-    {
-        uint32_t global_idle_idx = 0;
-        for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
-            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
-                auto per_core_args = reader_untilize_compile_time_args_base;
-                per_core_args.push_back(j);    // 11: core_id (relative to this sender's slice)
-                per_core_args.push_back(k_s);  // 12: num_idle_cores (per-sender slice size)
-                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));                  // 13
-                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));            // 14
-                tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);  // 15+
+    for (uint32_t j = 0; j < num_idle_cores; j++) {
+        auto per_core_args = reader_untilize_compile_time_args_base;
+        per_core_args.push_back(j);                                                   // 11: core_id (global)
+        per_core_args.push_back(num_idle_cores);                                      // 12: num_idle_cores (total)
+        per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 13
+        per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 14
+        per_core_args.push_back(num_cores);                                           // 15: num_senders
+        tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);  // 16+
 
-                CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
-                reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-                    program,
-                    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
-                    "reader_untilize.cpp",
-                    single_idle_core,
-                    tt::tt_metal::DataMovementConfig{
-                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                        .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                        .compile_args = per_core_args}));
-            }
-        }
+        CoreRangeSet single_idle_core({CoreRange(idle_row_cores[j])});
+        reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
+            "reader_untilize.cpp",
+            single_idle_core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                .compile_args = per_core_args}));
     }
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
@@ -600,9 +596,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
         auto per_sender_compile_args = reader_compile_time_args_base;
-        per_sender_compile_args.push_back(k_s);                                       // num_idle_cores for sender s
+        per_sender_compile_args.push_back(num_idle_cores);                            // num_idle_cores (all idle cores)
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
@@ -698,16 +693,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         reader_runtime_args.push_back(mcast_start_y);
         reader_runtime_args.push_back(mcast_end_x);
         reader_runtime_args.push_back(mcast_end_y);
-        reader_runtime_args.push_back(data_ready_semaphore_id);
-        reader_runtime_args.push_back(start_semaphore_id);
-        // Only pass NOC coords of idle cores assigned to this sender (slice [offset_s, offset_s+k_s))
-        {
-            uint32_t k_s = K_base + (core_idx < K_extra ? 1 : 0);
-            uint32_t offset_s = core_idx * K_base + std::min(core_idx, K_extra);
-            for (uint32_t j = 0; j < k_s; j++) {
-                reader_runtime_args.push_back(idle_noc_coords[offset_s + j].first);
-                reader_runtime_args.push_back(idle_noc_coords[offset_s + j].second);
-            }
+        reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
+        reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
+        // Pass NOC coords of ALL idle cores — all idle cores now handle all experts
+        for (uint32_t j = 0; j < num_idle_cores; j++) {
+            reader_runtime_args.push_back(idle_noc_coords[j].first);
+            reader_runtime_args.push_back(idle_noc_coords[j].second);
         }
 
         std::vector<uint32_t> writer_runtime_args = {
@@ -763,29 +754,22 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         core_idx++;
     }
 
-    // Set runtime args for idle cores using per-sender NOC coords and expert range.
-    {
-        uint32_t global_idle_idx = 0;
+    // Set runtime args for idle cores.  All idle cores cover the full expert range; the kernel
+    // determines the owning sender per expert via sender_idx = local_expert / experts_per_sender.
+    // Layout: counter_ready_sem, [data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s]]×num_senders,
+    //         dispatched_buffer_addr, expert_start=0, expert_end=experts_per_chip
+    for (uint32_t j = 0; j < num_idle_cores; j++) {
+        std::vector<uint32_t> idle_rt_args = {counter_ready_semaphore_id};
         for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
-            const auto& [sx, sy] = sender_noc_coords[s];
-            uint32_t expert_start = s * experts_per_core_range;
-            uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
-            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
-                tt::tt_metal::SetRuntimeArgs(
-                    program,
-                    reader_untilize_kernel_ids[global_idle_idx],
-                    idle_row_cores[global_idle_idx],
-                    {counter_ready_semaphore_id,
-                     data_ready_semaphore_id,
-                     sx,
-                     sy,
-                     start_semaphore_id,
-                     dispatched_buffer.buffer()->address(),
-                     expert_start,
-                     expert_end});
-            }
+            idle_rt_args.push_back(data_ready_semaphore_ids[s]);
+            idle_rt_args.push_back(sender_noc_coords[s].first);
+            idle_rt_args.push_back(sender_noc_coords[s].second);
+            idle_rt_args.push_back(start_semaphore_ids[s]);
         }
+        idle_rt_args.push_back(dispatched_buffer.buffer()->address());
+        idle_rt_args.push_back(0);                                      // expert_start = 0
+        idle_rt_args.push_back(operation_attributes.experts_per_chip);  // expert_end
+        tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
     }
 
     return {
@@ -801,8 +785,9 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
          .zero_init_semaphore_id = zero_init_semaphore_id,
          .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id,
          .counter_ready_semaphore_id = counter_ready_semaphore_id,
-         .data_ready_semaphore_id = data_ready_semaphore_id,
-         .start_semaphore_id = start_semaphore_id}};
+         .num_senders = num_cores,
+         .data_ready_semaphore_ids = std::move(data_ready_semaphore_ids),
+         .start_semaphore_ids = std::move(start_semaphore_ids)}};
 }
 
 void CombineProgramFactory::override_runtime_arguments(
@@ -839,7 +824,9 @@ void CombineProgramFactory::override_runtime_arguments(
         for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
             auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
                 program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-            idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
+            // dispatched_buffer_addr sits at index 1 + num_senders*4:
+            // index 0 = counter_ready_sem, then num_senders groups of {data_ready_sem, noc_x, noc_y, start_sem}
+            idle_rt_args.at(1 + shared_variables.num_senders * 4) = tensor_args.dispatched_buffer.buffer()->address();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -284,6 +284,15 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         detail::create_tensor_cb(
             program,
             sender_core_grid,
+            output_tensor,
+            /*buffering_factor=*/rw_buffering,
+            /*cb_id=*/tt::CBIndex::c_4,
+            "output_for_writer");
+    }
+
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
             dispatched_buffer,
             /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_4,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -159,7 +159,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t num_cores = effective_num_links;
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    // Interleaved layout: [sender0, idle0_0..idle0_{k0-1}, sender1, idle1_0..idle1_{k1-1}, ...]
+    // Core layout depends on dispatched_buffer layout:
+    //   TILE_LAYOUT: sender in the middle of its idle group to reduce NOC congestion.
+    //     Cores are divided into groups, sender placed at group_size/2:
+    //     [idle0_0..idle0_{m-1}, sender0, idle0_m..idle0_{k0-1}, ..., sender1, ...]
+    //   ROW_MAJOR: first num_cores cores are senders, remaining are idle (for zero-init only).
+    //     [sender0, sender1, idle0, idle1, idle2, ...]
     // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
     uint32_t sender_row_y = subdevice_cores.at(0).y;
     std::vector<CoreCoord> all_row_cores;
@@ -178,27 +183,44 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         total_row_cores,
         num_cores);
 
-    // Divide total_row_cores into num_cores groups: last (total_row_cores % num_cores) groups get +1.
-    // Within each group: first core = sender, remaining = that sender's idle cores.
-    uint32_t base_group_size = total_row_cores / num_cores;
-    uint32_t extra_groups = total_row_cores % num_cores;
-
     std::vector<CoreCoord> sender_cores;
     sender_cores.reserve(num_cores);
     std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
     std::vector<CoreCoord> all_idle_cores;
     std::vector<uint32_t> idle_sender_map;
 
-    {
+    if (is_tile_layout) {
+        // TILE_LAYOUT: divide into groups, sender in the middle of each group
+        uint32_t base_group_size = total_row_cores / num_cores;
+        uint32_t extra_groups = total_row_cores % num_cores;
+
         uint32_t pos = 0;
         for (uint32_t s = 0; s < num_cores; s++) {
             uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
-            sender_cores.push_back(all_row_cores[pos++]);
-            for (uint32_t j = 1; j < group_size; j++, pos++) {
-                sender_idle_groups[s].push_back(all_row_cores[pos]);
-                all_idle_cores.push_back(all_row_cores[pos]);
-                idle_sender_map.push_back(s);
+            uint32_t sender_offset = group_size / 2;
+
+            for (uint32_t j = 0; j < group_size; j++) {
+                if (j == sender_offset) {
+                    sender_cores.push_back(all_row_cores[pos]);
+                } else {
+                    sender_idle_groups[s].push_back(all_row_cores[pos]);
+                    all_idle_cores.push_back(all_row_cores[pos]);
+                    idle_sender_map.push_back(s);
+                }
+                pos++;
             }
+        }
+    } else {
+        // ROW_MAJOR: first num_cores cores are senders, all remaining are idle
+        for (uint32_t s = 0; s < num_cores; s++) {
+            sender_cores.push_back(all_row_cores[s]);
+        }
+        for (uint32_t i = num_cores; i < total_row_cores; i++) {
+            // Distribute idle cores round-robin across senders (for zero-init)
+            uint32_t s = (i - num_cores) % num_cores;
+            sender_idle_groups[s].push_back(all_row_cores[i]);
+            all_idle_cores.push_back(all_row_cores[i]);
+            idle_sender_map.push_back(s);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -158,19 +158,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t num_cores = effective_num_links;
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    // Step 1: Select sender cores using num_cores_to_corerangeset_in_subcoregrids.
-    // This picks the first num_cores from the subdevice in row-major order, keeping
-    // senders physically adjacent and (typically) in the same physical row.
-    CoreRangeSet sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+    auto sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
         subdevice_cores.at(0), num_cores, worker_core_range_set, true);
     std::vector<CoreCoord> sender_cores = corerange_to_cores(sender_core_grid);
     TT_FATAL(sender_cores.size() == num_cores, "Expected {} sender cores, got {}", num_cores, sender_cores.size());
 
-    // Step 2: Collect idle cores in the SAME physical row as sender_cores[0].
-    // NOC multicast requires a single-row bounding box: if idle cores span multiple
-    // physical rows the box widens to a rectangle that includes non-subdevice cores
-    // (Ethernet tiles, other workers), causing noc_async_write_barrier() to hang
-    // because the hardware waits for ACKs from cores that can't respond properly.
+    // Step 2: Collect idle cores in the SAME physical row as sender_cores[0]
     uint32_t sender_row_y_phys =
         (uint32_t)mesh_device->virtual_core_from_logical_core(sender_cores[0], tt::CoreType::WORKER).y;
     std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
@@ -230,14 +223,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     constexpr uint32_t read_batch_size = 32;
 
-    // // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
-    // detail::create_tensor_cb(
-    //     program,
-    //     sender_core_grid,
-    //     dispatched_buffer,
-    //     /*buffering_factor=*/hidden_size / 32,
-    //     /*cb_id=*/tt::CBIndex::c_0,
-    //     "dispatched_buffer_scratch");
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
         program,
@@ -476,9 +461,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     // c_1 on idle cores: receives the expert_token_counts multicast from the owning sender.
     // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
-    // The sender uses get_write_ptr(c_1_sender) as the multicast destination; if c_0 were
-    // allocated first here it would consume ~3 MB causing c_1 to wrap and corrupt the mailbox.
-    // One extra page holds the single receive_buf_addr that each sender appends before multicasting.
     {
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
@@ -490,12 +472,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                 .set_page_size(tt::CBIndex::c_1, counter_page_size);
         tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
     }
-    // c_0 on idle cores: dispatched_buffer tiles, one token's worth (hidden_size/32 tiles)
-    // MUST be at index 0: pack_untilize_block calls llk_math_eltwise_unary_datacopy with
-    // operand=0 (Blackhole UnpackToDestEn=true path), so MATH reads unpack_src_format[0].
-    // Placing dispatched_buffer (bfloat16) here ensures the correct format is used.
-    // NOTE: c_0 is allocated after c_1 (see above) so that the multicast destination address
-    // matches the sender; the CB index (0) is independent of allocation order.
+    // c_0 on idle cores: dispatched_buffer tiles
     detail::create_tensor_cb(
         program,
         idle_core_grid,
@@ -672,17 +649,18 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .compile_args = compile_time_args,
             .defines = writer_defines});
 
-    // Compute kernel on idle cores (c_3 signal, c_2 untilize out, c_0 tile in)
-    [[maybe_unused]] tt::tt_metal::KernelHandle compute_idle_kernel_id = tt::tt_metal::CreateKernel(
+    // Compute kernel on idle cores that untilizes dispatched_buffer data
+    tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
         "untilize_combine.cpp",
         idle_core_grid,
         tt::tt_metal::ComputeConfig{
             .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_untilize_id
-                static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_in_id (must be 0: MATH reads unpack_src_format[0])
+                static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_signal_id (CB used for signaling on the same core that
+                                                          // data is loaded and ready to be untilized)
+                static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_untilize_id (untilized dispatched_buffer data)
+                static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_in_id (dispatched_buffer data)
                 static_cast<uint32_t>(hidden_size),       // hidden_size
                 static_cast<uint32_t>(read_batch_size),   // read_batch_size
             }});

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -419,6 +419,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     std::map<std::string, std::string> reader_defines = fabric_defines;
     reader_defines["INIT_ZEROS"] = operation_attributes.init_zeros ? "1" : "0";
+    bool is_tile_layout = dispatched_buffer.layout() == tt::tt_metal::Layout::TILE;
+    reader_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
 
     const bool init_zeros = operation_attributes.init_zeros;
     tt::tt_metal::KernelHandle zero_init_kernel_id = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -294,6 +294,24 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             /*buffering_factor=*/read_batch_size,
             /*cb_id=*/tt::CBIndex::c_18,
             "untilized_output");
+        // c_10: sender-side NOC scratch that receives each idle core's c_9 L1 address during
+        //       the startup handshake (idle core writes its get_write_ptr(c_9) to slot
+        //       core_id * sizeof(uint32_t)). Sender copies this scratch into a plain local
+        //       uint32_t[num_idle_cores_group] array before the batch loop.
+        //       Sender's own c_10 L1 offset is appended to the counter multicast trailer so
+        //       idle cores know where to unicast their addresses.
+        {
+            uint32_t max_idle_group_size = 0;
+            for (uint32_t s = 0; s < num_cores; s++) {
+                max_idle_group_size = std::max(max_idle_group_size, (uint32_t)sender_idle_groups[s].size());
+            }
+            uint32_t needed_bytes = std::max(max_idle_group_size * (uint32_t)sizeof(uint32_t), l1_alignment);
+            uint32_t idle_c9_scratch_size = ((needed_bytes + l1_alignment - 1) / l1_alignment) * l1_alignment;
+            tt::tt_metal::CircularBufferConfig idle_c9_scratch_cfg =
+                tt::tt_metal::CircularBufferConfig(idle_c9_scratch_size, {{tt::CBIndex::c_10, tt::DataFormat::UInt8}})
+                    .set_page_size(tt::CBIndex::c_10, idle_c9_scratch_size);
+            tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, idle_c9_scratch_cfg);
+        }
     } else {
         // c_0 on sender cores: dispatched_buffer rows for ROW_MAJOR DMA reads
         detail::create_tensor_cb(
@@ -579,6 +597,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                     .set_page_size(tt::CBIndex::c_8, stop_signal_page_size);
             tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, stop_signal_cb_config);
         }
+        // c_9 on idle cores: metadata-batch CB. The owning sender unicasts one read_batch_size
+        // worth of metadata here per iteration. Idle cores report this CB's L1 address to their
+        // owning sender once at startup (via the idle_c9_addr handshake below) so the sender
+        // knows where to unicast. First uint32 of each unicast is a sender-written sentinel:
+        // 0xFFFFFFFF → non-local writes exist → idle sends its untilized data back to sender.
+        // Any other value → all-local → idle does the local writes itself using this metadata.
+        {
+            uint32_t metadata_batch_page_size = detail::get_aligned_page_size(dispatched_metadata);
+            auto metadata_fmt = tt::tt_metal::datatype_to_dataformat_converter(dispatched_metadata.dtype());
+            uint32_t metadata_batch_cb_size = read_batch_size * metadata_batch_page_size;
+            tt::tt_metal::CircularBufferConfig metadata_batch_idle_config =
+                tt::tt_metal::CircularBufferConfig(metadata_batch_cb_size, {{tt::CBIndex::c_9, metadata_fmt}})
+                    .set_page_size(tt::CBIndex::c_9, metadata_batch_page_size);
+            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, metadata_batch_idle_config);
+        }
     }
 
     // counter_offset mirrors the constexpr calculation in reader_combine.cpp
@@ -697,6 +730,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         zi_compile_time_args.push_back(detail::get_num_pages(expert_token_counts));  // experts_tok_counter_pages
         zi_compile_time_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // counter page size
         zi_compile_time_args.push_back(read_batch_size);
+        zi_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_9));  // cb_metadata_batch_id
 
         std::map<std::string, std::string> zi_defines;
         zi_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
@@ -734,6 +768,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender)
             per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+            per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_9));   // cb_metadata_batch_id
+            per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_10));  // cb_idle_c9_addr_scratch_id
         }
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
@@ -811,15 +847,26 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                 zi_runtime_args.push_back(noc_y);
             }
 
-            // TILE_LAYOUT: append owning-sender info so zero_init_writer can run its send loop.
-            // In ROW_MAJOR the trailing args are ignored (kernel compiled with IS_TILE_LAYOUT=0).
+            // TILE_LAYOUT: append owning-sender info so zero_init_writer can run its send loop
+            // + its c_9 address handshake.  In ROW_MAJOR the trailing args are ignored
+            // (kernel compiled with IS_TILE_LAYOUT=0).
             if (is_tile_layout) {
                 uint32_t s = idle_sender_map[idle_idx];
+                // core_id = this idle core's local index within sender s's group (0..k_s-1).
+                // Compute it by finding idle_idx's position in the sequential ordering of
+                // idle cores that belong to sender s.
+                uint32_t local_core_id = 0;
+                for (uint32_t j = 0; j < idle_idx; j++) {
+                    if (idle_sender_map[j] == s) {
+                        local_core_id++;
+                    }
+                }
                 zi_runtime_args.push_back(counter_ready_semaphore_id);
                 zi_runtime_args.push_back(sender_noc_coords[s].first);
                 zi_runtime_args.push_back(sender_noc_coords[s].second);
                 zi_runtime_args.push_back(data_ready_semaphore_ids[s]);
                 zi_runtime_args.push_back(start_semaphore_ids[s]);
+                zi_runtime_args.push_back(local_core_id);
             }
 
             tt::tt_metal::SetRuntimeArgs(program, zero_init_kernel_id, zero_init_cores_vec[idle_idx], zi_runtime_args);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -175,14 +175,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     constexpr uint32_t read_batch_size = 32;
 
-    // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        dispatched_buffer,
-        /*buffering_factor=*/hidden_size / 32,
-        /*cb_id=*/tt::CBIndex::c_0,
-        "dispatched_buffer_scratch");
+    // // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
+    // detail::create_tensor_cb(
+    //     program,
+    //     sender_core_grid,
+    //     dispatched_buffer,
+    //     /*buffering_factor=*/hidden_size / 32,
+    //     /*cb_id=*/tt::CBIndex::c_0,
+    //     "dispatched_buffer_scratch");
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
         program,
@@ -191,24 +191,23 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_1,
         "dispatched_metadata_scratch");
-    // c_2: expert_token_counts (reader-only, full tensor)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        expert_token_counts,
-        /*buffering_factor=*/detail::get_num_pages(expert_token_counts),
-        /*cb_id=*/tt::CBIndex::c_2,
-        "expert_token_counts");
-
-    // c_17: 1-page CB on sender cores (for reader->compute signaling)
+    // c_2: expert_token_counts scratch on sender.
+    // Sized one extra page larger than the raw counter data so reader_combine can append
+    // its receive_buf_addr (get_write_ptr(c_18)) immediately after the counter pages before the
+    // multicast, giving idle cores a host-side-free way to discover the sender's receive buffer.
+    // Extra space is one full counter_page_size (not l1_alignment) to keep cb_size divisible by page_size.
     {
-        uint32_t signal_page_size = l1_alignment;
-        tt::tt_metal::CircularBufferConfig signal_cb_config =
-            tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_17, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_17, signal_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, signal_cb_config);
+        uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
+        uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
+        auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
+        uint32_t cb_size = (counter_pages + 1) * counter_page_size;
+        tt::tt_metal::CircularBufferConfig c2_config =
+            tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_2, data_format}})
+                .set_page_size(tt::CBIndex::c_2, counter_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, c2_config);
     }
-    // c_18: same size as c_0 (for compute untilized output)
+
+    // c_18: receive buffer for idle-core untilized data written back via NOC
     detail::create_tensor_cb(
         program,
         sender_core_grid,
@@ -362,10 +361,181 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     tt::tt_metal::KernelHandle zero_init_kernel_id = 0;
     std::vector<CoreCoord> zero_init_cores_vec;
     uint32_t zi_done_semaphore_id = 0;
-    uint32_t num_zero_init_cores = 0;
-    uint32_t total_zero_init_cores = 0;
     uint32_t pages_per_core = 0;
     uint32_t remainder_pages = 0;
+
+    // Find idle worker cores in the same row as sender cores — always needed for reader_untilize
+    uint32_t sender_row_y = sender_cores[0].y;
+    std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
+    std::vector<CoreCoord> idle_row_cores;
+    for (const auto& core : subdevice_cores) {
+        if (core.y == sender_row_y && !sender_core_set.contains(core)) {
+            idle_row_cores.push_back(core);
+        }
+    }
+    uint32_t num_idle_cores = static_cast<uint32_t>(idle_row_cores.size());
+    TT_FATAL(
+        num_idle_cores >= num_cores,
+        "Need at least {} idle cores (one per sender) in sender row {}, found {}; "
+        "subdevice must have more than {} cores per row",
+        num_cores,
+        sender_row_y,
+        num_idle_cores,
+        num_cores);
+
+    std::set<CoreRange> idle_ranges_set;
+    for (const auto& core : idle_row_cores) {
+        idle_ranges_set.insert(CoreRange(core));
+    }
+    CoreRangeSet idle_core_grid(idle_ranges_set);
+
+    // Compute NOC coordinates and multicast bounding box for idle cores
+    std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
+    for (const auto& core : idle_row_cores) {
+        auto noc_coord = mesh_device->virtual_core_from_logical_core(core, tt::CoreType::WORKER);
+        idle_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
+    }
+    uint32_t mcast_start_x = idle_noc_coords[0].first, mcast_end_x = idle_noc_coords[0].first;
+    uint32_t mcast_start_y = idle_noc_coords[0].second, mcast_end_y = idle_noc_coords[0].second;
+    for (const auto& [x, y] : idle_noc_coords) {
+        mcast_start_x = std::min(mcast_start_x, x);
+        mcast_end_x = std::max(mcast_end_x, x);
+        mcast_start_y = std::min(mcast_start_y, y);
+        mcast_end_y = std::max(mcast_end_y, y);
+    }
+
+    // counter_ready semaphore: created only on sender + idle cores so get_semaphore() returns
+    // the same L1 offset on both sides (sender writes to idle's copy, idle waits on its own)
+    std::set<CoreRange> sender_and_idle_ranges;
+    for (const auto& cr : sender_core_grid.ranges()) {
+        sender_and_idle_ranges.insert(cr);
+    }
+    for (const auto& cr : idle_core_grid.ranges()) {
+        sender_and_idle_ranges.insert(cr);
+    }
+    CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
+    auto counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    auto data_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    auto start_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+
+    // c_1 on idle cores: receives the full expert_token_counts multicast from sender.
+    // MUST be allocated BEFORE c_0 so that its L1 data-buffer address matches the sender's
+    // c_1 (dispatched_metadata) address.  The sender uses get_write_ptr(c_1_sender) as the
+    // multicast destination; if c_0 were allocated first here, idle c_1 would land 449 KB
+    // higher in L1 and the multicast would write into the wrong location, leaving the token
+    // counts as all-zeros and causing a hang (idle cores see 0 batches → send only the
+    // sentinel → sender waits on data_ready forever).
+    // One extra page larger than the raw counter data so the receive_buf_addr word appended at
+    // the end of the multicast payload lands within the allocated CB region.
+    // Extra space is one full counter_page_size (not l1_alignment) to keep cb_size divisible by page_size.
+    {
+        uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
+        uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
+        auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
+        uint32_t cb_size = (counter_pages + 1) * counter_page_size;
+        tt::tt_metal::CircularBufferConfig c1_idle_config =
+            tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
+                .set_page_size(tt::CBIndex::c_1, counter_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
+    }
+    // c_0 on idle cores: dispatched_buffer tiles, one token's worth (hidden_size/32 tiles)
+    // MUST be at index 0: pack_untilize_block calls llk_math_eltwise_unary_datacopy with
+    // operand=0 (Blackhole UnpackToDestEn=true path), so MATH reads unpack_src_format[0].
+    // Placing dispatched_buffer (bfloat16) here ensures the correct format is used.
+    // NOTE: c_0 is allocated after c_1 (see above) so that the multicast destination address
+    // matches the sender; the CB index (0) is independent of allocation order.
+    detail::create_tensor_cb(
+        program,
+        idle_core_grid,
+        dispatched_buffer,
+        /*buffering_factor=*/hidden_size / 32,
+        /*cb_id=*/tt::CBIndex::c_0,
+        "dispatched_buffer_idle");
+    // c_2 on idle cores: untilized output rows, one full batch (read_batch_size rows)
+    detail::create_tensor_cb(
+        program,
+        idle_core_grid,
+        output_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_2,
+        "untilize_idle");
+    // c_3 on idle cores: 1-page signal CB (reader->compute, mirrors c_17 on sender cores)
+    {
+        uint32_t signal_page_size = l1_alignment;
+        tt::tt_metal::CircularBufferConfig signal_cb_config =
+            tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_3, signal_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+    }
+
+    // counter_offset mirrors the constexpr calculation in reader_combine.cpp
+    uint32_t mesh_row_coord = linearized_mesh_coord / mesh_cols;
+    uint32_t mesh_col_coord = linearized_mesh_coord % mesh_cols;
+    uint32_t experts_per_dispatch_group = operation_attributes.experts_per_chip * mesh_rows;
+    uint32_t counter_offset =
+        mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
+
+    // Base compile-time args shared across all idle cores (indices 0-12).
+    // core_id (13) and num_idle_cores (14) are appended per-core; remaining fixed args follow at
+    // 15-16; TensorAccessorArgs follow at 17+.
+    // Wait — actual layout (matching reader_untilize.cpp):
+    //   0-10: shared base (below)
+    //   11: core_id          (appended per-core)
+    //   12: num_idle_cores   (appended per-core)
+    //   13: aligned_output_page_size
+    //   14: aligned_experts_tok_counter_page_size
+    //   15+: TensorAccessorArgs for dispatched_buffer
+    const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
+        static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
+        detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
+        operation_attributes.experts_per_chip,             // 2:  experts_per_chip
+        counter_offset,                                    // 3:  counter_offset
+        static_cast<uint32_t>(tt::CBIndex::c_0),           // 4:  cb_dispatched_buffer_id
+        static_cast<uint32_t>(tt::CBIndex::c_2),           // 5:  cb_untilize_id
+        (uint32_t)hidden_size,                             // 6:  hidden_size
+        read_batch_size,                                   // 7:  read_batch_size
+        static_cast<uint32_t>(tt::CBIndex::c_3),           // 8:  cb_signal_id
+        detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
+        (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
+    };
+
+    // Partition idle cores among senders so each sender owns an exclusive slice.
+    // This prevents multiple senders from racing on the same start_semaphore.
+    // Sender s owns idle cores [offset_s, offset_s + k_s).
+    // k_s = K_base + (s < K_extra ? 1 : 0) where K_base = num_idle_cores / num_cores.
+    uint32_t K_base = num_idle_cores / num_cores;
+    uint32_t K_extra = num_idle_cores % num_cores;
+
+    // Create one reader_untilize kernel instance per idle core with per-sender
+    // core_id and num_idle_cores baked in at compile time.
+    std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
+    reader_untilize_kernel_ids.reserve(num_idle_cores);
+
+    {
+        uint32_t global_idle_idx = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
+                auto per_core_args = reader_untilize_compile_time_args_base;
+                per_core_args.push_back(j);    // 11: core_id (relative to this sender's slice)
+                per_core_args.push_back(k_s);  // 12: num_idle_cores (per-sender slice size)
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));                  // 13
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));            // 14
+                tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);  // 15+
+
+                CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
+                reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+                    program,
+                    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
+                    "reader_untilize.cpp",
+                    single_idle_core,
+                    tt::tt_metal::DataMovementConfig{
+                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                        .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                        .compile_args = per_core_args}));
+            }
+        }
+    }
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
 
@@ -385,33 +555,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                 .set_page_size(tt::CBIndex::c_7, noc_max_burst_size);
         tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, zi_inline_cb_config);
 
-        // Find idle worker cores in the same row as sender cores
-        uint32_t sender_row_y = sender_cores[0].y;
-        std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
-        std::vector<CoreCoord> idle_row_cores;
-        for (const auto& core : subdevice_cores) {
-            if (core.y == sender_row_y && !sender_core_set.contains(core)) {
-                idle_row_cores.push_back(core);
-            }
-        }
-
-        num_zero_init_cores = idle_row_cores.size();
-        TT_FATAL(
-            num_zero_init_cores > 0,
-            "No idle cores found in sender row {} for zero-init; subdevice must have more than {} cores per row",
-            sender_row_y,
-            num_cores);
-        total_zero_init_cores = num_cores + num_zero_init_cores;
-
+        uint32_t total_zero_init_cores = num_cores + num_idle_cores;
         uint32_t total_output_pages = detail::get_num_pages(output_tensor);
         pages_per_core = total_output_pages / total_zero_init_cores;
         remainder_pages = total_output_pages % total_zero_init_cores;
-
-        std::set<CoreRange> idle_ranges;
-        for (const auto& core : idle_row_cores) {
-            idle_ranges.insert(CoreRange(core));
-        }
-        CoreRangeSet idle_core_grid(idle_ranges);
 
         tt::tt_metal::CircularBufferConfig zi_idle_cb_config =
             tt::tt_metal::CircularBufferConfig(noc_max_burst_size, {{tt::CBIndex::c_6, tt::DataFormat::UInt8}})
@@ -441,24 +588,33 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         zero_init_cores_vec = idle_row_cores;
     }
 
-    // Reader gets its own compile-time args: shared base + zero-init args appended at the end
-    std::vector<uint32_t> reader_compile_time_args = compile_time_args;
+    // Reader compile-time args base (without num_idle_cores — that is per-sender and appended below).
+    std::vector<uint32_t> reader_compile_time_args_base = compile_time_args;
     if (init_zeros) {
-        reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_7));  // zi_cb_id
-        reader_compile_time_args.push_back(num_zero_init_cores);                      // num_idle_cores
+        reader_compile_time_args_base.push_back(static_cast<uint32_t>(tt::CBIndex::c_7));  // zi_cb_id
     }
-    reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_17));  // cb_signal_id
-    reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+    // num_idle_cores and cb_untilize_id are appended per-sender below.
 
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp",
-        sender_core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-            .compile_args = reader_compile_time_args,
-            .defines = reader_defines});
+    // Create one reader_combine kernel per sender so each can have its own per-sender num_idle_cores
+    // baked in at compile time (avoids a VLA whose size would vary across sender cores).
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    reader_kernel_ids.reserve(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+        auto per_sender_compile_args = reader_compile_time_args_base;
+        per_sender_compile_args.push_back(k_s);                                       // num_idle_cores for sender s
+        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+        CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
+        reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp",
+            single_sender_core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                .compile_args = per_sender_compile_args,
+                .defines = reader_defines}));
+    }
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -470,19 +626,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .compile_args = compile_time_args,
             .defines = writer_defines});
 
-    // Compute kernel on sender cores only (not on zero-init idle cores)
-    [[maybe_unused]] tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
+    // Compute kernel on idle cores (c_3 signal, c_2 untilize out, c_0 tile in)
+    [[maybe_unused]] tt::tt_metal::KernelHandle compute_idle_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
         "untilize_combine.cpp",
-        sender_core_grid,
+        idle_core_grid,
         tt::tt_metal::ComputeConfig{
             .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_17),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id
-                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                static_cast<uint32_t>(hidden_size),        // hidden_size
-                static_cast<uint32_t>(read_batch_size),    // read_batch_size
+                static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_signal_id
+                static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_untilize_id
+                static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_in_id (must be 0: MATH reads unpack_src_format[0])
+                static_cast<uint32_t>(hidden_size),       // hidden_size
+                static_cast<uint32_t>(read_batch_size),   // read_batch_size
             }});
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
@@ -494,7 +650,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     // Set runtime args for hybrid idle row cores
     if (init_zeros) {
-        for (uint32_t idle_idx = 0; idle_idx < num_zero_init_cores; idle_idx++) {
+        for (uint32_t idle_idx = 0; idle_idx < num_idle_cores; idle_idx++) {
             uint32_t row_idx = num_cores + idle_idx;
             uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
             uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
@@ -536,6 +692,22 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             reader_runtime_args.push_back(sender_page_start);
             reader_runtime_args.push_back(sender_page_end);
             reader_runtime_args.push_back(zi_done_semaphore_id);
+        }
+        reader_runtime_args.push_back(counter_ready_semaphore_id);
+        reader_runtime_args.push_back(mcast_start_x);
+        reader_runtime_args.push_back(mcast_start_y);
+        reader_runtime_args.push_back(mcast_end_x);
+        reader_runtime_args.push_back(mcast_end_y);
+        reader_runtime_args.push_back(data_ready_semaphore_id);
+        reader_runtime_args.push_back(start_semaphore_id);
+        // Only pass NOC coords of idle cores assigned to this sender (slice [offset_s, offset_s+k_s))
+        {
+            uint32_t k_s = K_base + (core_idx < K_extra ? 1 : 0);
+            uint32_t offset_s = core_idx * K_base + std::min(core_idx, K_extra);
+            for (uint32_t j = 0; j < k_s; j++) {
+                reader_runtime_args.push_back(idle_noc_coords[offset_s + j].first);
+                reader_runtime_args.push_back(idle_noc_coords[offset_s + j].second);
+            }
         }
 
         std::vector<uint32_t> writer_runtime_args = {
@@ -586,21 +758,51 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             }
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, sender_core, reader_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[core_idx], sender_core, reader_runtime_args);
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
         core_idx++;
     }
 
+    // Set runtime args for idle cores using per-sender NOC coords and expert range.
+    {
+        uint32_t global_idle_idx = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            const auto& [sx, sy] = sender_noc_coords[s];
+            uint32_t expert_start = s * experts_per_core_range;
+            uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
+                tt::tt_metal::SetRuntimeArgs(
+                    program,
+                    reader_untilize_kernel_ids[global_idle_idx],
+                    idle_row_cores[global_idle_idx],
+                    {counter_ready_semaphore_id,
+                     data_ready_semaphore_id,
+                     sx,
+                     sy,
+                     start_semaphore_id,
+                     dispatched_buffer.buffer()->address(),
+                     expert_start,
+                     expert_end});
+            }
+        }
+    }
+
     return {
         std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
+        {.reader_kernel_ids = std::move(reader_kernel_ids),
          .writer_kernel_id = writer_kernel_id,
          .zero_init_kernel_id = zero_init_kernel_id,
+         .reader_untilize_kernel_ids = std::move(reader_untilize_kernel_ids),
          .cores = sender_cores,
          .zero_init_cores = zero_init_cores_vec,
+         .idle_cores = idle_row_cores,
          .init_semaphore = init_semaphore,
          .zero_init_semaphore_id = zero_init_semaphore_id,
-         .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id}};
+         .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id,
+         .counter_ready_semaphore_id = counter_ready_semaphore_id,
+         .data_ready_semaphore_id = data_ready_semaphore_id,
+         .start_semaphore_id = start_semaphore_id}};
 }
 
 void CombineProgramFactory::override_runtime_arguments(
@@ -611,8 +813,10 @@ void CombineProgramFactory::override_runtime_arguments(
     for (auto& [range, program] : cached_workload.workload.get_programs()) {
         const auto& shared_variables = cached_workload.shared_variables.at(range);
 
-        for (const auto& core : shared_variables.cores) {
-            auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_id, core);
+        for (size_t s = 0; s < shared_variables.cores.size(); s++) {
+            const auto& core = shared_variables.cores[s];
+            auto& reader_runtime_args =
+                tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_ids[s], core);
             auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.writer_kernel_id, core);
 
             reader_runtime_args.at(0) = tensor_args.dispatched_buffer.buffer()->address();
@@ -630,6 +834,12 @@ void CombineProgramFactory::override_runtime_arguments(
         for (const auto& core : shared_variables.zero_init_cores) {
             auto& zi_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.zero_init_kernel_id, core);
             zi_runtime_args.at(0) = tensor_return_value.buffer()->address();
+        }
+
+        for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
+            auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
+                program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
+            idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -494,11 +494,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
     }
     // c_0 on idle cores: dispatched_buffer tiles
+    // cb_factor reduces CB size to fit L1: Blackhole has more L1, Wormhole needs 4x reduction
+    uint32_t cb_factor;
+    {
+        const auto arch = mesh_device->arch();
+        if (arch == tt::ARCH::BLACKHOLE) {
+            cb_factor = 1;
+        } else {
+            cb_factor = 4;  // Wormhole_B0 and others
+        }
+    }
     detail::create_tensor_cb(
         program,
         idle_core_grid,
         dispatched_buffer,
-        /*buffering_factor=*/hidden_size / 32,
+        /*buffering_factor=*/hidden_size / (32 * cb_factor),
         /*cb_id=*/tt::CBIndex::c_0,
         "dispatched_buffer_idle");
     // c_2 on idle cores: untilized output rows, one full batch (read_batch_size rows)
@@ -526,12 +536,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
 
     // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
-    //   0-10: shared base (below)
-    //   11:   core_id   — local index within sender s's idle group (0..k_s-1)
-    //   12:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
-    //   13:   aligned_output_page_size
-    //   14:   aligned_experts_tok_counter_page_size
-    //   15+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
+    //   0-11: shared base (below, includes cb_factor at index 11)
+    //   12:   core_id   — local index within sender s's idle group (0..k_s-1)
+    //   13:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
+    //   14:   aligned_output_page_size
+    //   15:   aligned_experts_tok_counter_page_size
+    //   16+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
     const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
         static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
         detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -544,6 +554,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         static_cast<uint32_t>(tt::CBIndex::c_3),           // 8:  cb_signal_id
         detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
         (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
+        cb_factor,                                         // 11: cb_factor
     };
 
     // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
@@ -559,11 +570,11 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
                 auto per_core_args = reader_untilize_compile_time_args_base;
-                per_core_args.push_back(j);    // 11: core_id (local to sender s's group)
-                per_core_args.push_back(k_s);  // 12: num_idle_cores (per-sender)
-                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 13
-                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 14
-                // 15+: TensorAccessorArgs (no num_senders — single-sender kernel)
+                per_core_args.push_back(j);    // 12: core_id (local to sender s's group)
+                per_core_args.push_back(k_s);  // 13: num_idle_cores (per-sender)
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 14
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 15
+                // 16+: TensorAccessorArgs (no num_senders — single-sender kernel)
                 tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);
 
                 CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -542,10 +542,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t cb_factor;
     {
         const auto arch = mesh_device->arch();
-        if (arch == tt::ARCH::BLACKHOLE) {
+        if (arch == tt::ARCH::BLACKHOLE || !is_tile_layout) {
             cb_factor = 1;
         } else {
-            cb_factor = 4;  // Wormhole_B0 and others
+            cb_factor = 4;  // Wormhole_B0 and others for TILE_LAYOUT
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -575,7 +575,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t output_aligned_page_size = detail::get_aligned_page_size(output_tensor);
         std::vector<uint32_t> zi_compile_time_args = {
             output_aligned_page_size,
-            1,  // num_sender_cores = 1: each idle core signals only its owning sender
+            num_cores,  // num_sender_cores = num_cores: each idle core signals all sender cores
             static_cast<uint32_t>(tt::CBIndex::c_6),
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(zi_compile_time_args);
@@ -610,6 +610,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         auto per_sender_compile_args = reader_compile_time_args_base;
         per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender k_s)
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+        if (init_zeros) {
+            per_sender_compile_args.push_back(
+                num_idle_cores);  // num_total_idle_cores (all idle cores across all senders)
+        }
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
             program,
@@ -662,16 +666,17 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
             uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
 
-            // Each idle core signals only its owning sender (num_sender_cores CT arg = 1)
-            uint32_t owning_sender = idle_sender_map[idle_idx];
+            // Each idle core signals all sender cores
             std::vector<uint32_t> zi_runtime_args = {
                 output_tensor.buffer()->address(),
                 page_start,
                 page_end,
                 zi_done_semaphore_id,
-                sender_noc_coords[owning_sender].first,
-                sender_noc_coords[owning_sender].second,
             };
+            for (const auto& [noc_x, noc_y] : sender_noc_coords) {
+                zi_runtime_args.push_back(noc_x);
+                zi_runtime_args.push_back(noc_y);
+            }
 
             tt::tt_metal::SetRuntimeArgs(program, zero_init_kernel_id, zero_init_cores_vec[idle_idx], zi_runtime_args);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -232,7 +232,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
 
-    constexpr uint32_t read_batch_size = 32;
+    const uint32_t read_batch_size = is_tile_layout ? dispatched_buffer.tensor_spec().tile().get_height() : 8;
 
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
@@ -295,15 +295,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             program,
             sender_core_grid,
             output_tensor,
-            /*buffering_factor=*/rw_buffering,
-            /*cb_id=*/tt::CBIndex::c_4,
-            "output_for_writer");
-    }
-
-        detail::create_tensor_cb(
-            program,
-            sender_core_grid,
-            dispatched_buffer,
             /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_4,
             "output_for_writer");
@@ -533,12 +524,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     if (is_tile_layout) {
         // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
-        //   0-11: shared base (below, includes cb_factor at index 11)
-        //   12:   core_id   — local index within sender s's idle group (0..k_s-1)
-        //   13:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
-        //   14:   aligned_output_page_size
-        //   15:   aligned_experts_tok_counter_page_size
-        //   16+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
+        //   0-13: shared base (below, includes tile_height/tile_width at 12-13)
+        //   14:   core_id   — local index within sender s's idle group (0..k_s-1)
+        //   15:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
+        //   16:   aligned_output_page_size
+        //   17:   aligned_experts_tok_counter_page_size
+        //   18+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
+        const uint32_t tile_height = dispatched_buffer.tensor_spec().tile().get_height();
+        const uint32_t tile_width = dispatched_buffer.tensor_spec().tile().get_width();
         const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
             static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
             detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -552,6 +545,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
             (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
             cb_factor,                                         // 11: cb_factor
+            tile_height,                                       // 12: tile_height
+            tile_width,                                        // 13: tile_width
         };
 
         // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
@@ -565,11 +560,11 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
                 auto per_core_args = reader_untilize_compile_time_args_base;
-                per_core_args.push_back(j);    // 12: core_id (local to sender s's group)
-                per_core_args.push_back(k_s);  // 13: num_idle_cores (per-sender)
-                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 14
-                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 15
-                // 16+: TensorAccessorArgs (no num_senders — single-sender kernel)
+                per_core_args.push_back(j);    // 14: core_id (local to sender s's group)
+                per_core_args.push_back(k_s);  // 15: num_idle_cores (per-sender)
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 16
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 17
+                // 18+: TensorAccessorArgs (no num_senders — single-sender kernel)
                 tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);
 
                 CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
@@ -641,8 +636,9 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<uint32_t> reader_compile_time_args_base = compile_time_args;
     if (init_zeros) {
         reader_compile_time_args_base.push_back(static_cast<uint32_t>(tt::CBIndex::c_7));  // zi_cb_id
+        reader_compile_time_args_base.push_back(num_idle_cores);  // num_total_idle_cores (both layouts need this)
     }
-    // num_idle_cores and cb_untilize_id are appended per-sender below.
+    // num_idle_cores (per-sender k_s) and cb_untilize_id are appended per-sender below (TILE_LAYOUT only).
 
     // One reader_combine kernel per sender.  For TILE_LAYOUT, k_s (per-sender idle count)
     // is baked in as num_idle_cores so the sender only round-robins across its own dedicated
@@ -655,10 +651,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender)
             per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
-            if (init_zeros) {
-                per_sender_compile_args.push_back(
-                    num_idle_cores);  // num_total_idle_cores (all idle cores across all senders)
-            }
         }
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -198,7 +198,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
         auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        uint32_t cb_size = (counter_pages + 1) * counter_page_size;
+        // Need num_cores extra words (one receive_buf_addr per sender) after the counter data.
+        uint32_t recv_buf_extra_bytes = num_cores * sizeof(uint32_t);
+        uint32_t extra_pages = std::max(1u, tt::div_up(recv_buf_extra_bytes, counter_page_size));
+        uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
         tt::tt_metal::CircularBufferConfig c2_config =
             tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_2, data_format}})
                 .set_page_size(tt::CBIndex::c_2, counter_page_size);
@@ -386,8 +389,13 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
     CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
     auto counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
-    auto data_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
-    auto start_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    // One data_ready and one start semaphore per sender so each sender's handshake with idle
+    // cores is independent — idle core routes to the correct pair via sender_idx = expert / experts_per_sender.
+    std::vector<uint32_t> data_ready_semaphore_ids, start_semaphore_ids;
+    for (uint32_t s = 0; s < num_cores; s++) {
+        data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+        start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+    }
 
     // c_1 on idle cores: receives the full expert_token_counts multicast from sender.
     // MUST be allocated BEFORE c_0 so that its L1 data-buffer address matches the sender's
@@ -396,14 +404,15 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     // higher in L1 and the multicast would write into the wrong location, leaving the token
     // counts as all-zeros and causing a hang (idle cores see 0 batches → send only the
     // sentinel → sender waits on data_ready forever).
-    // One extra page larger than the raw counter data so the receive_buf_addr word appended at
-    // the end of the multicast payload lands within the allocated CB region.
-    // Extra space is one full counter_page_size (not l1_alignment) to keep cb_size divisible by page_size.
+    // Extra pages after the counter data hold one receive_buf_addr per sender core so idle
+    // cores can discover each sender's receive buffer from the multicast payload alone.
     {
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
         auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        uint32_t cb_size = (counter_pages + 1) * counter_page_size;
+        uint32_t recv_buf_extra_bytes = num_cores * sizeof(uint32_t);
+        uint32_t extra_pages = std::max(1u, tt::div_up(recv_buf_extra_bytes, counter_page_size));
+        uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
         tt::tt_metal::CircularBufferConfig c1_idle_config =
             tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
                 .set_page_size(tt::CBIndex::c_1, counter_page_size);
@@ -446,16 +455,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t counter_offset =
         mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
 
-    // Base compile-time args shared across all idle cores (indices 0-12).
-    // core_id (13) and num_idle_cores (14) are appended per-core; remaining fixed args follow at
-    // 15-16; TensorAccessorArgs follow at 17+.
-    // Wait — actual layout (matching reader_untilize.cpp):
+    // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
     //   0-10: shared base (below)
-    //   11: core_id          (appended per-core)
-    //   12: num_idle_cores   (appended per-core)
-    //   13: aligned_output_page_size
-    //   14: aligned_experts_tok_counter_page_size
-    //   15+: TensorAccessorArgs for dispatched_buffer
+    //   11:   core_id (global index 0..num_idle_cores-1, appended per-core)
+    //   12:   num_idle_cores (total, appended per-core)
+    //   13:   aligned_output_page_size
+    //   14:   aligned_experts_tok_counter_page_size
+    //   15:   num_senders (= num_cores)
+    //   16+:  TensorAccessorArgs for dispatched_buffer
     const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
         static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
         detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -470,42 +477,31 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
     };
 
-    // Partition idle cores among senders so each sender owns an exclusive slice.
-    // This prevents multiple senders from racing on the same start_semaphore.
-    // Sender s owns idle cores [offset_s, offset_s + k_s).
-    // k_s = K_base + (s < K_extra ? 1 : 0) where K_base = num_idle_cores / num_cores.
-    uint32_t K_base = num_idle_cores / num_cores;
-    uint32_t K_extra = num_idle_cores % num_cores;
-
-    // Create one reader_untilize kernel instance per idle core with per-sender
-    // core_id and num_idle_cores baked in at compile time.
+    // All idle cores cover the full expert range; the kernel routes each expert to the
+    // correct sender via sender_idx = local_expert / experts_per_sender.
+    // core_id is a global index for round-robin batch assignment across all idle cores.
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     reader_untilize_kernel_ids.reserve(num_idle_cores);
 
-    {
-        uint32_t global_idle_idx = 0;
-        for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
-            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
-                auto per_core_args = reader_untilize_compile_time_args_base;
-                per_core_args.push_back(j);    // 11: core_id (relative to this sender's slice)
-                per_core_args.push_back(k_s);  // 12: num_idle_cores (per-sender slice size)
-                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));                  // 13
-                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));            // 14
-                tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);  // 15+
+    for (uint32_t j = 0; j < num_idle_cores; j++) {
+        auto per_core_args = reader_untilize_compile_time_args_base;
+        per_core_args.push_back(j);                                                   // 11: core_id (global)
+        per_core_args.push_back(num_idle_cores);                                      // 12: num_idle_cores (total)
+        per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 13
+        per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 14
+        per_core_args.push_back(num_cores);                                           // 15: num_senders
+        tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);  // 16+
 
-                CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
-                reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-                    program,
-                    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
-                    "reader_untilize.cpp",
-                    single_idle_core,
-                    tt::tt_metal::DataMovementConfig{
-                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                        .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                        .compile_args = per_core_args}));
-            }
-        }
+        CoreRangeSet single_idle_core({CoreRange(idle_row_cores[j])});
+        reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
+            "reader_untilize.cpp",
+            single_idle_core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                .compile_args = per_core_args}));
     }
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
@@ -571,9 +567,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
         auto per_sender_compile_args = reader_compile_time_args_base;
-        per_sender_compile_args.push_back(k_s);                                       // num_idle_cores for sender s
+        per_sender_compile_args.push_back(num_idle_cores);                            // num_idle_cores (all idle cores)
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
@@ -669,16 +664,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         reader_runtime_args.push_back(mcast_start_y);
         reader_runtime_args.push_back(mcast_end_x);
         reader_runtime_args.push_back(mcast_end_y);
-        reader_runtime_args.push_back(data_ready_semaphore_id);
-        reader_runtime_args.push_back(start_semaphore_id);
-        // Only pass NOC coords of idle cores assigned to this sender (slice [offset_s, offset_s+k_s))
-        {
-            uint32_t k_s = K_base + (core_idx < K_extra ? 1 : 0);
-            uint32_t offset_s = core_idx * K_base + std::min(core_idx, K_extra);
-            for (uint32_t j = 0; j < k_s; j++) {
-                reader_runtime_args.push_back(idle_noc_coords[offset_s + j].first);
-                reader_runtime_args.push_back(idle_noc_coords[offset_s + j].second);
-            }
+        reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
+        reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
+        // Pass NOC coords of ALL idle cores — all idle cores now handle all experts
+        for (uint32_t j = 0; j < num_idle_cores; j++) {
+            reader_runtime_args.push_back(idle_noc_coords[j].first);
+            reader_runtime_args.push_back(idle_noc_coords[j].second);
         }
 
         std::vector<uint32_t> writer_runtime_args = {
@@ -734,29 +725,22 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         core_idx++;
     }
 
-    // Set runtime args for idle cores using per-sender NOC coords and expert range.
-    {
-        uint32_t global_idle_idx = 0;
+    // Set runtime args for idle cores.  All idle cores cover the full expert range; the kernel
+    // determines the owning sender per expert via sender_idx = local_expert / experts_per_sender.
+    // Layout: counter_ready_sem, [data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s]]×num_senders,
+    //         dispatched_buffer_addr, expert_start=0, expert_end=experts_per_chip
+    for (uint32_t j = 0; j < num_idle_cores; j++) {
+        std::vector<uint32_t> idle_rt_args = {counter_ready_semaphore_id};
         for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
-            const auto& [sx, sy] = sender_noc_coords[s];
-            uint32_t expert_start = s * experts_per_core_range;
-            uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
-            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
-                tt::tt_metal::SetRuntimeArgs(
-                    program,
-                    reader_untilize_kernel_ids[global_idle_idx],
-                    idle_row_cores[global_idle_idx],
-                    {counter_ready_semaphore_id,
-                     data_ready_semaphore_id,
-                     sx,
-                     sy,
-                     start_semaphore_id,
-                     dispatched_buffer.buffer()->address(),
-                     expert_start,
-                     expert_end});
-            }
+            idle_rt_args.push_back(data_ready_semaphore_ids[s]);
+            idle_rt_args.push_back(sender_noc_coords[s].first);
+            idle_rt_args.push_back(sender_noc_coords[s].second);
+            idle_rt_args.push_back(start_semaphore_ids[s]);
         }
+        idle_rt_args.push_back(dispatched_buffer.buffer()->address());
+        idle_rt_args.push_back(0);                                      // expert_start = 0
+        idle_rt_args.push_back(operation_attributes.experts_per_chip);  // expert_end
+        tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
     }
 
     return {
@@ -772,8 +756,9 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
          .zero_init_semaphore_id = zero_init_semaphore_id,
          .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id,
          .counter_ready_semaphore_id = counter_ready_semaphore_id,
-         .data_ready_semaphore_id = data_ready_semaphore_id,
-         .start_semaphore_id = start_semaphore_id}};
+         .num_senders = num_cores,
+         .data_ready_semaphore_ids = std::move(data_ready_semaphore_ids),
+         .start_semaphore_ids = std::move(start_semaphore_ids)}};
 }
 
 void CombineProgramFactory::override_runtime_arguments(
@@ -810,7 +795,9 @@ void CombineProgramFactory::override_runtime_arguments(
         for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
             auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
                 program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-            idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
+            // dispatched_buffer_addr sits at index 1 + num_senders*4:
+            // index 0 = counter_ready_sem, then num_senders groups of {data_ready_sem, noc_x, noc_y, start_sem}
+            idle_rt_args.at(1 + shared_variables.num_senders * 4) = tensor_args.dispatched_buffer.buffer()->address();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -228,8 +228,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
         num_idle_cores,
         num_cores);
-    uint32_t K_base = num_idle_cores / num_cores;
-    uint32_t K_extra = num_idle_cores % num_cores;
+    uint32_t idle_cores_per_sender = num_idle_cores / num_cores;
+    uint32_t senders_with_extra_idle = num_idle_cores % num_cores;
 
     // Build sender_core_grid from selected sender cores
     std::set<CoreRange> sender_ranges_set;
@@ -242,14 +242,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     log_debug(
         tt::LogOp,
         "Combine program: hidden_size: {} num_cores: {} experts_per_core_range: {} "
-        "sender_cores: {} num_idle_cores: {} K_base: {} K_extra: {}",
+        "sender_cores: {} num_idle_cores: {} idle_cores_per_sender: {} senders_with_extra_idle: {}",
         hidden_size,
         num_cores,
         experts_per_core_range,
         sender_cores,
         num_idle_cores,
-        K_base,
-        K_extra);
+        idle_cores_per_sender,
+        senders_with_extra_idle);
 
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
@@ -316,7 +316,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         detail::create_tensor_cb(
             program,
             sender_core_grid,
-            output_tensor,
+            output_tensor,  // dispatched_buffer and output_tensor have same page size
             /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_4,
             "output_for_writer");
@@ -436,13 +436,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     };
     std::vector<SenderMcastCfg> sender_mcast_cfgs(num_cores);
     if (is_tile_layout) {
+        // Compute per-sender NOC multicast bounding box (min/max x,y over idle cores)
+        // and collect individual idle core NOC coordinates for semaphore signaling.
         for (uint32_t s = 0; s < num_cores; s++) {
             TT_FATAL(!sender_idle_groups[s].empty(), "Sender {} has no idle cores assigned", s);
             auto& cfg = sender_mcast_cfgs[s];
+
+            // Initialize bounding box from the first idle core in the group
             auto first_noc =
                 mesh_device->virtual_core_from_logical_core(sender_idle_groups[s][0], tt::CoreType::WORKER);
             cfg.mcast_start_x = cfg.mcast_end_x = first_noc.x;
             cfg.mcast_start_y = cfg.mcast_end_y = first_noc.y;
+
+            // Expand bounding box to cover all idle cores and record each core's NOC coords
             for (const auto& ic : sender_idle_groups[s]) {
                 auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
                 cfg.mcast_start_x = std::min(cfg.mcast_start_x, (uint32_t)noc.x);
@@ -484,7 +490,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         }
     }
 
-    // cb_factor reduces CB size to fit L1: Blackhole has more L1, Wormhole needs 4x reduction
+    // cb_factor reduces CB size to fit L1: Wormhole needs 4x reduction
     uint32_t cb_factor;
     {
         const auto arch = mesh_device->arch();
@@ -636,7 +642,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t output_aligned_page_size = detail::get_aligned_page_size(output_tensor);
         std::vector<uint32_t> zi_compile_time_args = {
             output_aligned_page_size,
-            num_cores,  // num_sender_cores = num_cores: each idle core signals all sender cores
+            num_cores,  // num_sender_cores = num_cores: each idle core signals all sender cores that its zero-init
+                        // portion is done and output pages are initializer with 0 for that chip
             static_cast<uint32_t>(tt::CBIndex::c_6),
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(zi_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -156,19 +156,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t num_cores = effective_num_links;
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    // Step 1: Select sender cores using num_cores_to_corerangeset_in_subcoregrids.
-    // This picks the first num_cores from the subdevice in row-major order, keeping
-    // senders physically adjacent and (typically) in the same physical row.
-    CoreRangeSet sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+    auto sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
         subdevice_cores.at(0), num_cores, worker_core_range_set, true);
     std::vector<CoreCoord> sender_cores = corerange_to_cores(sender_core_grid);
     TT_FATAL(sender_cores.size() == num_cores, "Expected {} sender cores, got {}", num_cores, sender_cores.size());
 
-    // Step 2: Collect idle cores in the SAME physical row as sender_cores[0].
-    // NOC multicast requires a single-row bounding box: if idle cores span multiple
-    // physical rows the box widens to a rectangle that includes non-subdevice cores
-    // (Ethernet tiles, other workers), causing noc_async_write_barrier() to hang
-    // because the hardware waits for ACKs from cores that can't respond properly.
+    // Step 2: Collect idle cores in the SAME physical row as sender_cores[0]
     uint32_t sender_row_y_phys =
         (uint32_t)mesh_device->virtual_core_from_logical_core(sender_cores[0], tt::CoreType::WORKER).y;
     std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
@@ -228,14 +221,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     constexpr uint32_t read_batch_size = 32;
 
-    // // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
-    // detail::create_tensor_cb(
-    //     program,
-    //     sender_core_grid,
-    //     dispatched_buffer,
-    //     /*buffering_factor=*/hidden_size / 32,
-    //     /*cb_id=*/tt::CBIndex::c_0,
-    //     "dispatched_buffer_scratch");
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
         program,
@@ -447,9 +432,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     // c_1 on idle cores: receives the expert_token_counts multicast from the owning sender.
     // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
-    // The sender uses get_write_ptr(c_1_sender) as the multicast destination; if c_0 were
-    // allocated first here it would consume ~3 MB causing c_1 to wrap and corrupt the mailbox.
-    // One extra page holds the single receive_buf_addr that each sender appends before multicasting.
     {
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
@@ -461,12 +443,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                 .set_page_size(tt::CBIndex::c_1, counter_page_size);
         tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
     }
-    // c_0 on idle cores: dispatched_buffer tiles, one token's worth (hidden_size/32 tiles)
-    // MUST be at index 0: pack_untilize_block calls llk_math_eltwise_unary_datacopy with
-    // operand=0 (Blackhole UnpackToDestEn=true path), so MATH reads unpack_src_format[0].
-    // Placing dispatched_buffer (bfloat16) here ensures the correct format is used.
-    // NOTE: c_0 is allocated after c_1 (see above) so that the multicast destination address
-    // matches the sender; the CB index (0) is independent of allocation order.
+    // c_0 on idle cores: dispatched_buffer tiles
     detail::create_tensor_cb(
         program,
         idle_core_grid,
@@ -643,17 +620,18 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .compile_args = compile_time_args,
             .defines = writer_defines});
 
-    // Compute kernel on idle cores (c_3 signal, c_2 untilize out, c_0 tile in)
-    [[maybe_unused]] tt::tt_metal::KernelHandle compute_idle_kernel_id = tt::tt_metal::CreateKernel(
+    // Compute kernel on idle cores that untilizes dispatched_buffer data
+    tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
         "untilize_combine.cpp",
         idle_core_grid,
         tt::tt_metal::ComputeConfig{
             .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_untilize_id
-                static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_in_id (must be 0: MATH reads unpack_src_format[0])
+                static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_signal_id (CB used for signaling on the same core that
+                                                          // data is loaded and ready to be untilized)
+                static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_untilize_id (untilized dispatched_buffer data)
+                static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_in_id (dispatched_buffer data)
                 static_cast<uint32_t>(hidden_size),       // hidden_size
                 static_cast<uint32_t>(read_batch_size),   // read_batch_size
             }});

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -173,14 +173,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     constexpr uint32_t read_batch_size = 32;
 
-    // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        dispatched_buffer,
-        /*buffering_factor=*/hidden_size / 32,
-        /*cb_id=*/tt::CBIndex::c_0,
-        "dispatched_buffer_scratch");
+    // // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
+    // detail::create_tensor_cb(
+    //     program,
+    //     sender_core_grid,
+    //     dispatched_buffer,
+    //     /*buffering_factor=*/hidden_size / 32,
+    //     /*cb_id=*/tt::CBIndex::c_0,
+    //     "dispatched_buffer_scratch");
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
         program,
@@ -189,24 +189,23 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_1,
         "dispatched_metadata_scratch");
-    // c_2: expert_token_counts (reader-only, full tensor)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        expert_token_counts,
-        /*buffering_factor=*/detail::get_num_pages(expert_token_counts),
-        /*cb_id=*/tt::CBIndex::c_2,
-        "expert_token_counts");
-
-    // c_17: 1-page CB on sender cores (for reader->compute signaling)
+    // c_2: expert_token_counts scratch on sender.
+    // Sized one extra page larger than the raw counter data so reader_combine can append
+    // its receive_buf_addr (get_write_ptr(c_18)) immediately after the counter pages before the
+    // multicast, giving idle cores a host-side-free way to discover the sender's receive buffer.
+    // Extra space is one full counter_page_size (not l1_alignment) to keep cb_size divisible by page_size.
     {
-        uint32_t signal_page_size = l1_alignment;
-        tt::tt_metal::CircularBufferConfig signal_cb_config =
-            tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_17, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_17, signal_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, signal_cb_config);
+        uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
+        uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
+        auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
+        uint32_t cb_size = (counter_pages + 1) * counter_page_size;
+        tt::tt_metal::CircularBufferConfig c2_config =
+            tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_2, data_format}})
+                .set_page_size(tt::CBIndex::c_2, counter_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, c2_config);
     }
-    // c_18: same size as c_0 (for compute untilized output)
+
+    // c_18: receive buffer for idle-core untilized data written back via NOC
     detail::create_tensor_cb(
         program,
         sender_core_grid,
@@ -333,10 +332,181 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     tt::tt_metal::KernelHandle zero_init_kernel_id = 0;
     std::vector<CoreCoord> zero_init_cores_vec;
     uint32_t zi_done_semaphore_id = 0;
-    uint32_t num_zero_init_cores = 0;
-    uint32_t total_zero_init_cores = 0;
     uint32_t pages_per_core = 0;
     uint32_t remainder_pages = 0;
+
+    // Find idle worker cores in the same row as sender cores — always needed for reader_untilize
+    uint32_t sender_row_y = sender_cores[0].y;
+    std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
+    std::vector<CoreCoord> idle_row_cores;
+    for (const auto& core : subdevice_cores) {
+        if (core.y == sender_row_y && !sender_core_set.contains(core)) {
+            idle_row_cores.push_back(core);
+        }
+    }
+    uint32_t num_idle_cores = static_cast<uint32_t>(idle_row_cores.size());
+    TT_FATAL(
+        num_idle_cores >= num_cores,
+        "Need at least {} idle cores (one per sender) in sender row {}, found {}; "
+        "subdevice must have more than {} cores per row",
+        num_cores,
+        sender_row_y,
+        num_idle_cores,
+        num_cores);
+
+    std::set<CoreRange> idle_ranges_set;
+    for (const auto& core : idle_row_cores) {
+        idle_ranges_set.insert(CoreRange(core));
+    }
+    CoreRangeSet idle_core_grid(idle_ranges_set);
+
+    // Compute NOC coordinates and multicast bounding box for idle cores
+    std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
+    for (const auto& core : idle_row_cores) {
+        auto noc_coord = mesh_device->virtual_core_from_logical_core(core, tt::CoreType::WORKER);
+        idle_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
+    }
+    uint32_t mcast_start_x = idle_noc_coords[0].first, mcast_end_x = idle_noc_coords[0].first;
+    uint32_t mcast_start_y = idle_noc_coords[0].second, mcast_end_y = idle_noc_coords[0].second;
+    for (const auto& [x, y] : idle_noc_coords) {
+        mcast_start_x = std::min(mcast_start_x, x);
+        mcast_end_x = std::max(mcast_end_x, x);
+        mcast_start_y = std::min(mcast_start_y, y);
+        mcast_end_y = std::max(mcast_end_y, y);
+    }
+
+    // counter_ready semaphore: created only on sender + idle cores so get_semaphore() returns
+    // the same L1 offset on both sides (sender writes to idle's copy, idle waits on its own)
+    std::set<CoreRange> sender_and_idle_ranges;
+    for (const auto& cr : sender_core_grid.ranges()) {
+        sender_and_idle_ranges.insert(cr);
+    }
+    for (const auto& cr : idle_core_grid.ranges()) {
+        sender_and_idle_ranges.insert(cr);
+    }
+    CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
+    auto counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    auto data_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    auto start_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+
+    // c_1 on idle cores: receives the full expert_token_counts multicast from sender.
+    // MUST be allocated BEFORE c_0 so that its L1 data-buffer address matches the sender's
+    // c_1 (dispatched_metadata) address.  The sender uses get_write_ptr(c_1_sender) as the
+    // multicast destination; if c_0 were allocated first here, idle c_1 would land 449 KB
+    // higher in L1 and the multicast would write into the wrong location, leaving the token
+    // counts as all-zeros and causing a hang (idle cores see 0 batches → send only the
+    // sentinel → sender waits on data_ready forever).
+    // One extra page larger than the raw counter data so the receive_buf_addr word appended at
+    // the end of the multicast payload lands within the allocated CB region.
+    // Extra space is one full counter_page_size (not l1_alignment) to keep cb_size divisible by page_size.
+    {
+        uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
+        uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
+        auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
+        uint32_t cb_size = (counter_pages + 1) * counter_page_size;
+        tt::tt_metal::CircularBufferConfig c1_idle_config =
+            tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
+                .set_page_size(tt::CBIndex::c_1, counter_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
+    }
+    // c_0 on idle cores: dispatched_buffer tiles, one token's worth (hidden_size/32 tiles)
+    // MUST be at index 0: pack_untilize_block calls llk_math_eltwise_unary_datacopy with
+    // operand=0 (Blackhole UnpackToDestEn=true path), so MATH reads unpack_src_format[0].
+    // Placing dispatched_buffer (bfloat16) here ensures the correct format is used.
+    // NOTE: c_0 is allocated after c_1 (see above) so that the multicast destination address
+    // matches the sender; the CB index (0) is independent of allocation order.
+    detail::create_tensor_cb(
+        program,
+        idle_core_grid,
+        dispatched_buffer,
+        /*buffering_factor=*/hidden_size / 32,
+        /*cb_id=*/tt::CBIndex::c_0,
+        "dispatched_buffer_idle");
+    // c_2 on idle cores: untilized output rows, one full batch (read_batch_size rows)
+    detail::create_tensor_cb(
+        program,
+        idle_core_grid,
+        output_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_2,
+        "untilize_idle");
+    // c_3 on idle cores: 1-page signal CB (reader->compute, mirrors c_17 on sender cores)
+    {
+        uint32_t signal_page_size = l1_alignment;
+        tt::tt_metal::CircularBufferConfig signal_cb_config =
+            tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_3, signal_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+    }
+
+    // counter_offset mirrors the constexpr calculation in reader_combine.cpp
+    uint32_t mesh_row_coord = linearized_mesh_coord / mesh_cols;
+    uint32_t mesh_col_coord = linearized_mesh_coord % mesh_cols;
+    uint32_t experts_per_dispatch_group = operation_attributes.experts_per_chip * mesh_rows;
+    uint32_t counter_offset =
+        mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
+
+    // Base compile-time args shared across all idle cores (indices 0-12).
+    // core_id (13) and num_idle_cores (14) are appended per-core; remaining fixed args follow at
+    // 15-16; TensorAccessorArgs follow at 17+.
+    // Wait — actual layout (matching reader_untilize.cpp):
+    //   0-10: shared base (below)
+    //   11: core_id          (appended per-core)
+    //   12: num_idle_cores   (appended per-core)
+    //   13: aligned_output_page_size
+    //   14: aligned_experts_tok_counter_page_size
+    //   15+: TensorAccessorArgs for dispatched_buffer
+    const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
+        static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
+        detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
+        operation_attributes.experts_per_chip,             // 2:  experts_per_chip
+        counter_offset,                                    // 3:  counter_offset
+        static_cast<uint32_t>(tt::CBIndex::c_0),           // 4:  cb_dispatched_buffer_id
+        static_cast<uint32_t>(tt::CBIndex::c_2),           // 5:  cb_untilize_id
+        (uint32_t)hidden_size,                             // 6:  hidden_size
+        read_batch_size,                                   // 7:  read_batch_size
+        static_cast<uint32_t>(tt::CBIndex::c_3),           // 8:  cb_signal_id
+        detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
+        (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
+    };
+
+    // Partition idle cores among senders so each sender owns an exclusive slice.
+    // This prevents multiple senders from racing on the same start_semaphore.
+    // Sender s owns idle cores [offset_s, offset_s + k_s).
+    // k_s = K_base + (s < K_extra ? 1 : 0) where K_base = num_idle_cores / num_cores.
+    uint32_t K_base = num_idle_cores / num_cores;
+    uint32_t K_extra = num_idle_cores % num_cores;
+
+    // Create one reader_untilize kernel instance per idle core with per-sender
+    // core_id and num_idle_cores baked in at compile time.
+    std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
+    reader_untilize_kernel_ids.reserve(num_idle_cores);
+
+    {
+        uint32_t global_idle_idx = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
+                auto per_core_args = reader_untilize_compile_time_args_base;
+                per_core_args.push_back(j);    // 11: core_id (relative to this sender's slice)
+                per_core_args.push_back(k_s);  // 12: num_idle_cores (per-sender slice size)
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));                  // 13
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));            // 14
+                tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);  // 15+
+
+                CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
+                reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+                    program,
+                    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
+                    "reader_untilize.cpp",
+                    single_idle_core,
+                    tt::tt_metal::DataMovementConfig{
+                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                        .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                        .compile_args = per_core_args}));
+            }
+        }
+    }
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
 
@@ -356,33 +526,10 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                 .set_page_size(tt::CBIndex::c_7, noc_max_burst_size);
         tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, zi_inline_cb_config);
 
-        // Find idle worker cores in the same row as sender cores
-        uint32_t sender_row_y = sender_cores[0].y;
-        std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
-        std::vector<CoreCoord> idle_row_cores;
-        for (const auto& core : subdevice_cores) {
-            if (core.y == sender_row_y && !sender_core_set.contains(core)) {
-                idle_row_cores.push_back(core);
-            }
-        }
-
-        num_zero_init_cores = idle_row_cores.size();
-        TT_FATAL(
-            num_zero_init_cores > 0,
-            "No idle cores found in sender row {} for zero-init; subdevice must have more than {} cores per row",
-            sender_row_y,
-            num_cores);
-        total_zero_init_cores = num_cores + num_zero_init_cores;
-
+        uint32_t total_zero_init_cores = num_cores + num_idle_cores;
         uint32_t total_output_pages = detail::get_num_pages(output_tensor);
         pages_per_core = total_output_pages / total_zero_init_cores;
         remainder_pages = total_output_pages % total_zero_init_cores;
-
-        std::set<CoreRange> idle_ranges;
-        for (const auto& core : idle_row_cores) {
-            idle_ranges.insert(CoreRange(core));
-        }
-        CoreRangeSet idle_core_grid(idle_ranges);
 
         tt::tt_metal::CircularBufferConfig zi_idle_cb_config =
             tt::tt_metal::CircularBufferConfig(noc_max_burst_size, {{tt::CBIndex::c_6, tt::DataFormat::UInt8}})
@@ -412,24 +559,33 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         zero_init_cores_vec = idle_row_cores;
     }
 
-    // Reader gets its own compile-time args: shared base + zero-init args appended at the end
-    std::vector<uint32_t> reader_compile_time_args = compile_time_args;
+    // Reader compile-time args base (without num_idle_cores — that is per-sender and appended below).
+    std::vector<uint32_t> reader_compile_time_args_base = compile_time_args;
     if (init_zeros) {
-        reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_7));  // zi_cb_id
-        reader_compile_time_args.push_back(num_zero_init_cores);                      // num_idle_cores
+        reader_compile_time_args_base.push_back(static_cast<uint32_t>(tt::CBIndex::c_7));  // zi_cb_id
     }
-    reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_17));  // cb_signal_id
-    reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+    // num_idle_cores and cb_untilize_id are appended per-sender below.
 
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp",
-        sender_core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-            .compile_args = reader_compile_time_args,
-            .defines = reader_defines});
+    // Create one reader_combine kernel per sender so each can have its own per-sender num_idle_cores
+    // baked in at compile time (avoids a VLA whose size would vary across sender cores).
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    reader_kernel_ids.reserve(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+        auto per_sender_compile_args = reader_compile_time_args_base;
+        per_sender_compile_args.push_back(k_s);                                       // num_idle_cores for sender s
+        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+        CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
+        reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp",
+            single_sender_core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                .compile_args = per_sender_compile_args,
+                .defines = reader_defines}));
+    }
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -441,19 +597,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .compile_args = compile_time_args,
             .defines = writer_defines});
 
-    // Compute kernel on sender cores only (not on zero-init idle cores)
-    [[maybe_unused]] tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
+    // Compute kernel on idle cores (c_3 signal, c_2 untilize out, c_0 tile in)
+    [[maybe_unused]] tt::tt_metal::KernelHandle compute_idle_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
         "untilize_combine.cpp",
-        sender_core_grid,
+        idle_core_grid,
         tt::tt_metal::ComputeConfig{
             .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_17),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id
-                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                static_cast<uint32_t>(hidden_size),        // hidden_size
-                static_cast<uint32_t>(read_batch_size),    // read_batch_size
+                static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_signal_id
+                static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_untilize_id
+                static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_in_id (must be 0: MATH reads unpack_src_format[0])
+                static_cast<uint32_t>(hidden_size),       // hidden_size
+                static_cast<uint32_t>(read_batch_size),   // read_batch_size
             }});
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
@@ -465,7 +621,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     // Set runtime args for hybrid idle row cores
     if (init_zeros) {
-        for (uint32_t idle_idx = 0; idle_idx < num_zero_init_cores; idle_idx++) {
+        for (uint32_t idle_idx = 0; idle_idx < num_idle_cores; idle_idx++) {
             uint32_t row_idx = num_cores + idle_idx;
             uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
             uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
@@ -507,6 +663,22 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             reader_runtime_args.push_back(sender_page_start);
             reader_runtime_args.push_back(sender_page_end);
             reader_runtime_args.push_back(zi_done_semaphore_id);
+        }
+        reader_runtime_args.push_back(counter_ready_semaphore_id);
+        reader_runtime_args.push_back(mcast_start_x);
+        reader_runtime_args.push_back(mcast_start_y);
+        reader_runtime_args.push_back(mcast_end_x);
+        reader_runtime_args.push_back(mcast_end_y);
+        reader_runtime_args.push_back(data_ready_semaphore_id);
+        reader_runtime_args.push_back(start_semaphore_id);
+        // Only pass NOC coords of idle cores assigned to this sender (slice [offset_s, offset_s+k_s))
+        {
+            uint32_t k_s = K_base + (core_idx < K_extra ? 1 : 0);
+            uint32_t offset_s = core_idx * K_base + std::min(core_idx, K_extra);
+            for (uint32_t j = 0; j < k_s; j++) {
+                reader_runtime_args.push_back(idle_noc_coords[offset_s + j].first);
+                reader_runtime_args.push_back(idle_noc_coords[offset_s + j].second);
+            }
         }
 
         std::vector<uint32_t> writer_runtime_args = {
@@ -557,21 +729,51 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             }
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, sender_core, reader_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[core_idx], sender_core, reader_runtime_args);
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
         core_idx++;
     }
 
+    // Set runtime args for idle cores using per-sender NOC coords and expert range.
+    {
+        uint32_t global_idle_idx = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            const auto& [sx, sy] = sender_noc_coords[s];
+            uint32_t expert_start = s * experts_per_core_range;
+            uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
+                tt::tt_metal::SetRuntimeArgs(
+                    program,
+                    reader_untilize_kernel_ids[global_idle_idx],
+                    idle_row_cores[global_idle_idx],
+                    {counter_ready_semaphore_id,
+                     data_ready_semaphore_id,
+                     sx,
+                     sy,
+                     start_semaphore_id,
+                     dispatched_buffer.buffer()->address(),
+                     expert_start,
+                     expert_end});
+            }
+        }
+    }
+
     return {
         std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
+        {.reader_kernel_ids = std::move(reader_kernel_ids),
          .writer_kernel_id = writer_kernel_id,
          .zero_init_kernel_id = zero_init_kernel_id,
+         .reader_untilize_kernel_ids = std::move(reader_untilize_kernel_ids),
          .cores = sender_cores,
          .zero_init_cores = zero_init_cores_vec,
+         .idle_cores = idle_row_cores,
          .init_semaphore = init_semaphore,
          .zero_init_semaphore_id = zero_init_semaphore_id,
-         .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id}};
+         .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id,
+         .counter_ready_semaphore_id = counter_ready_semaphore_id,
+         .data_ready_semaphore_id = data_ready_semaphore_id,
+         .start_semaphore_id = start_semaphore_id}};
 }
 
 void CombineProgramFactory::override_runtime_arguments(
@@ -582,8 +784,10 @@ void CombineProgramFactory::override_runtime_arguments(
     for (auto& [range, program] : cached_workload.workload.get_programs()) {
         const auto& shared_variables = cached_workload.shared_variables.at(range);
 
-        for (const auto& core : shared_variables.cores) {
-            auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_id, core);
+        for (size_t s = 0; s < shared_variables.cores.size(); s++) {
+            const auto& core = shared_variables.cores[s];
+            auto& reader_runtime_args =
+                tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_ids[s], core);
             auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.writer_kernel_id, core);
 
             reader_runtime_args.at(0) = tensor_args.dispatched_buffer.buffer()->address();
@@ -601,6 +805,12 @@ void CombineProgramFactory::override_runtime_arguments(
         for (const auto& core : shared_variables.zero_init_cores) {
             auto& zi_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.zero_init_kernel_id, core);
             zi_runtime_args.at(0) = tensor_return_value.buffer()->address();
+        }
+
+        for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
+            auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
+                program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
+            idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -171,14 +171,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
 
-    constexpr uint32_t read_batch_size = 8;  // matches BH DRAM bank count for full bandwidth utilization
+    constexpr uint32_t read_batch_size = 32;
 
     // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
         program,
         sender_core_grid,
         dispatched_buffer,
-        /*buffering_factor=*/read_batch_size,
+        /*buffering_factor=*/hidden_size / 32,
         /*cb_id=*/tt::CBIndex::c_0,
         "dispatched_buffer_scratch");
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
@@ -198,8 +198,24 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         /*cb_id=*/tt::CBIndex::c_2,
         "expert_token_counts");
 
-    // c_3, c_4: reader→writer CBs for (route_info, output) per remote entry.
-    // The reader pushes both per entry in lockstep, so small buffering (2) suffices.
+    // c_17: 1-page CB on sender cores (for reader->compute signaling)
+    {
+        uint32_t signal_page_size = l1_alignment;
+        tt::tt_metal::CircularBufferConfig signal_cb_config =
+            tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_17, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_17, signal_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, signal_cb_config);
+    }
+    // c_18: same size as c_0 (for compute untilized output)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        output_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_18,
+        "untilized_output");
+
+    // c_3: route_info (reader->writer, 4 x uint32_t per entry)
     {
         constexpr uint32_t rw_buffering = 2;
 
@@ -402,6 +418,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_7));  // zi_cb_id
         reader_compile_time_args.push_back(num_zero_init_cores);                      // num_idle_cores
     }
+    reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_17));  // cb_signal_id
+    reader_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
 
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -422,6 +440,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
             .compile_args = compile_time_args,
             .defines = writer_defines});
+
+    // Compute kernel on sender cores only (not on zero-init idle cores)
+    [[maybe_unused]] tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
+        "untilize_combine.cpp",
+        sender_core_grid,
+        tt::tt_metal::ComputeConfig{
+            .compile_args = {
+                static_cast<uint32_t>(tt::CBIndex::c_17),  // cb_signal_id
+                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id
+                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+                static_cast<uint32_t>(hidden_size),        // hidden_size
+                static_cast<uint32_t>(read_batch_size),    // read_batch_size
+            }});
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -156,27 +156,50 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t num_cores = effective_num_links;
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    auto sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
-        subdevice_cores.at(0), num_cores, worker_core_range_set, true);
-    std::vector<CoreCoord> sender_cores = corerange_to_cores(sender_core_grid);
-    TT_FATAL(sender_cores.size() == num_cores, "Expected {} sender cores, got {}", num_cores, sender_cores.size());
-
-    // Step 2: Collect idle cores in the SAME physical row as sender_cores[0]
-    uint32_t sender_row_y_phys =
-        (uint32_t)mesh_device->virtual_core_from_logical_core(sender_cores[0], tt::CoreType::WORKER).y;
-    std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
-    std::vector<CoreCoord> same_row_idle;
+    // Interleaved layout: [sender0, idle0_0..idle0_{k0-1}, sender1, idle1_0..idle1_{k1-1}, ...]
+    // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
+    uint32_t sender_row_y = subdevice_cores.at(0).y;
+    std::vector<CoreCoord> all_row_cores;
     for (const auto& core : subdevice_cores) {
-        if (sender_core_set.count(core)) {
-            continue;
+        if (core.y == sender_row_y) {
+            all_row_cores.push_back(core);
         }
-        auto noc = mesh_device->virtual_core_from_logical_core(core, tt::CoreType::WORKER);
-        if ((uint32_t)noc.y == sender_row_y_phys) {
-            same_row_idle.push_back(core);
+    }
+    std::sort(
+        all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) { return a.x < b.x; });
+
+    uint32_t total_row_cores = static_cast<uint32_t>(all_row_cores.size());
+    TT_FATAL(
+        total_row_cores > num_cores,
+        "Same-row has only {} cores for {} senders — need at least one idle core per sender",
+        total_row_cores,
+        num_cores);
+
+    // Divide total_row_cores into num_cores groups: last (total_row_cores % num_cores) groups get +1.
+    // Within each group: first core = sender, remaining = that sender's idle cores.
+    uint32_t base_group_size = total_row_cores / num_cores;
+    uint32_t extra_groups = total_row_cores % num_cores;
+
+    std::vector<CoreCoord> sender_cores;
+    sender_cores.reserve(num_cores);
+    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
+    std::vector<CoreCoord> all_idle_cores;
+    std::vector<uint32_t> idle_sender_map;
+
+    {
+        uint32_t pos = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
+            sender_cores.push_back(all_row_cores[pos++]);
+            for (uint32_t j = 1; j < group_size; j++, pos++) {
+                sender_idle_groups[s].push_back(all_row_cores[pos]);
+                all_idle_cores.push_back(all_row_cores[pos]);
+                idle_sender_map.push_back(s);
+            }
         }
     }
 
-    uint32_t num_idle_cores = static_cast<uint32_t>(same_row_idle.size());
+    uint32_t num_idle_cores = static_cast<uint32_t>(all_idle_cores.size());
     TT_FATAL(
         num_idle_cores >= num_cores,
         "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
@@ -185,24 +208,13 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t K_base = num_idle_cores / num_cores;
     uint32_t K_extra = num_idle_cores % num_cores;
 
-    // sender_idle_groups[s] = dedicated idle cores for sender s (all in same physical row)
-    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
-    std::vector<CoreCoord> all_idle_cores;
-    all_idle_cores.reserve(num_idle_cores);
-    // idle_sender_map[j] = which sender owns flat idle-core index j
-    std::vector<uint32_t> idle_sender_map;
-    idle_sender_map.reserve(num_idle_cores);
-    {
-        uint32_t pos = 0;
-        for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
-            for (uint32_t j = 0; j < k_s; j++, pos++) {
-                sender_idle_groups[s].push_back(same_row_idle[pos]);
-                all_idle_cores.push_back(same_row_idle[pos]);
-                idle_sender_map.push_back(s);
-            }
-        }
+    // Build sender_core_grid from selected sender cores
+    std::set<CoreRange> sender_ranges_set;
+    for (const auto& sc : sender_cores) {
+        sender_ranges_set.insert(CoreRange(sc));
     }
+    auto sender_core_grid = CoreRangeSet(sender_ranges_set);
+    TT_FATAL(sender_cores.size() == num_cores, "Expected {} sender cores, got {}", num_cores, sender_cores.size());
 
     log_debug(
         tt::LogOp,
@@ -506,7 +518,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     {
         uint32_t global_idle_idx = 0;
         for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
                 auto per_core_args = reader_untilize_compile_time_args_base;
                 per_core_args.push_back(j);    // 11: core_id (local to sender s's group)
@@ -594,7 +606,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
         auto per_sender_compile_args = reader_compile_time_args_base;
         per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender k_s)
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -157,7 +157,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t num_cores = effective_num_links;
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    // Interleaved layout: [sender0, idle0_0..idle0_{k0-1}, sender1, idle1_0..idle1_{k1-1}, ...]
+    // Core layout depends on dispatched_buffer layout:
+    //   TILE_LAYOUT: sender in the middle of its idle group to reduce NOC congestion.
+    //     Cores are divided into groups, sender placed at group_size/2:
+    //     [idle0_0..idle0_{m-1}, sender0, idle0_m..idle0_{k0-1}, ..., sender1, ...]
+    //   ROW_MAJOR: first num_cores cores are senders, remaining are idle (for zero-init only).
+    //     [sender0, sender1, idle0, idle1, idle2, ...]
     // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
     uint32_t sender_row_y = subdevice_cores.at(0).y;
     std::vector<CoreCoord> all_row_cores;
@@ -176,27 +181,44 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         total_row_cores,
         num_cores);
 
-    // Divide total_row_cores into num_cores groups: last (total_row_cores % num_cores) groups get +1.
-    // Within each group: first core = sender, remaining = that sender's idle cores.
-    uint32_t base_group_size = total_row_cores / num_cores;
-    uint32_t extra_groups = total_row_cores % num_cores;
-
     std::vector<CoreCoord> sender_cores;
     sender_cores.reserve(num_cores);
     std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
     std::vector<CoreCoord> all_idle_cores;
     std::vector<uint32_t> idle_sender_map;
 
-    {
+    if (is_tile_layout) {
+        // TILE_LAYOUT: divide into groups, sender in the middle of each group
+        uint32_t base_group_size = total_row_cores / num_cores;
+        uint32_t extra_groups = total_row_cores % num_cores;
+
         uint32_t pos = 0;
         for (uint32_t s = 0; s < num_cores; s++) {
             uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
-            sender_cores.push_back(all_row_cores[pos++]);
-            for (uint32_t j = 1; j < group_size; j++, pos++) {
-                sender_idle_groups[s].push_back(all_row_cores[pos]);
-                all_idle_cores.push_back(all_row_cores[pos]);
-                idle_sender_map.push_back(s);
+            uint32_t sender_offset = group_size / 2;
+
+            for (uint32_t j = 0; j < group_size; j++) {
+                if (j == sender_offset) {
+                    sender_cores.push_back(all_row_cores[pos]);
+                } else {
+                    sender_idle_groups[s].push_back(all_row_cores[pos]);
+                    all_idle_cores.push_back(all_row_cores[pos]);
+                    idle_sender_map.push_back(s);
+                }
+                pos++;
             }
+        }
+    } else {
+        // ROW_MAJOR: first num_cores cores are senders, all remaining are idle
+        for (uint32_t s = 0; s < num_cores; s++) {
+            sender_cores.push_back(all_row_cores[s]);
+        }
+        for (uint32_t i = num_cores; i < total_row_cores; i++) {
+            // Distribute idle cores round-robin across senders (for zero-init)
+            uint32_t s = (i - num_cores) % num_cores;
+            sender_idle_groups[s].push_back(all_row_cores[i]);
+            all_idle_cores.push_back(all_row_cores[i]);
+            idle_sender_map.push_back(s);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -156,17 +156,72 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t num_cores = effective_num_links;
     uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    auto sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+    // Step 1: Select sender cores using num_cores_to_corerangeset_in_subcoregrids.
+    // This picks the first num_cores from the subdevice in row-major order, keeping
+    // senders physically adjacent and (typically) in the same physical row.
+    CoreRangeSet sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
         subdevice_cores.at(0), num_cores, worker_core_range_set, true);
     std::vector<CoreCoord> sender_cores = corerange_to_cores(sender_core_grid);
+    TT_FATAL(sender_cores.size() == num_cores, "Expected {} sender cores, got {}", num_cores, sender_cores.size());
+
+    // Step 2: Collect idle cores in the SAME physical row as sender_cores[0].
+    // NOC multicast requires a single-row bounding box: if idle cores span multiple
+    // physical rows the box widens to a rectangle that includes non-subdevice cores
+    // (Ethernet tiles, other workers), causing noc_async_write_barrier() to hang
+    // because the hardware waits for ACKs from cores that can't respond properly.
+    uint32_t sender_row_y_phys =
+        (uint32_t)mesh_device->virtual_core_from_logical_core(sender_cores[0], tt::CoreType::WORKER).y;
+    std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
+    std::vector<CoreCoord> same_row_idle;
+    for (const auto& core : subdevice_cores) {
+        if (sender_core_set.count(core)) {
+            continue;
+        }
+        auto noc = mesh_device->virtual_core_from_logical_core(core, tt::CoreType::WORKER);
+        if ((uint32_t)noc.y == sender_row_y_phys) {
+            same_row_idle.push_back(core);
+        }
+    }
+
+    uint32_t num_idle_cores = static_cast<uint32_t>(same_row_idle.size());
+    TT_FATAL(
+        num_idle_cores >= num_cores,
+        "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
+        num_idle_cores,
+        num_cores);
+    uint32_t K_base = num_idle_cores / num_cores;
+    uint32_t K_extra = num_idle_cores % num_cores;
+
+    // sender_idle_groups[s] = dedicated idle cores for sender s (all in same physical row)
+    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
+    std::vector<CoreCoord> all_idle_cores;
+    all_idle_cores.reserve(num_idle_cores);
+    // idle_sender_map[j] = which sender owns flat idle-core index j
+    std::vector<uint32_t> idle_sender_map;
+    idle_sender_map.reserve(num_idle_cores);
+    {
+        uint32_t pos = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            for (uint32_t j = 0; j < k_s; j++, pos++) {
+                sender_idle_groups[s].push_back(same_row_idle[pos]);
+                all_idle_cores.push_back(same_row_idle[pos]);
+                idle_sender_map.push_back(s);
+            }
+        }
+    }
 
     log_debug(
         tt::LogOp,
-        "Combine program: hidden_size: {} num_cores: {} experts_per_core_range: {} cores: {}",
+        "Combine program: hidden_size: {} num_cores: {} experts_per_core_range: {} "
+        "sender_cores: {} num_idle_cores: {} K_base: {} K_extra: {}",
         hidden_size,
         num_cores,
         experts_per_core_range,
-        sender_cores);
+        sender_cores,
+        num_idle_cores,
+        K_base,
+        K_extra);
 
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
@@ -198,9 +253,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
         auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        // Need num_cores extra words (one receive_buf_addr per sender) after the counter data.
-        uint32_t recv_buf_extra_bytes = num_cores * sizeof(uint32_t);
-        uint32_t extra_pages = std::max(1u, tt::div_up(recv_buf_extra_bytes, counter_page_size));
+        // One extra page holds the single receive_buf_addr (uint32) appended after counter data.
+        uint32_t extra_pages = 1;
         uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
         tt::tt_metal::CircularBufferConfig c2_config =
             tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_2, data_format}})
@@ -338,45 +392,39 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t pages_per_core = 0;
     uint32_t remainder_pages = 0;
 
-    // Find idle worker cores in the same row as sender cores — always needed for reader_untilize
-    uint32_t sender_row_y = sender_cores[0].y;
-    std::set<CoreCoord> sender_core_set(sender_cores.begin(), sender_cores.end());
-    std::vector<CoreCoord> idle_row_cores;
-    for (const auto& core : subdevice_cores) {
-        if (core.y == sender_row_y && !sender_core_set.contains(core)) {
-            idle_row_cores.push_back(core);
+    // idle_row_cores: all same-row idle cores, ordered by sender group then by x.
+    std::vector<CoreCoord>& idle_row_cores = all_idle_cores;
+
+    // Per-sender multicast bounding boxes and idle NOC coordinates.
+    // Each sender multicasts only to its own dedicated idle group so both senders
+    // can run their multicast in parallel without interfering.
+    struct SenderMcastCfg {
+        uint32_t mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y;
+        std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
+    };
+    std::vector<SenderMcastCfg> sender_mcast_cfgs(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        TT_FATAL(!sender_idle_groups[s].empty(), "Sender {} has no idle cores assigned", s);
+        auto& cfg = sender_mcast_cfgs[s];
+        auto first_noc = mesh_device->virtual_core_from_logical_core(sender_idle_groups[s][0], tt::CoreType::WORKER);
+        cfg.mcast_start_x = cfg.mcast_end_x = first_noc.x;
+        cfg.mcast_start_y = cfg.mcast_end_y = first_noc.y;
+        for (const auto& ic : sender_idle_groups[s]) {
+            auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
+            cfg.mcast_start_x = std::min(cfg.mcast_start_x, (uint32_t)noc.x);
+            cfg.mcast_end_x = std::max(cfg.mcast_end_x, (uint32_t)noc.x);
+            cfg.mcast_start_y = std::min(cfg.mcast_start_y, (uint32_t)noc.y);
+            cfg.mcast_end_y = std::max(cfg.mcast_end_y, (uint32_t)noc.y);
+            cfg.idle_noc_coords.emplace_back((uint32_t)noc.x, (uint32_t)noc.y);
         }
     }
-    uint32_t num_idle_cores = static_cast<uint32_t>(idle_row_cores.size());
-    TT_FATAL(
-        num_idle_cores >= num_cores,
-        "Need at least {} idle cores (one per sender) in sender row {}, found {}; "
-        "subdevice must have more than {} cores per row",
-        num_cores,
-        sender_row_y,
-        num_idle_cores,
-        num_cores);
 
+    // Build idle CoreRangeSet
     std::set<CoreRange> idle_ranges_set;
     for (const auto& core : idle_row_cores) {
         idle_ranges_set.insert(CoreRange(core));
     }
     CoreRangeSet idle_core_grid(idle_ranges_set);
-
-    // Compute NOC coordinates and multicast bounding box for idle cores
-    std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
-    for (const auto& core : idle_row_cores) {
-        auto noc_coord = mesh_device->virtual_core_from_logical_core(core, tt::CoreType::WORKER);
-        idle_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
-    }
-    uint32_t mcast_start_x = idle_noc_coords[0].first, mcast_end_x = idle_noc_coords[0].first;
-    uint32_t mcast_start_y = idle_noc_coords[0].second, mcast_end_y = idle_noc_coords[0].second;
-    for (const auto& [x, y] : idle_noc_coords) {
-        mcast_start_x = std::min(mcast_start_x, x);
-        mcast_end_x = std::max(mcast_end_x, x);
-        mcast_start_y = std::min(mcast_start_y, y);
-        mcast_end_y = std::max(mcast_end_y, y);
-    }
 
     // counter_ready semaphore: created only on sender + idle cores so get_semaphore() returns
     // the same L1 offset on both sides (sender writes to idle's copy, idle waits on its own)
@@ -397,21 +445,16 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
     }
 
-    // c_1 on idle cores: receives the full expert_token_counts multicast from sender.
-    // MUST be allocated BEFORE c_0 so that its L1 data-buffer address matches the sender's
-    // c_1 (dispatched_metadata) address.  The sender uses get_write_ptr(c_1_sender) as the
-    // multicast destination; if c_0 were allocated first here, idle c_1 would land 449 KB
-    // higher in L1 and the multicast would write into the wrong location, leaving the token
-    // counts as all-zeros and causing a hang (idle cores see 0 batches → send only the
-    // sentinel → sender waits on data_ready forever).
-    // Extra pages after the counter data hold one receive_buf_addr per sender core so idle
-    // cores can discover each sender's receive buffer from the multicast payload alone.
+    // c_1 on idle cores: receives the expert_token_counts multicast from the owning sender.
+    // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
+    // The sender uses get_write_ptr(c_1_sender) as the multicast destination; if c_0 were
+    // allocated first here it would consume ~3 MB causing c_1 to wrap and corrupt the mailbox.
+    // One extra page holds the single receive_buf_addr that each sender appends before multicasting.
     {
         uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
         uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
         auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        uint32_t recv_buf_extra_bytes = num_cores * sizeof(uint32_t);
-        uint32_t extra_pages = std::max(1u, tt::div_up(recv_buf_extra_bytes, counter_page_size));
+        uint32_t extra_pages = 1;
         uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
         tt::tt_metal::CircularBufferConfig c1_idle_config =
             tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
@@ -457,12 +500,11 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
     //   0-10: shared base (below)
-    //   11:   core_id (global index 0..num_idle_cores-1, appended per-core)
-    //   12:   num_idle_cores (total, appended per-core)
+    //   11:   core_id   — local index within sender s's idle group (0..k_s-1)
+    //   12:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
     //   13:   aligned_output_page_size
     //   14:   aligned_experts_tok_counter_page_size
-    //   15:   num_senders (= num_cores)
-    //   16+:  TensorAccessorArgs for dispatched_buffer
+    //   15+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
     const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
         static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
         detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -477,31 +519,38 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
     };
 
-    // All idle cores cover the full expert range; the kernel routes each expert to the
-    // correct sender via sender_idx = local_expert / experts_per_sender.
-    // core_id is a global index for round-robin batch assignment across all idle cores.
+    // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
+    // core_id is LOCAL within the sender's group (0..k_s-1) for round-robin batch assignment.
+    // num_idle_cores baked in as k_s so the kernel only considers its own group.
+    // No num_senders arg — each kernel is bound to a single sender.
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     reader_untilize_kernel_ids.reserve(num_idle_cores);
 
-    for (uint32_t j = 0; j < num_idle_cores; j++) {
-        auto per_core_args = reader_untilize_compile_time_args_base;
-        per_core_args.push_back(j);                                                   // 11: core_id (global)
-        per_core_args.push_back(num_idle_cores);                                      // 12: num_idle_cores (total)
-        per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 13
-        per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 14
-        per_core_args.push_back(num_cores);                                           // 15: num_senders
-        tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);  // 16+
+    {
+        uint32_t global_idle_idx = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
+            for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
+                auto per_core_args = reader_untilize_compile_time_args_base;
+                per_core_args.push_back(j);    // 11: core_id (local to sender s's group)
+                per_core_args.push_back(k_s);  // 12: num_idle_cores (per-sender)
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 13
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 14
+                // 15+: TensorAccessorArgs (no num_senders — single-sender kernel)
+                tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);
 
-        CoreRangeSet single_idle_core({CoreRange(idle_row_cores[j])});
-        reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
-            "reader_untilize.cpp",
-            single_idle_core,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-                .compile_args = per_core_args}));
+                CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});
+                reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+                    program,
+                    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
+                    "reader_untilize.cpp",
+                    single_idle_core,
+                    tt::tt_metal::DataMovementConfig{
+                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                        .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                        .compile_args = per_core_args}));
+            }
+        }
     }
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
@@ -537,7 +586,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         uint32_t output_aligned_page_size = detail::get_aligned_page_size(output_tensor);
         std::vector<uint32_t> zi_compile_time_args = {
             output_aligned_page_size,
-            num_cores,
+            1,  // num_sender_cores = 1: each idle core signals only its owning sender
             static_cast<uint32_t>(tt::CBIndex::c_6),
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(zi_compile_time_args);
@@ -562,13 +611,15 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
     // num_idle_cores and cb_untilize_id are appended per-sender below.
 
-    // Create one reader_combine kernel per sender so each can have its own per-sender num_idle_cores
-    // baked in at compile time (avoids a VLA whose size would vary across sender cores).
+    // One reader_combine kernel per sender with k_s (per-sender idle count) baked in as
+    // num_idle_cores.  The VLA idle_start_noc_addrs[num_idle_cores] is sized exactly right
+    // and the sender only round-robins across its own k_s dedicated idle cores.
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
+        uint32_t k_s = K_base + (s < K_extra ? 1 : 0);
         auto per_sender_compile_args = reader_compile_time_args_base;
-        per_sender_compile_args.push_back(num_idle_cores);                            // num_idle_cores (all idle cores)
+        per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender k_s)
         per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
@@ -621,16 +672,16 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
             uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
 
+            // Each idle core signals only its owning sender (num_sender_cores CT arg = 1)
+            uint32_t owning_sender = idle_sender_map[idle_idx];
             std::vector<uint32_t> zi_runtime_args = {
                 output_tensor.buffer()->address(),
                 page_start,
                 page_end,
                 zi_done_semaphore_id,
+                sender_noc_coords[owning_sender].first,
+                sender_noc_coords[owning_sender].second,
             };
-            for (const auto& [noc_x, noc_y] : sender_noc_coords) {
-                zi_runtime_args.push_back(noc_x);
-                zi_runtime_args.push_back(noc_y);
-            }
 
             tt::tt_metal::SetRuntimeArgs(program, zero_init_kernel_id, zero_init_cores_vec[idle_idx], zi_runtime_args);
         }
@@ -659,17 +710,19 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             reader_runtime_args.push_back(sender_page_end);
             reader_runtime_args.push_back(zi_done_semaphore_id);
         }
+        // Multicast targets only this sender's dedicated idle group
+        const auto& mcast_cfg = sender_mcast_cfgs[core_idx];
         reader_runtime_args.push_back(counter_ready_semaphore_id);
-        reader_runtime_args.push_back(mcast_start_x);
-        reader_runtime_args.push_back(mcast_start_y);
-        reader_runtime_args.push_back(mcast_end_x);
-        reader_runtime_args.push_back(mcast_end_y);
+        reader_runtime_args.push_back(mcast_cfg.mcast_start_x);
+        reader_runtime_args.push_back(mcast_cfg.mcast_start_y);
+        reader_runtime_args.push_back(mcast_cfg.mcast_end_x);
+        reader_runtime_args.push_back(mcast_cfg.mcast_end_y);
         reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
         reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
-        // Pass NOC coords of ALL idle cores — all idle cores now handle all experts
-        for (uint32_t j = 0; j < num_idle_cores; j++) {
-            reader_runtime_args.push_back(idle_noc_coords[j].first);
-            reader_runtime_args.push_back(idle_noc_coords[j].second);
+        // Pass NOC coords of only this sender's k_s dedicated idle cores
+        for (const auto& [noc_x, noc_y] : mcast_cfg.idle_noc_coords) {
+            reader_runtime_args.push_back(noc_x);
+            reader_runtime_args.push_back(noc_y);
         }
 
         std::vector<uint32_t> writer_runtime_args = {
@@ -725,21 +778,23 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         core_idx++;
     }
 
-    // Set runtime args for idle cores.  All idle cores cover the full expert range; the kernel
-    // determines the owning sender per expert via sender_idx = local_expert / experts_per_sender.
-    // Layout: counter_ready_sem, [data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s]]×num_senders,
-    //         dispatched_buffer_addr, expert_start=0, expert_end=experts_per_chip
+    // Set runtime args for idle cores.  Each idle core is bound to its owning sender s.
+    // Layout: counter_ready_sem, data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s],
+    //         dispatched_buffer_addr, expert_start, expert_end
     for (uint32_t j = 0; j < num_idle_cores; j++) {
-        std::vector<uint32_t> idle_rt_args = {counter_ready_semaphore_id};
-        for (uint32_t s = 0; s < num_cores; s++) {
-            idle_rt_args.push_back(data_ready_semaphore_ids[s]);
-            idle_rt_args.push_back(sender_noc_coords[s].first);
-            idle_rt_args.push_back(sender_noc_coords[s].second);
-            idle_rt_args.push_back(start_semaphore_ids[s]);
-        }
-        idle_rt_args.push_back(dispatched_buffer.buffer()->address());
-        idle_rt_args.push_back(0);                                      // expert_start = 0
-        idle_rt_args.push_back(operation_attributes.experts_per_chip);  // expert_end
+        uint32_t s = idle_sender_map[j];
+        uint32_t expert_start = s * experts_per_core_range;
+        uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+        std::vector<uint32_t> idle_rt_args = {
+            counter_ready_semaphore_id,
+            data_ready_semaphore_ids[s],
+            sender_noc_coords[s].first,
+            sender_noc_coords[s].second,
+            start_semaphore_ids[s],
+            dispatched_buffer.buffer()->address(),
+            expert_start,
+            expert_end,
+        };
         tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
     }
 
@@ -756,7 +811,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
          .zero_init_semaphore_id = zero_init_semaphore_id,
          .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id,
          .counter_ready_semaphore_id = counter_ready_semaphore_id,
-         .num_senders = num_cores,
          .data_ready_semaphore_ids = std::move(data_ready_semaphore_ids),
          .start_semaphore_ids = std::move(start_semaphore_ids)}};
 }
@@ -795,9 +849,9 @@ void CombineProgramFactory::override_runtime_arguments(
         for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
             auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
                 program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-            // dispatched_buffer_addr sits at index 1 + num_senders*4:
-            // index 0 = counter_ready_sem, then num_senders groups of {data_ready_sem, noc_x, noc_y, start_sem}
-            idle_rt_args.at(1 + shared_variables.num_senders * 4) = tensor_args.dispatched_buffer.buffer()->address();
+            // RT layout: [0:counter_ready_sem, 1:data_ready_sem, 2:noc_x, 3:noc_y, 4:start_sem,
+            //             5:dispatched_buffer_addr, 6:expert_start, 7:expert_end]
+            idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -465,11 +465,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
     }
     // c_0 on idle cores: dispatched_buffer tiles
+    // cb_factor reduces CB size to fit L1: Blackhole has more L1, Wormhole needs 4x reduction
+    uint32_t cb_factor;
+    {
+        const auto arch = mesh_device->arch();
+        if (arch == tt::ARCH::BLACKHOLE) {
+            cb_factor = 1;
+        } else {
+            cb_factor = 4;  // Wormhole_B0 and others
+        }
+    }
     detail::create_tensor_cb(
         program,
         idle_core_grid,
         dispatched_buffer,
-        /*buffering_factor=*/hidden_size / 32,
+        /*buffering_factor=*/hidden_size / (32 * cb_factor),
         /*cb_id=*/tt::CBIndex::c_0,
         "dispatched_buffer_idle");
     // c_2 on idle cores: untilized output rows, one full batch (read_batch_size rows)
@@ -497,12 +507,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
 
     // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
-    //   0-10: shared base (below)
-    //   11:   core_id   — local index within sender s's idle group (0..k_s-1)
-    //   12:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
-    //   13:   aligned_output_page_size
-    //   14:   aligned_experts_tok_counter_page_size
-    //   15+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
+    //   0-11: shared base (below, includes cb_factor at index 11)
+    //   12:   core_id   — local index within sender s's idle group (0..k_s-1)
+    //   13:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
+    //   14:   aligned_output_page_size
+    //   15:   aligned_experts_tok_counter_page_size
+    //   16+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
     const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
         static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
         detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -515,6 +525,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         static_cast<uint32_t>(tt::CBIndex::c_3),           // 8:  cb_signal_id
         detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
         (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
+        cb_factor,                                         // 11: cb_factor
     };
 
     // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
@@ -530,11 +541,11 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
             for (uint32_t j = 0; j < k_s; j++, global_idle_idx++) {
                 auto per_core_args = reader_untilize_compile_time_args_base;
-                per_core_args.push_back(j);    // 11: core_id (local to sender s's group)
-                per_core_args.push_back(k_s);  // 12: num_idle_cores (per-sender)
-                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 13
-                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 14
-                // 15+: TensorAccessorArgs (no num_senders — single-sender kernel)
+                per_core_args.push_back(j);    // 12: core_id (local to sender s's group)
+                per_core_args.push_back(k_s);  // 13: num_idle_cores (per-sender)
+                per_core_args.push_back(detail::get_aligned_page_size(output_tensor));        // 14
+                per_core_args.push_back(detail::get_aligned_page_size(expert_token_counts));  // 15
+                // 16+: TensorAccessorArgs (no num_senders — single-sender kernel)
                 tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(per_core_args);
 
                 CoreRangeSet single_idle_core({CoreRange(idle_row_cores[global_idle_idx])});

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -390,6 +390,8 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     std::map<std::string, std::string> reader_defines = fabric_defines;
     reader_defines["INIT_ZEROS"] = operation_attributes.init_zeros ? "1" : "0";
+    bool is_tile_layout = dispatched_buffer.layout() == tt::tt_metal::Layout::TILE;
+    reader_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
 
     const bool init_zeros = operation_attributes.init_zeros;
     tt::tt_metal::KernelHandle zero_init_kernel_id = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -646,6 +646,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .defines = writer_defines});
 
     // Compute kernel on idle cores that untilizes dispatched_buffer data
+    const uint32_t full_ct_dim = static_cast<uint32_t>(hidden_size) / 32u;
+    uint32_t block_ct_dim = 8;
+    while (full_ct_dim % block_ct_dim != 0) {
+        --block_ct_dim;
+    }
+
     tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
@@ -653,12 +659,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         idle_core_grid,
         tt::tt_metal::ComputeConfig{
             .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_signal_id (CB used for signaling on the same core that
-                                                          // data is loaded and ready to be untilized)
-                static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_untilize_id (untilized dispatched_buffer data)
-                static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_in_id (dispatched_buffer data)
-                static_cast<uint32_t>(hidden_size),       // hidden_size
-                static_cast<uint32_t>(read_batch_size),   // read_batch_size
+                static_cast<uint32_t>(
+                    tt::CBIndex::c_3),  // 0: cb_signal_id (CB used for signaling on the same core that
+                                        //    data is loaded and ready to be untilized)
+                static_cast<uint32_t>(tt::CBIndex::c_2),  // 1: cb_untilize_id (untilized dispatched_buffer data)
+                static_cast<uint32_t>(tt::CBIndex::c_0),  // 2: cb_in_id (dispatched_buffer data)
+                read_batch_size,                          // 3: read_batch_size
+                full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
+                block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
             }});
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -104,6 +104,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     const auto& dispatched_metadata = tensor_args.dispatched_metadata;
     const auto& expert_token_counts = tensor_args.expert_token_counts;
     const auto& output_tensor = tensor_return_value;
+    const bool is_tile_layout = dispatched_buffer.layout() == tt::tt_metal::Layout::TILE;
 
     auto* mesh_device = dispatched_buffer.device();
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
@@ -259,14 +260,25 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, c2_config);
     }
 
-    // c_18: receive buffer for idle-core untilized data written back via NOC
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        output_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_18,
-        "untilized_output");
+    if (is_tile_layout) {
+        // c_18: receive buffer for idle-core untilized data written back via NOC (TILE_LAYOUT only)
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            output_tensor,
+            /*buffering_factor=*/read_batch_size,
+            /*cb_id=*/tt::CBIndex::c_18,
+            "untilized_output");
+    } else {
+        // c_0 on sender cores: dispatched_buffer rows for ROW_MAJOR DMA reads
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            dispatched_buffer,
+            /*buffering_factor=*/read_batch_size,
+            /*cb_id=*/tt::CBIndex::c_0,
+            "dispatched_buffer_sender");
+    }
 
     // c_3: route_info (reader->writer, 4 x uint32_t per entry)
     {
@@ -390,7 +402,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     std::map<std::string, std::string> reader_defines = fabric_defines;
     reader_defines["INIT_ZEROS"] = operation_attributes.init_zeros ? "1" : "0";
-    bool is_tile_layout = dispatched_buffer.layout() == tt::tt_metal::Layout::TILE;
     reader_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
 
     const bool init_zeros = operation_attributes.init_zeros;
@@ -403,7 +414,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     // idle_row_cores: all same-row idle cores, ordered by sender group then by x.
     std::vector<CoreCoord>& idle_row_cores = all_idle_cores;
 
-    // Per-sender multicast bounding boxes and idle NOC coordinates.
+    // Per-sender multicast bounding boxes and idle NOC coordinates (TILE_LAYOUT only).
     // Each sender multicasts only to its own dedicated idle group so both senders
     // can run their multicast in parallel without interfering.
     struct SenderMcastCfg {
@@ -411,19 +422,22 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
     };
     std::vector<SenderMcastCfg> sender_mcast_cfgs(num_cores);
-    for (uint32_t s = 0; s < num_cores; s++) {
-        TT_FATAL(!sender_idle_groups[s].empty(), "Sender {} has no idle cores assigned", s);
-        auto& cfg = sender_mcast_cfgs[s];
-        auto first_noc = mesh_device->virtual_core_from_logical_core(sender_idle_groups[s][0], tt::CoreType::WORKER);
-        cfg.mcast_start_x = cfg.mcast_end_x = first_noc.x;
-        cfg.mcast_start_y = cfg.mcast_end_y = first_noc.y;
-        for (const auto& ic : sender_idle_groups[s]) {
-            auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
-            cfg.mcast_start_x = std::min(cfg.mcast_start_x, (uint32_t)noc.x);
-            cfg.mcast_end_x = std::max(cfg.mcast_end_x, (uint32_t)noc.x);
-            cfg.mcast_start_y = std::min(cfg.mcast_start_y, (uint32_t)noc.y);
-            cfg.mcast_end_y = std::max(cfg.mcast_end_y, (uint32_t)noc.y);
-            cfg.idle_noc_coords.emplace_back((uint32_t)noc.x, (uint32_t)noc.y);
+    if (is_tile_layout) {
+        for (uint32_t s = 0; s < num_cores; s++) {
+            TT_FATAL(!sender_idle_groups[s].empty(), "Sender {} has no idle cores assigned", s);
+            auto& cfg = sender_mcast_cfgs[s];
+            auto first_noc =
+                mesh_device->virtual_core_from_logical_core(sender_idle_groups[s][0], tt::CoreType::WORKER);
+            cfg.mcast_start_x = cfg.mcast_end_x = first_noc.x;
+            cfg.mcast_start_y = cfg.mcast_end_y = first_noc.y;
+            for (const auto& ic : sender_idle_groups[s]) {
+                auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
+                cfg.mcast_start_x = std::min(cfg.mcast_start_x, (uint32_t)noc.x);
+                cfg.mcast_end_x = std::max(cfg.mcast_end_x, (uint32_t)noc.x);
+                cfg.mcast_start_y = std::min(cfg.mcast_start_y, (uint32_t)noc.y);
+                cfg.mcast_end_y = std::max(cfg.mcast_end_y, (uint32_t)noc.y);
+                cfg.idle_noc_coords.emplace_back((uint32_t)noc.x, (uint32_t)noc.y);
+            }
         }
     }
 
@@ -434,39 +448,29 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
     CoreRangeSet idle_core_grid(idle_ranges_set);
 
-    // counter_ready semaphore: created only on sender + idle cores so get_semaphore() returns
-    // the same L1 offset on both sides (sender writes to idle's copy, idle waits on its own)
-    std::set<CoreRange> sender_and_idle_ranges;
-    for (const auto& cr : sender_core_grid.ranges()) {
-        sender_and_idle_ranges.insert(cr);
-    }
-    for (const auto& cr : idle_core_grid.ranges()) {
-        sender_and_idle_ranges.insert(cr);
-    }
-    CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
-    auto counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
-    // One data_ready and one start semaphore per sender so each sender's handshake with idle
-    // cores is independent — idle core routes to the correct pair via sender_idx = expert / experts_per_sender.
+    // TILE_LAYOUT semaphores for sender <-> idle core handshake
+    uint32_t counter_ready_semaphore_id = 0;
     std::vector<uint32_t> data_ready_semaphore_ids, start_semaphore_ids;
-    for (uint32_t s = 0; s < num_cores; s++) {
-        data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
-        start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+    if (is_tile_layout) {
+        // counter_ready semaphore: created only on sender + idle cores so get_semaphore() returns
+        // the same L1 offset on both sides (sender writes to idle's copy, idle waits on its own)
+        std::set<CoreRange> sender_and_idle_ranges;
+        for (const auto& cr : sender_core_grid.ranges()) {
+            sender_and_idle_ranges.insert(cr);
+        }
+        for (const auto& cr : idle_core_grid.ranges()) {
+            sender_and_idle_ranges.insert(cr);
+        }
+        CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
+        counter_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+        // One data_ready and one start semaphore per sender so each sender's handshake with idle
+        // cores is independent — idle core routes to the correct pair via sender_idx = expert / experts_per_sender.
+        for (uint32_t s = 0; s < num_cores; s++) {
+            data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+            start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+        }
     }
 
-    // c_1 on idle cores: receives the expert_token_counts multicast from the owning sender.
-    // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
-    {
-        uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
-        uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
-        auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        uint32_t extra_pages = 1;
-        uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
-        tt::tt_metal::CircularBufferConfig c1_idle_config =
-            tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
-                .set_page_size(tt::CBIndex::c_1, counter_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
-    }
-    // c_0 on idle cores: dispatched_buffer tiles
     // cb_factor reduces CB size to fit L1: Blackhole has more L1, Wormhole needs 4x reduction
     uint32_t cb_factor;
     {
@@ -477,28 +481,45 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             cb_factor = 4;  // Wormhole_B0 and others
         }
     }
-    detail::create_tensor_cb(
-        program,
-        idle_core_grid,
-        dispatched_buffer,
-        /*buffering_factor=*/hidden_size / (32 * cb_factor),
-        /*cb_id=*/tt::CBIndex::c_0,
-        "dispatched_buffer_idle");
-    // c_2 on idle cores: untilized output rows, one full batch (read_batch_size rows)
-    detail::create_tensor_cb(
-        program,
-        idle_core_grid,
-        output_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_2,
-        "untilize_idle");
-    // c_3 on idle cores: 1-page signal CB (reader->compute, mirrors c_17 on sender cores)
-    {
-        uint32_t signal_page_size = l1_alignment;
-        tt::tt_metal::CircularBufferConfig signal_cb_config =
-            tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_3, signal_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+
+    if (is_tile_layout) {
+        // c_1 on idle cores: receives the expert_token_counts multicast from the owning sender.
+        // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
+        {
+            uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
+            uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
+            auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
+            uint32_t extra_pages = 1;
+            uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
+            tt::tt_metal::CircularBufferConfig c1_idle_config =
+                tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_1, data_format}})
+                    .set_page_size(tt::CBIndex::c_1, counter_page_size);
+            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, c1_idle_config);
+        }
+        // c_0 on idle cores: dispatched_buffer tiles
+        detail::create_tensor_cb(
+            program,
+            idle_core_grid,
+            dispatched_buffer,
+            /*buffering_factor=*/hidden_size / (32 * cb_factor),
+            /*cb_id=*/tt::CBIndex::c_0,
+            "dispatched_buffer_idle");
+        // c_2 on idle cores: untilized output rows, one full batch (read_batch_size rows)
+        detail::create_tensor_cb(
+            program,
+            idle_core_grid,
+            output_tensor,
+            /*buffering_factor=*/read_batch_size,
+            /*cb_id=*/tt::CBIndex::c_2,
+            "untilize_idle");
+        // c_3 on idle cores: 1-page signal CB (reader->compute, mirrors c_17 on sender cores)
+        {
+            uint32_t signal_page_size = l1_alignment;
+            tt::tt_metal::CircularBufferConfig signal_cb_config =
+                tt::tt_metal::CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
+                    .set_page_size(tt::CBIndex::c_3, signal_page_size);
+            tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+        }
     }
 
     // counter_offset mirrors the constexpr calculation in reader_combine.cpp
@@ -508,36 +529,37 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     uint32_t counter_offset =
         mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
 
-    // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
-    //   0-11: shared base (below, includes cb_factor at index 11)
-    //   12:   core_id   — local index within sender s's idle group (0..k_s-1)
-    //   13:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
-    //   14:   aligned_output_page_size
-    //   15:   aligned_experts_tok_counter_page_size
-    //   16+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
-    const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
-        static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
-        detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
-        operation_attributes.experts_per_chip,             // 2:  experts_per_chip
-        counter_offset,                                    // 3:  counter_offset
-        static_cast<uint32_t>(tt::CBIndex::c_0),           // 4:  cb_dispatched_buffer_id
-        static_cast<uint32_t>(tt::CBIndex::c_2),           // 5:  cb_untilize_id
-        (uint32_t)hidden_size,                             // 6:  hidden_size
-        read_batch_size,                                   // 7:  read_batch_size
-        static_cast<uint32_t>(tt::CBIndex::c_3),           // 8:  cb_signal_id
-        detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
-        (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
-        cb_factor,                                         // 11: cb_factor
-    };
-
-    // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
-    // core_id is LOCAL within the sender's group (0..k_s-1) for round-robin batch assignment.
-    // num_idle_cores baked in as k_s so the kernel only considers its own group.
-    // No num_senders arg — each kernel is bound to a single sender.
+    // reader_untilize + compute kernels only needed for TILE_LAYOUT
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
-    reader_untilize_kernel_ids.reserve(num_idle_cores);
+    if (is_tile_layout) {
+        // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
+        //   0-11: shared base (below, includes cb_factor at index 11)
+        //   12:   core_id   — local index within sender s's idle group (0..k_s-1)
+        //   13:   num_idle_cores — per-sender count k_s (for round-robin batch assignment)
+        //   14:   aligned_output_page_size
+        //   15:   aligned_experts_tok_counter_page_size
+        //   16+:  TensorAccessorArgs for dispatched_buffer (no num_senders — single-sender kernel)
+        const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
+            static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
+            detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
+            operation_attributes.experts_per_chip,             // 2:  experts_per_chip
+            counter_offset,                                    // 3:  counter_offset
+            static_cast<uint32_t>(tt::CBIndex::c_0),           // 4:  cb_dispatched_buffer_id
+            static_cast<uint32_t>(tt::CBIndex::c_2),           // 5:  cb_untilize_id
+            (uint32_t)hidden_size,                             // 6:  hidden_size
+            read_batch_size,                                   // 7:  read_batch_size
+            static_cast<uint32_t>(tt::CBIndex::c_3),           // 8:  cb_signal_id
+            detail::get_aligned_page_size(dispatched_buffer),  // 9:  aligned_dispatched_buffer_page_size
+            (uint32_t)max_dispatched_tokens_per_expert,        // 10: max_dispatched_tokens_per_expert
+            cb_factor,                                         // 11: cb_factor
+        };
 
-    {
+        // Partitioned idle cores: each sender s owns a dedicated group of k_s idle cores.
+        // core_id is LOCAL within the sender's group (0..k_s-1) for round-robin batch assignment.
+        // num_idle_cores baked in as k_s so the kernel only considers its own group.
+        // No num_senders arg — each kernel is bound to a single sender.
+        reader_untilize_kernel_ids.reserve(num_idle_cores);
+
         uint32_t global_idle_idx = 0;
         for (uint32_t s = 0; s < num_cores; s++) {
             uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
@@ -622,19 +644,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
     // num_idle_cores and cb_untilize_id are appended per-sender below.
 
-    // One reader_combine kernel per sender with k_s (per-sender idle count) baked in as
-    // num_idle_cores.  The VLA idle_start_noc_addrs[num_idle_cores] is sized exactly right
-    // and the sender only round-robins across its own k_s dedicated idle cores.
+    // One reader_combine kernel per sender.  For TILE_LAYOUT, k_s (per-sender idle count)
+    // is baked in as num_idle_cores so the sender only round-robins across its own dedicated
+    // idle cores.  For ROW_MAJOR, no idle-core args are needed.
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
-        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
         auto per_sender_compile_args = reader_compile_time_args_base;
-        per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender k_s)
-        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
-        if (init_zeros) {
-            per_sender_compile_args.push_back(
-                num_idle_cores);  // num_total_idle_cores (all idle cores across all senders)
+        if (is_tile_layout) {
+            uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
+            per_sender_compile_args.push_back(k_s);                                       // num_idle_cores (per-sender)
+            per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
+            if (init_zeros) {
+                per_sender_compile_args.push_back(
+                    num_idle_cores);  // num_total_idle_cores (all idle cores across all senders)
+            }
         }
         CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
         reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
@@ -658,29 +682,31 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             .compile_args = compile_time_args,
             .defines = writer_defines});
 
-    // Compute kernel on idle cores that untilizes dispatched_buffer data
-    const uint32_t full_ct_dim = static_cast<uint32_t>(hidden_size) / 32u;
-    uint32_t block_ct_dim = 8;
-    while (full_ct_dim % block_ct_dim != 0) {
-        --block_ct_dim;
-    }
+    // Compute kernel on idle cores that untilizes dispatched_buffer data (TILE_LAYOUT only)
+    if (is_tile_layout) {
+        const uint32_t full_ct_dim = static_cast<uint32_t>(hidden_size) / 32u;
+        uint32_t block_ct_dim = 8;
+        while (full_ct_dim % block_ct_dim != 0) {
+            --block_ct_dim;
+        }
 
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
-        "untilize_combine.cpp",
-        idle_core_grid,
-        tt::tt_metal::ComputeConfig{
-            .compile_args = {
-                static_cast<uint32_t>(
-                    tt::CBIndex::c_3),  // 0: cb_signal_id (CB used for signaling on the same core that
-                                        //    data is loaded and ready to be untilized)
-                static_cast<uint32_t>(tt::CBIndex::c_2),  // 1: cb_untilize_id (untilized dispatched_buffer data)
-                static_cast<uint32_t>(tt::CBIndex::c_0),  // 2: cb_in_id (dispatched_buffer data)
-                read_batch_size,                          // 3: read_batch_size
-                full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
-                block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
-            }});
+        tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/"
+            "untilize_combine.cpp",
+            idle_core_grid,
+            tt::tt_metal::ComputeConfig{
+                .compile_args = {
+                    static_cast<uint32_t>(
+                        tt::CBIndex::c_3),  // 0: cb_signal_id (CB used for signaling on the same core that
+                                            //    data is loaded and ready to be untilized)
+                    static_cast<uint32_t>(tt::CBIndex::c_2),  // 1: cb_untilize_id (untilized dispatched_buffer data)
+                    static_cast<uint32_t>(tt::CBIndex::c_0),  // 2: cb_in_id (dispatched_buffer data)
+                    read_batch_size,                          // 3: read_batch_size
+                    full_ct_dim,                              // 4: full_ct_dim = hidden_size / 32
+                    block_ct_dim,                             // 5: block_ct_dim = largest divisor of full_ct_dim <= 8
+                }});
+    }
 
     // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;
@@ -735,19 +761,21 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
             reader_runtime_args.push_back(sender_page_end);
             reader_runtime_args.push_back(zi_done_semaphore_id);
         }
-        // Multicast targets only this sender's dedicated idle group
-        const auto& mcast_cfg = sender_mcast_cfgs[core_idx];
-        reader_runtime_args.push_back(counter_ready_semaphore_id);
-        reader_runtime_args.push_back(mcast_cfg.mcast_start_x);
-        reader_runtime_args.push_back(mcast_cfg.mcast_start_y);
-        reader_runtime_args.push_back(mcast_cfg.mcast_end_x);
-        reader_runtime_args.push_back(mcast_cfg.mcast_end_y);
-        reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
-        reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
-        // Pass NOC coords of only this sender's k_s dedicated idle cores
-        for (const auto& [noc_x, noc_y] : mcast_cfg.idle_noc_coords) {
-            reader_runtime_args.push_back(noc_x);
-            reader_runtime_args.push_back(noc_y);
+        if (is_tile_layout) {
+            // Multicast targets only this sender's dedicated idle group
+            const auto& mcast_cfg = sender_mcast_cfgs[core_idx];
+            reader_runtime_args.push_back(counter_ready_semaphore_id);
+            reader_runtime_args.push_back(mcast_cfg.mcast_start_x);
+            reader_runtime_args.push_back(mcast_cfg.mcast_start_y);
+            reader_runtime_args.push_back(mcast_cfg.mcast_end_x);
+            reader_runtime_args.push_back(mcast_cfg.mcast_end_y);
+            reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
+            reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
+            // Pass NOC coords of only this sender's k_s dedicated idle cores
+            for (const auto& [noc_x, noc_y] : mcast_cfg.idle_noc_coords) {
+                reader_runtime_args.push_back(noc_x);
+                reader_runtime_args.push_back(noc_y);
+            }
         }
 
         std::vector<uint32_t> writer_runtime_args = {
@@ -803,24 +831,27 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         core_idx++;
     }
 
-    // Set runtime args for idle cores.  Each idle core is bound to its owning sender s.
+    // Set runtime args for idle cores (TILE_LAYOUT only — reader_untilize kernel).
+    // Each idle core is bound to its owning sender s.
     // Layout: counter_ready_sem, data_ready_sem[s], noc_x[s], noc_y[s], start_sem[s],
     //         dispatched_buffer_addr, expert_start, expert_end
-    for (uint32_t j = 0; j < num_idle_cores; j++) {
-        uint32_t s = idle_sender_map[j];
-        uint32_t expert_start = s * experts_per_core_range;
-        uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
-        std::vector<uint32_t> idle_rt_args = {
-            counter_ready_semaphore_id,
-            data_ready_semaphore_ids[s],
-            sender_noc_coords[s].first,
-            sender_noc_coords[s].second,
-            start_semaphore_ids[s],
-            dispatched_buffer.buffer()->address(),
-            expert_start,
-            expert_end,
-        };
-        tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
+    if (is_tile_layout) {
+        for (uint32_t j = 0; j < num_idle_cores; j++) {
+            uint32_t s = idle_sender_map[j];
+            uint32_t expert_start = s * experts_per_core_range;
+            uint32_t expert_end = std::min((s + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+            std::vector<uint32_t> idle_rt_args = {
+                counter_ready_semaphore_id,
+                data_ready_semaphore_ids[s],
+                sender_noc_coords[s].first,
+                sender_noc_coords[s].second,
+                start_semaphore_ids[s],
+                dispatched_buffer.buffer()->address(),
+                expert_start,
+                expert_end,
+            };
+            tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], idle_row_cores[j], idle_rt_args);
+        }
     }
 
     return {
@@ -871,12 +902,15 @@ void CombineProgramFactory::override_runtime_arguments(
             zi_runtime_args.at(0) = tensor_return_value.buffer()->address();
         }
 
-        for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
-            auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
-                program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-            // RT layout: [0:counter_ready_sem, 1:data_ready_sem, 2:noc_x, 3:noc_y, 4:start_sem,
-            //             5:dispatched_buffer_addr, 6:expert_start, 7:expert_end]
-            idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
+        // Update idle core runtime args only when reader_untilize kernels exist (TILE_LAYOUT)
+        if (!shared_variables.reader_untilize_kernel_ids.empty()) {
+            for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
+                auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
+                    program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
+                // RT layout: [0:counter_ready_sem, 1:data_ready_sem, 2:noc_x, 3:noc_y, 4:start_sem,
+                //             5:dispatched_buffer_addr, 6:expert_start, 7:expert_end]
+                idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
+            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -282,6 +282,15 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         detail::create_tensor_cb(
             program,
             sender_core_grid,
+            output_tensor,
+            /*buffering_factor=*/rw_buffering,
+            /*cb_id=*/tt::CBIndex::c_4,
+            "output_for_writer");
+    }
+
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
             dispatched_buffer,
             /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_4,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <vector>
 #include "combine_types.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
@@ -12,14 +13,19 @@
 namespace ttnn::operations::experimental::deepseek_prefill::combine {
 
 struct CombineSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;  // one per sender core
     tt::tt_metal::KernelHandle writer_kernel_id = 0;
     tt::tt_metal::KernelHandle zero_init_kernel_id = 0;
+    std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;  // one per idle core
     std::vector<CoreCoord> cores;
     std::vector<CoreCoord> zero_init_cores;
+    std::vector<CoreCoord> idle_cores;
     GlobalSemaphore init_semaphore;       // Initialized in create_at()
     uint32_t zero_init_semaphore_id = 0;  // Local semaphore ID for reader->writer sync
     uint32_t zero_init_barrier_semaphore_id = 0;  // Barrier: writer signals reader after global init
+    uint32_t counter_ready_semaphore_id = 0;      // Sender signals idle cores after token count multicast
+    uint32_t data_ready_semaphore_id = 0;         // Idle core signals sender that data is ready
+    uint32_t start_semaphore_id = 0;              // Sender signals idle core to start sending data
 };
 
 struct CombineProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
@@ -24,7 +24,6 @@ struct CombineSharedVariables {
     uint32_t zero_init_semaphore_id = 0;  // Local semaphore ID for reader->writer sync
     uint32_t zero_init_barrier_semaphore_id = 0;     // Barrier: writer signals reader after global init
     uint32_t counter_ready_semaphore_id = 0;         // Sender signals idle cores after token count multicast
-    uint32_t num_senders = 0;                        // Number of sender cores (= num_cores)
     std::vector<uint32_t> data_ready_semaphore_ids;  // One per sender: idle core signals sender data is ready
     std::vector<uint32_t> start_semaphore_ids;       // One per sender: sender signals idle core to start
 };

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
@@ -22,10 +22,11 @@ struct CombineSharedVariables {
     std::vector<CoreCoord> idle_cores;
     GlobalSemaphore init_semaphore;       // Initialized in create_at()
     uint32_t zero_init_semaphore_id = 0;  // Local semaphore ID for reader->writer sync
-    uint32_t zero_init_barrier_semaphore_id = 0;  // Barrier: writer signals reader after global init
-    uint32_t counter_ready_semaphore_id = 0;      // Sender signals idle cores after token count multicast
-    uint32_t data_ready_semaphore_id = 0;         // Idle core signals sender that data is ready
-    uint32_t start_semaphore_id = 0;              // Sender signals idle core to start sending data
+    uint32_t zero_init_barrier_semaphore_id = 0;     // Barrier: writer signals reader after global init
+    uint32_t counter_ready_semaphore_id = 0;         // Sender signals idle cores after token count multicast
+    uint32_t num_senders = 0;                        // Number of sender cores (= num_cores)
+    std::vector<uint32_t> data_ready_semaphore_ids;  // One per sender: idle core signals sender data is ready
+    std::vector<uint32_t> start_semaphore_ids;       // One per sender: sender signals idle core to start
 };
 
 struct CombineProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/common.h"
+#include "api/compute/cb_api.h"
+#include "api/compute/pack_untilize.h"
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
+// Compile-time args:
+//   0: cb_signal_id    - CB for reader->compute signaling (c_17)
+//   1: cb_untilize_id  - CB for compute untilized output (c_18)
+//   2: cb_in_id        - CB for untilize input tile data (c_0)
+//   3: hidden_size     - hidden dimension (e.g., 7168)
+//   4: read_batch_size - number of rows per untilize batch (e.g., 32)
+void kernel_main() {
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_in_id = get_compile_time_arg_val(2);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(3);
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(4);
+
+    constexpr uint32_t block_ct_dim = 8;
+    constexpr uint32_t full_ct_dim = hidden_size / 32;
+    constexpr uint32_t num_blocks = full_ct_dim / block_ct_dim;
+
+    compute_kernel_hw_startup(cb_in_id, cb_untilize_id);
+    pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in_id, cb_untilize_id);
+
+    while (true) {
+        cb_reserve_back(cb_untilize_id, read_batch_size);
+        cb_wait_front(cb_signal_id, 1);
+        uint32_t val = read_tile_value(cb_signal_id, 0, 0);
+        cb_pop_front(cb_signal_id, 1);
+        if (val == ROUTE_INFO_SENTINEL) {
+            break;
+        }
+        for (uint32_t block = 0; block < num_blocks; block++) {
+            cb_wait_front(cb_in_id, block_ct_dim);
+            pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in_id, 1, cb_untilize_id, block);
+            cb_pop_front(cb_in_id, block_ct_dim);
+        }
+
+        cb_push_back(cb_untilize_id, read_batch_size);
+    }
+    pack_untilize_uninit(cb_untilize_id);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
@@ -26,17 +26,16 @@ constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 //   0: cb_signal_id    - CB for reader->compute signaling (c_17)
 //   1: cb_untilize_id  - CB for compute untilized output (c_18)
 //   2: cb_in_id        - CB for untilize input tile data (c_0)
-//   3: hidden_size     - hidden dimension (e.g., 7168)
-//   4: read_batch_size - number of rows per untilize batch (e.g., 32)
+//   3: read_batch_size - number of rows per untilize batch (e.g., 32)
+//   4: full_ct_dim     - hidden_size / 32 (e.g., 224 for hidden_size=7168)
+//   5: block_ct_dim    - largest divisor of full_ct_dim <= 8
 void kernel_main() {
     constexpr uint32_t cb_signal_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(1);
     constexpr uint32_t cb_in_id = get_compile_time_arg_val(2);
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(3);
-    constexpr uint32_t read_batch_size = get_compile_time_arg_val(4);
-
-    constexpr uint32_t block_ct_dim = 8;
-    constexpr uint32_t full_ct_dim = hidden_size / 32;
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(3);
+    constexpr uint32_t full_ct_dim = get_compile_time_arg_val(4);
+    constexpr uint32_t block_ct_dim = get_compile_time_arg_val(5);
     constexpr uint32_t num_blocks = full_ct_dim / block_ct_dim;
 
     compute_kernel_hw_startup(cb_in_id, cb_untilize_id);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
@@ -42,8 +42,6 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_in_id, cb_untilize_id);
     pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in_id, cb_untilize_id);
 
-    uint32_t batch_counter = 0;
-
     while (true) {
         cb_reserve_back(cb_untilize_id, read_batch_size);
         cb_wait_front(cb_signal_id, 1);
@@ -59,8 +57,6 @@ void kernel_main() {
         }
 
         cb_push_back(cb_untilize_id, read_batch_size);
-        DPRINT_COMBINE << "Processed batch %u\n" << batch_counter << ENDL();
-        batch_counter++;
     }
     pack_untilize_uninit(cb_untilize_id);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
@@ -9,6 +9,16 @@
 #include "api/compute/pack_untilize.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "api/debug/dprint.h"
+
+#define ENABLE_COMBINE_DEBUG 0
+#if ENABLE_COMBINE_DEBUG
+#define DPRINT_COMBINE DPRINT
+#else
+#define DPRINT_COMBINE \
+    if (0)             \
+    DebugPrinter()
+#endif
 
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
@@ -32,6 +42,8 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_in_id, cb_untilize_id);
     pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in_id, cb_untilize_id);
 
+    uint32_t batch_counter = 0;
+
     while (true) {
         cb_reserve_back(cb_untilize_id, read_batch_size);
         cb_wait_front(cb_signal_id, 1);
@@ -47,6 +59,8 @@ void kernel_main() {
         }
 
         cb_push_back(cb_untilize_id, read_batch_size);
+        DPRINT_COMBINE << "Processed batch %u\n" << batch_counter << ENDL();
+        batch_counter++;
     }
     pack_untilize_uninit(cb_untilize_id);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
@@ -10,6 +10,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "api/debug/dprint.h"
+#include "internal/circular_buffer_interface.h"
 
 #define ENABLE_COMBINE_DEBUG 0
 #if ENABLE_COMBINE_DEBUG
@@ -22,13 +23,27 @@
 
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
+// Push a single uint32 scalar value to cb_id from a compute kernel (pack TRISC only).
+// Dataflow kernels use get_write_ptr(cb_id), but compute kernels have to go through the
+// local CB interface and apply cb_addr_shift.
+inline void push_scalar_signal(uint32_t cb_id, uint32_t value) {
+#ifdef TRISC_PACK
+    cb_reserve_back(cb_id, 1);
+    auto wr_ptr = (get_local_cb_interface(cb_id).fifo_wr_ptr) << cb_addr_shift;
+    auto* slot = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(wr_ptr);
+    slot[0] = value;
+    cb_push_back(cb_id, 1);
+#endif
+}
+
 // Compile-time args:
-//   0: cb_signal_id    - CB for reader->compute signaling (c_17)
-//   1: cb_untilize_id  - CB for compute untilized output (c_18)
-//   2: cb_in_id        - CB for untilize input tile data (c_0)
-//   3: read_batch_size - number of rows per untilize batch (e.g., 32)
-//   4: full_ct_dim     - hidden_size / 32 (e.g., 224 for hidden_size=7168)
-//   5: block_ct_dim    - largest divisor of full_ct_dim <= 8
+//   0: cb_signal_id       - CB for reader_untilize -> compute signaling (c_3)
+//   1: cb_untilize_id     - CB for compute's untilized output (c_2)
+//   2: cb_in_id           - CB for untilize input tile data (c_0)
+//   3: read_batch_size    - number of rows per untilize batch (e.g., 32)
+//   4: full_ct_dim        - hidden_size / 32 (e.g., 224 for hidden_size=7168)
+//   5: block_ct_dim       - largest divisor of full_ct_dim <= 8
+//   6: cb_stop_signal_id  - CB for compute -> zero_init_writer per-batch + stop signal (c_8)
 void kernel_main() {
     constexpr uint32_t cb_signal_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(1);
@@ -36,6 +51,7 @@ void kernel_main() {
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(3);
     constexpr uint32_t full_ct_dim = get_compile_time_arg_val(4);
     constexpr uint32_t block_ct_dim = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_stop_signal_id = get_compile_time_arg_val(6);
     constexpr uint32_t num_blocks = full_ct_dim / block_ct_dim;
 
     compute_kernel_hw_startup(cb_in_id, cb_untilize_id);
@@ -56,6 +72,12 @@ void kernel_main() {
         }
 
         cb_push_back(cb_untilize_id, read_batch_size);
+
+        // Tell zero_init_writer that a batch has been pushed onto cb_untilize_id and is ready to send.
+        push_scalar_signal(cb_stop_signal_id, 0x00000000);
     }
     pack_untilize_uninit(cb_untilize_id);
+
+    // Tell zero_init_writer to exit its send loop — all batches have been untilized.
+    push_scalar_signal(cb_stop_signal_id, ROUTE_INFO_SENTINEL);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -342,17 +342,17 @@ void kernel_main() {
                 }
             }
 
-            // Unicast the metadata batch to the current idle core's c_9 CB.
-            uint32_t metadata_unicast_bytes = batch_count * aligned_dispatched_metadata_page_size;
-            noc_async_write(metadata_base, idle_metadata_noc_addrs[current_idle_core], metadata_unicast_bytes);
-            noc_async_write_barrier();
-
-            // If any non-local writes exist, overwrite the first uint32 on idle's c_9 with the
-            // sentinel so the idle core knows to send its untilized data back to us.  Otherwise
-            // the first uint32 is the real dst_chip (== linearized_mesh_coord) and idle handles
-            // the entire batch locally.
             if (has_non_local) {
+                // Idle core only checks c_9[0] on the non-local path — skip the full metadata
+                // unicast and just write the sentinel directly.
                 noc_inline_dw_write(idle_metadata_noc_addrs[current_idle_core], ROUTE_INFO_SENTINEL);
+            } else {
+                // Unicast the full metadata batch to the idle core's c_9 so it can write each
+                // row directly to output DRAM, then set c_9[0] = batch_count as the signal.
+                uint32_t metadata_unicast_bytes = batch_count * aligned_dispatched_metadata_page_size;
+                noc_async_write(metadata_base, idle_metadata_noc_addrs[current_idle_core], metadata_unicast_bytes);
+                noc_async_write_barrier();
+                noc_inline_dw_write(idle_metadata_noc_addrs[current_idle_core], batch_count);
             }
 
             // Signal the idle core that the metadata batch is ready in its c_9.
@@ -368,9 +368,8 @@ void kernel_main() {
             noc_semaphore_set(data_ready_sem_ptr, 0);
 #endif
 
-            // In TILE_LAYOUT the sender only routes tokens when has_non_local is true (the idle
-            // core already did the writes for all-local batches). In ROW_MAJOR there's no idle
-            // offload, so we always route.
+            // In TILE_LAYOUT the sender only routes when has_non_local is true — idle already
+            // handled all-local batches directly. In ROW_MAJOR there is no idle offload.
 #if IS_TILE_LAYOUT
             if (has_non_local)
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -92,6 +92,7 @@ void kernel_main() {
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
 #else
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
@@ -131,7 +132,7 @@ void kernel_main() {
 
         volatile tt_l1_ptr uint32_t* zi_done_sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zi_done_sem_address);
-        noc_semaphore_wait(zi_done_sem_ptr, num_idle_cores);
+        noc_semaphore_wait(zi_done_sem_ptr, num_total_idle_cores);
         noc_semaphore_set(zi_done_sem_ptr, 0);
     }
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -91,15 +91,14 @@ void kernel_main() {
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
-#if IS_TILE_LAYOUT
-    constexpr uint32_t num_idle_cores_group = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
-    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
-#endif
+    constexpr uint32_t tile_layout_args_base = output_args.next_compile_time_args_offset() + 2;
 #else
-#if IS_TILE_LAYOUT
-    constexpr uint32_t num_idle_cores_group = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
-    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
+    constexpr uint32_t tile_layout_args_base = output_args.next_compile_time_args_offset();
 #endif
+
+#if IS_TILE_LAYOUT
+    constexpr uint32_t num_idle_cores_group = get_compile_time_arg_val(tile_layout_args_base);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(tile_layout_args_base + 1);
 #endif
 
     // ===== Runtime Args =====
@@ -244,18 +243,14 @@ void kernel_main() {
     // Set up scratch buffers for batched reads
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
+    const auto dispatched_metadata_addr_gen =
+        TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr, aligned_dispatched_metadata_page_size);
 
 #if IS_TILE_LAYOUT
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);
 #else
     cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
-#endif
-
-    const auto dispatched_metadata_addr_gen =
-        TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr, aligned_dispatched_metadata_page_size);
-
-#if !IS_TILE_LAYOUT
     const auto dispatched_buffer_addr_gen =
         TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -99,6 +99,8 @@ void kernel_main() {
 #if IS_TILE_LAYOUT
     constexpr uint32_t num_idle_cores_group = get_compile_time_arg_val(tile_layout_args_base);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(tile_layout_args_base + 1);
+    constexpr uint32_t cb_metadata_batch_id = get_compile_time_arg_val(tile_layout_args_base + 2);
+    constexpr uint32_t cb_idle_c9_addr_scratch_id = get_compile_time_arg_val(tile_layout_args_base + 3);
 #endif
 
     // ===== Runtime Args =====
@@ -160,10 +162,12 @@ void kernel_main() {
     uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args++);
     uint32_t start_sem_l1_offset = get_semaphore(start_semaphore_id);
     uint64_t idle_start_noc_addrs[num_idle_cores_group];
+    uint32_t idle_noc_x[num_idle_cores_group];
+    uint32_t idle_noc_y[num_idle_cores_group];
     for (uint32_t c = 0; c < num_idle_cores_group; c++) {
-        uint32_t noc_x = get_arg_val<uint32_t>(rt_args++);
-        uint32_t noc_y = get_arg_val<uint32_t>(rt_args++);
-        idle_start_noc_addrs[c] = get_noc_addr(noc_x, noc_y, start_sem_l1_offset);
+        idle_noc_x[c] = get_arg_val<uint32_t>(rt_args++);
+        idle_noc_y[c] = get_arg_val<uint32_t>(rt_args++);
+        idle_start_noc_addrs[c] = get_noc_addr(idle_noc_x[c], idle_noc_y[c], start_sem_l1_offset);
     }
 #endif
 
@@ -201,16 +205,19 @@ void kernel_main() {
     constexpr uint32_t offset = dispatch_group_idx * experts_per_dispatch_group + mesh_row * experts_per_chip;
     // Multicast expert token counts + receive_buf_addr to all idle cores
 #if IS_TILE_LAYOUT
-    // Each sender multicasts token counts + its own receive_buf_addr to its dedicated idle group.
-    // The mcast destination covers only this sender's k_s idle cores (per-sender bounding box),
-    // so all senders can multicast in parallel without interfering with each other.
+    // Each sender multicasts token counts + its own receive_buf_addr + its c_10 scratch L1
+    // address to its dedicated idle group. The mcast destination covers only this sender's
+    // k_s idle cores (per-sender bounding box), so all senders can multicast in parallel.
+    // Trailer layout (one l1_alignment region after counter_total_size bytes):
+    //   [0]: receive_buf_addr  — sender's c_18 L1 offset (where idle NOC-writes untilized data)
+    //   [1]: idle_c9_scratch_addr — sender's c_10 L1 offset (where idle NOC-writes its c_9 addr)
     {
         constexpr uint32_t counter_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
-        // Append this sender's receive_buf_addr so its idle cores know where to write untilized data.
-        volatile tt_l1_ptr uint32_t* receive_buf_slot =
+        volatile tt_l1_ptr uint32_t* trailer_slot =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr + counter_total_size);
-        receive_buf_slot[0] = get_write_ptr(cb_untilize_id);
+        trailer_slot[0] = get_write_ptr(cb_untilize_id);
+        trailer_slot[1] = get_write_ptr(cb_idle_c9_addr_scratch_id);
 
         constexpr uint32_t mcast_total_size = counter_total_size + l1_alignment;
         uint32_t off = 0;
@@ -248,6 +255,24 @@ void kernel_main() {
 
 #if IS_TILE_LAYOUT
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);
+
+    // ===== Idle c_9 address handshake =====
+    // After the counter multicast above, each idle core knows where our c_10 scratch lives and
+    // will write its get_write_ptr(c_9) L1 offset to slot core_id * sizeof(uint32_t).  They then
+    // increment data_ready_sem (same sem reused for its normal per-batch role below).  Once we
+    // see data_ready_sem == num_idle_cores_group, all idle c_9 addresses are in our c_10 scratch.
+    noc_semaphore_wait(data_ready_sem_ptr, num_idle_cores_group);
+    noc_semaphore_set(data_ready_sem_ptr, 0);
+
+    // Copy the received L1 offsets out of c_10 into a plain uint32_t[] array, then build the
+    // per-idle-core NOC addresses used by the batch loop below for the metadata unicast.
+    uint32_t idle_c9_scratch_base = get_write_ptr(cb_idle_c9_addr_scratch_id);
+    uint32_t idle_c9_addrs[num_idle_cores_group];
+    uint64_t idle_metadata_noc_addrs[num_idle_cores_group];
+    for (uint32_t c = 0; c < num_idle_cores_group; c++) {
+        idle_c9_addrs[c] = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idle_c9_scratch_base + c * sizeof(uint32_t));
+        idle_metadata_noc_addrs[c] = get_noc_addr(idle_noc_x[c], idle_noc_y[c], idle_c9_addrs[c]);
+    }
 #else
     cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
@@ -278,24 +303,51 @@ void kernel_main() {
 #if IS_TILE_LAYOUT
             uint32_t current_idle_core = B % num_idle_cores_group;
 
-            // Signal idle core to send its untilized batch
-            noc_semaphore_inc(idle_start_noc_addrs[current_idle_core], 1);
-            noc_async_atomic_barrier();
-
-            // Speculatively read metadata for this batch
+            // Read metadata FIRST (we need to inspect it to decide if idle can handle the whole
+            // batch locally or whether we need untilized data back to do non-local routing).
             for (uint32_t t = 0; t < batch_count; t++) {
                 noc_async_read_page(
                     batch_start + t,
                     dispatched_metadata_addr_gen,
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
+            noc_async_read_barrier();
 
-            // Wait for idle core to write untilized data
+            // Scan metadata for any non-local writes (dst_chip != our linearized_mesh_coord).
+            bool has_non_local = false;
+            for (uint32_t t = 0; t < batch_count; t++) {
+                volatile tt_l1_ptr uint32_t* m = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    metadata_base + t * aligned_dispatched_metadata_page_size);
+                if (m[0] != linearized_mesh_coord) {
+                    has_non_local = true;
+                    break;
+                }
+            }
+
+            // Unicast the metadata batch to the current idle core's c_9 CB.
+            uint32_t metadata_unicast_bytes = batch_count * aligned_dispatched_metadata_page_size;
+            noc_async_write(metadata_base, idle_metadata_noc_addrs[current_idle_core], metadata_unicast_bytes);
+            noc_async_write_barrier();
+
+            // If any non-local writes exist, overwrite the first uint32 on idle's c_9 with the
+            // sentinel so the idle core knows to send its untilized data back to us.  Otherwise
+            // the first uint32 is the real dst_chip (== linearized_mesh_coord) and idle handles
+            // the entire batch locally.
+            if (has_non_local) {
+                noc_inline_dw_write(idle_metadata_noc_addrs[current_idle_core], ROUTE_INFO_SENTINEL);
+            }
+
+            // Signal the idle core that the metadata batch is ready in its c_9.
+            noc_semaphore_inc(idle_start_noc_addrs[current_idle_core], 1);
+            noc_async_atomic_barrier();
+
+            // Always wait on data_ready — even if has_non_local is false — to keep start_sem
+            // strictly 1:1 with idle's consume/reset.  Idle's `wait(>=1); set(0)` collapses
+            // multiple pending increments into a single consume, so if we advance without
+            // syncing, a later start_sem inc to the same idle core gets silently dropped and
+            // the idle deadlocks waiting for a signal that never re-arrives.
             noc_semaphore_wait(data_ready_sem_ptr, 1);
             noc_semaphore_set(data_ready_sem_ptr, 0);
-
-            // Ensure metadata is ready
-            noc_async_read_barrier();
 #else
             // ROW_MAJOR: DMA read dispatched_buffer rows + metadata
             for (uint32_t t = 0; t < batch_count; t++) {
@@ -309,59 +361,66 @@ void kernel_main() {
             noc_async_read_barrier();
 #endif
 
-            // Route tokens
-            for (uint32_t t = 0; t < batch_count; t++) {
+            // In TILE_LAYOUT the sender only routes tokens when has_non_local is true (the idle
+            // core already did the writes for all-local batches). In ROW_MAJOR there's no idle
+            // offload, so we always route.
 #if IS_TILE_LAYOUT
-                uint32_t buffer_scratch_addr = untilize_base + t * aligned_output_page_size;
-#else
-                uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
+            if (has_non_local)
 #endif
-                uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
-                volatile tt_l1_ptr uint32_t* metadata =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_scratch_addr);
-
-                auto dst_chip = metadata[0];
-                auto dst_token_idx = metadata[1];
-                auto dst_topk_indice = metadata[2];
-                uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
-
-                if (dst_chip == linearized_mesh_coord) {
-                    noc_async_write_page(output_page_idx, output_addr_gen, buffer_scratch_addr);
-                    noc_async_writes_flushed();
-                    batch_did_local_write = true;
-                } else {
-                    if constexpr (is_1d_topology<topology>()) {
-                        uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
-                        uint32_t distance =
-                            manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
-
-                        // Push route info to writer
-                        cb_reserve_back(cb_route_info_id, 1);
-                        volatile tt_l1_ptr uint32_t* route_info =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
-                        route_info[0] = route;
-                        route_info[1] = distance;
-                        route_info[2] = output_page_idx;
-                        route_info[3] = 0;
-                        cb_push_back(cb_route_info_id, 1);
-
-                        // Push output payload to writer
-                        cb_reserve_back(cb_output_for_writer_id, 1);
-                        uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
+            {
+                for (uint32_t t = 0; t < batch_count; t++) {
 #if IS_TILE_LAYOUT
-                        noc_async_read(get_noc_addr(buffer_scratch_addr), output_dst, aligned_output_page_size);
+                    uint32_t buffer_scratch_addr = untilize_base + t * aligned_output_page_size;
 #else
-                        noc_async_read(
-                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
+                    uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
 #endif
-                        noc_async_read_barrier();
-                        cb_push_back(cb_output_for_writer_id, 1);
+                    uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
+                    volatile tt_l1_ptr uint32_t* metadata =
+                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_scratch_addr);
+
+                    auto dst_chip = metadata[0];
+                    auto dst_token_idx = metadata[1];
+                    auto dst_topk_indice = metadata[2];
+                    uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
+
+                    if (dst_chip == linearized_mesh_coord) {
+                        noc_async_write_page(output_page_idx, output_addr_gen, buffer_scratch_addr);
+                        noc_async_writes_flushed();
+                        batch_did_local_write = true;
+                    } else {
+                        if constexpr (is_1d_topology<topology>()) {
+                            uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
+                            uint32_t distance =
+                                manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
+
+                            // Push route info to writer
+                            cb_reserve_back(cb_route_info_id, 1);
+                            volatile tt_l1_ptr uint32_t* route_info =
+                                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
+                            route_info[0] = route;
+                            route_info[1] = distance;
+                            route_info[2] = output_page_idx;
+                            route_info[3] = 0;
+                            cb_push_back(cb_route_info_id, 1);
+
+                            // Push output payload to writer
+                            cb_reserve_back(cb_output_for_writer_id, 1);
+                            uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
+#if IS_TILE_LAYOUT
+                            noc_async_read(get_noc_addr(buffer_scratch_addr), output_dst, aligned_output_page_size);
+#else
+                            noc_async_read(
+                                get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
+#endif
+                            noc_async_read_barrier();
+                            cb_push_back(cb_output_for_writer_id, 1);
+                        }
                     }
                 }
-            }
 
-            if (batch_did_local_write) {
-                noc_async_write_barrier();
+                if (batch_did_local_write) {
+                    noc_async_write_barrier();
+                }
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -90,14 +90,14 @@ void kernel_main() {
 #if INIT_ZEROS
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
 #if IS_TILE_LAYOUT
-    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
-    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
-    constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+    constexpr uint32_t num_idle_cores_group = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
 #endif
 #else
 #if IS_TILE_LAYOUT
-    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t num_idle_cores_group = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
 #endif
 #endif
@@ -160,8 +160,8 @@ void kernel_main() {
 
     uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args++);
     uint32_t start_sem_l1_offset = get_semaphore(start_semaphore_id);
-    uint64_t idle_start_noc_addrs[num_idle_cores];
-    for (uint32_t c = 0; c < num_idle_cores; c++) {
+    uint64_t idle_start_noc_addrs[num_idle_cores_group];
+    for (uint32_t c = 0; c < num_idle_cores_group; c++) {
         uint32_t noc_x = get_arg_val<uint32_t>(rt_args++);
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args++);
         idle_start_noc_addrs[c] = get_noc_addr(noc_x, noc_y, start_sem_l1_offset);
@@ -218,11 +218,12 @@ void kernel_main() {
         while (off < mcast_total_size) {
             uint32_t chunk = ((mcast_total_size - off) > (uint32_t)NOC_MAX_BURST_SIZE) ? (uint32_t)NOC_MAX_BURST_SIZE
                                                                                        : (mcast_total_size - off);
-            noc_async_write_multicast(counter_base_addr + off, mcast_counter_noc_addr + off, chunk, num_idle_cores);
+            noc_async_write_multicast(
+                counter_base_addr + off, mcast_counter_noc_addr + off, chunk, num_idle_cores_group);
             off += chunk;
         }
         noc_async_write_barrier();
-        noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores);
+        noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores_group);
         noc_async_atomic_barrier();
     }
 <<<<<<< HEAD
@@ -280,10 +281,10 @@ void kernel_main() {
             bool batch_did_local_write = false;
 
 #if IS_TILE_LAYOUT
-            uint32_t C = B % num_idle_cores;
+            uint32_t current_idle_core = B % num_idle_cores_group;
 
-            // Signal idle core C to send its untilized batch
-            noc_semaphore_inc(idle_start_noc_addrs[C], 1);
+            // Signal idle core to send its untilized batch
+            noc_semaphore_inc(idle_start_noc_addrs[current_idle_core], 1);
             noc_async_atomic_barrier();
 
             // Speculatively read metadata for this batch

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -91,6 +91,11 @@ void kernel_main() {
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+#else
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
 #endif
 
     // ===== Runtime Args =====
@@ -167,29 +172,29 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 
-    // Reserve scratch space once — these CBs are not used as FIFOs. Each batch
-    // overwrites the same region at offsets [0, batch_count) without push/pop.
-    // DRAM reads are batched to saturate DRAM bandwidth, while the scratch-to-writer-CB
-    // copies below are done one page at a time — this avoids CB FIFO pointer wrapping
-    // and measured faster in practice.
-    cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
+    // Set up scratch buffers for batched reads
+    constexpr uint32_t read_batch_size = 32;
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
+    uint32_t untilize_base = get_write_ptr(cb_untilize_id);
 
     const auto dispatched_buffer_addr_gen = TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr);
     const auto dispatched_metadata_addr_gen = TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr);
 
     constexpr auto expert_stride = max_dispatched_tokens_per_expert;
+    constexpr auto expert_stride_tile = (max_dispatched_tokens_per_expert / 32) * (hidden_size / 32);
 
     // Process each expert in assigned range
     for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
+        uint32_t tile_batch_counter = 0;
         uint32_t start_page = local_expert * expert_stride;
         uint32_t expert_tokens = experts_tok_counter_l1[local_expert];
         if (expert_tokens > max_dispatched_tokens_per_expert) {
             expert_tokens = max_dispatched_tokens_per_expert;
         }
         uint32_t end_page = start_page + expert_tokens;
+        uint32_t start_page_tiled = local_expert * expert_stride_tile;
 
         DPRINT_COMBINE << "Expert=" << local_expert << " tokens=" << expert_tokens << ENDL();
 
@@ -199,13 +204,29 @@ void kernel_main() {
         if (first_batch_count > 0) {
             for (uint32_t t = 0; t < first_batch_count; t++) {
                 noc_async_read_page(
-                    start_page + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
-                noc_async_read_page(
                     start_page + t,
                     dispatched_metadata_addr_gen,
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
+            cb_reserve_back(cb_dispatched_buffer_id, hidden_size / 32);
+            for (uint32_t t = 0; t < hidden_size / 32; t++) {
+                noc_async_read_page(
+                    start_page_tiled + t,
+                    dispatched_buffer_addr_gen,
+                    buffer_base + t * aligned_dispatched_buffer_page_size);
+            }
+
             noc_async_read_barrier();
+
+            // Push tiles to c_0 so compute's cb_wait_front(cb_in_id) can proceed
+            cb_push_back(cb_dispatched_buffer_id, hidden_size / 32);
+
+            cb_reserve_back(cb_signal_id, 1);
+            volatile tt_l1_ptr uint32_t* signal_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+            signal_ptr[0] = 0x00000000;
+            cb_push_back(cb_signal_id, 1);
+            tile_batch_counter++;
         }
 
         for (uint32_t batch_start = start_page; batch_start < end_page; batch_start += read_batch_size) {
@@ -213,8 +234,9 @@ void kernel_main() {
             uint32_t batch_count = batch_end - batch_start;
             bool batch_did_local_write = false;
 
+            cb_wait_front(cb_untilize_id, read_batch_size);
             for (uint32_t t = 0; t < batch_count; t++) {
-                uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
+                uint32_t buffer_scratch_addr = untilize_base + t * aligned_output_page_size;
                 uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
                 volatile tt_l1_ptr uint32_t* metadata =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_scratch_addr);
@@ -247,16 +269,17 @@ void kernel_main() {
                         // Push output payload to writer
                         cb_reserve_back(cb_output_for_writer_id, 1);
                         uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
-                        noc_async_read(
-                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
+                        noc_async_read(get_noc_addr(buffer_scratch_addr), output_dst, aligned_output_page_size);
                         noc_async_read_barrier();
                         cb_push_back(cb_output_for_writer_id, 1);
                     }
                 }
             }
+            cb_pop_front(cb_untilize_id, read_batch_size);
 
             // Issue next batch reads BEFORE write barrier
             uint32_t next_batch_start = batch_start + read_batch_size;
+            uint32_t next_batch_start_tiled = start_page_tiled + tile_batch_counter * hidden_size / 32;
             bool has_next_batch = (next_batch_start < end_page);
             if (has_next_batch) {
                 uint32_t next_batch_end =
@@ -265,13 +288,18 @@ void kernel_main() {
                 for (uint32_t t = 0; t < next_batch_count; t++) {
                     noc_async_read_page(
                         next_batch_start + t,
-                        dispatched_buffer_addr_gen,
-                        buffer_base + t * aligned_dispatched_buffer_page_size);
-                    noc_async_read_page(
-                        next_batch_start + t,
                         dispatched_metadata_addr_gen,
                         metadata_base + t * aligned_dispatched_metadata_page_size);
                 }
+                // Reserve c_0 for next batch (compute popped previous tiles)
+                cb_reserve_back(cb_dispatched_buffer_id, hidden_size / 32);
+                for (uint32_t t = 0; t < hidden_size / 32; t++) {
+                    noc_async_read_page(
+                        next_batch_start_tiled + t,
+                        dispatched_buffer_addr_gen,
+                        buffer_base + t * aligned_dispatched_buffer_page_size);
+                }
+                tile_batch_counter++;
             }
 
             if (batch_did_local_write) {
@@ -280,9 +308,19 @@ void kernel_main() {
 
             if (has_next_batch) {
                 noc_async_read_barrier();
+                // Push tiles to c_0 so compute's cb_wait_front(cb_in_id) can proceed
+                cb_push_back(cb_dispatched_buffer_id, hidden_size / 32);
+                cb_reserve_back(cb_signal_id, 1);
+                cb_push_back(cb_signal_id, 1);
             }
         }
     }
+
+    cb_reserve_back(cb_signal_id, 1);
+    volatile tt_l1_ptr uint32_t* signal_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+    signal_ptr[0] = ROUTE_INFO_SENTINEL;  // Signal writer that first batch is ready
+    cb_push_back(cb_signal_id, 1);
 
     // Push sentinel to signal writer that all dispatches are done
     cb_reserve_back(cb_route_info_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -232,18 +232,8 @@ void kernel_main() {
         noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores_group);
         noc_async_atomic_barrier();
     }
-<<<<<<< HEAD
-=======
 #endif
 
-    // Expert token counts are laid out as [n_dispatch_groups, experts_per_dispatch_group]
-    // where each dispatch group is a mesh column (all rows in that column).
-    // Row-major linearization: linearized_mesh_coord = mesh_row * mesh_cols + mesh_col
-    constexpr uint32_t mesh_row = linearized_mesh_coord / mesh_cols;  // position within dispatch group
-    constexpr uint32_t mesh_col = linearized_mesh_coord % mesh_cols;  // which dispatch group
-    constexpr uint32_t experts_per_dispatch_group = experts_per_chip * mesh_rows;
-    constexpr uint32_t offset = mesh_col * experts_per_dispatch_group + mesh_row * experts_per_chip;
->>>>>>> 8ea4f244e1 (Adding TILE_LAYOUT defines into reader_combine kernel)
     volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -294,6 +294,24 @@ void kernel_main() {
 
         DPRINT_COMBINE << "Expert=" << local_expert << " tokens=" << expert_tokens << ENDL();
 
+#if IS_TILE_LAYOUT
+#else
+        // Prefetch first batch
+        uint32_t first_batch_end = (start_page + read_batch_size < end_page) ? start_page + read_batch_size : end_page;
+        uint32_t first_batch_count = first_batch_end - start_page;
+        if (first_batch_count > 0) {
+            for (uint32_t t = 0; t < first_batch_count; t++) {
+                noc_async_read_page(
+                    start_page + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
+                noc_async_read_page(
+                    start_page + t,
+                    dispatched_metadata_addr_gen,
+                    metadata_base + t * aligned_dispatched_metadata_page_size);
+            }
+            noc_async_read_barrier();
+        }
+#endif
+
         for (uint32_t B = 0; B < num_batches; B++) {
             uint32_t batch_start = start_page + B * read_batch_size;
             uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
@@ -348,17 +366,6 @@ void kernel_main() {
             // the idle deadlocks waiting for a signal that never re-arrives.
             noc_semaphore_wait(data_ready_sem_ptr, 1);
             noc_semaphore_set(data_ready_sem_ptr, 0);
-#else
-            // ROW_MAJOR: DMA read dispatched_buffer rows + metadata
-            for (uint32_t t = 0; t < batch_count; t++) {
-                noc_async_read_page(
-                    batch_start + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
-                noc_async_read_page(
-                    batch_start + t,
-                    dispatched_metadata_addr_gen,
-                    metadata_base + t * aligned_dispatched_metadata_page_size);
-            }
-            noc_async_read_barrier();
 #endif
 
             // In TILE_LAYOUT the sender only routes tokens when has_non_local is true (the idle
@@ -418,9 +425,38 @@ void kernel_main() {
                     }
                 }
 
+#if IS_TILE_LAYOUT
+#else
+                // Issue next batch reads BEFORE write barrier to overlap DMA reads with NOC writes
+                uint32_t next_batch_start = batch_start + read_batch_size;
+                bool has_next_batch = (next_batch_start < end_page);
+                if (has_next_batch) {
+                    uint32_t next_batch_end =
+                        (next_batch_start + read_batch_size < end_page) ? next_batch_start + read_batch_size : end_page;
+                    uint32_t next_batch_count = next_batch_end - next_batch_start;
+                    for (uint32_t t = 0; t < next_batch_count; t++) {
+                        noc_async_read_page(
+                            next_batch_start + t,
+                            dispatched_buffer_addr_gen,
+                            buffer_base + t * aligned_dispatched_buffer_page_size);
+                        noc_async_read_page(
+                            next_batch_start + t,
+                            dispatched_metadata_addr_gen,
+                            metadata_base + t * aligned_dispatched_metadata_page_size);
+                    }
+                }
+#endif
+
                 if (batch_did_local_write) {
                     noc_async_write_barrier();
                 }
+
+#if IS_TILE_LAYOUT
+#else
+                if (has_next_batch) {
+                    noc_async_read_barrier();
+                }
+#endif
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -197,10 +197,14 @@ void kernel_main() {
     {
         constexpr uint32_t counter_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
-        // Append receive_buf_addr so idle cores know where to NOC-write untilized data
+        // Append receive_buf_addr for every sender so idle cores know where to NOC-write untilized data.
+        // All sender cores share the same cb_untilize_id L1 address (identical CB layout), so fill each
+        // slot with this core's value — it is the same on every sender.
         volatile tt_l1_ptr uint32_t* receive_buf_slot =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr + counter_total_size);
-        receive_buf_slot[0] = get_write_ptr(cb_untilize_id);
+        for (uint32_t s = 0; s < num_cores; s++) {
+            receive_buf_slot[s] = get_write_ptr(cb_untilize_id);
+        }
 
         constexpr uint32_t mcast_total_size = counter_total_size + l1_alignment;
         uint32_t off = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -90,12 +90,16 @@ void kernel_main() {
 #if INIT_ZEROS
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+#if IS_TILE_LAYOUT
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
     constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+#endif
 #else
+#if IS_TILE_LAYOUT
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
+#endif
 #endif
 
     // ===== Runtime Args =====
@@ -137,6 +141,7 @@ void kernel_main() {
     }
 #endif
 
+#if IS_TILE_LAYOUT
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
     uint32_t mcast_start_x = get_arg_val<uint32_t>(rt_args++);
     uint32_t mcast_start_y = get_arg_val<uint32_t>(rt_args++);
@@ -161,6 +166,7 @@ void kernel_main() {
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args++);
         idle_start_noc_addrs[c] = get_noc_addr(noc_x, noc_y, start_sem_l1_offset);
     }
+#endif
 
     // Signal writer that zero-init is complete
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
@@ -195,6 +201,10 @@ void kernel_main() {
     constexpr uint32_t experts_per_dispatch_group = experts_per_chip * num_chips;
     constexpr uint32_t offset = dispatch_group_idx * experts_per_dispatch_group + mesh_row * experts_per_chip;
     // Multicast expert token counts + receive_buf_addr to all idle cores
+#if IS_TILE_LAYOUT
+    // Each sender multicasts token counts + its own receive_buf_addr to its dedicated idle group.
+    // The mcast destination covers only this sender's k_s idle cores (per-sender bounding box),
+    // so all senders can multicast in parallel without interfering with each other.
     {
         constexpr uint32_t counter_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
@@ -215,16 +225,39 @@ void kernel_main() {
         noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores);
         noc_async_atomic_barrier();
     }
+<<<<<<< HEAD
+=======
+#endif
+
+    // Expert token counts are laid out as [n_dispatch_groups, experts_per_dispatch_group]
+    // where each dispatch group is a mesh column (all rows in that column).
+    // Row-major linearization: linearized_mesh_coord = mesh_row * mesh_cols + mesh_col
+    constexpr uint32_t mesh_row = linearized_mesh_coord / mesh_cols;  // position within dispatch group
+    constexpr uint32_t mesh_col = linearized_mesh_coord % mesh_cols;  // which dispatch group
+    constexpr uint32_t experts_per_dispatch_group = experts_per_chip * mesh_rows;
+    constexpr uint32_t offset = mesh_col * experts_per_dispatch_group + mesh_row * experts_per_chip;
+>>>>>>> 8ea4f244e1 (Adding TILE_LAYOUT defines into reader_combine kernel)
     volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 
     // Set up scratch buffers for batched reads
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
+
+#if IS_TILE_LAYOUT
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);
+#else
+    cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
+    uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
+#endif
 
     const auto dispatched_metadata_addr_gen =
         TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr, aligned_dispatched_metadata_page_size);
+
+#if !IS_TILE_LAYOUT
+    const auto dispatched_buffer_addr_gen =
+        TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
+#endif
 
     constexpr auto expert_stride = max_dispatched_tokens_per_expert;
 
@@ -244,14 +277,16 @@ void kernel_main() {
             uint32_t batch_start = start_page + B * read_batch_size;
             uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
             uint32_t batch_count = batch_end - batch_start;
-            uint32_t C = B % num_idle_cores;
             bool batch_did_local_write = false;
+
+#if IS_TILE_LAYOUT
+            uint32_t C = B % num_idle_cores;
 
             // Signal idle core C to send its untilized batch
             noc_semaphore_inc(idle_start_noc_addrs[C], 1);
             noc_async_atomic_barrier();
 
-            // Speculatively read metadata for this batch (overlaps with idle core's NOC write)
+            // Speculatively read metadata for this batch
             for (uint32_t t = 0; t < batch_count; t++) {
                 noc_async_read_page(
                     batch_start + t,
@@ -259,16 +294,32 @@ void kernel_main() {
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
 
-            // Wait for idle core to write untilized data to sender's cb_untilize_id
+            // Wait for idle core to write untilized data
             noc_semaphore_wait(data_ready_sem_ptr, 1);
             noc_semaphore_set(data_ready_sem_ptr, 0);
 
             // Ensure metadata is ready
             noc_async_read_barrier();
+#else
+            // ROW_MAJOR: DMA read dispatched_buffer rows + metadata
+            for (uint32_t t = 0; t < batch_count; t++) {
+                noc_async_read_page(
+                    batch_start + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
+                noc_async_read_page(
+                    batch_start + t,
+                    dispatched_metadata_addr_gen,
+                    metadata_base + t * aligned_dispatched_metadata_page_size);
+            }
+            noc_async_read_barrier();
+#endif
 
             // Route tokens
             for (uint32_t t = 0; t < batch_count; t++) {
+#if IS_TILE_LAYOUT
                 uint32_t buffer_scratch_addr = untilize_base + t * aligned_output_page_size;
+#else
+                uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
+#endif
                 uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
                 volatile tt_l1_ptr uint32_t* metadata =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_scratch_addr);
@@ -301,7 +352,12 @@ void kernel_main() {
                         // Push output payload to writer
                         cb_reserve_back(cb_output_for_writer_id, 1);
                         uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
+#if IS_TILE_LAYOUT
                         noc_async_read(get_noc_addr(buffer_scratch_addr), output_dst, aligned_output_page_size);
+#else
+                        noc_async_read(
+                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
+#endif
                         noc_async_read_barrier();
                         cb_push_back(cb_output_for_writer_id, 1);
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -91,10 +91,9 @@ void kernel_main() {
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
-    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
-    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
 #else
-    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
 #endif
 
@@ -137,6 +136,31 @@ void kernel_main() {
     }
 #endif
 
+    uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_start_x = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_start_y = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_end_x = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_end_y = get_arg_val<uint32_t>(rt_args++);
+    uint32_t idle_counter_l1_offset = get_write_ptr(cb_dispatched_metadata_id);
+    uint32_t counter_ready_sem_l1_offset = get_semaphore(counter_ready_semaphore_id);
+    uint64_t mcast_counter_noc_addr =
+        get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, idle_counter_l1_offset);
+    uint64_t mcast_counter_sem_noc_addr =
+        get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, counter_ready_sem_l1_offset);
+
+    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    volatile tt_l1_ptr uint32_t* data_ready_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(data_ready_semaphore_id));
+
+    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t start_sem_l1_offset = get_semaphore(start_semaphore_id);
+    uint64_t idle_start_noc_addrs[num_idle_cores];
+    for (uint32_t c = 0; c < num_idle_cores; c++) {
+        uint32_t noc_x = get_arg_val<uint32_t>(rt_args++);
+        uint32_t noc_y = get_arg_val<uint32_t>(rt_args++);
+        idle_start_noc_addrs[c] = get_noc_addr(noc_x, noc_y, start_sem_l1_offset);
+    }
+
     // Signal writer that zero-init is complete
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
@@ -169,72 +193,80 @@ void kernel_main() {
     constexpr uint32_t dispatch_group_idx = mesh_col % num_dispatch_groups;
     constexpr uint32_t experts_per_dispatch_group = experts_per_chip * num_chips;
     constexpr uint32_t offset = dispatch_group_idx * experts_per_dispatch_group + mesh_row * experts_per_chip;
+    // Multicast expert token counts + receive_buf_addr to all idle cores
+    {
+        constexpr uint32_t counter_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
+
+        // Append receive_buf_addr so idle cores know where to NOC-write untilized data
+        volatile tt_l1_ptr uint32_t* receive_buf_slot =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr + counter_total_size);
+        receive_buf_slot[0] = get_write_ptr(cb_untilize_id);
+
+        constexpr uint32_t mcast_total_size = counter_total_size + l1_alignment;
+        uint32_t off = 0;
+        while (off < mcast_total_size) {
+            uint32_t chunk = ((mcast_total_size - off) > (uint32_t)NOC_MAX_BURST_SIZE) ? (uint32_t)NOC_MAX_BURST_SIZE
+                                                                                       : (mcast_total_size - off);
+            noc_async_write_multicast(counter_base_addr + off, mcast_counter_noc_addr + off, chunk, num_idle_cores);
+            off += chunk;
+        }
+        noc_async_write_barrier();
+        noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores);
+        noc_async_atomic_barrier();
+    }
     volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 
     // Set up scratch buffers for batched reads
     constexpr uint32_t read_batch_size = 32;
-    uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);
 
-    const auto dispatched_buffer_addr_gen = TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr);
-    const auto dispatched_metadata_addr_gen = TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr);
+    const auto dispatched_metadata_addr_gen =
+        TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr, aligned_dispatched_metadata_page_size);
 
     constexpr auto expert_stride = max_dispatched_tokens_per_expert;
-    constexpr auto expert_stride_tile = (max_dispatched_tokens_per_expert / 32) * (hidden_size / 32);
 
     // Process each expert in assigned range
     for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
-        uint32_t tile_batch_counter = 0;
         uint32_t start_page = local_expert * expert_stride;
         uint32_t expert_tokens = experts_tok_counter_l1[local_expert];
         if (expert_tokens > max_dispatched_tokens_per_expert) {
             expert_tokens = max_dispatched_tokens_per_expert;
         }
         uint32_t end_page = start_page + expert_tokens;
-        uint32_t start_page_tiled = local_expert * expert_stride_tile;
+        uint32_t num_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
         DPRINT_COMBINE << "Expert=" << local_expert << " tokens=" << expert_tokens << ENDL();
 
-        // Prefetch first batch
-        uint32_t first_batch_end = (start_page + read_batch_size < end_page) ? start_page + read_batch_size : end_page;
-        uint32_t first_batch_count = first_batch_end - start_page;
-        if (first_batch_count > 0) {
-            for (uint32_t t = 0; t < first_batch_count; t++) {
+        for (uint32_t B = 0; B < num_batches; B++) {
+            uint32_t batch_start = start_page + B * read_batch_size;
+            uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
+            uint32_t batch_count = batch_end - batch_start;
+            uint32_t C = B % num_idle_cores;
+            bool batch_did_local_write = false;
+
+            // Signal idle core C to send its untilized batch
+            noc_semaphore_inc(idle_start_noc_addrs[C], 1);
+            noc_async_atomic_barrier();
+
+            // Speculatively read metadata for this batch (overlaps with idle core's NOC write)
+            for (uint32_t t = 0; t < batch_count; t++) {
                 noc_async_read_page(
-                    start_page + t,
+                    batch_start + t,
                     dispatched_metadata_addr_gen,
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
-            cb_reserve_back(cb_dispatched_buffer_id, hidden_size / 32);
-            for (uint32_t t = 0; t < hidden_size / 32; t++) {
-                noc_async_read_page(
-                    start_page_tiled + t,
-                    dispatched_buffer_addr_gen,
-                    buffer_base + t * aligned_dispatched_buffer_page_size);
-            }
 
+            // Wait for idle core to write untilized data to sender's cb_untilize_id
+            noc_semaphore_wait(data_ready_sem_ptr, 1);
+            noc_semaphore_set(data_ready_sem_ptr, 0);
+
+            // Ensure metadata is ready
             noc_async_read_barrier();
 
-            // Push tiles to c_0 so compute's cb_wait_front(cb_in_id) can proceed
-            cb_push_back(cb_dispatched_buffer_id, hidden_size / 32);
-
-            cb_reserve_back(cb_signal_id, 1);
-            volatile tt_l1_ptr uint32_t* signal_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
-            signal_ptr[0] = 0x00000000;
-            cb_push_back(cb_signal_id, 1);
-            tile_batch_counter++;
-        }
-
-        for (uint32_t batch_start = start_page; batch_start < end_page; batch_start += read_batch_size) {
-            uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
-            uint32_t batch_count = batch_end - batch_start;
-            bool batch_did_local_write = false;
-
-            cb_wait_front(cb_untilize_id, read_batch_size);
+            // Route tokens
             for (uint32_t t = 0; t < batch_count; t++) {
                 uint32_t buffer_scratch_addr = untilize_base + t * aligned_output_page_size;
                 uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
@@ -275,52 +307,12 @@ void kernel_main() {
                     }
                 }
             }
-            cb_pop_front(cb_untilize_id, read_batch_size);
-
-            // Issue next batch reads BEFORE write barrier
-            uint32_t next_batch_start = batch_start + read_batch_size;
-            uint32_t next_batch_start_tiled = start_page_tiled + tile_batch_counter * hidden_size / 32;
-            bool has_next_batch = (next_batch_start < end_page);
-            if (has_next_batch) {
-                uint32_t next_batch_end =
-                    (next_batch_start + read_batch_size < end_page) ? next_batch_start + read_batch_size : end_page;
-                uint32_t next_batch_count = next_batch_end - next_batch_start;
-                for (uint32_t t = 0; t < next_batch_count; t++) {
-                    noc_async_read_page(
-                        next_batch_start + t,
-                        dispatched_metadata_addr_gen,
-                        metadata_base + t * aligned_dispatched_metadata_page_size);
-                }
-                // Reserve c_0 for next batch (compute popped previous tiles)
-                cb_reserve_back(cb_dispatched_buffer_id, hidden_size / 32);
-                for (uint32_t t = 0; t < hidden_size / 32; t++) {
-                    noc_async_read_page(
-                        next_batch_start_tiled + t,
-                        dispatched_buffer_addr_gen,
-                        buffer_base + t * aligned_dispatched_buffer_page_size);
-                }
-                tile_batch_counter++;
-            }
 
             if (batch_did_local_write) {
                 noc_async_write_barrier();
             }
-
-            if (has_next_batch) {
-                noc_async_read_barrier();
-                // Push tiles to c_0 so compute's cb_wait_front(cb_in_id) can proceed
-                cb_push_back(cb_dispatched_buffer_id, hidden_size / 32);
-                cb_reserve_back(cb_signal_id, 1);
-                cb_push_back(cb_signal_id, 1);
-            }
         }
     }
-
-    cb_reserve_back(cb_signal_id, 1);
-    volatile tt_l1_ptr uint32_t* signal_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
-    signal_ptr[0] = ROUTE_INFO_SENTINEL;  // Signal writer that first batch is ready
-    cb_push_back(cb_signal_id, 1);
 
     // Push sentinel to signal writer that all dispatches are done
     cb_reserve_back(cb_route_info_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -197,14 +197,10 @@ void kernel_main() {
     {
         constexpr uint32_t counter_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
-        // Append receive_buf_addr for every sender so idle cores know where to NOC-write untilized data.
-        // All sender cores share the same cb_untilize_id L1 address (identical CB layout), so fill each
-        // slot with this core's value — it is the same on every sender.
+        // Append this sender's receive_buf_addr so its idle cores know where to write untilized data.
         volatile tt_l1_ptr uint32_t* receive_buf_slot =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr + counter_total_size);
-        for (uint32_t s = 0; s < num_cores; s++) {
-            receive_buf_slot[s] = get_write_ptr(cb_untilize_id);
-        }
+        receive_buf_slot[0] = get_write_ptr(cb_untilize_id);
 
         constexpr uint32_t mcast_total_size = counter_total_size + l1_alignment;
         uint32_t off = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -219,7 +219,6 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 
     // Set up scratch buffers for batched reads
-    constexpr uint32_t read_batch_size = 32;
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -88,12 +88,16 @@ void kernel_main() {
 #if INIT_ZEROS
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+#if IS_TILE_LAYOUT
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
     constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+#endif
 #else
+#if IS_TILE_LAYOUT
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
+#endif
 #endif
 
     // ===== Runtime Args =====
@@ -135,6 +139,7 @@ void kernel_main() {
     }
 #endif
 
+#if IS_TILE_LAYOUT
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
     uint32_t mcast_start_x = get_arg_val<uint32_t>(rt_args++);
     uint32_t mcast_start_y = get_arg_val<uint32_t>(rt_args++);
@@ -159,6 +164,7 @@ void kernel_main() {
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args++);
         idle_start_noc_addrs[c] = get_noc_addr(noc_x, noc_y, start_sem_l1_offset);
     }
+#endif
 
     // Signal writer that zero-init is complete
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
@@ -183,6 +189,7 @@ void kernel_main() {
     }
     noc_async_read_barrier();
 
+#if IS_TILE_LAYOUT
     // Each sender multicasts token counts + its own receive_buf_addr to its dedicated idle group.
     // The mcast destination covers only this sender's k_s idle cores (per-sender bounding box),
     // so all senders can multicast in parallel without interfering with each other.
@@ -206,6 +213,7 @@ void kernel_main() {
         noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores);
         noc_async_atomic_barrier();
     }
+#endif
 
     // Expert token counts are laid out as [n_dispatch_groups, experts_per_dispatch_group]
     // where each dispatch group is a mesh column (all rows in that column).
@@ -220,10 +228,21 @@ void kernel_main() {
     // Set up scratch buffers for batched reads
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
+
+#if IS_TILE_LAYOUT
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);
+#else
+    cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
+    uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
+#endif
 
     const auto dispatched_metadata_addr_gen =
         TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr, aligned_dispatched_metadata_page_size);
+
+#if !IS_TILE_LAYOUT
+    const auto dispatched_buffer_addr_gen =
+        TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
+#endif
 
     constexpr auto expert_stride = max_dispatched_tokens_per_expert;
 
@@ -243,14 +262,16 @@ void kernel_main() {
             uint32_t batch_start = start_page + B * read_batch_size;
             uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
             uint32_t batch_count = batch_end - batch_start;
-            uint32_t C = B % num_idle_cores;
             bool batch_did_local_write = false;
+
+#if IS_TILE_LAYOUT
+            uint32_t C = B % num_idle_cores;
 
             // Signal idle core C to send its untilized batch
             noc_semaphore_inc(idle_start_noc_addrs[C], 1);
             noc_async_atomic_barrier();
 
-            // Speculatively read metadata for this batch (overlaps with idle core's NOC write)
+            // Speculatively read metadata for this batch
             for (uint32_t t = 0; t < batch_count; t++) {
                 noc_async_read_page(
                     batch_start + t,
@@ -258,16 +279,32 @@ void kernel_main() {
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
 
-            // Wait for idle core to write untilized data to sender's cb_untilize_id
+            // Wait for idle core to write untilized data
             noc_semaphore_wait(data_ready_sem_ptr, 1);
             noc_semaphore_set(data_ready_sem_ptr, 0);
 
             // Ensure metadata is ready
             noc_async_read_barrier();
+#else
+            // ROW_MAJOR: DMA read dispatched_buffer rows + metadata
+            for (uint32_t t = 0; t < batch_count; t++) {
+                noc_async_read_page(
+                    batch_start + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
+                noc_async_read_page(
+                    batch_start + t,
+                    dispatched_metadata_addr_gen,
+                    metadata_base + t * aligned_dispatched_metadata_page_size);
+            }
+            noc_async_read_barrier();
+#endif
 
             // Route tokens
             for (uint32_t t = 0; t < batch_count; t++) {
+#if IS_TILE_LAYOUT
                 uint32_t buffer_scratch_addr = untilize_base + t * aligned_output_page_size;
+#else
+                uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
+#endif
                 uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
                 volatile tt_l1_ptr uint32_t* metadata =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_scratch_addr);
@@ -300,7 +337,12 @@ void kernel_main() {
                         // Push output payload to writer
                         cb_reserve_back(cb_output_for_writer_id, 1);
                         uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
+#if IS_TILE_LAYOUT
                         noc_async_read(get_noc_addr(buffer_scratch_addr), output_dst, aligned_output_page_size);
+#else
+                        noc_async_read(
+                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
+#endif
                         noc_async_read_barrier();
                         cb_push_back(cb_output_for_writer_id, 1);
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -88,14 +88,14 @@ void kernel_main() {
 #if INIT_ZEROS
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
 #if IS_TILE_LAYOUT
-    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
-    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
-    constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+    constexpr uint32_t num_idle_cores_group = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
 #endif
 #else
 #if IS_TILE_LAYOUT
-    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t num_idle_cores_group = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
 #endif
 #endif
@@ -158,8 +158,8 @@ void kernel_main() {
 
     uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args++);
     uint32_t start_sem_l1_offset = get_semaphore(start_semaphore_id);
-    uint64_t idle_start_noc_addrs[num_idle_cores];
-    for (uint32_t c = 0; c < num_idle_cores; c++) {
+    uint64_t idle_start_noc_addrs[num_idle_cores_group];
+    for (uint32_t c = 0; c < num_idle_cores_group; c++) {
         uint32_t noc_x = get_arg_val<uint32_t>(rt_args++);
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args++);
         idle_start_noc_addrs[c] = get_noc_addr(noc_x, noc_y, start_sem_l1_offset);
@@ -206,11 +206,12 @@ void kernel_main() {
         while (off < mcast_total_size) {
             uint32_t chunk = ((mcast_total_size - off) > (uint32_t)NOC_MAX_BURST_SIZE) ? (uint32_t)NOC_MAX_BURST_SIZE
                                                                                        : (mcast_total_size - off);
-            noc_async_write_multicast(counter_base_addr + off, mcast_counter_noc_addr + off, chunk, num_idle_cores);
+            noc_async_write_multicast(
+                counter_base_addr + off, mcast_counter_noc_addr + off, chunk, num_idle_cores_group);
             off += chunk;
         }
         noc_async_write_barrier();
-        noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores);
+        noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores_group);
         noc_async_atomic_barrier();
     }
 #endif
@@ -265,10 +266,10 @@ void kernel_main() {
             bool batch_did_local_write = false;
 
 #if IS_TILE_LAYOUT
-            uint32_t C = B % num_idle_cores;
+            uint32_t current_idle_core = B % num_idle_cores_group;
 
-            // Signal idle core C to send its untilized batch
-            noc_semaphore_inc(idle_start_noc_addrs[C], 1);
+            // Signal idle core to send its untilized batch
+            noc_semaphore_inc(idle_start_noc_addrs[current_idle_core], 1);
             noc_async_atomic_barrier();
 
             // Speculatively read metadata for this batch

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -90,6 +90,7 @@ void kernel_main() {
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t num_total_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
 #else
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
@@ -129,7 +130,7 @@ void kernel_main() {
 
         volatile tt_l1_ptr uint32_t* zi_done_sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zi_done_sem_address);
-        noc_semaphore_wait(zi_done_sem_ptr, num_idle_cores);
+        noc_semaphore_wait(zi_done_sem_ptr, num_total_idle_cores);
         noc_semaphore_set(zi_done_sem_ptr, 0);
     }
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -218,7 +218,6 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 
     // Set up scratch buffers for batched reads
-    constexpr uint32_t read_batch_size = 32;
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -182,14 +182,20 @@ void kernel_main() {
     }
     noc_async_read_barrier();
 
-    // Multicast expert token counts + receive_buf_addr to all idle cores
-    {
+    // Only the primary sender (expert_start_idx == 0) multicasts token counts + receive_buf_addrs.
+    // Other senders skip this block entirely — executing it from multiple cores would race-corrupt
+    // the idle cores' L1 and double-signal counter_ready_semaphore.
+    if (expert_start_idx == 0) {
         constexpr uint32_t counter_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
-        // Append receive_buf_addr so idle cores know where to NOC-write untilized data
+        // Append receive_buf_addr for every sender so idle cores know where to NOC-write untilized data.
+        // All sender cores share the same cb_untilize_id L1 address (identical CB layout), so fill each
+        // slot with this core's value — it is the same on every sender.
         volatile tt_l1_ptr uint32_t* receive_buf_slot =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr + counter_total_size);
-        receive_buf_slot[0] = get_write_ptr(cb_untilize_id);
+        for (uint32_t s = 0; s < num_cores; s++) {
+            receive_buf_slot[s] = get_write_ptr(cb_untilize_id);
+        }
 
         constexpr uint32_t mcast_total_size = counter_total_size + l1_alignment;
         uint32_t off = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -182,20 +182,16 @@ void kernel_main() {
     }
     noc_async_read_barrier();
 
-    // Only the primary sender (expert_start_idx == 0) multicasts token counts + receive_buf_addrs.
-    // Other senders skip this block entirely — executing it from multiple cores would race-corrupt
-    // the idle cores' L1 and double-signal counter_ready_semaphore.
-    if (expert_start_idx == 0) {
+    // Each sender multicasts token counts + its own receive_buf_addr to its dedicated idle group.
+    // The mcast destination covers only this sender's k_s idle cores (per-sender bounding box),
+    // so all senders can multicast in parallel without interfering with each other.
+    {
         constexpr uint32_t counter_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
-        // Append receive_buf_addr for every sender so idle cores know where to NOC-write untilized data.
-        // All sender cores share the same cb_untilize_id L1 address (identical CB layout), so fill each
-        // slot with this core's value — it is the same on every sender.
+        // Append this sender's receive_buf_addr so its idle cores know where to write untilized data.
         volatile tt_l1_ptr uint32_t* receive_buf_slot =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr + counter_total_size);
-        for (uint32_t s = 0; s < num_cores; s++) {
-            receive_buf_slot[s] = get_write_ptr(cb_untilize_id);
-        }
+        receive_buf_slot[0] = get_write_ptr(cb_untilize_id);
 
         constexpr uint32_t mcast_total_size = counter_total_size + l1_alignment;
         uint32_t off = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -89,6 +89,11 @@ void kernel_main() {
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+#else
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
 #endif
 
     // ===== Runtime Args =====
@@ -163,29 +168,29 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 
-    // Reserve scratch space once — these CBs are not used as FIFOs. Each batch
-    // overwrites the same region at offsets [0, batch_count) without push/pop.
-    // DRAM reads are batched to saturate DRAM bandwidth, while the scratch-to-writer-CB
-    // copies below are done one page at a time — this avoids CB FIFO pointer wrapping
-    // and measured faster in practice.
-    cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
+    // Set up scratch buffers for batched reads
+    constexpr uint32_t read_batch_size = 32;
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
+    uint32_t untilize_base = get_write_ptr(cb_untilize_id);
 
     const auto dispatched_buffer_addr_gen = TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr);
     const auto dispatched_metadata_addr_gen = TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr);
 
     constexpr auto expert_stride = max_dispatched_tokens_per_expert;
+    constexpr auto expert_stride_tile = (max_dispatched_tokens_per_expert / 32) * (hidden_size / 32);
 
     // Process each expert in assigned range
     for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
+        uint32_t tile_batch_counter = 0;
         uint32_t start_page = local_expert * expert_stride;
         uint32_t expert_tokens = experts_tok_counter_l1[local_expert];
         if (expert_tokens > max_dispatched_tokens_per_expert) {
             expert_tokens = max_dispatched_tokens_per_expert;
         }
         uint32_t end_page = start_page + expert_tokens;
+        uint32_t start_page_tiled = local_expert * expert_stride_tile;
 
         DPRINT_COMBINE << "Expert=" << local_expert << " tokens=" << expert_tokens << ENDL();
 
@@ -195,13 +200,29 @@ void kernel_main() {
         if (first_batch_count > 0) {
             for (uint32_t t = 0; t < first_batch_count; t++) {
                 noc_async_read_page(
-                    start_page + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
-                noc_async_read_page(
                     start_page + t,
                     dispatched_metadata_addr_gen,
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
+            cb_reserve_back(cb_dispatched_buffer_id, hidden_size / 32);
+            for (uint32_t t = 0; t < hidden_size / 32; t++) {
+                noc_async_read_page(
+                    start_page_tiled + t,
+                    dispatched_buffer_addr_gen,
+                    buffer_base + t * aligned_dispatched_buffer_page_size);
+            }
+
             noc_async_read_barrier();
+
+            // Push tiles to c_0 so compute's cb_wait_front(cb_in_id) can proceed
+            cb_push_back(cb_dispatched_buffer_id, hidden_size / 32);
+
+            cb_reserve_back(cb_signal_id, 1);
+            volatile tt_l1_ptr uint32_t* signal_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+            signal_ptr[0] = 0x00000000;
+            cb_push_back(cb_signal_id, 1);
+            tile_batch_counter++;
         }
 
         for (uint32_t batch_start = start_page; batch_start < end_page; batch_start += read_batch_size) {
@@ -209,8 +230,9 @@ void kernel_main() {
             uint32_t batch_count = batch_end - batch_start;
             bool batch_did_local_write = false;
 
+            cb_wait_front(cb_untilize_id, read_batch_size);
             for (uint32_t t = 0; t < batch_count; t++) {
-                uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
+                uint32_t buffer_scratch_addr = untilize_base + t * aligned_output_page_size;
                 uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
                 volatile tt_l1_ptr uint32_t* metadata =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_scratch_addr);
@@ -243,16 +265,17 @@ void kernel_main() {
                         // Push output payload to writer
                         cb_reserve_back(cb_output_for_writer_id, 1);
                         uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
-                        noc_async_read(
-                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
+                        noc_async_read(get_noc_addr(buffer_scratch_addr), output_dst, aligned_output_page_size);
                         noc_async_read_barrier();
                         cb_push_back(cb_output_for_writer_id, 1);
                     }
                 }
             }
+            cb_pop_front(cb_untilize_id, read_batch_size);
 
             // Issue next batch reads BEFORE write barrier
             uint32_t next_batch_start = batch_start + read_batch_size;
+            uint32_t next_batch_start_tiled = start_page_tiled + tile_batch_counter * hidden_size / 32;
             bool has_next_batch = (next_batch_start < end_page);
             if (has_next_batch) {
                 uint32_t next_batch_end =
@@ -261,13 +284,18 @@ void kernel_main() {
                 for (uint32_t t = 0; t < next_batch_count; t++) {
                     noc_async_read_page(
                         next_batch_start + t,
-                        dispatched_buffer_addr_gen,
-                        buffer_base + t * aligned_dispatched_buffer_page_size);
-                    noc_async_read_page(
-                        next_batch_start + t,
                         dispatched_metadata_addr_gen,
                         metadata_base + t * aligned_dispatched_metadata_page_size);
                 }
+                // Reserve c_0 for next batch (compute popped previous tiles)
+                cb_reserve_back(cb_dispatched_buffer_id, hidden_size / 32);
+                for (uint32_t t = 0; t < hidden_size / 32; t++) {
+                    noc_async_read_page(
+                        next_batch_start_tiled + t,
+                        dispatched_buffer_addr_gen,
+                        buffer_base + t * aligned_dispatched_buffer_page_size);
+                }
+                tile_batch_counter++;
             }
 
             if (batch_did_local_write) {
@@ -276,9 +304,19 @@ void kernel_main() {
 
             if (has_next_batch) {
                 noc_async_read_barrier();
+                // Push tiles to c_0 so compute's cb_wait_front(cb_in_id) can proceed
+                cb_push_back(cb_dispatched_buffer_id, hidden_size / 32);
+                cb_reserve_back(cb_signal_id, 1);
+                cb_push_back(cb_signal_id, 1);
             }
         }
     }
+
+    cb_reserve_back(cb_signal_id, 1);
+    volatile tt_l1_ptr uint32_t* signal_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+    signal_ptr[0] = ROUTE_INFO_SENTINEL;  // Signal writer that first batch is ready
+    cb_push_back(cb_signal_id, 1);
 
     // Push sentinel to signal writer that all dispatches are done
     cb_reserve_back(cb_route_info_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -89,10 +89,9 @@ void kernel_main() {
     // Zero-init args follow immediately after the TensorAccessorArgs block
     constexpr uint32_t zi_cb_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
-    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
-    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
 #else
-    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
 #endif
 
@@ -135,6 +134,31 @@ void kernel_main() {
     }
 #endif
 
+    uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_start_x = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_start_y = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_end_x = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_end_y = get_arg_val<uint32_t>(rt_args++);
+    uint32_t idle_counter_l1_offset = get_write_ptr(cb_dispatched_metadata_id);
+    uint32_t counter_ready_sem_l1_offset = get_semaphore(counter_ready_semaphore_id);
+    uint64_t mcast_counter_noc_addr =
+        get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, idle_counter_l1_offset);
+    uint64_t mcast_counter_sem_noc_addr =
+        get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, counter_ready_sem_l1_offset);
+
+    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    volatile tt_l1_ptr uint32_t* data_ready_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(data_ready_semaphore_id));
+
+    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t start_sem_l1_offset = get_semaphore(start_semaphore_id);
+    uint64_t idle_start_noc_addrs[num_idle_cores];
+    for (uint32_t c = 0; c < num_idle_cores; c++) {
+        uint32_t noc_x = get_arg_val<uint32_t>(rt_args++);
+        uint32_t noc_y = get_arg_val<uint32_t>(rt_args++);
+        idle_start_noc_addrs[c] = get_noc_addr(noc_x, noc_y, start_sem_l1_offset);
+    }
+
     // Signal writer that zero-init is complete
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
@@ -158,6 +182,28 @@ void kernel_main() {
     }
     noc_async_read_barrier();
 
+    // Multicast expert token counts + receive_buf_addr to all idle cores
+    {
+        constexpr uint32_t counter_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
+
+        // Append receive_buf_addr so idle cores know where to NOC-write untilized data
+        volatile tt_l1_ptr uint32_t* receive_buf_slot =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr + counter_total_size);
+        receive_buf_slot[0] = get_write_ptr(cb_untilize_id);
+
+        constexpr uint32_t mcast_total_size = counter_total_size + l1_alignment;
+        uint32_t off = 0;
+        while (off < mcast_total_size) {
+            uint32_t chunk = ((mcast_total_size - off) > (uint32_t)NOC_MAX_BURST_SIZE) ? (uint32_t)NOC_MAX_BURST_SIZE
+                                                                                       : (mcast_total_size - off);
+            noc_async_write_multicast(counter_base_addr + off, mcast_counter_noc_addr + off, chunk, num_idle_cores);
+            off += chunk;
+        }
+        noc_async_write_barrier();
+        noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_idle_cores);
+        noc_async_atomic_barrier();
+    }
+
     // Expert token counts are laid out as [n_dispatch_groups, experts_per_dispatch_group]
     // where each dispatch group is a mesh column (all rows in that column).
     // Row-major linearization: linearized_mesh_coord = mesh_row * mesh_cols + mesh_col
@@ -170,67 +216,54 @@ void kernel_main() {
 
     // Set up scratch buffers for batched reads
     constexpr uint32_t read_batch_size = 32;
-    uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
     uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);
 
-    const auto dispatched_buffer_addr_gen = TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr);
-    const auto dispatched_metadata_addr_gen = TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr);
+    const auto dispatched_metadata_addr_gen =
+        TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr, aligned_dispatched_metadata_page_size);
 
     constexpr auto expert_stride = max_dispatched_tokens_per_expert;
-    constexpr auto expert_stride_tile = (max_dispatched_tokens_per_expert / 32) * (hidden_size / 32);
 
     // Process each expert in assigned range
     for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
-        uint32_t tile_batch_counter = 0;
         uint32_t start_page = local_expert * expert_stride;
         uint32_t expert_tokens = experts_tok_counter_l1[local_expert];
         if (expert_tokens > max_dispatched_tokens_per_expert) {
             expert_tokens = max_dispatched_tokens_per_expert;
         }
         uint32_t end_page = start_page + expert_tokens;
-        uint32_t start_page_tiled = local_expert * expert_stride_tile;
+        uint32_t num_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
         DPRINT_COMBINE << "Expert=" << local_expert << " tokens=" << expert_tokens << ENDL();
 
-        // Prefetch first batch
-        uint32_t first_batch_end = (start_page + read_batch_size < end_page) ? start_page + read_batch_size : end_page;
-        uint32_t first_batch_count = first_batch_end - start_page;
-        if (first_batch_count > 0) {
-            for (uint32_t t = 0; t < first_batch_count; t++) {
+        for (uint32_t B = 0; B < num_batches; B++) {
+            uint32_t batch_start = start_page + B * read_batch_size;
+            uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
+            uint32_t batch_count = batch_end - batch_start;
+            uint32_t C = B % num_idle_cores;
+            bool batch_did_local_write = false;
+
+            // Signal idle core C to send its untilized batch
+            noc_semaphore_inc(idle_start_noc_addrs[C], 1);
+            noc_async_atomic_barrier();
+
+            // Speculatively read metadata for this batch (overlaps with idle core's NOC write)
+            for (uint32_t t = 0; t < batch_count; t++) {
                 noc_async_read_page(
-                    start_page + t,
+                    batch_start + t,
                     dispatched_metadata_addr_gen,
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
-            cb_reserve_back(cb_dispatched_buffer_id, hidden_size / 32);
-            for (uint32_t t = 0; t < hidden_size / 32; t++) {
-                noc_async_read_page(
-                    start_page_tiled + t,
-                    dispatched_buffer_addr_gen,
-                    buffer_base + t * aligned_dispatched_buffer_page_size);
-            }
 
+            // Wait for idle core to write untilized data to sender's cb_untilize_id
+            noc_semaphore_wait(data_ready_sem_ptr, 1);
+            noc_semaphore_set(data_ready_sem_ptr, 0);
+
+            // Ensure metadata is ready
             noc_async_read_barrier();
 
-            // Push tiles to c_0 so compute's cb_wait_front(cb_in_id) can proceed
-            cb_push_back(cb_dispatched_buffer_id, hidden_size / 32);
-
-            cb_reserve_back(cb_signal_id, 1);
-            volatile tt_l1_ptr uint32_t* signal_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
-            signal_ptr[0] = 0x00000000;
-            cb_push_back(cb_signal_id, 1);
-            tile_batch_counter++;
-        }
-
-        for (uint32_t batch_start = start_page; batch_start < end_page; batch_start += read_batch_size) {
-            uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
-            uint32_t batch_count = batch_end - batch_start;
-            bool batch_did_local_write = false;
-
-            cb_wait_front(cb_untilize_id, read_batch_size);
+            // Route tokens
             for (uint32_t t = 0; t < batch_count; t++) {
                 uint32_t buffer_scratch_addr = untilize_base + t * aligned_output_page_size;
                 uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
@@ -271,52 +304,12 @@ void kernel_main() {
                     }
                 }
             }
-            cb_pop_front(cb_untilize_id, read_batch_size);
-
-            // Issue next batch reads BEFORE write barrier
-            uint32_t next_batch_start = batch_start + read_batch_size;
-            uint32_t next_batch_start_tiled = start_page_tiled + tile_batch_counter * hidden_size / 32;
-            bool has_next_batch = (next_batch_start < end_page);
-            if (has_next_batch) {
-                uint32_t next_batch_end =
-                    (next_batch_start + read_batch_size < end_page) ? next_batch_start + read_batch_size : end_page;
-                uint32_t next_batch_count = next_batch_end - next_batch_start;
-                for (uint32_t t = 0; t < next_batch_count; t++) {
-                    noc_async_read_page(
-                        next_batch_start + t,
-                        dispatched_metadata_addr_gen,
-                        metadata_base + t * aligned_dispatched_metadata_page_size);
-                }
-                // Reserve c_0 for next batch (compute popped previous tiles)
-                cb_reserve_back(cb_dispatched_buffer_id, hidden_size / 32);
-                for (uint32_t t = 0; t < hidden_size / 32; t++) {
-                    noc_async_read_page(
-                        next_batch_start_tiled + t,
-                        dispatched_buffer_addr_gen,
-                        buffer_base + t * aligned_dispatched_buffer_page_size);
-                }
-                tile_batch_counter++;
-            }
 
             if (batch_did_local_write) {
                 noc_async_write_barrier();
             }
-
-            if (has_next_batch) {
-                noc_async_read_barrier();
-                // Push tiles to c_0 so compute's cb_wait_front(cb_in_id) can proceed
-                cb_push_back(cb_dispatched_buffer_id, hidden_size / 32);
-                cb_reserve_back(cb_signal_id, 1);
-                cb_push_back(cb_signal_id, 1);
-            }
         }
     }
-
-    cb_reserve_back(cb_signal_id, 1);
-    volatile tt_l1_ptr uint32_t* signal_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
-    signal_ptr[0] = ROUTE_INFO_SENTINEL;  // Signal writer that first batch is ready
-    cb_push_back(cb_signal_id, 1);
 
     // Push sentinel to signal writer that all dispatches are done
     cb_reserve_back(cb_route_info_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -6,8 +6,7 @@
 // Reader kernel for idle cores.
 // Each idle core is permanently bound to ONE sender core (its owning sender).
 // The owning sender multicasts the expert token counts + its receive_buf_addr to this idle
-// core's group, then each idle core untilizes the tiles for its assigned expert batches and
-// writes the result directly to the owning sender's receive buffer via NOC.
+// core's group, then each idle core untilizes the tiles for its assigned expert batches.
 //
 // Expert range: each idle group handles experts [expert_start_idx, expert_end_idx) which maps
 // 1:1 to the owning sender's expert range.
@@ -16,11 +15,10 @@
 // cores in the group.  Core i (local 0-based) processes batches i, i+k_s, i+2*k_s, …
 //
 // For each assigned batch:
-//   1. Speculatively read dispatched_buffer tiles and trigger compute to untilize them.
-//   2. Wait for compute to finish (cb_wait_front on cb_untilize_id).
-//   3. Wait for the owning sender's "send now" signal (start_semaphore).
-//   4. NOC-write the untilized rows to the owning sender's receive buffer.
-//   5. Signal the sender that the data has landed (data_ready_semaphore).
+//   1. Signal compute to start untilizing this batch (via cb_signal_id).
+//   2. Read dispatched_buffer tiles into cb_dispatched_buffer_id for compute to consume.
+// The actual send of untilized data to the sender (former steps 3-7) now runs on the
+// zero_init_writer kernel on the same core, driven by compute via cb_stop_signal_id.
 //
 
 #include <cstdint>
@@ -83,46 +81,36 @@ void kernel_main() {
     constexpr uint32_t tiles_per_batch = hidden_size / tile_width;
     constexpr uint32_t expert_stride_tile =
         ((max_dispatched_tokens_per_expert + tile_height - 1) / tile_height) * (hidden_size / tile_width);
-    constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
-    // Byte offset past counter data where the sender appended receive_buf_addr
-    constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
     // ===== Runtime args =====
     //   0: counter_ready_semaphore_id  - idle core waits for this before reading token counts
     //                                    (incremented by the owning sender after its multicast)
-    //   1: data_ready_semaphore_id     - idle core increments sender's copy after each write
-    //   2: sender_noc_x
-    //   3: sender_noc_y
-    //   4: start_semaphore_id          - idle core waits for sender's "send now" per batch
-    //   5: dispatched_buffer_addr
-    //   6: expert_start_idx
-    //   7: expert_end_idx
+    //   1: dispatched_buffer_addr
+    //   2: expert_start_idx
+    //   3: expert_end_idx
+    // (sender NOC coords, data_ready and start semaphores are now consumed by the
+    //  zero_init_writer kernel on the same core — they no longer belong here.)
     uint32_t rt_idx = 0;
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
     uint32_t dispatched_buffer_addr = get_arg_val<uint32_t>(rt_idx++);
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_idx++);
 
-    uint64_t sender_data_ready_noc_addr =
-        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
-    volatile tt_l1_ptr uint32_t* start_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
-
     // ===== Step 1: Wait for the owning sender to multicast expert token counts + receive_buf_addr =====
+    // Note: don't reset counter_ready_sem — zero_init_writer on this same core also waits on it
+    // to read the sender's receive_buf_addr from c_1. Since neither kernel re-uses the sem within
+    // a single invocation, leaving it latched at >=1 is safe.
     cb_reserve_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
 
     volatile tt_l1_ptr uint32_t* counter_ready_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(counter_ready_semaphore_id));
     noc_semaphore_wait(counter_ready_sem_ptr, 1);
-    noc_semaphore_set(counter_ready_sem_ptr, 0);
 
     cb_push_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
 
-    // ===== Step 2: Read per-expert token counts and the sender's receive buffer address =====
+    // ===== Step 2: Read per-expert token counts =====
+    // zero_init_writer independently reads the sender's receive_buf_addr from c_1 at offset
+    // experts_tok_counter_pages * aligned_experts_tok_counter_page_size (same L1 layout).
     cb_wait_front(cb_experts_tok_counter_id, experts_tok_counter_pages);
     uint32_t token_counter_base = get_read_ptr(cb_experts_tok_counter_id);
     const volatile tt_l1_ptr uint32_t* counter_l1_src =
@@ -133,12 +121,7 @@ void kernel_main() {
         DPRINT_COMBINE << "Expert " << e << ": tokens=" << counter_l1_src[e] << ENDL();
     }
 
-    // receive_buf_addr is packed immediately after the counter data
-    const volatile tt_l1_ptr uint32_t* recv_buf_addrs =
-        reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(token_counter_base + counter_data_total_size);
-    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, recv_buf_addrs[0]);
-
-    // ===== Step 3: For each assigned batch: untilize then send to the owning sender =====
+    // ===== Step 3: For each assigned batch: trigger compute to untilize and read tiles =====
     const auto dispatched_buffer_addr_gen =
         TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
@@ -185,32 +168,8 @@ void kernel_main() {
                 noc_async_read_barrier();
                 cb_push_back(cb_dispatched_buffer_id, tiles_per_batch_per_cb);
             }
-
-            // 3. Wait for compute to finish untilizing
-            cb_wait_front(cb_untilize_id, read_batch_size);
-
-            // 4. Wait for the sender's "send now" signal
-            noc_semaphore_wait(start_sem_ptr, 1);
-            noc_semaphore_set(start_sem_ptr, 0);
-
-            // 5. NOC-write untilized rows to the sender's receive buffer (chunked for NOC burst limit)
-            uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
-            uint32_t off = 0;
-            while (off < total_transfer_size) {
-                uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
-                                     ? (uint32_t)NOC_MAX_BURST_SIZE
-                                     : (total_transfer_size - off);
-                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
-                off += chunk;
-            }
-            noc_async_write_barrier();
-
-            // 6. Signal the sender that untilized data has landed
-            noc_semaphore_inc(sender_data_ready_noc_addr, 1);
-            noc_async_atomic_barrier();
-
-            // 7. Release untilize CB
-            cb_pop_front(cb_untilize_id, read_batch_size);
+            // Steps 3-7 (wait for untilize, wait for sender's send signal, NOC-write to
+            // sender, signal sender, pop untilize CB) now run on zero_init_writer.
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Reader kernel for idle cores.
+// Waits for the sender core to multicast the full expert token counts tensor, then
+// processes a compile-time-determined slice of batches for each expert.
+//
+// Batch splitting: each expert's rows are divided into batches of read_batch_size and
+// distributed round-robin across idle cores.  Core i processes batches i, i+N, i+2N, …
+// where N = num_idle_cores.  Example: 50 batches, 10 cores → core 0 handles batches
+// 0,10,20,30,40; core 1 handles 1,11,21,31,41; …; core 9 handles 9,19,29,39,49.
+//
+// For each assigned batch:
+//   1. Speculatively read dispatched_buffer tiles and trigger compute to untilize them.
+//   2. Wait for compute to finish (cb_wait_front on cb_untilize_id).
+//   3. Wait for sender's "send now" signal (start_semaphore).
+//   4. NOC-write the untilized rows to sender's receive buffer.
+//   5. Signal sender that the data has landed (data_ready_semaphore).
+//
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+
+#define ENABLE_COMBINE_DEBUG 0
+#if ENABLE_COMBINE_DEBUG
+#define DPRINT_COMBINE DPRINT
+#else
+#define DPRINT_COMBINE \
+    if (0)             \
+    DebugPrinter()
+#endif
+
+// Signal last element to compute to break out of loop
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
+void kernel_main() {
+    // ===== Compile-time args =====
+    //   0: cb_experts_tok_counter_id              - CB that receives the multicasted expert token counts
+    //   1: experts_tok_counter_pages              - number of pages in the expert_token_counts tensor
+    //   2: experts_per_chip                       - number of experts assigned to this chip (array sizing)
+    //   3: counter_offset                         - uint32_t offset into the token count buffer for this chip
+    //                                               == mesh_col * experts_per_dispatch_group + mesh_row *
+    //                                               experts_per_chip
+    //   4: cb_dispatched_buffer_id                - CB for reading dispatched_buffer tiles (tiles_per_token
+    //   tiles/batch) 5: cb_untilize_id                         - CB for untilized output produced by the paired compute
+    //   kernel 6: hidden_size                            - hidden dimension (e.g. 7168) 7: read_batch_size - number of
+    //   rows per untilize batch (e.g. 32) 8: cb_signal_id                           - CB for reader->compute signalling
+    //   (one page per batch) 9: aligned_dispatched_buffer_page_size    - aligned page size of dispatched_buffer tensor
+    //  10: max_dispatched_tokens_per_expert       - max tokens per expert (caps expert_tokens)
+    //  11: core_id                                - index of this idle core (0-based)
+    //  12: num_idle_cores                         - total number of idle cores
+    //  13: aligned_output_page_size               - aligned page size of output tensor (bytes per untilized row)
+    //  14: aligned_experts_tok_counter_page_size  - aligned page size of expert_token_counts tensor
+    //  15+: TensorAccessorArgs for dispatched_buffer
+    constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(0);
+    constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(1);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(2);
+    constexpr uint32_t counter_offset = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_dispatched_buffer_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(5);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(6);
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(8);
+    constexpr uint32_t aligned_dispatched_buffer_page_size = get_compile_time_arg_val(9);
+    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(10);
+    constexpr uint32_t core_id = get_compile_time_arg_val(11);
+    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(12);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(14);
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<15>();
+
+    constexpr uint32_t tiles_per_token = hidden_size / 32;
+    constexpr uint32_t expert_stride_tile = (max_dispatched_tokens_per_expert / 32) * (hidden_size / 32);
+    constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
+    // Byte offset past counter data where sender appended its receive_buf_addr
+    constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
+
+    // ===== Runtime args =====
+    //   0: counter_ready_semaphore_id  - idle core waits for this before reading token counts
+    //   1: data_ready_semaphore_id     - idle core increments sender's copy after each write
+    //   2: sender_noc_x
+    //   3: sender_noc_y
+    //   4: start_semaphore_id          - idle core waits for sender's "send now" per batch
+    //   5: dispatched_buffer_addr
+    //   6: expert_start_idx
+    //   7: expert_end_idx
+    uint32_t rt_idx = 0;
+    uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t dispatched_buffer_addr = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_idx++);
+
+    // NOC address of sender's data_ready semaphore (idle core increments this per batch)
+    uint64_t sender_data_ready_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
+
+    // Local start semaphore pointer — sender increments this to say "send batch now"
+    volatile tt_l1_ptr uint32_t* start_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
+
+    // ===== Step 1: Wait for sender to multicast expert token counts + receive_buf_addr =====
+    cb_reserve_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
+
+    volatile tt_l1_ptr uint32_t* counter_ready_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(counter_ready_semaphore_id));
+    noc_semaphore_wait(counter_ready_sem_ptr, 1);
+    noc_semaphore_set(counter_ready_sem_ptr, 0);
+
+    cb_push_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
+
+    // ===== Step 2: Read per-expert token counts and sender receive buffer address =====
+    // The multicast payload is: [counter_data (counter_data_total_size bytes)] [receive_buf_addr (4 bytes)]
+    cb_wait_front(cb_experts_tok_counter_id, experts_tok_counter_pages);
+    uint32_t token_counter_base = get_read_ptr(cb_experts_tok_counter_id);
+    const volatile tt_l1_ptr uint32_t* counter_l1_src =
+        reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(token_counter_base) + counter_offset;
+    uint32_t local_expert_counts[experts_per_chip];
+    for (uint32_t e = 0; e < experts_per_chip; e++) {
+        local_expert_counts[e] = counter_l1_src[e];
+        DPRINT_COMBINE << "Expert " << e << ": tokens=" << counter_l1_src[e] << ENDL();
+    }
+
+    // receive_buf_addr is appended by sender after the counter data in the same multicast
+    uint32_t sender_receive_buf_addr =
+        reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(token_counter_base + counter_data_total_size)[0];
+    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_receive_buf_addr);
+
+    // ===== Step 3: For each assigned batch: untilize then send to sender =====
+    const auto dispatched_buffer_addr_gen =
+        TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
+    uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
+
+    DPRINT_COMBINE << "Pocetak CORE ID:" << core_id << ENDL();
+
+    for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
+        uint32_t expert_tokens = local_expert_counts[local_expert];
+        if (expert_tokens > max_dispatched_tokens_per_expert) {
+            expert_tokens = max_dispatched_tokens_per_expert;
+        }
+        DPRINT_COMBINE << "Expert TOKENS" << expert_tokens
+                       << ": max_dispatched_tokens_per_expert=" << max_dispatched_tokens_per_expert << ENDL();
+        uint32_t start_page_tiled = local_expert * expert_stride_tile;
+
+        uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
+
+        DPRINT_COMBINE << "Expert " << local_expert << ": tokens=" << expert_tokens << ", batches=" << actual_batches
+                       << ENDL();
+
+        for (uint32_t batch_idx = core_id; batch_idx < actual_batches; batch_idx += num_idle_cores) {
+            uint32_t batch_tile_start = start_page_tiled + batch_idx * tiles_per_token;
+
+            DPRINT_COMBINE << "Batch tile start: " << batch_tile_start << " (expert " << local_expert << ", tokens "
+                           << expert_tokens << ")" << ENDL();
+
+            // 1. Speculatively read tiles (no waiting on sender)
+            cb_reserve_back(cb_dispatched_buffer_id, tiles_per_token);
+            for (uint32_t t = 0; t < tiles_per_token; t++) {
+                noc_async_read_page(
+                    batch_tile_start + t,
+                    dispatched_buffer_addr_gen,
+                    buffer_base + t * aligned_dispatched_buffer_page_size);
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_dispatched_buffer_id, tiles_per_token);
+
+            // 2. Signal compute to untilize this batch
+            cb_reserve_back(cb_signal_id, 1);
+            volatile tt_l1_ptr uint32_t* signal_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+            signal_ptr[0] = 0x00000000;
+            cb_push_back(cb_signal_id, 1);
+            DPRINT_COMBINE << "[core " << core_id << "] Untilize batch " << batch_idx << " for expert " << local_expert
+                           << ENDL();
+
+            // 3. Wait for compute to finish untilizing
+            cb_wait_front(cb_untilize_id, read_batch_size);
+
+            // 4. Wait for sender's "send now" signal
+            noc_semaphore_wait(start_sem_ptr, 1);
+            noc_semaphore_set(start_sem_ptr, 0);
+
+            // 5. NOC-write untilized rows to sender's receive buffer (chunked for NOC burst limit)
+            uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
+            uint32_t off = 0;
+            while (off < total_transfer_size) {
+                uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
+                                     ? (uint32_t)NOC_MAX_BURST_SIZE
+                                     : (total_transfer_size - off);
+                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
+                off += chunk;
+            }
+            noc_async_write_barrier();
+
+            // 6. Signal sender that untilized data has landed
+            noc_semaphore_inc(sender_data_ready_noc_addr, 1);
+            noc_async_atomic_barrier();
+
+            // 7. Release untilize CB
+            cb_pop_front(cb_untilize_id, read_batch_size);
+        }
+    }
+
+    // Send sentinel to compute to break out of its loop
+    cb_reserve_back(cb_signal_id, 1);
+    volatile tt_l1_ptr uint32_t* signal_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+    signal_ptr[0] = ROUTE_INFO_SENTINEL;
+    cb_push_back(cb_signal_id, 1);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -53,11 +53,13 @@ void kernel_main() {
     //   9: aligned_dispatched_buffer_page_size   - aligned page size of dispatched_buffer tensor
     //  10: max_dispatched_tokens_per_expert      - max tokens per expert
     //  11: cb_factor                             - CB size reduction factor (1 for Blackhole, 4 for Wormhole)
-    //  12: core_id                               - local index within the owning sender's idle group (0-based)
-    //  13: num_idle_cores                        - size of the owning sender's idle group (k_s)
-    //  14: aligned_output_page_size              - aligned page size of output tensor (bytes per untilized row)
-    //  15: aligned_experts_tok_counter_page_size - aligned page size of expert_token_counts tensor
-    //  16+: TensorAccessorArgs for dispatched_buffer
+    //  12: tile_height                            - tile height in rows (e.g. 32)
+    //  13: tile_width                             - tile width in columns (e.g. 32)
+    //  14: core_id                               - local index within the owning sender's idle group (0-based)
+    //  15: num_idle_cores                        - size of the owning sender's idle group (k_s)
+    //  16: aligned_output_page_size              - aligned page size of output tensor (bytes per untilized row)
+    //  17: aligned_experts_tok_counter_page_size - aligned page size of expert_token_counts tensor
+    //  18+: TensorAccessorArgs for dispatched_buffer
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(0);
     constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(1);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(2);
@@ -70,14 +72,17 @@ void kernel_main() {
     constexpr uint32_t aligned_dispatched_buffer_page_size = get_compile_time_arg_val(9);
     constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(10);
     constexpr uint32_t cb_factor = get_compile_time_arg_val(11);
-    constexpr uint32_t core_id = get_compile_time_arg_val(12);
-    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(13);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(14);
-    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(15);
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<16>();
+    constexpr uint32_t tile_height = get_compile_time_arg_val(12);
+    constexpr uint32_t tile_width = get_compile_time_arg_val(13);
+    constexpr uint32_t core_id = get_compile_time_arg_val(14);
+    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(15);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(16);
+    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(17);
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<18>();
 
-    constexpr uint32_t tiles_per_batch = hidden_size / 32;
-    constexpr uint32_t expert_stride_tile = ((max_dispatched_tokens_per_expert + 31) / 32) * (hidden_size / 32);
+    constexpr uint32_t tiles_per_batch = hidden_size / tile_width;
+    constexpr uint32_t expert_stride_tile =
+        ((max_dispatched_tokens_per_expert + tile_height - 1) / tile_height) * (hidden_size / tile_width);
     constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
     // Byte offset past counter data where the sender appended receive_buf_addr
     constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
@@ -138,27 +143,26 @@ void kernel_main() {
         TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
 
-    DPRINT_COMBINE << "Pocetak CORE ID:" << core_id << ENDL();
-
     for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
         uint32_t expert_tokens = local_expert_counts[local_expert];
         if (expert_tokens > max_dispatched_tokens_per_expert) {
             expert_tokens = max_dispatched_tokens_per_expert;
         }
-        DPRINT_COMBINE << "Expert TOKENS" << expert_tokens
-                       << ": max_dispatched_tokens_per_expert=" << max_dispatched_tokens_per_expert << ENDL();
-        uint32_t start_page_tiled = local_expert * expert_stride_tile;
+        DPRINT_COMBINE << "Expert " << local_expert << ": tokens=" << expert_tokens
+                       << ", max_dispatched_tokens_per_expert=" << max_dispatched_tokens_per_expert << ENDL();
 
+        uint32_t start_page_tiled = local_expert * expert_stride_tile;
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
-        DPRINT_COMBINE << "Expert " << local_expert << ": tokens=" << expert_tokens << ", batches=" << actual_batches
-                       << ENDL();
-
+        // Round-robin batch assignment across the idle cores in this sender's group.
+        // Each idle core starts at its own core_id and strides by num_idle_cores, so:
+        //   core 0 processes batches 0, k, 2k, ...
+        //   core 1 processes batches 1, k+1, 2k+1, ...
+        //   core j processes batches j, j+k, j+2k, ...
+        // where k = num_idle_cores.  This spreads the work evenly and ensures the
+        // owning sender can predict which idle core handles each batch (batch_idx % k).
         for (uint32_t batch_idx = core_id; batch_idx < actual_batches; batch_idx += num_idle_cores) {
             uint32_t batch_tile_start = start_page_tiled + batch_idx * tiles_per_batch;
-
-            DPRINT_COMBINE << "Batch tile start: " << batch_tile_start << " (expert " << local_expert << ", tokens "
-                           << expert_tokens << ")" << ENDL();
 
             // 1. Signal compute to start untilizing this batch
             cb_reserve_back(cb_signal_id, 1);
@@ -166,8 +170,6 @@ void kernel_main() {
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
             signal_ptr[0] = 0x00000000;
             cb_push_back(cb_signal_id, 1);
-            DPRINT_COMBINE << "[core " << core_id << "] Untilize batch " << batch_idx << " for expert " << local_expert
-                           << ENDL();
 
             // 2. Reading tiles for this batch
             constexpr uint32_t tiles_per_batch_per_cb = tiles_per_batch / cb_factor;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -75,7 +75,7 @@ void kernel_main() {
     constexpr auto dispatched_buffer_args = TensorAccessorArgs<15>();
 
     constexpr uint32_t tiles_per_token = hidden_size / 32;
-    constexpr uint32_t expert_stride_tile = (max_dispatched_tokens_per_expert / 32) * (hidden_size / 32);
+    constexpr uint32_t expert_stride_tile = ((max_dispatched_tokens_per_expert + 31) / 32) * (hidden_size / 32);
     constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
     // Byte offset past counter data where the sender appended receive_buf_addr
     constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -52,11 +52,12 @@ void kernel_main() {
     //   8: cb_signal_id                          - CB for reader->compute signalling (one page per batch)
     //   9: aligned_dispatched_buffer_page_size   - aligned page size of dispatched_buffer tensor
     //  10: max_dispatched_tokens_per_expert      - max tokens per expert
-    //  11: core_id                               - local index within the owning sender's idle group (0-based)
-    //  12: num_idle_cores                        - size of the owning sender's idle group (k_s)
-    //  13: aligned_output_page_size              - aligned page size of output tensor (bytes per untilized row)
-    //  14: aligned_experts_tok_counter_page_size - aligned page size of expert_token_counts tensor
-    //  15+: TensorAccessorArgs for dispatched_buffer
+    //  11: cb_factor                             - CB size reduction factor (1 for Blackhole, 4 for Wormhole)
+    //  12: core_id                               - local index within the owning sender's idle group (0-based)
+    //  13: num_idle_cores                        - size of the owning sender's idle group (k_s)
+    //  14: aligned_output_page_size              - aligned page size of output tensor (bytes per untilized row)
+    //  15: aligned_experts_tok_counter_page_size - aligned page size of expert_token_counts tensor
+    //  16+: TensorAccessorArgs for dispatched_buffer
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(0);
     constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(1);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(2);
@@ -68,13 +69,14 @@ void kernel_main() {
     constexpr uint32_t cb_signal_id = get_compile_time_arg_val(8);
     constexpr uint32_t aligned_dispatched_buffer_page_size = get_compile_time_arg_val(9);
     constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(10);
-    constexpr uint32_t core_id = get_compile_time_arg_val(11);
-    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(12);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(13);
-    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(14);
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<15>();
+    constexpr uint32_t cb_factor = get_compile_time_arg_val(11);
+    constexpr uint32_t core_id = get_compile_time_arg_val(12);
+    constexpr uint32_t num_idle_cores = get_compile_time_arg_val(13);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(14);
+    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(15);
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<16>();
 
-    constexpr uint32_t tiles_per_token = hidden_size / 32;
+    constexpr uint32_t tiles_per_batch = hidden_size / 32;
     constexpr uint32_t expert_stride_tile = ((max_dispatched_tokens_per_expert + 31) / 32) * (hidden_size / 32);
     constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
     // Byte offset past counter data where the sender appended receive_buf_addr
@@ -153,23 +155,12 @@ void kernel_main() {
                        << ENDL();
 
         for (uint32_t batch_idx = core_id; batch_idx < actual_batches; batch_idx += num_idle_cores) {
-            uint32_t batch_tile_start = start_page_tiled + batch_idx * tiles_per_token;
+            uint32_t batch_tile_start = start_page_tiled + batch_idx * tiles_per_batch;
 
             DPRINT_COMBINE << "Batch tile start: " << batch_tile_start << " (expert " << local_expert << ", tokens "
                            << expert_tokens << ")" << ENDL();
 
-            // 1. Speculatively read tiles (no waiting on sender)
-            cb_reserve_back(cb_dispatched_buffer_id, tiles_per_token);
-            for (uint32_t t = 0; t < tiles_per_token; t++) {
-                noc_async_read_page(
-                    batch_tile_start + t,
-                    dispatched_buffer_addr_gen,
-                    buffer_base + t * aligned_dispatched_buffer_page_size);
-            }
-            noc_async_read_barrier();
-            cb_push_back(cb_dispatched_buffer_id, tiles_per_token);
-
-            // 2. Signal compute to untilize this batch
+            // 1. Signal compute to start untilizing this batch
             cb_reserve_back(cb_signal_id, 1);
             volatile tt_l1_ptr uint32_t* signal_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
@@ -177,6 +168,21 @@ void kernel_main() {
             cb_push_back(cb_signal_id, 1);
             DPRINT_COMBINE << "[core " << core_id << "] Untilize batch " << batch_idx << " for expert " << local_expert
                            << ENDL();
+
+            // 2. Reading tiles for this batch
+            constexpr uint32_t tiles_per_batch_per_cb = tiles_per_batch / cb_factor;
+            for (uint32_t cnt = 0; cnt < cb_factor; cnt++) {
+                uint32_t batch_tile = batch_tile_start + cnt * tiles_per_batch_per_cb;
+                cb_reserve_back(cb_dispatched_buffer_id, tiles_per_batch_per_cb);
+                for (uint32_t t = 0; t < tiles_per_batch_per_cb; t++) {
+                    noc_async_read_page(
+                        batch_tile + t,
+                        dispatched_buffer_addr_gen,
+                        buffer_base + t * aligned_dispatched_buffer_page_size);
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_dispatched_buffer_id, tiles_per_batch_per_cb);
+            }
 
             // 3. Wait for compute to finish untilizing
             cb_wait_front(cb_untilize_id, read_batch_size);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -12,12 +12,19 @@
 // where N = num_idle_cores.  Example: 50 batches, 10 cores → core 0 handles batches
 // 0,10,20,30,40; core 1 handles 1,11,21,31,41; …; core 9 handles 9,19,29,39,49.
 //
+// Multi-sender support: experts are divided into num_senders contiguous chunks of size
+// ceil(experts_per_chip / num_senders).  Expert e belongs to sender s = e / experts_per_sender.
+// Example: 8 experts, 2 senders → experts 0-3 → sender 0, experts 4-7 → sender 1.
+// Example: 9 experts, 3 senders → experts 0-2 → sender 0, experts 3-5 → sender 1,
+//                                  experts 6-8 → sender 2.
+//
 // For each assigned batch:
 //   1. Speculatively read dispatched_buffer tiles and trigger compute to untilize them.
 //   2. Wait for compute to finish (cb_wait_front on cb_untilize_id).
-//   3. Wait for sender's "send now" signal (start_semaphore).
-//   4. NOC-write the untilized rows to sender's receive buffer.
-//   5. Signal sender that the data has landed (data_ready_semaphore).
+//   3. Determine the owning sender s = local_expert / experts_per_sender.
+//   4. Wait for sender s's "send now" signal (start_semaphore[s]).
+//   5. NOC-write the untilized rows to sender s's receive buffer.
+//   6. Signal sender s that the data has landed (data_ready_semaphore[s]).
 //
 
 #include <cstdint>
@@ -54,7 +61,8 @@ void kernel_main() {
     //  12: num_idle_cores                         - total number of idle cores
     //  13: aligned_output_page_size               - aligned page size of output tensor (bytes per untilized row)
     //  14: aligned_experts_tok_counter_page_size  - aligned page size of expert_token_counts tensor
-    //  15+: TensorAccessorArgs for dispatched_buffer
+    //  15: num_senders                            - number of sender cores (experts split into num_senders chunks)
+    //  16+: TensorAccessorArgs for dispatched_buffer
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(0);
     constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(1);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(2);
@@ -70,42 +78,54 @@ void kernel_main() {
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(12);
     constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(13);
     constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(14);
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<15>();
+    constexpr uint32_t num_senders = get_compile_time_arg_val(15);
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<16>();
 
     constexpr uint32_t tiles_per_token = hidden_size / 32;
     constexpr uint32_t expert_stride_tile = (max_dispatched_tokens_per_expert / 32) * (hidden_size / 32);
     constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
-    // Byte offset past counter data where sender appended its receive_buf_addr
+    // Byte offset past counter data where the primary sender appended num_senders receive_buf_addrs
     constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
+    // Ceiling division: each sender owns this many consecutive experts
+    constexpr uint32_t experts_per_sender = (experts_per_chip + num_senders - 1) / num_senders;
 
     // ===== Runtime args =====
     //   0: counter_ready_semaphore_id  - idle core waits for this before reading token counts
-    //   1: data_ready_semaphore_id     - idle core increments sender's copy after each write
-    //   2: sender_noc_x
-    //   3: sender_noc_y
-    //   4: start_semaphore_id          - idle core waits for sender's "send now" per batch
-    //   5: dispatched_buffer_addr
-    //   6: expert_start_idx
-    //   7: expert_end_idx
+    //                                    (incremented by the primary sender after multicast)
+    //   For each sender s in [0, num_senders):
+    //     1 + s*4 + 0: data_ready_semaphore_id[s]  - idle core increments sender s's copy after each write
+    //     1 + s*4 + 1: sender_noc_x[s]
+    //     1 + s*4 + 2: sender_noc_y[s]
+    //     1 + s*4 + 3: start_semaphore_id[s]        - idle core waits for sender s's "send now" per batch
+    //   1 + num_senders*4 + 0: dispatched_buffer_addr
+    //   1 + num_senders*4 + 1: expert_start_idx
+    //   1 + num_senders*4 + 2: expert_end_idx
     uint32_t rt_idx = 0;
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+
+    // Per-sender NOC addresses and local semaphore pointers — indexed by sender
+    uint64_t sender_data_ready_noc_addr[num_senders];
+    volatile tt_l1_ptr uint32_t* start_sem_ptr[num_senders];
+    uint32_t sender_noc_x_arr[num_senders];
+    uint32_t sender_noc_y_arr[num_senders];
+
+    for (uint32_t s = 0; s < num_senders; s++) {
+        uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+        uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
+        uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
+        uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+        sender_noc_x_arr[s] = sender_noc_x;
+        sender_noc_y_arr[s] = sender_noc_y;
+        sender_data_ready_noc_addr[s] =
+            get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
+        start_sem_ptr[s] = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
+    }
+
     uint32_t dispatched_buffer_addr = get_arg_val<uint32_t>(rt_idx++);
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_idx++);
 
-    // NOC address of sender's data_ready semaphore (idle core increments this per batch)
-    uint64_t sender_data_ready_noc_addr =
-        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
-
-    // Local start semaphore pointer — sender increments this to say "send batch now"
-    volatile tt_l1_ptr uint32_t* start_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
-
-    // ===== Step 1: Wait for sender to multicast expert token counts + receive_buf_addr =====
+    // ===== Step 1: Wait for primary sender to multicast expert token counts + receive_buf_addrs =====
     cb_reserve_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
 
     volatile tt_l1_ptr uint32_t* counter_ready_sem_ptr =
@@ -115,8 +135,10 @@ void kernel_main() {
 
     cb_push_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
 
-    // ===== Step 2: Read per-expert token counts and sender receive buffer address =====
-    // The multicast payload is: [counter_data (counter_data_total_size bytes)] [receive_buf_addr (4 bytes)]
+    // ===== Step 2: Read per-expert token counts and per-sender receive buffer addresses =====
+    // Multicast payload layout:
+    //   [counter_data (counter_data_total_size bytes)]
+    //   [receive_buf_addr_0][receive_buf_addr_1]...[receive_buf_addr_{num_senders-1}]  (4 bytes each)
     cb_wait_front(cb_experts_tok_counter_id, experts_tok_counter_pages);
     uint32_t token_counter_base = get_read_ptr(cb_experts_tok_counter_id);
     const volatile tt_l1_ptr uint32_t* counter_l1_src =
@@ -127,12 +149,15 @@ void kernel_main() {
         DPRINT_COMBINE << "Expert " << e << ": tokens=" << counter_l1_src[e] << ENDL();
     }
 
-    // receive_buf_addr is appended by sender after the counter data in the same multicast
-    uint32_t sender_receive_buf_addr =
-        reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(token_counter_base + counter_data_total_size)[0];
-    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_receive_buf_addr);
+    // receive_buf_addr for each sender is packed sequentially after the counter data
+    const volatile tt_l1_ptr uint32_t* recv_buf_addrs =
+        reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(token_counter_base + counter_data_total_size);
+    uint64_t sender_receive_buf_noc_addr[num_senders];
+    for (uint32_t s = 0; s < num_senders; s++) {
+        sender_receive_buf_noc_addr[s] = get_noc_addr(sender_noc_x_arr[s], sender_noc_y_arr[s], recv_buf_addrs[s]);
+    }
 
-    // ===== Step 3: For each assigned batch: untilize then send to sender =====
+    // ===== Step 3: For each assigned batch: untilize then send to the owning sender =====
     const auto dispatched_buffer_addr_gen =
         TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
@@ -140,6 +165,9 @@ void kernel_main() {
     DPRINT_COMBINE << "Pocetak CORE ID:" << core_id << ENDL();
 
     for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
+        // Determine which sender owns this expert (contiguous chunks of experts_per_sender)
+        uint32_t sender_idx = local_expert / experts_per_sender;
+
         uint32_t expert_tokens = local_expert_counts[local_expert];
         if (expert_tokens > max_dispatched_tokens_per_expert) {
             expert_tokens = max_dispatched_tokens_per_expert;
@@ -151,7 +179,7 @@ void kernel_main() {
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
         DPRINT_COMBINE << "Expert " << local_expert << ": tokens=" << expert_tokens << ", batches=" << actual_batches
-                       << ENDL();
+                       << " sender=" << sender_idx << ENDL();
 
         for (uint32_t batch_idx = core_id; batch_idx < actual_batches; batch_idx += num_idle_cores) {
             uint32_t batch_tile_start = start_page_tiled + batch_idx * tiles_per_token;
@@ -182,24 +210,24 @@ void kernel_main() {
             // 3. Wait for compute to finish untilizing
             cb_wait_front(cb_untilize_id, read_batch_size);
 
-            // 4. Wait for sender's "send now" signal
-            noc_semaphore_wait(start_sem_ptr, 1);
-            noc_semaphore_set(start_sem_ptr, 0);
+            // 4. Wait for the owning sender's "send now" signal
+            noc_semaphore_wait(start_sem_ptr[sender_idx], 1);
+            noc_semaphore_set(start_sem_ptr[sender_idx], 0);
 
-            // 5. NOC-write untilized rows to sender's receive buffer (chunked for NOC burst limit)
+            // 5. NOC-write untilized rows to the owning sender's receive buffer (chunked for NOC burst limit)
             uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
             uint32_t off = 0;
             while (off < total_transfer_size) {
                 uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
                                      ? (uint32_t)NOC_MAX_BURST_SIZE
                                      : (total_transfer_size - off);
-                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
+                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr[sender_idx] + off, chunk);
                 off += chunk;
             }
             noc_async_write_barrier();
 
-            // 6. Signal sender that untilized data has landed
-            noc_semaphore_inc(sender_data_ready_noc_addr, 1);
+            // 6. Signal the owning sender that untilized data has landed
+            noc_semaphore_inc(sender_data_ready_noc_addr[sender_idx], 1);
             noc_async_atomic_barrier();
 
             // 7. Release untilize CB

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -4,27 +4,23 @@
 
 //
 // Reader kernel for idle cores.
-// Waits for the sender core to multicast the full expert token counts tensor, then
-// processes a compile-time-determined slice of batches for each expert.
+// Each idle core is permanently bound to ONE sender core (its owning sender).
+// The owning sender multicasts the expert token counts + its receive_buf_addr to this idle
+// core's group, then each idle core untilizes the tiles for its assigned expert batches and
+// writes the result directly to the owning sender's receive buffer via NOC.
 //
-// Batch splitting: each expert's rows are divided into batches of read_batch_size and
-// distributed round-robin across idle cores.  Core i processes batches i, i+N, i+2N, …
-// where N = num_idle_cores.  Example: 50 batches, 10 cores → core 0 handles batches
-// 0,10,20,30,40; core 1 handles 1,11,21,31,41; …; core 9 handles 9,19,29,39,49.
+// Expert range: each idle group handles experts [expert_start_idx, expert_end_idx) which maps
+// 1:1 to the owning sender's expert range.
 //
-// Multi-sender support: experts are divided into num_senders contiguous chunks of size
-// ceil(experts_per_chip / num_senders).  Expert e belongs to sender s = e / experts_per_sender.
-// Example: 8 experts, 2 senders → experts 0-3 → sender 0, experts 4-7 → sender 1.
-// Example: 9 experts, 3 senders → experts 0-2 → sender 0, experts 3-5 → sender 1,
-//                                  experts 6-8 → sender 2.
+// Batch splitting within the group: batches are distributed round-robin across the k_s idle
+// cores in the group.  Core i (local 0-based) processes batches i, i+k_s, i+2*k_s, …
 //
 // For each assigned batch:
 //   1. Speculatively read dispatched_buffer tiles and trigger compute to untilize them.
 //   2. Wait for compute to finish (cb_wait_front on cb_untilize_id).
-//   3. Determine the owning sender s = local_expert / experts_per_sender.
-//   4. Wait for sender s's "send now" signal (start_semaphore[s]).
-//   5. NOC-write the untilized rows to sender s's receive buffer.
-//   6. Signal sender s that the data has landed (data_ready_semaphore[s]).
+//   3. Wait for the owning sender's "send now" signal (start_semaphore).
+//   4. NOC-write the untilized rows to the owning sender's receive buffer.
+//   5. Signal the sender that the data has landed (data_ready_semaphore).
 //
 
 #include <cstdint>
@@ -45,24 +41,22 @@ constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
     // ===== Compile-time args =====
-    //   0: cb_experts_tok_counter_id              - CB that receives the multicasted expert token counts
-    //   1: experts_tok_counter_pages              - number of pages in the expert_token_counts tensor
-    //   2: experts_per_chip                       - number of experts assigned to this chip (array sizing)
-    //   3: counter_offset                         - uint32_t offset into the token count buffer for this chip
-    //                                               == mesh_col * experts_per_dispatch_group + mesh_row *
-    //                                               experts_per_chip
-    //   4: cb_dispatched_buffer_id                - CB for reading dispatched_buffer tiles (tiles_per_token
-    //   tiles/batch) 5: cb_untilize_id                         - CB for untilized output produced by the paired compute
-    //   kernel 6: hidden_size                            - hidden dimension (e.g. 7168) 7: read_batch_size - number of
-    //   rows per untilize batch (e.g. 32) 8: cb_signal_id                           - CB for reader->compute signalling
-    //   (one page per batch) 9: aligned_dispatched_buffer_page_size    - aligned page size of dispatched_buffer tensor
-    //  10: max_dispatched_tokens_per_expert       - max tokens per expert (caps expert_tokens)
-    //  11: core_id                                - index of this idle core (0-based)
-    //  12: num_idle_cores                         - total number of idle cores
-    //  13: aligned_output_page_size               - aligned page size of output tensor (bytes per untilized row)
-    //  14: aligned_experts_tok_counter_page_size  - aligned page size of expert_token_counts tensor
-    //  15: num_senders                            - number of sender cores (experts split into num_senders chunks)
-    //  16+: TensorAccessorArgs for dispatched_buffer
+    //   0: cb_experts_tok_counter_id             - CB that receives the multicasted expert token counts
+    //   1: experts_tok_counter_pages             - number of pages in the expert_token_counts tensor
+    //   2: experts_per_chip                      - number of experts assigned to this chip
+    //   3: counter_offset                        - uint32_t offset into the token count buffer for this chip
+    //   4: cb_dispatched_buffer_id               - CB for reading dispatched_buffer tiles
+    //   5: cb_untilize_id                        - CB for untilized output produced by the paired compute kernel
+    //   6: hidden_size                           - hidden dimension (e.g. 7168)
+    //   7: read_batch_size                       - number of rows per untilize batch (e.g. 32)
+    //   8: cb_signal_id                          - CB for reader->compute signalling (one page per batch)
+    //   9: aligned_dispatched_buffer_page_size   - aligned page size of dispatched_buffer tensor
+    //  10: max_dispatched_tokens_per_expert      - max tokens per expert
+    //  11: core_id                               - local index within the owning sender's idle group (0-based)
+    //  12: num_idle_cores                        - size of the owning sender's idle group (k_s)
+    //  13: aligned_output_page_size              - aligned page size of output tensor (bytes per untilized row)
+    //  14: aligned_experts_tok_counter_page_size - aligned page size of expert_token_counts tensor
+    //  15+: TensorAccessorArgs for dispatched_buffer
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(0);
     constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(1);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(2);
@@ -78,54 +72,40 @@ void kernel_main() {
     constexpr uint32_t num_idle_cores = get_compile_time_arg_val(12);
     constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(13);
     constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(14);
-    constexpr uint32_t num_senders = get_compile_time_arg_val(15);
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<16>();
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<15>();
 
     constexpr uint32_t tiles_per_token = hidden_size / 32;
     constexpr uint32_t expert_stride_tile = (max_dispatched_tokens_per_expert / 32) * (hidden_size / 32);
     constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
-    // Byte offset past counter data where the primary sender appended num_senders receive_buf_addrs
+    // Byte offset past counter data where the sender appended receive_buf_addr
     constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
-    // Ceiling division: each sender owns this many consecutive experts
-    constexpr uint32_t experts_per_sender = (experts_per_chip + num_senders - 1) / num_senders;
 
     // ===== Runtime args =====
     //   0: counter_ready_semaphore_id  - idle core waits for this before reading token counts
-    //                                    (incremented by the primary sender after multicast)
-    //   For each sender s in [0, num_senders):
-    //     1 + s*4 + 0: data_ready_semaphore_id[s]  - idle core increments sender s's copy after each write
-    //     1 + s*4 + 1: sender_noc_x[s]
-    //     1 + s*4 + 2: sender_noc_y[s]
-    //     1 + s*4 + 3: start_semaphore_id[s]        - idle core waits for sender s's "send now" per batch
-    //   1 + num_senders*4 + 0: dispatched_buffer_addr
-    //   1 + num_senders*4 + 1: expert_start_idx
-    //   1 + num_senders*4 + 2: expert_end_idx
+    //                                    (incremented by the owning sender after its multicast)
+    //   1: data_ready_semaphore_id     - idle core increments sender's copy after each write
+    //   2: sender_noc_x
+    //   3: sender_noc_y
+    //   4: start_semaphore_id          - idle core waits for sender's "send now" per batch
+    //   5: dispatched_buffer_addr
+    //   6: expert_start_idx
+    //   7: expert_end_idx
     uint32_t rt_idx = 0;
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-
-    // Per-sender NOC addresses and local semaphore pointers — indexed by sender
-    uint64_t sender_data_ready_noc_addr[num_senders];
-    volatile tt_l1_ptr uint32_t* start_sem_ptr[num_senders];
-    uint32_t sender_noc_x_arr[num_senders];
-    uint32_t sender_noc_y_arr[num_senders];
-
-    for (uint32_t s = 0; s < num_senders; s++) {
-        uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-        uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
-        uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
-        uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-        sender_noc_x_arr[s] = sender_noc_x;
-        sender_noc_y_arr[s] = sender_noc_y;
-        sender_data_ready_noc_addr[s] =
-            get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
-        start_sem_ptr[s] = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
-    }
-
+    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
     uint32_t dispatched_buffer_addr = get_arg_val<uint32_t>(rt_idx++);
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_idx++);
 
-    // ===== Step 1: Wait for primary sender to multicast expert token counts + receive_buf_addrs =====
+    uint64_t sender_data_ready_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
+    volatile tt_l1_ptr uint32_t* start_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
+
+    // ===== Step 1: Wait for the owning sender to multicast expert token counts + receive_buf_addr =====
     cb_reserve_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
 
     volatile tt_l1_ptr uint32_t* counter_ready_sem_ptr =
@@ -135,10 +115,7 @@ void kernel_main() {
 
     cb_push_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
 
-    // ===== Step 2: Read per-expert token counts and per-sender receive buffer addresses =====
-    // Multicast payload layout:
-    //   [counter_data (counter_data_total_size bytes)]
-    //   [receive_buf_addr_0][receive_buf_addr_1]...[receive_buf_addr_{num_senders-1}]  (4 bytes each)
+    // ===== Step 2: Read per-expert token counts and the sender's receive buffer address =====
     cb_wait_front(cb_experts_tok_counter_id, experts_tok_counter_pages);
     uint32_t token_counter_base = get_read_ptr(cb_experts_tok_counter_id);
     const volatile tt_l1_ptr uint32_t* counter_l1_src =
@@ -149,13 +126,10 @@ void kernel_main() {
         DPRINT_COMBINE << "Expert " << e << ": tokens=" << counter_l1_src[e] << ENDL();
     }
 
-    // receive_buf_addr for each sender is packed sequentially after the counter data
+    // receive_buf_addr is packed immediately after the counter data
     const volatile tt_l1_ptr uint32_t* recv_buf_addrs =
         reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(token_counter_base + counter_data_total_size);
-    uint64_t sender_receive_buf_noc_addr[num_senders];
-    for (uint32_t s = 0; s < num_senders; s++) {
-        sender_receive_buf_noc_addr[s] = get_noc_addr(sender_noc_x_arr[s], sender_noc_y_arr[s], recv_buf_addrs[s]);
-    }
+    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, recv_buf_addrs[0]);
 
     // ===== Step 3: For each assigned batch: untilize then send to the owning sender =====
     const auto dispatched_buffer_addr_gen =
@@ -165,9 +139,6 @@ void kernel_main() {
     DPRINT_COMBINE << "Pocetak CORE ID:" << core_id << ENDL();
 
     for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
-        // Determine which sender owns this expert (contiguous chunks of experts_per_sender)
-        uint32_t sender_idx = local_expert / experts_per_sender;
-
         uint32_t expert_tokens = local_expert_counts[local_expert];
         if (expert_tokens > max_dispatched_tokens_per_expert) {
             expert_tokens = max_dispatched_tokens_per_expert;
@@ -179,7 +150,7 @@ void kernel_main() {
         uint32_t actual_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
 
         DPRINT_COMBINE << "Expert " << local_expert << ": tokens=" << expert_tokens << ", batches=" << actual_batches
-                       << " sender=" << sender_idx << ENDL();
+                       << ENDL();
 
         for (uint32_t batch_idx = core_id; batch_idx < actual_batches; batch_idx += num_idle_cores) {
             uint32_t batch_tile_start = start_page_tiled + batch_idx * tiles_per_token;
@@ -210,24 +181,24 @@ void kernel_main() {
             // 3. Wait for compute to finish untilizing
             cb_wait_front(cb_untilize_id, read_batch_size);
 
-            // 4. Wait for the owning sender's "send now" signal
-            noc_semaphore_wait(start_sem_ptr[sender_idx], 1);
-            noc_semaphore_set(start_sem_ptr[sender_idx], 0);
+            // 4. Wait for the sender's "send now" signal
+            noc_semaphore_wait(start_sem_ptr, 1);
+            noc_semaphore_set(start_sem_ptr, 0);
 
-            // 5. NOC-write untilized rows to the owning sender's receive buffer (chunked for NOC burst limit)
+            // 5. NOC-write untilized rows to the sender's receive buffer (chunked for NOC burst limit)
             uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
             uint32_t off = 0;
             while (off < total_transfer_size) {
                 uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
                                      ? (uint32_t)NOC_MAX_BURST_SIZE
                                      : (total_transfer_size - off);
-                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr[sender_idx] + off, chunk);
+                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
                 off += chunk;
             }
             noc_async_write_barrier();
 
-            // 6. Signal the owning sender that untilized data has landed
-            noc_semaphore_inc(sender_data_ready_noc_addr[sender_idx], 1);
+            // 6. Signal the sender that untilized data has landed
+            noc_semaphore_inc(sender_data_ready_noc_addr, 1);
             noc_async_atomic_barrier();
 
             // 7. Release untilize CB

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
@@ -74,6 +74,7 @@ void kernel_main() {
     //   +3: experts_tok_counter_pages             - number of counter pages multicasted
     //   +4: aligned_experts_tok_counter_page_size - aligned counter page size (L1 stride)
     //   +5: read_batch_size                       - number of rows per untilize batch
+    //   +6: cb_metadata_batch_id                  - this idle core's c_9 CB (target of sender's metadata unicast)
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_stop_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
     constexpr uint32_t cb_experts_tok_counter_id =
@@ -83,6 +84,7 @@ void kernel_main() {
     constexpr uint32_t aligned_experts_tok_counter_page_size =
         get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 4);
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 5);
+    constexpr uint32_t cb_metadata_batch_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 6);
     constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
     constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
@@ -90,12 +92,15 @@ void kernel_main() {
     //   counter_ready_semaphore_id   - sem the sender increments once after its counter multicast
     //   sender_noc_x / sender_noc_y  - NOC coords of the owning sender core
     //   data_ready_semaphore_id      - sender-side sem this kernel increments after each send
+    //                                  (also used once up-front to signal the c_9 addr handshake)
     //   start_semaphore_id           - local sem the sender increments to say "send now"
+    //   core_id                      - this idle core's local index within its sender's group (0..k_s-1)
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t core_id = get_arg_val<uint32_t>(rt_args_idx++);
 
     uint64_t sender_data_ready_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
@@ -104,15 +109,31 @@ void kernel_main() {
 
     // Wait on the same counter_ready sem reader_untilize waits on (neither kernel resets it,
     // so both see the single increment from the sender's multicast).  Then read the sender's
-    // receive_buf_addr out of c_1's trailer — shared L1 on this core.
+    // receive_buf_addr AND its idle-c9-addr scratch L1 offset from c_1's trailer on this core.
+    //   trailer[0] = sender's c_18 L1 offset (receive buffer for untilized data)
+    //   trailer[1] = sender's c_10 L1 offset (scratch where this kernel writes its own c_9 addr)
     volatile tt_l1_ptr uint32_t* counter_ready_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(counter_ready_semaphore_id));
     noc_semaphore_wait(counter_ready_sem_ptr, 1);
 
     uint32_t counter_cb_base = get_write_ptr(cb_experts_tok_counter_id);
-    const volatile tt_l1_ptr uint32_t* recv_buf_addrs =
+    const volatile tt_l1_ptr uint32_t* trailer =
         reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(counter_cb_base + counter_data_total_size);
-    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, recv_buf_addrs[0]);
+    uint32_t sender_receive_buf_l1_offset = trailer[0];
+    uint32_t sender_idle_c9_scratch_l1_offset = trailer[1];
+    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_receive_buf_l1_offset);
+
+    // ===== c_9 address handshake =====
+    // Write this core's c_9 L1 offset into sender's c_10 scratch at slot core_id, then increment
+    // sender's data_ready_sem.  After all k_s idle cores have done this the sender sees
+    // data_ready_sem == num_idle_cores_group and reads the array of addresses.  data_ready_sem
+    // is reset to 0 by the sender before the batch loop, so it can be reused per-batch below.
+    uint32_t my_c9_l1_offset = get_write_ptr(cb_metadata_batch_id);
+    uint64_t sender_c9_slot_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, sender_idle_c9_scratch_l1_offset + core_id * sizeof(uint32_t));
+    noc_inline_dw_write(sender_c9_slot_noc_addr, my_c9_l1_offset);
+    noc_semaphore_inc(sender_data_ready_noc_addr, 1);
+    noc_async_atomic_barrier();
 
     // Process untilized batches until compute pushes ROUTE_INFO_SENTINEL onto cb_stop_signal_id.
     // A non-sentinel value means "another batch is on cb_untilize_id, send it to the owning sender".

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
@@ -5,12 +5,21 @@
 //
 // Lightweight data-movement kernel that zeroes a page range of an interleaved
 // DRAM output tensor, then signals the combine reader cores via semaphore.
-// Deployed on idle cores to speed up zero-init process by spreading out across more banks
+// Deployed on idle cores to speed up zero-init process by spreading out across more banks.
+//
+// In TILE_LAYOUT, after zero-init completes this kernel also takes over the untilized-data
+// send path (previously in reader_untilize.cpp steps 3-7): it waits for compute to push a
+// batch onto cb_untilize_id, waits for the owning sender's "send now" signal, NOC-writes
+// the untilized rows to the sender's receive buffer, and signals the sender that data has
+// landed. The loop exits when compute pushes ROUTE_INFO_SENTINEL onto cb_stop_signal_id.
 //
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_common.hpp"
+
+// Sentinel used by compute to tell this kernel to exit its send loop.
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
     // ===== Compile-time args =====
@@ -53,4 +62,94 @@ void kernel_main() {
     }
 
     noc_async_atomic_barrier();
+
+#if IS_TILE_LAYOUT
+    // ===== Untilized-data send path (moved from reader_untilize.cpp steps 3-7) =====
+    //
+    // Compile-time args (appended after the zero-init TensorAccessorArgs block):
+    //   +0: cb_untilize_id                        - CB into which compute pushes untilized batches
+    //   +1: cb_stop_signal_id                     - CB for compute -> this-kernel per-batch / stop signal
+    //   +2: cb_experts_tok_counter_id             - CB c_1 multicasted by sender; sender's
+    //                                               receive_buf_addr lives at the trailer
+    //   +3: experts_tok_counter_pages             - number of counter pages multicasted
+    //   +4: aligned_experts_tok_counter_page_size - aligned counter page size (L1 stride)
+    //   +5: read_batch_size                       - number of rows per untilize batch
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    constexpr uint32_t cb_stop_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
+    constexpr uint32_t cb_experts_tok_counter_id =
+        get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t experts_tok_counter_pages =
+        get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
+    constexpr uint32_t aligned_experts_tok_counter_page_size =
+        get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 4);
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 5);
+    constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
+    constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
+
+    // Runtime args appended after the sender_sem_noc_addrs loop above:
+    //   counter_ready_semaphore_id   - sem the sender increments once after its counter multicast
+    //   sender_noc_x / sender_noc_y  - NOC coords of the owning sender core
+    //   data_ready_semaphore_id      - sender-side sem this kernel increments after each send
+    //   start_semaphore_id           - local sem the sender increments to say "send now"
+    uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    uint64_t sender_data_ready_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
+    volatile tt_l1_ptr uint32_t* start_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
+
+    // Wait on the same counter_ready sem reader_untilize waits on (neither kernel resets it,
+    // so both see the single increment from the sender's multicast).  Then read the sender's
+    // receive_buf_addr out of c_1's trailer — shared L1 on this core.
+    volatile tt_l1_ptr uint32_t* counter_ready_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(counter_ready_semaphore_id));
+    noc_semaphore_wait(counter_ready_sem_ptr, 1);
+
+    uint32_t counter_cb_base = get_write_ptr(cb_experts_tok_counter_id);
+    const volatile tt_l1_ptr uint32_t* recv_buf_addrs =
+        reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(counter_cb_base + counter_data_total_size);
+    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, recv_buf_addrs[0]);
+
+    // Process untilized batches until compute pushes ROUTE_INFO_SENTINEL onto cb_stop_signal_id.
+    // A non-sentinel value means "another batch is on cb_untilize_id, send it to the owning sender".
+    while (true) {
+        cb_wait_front(cb_stop_signal_id, 1);
+        volatile tt_l1_ptr uint32_t* stop_signal_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_stop_signal_id));
+        uint32_t signal_value = stop_signal_ptr[0];
+        cb_pop_front(cb_stop_signal_id, 1);
+        if (signal_value == ROUTE_INFO_SENTINEL) {
+            break;
+        }
+
+        // 3. Wait for compute to finish untilizing this batch
+        cb_wait_front(cb_untilize_id, read_batch_size);
+
+        // 4. Wait for the sender's "send now" signal
+        noc_semaphore_wait(start_sem_ptr, 1);
+        noc_semaphore_set(start_sem_ptr, 0);
+
+        // 5. NOC-write untilized rows to the sender's receive buffer (chunked for NOC burst limit)
+        uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
+        uint32_t off = 0;
+        while (off < total_transfer_size) {
+            uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE) ? (uint32_t)NOC_MAX_BURST_SIZE
+                                                                                        : (total_transfer_size - off);
+            noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
+            off += chunk;
+        }
+        noc_async_write_barrier();
+
+        // 6. Signal the sender that untilized data has landed
+        noc_semaphore_inc(sender_data_ready_noc_addr, 1);
+        noc_async_atomic_barrier();
+
+        // 7. Release untilize CB
+        cb_pop_front(cb_untilize_id, read_batch_size);
+    }
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
@@ -75,6 +75,8 @@ void kernel_main() {
     //   +4: aligned_experts_tok_counter_page_size - aligned counter page size (L1 stride)
     //   +5: read_batch_size                       - number of rows per untilize batch
     //   +6: cb_metadata_batch_id                  - this idle core's c_9 CB (target of sender's metadata unicast)
+    //   +7: num_experts_per_tok                   - number of experts each token is routed to (for output_page_idx)
+    //   +8: aligned_dispatched_metadata_page_size - aligned metadata page size (stride in c_9)
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
     constexpr uint32_t cb_stop_signal_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
     constexpr uint32_t cb_experts_tok_counter_id =
@@ -85,6 +87,9 @@ void kernel_main() {
         get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 4);
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 5);
     constexpr uint32_t cb_metadata_batch_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 6);
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 7);
+    constexpr uint32_t aligned_dispatched_metadata_page_size =
+        get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 8);
     constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
     constexpr uint32_t counter_data_total_size = experts_tok_counter_pages * aligned_experts_tok_counter_page_size;
 
@@ -136,7 +141,10 @@ void kernel_main() {
     noc_async_atomic_barrier();
 
     // Process untilized batches until compute pushes ROUTE_INFO_SENTINEL onto cb_stop_signal_id.
-    // A non-sentinel value means "another batch is on cb_untilize_id, send it to the owning sender".
+    // A non-sentinel value means "another batch is on cb_untilize_id".
+    // After the sender signals start_sem, c_9[0] tells us which path to take:
+    //   ROUTE_INFO_SENTINEL → sender has non-local writes; send untilized data to sender
+    //   any other value     → batch_count; all writes are local; write directly to output DRAM
     while (true) {
         cb_wait_front(cb_stop_signal_id, 1);
         volatile tt_l1_ptr uint32_t* stop_signal_ptr =
@@ -150,22 +158,45 @@ void kernel_main() {
         // 3. Wait for compute to finish untilizing this batch
         cb_wait_front(cb_untilize_id, read_batch_size);
 
-        // 4. Wait for the sender's "send now" signal
+        // 4. Wait for the sender's "send now" signal.
+        //    By the time start_sem arrives, sender has already written metadata to c_9 and
+        //    set c_9[0] to ROUTE_INFO_SENTINEL (non-local) or batch_count (all-local).
         noc_semaphore_wait(start_sem_ptr, 1);
         noc_semaphore_set(start_sem_ptr, 0);
 
-        // 5. NOC-write untilized rows to the sender's receive buffer (chunked for NOC burst limit)
         uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
-        uint32_t off = 0;
-        while (off < total_transfer_size) {
-            uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE) ? (uint32_t)NOC_MAX_BURST_SIZE
-                                                                                        : (total_transfer_size - off);
-            noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
-            off += chunk;
-        }
-        noc_async_write_barrier();
+        volatile tt_l1_ptr uint32_t* c9_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(my_c9_l1_offset);
 
-        // 6. Signal the sender that untilized data has landed
+        if (c9_ptr[0] == ROUTE_INFO_SENTINEL) {
+            // 5a. Non-local path: send untilized rows to the sender's receive buffer
+            uint32_t off = 0;
+            while (off < total_transfer_size) {
+                uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
+                                     ? (uint32_t)NOC_MAX_BURST_SIZE
+                                     : (total_transfer_size - off);
+                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
+                off += chunk;
+            }
+            noc_async_write_barrier();
+        } else {
+            // 5b. All-local path: c9[0] = batch_count, write each row directly to output DRAM.
+            //     Metadata layout in c_9: each entry is aligned_dispatched_metadata_page_size bytes,
+            //     with [0]=dst_chip (ignored, all local), [1]=dst_token_idx, [2]=dst_topk_indice.
+            uint32_t batch_count = c9_ptr[0];
+            for (uint32_t t = 0; t < batch_count; t++) {
+                const volatile tt_l1_ptr uint32_t* metadata = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(
+                    my_c9_l1_offset + t * aligned_dispatched_metadata_page_size);
+                uint32_t dst_token_idx = metadata[1];
+                uint32_t dst_topk_indice = metadata[2];
+                uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
+                noc_async_write_page(
+                    output_page_idx, output_addr_gen, untilize_read_ptr + t * aligned_output_page_size);
+                noc_async_writes_flushed();
+            }
+            noc_async_write_barrier();
+        }
+
+        // 6. Signal the sender that this batch is done (data sent OR local writes done)
         noc_semaphore_inc(sender_data_ready_noc_addr, 1);
         noc_async_atomic_barrier();
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39674

### Problem description
Combine operator previously worked only with `dispatched_buffer` in `ROW_MAJOR layout`. This is inefficient since `ttnn.to_layout(dispatched_buffer, ROW_MAJOR)` was needed in **MoE** before **combine** operator, so the besy way is to overlap **untilize** with **combine operator data movement part**.

### What's changed
- Added **compute kernel** on **idle cores**
- Every sender core has its **own group of idle cores**, that untilize data for local experts that sender core is responsible for and they untilize in **parallel**
- Sender core is always in middle of its idle group, for example if sender core has 4 idle cores that coordinate with him, layout will look like this (sender-idle1-idle2-idle3-idle4) in order to reduce **NOC congestions** as much as possible and sender is **left**, because idle cores use **NOC1** for sending data to sender
- If all writes in one batch of read_batch_size are **local DRAM writes**, then idle cores do that **writing**, because their writer kernel is on NOC1, while **sender cores** can only **write to local DRAM** through their **NOC0**, that is not very good choice of writing
- `read_batch_size` set to be `TILE_HEIGHT` in order to be able to properly **untilize row of tiles** and make **TILE_HEIGHT number of rows of ROW_MAJOR data**
- Keeping code for ROW_MAJOR input so TILE_LAYOUT and ROW_MAJOR are now both valid so `test_prefill_combine` and `test_ttnn_dispatch_combine` are added to test both type of inputs

### Performance measurements on **test_ttnn_moe** bh-lb harvested 2-link BFLOAT16 input and output

  | Mesh | Input (seq_len_per_chip, emb_dim, hidden_dim, num_routed_experts, num_experts_per_tok, capacity_factor, gate_fallback_mode)| Branch | Untilize | Combine |
  | -------- | -------- | -------- | -------- | -------- |
  |   Linear-8 |     (3200, 7168, 2048, 256, 8, 2, GateComputeMode.DEVICE) |      main    |    4,544 µs      |      15,815 µs    |
  |  Linear-8         |      (1600, 7168, 2048, 64, 8, 2, GateComputeMode.HOST_ALL)    |      main    |     72,529 µs     |       8,340 µs   |
  |   Mesh 4x2       |     (3200, 7168, 2048, 256, 8, 2, GateComputeMode.DEVICE)     |    main      |    72,531 µs      |    6,071 µs      |
  |    Mesh 4x2       |     (1600, 7168, 2048, 64, 8, 2, GateComputeMode.HOST_ALL)      |      main    |     1,146 µs     |   3,085 µs       |
  |   Linear-8        |   (3200, 7168, 2048, 256, 8, 2, GateComputeMode.DEVICE)        |   PR branch      |     0 µs     |    15,885 µs      |
  |   Linear-8        |    (1600, 7168, 2048, 64, 8, 2, GateComputeMode.HOST_ALL)       |    PR branch      |     0 µs      |    8,372 µs     |
  |     Mesh 4x2      |    (3200, 7168, 2048, 256, 8, 2, GateComputeMode.DEVICE)       |   PR branch      |     0 µs      |     6,461 µs   |
  |    Mesh 4x2       |    (1600, 7168, 2048, 64, 8, 2, GateComputeMode.HOST_ALL)       |    PR branch     |    0 µs       |  3,377 µs        |


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/deepseekV3-combine-untilize-fused-pccworks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/deepseekV3-combine-untilize-fused-pccworks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/deepseekV3-combine-untilize-fused-pccworks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/deepseekV3-combine-untilize-fused-pccworks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/deepseekV3-combine-untilize-fused-pccworks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/deepseekV3-combine-untilize-fused-pccworks)
- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/deepseekV3-combine-untilize-fused-pccworks)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/deepseekV3-combine-untilize-fused-pccworks)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/deepseekV3-combine-untilize-fused-pccworks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/deepseekV3-combine-untilize-fused-pccworks)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/deepseekV3-combine-untilize-fused-pccworks)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/deepseekV3-combine-untilize-fused-pccworks)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/deepseekV3-combine-untilize-fused-pccworks)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/deepseekV3-combine-untilize-fused-pccworks)