### PR TITLE
interleaved_to_sharded: support DRAM destination for WIDTH_SHARDED tile layouts

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded_reshard.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded_reshard.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Validates the DRAM-sharded matmul path when weights are resharded on-device
+via ttnn.interleaved_to_sharded (DRAM interleaved -> DRAM WIDTH_SHARDED),
+vs. the baseline of weights loaded directly as DRAM WIDTH_SHARDED.
+
+This exercises the interleaved_to_sharded -> DRAM destination path that
+enables MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig for tt-mlir
+compiler flows, which cannot pre-allocate sharded weights host-side.
+"""
+
+import time
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch2tt_tensor
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+N_ITERS = 200
+PCC = 0.99
+
+
+def pad_to_dram_banks(num, num_banks):
+    lcm = 32 * num_banks
+    rem = num % lcm
+    return num if rem == 0 else num + (lcm - rem)
+
+
+# Shapes sorted by weight size (K * N).
+# Larger shapes (e.g. K=8192 N=4096, K=32768 N=1024) currently OOM the staging
+# CB in interleaved_to_sharded and require the follow-up L1-budgeted chunking
+# change to the reader/writer kernels.
+@pytest.mark.parametrize(
+    "M, K, N, grid",
+    [
+        (32, 8192, 1024, (8, 1)),
+        (32, 8192, 1280, (8, 1)),
+    ],
+)
+def test_matmul_dram_sharded_via_reshard(device, M, K, N, grid):
+    num_banks = device.dram_grid_size().x
+    N_padded = pad_to_dram_banks(N, num_banks)
+    num_cores = grid[0] * grid[1]
+
+    in0_block_w = K // num_cores // 32
+    per_core_M = M // 32
+    per_core_N = N // num_cores // 32
+
+    interleaved_dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    sharded_l1 = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+
+    compute_cfg = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    torch.manual_seed(0)
+    in0_raw = torch.randn([1, 1, M, K]).bfloat16().float()
+    in1_raw = torch.randn([1, 1, K, N]).bfloat16().float()
+    expected = in0_raw @ in1_raw
+
+    # in0: interleaved DRAM -> L1 WIDTH_SHARDED (shared by both variants)
+    in0_dram = torch2tt_tensor(in0_raw, device, tt_memory_config=interleaved_dram, tt_dtype=ttnn.bfloat16)
+    in0_l1 = ttnn.interleaved_to_sharded(
+        in0_dram,
+        grid,
+        [M, in0_block_w * 32],
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    # DRAM WIDTH_SHARDED memory config for weights. Shard grid uses DRAM bank
+    # logical coords; the program factory remaps them to compute worker cores
+    # for kernel/CB placement.
+    dram_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_banks - 1, 0))})
+    in1_shard_spec = ttnn.ShardSpec(dram_grid, [K, N_padded // num_banks], ttnn.ShardOrientation.ROW_MAJOR)
+    in1_dram_sharded_cfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
+    )
+
+    prog_cfg = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+        in0_block_w=in0_block_w // 4,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        fused_activation=None,
+    )
+
+    def run(weights):
+        return ttnn.matmul(
+            in0_l1,
+            weights,
+            program_config=prog_cfg,
+            memory_config=sharded_l1,
+            dtype=ttnn.bfloat16,
+            compute_kernel_config=compute_cfg,
+        )
+
+    def run_variant(weights, label):
+        out = run(weights)
+        out_torch = ttnn.to_torch(ttnn.to_memory_config(out, ttnn.L1_MEMORY_CONFIG))
+        assert_with_pcc(expected, out_torch, pcc=PCC)
+        ttnn.deallocate(out)
+
+        t0 = time.perf_counter()
+        for _ in range(N_ITERS):
+            out = run(weights)
+        out.cpu()
+        us = (time.perf_counter() - t0) / N_ITERS * 1e6
+        logger.info(f"  {label}: {us:6.1f} us/iter")
+        return us
+
+    # Variant 1: weights loaded directly as DRAM WIDTH_SHARDED (baseline)
+    w_direct = torch2tt_tensor(in1_raw, device, tt_memory_config=in1_dram_sharded_cfg, tt_dtype=ttnn.bfloat8_b)
+    direct_us = run_variant(w_direct, "dram_sharded (direct)")
+    ttnn.deallocate(w_direct)
+
+    # Variant 2: weights loaded as DRAM interleaved, resharded via interleaved_to_sharded
+    w_interleaved = torch2tt_tensor(in1_raw, device, tt_memory_config=interleaved_dram, tt_dtype=ttnn.bfloat8_b)
+    w_reshard = ttnn.interleaved_to_sharded(w_interleaved, in1_dram_sharded_cfg)
+    reshard_us = run_variant(w_reshard, "dram_reshrd (via interleaved_to_sharded)")
+    ttnn.deallocate(w_interleaved)
+    ttnn.deallocate(w_reshard)
+
+    logger.info(f"  M={M} K={K} N={N}: reshard/direct = {reshard_us/direct_us:.2f}x")

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -51,14 +51,27 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
 
     bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
-    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end_coord;
-
     bool convert_df = input_cb_data_format != output_cb_data_format;
     auto* src_buffer = input.buffer();
     auto* dst_buffer = output.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
+
+    // When the destination is DRAM, the shard_spec grid uses DRAM bank coordinates
+    // (e.g. (0,0)-(11,0) on WH) which can exceed the compute grid (8x8).
+    // Map those to compute worker cores adjacent to each DRAM bank for kernel/CB placement.
+    // The output tensor's buffer shard spec retains the DRAM bank coords for correct
+    // buffer allocation and shard_builder address generation.
+    std::vector<CoreCoord> dram_worker_cores;
+    if (dst_is_dram) {
+        auto all_dram_workers = input.device()->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_0);
+        auto shard_grid_cores = corerange_to_cores(shard_spec.grid, std::nullopt, rm_orientation);
+        dram_worker_cores.reserve(shard_grid_cores.size());
+        for (const auto& dram_core : shard_grid_cores) {
+            dram_worker_cores.push_back(all_dram_workers[dram_core.x]);
+        }
+    }
 
     if (input.layout() == Layout::TILE) {
         input_unit_size = tt::tile_size(input_cb_data_format);
@@ -105,7 +118,16 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
         }
     }
 
-    auto all_cores = shard_spec.grid;
+    CoreRangeSet all_cores = shard_spec.grid;
+    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end_coord;
+    if (dst_is_dram) {
+        std::vector<CoreRange> worker_ranges;
+        worker_ranges.reserve(dram_worker_cores.size());
+        for (const auto& wc : dram_worker_cores) {
+            worker_ranges.emplace_back(CoreRange(wc, wc));
+        }
+        all_cores = CoreRangeSet(std::move(worker_ranges));
+    }
     uint32_t input_cb_index = tt::CBIndex::c_0;
     uint32_t scratch_cb_index = tt::CBIndex::c_1;
     uint32_t out_cb_index = input_cb_index;
@@ -199,19 +221,27 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
     uint32_t curr_idx_h = 0;
     uint32_t curr_idx_w = 0;
 
-    const auto cores = corerange_to_cores(shard_spec.grid, std::nullopt, rm_orientation);
-    for (const auto& core : cores) {
+    // When dst is DRAM, iterate over worker cores (in DRAM bank order) instead of
+    // shard_spec grid coords. The shard offset calculations are purely index-based.
+    const auto cores = dst_is_dram
+        ? dram_worker_cores
+        : corerange_to_cores(shard_spec.grid, std::nullopt, rm_orientation);
+    const uint32_t num_cores = cores.size();
+
+    for (uint32_t core_idx = 0; core_idx < num_cores; core_idx++) {
+        const auto& core = cores[core_idx];
+        bool is_last_core_in_shard = (core_idx == num_cores - 1);
         uint32_t curr_num_units_per_shard = num_units_per_shard;
         if (input.layout() == Layout::TILE) {
             uint32_t shard_height = num_units_per_shard_height;
             uint32_t shard_width = num_units_per_shard_width;
             uint32_t padded_offset = 0;
             if (shard_strategy == TensorMemoryLayout::HEIGHT_SHARDED) {
-                if (core == end_core) {
+                if (dst_is_dram ? is_last_core_in_shard : (core == end_core)) {
                     shard_height = num_units_per_shard_height_last;
                 }
             } else if (shard_strategy == TensorMemoryLayout::WIDTH_SHARDED) {
-                if (core == end_core) {
+                if (dst_is_dram ? is_last_core_in_shard : (core == end_core)) {
                     shard_width = num_units_per_shard_width_last;
                     padded_offset = padded_offset_bytes;
                 }
@@ -277,12 +307,12 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
             uint32_t shard_height = num_units_per_shard_height;
             uint32_t shard_width = input_unit_size;
             if (shard_strategy == TensorMemoryLayout::HEIGHT_SHARDED) {
-                if (core.x == end_core.x && core.y == end_core.y) {
+                if (dst_is_dram ? is_last_core_in_shard : (core.x == end_core.x && core.y == end_core.y)) {
                     shard_height = num_units_per_shard_height_last;
                     curr_num_units_per_shard = shard_height * num_units_per_shard_width;
                 }
             } else if (shard_strategy == TensorMemoryLayout::WIDTH_SHARDED) {
-                if (core.x == end_core.x && core.y == end_core.y) {
+                if (dst_is_dram ? is_last_core_in_shard : (core.x == end_core.x && core.y == end_core.y)) {
                     shard_width = num_units_per_shard_width_last;
                 }
             } else if (shard_strategy == TensorMemoryLayout::BLOCK_SHARDED) {


### PR DESCRIPTION
## Ticket
#42595 


## Summary

Enables `ttnn::interleaved_to_sharded` (and `to_memory_config`) to produce DRAM WIDTH_SHARDED tensors from DRAM interleaved inputs for tiled data. This unlocks the DRAM-sharded matmul path (`MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig`) for flows that can't pre-allocate sharded weights on the host — most notably the tt-mlir compiler pipeline, where weights arrive as DRAM interleaved tensors and must be resharded on-device via consteval.

## Motivation

DRAM-sharded matmul is significantly faster than alternatives for M=32, large-K GEMMs common in transformer decoders:

| Shape (M × K × N) | dram_sharded | 1d_mcast | 2d_mcast | auto |
|---|---|---|---|---|
| 32 × 8192 × 1280 | **61.6 µs** | 90.4 (1.47×) | 90.2 (1.46×) | 153.1 (2.48×) |
| 32 × 8192 × 1024 | **50.7 µs** | 69.4 (1.37×) | 69.9 (1.38×) | 141.8 (2.79×) |

Prior to this change, `interleaved_to_sharded` crashed with `CoreRangeSet::validate_no_overlap` (or `CB core range exceeds compute grid` depending on which validator fired first) when given a DRAM destination, because the op used the shard spec's DRAM-bank-coordinate grid (e.g. `(0,0)-(11,0)` on WH) directly for kernel/CB placement — which doesn't fit on the 8×8 compute grid.

## Changes

### 1. DRAM bank → worker core mapping (`interleaved_to_sharded_program_factory.cpp`)

Split the two roles of `shard_spec.grid` when the destination is DRAM:

- **Buffer allocation** keeps using DRAM bank logical coordinates (so the output buffer is correctly sharded across banks and `shard_builder` address generation works unchanged).
- **Kernel/CB placement** now uses compute worker cores adjacent to each DRAM bank, obtained via `device->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_0)`.

Per-shard last-core detection in the runtime-args loop switched from `core == end_core` to an index-based `core_idx == num_cores - 1`, since worker-core coordinates no longer match the shard grid's end coord.

### 2. Test coverage

Added `tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded_reshard.py`. Validates that DRAM-sharded matmul produces the correct (PCC-checked) output when weights are resharded on-device via `interleaved_to_sharded`, and compares latency to the baseline of directly-allocated DRAM-sharded weights.

## Known limitation / follow-up

For DRAM destinations the output CB is a staging buffer in L1 (not globally allocated to the output buffer), so shards whose padded size exceeds a worker's usable L1 (~1 MB on WH) will fail with:

```
TT_THROW: Statically allocated circular buffers ... grow to N B which is beyond max L1 size
```

In practice this affects larger weight matrices, e.g.:

| Shape (M × K × N) | Status |
|---|---|
| 32 × 8192 × 1024 | ✓ works |
| 32 × 8192 × 1280 | ✓ works |
| 32 × 8192 × 4096 | ✗ OOM |
| 32 × 32768 × 1024 | ✗ OOM |

The follow-up PR will add L1-budgeted height chunking in the reader/writer kernels (`reader_unary_sharded_blocks_interleaved_start_id.cpp`, `writer_unary_sharded_blocks_start_id.cpp`) to process large shards in chunks.