### PR TITLE
ci: trigger llk tests if sfpi changes

### DIFF
--- a/.github/actions/find-changed-files/action.yml
+++ b/.github/actions/find-changed-files/action.yml
@@ -38,6 +38,8 @@ outputs:
     value: ${{ steps.find-changed-files.outputs.llk-blackhole-changed }}
   llk-common-changed:
     value: ${{ steps.find-changed-files.outputs.llk-common-changed }}
+  llk-sfpi-changed:
+    value: ${{ steps.find-changed-files.outputs.llk-sfpi-changed }}
   llk-quasar-changed:
     value: ${{ steps.find-changed-files.outputs.llk-quasar-changed }}
   llk-tests-changed:

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -26,6 +26,7 @@ BUILD_WORKFLOWS_CHANGED=false
 LLK_WORMHOLE_CHANGED=false
 LLK_BLACKHOLE_CHANGED=false
 LLK_COMMON_CHANGED=false
+LLK_SFPI_CHANGED=false
 LLK_QUASAR_CHANGED=false
 LLK_TESTS_CHANGED=false
 LLK_PERF_CHANGED=false
@@ -37,13 +38,11 @@ while IFS= read -r FILE; do
         CMakeLists.txt|**/CMakeLists.txt|**/*.cmake)
             CMAKE_CHANGED=true
             ;;
-        tt_metal/sfpi-info.sh)
-            # Read in by a cmake file
+        tt_metal/sfpi-info.sh|tt_metal/sfpi-version)
+            # Read in by a cmake file; also pins the SFPI compiler used to build LLK
+            # device kernels, so any change must re-run LLK tests on all archs.
             CMAKE_CHANGED=true
-            ;;
-        tt_metal/sfpi-version)
-            # Read in by a cmake file
-            CMAKE_CHANGED=true
+            LLK_SFPI_CHANGED=true
             ;;
         .clang-tidy|**/.clang-tidy)
             CLANG_TIDY_CONFIG_CHANGED=true
@@ -152,7 +151,7 @@ if [[ "$SUBMODULE_CHANGED" = true ]]; then
 fi
 
 # LLK engine changes imply Metalium may be affected (LLK is compiled into device kernels)
-if [[ "$LLK_WORMHOLE_CHANGED" = true || "$LLK_BLACKHOLE_CHANGED" = true || "$LLK_COMMON_CHANGED" = true ]]; then
+if [[ "$LLK_WORMHOLE_CHANGED" = true || "$LLK_BLACKHOLE_CHANGED" = true || "$LLK_COMMON_CHANGED" = true || "$LLK_SFPI_CHANGED" = true ]]; then
     TTMETALIUM_CHANGED=true
     ANY_CODE_CHANGED=true
 fi
@@ -183,6 +182,7 @@ declare -A changes=(
     [llk-wormhole-changed]=$LLK_WORMHOLE_CHANGED
     [llk-blackhole-changed]=$LLK_BLACKHOLE_CHANGED
     [llk-common-changed]=$LLK_COMMON_CHANGED
+    [llk-sfpi-changed]=$LLK_SFPI_CHANGED
     [llk-quasar-changed]=$LLK_QUASAR_CHANGED
     [llk-tests-changed]=$LLK_TESTS_CHANGED
     [llk-perf-changed]=$LLK_PERF_CHANGED

--- a/.github/workflows/llk-run-perf-tests.yaml
+++ b/.github/workflows/llk-run-perf-tests.yaml
@@ -28,6 +28,7 @@ jobs:
       wormhole: ${{ steps.set.outputs.wormhole }}
       blackhole: ${{ steps.set.outputs.blackhole }}
       common: ${{ steps.set.outputs.common }}
+      sfpi: ${{ steps.set.outputs.sfpi }}
       performance: ${{ steps.set.outputs.performance }}
     steps:
       - name: Checkout code
@@ -47,6 +48,9 @@ jobs:
                 - 'tt_metal/tt-llk/tt_llk_blackhole/**'
               common:
                 - 'tt_metal/tt-llk/common/**'
+              sfpi:
+                - 'tt_metal/sfpi-info.sh'
+                - 'tt_metal/sfpi-version'
               performance:
                 - 'tt_metal/tt-llk/**/*perf**'
                 - 'tt_metal/tt-llk/**/*profiler**'
@@ -58,11 +62,13 @@ jobs:
             echo "wormhole=true" >> $GITHUB_OUTPUT
             echo "blackhole=true" >> $GITHUB_OUTPUT
             echo "common=true" >> $GITHUB_OUTPUT
+            echo "sfpi=true" >> $GITHUB_OUTPUT
             echo "performance=true" >> $GITHUB_OUTPUT
           else
             echo "wormhole=${{ steps.filter.outputs.wormhole }}" >> $GITHUB_OUTPUT
             echo "blackhole=${{ steps.filter.outputs.blackhole }}" >> $GITHUB_OUTPUT
             echo "common=${{ steps.filter.outputs.common }}" >> $GITHUB_OUTPUT
+            echo "sfpi=${{ steps.filter.outputs.sfpi }}" >> $GITHUB_OUTPUT
             echo "performance=${{ steps.filter.outputs.performance }}" >> $GITHUB_OUTPUT
           fi
 
@@ -78,6 +84,7 @@ jobs:
     needs: [build-images, detect-changes]
     if: ${{ needs.detect-changes.outputs.wormhole == 'true' ||
             needs.detect-changes.outputs.common == 'true' ||
+            needs.detect-changes.outputs.sfpi == 'true' ||
             needs.detect-changes.outputs.performance == 'true' ||
             github.event_name == 'workflow_dispatch' ||
             github.event_name == 'workflow_call' }}
@@ -96,6 +103,7 @@ jobs:
     needs: [build-images, detect-changes]
     if: ${{ needs.detect-changes.outputs.blackhole == 'true' ||
             needs.detect-changes.outputs.common == 'true' ||
+            needs.detect-changes.outputs.sfpi == 'true' ||
             needs.detect-changes.outputs.performance == 'true' ||
             github.event_name == 'workflow_dispatch' ||
             github.event_name == 'workflow_call' }}

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -147,6 +147,7 @@ jobs:
       llk-wormhole-changed: ${{ steps.find-changes.outputs.llk-wormhole-changed }}
       llk-blackhole-changed: ${{ steps.find-changes.outputs.llk-blackhole-changed }}
       llk-common-changed: ${{ steps.find-changes.outputs.llk-common-changed }}
+      llk-sfpi-changed: ${{ steps.find-changes.outputs.llk-sfpi-changed }}
       llk-quasar-changed: ${{ steps.find-changes.outputs.llk-quasar-changed }}
       llk-tests-changed: ${{ steps.find-changes.outputs.llk-tests-changed }}
       llk-perf-changed: ${{ steps.find-changes.outputs.llk-perf-changed }}
@@ -451,6 +452,7 @@ jobs:
         (needs.find-changed-files.outputs.llk-wormhole-changed == 'true' ||
          needs.find-changed-files.outputs.llk-blackhole-changed == 'true' ||
          needs.find-changed-files.outputs.llk-common-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-sfpi-changed == 'true' ||
          needs.find-changed-files.outputs.llk-tests-changed == 'true' ||
          needs.find-changed-files.outputs.llk-ci-changed == 'true' ||
          needs.find-changed-files.outputs.llk-perf-changed == 'true' ||
@@ -467,13 +469,14 @@ jobs:
             if ("${{ needs.find-changed-files.outputs.llk-wormhole-changed }}" === "true") expectedLabels.add("llk:wormhole");
             if ("${{ needs.find-changed-files.outputs.llk-blackhole-changed }}" === "true") expectedLabels.add("llk:blackhole");
             if ("${{ needs.find-changed-files.outputs.llk-common-changed }}" === "true") expectedLabels.add("llk:common");
+            if ("${{ needs.find-changed-files.outputs.llk-sfpi-changed }}" === "true") expectedLabels.add("sfpi");
             if ("${{ needs.find-changed-files.outputs.llk-tests-changed }}" === "true") expectedLabels.add("llk:test-infra");
             if ("${{ needs.find-changed-files.outputs.llk-ci-changed }}" === "true") expectedLabels.add("llk:ci");
             if ("${{ needs.find-changed-files.outputs.llk-perf-changed }}" === "true") expectedLabels.add("llk:performance");
             if ("${{ needs.find-changed-files.outputs.llk-quasar-changed }}" === "true") expectedLabels.add("llk:quasar");
 
             const managedLabels = new Set(["llk:wormhole", "llk:blackhole", "llk:common",
-                                           "llk:ci", "llk:test-infra",
+                                           "sfpi", "llk:ci", "llk:test-infra",
                                            "llk:performance", "llk:quasar"]);
 
             const {data: currentLabels} = await github.rest.issues.listLabelsOnIssue({
@@ -507,7 +510,7 @@ jobs:
               ));
             }
 
-  # LLK Functional Unit Tests on Wormhole (PR gate - runs on wormhole/common/test/ci changes)
+  # LLK Functional Unit Tests on Wormhole (PR gate - runs on wormhole/common/sfpi/test/ci changes)
   llk-test-wormhole:
     needs: [ build-docker-images, find-changed-files ]
     if: ${{
@@ -516,6 +519,7 @@ jobs:
         (github.ref_name == 'main' ||
          needs.find-changed-files.outputs.llk-wormhole-changed == 'true' ||
          needs.find-changed-files.outputs.llk-common-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-sfpi-changed == 'true' ||
          needs.find-changed-files.outputs.llk-tests-changed == 'true' ||
          needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
@@ -527,7 +531,7 @@ jobs:
       test_splits: 2
       pytest_markers: "not perf and not nightly and not quasar"
 
-  # LLK Functional Unit Tests on Blackhole (PR gate - runs on blackhole/common/test/ci changes)
+  # LLK Functional Unit Tests on Blackhole (PR gate - runs on blackhole/common/sfpi/test/ci changes)
   llk-test-blackhole:
     needs: [ build-docker-images, find-changed-files ]
     if: ${{
@@ -536,6 +540,7 @@ jobs:
         (github.ref_name == 'main' ||
          needs.find-changed-files.outputs.llk-blackhole-changed == 'true' ||
          needs.find-changed-files.outputs.llk-common-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-sfpi-changed == 'true' ||
          needs.find-changed-files.outputs.llk-tests-changed == 'true' ||
          needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}
@@ -556,6 +561,7 @@ jobs:
         (github.ref_name == 'main' ||
          needs.find-changed-files.outputs.llk-quasar-changed == 'true' ||
          needs.find-changed-files.outputs.llk-common-changed == 'true' ||
+         needs.find-changed-files.outputs.llk-sfpi-changed == 'true' ||
          needs.find-changed-files.outputs.llk-tests-changed == 'true' ||
          needs.find-changed-files.outputs.llk-ci-changed == 'true')
       }}


### PR DESCRIPTION
### Summary
Restore CI test gating for SFPI changes that was missed in #42032. 
`tt_metal/sfpi-info.sh` and `tt_metal/sfpi-version` pin the SFPI compiler used to build LLK device kernels for all architectures, so any change to these files must re-run the LLK functional test suites, but currently they only flag a CMake change and skip LLK CI entirely.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/run-llk-tests-when-sfpi-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/run-llk-tests-when-sfpi-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=filip/run-llk-tests-when-sfpi-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/run-llk-tests-when-sfpi-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/run-llk-tests-when-sfpi-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/run-llk-tests-when-sfpi-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/run-llk-tests-when-sfpi-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/run-llk-tests-when-sfpi-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/run-llk-tests-when-sfpi-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/run-llk-tests-when-sfpi-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/run-llk-tests-when-sfpi-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/run-llk-tests-when-sfpi-changes)