### PR TITLE
Fix llama_galaxy non-traced decode (36403)

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -168,9 +168,6 @@ class Generator(WarmupForwardMixin):
         self.trace_ids_decode = defaultdict(lambda: None)  # {return_logits: {device_id: trace_id}}
         self.trace_inputs_decode = defaultdict(lambda: None)
         self.trace_output_decode = defaultdict(lambda: None)
-        # Split sampling: decode trace captures transformer only, sampling runs separately
-        self.enable_split_sampling = True  # Decode trace returns logits, sampling is separate
-        self.model.enable_internal_trace = self.enable_split_sampling  # NEVER trace sampling - causes buffer corruption
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
         self._disable_decode_tracing = False  # Whether to disable decode traces
 
@@ -1149,10 +1146,9 @@ class Generator(WarmupForwardMixin):
             tt_out_logits_saved=tt_out_logits_saved,
             is_cur_pos_sharded=is_cur_pos_sharded,
             return_logits=return_logits,
-            capture_sampling_trace=self.enable_split_sampling,
         )
 
-        if self.enable_split_sampling and not return_logits:
+        if not return_logits:
             return self.model.sampling.sample(
                 logits=tt_tok,
                 tt_out_tok=tt_tokens,
@@ -1202,7 +1198,6 @@ class Generator(WarmupForwardMixin):
             kv_cache=kv_cache,
             is_cur_pos_sharded=is_cur_pos_sharded,
             return_logits=return_logits,
-            capture_sampling_trace=self.enable_split_sampling,
         )
 
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
@@ -1275,7 +1270,7 @@ class Generator(WarmupForwardMixin):
             page_table=page_table,
         )
 
-        if self.enable_split_sampling and not return_logits:
+        if not return_logits:
             return self.model.sampling.sample(
                 logits=trace_tok_rm[0],
                 tt_out_tok=self.trace_inputs_decode[return_logits][0],

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1103,11 +1103,10 @@ class Generator(WarmupForwardMixin):
                 return_logits=return_logits,
             )
         else:
-            tt_tok = self._decode_forward_no_trace_text(
+            tt_tok, tt_log_probs = self._decode_forward_no_trace_text(
                 **decode_kwargs,
                 return_logits=return_logits,
             )
-            tt_log_probs = None
 
         if read_from_device:
             # IMPORTANT: If split sampling is enabled, `tt_log_probs` is produced by the sampling
@@ -1136,7 +1135,7 @@ class Generator(WarmupForwardMixin):
     ):
         """
         Performs text decode step.
-        Returns tt_logits on device
+        Returns `(tt_output, tt_log_probs)` on device.
         """
         tt_tokens, tt_current_pos, rot_mat_idxs, tt_page_table = self.model.prepare_inputs_decode(
             tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
@@ -1152,9 +1151,15 @@ class Generator(WarmupForwardMixin):
             return_logits=return_logits,
             capture_sampling_trace=self.enable_split_sampling,
         )
-        # TODO this actually never calls sampling, because we're telling the model we'll do it ourselves.
-        # We also never set the sampling module up with the right parameters.
-        return tt_tok
+
+        if self.enable_split_sampling and not return_logits:
+            return self.model.sampling.sample(
+                logits=tt_tok,
+                tt_out_tok=tt_tokens,
+                enable_trace=False,
+            )
+
+        return tt_tok, None
 
     def _capture_trace_text(
         self,

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1150,12 +1150,10 @@ class Generator(WarmupForwardMixin):
 
         if not return_logits:
             return self.model.sampling.sample(
-                logits=tt_tok,
-                tt_out_tok=tt_tokens,
+                logits=tt_tok[0],
                 enable_trace=False,
             )
-
-        return tt_tok, None
+        return tt_tok
 
     def _capture_trace_text(
         self,

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -701,7 +701,6 @@ class TtTransformer(LightweightModule):
         tt_out_logits_saved=None,
         is_cur_pos_sharded=False,
         return_logits=False,
-        capture_sampling_trace=False,  # If true, return logits so sampling can be traced elsewhere
     ):
         """
         This method will take device tensors and any other args to run forward.
@@ -745,15 +744,7 @@ class TtTransformer(LightweightModule):
 
             tt_out_logits_saved.copy_(tt_out_logits)
 
-        if capture_sampling_trace:
-            return tt_logits
-
-        tt_toks, tt_log_probs = self.sampling.sample(
-            tt_logits[0],
-            tt_out_tok=x,
-            enable_trace=False,
-        )
-        return tt_toks, tt_log_probs
+        return tt_logits
 
     def switch_mode(self, mode):
         if mode == "decode":


### PR DESCRIPTION
### Summary
Fixed #36403

Properly call sampling in the non-traced path
Remove the mechanism for joint tracing of model and sampling module (it was hardcoded off and never valid as model doesn't have enough info to decide trace invalidation)
### Notes for reviewers

Companion vLLM pr to be merged after this one: (https://github.com/tenstorrent/vllm/pull/361)
CI run through vllm: https://github.com/tenstorrent/tt-metal/actions/runs/24577238243 (exercises the non-traced path because it contains the companion vllm changes removing the workaround from #41763 )

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/llama3-galaxy-no-trace-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/llama3-galaxy-no-trace-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tcheda/llama3-galaxy-no-trace-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tcheda/llama3-galaxy-no-trace-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/llama3-galaxy-no-trace-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/llama3-galaxy-no-trace-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/llama3-galaxy-no-trace-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/llama3-galaxy-no-trace-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/llama3-galaxy-no-trace-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/llama3-galaxy-no-trace-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/llama3-galaxy-no-trace-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/llama3-galaxy-no-trace-sampling)