### PR TITLE
Fix Metal 2.0 API unit test causing L2 nightly regression

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1561,8 +1561,9 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
 // These tests use the WH mock device, not real hardware.
 
 TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
-    // {0, 8}: y=8 is one past the 8-tall compute grid.
-    const NodeCoord oob_node{0, 8};
+    // Use a large y coordinate that is out of bounds on any WH/BH grid configuration
+    // (including unharvested "galaxy" variants with up to 10 rows).
+    const NodeCoord oob_node{0, 1000};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
@@ -1577,8 +1578,8 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
 }
 
 TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
-    // {8, 0} is out of bounds: x=8 is beyond the 8-wide compute grid.
-    const NodeCoord oob_node{8, 0};
+    // Use a large x coordinate that is out of bounds on any WH/BH grid configuration.
+    const NodeCoord oob_node{1000, 0};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
@@ -1596,7 +1597,7 @@ TEST_F(ProgramSpecTestGen1, DFBTargetsOutOfBoundsNodeFails) {
     // Bounds checking applies to DFBs as well as kernels. The kernel itself is on a
     // valid node, but the DFB it produces to targets an OOB node.
     const NodeCoord valid_node{0, 0};
-    const NodeCoord oob_node{0, 100};
+    const NodeCoord oob_node{0, 1000};
 
     ProgramSpec spec;
     spec.program_id = "test_program";

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1554,16 +1554,18 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
 }
 
-// WH N150 grid reference (wormhole_N150.yaml, harvest_mask=0x40 = 1 row harvested):
-//   - compute_grid = 8x8 (valid nodes: x in [0,7], y in [0,7])
-//   - OOB examples: {8, 0} (x too large), {0, 8} (y too large), {0, 100} (far OOB)
+// WH N150 mock grid reference (wormhole_N150.yaml, harvest_mask=0x40 = 1 row harvested):
+//   - Fast dispatch: compute_grid = 8x8 (y in [0,7]; one row reserved for dispatch)
+//   - Slow dispatch: compute_grid = 8x9 (y in [0,8]; full logical tensix grid, no rows reserved)
+//
+// The apparent grid size is different in slow dispatch vs. fast dispatch mode. CI runs with
+// both, so choose OOB coordinates that will fail in both cases.
 //
 // These tests use the WH mock device, not real hardware.
 
 TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
-    // Use a large y coordinate that is out of bounds on any WH/BH grid configuration
-    // (including unharvested "galaxy" variants with up to 10 rows).
-    const NodeCoord oob_node{0, 1000};
+    // y=9 is just outside the 9-row slow-dispatch grid (also outside the 8-row fast-dispatch grid).
+    const NodeCoord oob_node{0, 9};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
@@ -1578,8 +1580,8 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
 }
 
 TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
-    // Use a large x coordinate that is out of bounds on any WH/BH grid configuration.
-    const NodeCoord oob_node{1000, 0};
+    // x=8 is just outside the 8-column grid (same in fast and slow dispatch).
+    const NodeCoord oob_node{8, 0};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
@@ -1597,7 +1599,7 @@ TEST_F(ProgramSpecTestGen1, DFBTargetsOutOfBoundsNodeFails) {
     // Bounds checking applies to DFBs as well as kernels. The kernel itself is on a
     // valid node, but the DFB it produces to targets an OOB node.
     const NodeCoord valid_node{0, 0};
-    const NodeCoord oob_node{0, 1000};
+    const NodeCoord oob_node{0, 9};  // just outside the 9-row slow-dispatch grid
 
     ProgramSpec spec;
     spec.program_id = "test_program";


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/42513

### PR Type
Bug fix

### Problem description

Three new tests in `ProgramSpecTestGen1` regressed the Nightly L2 `sd-unit-tests (wormhole_b0, N150)` job.
They're just stupid unit tests for out-of-bounds worker node assignments error messages in the new Metal 2.0 APIs. 

**Root cause:** That CI unit test job sets `TT_METAL_SLOW_DISPATCH_MODE=1`. My local tests (and PR gate) were using fast dispatch. The node the tests was targeting was just off the grid.... out-of-bounds with fast dispatch, but not slow dispatch. Oops.

### What's changed

Replace the three OOB test coordinates with values that are outside the grid in *both* dispatch modes

### Testing

Reproduced locally by running tests with slow dispatch enabled.
Works now with the fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-wh-mock-bounds-check-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-wh-mock-bounds-check-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-wh-mock-bounds-check-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-wh-mock-bounds-check-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-wh-mock-bounds-check-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-wh-mock-bounds-check-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-wh-mock-bounds-check-v2)