### PR TITLE
[tt-train] Migrate non-sharded Qwen3 to ttml models

### DIFF
--- a/tt-train/docs/proposals/kv_cache_python_migration.md
+++ b/tt-train/docs/proposals/kv_cache_python_migration.md
@@ -1,0 +1,35 @@
+# KvCache: move Python models off the C++ binding
+
+## Problem
+
+`ttml.models.KvCache` is a C++ class (`tt-train/sources/ttml/models/common/transformer_common.{hpp,cpp}`) bound via nanobind. Its entire job on the device is two `ttnn::experimental::slice_write` calls plus a `cache_position` counter — every primitive it needs is already available to Python via `ttnn.*`.
+
+Living in C++ costs us two things. First, iteration friction: a signature or behavior change means hpp + cpp + nb_models.cpp + rebuild. Second, Qwen3 needed things the C++ class doesn't provide (lazy init once `(B, H, D)` are known, autograd-tensor I/O at the call site, prefill-vs-decode return convention, causal-mask slicing) and wrapped the C++ class in Python to get them (`tt-train/sources/examples/qwen3/utils/kv_cache.py`). Llama calls the C++ class directly (`tt-train/sources/ttml/ttml/models/llama/gqattn.py:90-109`) and pays for the missing ergonomics at the call site.
+
+C++ models still consume the C++ KvCache (`models/llama.cpp`, `modules/grouped_query_attention.cpp`, `modules/llama_block.cpp`), so a hard replacement isn't on the table yet.
+
+## Desired end state
+
+A Python `ttml.models.kv_cache` used by Python models (Qwen3, Llama). The C++ class stays in place until C++ models migrate off it. Expected design moves (not a spec — just the direction the Qwen3 wrapper already validated):
+
+- Autograd tensors in and out. No `.get_value()` at every attention call site.
+- Lazy allocation on first `update` so construction doesn't need `(B, num_groups, head_dim)` up front.
+- `update` infers `new_tokens` from the K tensor's seq dim rather than taking it as a separate arg.
+- Prefill returns the freshly-written K/V; decode returns the full cached K/V. Same convention Qwen3's wrapper uses today.
+- Mask helper stays a free function, **not** a method on the cache. Putting it on the cache couples attention and training paths to the cache's lifetime, and the Llama style ("caller owns the mask") is the right default.
+
+## Open design calls for the follow-up
+
+- Whether to reuse `ttml.models.KvCacheConfig` (C++ dataclass-ish) or take a flat Python constructor.
+- Whether the Python cache holds raw `ttnn.Tensor` or `ttml.autograd.Tensor` internally. Autograd-tensor is friendlier at call sites; raw ttnn is closer to what `slice_write` expects and matches the C++ class.
+- Whether to accept the `new_tokens != K.shape[-2]` case at all. The C++ class supports it (writing a prefix of K into the cache); nothing in Qwen3 or Llama uses that capability today. Dropping it would simplify `update`.
+
+## Consumers to update when this lands
+
+Python side: `ttml/models/llama/gqattn.py:90-109`, plus the new `ttml/models/qwen3/attention.py`, plus the Python generation/inference paths that allocate a cache today (`examples/qwen3/generate.py`, Llama's callers).
+
+C++ side: unchanged in this work.
+
+## Constraint worth naming
+
+The follow-up isn't a performance win — every meaningful op still calls into ttnn. The case for doing it is iteration velocity and getting the Qwen3 wrapper's improvements into the default API. If that's not a pain point anyone's feeling when this comes up, it's fine to defer.

--- a/tt-train/sources/ttml/ttml/models/__init__.py
+++ b/tt-train/sources/ttml/ttml/models/__init__.py
@@ -40,6 +40,7 @@ sys.modules[f"{__name__}.distributed"] = distributed
 from .linear_regression import LinearRegression, create_linear_regression_model
 from .nanogpt import NanoGPT, NanoGPTConfig, create_nanogpt
 from .llama import Llama, LlamaConfig
+from .qwen3 import Qwen3, Qwen3Config, Qwen3RopeScalingConfig
 
 __all__ = [
     # C++ enums / classes
@@ -59,6 +60,9 @@ __all__ = [
     "LinearRegression",
     "NanoGPT",
     "NanoGPTConfig",
+    "Qwen3",
+    "Qwen3Config",
+    "Qwen3RopeScalingConfig",
     "create_linear_regression_model",
     "create_nanogpt",
 ]

--- a/tt-train/sources/ttml/ttml/models/qwen3/__init__.py
+++ b/tt-train/sources/ttml/ttml/models/qwen3/__init__.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python Qwen3 model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import ttml
+from ttml.modules import AbstractModuleBase, Embedding, LinearLayer, ModuleList
+
+from .. import RunnerType, WeightTyingType, memory_efficient_runner
+from .attention import Qwen3Attention, build_attn_mask
+from .rmsnorm import Qwen3RMSNorm, RMSNormFunction
+from .transformer import Qwen3DecoderLayer, Qwen3MLP
+
+
+@dataclass(frozen=True)
+class Qwen3RopeScalingConfig:
+    scaling_factor: float = 0.0  # 0.0 disables scaling
+    high_freq_factor: float = 4.0
+    low_freq_factor: float = 1.0
+    original_context_length: int = 0  # 0 disables scaling
+
+
+@dataclass(frozen=True)
+class Qwen3Config:
+    vocab_size: int = 151936
+    hidden_size: int = 4096
+    intermediate_size: int = 22016
+    num_hidden_layers: int = 32
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 32
+    head_dim: int = 128
+    max_position_embeddings: int = 32768
+    rms_norm_eps: float = 1e-6
+    attention_bias: bool = True
+    attention_dropout: float = 0.0
+    rope_theta: float = 1000000.0
+    runner_type: RunnerType = RunnerType.Default
+    weight_tying: WeightTyingType = WeightTyingType.Disabled
+    rope_scaling: Qwen3RopeScalingConfig = field(default_factory=Qwen3RopeScalingConfig)
+
+    def __post_init__(self):
+        if self.max_position_embeddings % 32 != 0:
+            raise ValueError(
+                "max_position_embeddings must be divisible by 32 (tile size); " f"got {self.max_position_embeddings}"
+            )
+        if self.hidden_size % 32 != 0:
+            raise ValueError(f"hidden_size must be divisible by 32 (tile size); got {self.hidden_size}")
+        if self.head_dim % 32 != 0:
+            raise ValueError(f"head_dim must be divisible by 32 (tile size); got {self.head_dim}")
+        if self.num_attention_heads <= 0:
+            raise ValueError(f"num_attention_heads must be positive; got {self.num_attention_heads}")
+        if self.num_key_value_heads <= 0:
+            raise ValueError(f"num_key_value_heads must be positive; got {self.num_key_value_heads}")
+        if self.num_attention_heads % self.num_key_value_heads != 0:
+            raise ValueError(
+                "num_attention_heads must be divisible by num_key_value_heads; "
+                f"got num_attention_heads={self.num_attention_heads}, "
+                f"num_key_value_heads={self.num_key_value_heads}"
+            )
+
+
+def create_qwen3_config_from_hf(hf_config, max_sequence_length: int) -> Qwen3Config:
+    """Build a Qwen3Config from a HuggingFace config object."""
+    rope_scaling = Qwen3RopeScalingConfig()
+    if getattr(hf_config, "rope_scaling", None):
+        rs = hf_config.rope_scaling
+        rope_scaling = Qwen3RopeScalingConfig(
+            scaling_factor=rs.get("factor", 0.0),
+            high_freq_factor=rs.get("high_freq_factor", 4.0),
+            low_freq_factor=rs.get("low_freq_factor", 1.0),
+            original_context_length=rs.get("original_max_position_embeddings", 0),
+        )
+
+    return Qwen3Config(
+        vocab_size=hf_config.vocab_size,
+        hidden_size=hf_config.hidden_size,
+        intermediate_size=hf_config.intermediate_size,
+        num_hidden_layers=hf_config.num_hidden_layers,
+        num_attention_heads=hf_config.num_attention_heads,
+        num_key_value_heads=hf_config.num_key_value_heads,
+        head_dim=getattr(hf_config, "head_dim", hf_config.hidden_size // hf_config.num_attention_heads),
+        max_position_embeddings=max_sequence_length,
+        rms_norm_eps=hf_config.rms_norm_eps,
+        attention_bias=getattr(hf_config, "attention_bias", True),
+        rope_theta=getattr(hf_config, "rope_theta", 1000000.0),
+        rope_scaling=rope_scaling,
+        weight_tying=(
+            WeightTyingType.Enabled if getattr(hf_config, "tie_word_embeddings", False) else WeightTyingType.Disabled
+        ),
+    )
+
+
+def _build_rope_params(config: Qwen3Config) -> ttml.ops.rope.RotaryEmbeddingParams:
+    scaling = ttml.ops.rope.RopeScalingParams()
+    if config.rope_scaling.scaling_factor != 0.0 and config.rope_scaling.original_context_length != 0:
+        scaling.scaling_factor = config.rope_scaling.scaling_factor
+        scaling.high_freq_factor = config.rope_scaling.high_freq_factor
+        scaling.low_freq_factor = config.rope_scaling.low_freq_factor
+        scaling.original_context_length = config.rope_scaling.original_context_length
+    return ttml.ops.rope.build_rope_params(
+        sequence_length=config.max_position_embeddings,
+        head_dim=config.head_dim,
+        theta=config.rope_theta,
+        rope_scaling_params=scaling,
+    )
+
+
+def _padded_vocab_size(vocab_size: int) -> int:
+    return ((vocab_size + 31) // 32) * 32
+
+
+class Qwen3Model(AbstractModuleBase):
+    """Qwen3 backbone: embeddings → decoder stack → final RMSNorm."""
+
+    def __init__(self, config: Qwen3Config) -> None:
+        super().__init__()
+        self.config = config
+
+        rope_params = _build_rope_params(config)
+
+        self.embed_tokens = Embedding(
+            _padded_vocab_size(config.vocab_size),
+            config.hidden_size,
+            weight_init=ttml.init.normal(0.0, 0.02),
+        )
+        self.layers = ModuleList(
+            [
+                Qwen3DecoderLayer(
+                    hidden_size=config.hidden_size,
+                    intermediate_size=config.intermediate_size,
+                    num_attention_heads=config.num_attention_heads,
+                    num_key_value_heads=config.num_key_value_heads,
+                    head_dim=config.head_dim,
+                    rope_params=rope_params,
+                    attention_bias=config.attention_bias,
+                    rms_norm_eps=config.rms_norm_eps,
+                )
+                for _ in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: ttml.autograd.Tensor,
+        mask: ttml.autograd.Tensor,
+        kv_cache: Optional[ttml.models.KvCache] = None,
+        new_tokens: Optional[int] = None,
+    ) -> ttml.autograd.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+
+        for layer_idx, layer in enumerate(self.layers):
+            extra_args = () if kv_cache is None else (kv_cache, layer_idx, new_tokens)
+            if self.config.runner_type == RunnerType.MemoryEfficient:
+                hidden_states = memory_efficient_runner(layer, hidden_states, mask, *extra_args)
+            elif self.config.runner_type == RunnerType.Default:
+                hidden_states = layer(hidden_states, mask, *extra_args)
+            else:
+                raise ValueError(f"Unknown runner_type: {self.config.runner_type}")
+
+        return self.norm(hidden_states)
+
+
+class Qwen3(AbstractModuleBase):
+    """Qwen3 causal-LM: backbone + unembedding head."""
+
+    def __init__(self, config: Qwen3Config) -> None:
+        super().__init__()
+        self.config = config
+
+        self.model = Qwen3Model(config)
+        self.lm_head = LinearLayer(
+            config.hidden_size,
+            _padded_vocab_size(config.vocab_size),
+            has_bias=False,
+            weight_init=ttml.init.normal(0.0, 0.02),
+        )
+
+        if config.weight_tying == WeightTyingType.Enabled:
+            self.lm_head.weight = self.model.embed_tokens.weight.tensor
+
+    def forward(
+        self,
+        input_ids: ttml.autograd.Tensor,
+        mask: ttml.autograd.Tensor,
+        kv_cache: Optional[ttml.models.KvCache] = None,
+        new_tokens: Optional[int] = None,
+    ) -> ttml.autograd.Tensor:
+        hidden_states = self.model(input_ids, mask, kv_cache, new_tokens)
+        return self.lm_head(hidden_states)
+
+
+from .safetensors_loader import export_hf_model, load_from_hf
+
+__all__ = [
+    "Qwen3",
+    "Qwen3Attention",
+    "Qwen3Config",
+    "Qwen3DecoderLayer",
+    "Qwen3MLP",
+    "Qwen3Model",
+    "Qwen3RMSNorm",
+    "Qwen3RopeScalingConfig",
+    "RMSNormFunction",
+    "build_attn_mask",
+    "create_qwen3_config_from_hf",
+    "export_hf_model",
+    "load_from_hf",
+]

--- a/tt-train/sources/ttml/ttml/models/qwen3/attention.py
+++ b/tt-train/sources/ttml/ttml/models/qwen3/attention.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Grouped-query attention for Qwen3.
+
+Differs from ttml's standard GQA in three places:
+  - Separate Q / K / V projections (HF layout), not a fused KV matrix.
+  - QK-Norm: per-head RMSNorm applied to Q and K before RoPE.
+  - Explicit ``head_dim`` (not ``hidden_size // num_heads``) and configurable
+    attention bias.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import ml_dtypes
+
+import ttnn
+import ttml
+from ttml.modules import AbstractModuleBase, LinearLayer
+
+from .rmsnorm import Qwen3RMSNorm
+
+
+class _ConcatLastDim(ttml.autograd.Function):
+    """Autograd-aware concat along the last dim (K, V fusion before head split)."""
+
+    @staticmethod
+    def forward(ctx, a, b):
+        a_shape = a.shape()
+        b_shape = b.shape()
+        ctx.save_for_backward(a_shape, b_shape)
+        return ttml.autograd.create_tensor(ttnn.concat([a.get_value(), b.get_value()], dim=-1))
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        a_shape, b_shape = ctx.saved_tensors
+        a_last = a_shape[-1]
+        b_last = b_shape[-1]
+        grad_a = ttnn.slice(grad_output, [0, 0, 0, 0], [a_shape[0], a_shape[1], a_shape[2], a_last])
+        grad_b = ttnn.slice(
+            grad_output,
+            [0, 0, 0, a_last],
+            [b_shape[0], b_shape[1], b_shape[2], a_last + b_last],
+        )
+        return grad_a, grad_b
+
+
+class Qwen3Attention(AbstractModuleBase):
+    """Grouped-query attention with QK-Norm.
+
+    Shapes assume 4-D tensors ``(B, 1, S, ·)``. ``num_kv_heads`` divides
+    ``num_heads``; the grouped-head split is handled by
+    ``ttml.ops.multi_head_utils.grouped_heads_creation``.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        rope_params: ttml.ops.rope.RotaryEmbeddingParams,
+        attention_bias: bool = True,
+        rms_norm_eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.num_heads = num_attention_heads
+        self.num_kv_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.rope_params = rope_params
+
+        q_out = num_attention_heads * head_dim
+        kv_out = num_key_value_heads * head_dim
+
+        # Separate Q/K/V/O projections (HF layout). A fused kv matrix would
+        # break the HF safetensors key map used by the loader.
+        self.q_proj = LinearLayer(hidden_size, q_out, has_bias=attention_bias)
+        self.k_proj = LinearLayer(hidden_size, kv_out, has_bias=attention_bias)
+        self.v_proj = LinearLayer(hidden_size, kv_out, has_bias=attention_bias)
+        self.o_proj = LinearLayer(q_out, hidden_size, has_bias=attention_bias)
+
+        # QK-Norm: per-head RMSNorm over head_dim, applied to Q and K before RoPE.
+        self.q_norm = Qwen3RMSNorm(head_dim, eps=rms_norm_eps)
+        self.k_norm = Qwen3RMSNorm(head_dim, eps=rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: ttml.autograd.Tensor,
+        mask: ttml.autograd.Tensor,
+        kv_cache: Optional[ttml.models.KvCache] = None,
+        layer_idx: Optional[int] = None,
+        new_tokens: Optional[int] = None,
+    ) -> ttml.autograd.Tensor:
+        # Project Q/K/V from hidden (B, 1, S, hidden) to (B, 1, S, num_heads·head_dim)
+        # and (B, 1, S, num_kv_heads·head_dim) respectively.
+        q = self.q_proj(hidden_states)
+        k = self.k_proj(hidden_states)
+        v = self.v_proj(hidden_states)
+
+        q_shape = q.shape()
+        k_shape = k.shape()
+        B, S = q_shape[0], q_shape[2]
+
+        # Per-head QK-Norm: fold the head dim into the seq dim so a single
+        # RMSNorm over the last axis normalizes each head independently.
+        q = ttml.ops.reshape.reshape(q, [B, 1, S * self.num_heads, self.head_dim])
+        k = ttml.ops.reshape.reshape(k, [B, 1, S * self.num_kv_heads, self.head_dim])
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        q = ttml.ops.reshape.reshape(q, q_shape)
+        k = ttml.ops.reshape.reshape(k, k_shape)
+
+        # Fuse K and V along the last dim so grouped_heads_creation can split
+        # Q plus a single KV tensor into (q_heads, k_heads, v_heads).
+        kvs = _ConcatLastDim.apply(k, v)
+        query_heads, key_heads, value_heads = ttml.ops.multi_head_utils.grouped_heads_creation(
+            q, kvs, self.num_heads, self.num_kv_heads
+        )
+
+        # RoPE: offset by the current KV-cache position so decode steps line
+        # up with the cached prefix.
+        position_offset = kv_cache.get_cache_position() if kv_cache is not None else 0
+        query_heads = ttml.ops.rope.rope(query_heads, self.rope_params, position_offset)
+        key_heads = ttml.ops.rope.rope(key_heads, self.rope_params, position_offset)
+
+        # KV-cache update convention:
+        #   - Prefill (cache_position == 0): write the fresh K/V and attend
+        #     over just this step — caller passed a square causal mask.
+        #   - Decode (cache_position > 0):   write the new row, then attend
+        #     over the full cached K/V — caller passed a slab mask.
+        if kv_cache is not None:
+            if layer_idx is None:
+                raise ValueError("forward with kv_cache requires layer_idx")
+            is_prefill = kv_cache.get_cache_position() == 0
+            tokens_to_write = new_tokens if new_tokens is not None else key_heads.shape()[2]
+            kv_cache.update(layer_idx, key_heads.get_value(), value_heads.get_value(), tokens_to_write)
+            if not is_prefill:
+                key_heads = ttml.autograd.create_tensor(kv_cache.get_k_cache(layer_idx), requires_grad=False)
+                value_heads = ttml.autograd.create_tensor(kv_cache.get_v_cache(layer_idx), requires_grad=False)
+
+        # Full SDPA op fuses softmax+matmul and requires q_seq == k_seq.
+        # Decode (q_seq=1, k_seq=max_seq_len) falls back to the composite variant.
+        q_seq = query_heads.shape()[2]
+        k_seq = key_heads.shape()[2]
+        sdpa_fn = (
+            ttml.ops.attention.scaled_dot_product_attention
+            if q_seq == k_seq
+            else ttml.ops.attention.scaled_dot_product_attention_composite
+        )
+        attn = sdpa_fn(query_heads, key_heads, value_heads, mask)
+        attn = ttml.ops.multi_head_utils.heads_fusion(attn)
+        return self.o_proj(attn)
+
+
+def build_attn_mask(
+    seq_len: int,
+    *,
+    kv_cache: Optional[ttml.models.KvCache] = None,
+    max_seq_len: Optional[int] = None,
+) -> ttml.autograd.Tensor:
+    """Build a Qwen3 attention mask.
+
+    Without ``kv_cache`` (or at position 0): square causal mask ``[1, 1, seq_len, seq_len]``.
+    With ``kv_cache`` at position > 0 (decode step): slab mask
+    ``[1, 1, 1, max_seq_len]`` with unmasked positions ``[0, cache_pos]``.
+    """
+    if kv_cache is None or kv_cache.get_cache_position() == 0:
+        mask = np.tril(np.ones((seq_len, seq_len), dtype=ml_dtypes.bfloat16)).reshape(1, 1, seq_len, seq_len)
+        return ttml.autograd.Tensor.from_numpy(mask, layout=ttnn.Layout.TILE)
+
+    if max_seq_len is None:
+        raise ValueError("build_attn_mask requires max_seq_len during decode steps")
+    cache_pos = kv_cache.get_cache_position()
+    row = np.zeros((max_seq_len,), dtype=ml_dtypes.bfloat16)
+    row[: cache_pos + 1] = 1
+    mask = row.reshape(1, 1, 1, max_seq_len)
+    return ttml.autograd.Tensor.from_numpy(mask, layout=ttnn.Layout.TILE)

--- a/tt-train/sources/ttml/ttml/models/qwen3/rmsnorm.py
+++ b/tt-train/sources/ttml/ttml/models/qwen3/rmsnorm.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""RMSNorm for Qwen3.
+
+Replaces ``ttml.ops.rmsnorm.rmsnorm`` (composite) with an explicit rsqrt-based
+autograd function. The composite backward blows past L1 on 14B/32B configs —
+see the error note on ``Qwen3RMSNorm.forward`` below for the exact symptom.
+
+Works with any 4-D shape as long as the last dim matches the weight.
+"""
+
+from __future__ import annotations
+
+import ttnn
+import ttml
+from ttml.modules import AbstractModuleBase, Parameter
+
+
+class RMSNormFunction(ttml.autograd.Function):
+    """RMSNorm via rsqrt: ``y = (x · rsqrt(mean(x², dim=-1) + eps)) · weight``."""
+
+    @staticmethod
+    def forward(ctx, x, weight, eps):
+        x_val = x.get_value()
+        w_val = weight.get_value()
+
+        # variance = mean(x², dim=-1) + eps  →  rrms = rsqrt(variance)
+        x_sq = ttnn.mul(x_val, x_val)
+        mean_sq = ttnn.mean(x_sq, dim=-1, keepdim=True)  # (B, 1, S, 1)
+        variance = ttnn.add(mean_sq, eps)  # (B, 1, S, 1)
+        rrms = ttnn.rsqrt(variance)  # (B, 1, S, 1)
+
+        # x_hat = x · rrms,  y = x_hat · w
+        x_hat = ttnn.mul(x_val, rrms)  # (B, 1, S, D)
+        out = ttnn.mul(x_hat, w_val)  # (B, 1, S, D)
+
+        ctx.save_for_backward(x_hat, rrms, w_val)
+        return ttml.autograd.create_tensor(out)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x_hat, rrms, w_val = ctx.saved_tensors
+
+        # grad_w = Σ (g · x_hat) over all dims except last  →  (1, 1, 1, D)
+        grad_w = ttnn.mul(grad_output, x_hat)
+        for d in range(3):
+            grad_w = ttnn.sum(grad_w, dim=d, keepdim=True)
+
+        # grad_x = rrms · (g⊙w − x_hat · mean(g⊙w⊙x_hat, dim=-1))
+        gw = ttnn.mul(grad_output, w_val)  # (B, 1, S, D)
+        dot = ttnn.mul(gw, x_hat)  # (B, 1, S, D)
+        dot_mean = ttnn.mean(dot, dim=-1, keepdim=True)  # (B, 1, S, 1)
+        correction = ttnn.mul(x_hat, dot_mean)  # (B, 1, S, D)
+        grad_x = ttnn.mul(ttnn.subtract(gw, correction), rrms)  # (B, 1, S, D)
+
+        return grad_x, grad_w
+
+
+class Qwen3RMSNorm(AbstractModuleBase):
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.eps = eps
+        self.hidden_size = hidden_size
+        self.weight = Parameter(ttml.init.ones()((1, 1, 1, hidden_size)))
+
+    def forward(self, hidden_states: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        # Custom autograd is required on 14B/32B — the composite backward
+        # (ttml::metal::rmsnorm_bw) allocates CBs that exceed L1:
+        #   "Statically allocated circular buffers on core range
+        #    [(x=0,y=0) - (x=4,y=3)] grow to 1764640 B which is beyond max L1
+        #    size of 1499136 B"
+        return RMSNormFunction.apply(hidden_states, self.weight.tensor, self.eps)

--- a/tt-train/sources/ttml/ttml/models/qwen3/safetensors_loader.py
+++ b/tt-train/sources/ttml/ttml/models/qwen3/safetensors_loader.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Safetensors I/O for Python Qwen3.
+
+Two entry points:
+  - :func:`load_from_hf` loads HuggingFace ``Qwen3ForCausalLM`` safetensors into
+    a :class:`Qwen3` instance, applying RoPE-pair unpermutation to Q/K
+    weights/biases, QK-norm unpermutation, and vocab tile-padding.
+  - :func:`export_hf_model` re-permutes and crops back to HF layout and writes a
+    safetensors directory that ``AutoModelForCausalLM.from_pretrained`` can load.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Dict
+
+import ml_dtypes
+import numpy as np
+
+import ttnn
+import ttml
+
+from .. import WeightTyingType
+
+
+# ---------------------------------------------------------------------------
+# Weight-permutation helpers (module-private)
+# ---------------------------------------------------------------------------
+
+
+def _unpermute_proj_rows(w: np.ndarray, n_heads: int) -> np.ndarray:
+    """HF ``[first_half, second_half]`` → ttml interleaved ``[r0, i0, r1, i1, ...]``."""
+    if w.ndim == 1:
+        total = w.shape[0]
+        D = total // n_heads
+        half = D // 2
+        wv = w.reshape(n_heads, D)
+        first_half = wv[:, :half]
+        second_half = wv[:, half:]
+        return np.stack([first_half, second_half], axis=2).reshape(total)
+    if w.ndim == 2:
+        rows, cols = w.shape
+        D = rows // n_heads
+        half = D // 2
+        wv = w.reshape(n_heads, D, cols)
+        first_half = wv[:, :half, :]
+        second_half = wv[:, half:, :]
+        return np.stack([first_half, second_half], axis=2).reshape(rows, cols)
+    raise ValueError(f"Expected 1D or 2D tensor, got {w.ndim}D")
+
+
+def _unpermute_norm_weights(w: np.ndarray) -> np.ndarray:
+    """QK-Norm: HF ``[x1, x2, ..., y1, y2, ...]`` → ttml ``[x1, y1, x2, y2, ...]``."""
+    head_dim = w.shape[0]
+    if head_dim % 2 != 0:
+        raise ValueError(f"QK-Norm weight dim must be even; got {head_dim}")
+    half = head_dim // 2
+    return w.reshape(2, half).T.reshape(-1)
+
+
+def _repermute_proj_rows(w: np.ndarray, n_heads: int) -> np.ndarray:
+    if w.ndim == 1:
+        total = w.shape[0]
+        D = total // n_heads
+        wv = w.reshape(n_heads, D)
+        reals = wv[:, 0::2]
+        imags = wv[:, 1::2]
+        return np.concatenate([reals, imags], axis=1).reshape(total)
+    if w.ndim == 2:
+        rows, cols = w.shape
+        D = rows // n_heads
+        wv = w.reshape(n_heads, D, cols)
+        reals = wv[:, 0::2, :]
+        imags = wv[:, 1::2, :]
+        return np.concatenate([reals, imags], axis=1).reshape(rows, cols)
+    raise ValueError(f"Expected 1D or 2D tensor, got {w.ndim}D")
+
+
+def _repermute_norm_weights(w: np.ndarray) -> np.ndarray:
+    head_dim = w.shape[0]
+    half = head_dim // 2
+    return w.reshape(half, 2).T.reshape(-1)
+
+
+# ---------------------------------------------------------------------------
+# Shape helpers
+# ---------------------------------------------------------------------------
+
+
+def _pad_to_tile(arr: np.ndarray, tgt_rows: int, tgt_cols: int) -> np.ndarray:
+    src_rows, src_cols = arr.shape
+    if src_rows == tgt_rows and src_cols == tgt_cols:
+        return arr
+    out = np.zeros((tgt_rows, tgt_cols), dtype=arr.dtype)
+    cr = min(src_rows, tgt_rows)
+    cc = min(src_cols, tgt_cols)
+    out[:cr, :cc] = arr[:cr, :cc]
+    return out
+
+
+def _crop_to_hf_2d(arr: np.ndarray, rows: int, cols: int) -> np.ndarray:
+    return arr[:rows, :cols]
+
+
+def _crop_to_hf_1d(arr: np.ndarray, dim: int) -> np.ndarray:
+    return arr[:dim]
+
+
+def _to_bf16_4d(arr: np.ndarray) -> np.ndarray:
+    if arr.ndim == 1:
+        arr = arr.reshape(1, 1, 1, -1)
+    elif arr.ndim == 2:
+        arr = arr.reshape(1, 1, arr.shape[0], arr.shape[1])
+    return arr.astype(ml_dtypes.bfloat16)
+
+
+def _assign(param, arr_4d: np.ndarray) -> None:
+    param.assign(ttml.autograd.Tensor.from_numpy(arr_4d, layout=ttnn.Layout.TILE))
+
+
+# ---------------------------------------------------------------------------
+# HF ↔ ttml name mapping
+# ---------------------------------------------------------------------------
+
+
+def _hf_to_ttml_name(hf_name: str, *, root: str = "Qwen3") -> str:
+    """``model.layers.0.self_attn.q_proj.weight`` → ``Qwen3/model/layers/0/self_attn/q_proj/weight``.
+
+    ``lm_head.weight`` has no ``model.`` prefix in HF, so it stays at the top
+    level; adding the root prefix gives ``Qwen3/lm_head/weight``.
+    """
+    return f"{root}/{hf_name.replace('.', '/')}"
+
+
+def _ttml_to_hf_name(ttml_name: str, *, root: str = "Qwen3") -> str:
+    prefix = f"{root}/"
+    assert ttml_name.startswith(prefix), f"expected ttml name to start with {prefix!r}; got {ttml_name!r}"
+    return ttml_name[len(prefix) :].replace("/", ".")
+
+
+def _proj_transform_heads(hf_name: str, num_attention_heads: int, num_key_value_heads: int) -> int | None:
+    """Return the head count to use when un/repermuting, or None if not a Q/K projection."""
+    if ".self_attn.q_proj." in hf_name:
+        return num_attention_heads
+    if ".self_attn.k_proj." in hf_name:
+        return num_key_value_heads
+    return None
+
+
+def _is_norm_proj(hf_name: str) -> bool:
+    return hf_name.endswith(".self_attn.q_norm.weight") or hf_name.endswith(".self_attn.k_norm.weight")
+
+
+# ---------------------------------------------------------------------------
+# Public API: load HF → ttml
+# ---------------------------------------------------------------------------
+
+
+def load_from_hf(model, safetensors_path, config) -> None:
+    """Load HuggingFace ``Qwen3ForCausalLM`` safetensors into a Python Qwen3 model.
+
+    Args:
+        model: A :class:`~ttml.models.qwen3.Qwen3` instance.
+        safetensors_path: Directory containing one or more ``.safetensors`` shards.
+        config: The :class:`~ttml.models.qwen3.Qwen3Config` used to build the model.
+    """
+    from safetensors.numpy import load_file
+
+    directory = Path(safetensors_path)
+    shards = sorted(directory.glob("*.safetensors"))
+    if not shards:
+        raise FileNotFoundError(f"No .safetensors files found in {directory}")
+
+    hf_tensors: Dict[str, np.ndarray] = {}
+    for shard in shards:
+        hf_tensors.update(load_file(str(shard)))
+
+    parameters = model.parameters()
+    tied = config.weight_tying == WeightTyingType.Enabled
+    loaded: set[str] = set()
+
+    for hf_name, hf_arr in hf_tensors.items():
+        arr = hf_arr.astype(np.float32)
+
+        if tied and hf_name == "lm_head.weight":
+            # Tied: HF may or may not emit this key; either way the tied embedding covers it.
+            continue
+
+        heads = _proj_transform_heads(hf_name, config.num_attention_heads, config.num_key_value_heads)
+        if heads is not None:
+            arr = _unpermute_proj_rows(arr, heads)
+        elif _is_norm_proj(hf_name):
+            arr = _unpermute_norm_weights(arr)
+
+        ttml_name = _hf_to_ttml_name(hf_name)
+        if ttml_name not in parameters:
+            continue
+
+        param = parameters[ttml_name]
+        shape = param.shape()
+
+        if arr.ndim == 2:
+            tgt_rows, tgt_cols = shape[-2], shape[-1]
+            r, c = arr.shape
+            if r == tgt_rows and c == tgt_cols:
+                pass
+            elif c == tgt_rows and r == tgt_cols:
+                arr = arr.T
+            elif r <= tgt_rows and c <= tgt_cols:
+                arr = _pad_to_tile(arr, tgt_rows, tgt_cols)
+            else:
+                raise RuntimeError(f"shape mismatch for {hf_name}: HF ({r}x{c}) vs ttml ({tgt_rows}x{tgt_cols})")
+        elif arr.ndim == 1:
+            tgt_dim = shape[-1]
+            if arr.shape[0] > tgt_dim:
+                raise RuntimeError(f"shape mismatch for {hf_name}: HF ({arr.shape[0]},) vs ttml ({tgt_dim},)")
+            if arr.shape[0] != tgt_dim:
+                padded = np.zeros((tgt_dim,), dtype=arr.dtype)
+                padded[: arr.shape[0]] = arr
+                arr = padded
+
+        _assign(param, _to_bf16_4d(arr))
+        loaded.add(ttml_name)
+
+    unused = sorted(p for p in parameters if p not in loaded)
+    if tied:
+        # The tied lm_head weight is loaded via embed_tokens; don't flag it as missing.
+        unused = [p for p in unused if not p.endswith("/lm_head/weight")]
+    if unused:
+        print(f"Warning: {len(unused)} model parameters were NOT loaded from safetensors:")
+        for name in unused:
+            print(f"  - {name}")
+
+
+# ---------------------------------------------------------------------------
+# Public API: export ttml → HF
+# ---------------------------------------------------------------------------
+
+
+def _build_hf_shapes(config) -> Dict[str, tuple]:
+    shapes: Dict[str, tuple] = {}
+    q_dim = config.num_attention_heads * config.head_dim
+    kv_dim = config.num_key_value_heads * config.head_dim
+
+    shapes["model.embed_tokens.weight"] = (config.vocab_size, config.hidden_size)
+    if config.weight_tying == WeightTyingType.Disabled:
+        shapes["lm_head.weight"] = (config.vocab_size, config.hidden_size)
+
+    for i in range(config.num_hidden_layers):
+        p = f"model.layers.{i}"
+        shapes[f"{p}.self_attn.q_proj.weight"] = (q_dim, config.hidden_size)
+        shapes[f"{p}.self_attn.k_proj.weight"] = (kv_dim, config.hidden_size)
+        shapes[f"{p}.self_attn.v_proj.weight"] = (kv_dim, config.hidden_size)
+        shapes[f"{p}.self_attn.o_proj.weight"] = (config.hidden_size, q_dim)
+        if config.attention_bias:
+            shapes[f"{p}.self_attn.q_proj.bias"] = (q_dim,)
+            shapes[f"{p}.self_attn.k_proj.bias"] = (kv_dim,)
+            shapes[f"{p}.self_attn.v_proj.bias"] = (kv_dim,)
+            shapes[f"{p}.self_attn.o_proj.bias"] = (config.hidden_size,)
+        shapes[f"{p}.self_attn.q_norm.weight"] = (config.head_dim,)
+        shapes[f"{p}.self_attn.k_norm.weight"] = (config.head_dim,)
+        shapes[f"{p}.input_layernorm.weight"] = (config.hidden_size,)
+        shapes[f"{p}.post_attention_layernorm.weight"] = (config.hidden_size,)
+        shapes[f"{p}.mlp.gate_proj.weight"] = (config.intermediate_size, config.hidden_size)
+        shapes[f"{p}.mlp.up_proj.weight"] = (config.intermediate_size, config.hidden_size)
+        shapes[f"{p}.mlp.down_proj.weight"] = (config.hidden_size, config.intermediate_size)
+
+    shapes["model.norm.weight"] = (config.hidden_size,)
+    return shapes
+
+
+_HF_CONFIG_FILES = (
+    "config.json",
+    "generation_config.json",
+    "merges.txt",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer.model",
+    "tokenizer_config.json",
+    "vocab.json",
+)
+
+
+def export_hf_model(model, config, out_dir, hf_source_dir=None) -> str:
+    """Export the model in HF-compatible format.
+
+    Applies inverse transforms (re-permute Q/K rows, re-permute QK-Norm weights,
+    crop vocab/intermediate back to their HF shape) and writes
+    ``model.safetensors`` to ``out_dir``. When ``hf_source_dir`` is provided,
+    tokenizer + config files are copied alongside so the directory loads with
+    ``AutoModelForCausalLM.from_pretrained``.
+    """
+    from safetensors.numpy import save_file
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    hf_shapes = _build_hf_shapes(config)
+    parameters = model.parameters()
+
+    hf_state: Dict[str, np.ndarray] = {}
+    for ttml_name, param in parameters.items():
+        hf_name = _ttml_to_hf_name(ttml_name)
+        if hf_name not in hf_shapes:
+            # When tied, lm_head.weight is omitted from hf_shapes because HF only
+            # emits model.embed_tokens.weight. Any other name here is unexpected.
+            continue
+        arr = param.to_numpy(ttnn.DataType.FLOAT32).squeeze()
+
+        heads = _proj_transform_heads(hf_name, config.num_attention_heads, config.num_key_value_heads)
+        if heads is not None:
+            arr = _repermute_proj_rows(arr, heads)
+        elif _is_norm_proj(hf_name):
+            arr = _repermute_norm_weights(arr)
+
+        hf_shape = hf_shapes[hf_name]
+        if arr.ndim == 2:
+            arr = _crop_to_hf_2d(arr, hf_shape[0], hf_shape[1])
+        elif arr.ndim == 1:
+            arr = _crop_to_hf_1d(arr, hf_shape[0])
+
+        hf_state[hf_name] = arr.astype(ml_dtypes.bfloat16)
+
+    save_file(hf_state, str(out_path / "model.safetensors"))
+
+    # Minimal single-shard index so HF treats this as a valid model dir.
+    index = {"metadata": {"total_size": 0}, "weight_map": {}}
+    with open(out_path / "model.safetensors.index.json", "w") as f:
+        json.dump(index, f, indent=2)
+
+    if hf_source_dir is not None and os.path.isdir(hf_source_dir):
+        for fname in _HF_CONFIG_FILES:
+            src = os.path.join(hf_source_dir, fname)
+            if os.path.exists(src):
+                shutil.copy2(src, out_path / fname)
+
+    return str(out_path)

--- a/tt-train/sources/ttml/ttml/models/qwen3/transformer.py
+++ b/tt-train/sources/ttml/ttml/models/qwen3/transformer.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3 MLP and decoder-layer blocks."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import ttml
+from ttml.modules import AbstractModuleBase, LinearLayer
+
+from .attention import Qwen3Attention
+from .rmsnorm import Qwen3RMSNorm
+
+
+class Qwen3MLP(AbstractModuleBase):
+    """SwiGLU feed-forward block: ``down_proj(silu(gate_proj(x)) * up_proj(x))``."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int) -> None:
+        super().__init__()
+        self.gate_proj = LinearLayer(hidden_size, intermediate_size, has_bias=False)
+        self.up_proj = LinearLayer(hidden_size, intermediate_size, has_bias=False)
+        self.down_proj = LinearLayer(intermediate_size, hidden_size, has_bias=False)
+
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        gate = ttml.ops.unary.silu(self.gate_proj(x))
+        up = self.up_proj(x)
+        return self.down_proj(ttml.ops.binary.mul(gate, up))
+
+
+class Qwen3DecoderLayer(AbstractModuleBase):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        rope_params: ttml.ops.rope.RotaryEmbeddingParams,
+        attention_bias: bool = True,
+        rms_norm_eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+
+        self.input_layernorm = Qwen3RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.self_attn = Qwen3Attention(
+            hidden_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            rope_params=rope_params,
+            attention_bias=attention_bias,
+            rms_norm_eps=rms_norm_eps,
+        )
+        self.post_attention_layernorm = Qwen3RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.mlp = Qwen3MLP(hidden_size, intermediate_size)
+
+    def forward(
+        self,
+        hidden_states: ttml.autograd.Tensor,
+        mask: ttml.autograd.Tensor,
+        kv_cache: Optional[ttml.models.KvCache] = None,
+        layer_idx: Optional[int] = None,
+        new_tokens: Optional[int] = None,
+    ) -> ttml.autograd.Tensor:
+        residual = hidden_states
+        h = self.input_layernorm(hidden_states)
+        h = self.self_attn(h, mask, kv_cache, layer_idx, new_tokens)
+        h = ttml.ops.binary.add(residual, h)
+
+        residual = h
+        x = self.post_attention_layernorm(h)
+        x = self.mlp(x)
+        return ttml.ops.binary.add(residual, x)


### PR DESCRIPTION
### Summary

Migrating Qwen3 to live next to other ttml models for following reasons:

- Easier imports across separate projects (i.e. tt-training-services)
- Increase code reuse
- Align function signatures (e.g. `load_from_hf`) to reduce harness bloat.

Also in the PR:

- A KvCache migration from C++ to Python proposal for a follow-up PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=imichalak/ttml_models_qwen3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:imichalak/ttml_models_qwen3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=imichalak/ttml_models_qwen3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:imichalak/ttml_models_qwen3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=imichalak/ttml_models_qwen3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:imichalak/ttml_models_qwen3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=imichalak/ttml_models_qwen3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:imichalak/ttml_models_qwen3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=imichalak/ttml_models_qwen3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:imichalak/ttml_models_qwen3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=imichalak/ttml_models_qwen3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:imichalak/ttml_models_qwen3)