### PR TITLE
Fix straddle-chunk attention dropout in balanced-causal ring joint SDPA

### DIFF
--- a/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
@@ -213,6 +213,25 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
 
     configs.append(
         ModelConfig(
+            name="mla_causal_v2",
+            nhq=mla_nhq,
+            nhk=1,
+            nhv=mla_nhq,
+            d_q=576,
+            d_k=576,
+            d_v=128,
+            is_causal=True,
+            is_balanced=True,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat8_b,
+            q_chunk_sizes=[160],
+            k_chunk_sizes=[256],
+            seq_len=3200,
+        )
+    )
+
+    configs.append(
+        ModelConfig(
             name="mla_128k",
             nhq=mla_nhq,
             nhk=1,
@@ -452,7 +471,9 @@ def run_ring_joint_sdpa(
 
     # Open mesh device based on calculated configuration
     mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+    # worker_l1_size empirically tuned to give +5 KiB kernel config buffer headroom for
+    # the ring_joint_sdpa straddle-mask branch on Sk_chunk_t=8 shapes (e.g. mla_causal_v2).
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, worker_l1_size=1456640)
     num_links = 2
 
     try:

--- a/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
@@ -23,7 +23,7 @@ import math
 import torch
 from dataclasses import dataclass, field
 from itertools import product
-from typing import ClassVar, List, Tuple, Dict
+from typing import ClassVar, List, Tuple, Dict, Optional
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
@@ -75,6 +75,10 @@ class ModelConfig:
 
     # Can be hardware-dependent to keep per-core work balanced between Galaxy and Quiet Box
     seq_len: int
+
+    # Override worker L1 size for configs whose kernel binary exceeds the default buffer.
+    # None means use the device default.
+    worker_l1_size: Optional[int] = None
 
 
 def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
@@ -213,7 +217,7 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
 
     configs.append(
         ModelConfig(
-            name="mla_causal_v2",
+            name="mla_100k_straddle",  # k_chunk doesn't divide seq_len
             nhq=mla_nhq,
             nhk=1,
             nhv=mla_nhq,
@@ -227,6 +231,9 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
             q_chunk_sizes=[160],
             k_chunk_sizes=[256],
             seq_len=3200,
+            # Sk_chunk_t=8 straddle-mask branch exceeds default kernel config buffer.
+            # Empirically tuned to give +5 KiB headroom on this shape.
+            worker_l1_size=1456640,
         )
     )
 
@@ -357,6 +364,7 @@ def generate_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, Mode
                     model.is_balanced,
                     model.q_dtype,
                     model.kv_dtype,
+                    model.worker_l1_size,
                 )
             )
             config_ids.append(get_test_case_id(model, q_chunk, k_chunk))
@@ -390,6 +398,7 @@ def run_ring_joint_sdpa(
     rmse_threshold=None,
     do_check=True,
     num_iterations=1,
+    worker_l1_size=None,
 ):
     """
     Run Ring Joint Attention SDPA using direct ttnn operations with auto-detected devices.
@@ -471,9 +480,10 @@ def run_ring_joint_sdpa(
 
     # Open mesh device based on calculated configuration
     mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
-    # worker_l1_size empirically tuned to give +5 KiB kernel config buffer headroom for
-    # the ring_joint_sdpa straddle-mask branch on Sk_chunk_t=8 shapes (e.g. mla_causal_v2).
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, worker_l1_size=1456640)
+    open_kwargs = {}
+    if worker_l1_size is not None:
+        open_kwargs["worker_l1_size"] = worker_l1_size
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **open_kwargs)
     num_links = 2
 
     try:
@@ -792,12 +802,26 @@ TEST_CONFIG_MODELS = list(MODEL_CONFIGS.keys())
 # === TEST 1: PERFORMANCE SWEEP (skipped on CI) ===
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
 @pytest.mark.parametrize(
-    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
+    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype,worker_l1_size",
     TEST_CONFIGS,
     ids=TEST_CONFIG_IDS,
 )
 def test_ring_joint_attention_sdpa_sweep_perf_impl(
-    b, sq, nhq, nhk, nhv, d_q, d_k, d_v, q_chunk_size, k_chunk_size, is_causal, is_balanced, q_dtype, kv_dtype
+    b,
+    sq,
+    nhq,
+    nhk,
+    nhv,
+    d_q,
+    d_k,
+    d_v,
+    q_chunk_size,
+    k_chunk_size,
+    is_causal,
+    is_balanced,
+    q_dtype,
+    kv_dtype,
+    worker_l1_size,
 ):
     """
     Performance sweep test for ring joint attention SDPA.
@@ -823,12 +847,13 @@ def test_ring_joint_attention_sdpa_sweep_perf_impl(
         is_causal=is_causal,
         is_balanced=is_balanced,
         do_check=False,
+        worker_l1_size=worker_l1_size,
     )
 
 
 # === TEST 2: ACCURACY VERIFICATION ===
 @pytest.mark.parametrize(
-    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
+    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype,worker_l1_size",
     TEST_CONFIGS,
     ids=TEST_CONFIG_IDS,
 )
@@ -847,6 +872,7 @@ def test_ring_joint_attention_sdpa_accuracy(
     is_balanced,
     q_dtype,
     kv_dtype,
+    worker_l1_size,
 ):
     """
     Accuracy verification test for ring joint attention SDPA.
@@ -881,12 +907,13 @@ def test_ring_joint_attention_sdpa_accuracy(
         is_balanced=is_balanced,
         pcc_threshold=pcc_threshold,
         rmse_threshold=rmse_threshold,
+        worker_l1_size=worker_l1_size,
     )
 
 
 # === TEST 3: DETERMINISM VERIFICATION ===
 @pytest.mark.parametrize(
-    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
+    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype,worker_l1_size",
     TEST_CONFIGS,
     ids=TEST_CONFIG_IDS,
 )
@@ -905,6 +932,7 @@ def test_ring_joint_attention_sdpa_determinism(
     is_balanced,
     q_dtype,
     kv_dtype,
+    worker_l1_size,
 ):
     """
     Test ring joint attention SDPA determinism: run 10 times with same inputs and verify outputs match exactly.
@@ -929,6 +957,7 @@ def test_ring_joint_attention_sdpa_determinism(
         is_causal=is_causal,
         is_balanced=is_balanced,
         num_iterations=num_iterations,
+        worker_l1_size=worker_l1_size,
     )
 
 
@@ -999,6 +1028,7 @@ def test_ring_joint_attention_create_perf_table(model_name):
             is_balanced,
             q_dtype,
             kv_dtype,
+            worker_l1_size,
         ) = config
 
         # Config now contains global (TP/SP-scaled) values

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1454,6 +1454,8 @@ struct LightweightMaskContext {
     uint32_t joint_l_partial_col = 0;        // Column within tile where joint_l padding starts (0 = no partial)
     uint32_t global_n_partial_tile_idx = 0;  // Index of global_n partial tile in the mask CB
     uint32_t joint_l_partial_tile_idx = 0;   // Index of joint_l partial tile in the mask CB
+    uint32_t straddle_num_padded_tiles = 0;  // Trailing -inf tiles on straddle chunk (0 = inactive)
+    uint32_t straddle_mask_chunk_id = 0;     // K chunk index where straddle mask applies
 
     /**
      * Resolve which mask type applies for a given K chunk and return pre-resolved params.
@@ -1490,6 +1492,8 @@ struct LightweightMaskContext {
             out_has_partial = (joint_l_partial_col > 0);
             out_boundary_col = Sk_chunk_t - out_num_padded - (out_has_partial ? 1 : 0);
             out_partial_tile_idx = joint_l_partial_tile_idx;
+        } else if (straddle_num_padded_tiles > 0 && k_chunk == straddle_mask_chunk_id) {
+            out_num_padded = straddle_num_padded_tiles;
         }
     }
 
@@ -1841,7 +1845,8 @@ void sdpa_inner_loop(
                 (sdpa_type == RING) &&
                 ((ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) ||
                  (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) ||
-                 (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id));
+                 (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id) ||
+                 (lw_mask.straddle_num_padded_tiles > 0 && k_chunk == lw_mask.straddle_mask_chunk_id));
             if (sdpa_type == RING && !is_causal) {
                 apply_mask = needs_padding_mask;
             } else if (is_causal || sliding_window_size > 0) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -134,6 +134,17 @@ void kernel_main() {
         (local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (local_padded_Nt % Sk_chunk_t)) : 0;
     constexpr uint32_t joint_n_padded_tiles = (Lt % Sk_chunk_t != 0) ? (Sk_chunk_t - (Lt % Sk_chunk_t)) : 0;
 
+    // Straddle chunk: balanced-zigzag causal places two coarse-chunks-worth of sequence on each
+    // device; local K shard is monotonic in original positions but with a gap at the coarse
+    // boundary (local position coarse_chunk_size_t tiles). When k_chunk_size does not divide the
+    // coarse chunk size, one K chunk straddles early/late content — its late-half columns must be
+    // -inf-masked on rix > rid halved iters where compute would otherwise attend them, and the
+    // K-loop must be extended by one chunk so the early-half is not dropped.
+    constexpr uint32_t coarse_chunk_size_t = local_padded_Nt / 2;
+    constexpr bool has_straddle = (coarse_chunk_size_t % Sk_chunk_t) != 0;
+    constexpr uint32_t straddle_chunk_id = coarse_chunk_size_t / Sk_chunk_t;
+    constexpr uint32_t straddle_num_padded_tiles = has_straddle ? (Sk_chunk_t - (coarse_chunk_size_t % Sk_chunk_t)) : 0;
+
     RingAccumulatorState acc_state = {
         {cb_sum_A, cb_max_A, cb_out_im_A},  // prev
         {cb_sum_B, cb_max_B, cb_out_im_B},  // cur
@@ -189,6 +200,11 @@ void kernel_main() {
         lw_mask.joint_l_partial_col = joint_l_partial_col;
         lw_mask.global_n_partial_tile_idx = global_n_partial_tile_idx;
         lw_mask.joint_l_partial_tile_idx = joint_l_partial_tile_idx;
+        // Straddle mask fires only on the rix>rid halved-range iters that would otherwise exclude
+        // the straddle chunk. Must agree with the K-loop extension condition below.
+        const bool ring_iter_needs_straddle_mask = has_straddle && is_causal && is_balanced && (ring_index > ring_id);
+        lw_mask.straddle_num_padded_tiles = ring_iter_needs_straddle_mask ? straddle_num_padded_tiles : 0;
+        lw_mask.straddle_mask_chunk_id = straddle_chunk_id;
         if (ring_iter_needs_global_n_mask) {
             const uint32_t unpadded_in_chunk = global_n_within_ring_iter % (Sk_chunk_t * tt::constants::TILE_HEIGHT);
             const uint32_t valid_tiles =
@@ -253,6 +269,11 @@ void kernel_main() {
             uint32_t iter_num_kv_chunks = num_kv_chunks;
             if (is_causal && is_balanced && ring_index > ring_id) {
                 iter_num_kv_chunks /= 2;
+                // Extend by one chunk to include the straddle chunk; its late-half columns are
+                // -inf-masked via lw_mask.straddle_* above, early-half columns attend normally.
+                if constexpr (has_straddle) {
+                    iter_num_kv_chunks = straddle_chunk_id + 1;
+                }
             }
             bool skip_first_half_q = (ring_index >= ring_id ? false : is_balanced);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -134,16 +134,10 @@ void kernel_main() {
         (local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (local_padded_Nt % Sk_chunk_t)) : 0;
     constexpr uint32_t joint_n_padded_tiles = (Lt % Sk_chunk_t != 0) ? (Sk_chunk_t - (Lt % Sk_chunk_t)) : 0;
 
-    // Straddle chunk: balanced-zigzag causal places two coarse-chunks-worth of sequence on each
-    // device; local K shard is monotonic in original positions but with a gap at the coarse
-    // boundary (local position coarse_chunk_size_t tiles). When k_chunk_size does not divide the
-    // coarse chunk size, one K chunk straddles early/late content — its late-half columns must be
-    // -inf-masked on rix > rid halved iters where compute would otherwise attend them, and the
-    // K-loop must be extended by one chunk so the early-half is not dropped.
-    constexpr uint32_t coarse_chunk_size_t = local_padded_Nt / 2;
-    constexpr bool has_straddle = (coarse_chunk_size_t % Sk_chunk_t) != 0;
-    constexpr uint32_t straddle_chunk_id = coarse_chunk_size_t / Sk_chunk_t;
-    constexpr uint32_t straddle_num_padded_tiles = has_straddle ? (Sk_chunk_t - (coarse_chunk_size_t % Sk_chunk_t)) : 0;
+    using Straddle = KCausalStraddleInfo<local_padded_Nt, Sk_chunk_t>;
+    constexpr bool has_straddle = Straddle::has_straddle;
+    constexpr uint32_t straddle_chunk_id = Straddle::straddle_chunk_id;
+    constexpr uint32_t straddle_num_padded_tiles = Straddle::straddle_num_padded_tiles;
 
     RingAccumulatorState acc_state = {
         {cb_sum_A, cb_max_A, cb_out_im_A},  // prev
@@ -268,11 +262,12 @@ void kernel_main() {
 
             uint32_t iter_num_kv_chunks = num_kv_chunks;
             if (is_causal && is_balanced && ring_index > ring_id) {
-                iter_num_kv_chunks /= 2;
-                // Extend by one chunk to include the straddle chunk; its late-half columns are
-                // -inf-masked via lw_mask.straddle_* above, early-half columns attend normally.
                 if constexpr (has_straddle) {
+                    // Straddle chunk straddles the coarse-half boundary; extend to include it.
+                    // Its late-half columns are -inf-masked via lw_mask.straddle_* above.
                     iter_num_kv_chunks = straddle_chunk_id + 1;
+                } else {
+                    iter_num_kv_chunks /= 2;
                 }
             }
             bool skip_first_half_q = (ring_index >= ring_id ? false : is_balanced);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -205,14 +205,11 @@ void kernel_main() {
         // Indexes are updated accordingly; compute is skipped
         if (is_causal && is_balanced && ring_index > ring_id) {
             iter_num_kv_chunks /= 2;
-            // Mirror compute's K-loop extension in ring_joint_sdpa.cpp: when k_chunk_size does not
-            // divide the coarse-chunk size (local_padded_Nt/2), include the straddle chunk so K/V
-            // tiles for it get loaded. Compute -inf-masks its late-half columns via lw_mask.
-            constexpr uint32_t coarse_chunk_size_t = local_padded_Nt / 2;
-            constexpr bool has_straddle = (coarse_chunk_size_t % Sk_chunk_t) != 0;
-            constexpr uint32_t straddle_chunk_id = coarse_chunk_size_t / Sk_chunk_t;
-            if constexpr (has_straddle) {
-                iter_num_kv_chunks = straddle_chunk_id + 1;
+            // Mirror compute's K-loop extension: include the straddle chunk so K/V tiles
+            // for it get loaded. Compute -inf-masks its late-half columns via lw_mask.
+            using Straddle = KCausalStraddleInfo<local_padded_Nt, Sk_chunk_t>;
+            if constexpr (Straddle::has_straddle) {
+                iter_num_kv_chunks = Straddle::straddle_chunk_id + 1;
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -205,6 +205,15 @@ void kernel_main() {
         // Indexes are updated accordingly; compute is skipped
         if (is_causal && is_balanced && ring_index > ring_id) {
             iter_num_kv_chunks /= 2;
+            // Mirror compute's K-loop extension in ring_joint_sdpa.cpp: when k_chunk_size does not
+            // divide the coarse-chunk size (local_padded_Nt/2), include the straddle chunk so K/V
+            // tiles for it get loaded. Compute -inf-masks its late-half columns via lw_mask.
+            constexpr uint32_t coarse_chunk_size_t = local_padded_Nt / 2;
+            constexpr bool has_straddle = (coarse_chunk_size_t % Sk_chunk_t) != 0;
+            constexpr uint32_t straddle_chunk_id = coarse_chunk_size_t / Sk_chunk_t;
+            if constexpr (has_straddle) {
+                iter_num_kv_chunks = straddle_chunk_id + 1;
+            }
         }
 
         for (uint32_t q_iter = 0; global_q_start + q_iter < global_q_end; ++q_iter) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
@@ -143,3 +143,29 @@ inline uint32_t count_valid_kv_chunks(
     }
     return count;
 }
+
+/**
+ * Compile-time geometry for the K-chunk that straddles the causal coarse-half boundary
+ * in balanced-zigzag ring SDPA.
+ *
+ * Each device holds `local_padded_Nt` K tiles split as two equal coarse halves
+ * (early sequence / late sequence).  When `Sk_chunk_t` does not divide the
+ * coarse half size (`local_padded_Nt / 2`), exactly one K chunk straddles the
+ * boundary: its first part belongs to the early half (valid on rix > rid halved
+ * iterations) and its remainder belongs to the late half (must be -inf-masked).
+ * The K-loop must be extended by one chunk to include it, and compute must
+ * stamp -inf on the trailing `straddle_num_padded_tiles` columns.
+ *
+ * Used by both the compute kernel (ring_joint_sdpa.cpp) and the reader
+ * dataflow kernel (ring_joint_reader.cpp) to keep the K-loop bounds in sync.
+ */
+template <uint32_t local_padded_Nt, uint32_t Sk_chunk_t>
+struct KCausalStraddleInfo {
+    static constexpr uint32_t coarse_chunk_size_t = local_padded_Nt / 2;
+    static constexpr bool has_straddle = (coarse_chunk_size_t % Sk_chunk_t) != 0;
+    // Index of the straddling K chunk (floor(coarse_chunk_size_t / Sk_chunk_t)).
+    static constexpr uint32_t straddle_chunk_id = coarse_chunk_size_t / Sk_chunk_t;
+    // Trailing tiles in the straddle chunk that belong to the late half (0 if no straddle).
+    static constexpr uint32_t straddle_num_padded_tiles =
+        has_straddle ? (Sk_chunk_t - (coarse_chunk_size_t % Sk_chunk_t)) : 0;
+};


### PR DESCRIPTION
## Summary

Balanced-zigzag causal configs on the non-streaming ring-joint SDPA path silently drop a slice of causally-valid attention when `k_chunk_size` does not divide the coarse-chunk size (`total_seq / (2 * sp_size)`).

### The problem

Each device holds `local_padded_Nt` K tiles split as two equal coarse halves (early / late sequence). When `Sk_chunk_t` does not divide the coarse half size, one K chunk straddles the boundary:

```
|<-- early coarse half (coarse_chunk_size_t tiles) -->|<-- late coarse half -->|
 chunk 0 | chunk 1 | ... | chunk S-1 | [STRADDLE at S] | chunk S+1 | ...
                                            ^-- first few cols: early (valid)
                                                remaining cols: late (must be -inf on rix>rid)
```

For `ring_index > ring_id` iterations (causal: late half must be invisible):

```
BEFORE FIX:
  iter_num_kv_chunks = num_kv_chunks/2 = S   →  straddle chunk SKIPPED entirely
                              ↑
                    tile at straddle boundary (valid early content) is DROPPED

AFTER FIX:
  iter_num_kv_chunks = straddle_chunk_id + 1  →  straddle chunk INCLUDED
                              │
           straddle chunk mask:  early cols attend normally
                                 late cols stamped -inf via lw_mask.straddle_*
```

### Changes

- **Compute** (`ring_joint_sdpa.cpp`): extend `iter_num_kv_chunks` to `straddle_chunk_id + 1` on `rix > rid` iters; arm `lw_mask.straddle_num_padded_tiles` so the late-half columns are -inf stamped.
- **Reader** (`ring_joint_reader.cpp`): mirror the K-loop extension so K/V tiles for the straddle chunk are loaded.
- **Mask dispatch** (`compute_common.hpp`): add straddle fields to `LightweightMaskContext`; wire into `resolve_for_chunk` and `needs_padding_mask`.
- **Shared geometry** (`ring_utils.hpp`): extract `KCausalStraddleInfo<local_padded_Nt, Sk_chunk_t>` — single source of truth used by both compute and reader.
- **Test** (`test_ring_joint_sdpa.py`): add `mla_100k_straddle` (seq=3200, q=160, k=256) — the shape that exercises `has_straddle=true` and was previously silently wrong. Rename config, per-config `worker_l1_size`, `if constexpr / else` cleanup per review.

`rix == rid` (own causal-diagonal iter) and `rix < rid` (skip_first_half_q + full K) are unaffected — local-position ordering is monotonic within each shard, so local-causal masking and full-K processing remain correct there.

### Build-size note

The straddle mask branch increases the `ring_joint_sdpa` compute kernel binary by ~1.8 KiB for `Sk_chunk_t=8` (the `mla_100k_straddle` shape), pushing it over the Blackhole default 70,656-byte kernel config buffer. The increase is dominated by **loop unrolling on `dst_tiles`** — the inner exp/pack loops over K tiles in `sub_exp_block_bcast_cols_inplace` get unrolled 8× at O3, vs 5× for `Sk_chunk_t=5` shapes. Disabling those unrolls via `#pragma GCC unroll 0` recovers ~85% of the growth, confirming it is compiler-amplified rather than structural.

As a temporary workaround, `mla_100k_straddle` carries a `worker_l1_size=1456640` override in `ModelConfig` that expands the kernel config buffer for that test case only — all other configs continue to use the hardware default. This is an acknowledged stopgap until a proper fix (targeted unroll control or O2 gating on `has_straddle` shapes) is landed.

## Test plan

- [x] `mla_100k-q160-k160` (no straddle, regression) — PCC 0.9995, RMSE 0.0069 — **PASS**
- [x] `mla_100k_straddle-q160-k256` (straddle fix target) — PCC 0.9995, RMSE 0.0069 — **PASS**
- [x] `wan2_2_1xGLX-q288-k512` (non-causal spot-check) — PCC 0.9997, RMSE 0.0064 — **PASS**
- [ ] CI: all existing MLA + WAN configs pass without regression
- [ ] Follow-up: reduce `Sk_chunk_t=8` binary size (targeted unroll control / O2 gating) and remove the `worker_l1_size` override

All hardware validation on 4×Blackhole Quiet Box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_straddle_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dnijemcevic/causal_straddle_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dnijemcevic/causal_straddle_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dnijemcevic/causal_straddle_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/causal_straddle_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/causal_straddle_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dnijemcevic/causal_straddle_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dnijemcevic/causal_straddle_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dnijemcevic/causal_straddle_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dnijemcevic/causal_straddle_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dnijemcevic/causal_straddle_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dnijemcevic/causal_straddle_mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dnijemcevic/causal_straddle_mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dnijemcevic/causal_straddle_mask)