### PR TITLE
llrt: use versim core descriptor for mock WH/BH devices

### DIFF
--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -52,6 +52,19 @@ inline std::string get_core_descriptor_file(
     }
     core_desc_dir += "tt_metal/core_descriptors/";
 
+    // For mock devices (hardware-free testing), use small simulation YAML files.
+    // This gives a predictable 1x1 compute grid so that bounds-checking validation
+    // in MakeProgramFromSpec works correctly for out-of-bounds tests.
+    // (Without this, the mock WH cluster has 0 harvested rows → "galaxy" product →
+    //  9-row grid, so coordinates like {0, 8} appear in-bounds and no exception is thrown.)
+    if (env.get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        switch (arch) {
+            case tt::ARCH::WORMHOLE_B0: return core_desc_dir + "wormhole_b0_versim_1x1_arch.yaml";
+            case tt::ARCH::BLACKHOLE: return core_desc_dir + "blackhole_simulation_1x2_arch.yaml";
+            default: break;  // QUASAR handled below (always uses simulation YAML)
+        }
+    }
+
     if (env.get_rtoptions().get_simulator_enabled()) {
         auto soc_desc = tt::umd::SimulationChip::get_soc_descriptor_path_from_simulator_path(
             env.get_rtoptions().get_simulator_path());
@@ -258,7 +271,9 @@ const core_descriptor_t& get_core_descriptor_config(
         dispatch_cores.push_back(coord);
     }
     TT_ASSERT(
-        !dispatch_cores.empty() || env.get_rtoptions().get_simulator_enabled(), "Dispatch cores size must be positive");
+        !dispatch_cores.empty() || env.get_rtoptions().get_simulator_enabled() ||
+            env.get_cluster().get_target_device_type() == tt::TargetDevice::Mock,
+        "Dispatch cores size must be positive");
 
     // Parse fabric_mux_cores
     std::vector<RelativeCoreCoord> fabric_mux_cores;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/42513

### PR Type
Bug fix / Test infra

### Problem description

Three `ProgramSpecTestGen1` tests regressed in the Nightly L2 run after #42133:
- `KernelTargetsNodeBeyondGridYFails`
- `KernelTargetsOutOfBoundsNodeFails`
- `DFBTargetsOutOfBoundsNodeFails`

**Root cause:** `configure_mock_mode(WORMHOLE_B0, 1)` creates a mock cluster using `wormhole_N150.yaml`. That cluster has 0 harvested rows → `get_product_name(WH, 0)` returns "galaxy". In `wormhole_b0_80_arch.yaml`, the galaxy row-1-CQ grid is `end:[7,8]` = **9 rows**. The test coordinate `{0, 8}` (y=8) satisfies `8 < 9` → in-bounds → `ValidateNodeBounds` does not throw → test fails.

### What's changed

In `get_core_descriptor_file()` (`tt_metal/llrt/core_descriptor.cpp`), detect `TargetDevice::Mock` and route WH/BH mock devices to the versim/simulation YAML files:
- `wormhole_b0_versim_1x1_arch.yaml` → 1×1 compute grid
- `blackhole_simulation_1x2_arch.yaml` → 1×2 compute grid

This gives a predictable small grid so that OOB coordinates in the bounds-check tests always trigger `TT_FATAL` as expected. (Quasar already always uses its simulation YAML — this brings WH/BH mock into alignment.)

Also relaxes the `dispatch_cores` assertion to permit empty dispatch cores for mock devices (the versim YAMLs have `dispatch_cores: []`).

### Checklist

- [x] Fixes the three failing `ProgramSpecTestGen1` bounds-check tests on N150
- [x] No changes to test logic or test coordinates
- [x] Existing passing `ProgramSpecTestGen1` tests unaffected (all use `{0,0}` which is in-bounds for a 1×1 grid)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-wh-mock-bounds-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-wh-mock-bounds-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-wh-mock-bounds-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-wh-mock-bounds-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-wh-mock-bounds-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-wh-mock-bounds-check)