### PR TITLE
ttnn: skip test_from_torch_width_sharded_l1_tilize_with_sub_devices on slow dispatch

### DIFF
--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -1138,6 +1138,7 @@ def test_from_torch_sharded_tilize_dispatch_core_overlap(device):
     assert list(result.shape) == list(shape)
 
 
+@skip_for_slow_dispatch()
 @pytest.mark.parametrize(
     "torch_dtype,ttnn_dtype,total_width,num_shards",
     [


### PR DESCRIPTION
Sub-device managers require fast dispatch. The test hits `TT_FATAL` at `sub_device_manager_tracker.cpp:87` when run in SD mode:
```
Using sub device managers is unsupported with slow dispatch
```

Adds `@skip_for_slow_dispatch()` consistent with the two other sub-device tests in the same file (lines 856 and 969).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/fix-sub-device-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-sub-device-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/fix-sub-device-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/fix-sub-device-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/fix-sub-device-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-sub-device-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/fix-sub-device-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-sub-device-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/fix-sub-device-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-sub-device-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/fix-sub-device-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-sub-device-slow-dispatch-skip)