### PR TITLE
#0: Refactor post_sdpa to TP4 sliced matmul5 + gather reduce + all re…

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -34,10 +34,13 @@
 #include "../../../unified_kernels/kernel_op_api.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
 #include "../../../unified_kernels/matmul.hpp"
+#include "../../../unified_kernels/kn_sliced_matmul.hpp"
 #include "../../../unified_kernels/gather.hpp"
+#include "../../../unified_kernels/gather_reduce.hpp"
 #include "../../../unified_kernels/mcast.hpp"
 #ifndef SKIP_CCL
 #include "../../../unified_kernels/all_reduce.hpp"
+#include "../../../unified_kernels/all_gather.hpp"
 #endif
 
 // SDPA Reduce-to-All unified headers (replaces inlined SDPA code)
@@ -131,31 +134,28 @@ void kernel_main() {
             },
     };
 
-    // Matmul5 CTArgs
-    using Matmul5CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
-    deepseek_b1_ops::Matmul::ReaderArgs matmul5_args{};
+    // Matmul5 (KNSlicedMatmul) reader args - NCRISC is no-op
+    using Matmul5CTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::ReaderArgs matmul5_args{};
 
-    // Gather3 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
-    // via gather3_sender_idx, avoiding gaps from the non-rectangular o_proj grid)
-    deepseek_b1_ops::Gather::DMArgs gather3_args{
-        .sender =
-            {
-                get_named_compile_time_arg_val("gather3_dest_noc_x"),
-                get_named_compile_time_arg_val("gather3_dest_noc_y"),
-                get_named_compile_time_arg_val("gather3_data_size_bytes"),
-                get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
-                get_named_compile_time_arg_val("gather3_src_cb"),
-                get_named_compile_time_arg_val("gather3_src_num_pages"),
-                get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
-                get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
-                get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
-                get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
-                get_named_compile_time_arg_val("gather3_row_major"),
-                get_named_compile_time_arg_val("gather3_receiver_data_addr"),
-                get_named_compile_time_arg_val("gather3_sender_idx"),
-                noc_index,
-            },
-        .receiver = {},
+    // GatherReduce3 sender args (half_num_cores, dst_cb_id, half_size_bytes select
+    // the correct half slot on the receiver for each of the 2 K-slice halves)
+    deepseek_b1_ops::GatherReduce::SenderArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_dest_noc_x"),
+        get_named_compile_time_arg_val("gather3_dest_noc_y"),
+        get_named_compile_time_arg_val("gather3_data_size_bytes"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather3_src_cb"),
+        get_named_compile_time_arg_val("gather3_src_num_pages"),
+        get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
+        get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
+        get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
+        get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
+        get_named_compile_time_arg_val("gather3_half_num_cores"),
+        get_named_compile_time_arg_val("gather3_dst_cb_id"),
+        get_named_compile_time_arg_val("gather3_half_size_bytes"),
+        get_named_compile_time_arg_val("gather3_sender_idx"),
+        get_named_compile_time_arg_val("gather3_noc_idx"),
     };
 #ifndef SKIP_CCL
     using AllReduceWriterCTArgs = deepseek_b1_ops::AllReduce::WriterCTArgs<
@@ -181,6 +181,78 @@ void kernel_main() {
         get_named_compile_time_arg_val("allreduce_last_chunk_tiles"),
         get_named_compile_time_arg_val("allreduce_num_chunks"),
         get_named_compile_time_arg_val("allreduce_num_links")>;
+
+    deepseek_b1_ops::AllReduce::SenderArgs ccl_sender_args{};
+    deepseek_b1_ops::AllReduce::ReceiverArgs ccl_receiver_args{};
+    uint32_t ncrisc_allreduce_fabric_count = 0;
+    uint32_t per_core_rta_arg_idx = 0;
+
+    if constexpr (Core::is_allreduce_sender_core) {
+        ccl_sender_args.intermediate_buffer_address = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_sender_args.dest_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_sender_args.dest_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        // Read allreduce fabric arg count (placed before fabric args in RT arg stream)
+        ncrisc_allreduce_fabric_count = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_sender_args.per_core_rta_start_idx = per_core_rta_arg_idx;
+    }
+
+    if constexpr (Core::is_allreduce_receiver_core) {
+        ccl_receiver_args.sem_bank_addr_0 = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_receiver_args.sem_bank_addr_1 = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_receiver_args.sender_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_receiver_args.sender_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_receiver_args.sender_local_data_l1_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_receiver_args.local_ready_sem_bank_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+    }
+
+    // AllGather CT types (NCRISC: gather controller on receiver + bwd transport on sender)
+    using AllGatherGatherCT = deepseek_b1_ops::AllGather::GatherCTArgs<
+        get_named_compile_time_arg_val("allgather_gather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_gather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_ring_size"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot")>;
+
+    using AllGatherTransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+        get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+        get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+        get_named_compile_time_arg_val("allgather_num_links"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+        get_named_compile_time_arg_val("allgather_r2_active")>;
+
+    // AllGather transport args (sender core NCRISC = backward sender)
+    deepseek_b1_ops::AllGather::TransportArgs allgather_transport_args{};
+    if constexpr (Core::is_allreduce_sender_core) {
+        // Skip past allreduce fabric per-core RT args using pre-read count
+        per_core_rta_arg_idx += ncrisc_allreduce_fabric_count;
+
+        allgather_transport_args.scratch_base_addr = get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_transport_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_transport_args.dest_output_base_addr =
+            get_named_compile_time_arg_val("allgather_dest_output_base_addr");
+        allgather_transport_args.r1_dest_slot_index = get_named_compile_time_arg_val("allgather_r1_dest_slot_index");
+        allgather_transport_args.dest_noc_x = get_named_compile_time_arg_val("allgather_dest_noc_x");
+        allgather_transport_args.dest_noc_y = get_named_compile_time_arg_val("allgather_dest_noc_y");
+        allgather_transport_args.dest_recv_sem_addr = get_named_compile_time_arg_val("allgather_dest_recv_sem_addr");
+        allgather_transport_args.r2_dest_slot_index = get_named_compile_time_arg_val("allgather_r2_dest_slot_index");
+        allgather_transport_args.per_core_rta_start_idx = per_core_rta_arg_idx;
+    }
+
+    // AllGather gather args (receiver core NCRISC = gather controller)
+    deepseek_b1_ops::AllGather::GatherArgs allgather_gather_args{};
+    if constexpr (Core::is_allreduce_receiver_core) {
+        // local_input_addr set at runtime after cb_wait_front in execution section
+        allgather_gather_args.output_buffer_addr = get_common_arg_val<uint32_t>(6);
+        allgather_gather_args.self_slot_index = get_named_compile_time_arg_val("allgather_self_slot_index");
+        allgather_gather_args.transport_scratch_base_addr =
+            get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_gather_args.transport_noc_x = get_named_compile_time_arg_val("allgather_transport_noc_x");
+        allgather_gather_args.transport_noc_y = get_named_compile_time_arg_val("allgather_transport_noc_y");
+        allgather_gather_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_gather_args.recv_sem_addr = get_named_compile_time_arg_val("allgather_recv_sem_addr");
+        allgather_gather_args.r2_src_slot_index = get_named_compile_time_arg_val("allgather_r2_src_slot_index");
+    }
 #endif
 // ============================================================================
 // BRISC (Writer)
@@ -192,9 +264,9 @@ void kernel_main() {
 #elif defined(COMPILE_FOR_BRISC)
     // Matmul4/2 CTArgs (BRISC is no-op for matmul)
     using Matmul4CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
-    using Matmul5CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    using Matmul5CTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
     deepseek_b1_ops::Matmul::WriterArgs matmul4_args{};
-    deepseek_b1_ops::Matmul::WriterArgs matmul5_args{};
+    deepseek_b1_ops::KNSlicedMatmul::WriterArgs matmul5_args{};
 
     // Gather2 receiver args
     deepseek_b1_ops::Gather::DMArgs gather2_args{
@@ -236,18 +308,14 @@ void kernel_main() {
         .receiver = {},
     };
 
-    // Gather3 receiver args
-    deepseek_b1_ops::Gather::DMArgs gather3_args{
-        .sender = {},
-        .receiver =
-            {
-                get_named_compile_time_arg_val("gather3_noc0_num_senders"),
-                get_named_compile_time_arg_val("gather3_noc1_num_senders"),
-                get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
-                get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-                get_named_compile_time_arg_val("gather3_dst_cb"),
-                get_named_compile_time_arg_val("gather3_dst_num_pages"),
-            },
+    // GatherReduce3 receiver args (on sender core 11,9)
+    deepseek_b1_ops::GatherReduce::ReceiverArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather3_noc1_num_senders"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather3_dst_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_tiles"),
     };
 
 #ifndef SKIP_CCL
@@ -262,6 +330,45 @@ void kernel_main() {
         get_named_compile_time_arg_val("allreduce_writer_link_index"),
         get_named_compile_time_arg_val("allreduce_writer_signal_local_ready"),
         get_named_compile_time_arg_val("allreduce_skip_local_push")>;
+
+    deepseek_b1_ops::AllReduce::SenderArgs ccl_sender_args{};
+    uint32_t brisc_allreduce_fabric_count = 0;
+    uint32_t per_core_rta_arg_idx = 0;
+    if constexpr (Core::is_allreduce_sender_core) {
+        ccl_sender_args.intermediate_buffer_address = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_sender_args.dest_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_sender_args.dest_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        // Read allreduce fabric arg count (placed before fabric args in RT arg stream)
+        brisc_allreduce_fabric_count = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_sender_args.per_core_rta_start_idx = per_core_rta_arg_idx;
+    }
+
+    // AllGather CT types (BRISC = forward transport sender on sender core)
+    using AllGatherTransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+        get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+        get_named_compile_time_arg_val("allgather_num_chunks"),
+        get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+        get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+        get_named_compile_time_arg_val("allgather_num_links"),
+        get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+        get_named_compile_time_arg_val("allgather_r2_active")>;
+
+    deepseek_b1_ops::AllGather::TransportArgs allgather_transport_args{};
+    if constexpr (Core::is_allreduce_sender_core) {
+        // Skip past allreduce fabric per-core RT args using pre-read count
+        per_core_rta_arg_idx += brisc_allreduce_fabric_count;
+
+        allgather_transport_args.scratch_base_addr = get_named_compile_time_arg_val("allgather_scratch_base_addr");
+        allgather_transport_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+        allgather_transport_args.dest_output_base_addr =
+            get_named_compile_time_arg_val("allgather_dest_output_base_addr");
+        allgather_transport_args.r1_dest_slot_index = get_named_compile_time_arg_val("allgather_r1_dest_slot_index");
+        allgather_transport_args.dest_noc_x = get_named_compile_time_arg_val("allgather_dest_noc_x");
+        allgather_transport_args.dest_noc_y = get_named_compile_time_arg_val("allgather_dest_noc_y");
+        allgather_transport_args.dest_recv_sem_addr = get_named_compile_time_arg_val("allgather_dest_recv_sem_addr");
+        allgather_transport_args.r2_dest_slot_index = get_named_compile_time_arg_val("allgather_r2_dest_slot_index");
+        allgather_transport_args.per_core_rta_start_idx = per_core_rta_arg_idx;
+    }
 #endif
 // ============================================================================
 // TRISC (Compute)
@@ -287,18 +394,26 @@ void kernel_main() {
     using Mcast3CTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
     deepseek_b1_ops::Mcast::ComputeArgs mcast3_args{};
 
-    // Matmul5 CTArgs
+    // Matmul5 (KNSlicedMatmul) CTArgs + compute args
+    constexpr uint32_t matmul5_k_offset = get_named_compile_time_arg_val("matmul5_k_offset");
+
     using Matmul5CTArgs =
-        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
-    deepseek_b1_ops::Matmul::ComputeArgs matmul5_args{
+        deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
+    deepseek_b1_ops::KNSlicedMatmul::ComputeArgs matmul5_args{
         get_named_compile_time_arg_val("matmul5_in0"),
         get_named_compile_time_arg_val("matmul5_in1"),
         get_named_compile_time_arg_val("matmul5_out"),
-        get_named_compile_time_arg_val("matmul5_k_num_tiles"),
+        matmul5_k_offset,
+        get_named_compile_time_arg_val("matmul5_k_per_core"),
+        get_named_compile_time_arg_val("matmul5_act_total_tiles"),
     };
 
-    // Gather3 compute args (no-op)
-    deepseek_b1_ops::Gather::ComputeArgs gather3_args{};
+    // GatherReduce3 compute args
+    deepseek_b1_ops::GatherReduce::ComputeArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_scratch_cb"),
+        get_named_compile_time_arg_val("gather3_out_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_tiles"),
+    };
 
 #ifndef SKIP_CCL
     using AllReduceComputeCTArgs = deepseek_b1_ops::AllReduce::ComputeCTArgs<
@@ -507,9 +622,9 @@ void kernel_main() {
     // Matmul5 buffers (112 active cores) - weights only, input comes from mcast3
     if constexpr (Core::is_matmul5_core) {
         constexpr uint32_t matmul5_in1 = get_named_compile_time_arg_val("matmul5_in1");
-        constexpr uint32_t matmul5_k_num_tiles = get_named_compile_time_arg_val("matmul5_k_num_tiles");
+        constexpr uint32_t matmul5_k_per_core = get_named_compile_time_arg_val("matmul5_k_per_core");
         constexpr uint32_t matmul5_out_w_per_core = get_named_compile_time_arg_val("matmul5_out_w_per_core");
-        unified_kernels::setup_sharded_buffer(matmul5_in1, matmul5_k_num_tiles * matmul5_out_w_per_core);
+        unified_kernels::setup_sharded_buffer(matmul5_in1, matmul5_k_per_core * matmul5_out_w_per_core);
     }
 #endif
 
@@ -550,85 +665,105 @@ void kernel_main() {
     mcast3.teardown(mcast3_args);
 
     // ========================================================================
-    // Matmul5: [1, 8192] x [8192, 64] -> [1, 64] per core (112 active cores)
+    // Matmul5 (KNSlicedMatmul): [1, 8192] x [4096, 32] -> [1, 32] per core (112 active cores)
     // Input: mcast3_dst_cb (CB 4), Weights: matmul5_in1 (CB 5), Output: matmul5_out (CB 6)
-    // Only runs on 112 active cores (is_matmul5_core=true), 18 inactive cores skip
+    // K-split: 2 halves of 56 cores, each core does [1, 4096] @ [4096, 32] -> [1, 32]
     // ========================================================================
     {
         DeviceZoneScopedN("MATMUL5");
         // pop_in0 = true (mcast3 output consumed), pop_in1 = false (weights persistent)
-        deepseek_b1_ops::Matmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
+        deepseek_b1_ops::KNSlicedMatmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
         matmul5(matmul5_args);
     }
 
     // ========================================================================
-    // Gather3: 112 active matmul5 cores -> sender core (11, 9)
-    // Collects [1, 64] * 112 = [1, 7168]
+    // GatherReduce3: 112 matmul5 cores (2x56 halves) -> sender core (11, 9)
+    // Reduces [1, 32] * 56 from each half -> [1, 1792] per device
     // ========================================================================
     {
         DeviceZoneScopedN("GATHER3");
-        deepseek_b1_ops::Gather::Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, true, true> gather3;
+        deepseek_b1_ops::GatherReduce::
+            Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, Core::is_allreduce_sender_core, true, true>
+                gather3;
         gather3(gather3_args);
     }
 
 #ifndef SKIP_CCL
     // ========================================================================
-    // CCL All-Reduce: Exchange [1, 7168] between devices
-    // Sender core (11,9): NCRISC writer (link 1) + BRISC writer (link 0)
-    // Receiver core (12,9): NCRISC reader + TRISC compute
+    // CCL All-Reduce + All-Gather: Exchange [1, per_device_out_w] between column
+    // devices, then all-gather row across 4 devices into the output buffer.
+    // - Sender core (11,9): NCRISC writer (link 1) + BRISC writer (link 0) +
+    //   AllGather transport sender (BRISC=fwd, NCRISC=bwd)
+    // - Receiver core (12,9): NCRISC reader + TRISC compute + AllGather gather
+    //   controller (after reduce completes)
     // ========================================================================
-#if defined(COMPILE_FOR_NCRISC)
     if constexpr (Core::is_allreduce_sender_core) {
         DeviceZoneScopedN("CCL_SENDER_WRITER");
-        deepseek_b1_ops::AllReduce::SenderArgs args{};
-        args.intermediate_buffer_address = get_common_arg_val<uint32_t>(0);
-        args.dest_noc_x = get_common_arg_val<uint32_t>(1);
-        args.dest_noc_y = get_common_arg_val<uint32_t>(2);
-        args.per_core_rta_start_idx = 0;
-        deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> writer;
-        writer(args);
-    }
-    if constexpr (Core::is_allreduce_receiver_core) {
-        DeviceZoneScopedN("CCL_READER");
-        deepseek_b1_ops::AllReduce::ReceiverArgs args{};
-        args.sem_bank_addr_0 = get_common_arg_val<uint32_t>(0);
-        args.sem_bank_addr_1 = get_common_arg_val<uint32_t>(1);
-        args.sender_noc_x = get_common_arg_val<uint32_t>(2);
-        args.sender_noc_y = get_common_arg_val<uint32_t>(3);
-        args.sender_local_data_l1_addr = get_common_arg_val<uint32_t>(4);
-        args.local_ready_sem_bank_addr = get_common_arg_val<uint32_t>(5);
+#if defined(COMPILE_FOR_NCRISC)
+        deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> ccl_writer;
+        ccl_writer(ccl_sender_args);
 
-        // Residual CB is tensor-backed (data already in L1); signal TRISC so
-        // Compute's cb_wait_front(cb_residual) unblocks. Reader no longer does
-        // this — responsibility moved to the caller.
-        if constexpr (AllReduceReaderCTArgs::has_residual) {
-            cb_reserve_back(AllReduceReaderCTArgs::residual_cb_id, AllReduceReaderCTArgs::total_num_tiles);
-            cb_push_back(AllReduceReaderCTArgs::residual_cb_id, AllReduceReaderCTArgs::total_num_tiles);
+        // All-Gather: transport sender (NCRISC=bwd)
+        {
+            DeviceZoneScopedN("ALLGATHER_TRANSPORT");
+            deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
+            allgather_sender(allgather_transport_args);
+        }
+#elif defined(COMPILE_FOR_BRISC)
+        deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceBriscWriterCTArgs> ccl_writer;
+        ccl_writer(ccl_sender_args);
+
+        // All-Gather: transport sender (BRISC=fwd)
+        {
+            DeviceZoneScopedN("ALLGATHER_TRANSPORT");
+            deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
+            allgather_sender(allgather_transport_args);
+        }
+#endif
+    }
+
+    if constexpr (Core::is_allreduce_receiver_core) {
+        DeviceZoneScopedN("CCL_RECEIVER");
+#if defined(COMPILE_FOR_NCRISC)
+        // TP4 outer-dim: NOC-copy the correct [1, per_device_out_w] slice of the
+        // input tensor into the residual CB (2 tiles of 32x32) before AllReduce.
+        {
+            constexpr uint32_t residual_offset = get_named_compile_time_arg_val("residual_byte_offset");
+            constexpr uint32_t residual_size = get_named_compile_time_arg_val("residual_copy_size");
+            constexpr uint32_t residual_cb = get_named_compile_time_arg_val("residual_cb_id");
+            constexpr uint32_t residual_num_tiles = get_named_compile_time_arg_val("residual_num_tiles");
+            constexpr uint32_t inp_noc_x = get_named_compile_time_arg_val("input_noc_coord_x");
+            constexpr uint32_t inp_noc_y = get_named_compile_time_arg_val("input_noc_coord_y");
+            uint32_t input_l1_addr = get_common_arg_val<uint32_t>(7);
+            cb_reserve_back(residual_cb, residual_num_tiles);
+            uint32_t residual_dst = get_write_ptr(residual_cb);
+            uint64_t src_noc_addr = get_noc_addr(inp_noc_x, inp_noc_y, input_l1_addr + residual_offset);
+            noc_async_read(src_noc_addr, residual_dst, residual_size);
+            noc_async_read_barrier();
+            cb_push_back(residual_cb, residual_num_tiles);
         }
 
-        deepseek_b1_ops::AllReduce::Reader<AllReduceReaderCTArgs> reader;
-        reader(args);
-    }
+        deepseek_b1_ops::AllReduce::Reader<AllReduceReaderCTArgs> ccl_reader;
+        ccl_reader(ccl_receiver_args);
 
-#elif defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_allreduce_sender_core) {
-        DeviceZoneScopedN("CCL_SENDER_WRITER");
-        deepseek_b1_ops::AllReduce::SenderArgs args{};
-        args.intermediate_buffer_address = get_common_arg_val<uint32_t>(0);
-        args.dest_noc_x = get_common_arg_val<uint32_t>(1);
-        args.dest_noc_y = get_common_arg_val<uint32_t>(2);
-        args.per_core_rta_start_idx = 0;
-        deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceBriscWriterCTArgs> writer;
-        writer(args);
-    }
+        // All-Gather: gather controller — reads [1, per_device_out_w] from
+        // ccl_output_cb and distributes across row ring into output tensor.
+        {
+            DeviceZoneScopedN("ALLGATHER_GATHER");
+            constexpr uint32_t out_cb = get_named_compile_time_arg_val("output_cb_id");
+            constexpr uint32_t out_num_tiles = get_named_compile_time_arg_val("output_num_tiles");
+            cb_wait_front(out_cb, out_num_tiles);
+            allgather_gather_args.local_input_addr = get_read_ptr(out_cb);
 
+            deepseek_b1_ops::AllGather::GatherController<AllGatherGatherCT> allgather_controller;
+            allgather_controller(allgather_gather_args);
+            cb_pop_front(out_cb, out_num_tiles);
+        }
 #elif defined(COMPILE_FOR_TRISC)
-    if constexpr (Core::is_allreduce_receiver_core) {
-        DeviceZoneScopedN("CCL_COMPUTE");
-        deepseek_b1_ops::AllReduce::ComputeArgs args{};
-        deepseek_b1_ops::AllReduce::Compute<AllReduceComputeCTArgs> compute;
-        compute(args);
-    }
+        deepseek_b1_ops::AllReduce::ComputeArgs ccl_compute_args{};
+        deepseek_b1_ops::AllReduce::Compute<AllReduceComputeCTArgs> ccl_compute;
+        ccl_compute(ccl_compute_args);
 #endif
+    }
 #endif  // SKIP_CCL
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -41,16 +41,28 @@ import torch
 
 import ttnn
 from models.demos.deepseek_v3_b1.circular_buffer_utils import cb_descriptor_from_overlapped_tensor
+from models.demos.deepseek_v3_b1.micro_ops.ccl_all_gather.op import AllGatherConfig
 from models.demos.deepseek_v3_b1.micro_ops.ccl_all_reduce.op import DeepseekMinimalAllReduce
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     PerCoreCompileTimeDescriptor,
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
 )
+from models.demos.deepseek_v3_b1.utils import get_worker_noc_hop_distance
 from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
     KVB12_PROJ_SingleDeviceOverlapSpec,
     O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec,
 )
+
+
+def _get_gather_noc_idx_per_core(mesh_device, mesh_coord, sender_grid, target_core):
+    """Per-core noc selection: pick the NOC with fewer hops from sender to target."""
+    gather_noc_idx_per_core = []
+    for core in ttnn.corerange_to_cores(sender_grid, row_wise=True):
+        noc0_hop = get_worker_noc_hop_distance(mesh_device, core, target_core, ttnn.NOC.NOC_0, mesh_coord)
+        noc1_hop = get_worker_noc_hop_distance(mesh_device, core, target_core, ttnn.NOC.NOC_1, mesh_coord)
+        gather_noc_idx_per_core.append((core, 0 if noc0_hop <= noc1_hop else 1))
+    return gather_noc_idx_per_core
 
 
 def _round_up(value: int, alignment: int) -> int:
@@ -137,16 +149,22 @@ class PostSDPA:
         return result
 
     SDPA_NUM_GLOBAL_SEMAPHORES = 2  # SdpaReduceToAll recv semaphores (r1, r2)
+    ALLGATHER_NUM_GLOBAL_SEMAPHORES = 2  # AllGather handoff + recv semaphores
 
     @staticmethod
     def get_num_semaphores(num_links=1):
         """Return the total number of global semaphores required by PostSDPA.
 
         The flat list contains CCL all-reduce semaphores followed by SDPA
-        reduce-to-all semaphores.  The count is fixed regardless of whether
-        CCL or SDPA are actually enabled at runtime.
+        reduce-to-all semaphores followed by AllGather semaphores.  The count
+        is fixed regardless of whether CCL or SDPA are actually enabled at
+        runtime.
         """
-        return DeepseekMinimalAllReduce.get_num_semaphores(num_links=num_links) + PostSDPA.SDPA_NUM_GLOBAL_SEMAPHORES
+        return (
+            DeepseekMinimalAllReduce.get_num_semaphores(num_links=num_links)
+            + PostSDPA.SDPA_NUM_GLOBAL_SEMAPHORES
+            + PostSDPA.ALLGATHER_NUM_GLOBAL_SEMAPHORES
+        )
 
     @staticmethod
     def create_semaphores(mesh_device, num_links=1):
@@ -242,6 +260,12 @@ class PostSDPA:
         semaphore_index += ccl_num_sems
         sdpa_semaphores = semaphores[semaphore_index : semaphore_index + PostSDPA.SDPA_NUM_GLOBAL_SEMAPHORES]
         semaphore_index += PostSDPA.SDPA_NUM_GLOBAL_SEMAPHORES
+        allgather_handoff_semaphore = semaphores[semaphore_index]
+        semaphore_index += 1
+        allgather_recv_semaphore = semaphores[semaphore_index]
+        semaphore_index += 1
+        allgather_handoff_sem_addr = ttnn.get_global_semaphore_address(allgather_handoff_semaphore)
+        allgather_recv_sem_addr = ttnn.get_global_semaphore_address(allgather_recv_semaphore)
         assert semaphore_index == len(semaphores), "Unexpected PostSDPA semaphore consumption"
 
         if ccl_enabled:
@@ -295,16 +319,25 @@ class PostSDPA:
         mcast3_core_grid = ttnn.CoreRangeSet([mcast3_grid])
         num_mcast3_cores = mcast3_grid.grid_size().x * mcast3_grid.grid_size().y  # 130
 
+        # TP4 outer-dim: each device produces [1, per_device_out_w]
+        num_sp = mesh_shape[0]
+
         # Active Matmul5 cores: o_proj cores (12×8 + 8×2 = 112 cores)
         o_proj_spec = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
         matmul5_active_core_grid = o_proj_spec.o_proj.core_range_set
         num_matmul5_cores = matmul5_active_core_grid.num_cores()  # 112
+        matmul5_half_num_cores = num_matmul5_cores // 2  # 56
 
         # Per-core gather3 sender index: contiguous 0..111 in row-major order.
         # Needed because o_proj grid is non-rectangular (12×8 + 8×2).
         # Row-major (y then x) matches WIDTH_SHARDED shard placement order.
         matmul5_cores = ttnn.corerange_to_cores(matmul5_active_core_grid, row_wise=True)
         gather3_sender_idx_per_core = [(core, idx) for idx, core in enumerate(matmul5_cores)]
+
+        # TP4 outer-dim: each device produces [1, per_device_out_w]
+        # per_device_out_w = matmul5_half_num_cores * 32 * matmul5_out_w_per_core = 56*32*1 = 1792
+        per_device_out_w = matmul5_half_num_cores * 32  # 1792 (matmul5_out_w_per_core=1)
+        per_device_out_tiles = matmul5_half_num_cores  # 1792 / 32 = 56 1x32 tiles
 
         # Full grid (union of all cores for semaphore allocation)
         full_grid = matmul4_core_grid
@@ -435,10 +468,16 @@ class PostSDPA:
         matmul4_out_w_per_core = 4  # 128 / 32 = 4 tiles per core
 
         # ========================================================================
-        # Matmul5 parameters: [1, 8192] x [8192, 64] -> [1, 64]
+        # Matmul5 (KNSlicedMatmul) parameters: [1, 8192] x [4096, 32] -> [1, 32]
+        # TP4 outer-dim: weights packed as (4096, 3584) with K-halves interleaved
+        # 112 cores split into 2 halves of 56; each core: [1, 4096] @ [4096, 32] -> [1, 32]
         # ========================================================================
-        matmul5_k_num_tiles = 256  # 8192 / 32 = 256 tiles
-        matmul5_out_w_per_core = 2  # 64 / 32 = 2 tiles per core
+        matmul5_act_total_tiles = 256  # 8192 / 32 = 256 tiles (full activation)
+        matmul5_k_per_core = matmul5_act_total_tiles // 2  # 128 tiles per half
+        matmul5_out_w_per_core = 1  # 32 / 32 = 1 tile per core
+        matmul5_k_offset_per_core = [
+            (core, 0 if idx < matmul5_half_num_cores else matmul5_k_per_core) for idx, core in enumerate(matmul5_cores)
+        ]
 
         # ========================================================================
         # CB indices
@@ -450,11 +489,12 @@ class PostSDPA:
         matmul5_in0_cb = 48  # Mcast3 dst = Matmul5 input (13x10 mcast3 grid)
         matmul5_in1_cb = 49  # Matmul5 weights (112 active cores)
         matmul5_out_cb = 50  # Matmul5 output (112 active cores)
-        gather3_dst_cb = 51  # Gather3 output = CCL local data (sender core 11,9)
-        ccl_recv_local_data_cb = 52  # CCL receiver-side local data (receiver core 12,9)
-        ccl_remote_data_cb = 53  # CCL received remote data (receiver core 12,9)
-        ccl_residual_cb = 54  # CCL residual (receiver core 12,9)
-        ccl_output_cb = 55  # CCL output (receiver core 12,9)
+        gather3_scratch_cb = 51  # GatherReduce3 scratch (2 halves, reused as AllGather transport scratch)
+        gather3_out_cb = 52  # GatherReduce3 output = CCL local data (sender core 11,9)
+        ccl_recv_local_data_cb = 53  # CCL receiver-side local data (receiver core 12,9)
+        ccl_remote_data_cb = 54  # CCL received remote data (receiver core 12,9)
+        ccl_residual_cb = 55  # CCL residual (receiver core 12,9)
+        ccl_output_cb = 56  # CCL output (receiver core 12,9) = AllGather destination base
 
         # ========================================================================
         # Gather2 parameters: 64 cores -> [1, 8192]
@@ -473,20 +513,27 @@ class PostSDPA:
         mcast3_dst_num_pages = gather2_dst_num_pages  # 256 pages per receiver
 
         # ========================================================================
-        # Gather3 parameters: 112 cores -> [1, 7168]
+        # GatherReduce3 parameters: 112 cores (2x56 halves) -> [1, per_device_out_w]
+        # Each sender produces 1 tile of 1x32; halves are reduced on receiver
+        # using 32x32 tile reinterpretation (ceil(56/32) = 2 tiles per half).
         # ========================================================================
-        gather3_data_size_bytes = matmul5_out_w_per_core * tile_1x32_size
-        gather3_src_num_pages = matmul5_out_w_per_core  # 2 pages per sender
-        gather3_dst_num_pages = num_matmul5_cores * matmul5_out_w_per_core // 32  # 112 * 2 / 32 = 7 pages
+        gather3_data_size_bytes = matmul5_out_w_per_core * tile_1x32_size  # 1 tile per sender
+        gather3_src_num_pages = matmul5_out_w_per_core  # 1 page per sender
+        gather3_dst_num_tiles = (per_device_out_tiles + 31) // 32  # 2 tiles of 32x32 per half
+        gather3_half_size_bytes = gather3_dst_num_tiles * tile_32x32_size  # padded to 32x32 boundary
         gather3_noc0_num_senders = num_matmul5_cores
         gather3_noc1_num_senders = 0
 
         # ========================================================================
-        # CCL parameters: [1, 7168] all-reduce
+        # CCL parameters: [1, per_device_out_w] all-reduce then [1, full_out_w] all-gather
         # ========================================================================
         # CCL all-reduce uses 32x32 tile format to match gather3 output.
-        ccl_num_tiles = gather3_dst_num_pages  # 7 tiles of 32x32
+        ccl_num_tiles = gather3_dst_num_tiles  # 2 tiles of 32x32
         ccl_page_size_bytes = tile_32x32_size
+        ccl_cb_total_size = gather3_dst_num_tiles * tile_32x32_size
+        allgather_slice_size_bytes = per_device_out_tiles * tile_1x32_size  # 56 * 64 = 3584
+        allgather_num_links = 1
+        allgather_cluster_axis = 0  # gather along rows
 
         # ========================================================================
         # Semaphore IDs
@@ -507,7 +554,7 @@ class PostSDPA:
             cluster_axis=cluster_axis,
             num_links=ccl_num_links,
             chunk_num_tiles=None,
-            local_data_cb_id=gather3_dst_cb,
+            local_data_cb_id=gather3_out_cb,
             recv_local_data_cb_id=ccl_recv_local_data_cb,
             remote_data_cb_id=ccl_remote_data_cb,
             output_cb_id=ccl_output_cb,
@@ -515,11 +562,17 @@ class PostSDPA:
             skip_local_push=True,
             skip_ccl=not ccl_enabled,
             sender_core=sender_core,
+            num_tiles_override=gather3_dst_num_tiles,
+            page_size_override=tile_32x32_size,
         )
 
         if ccl_enabled:
             allreduce_config.set_local_data_addr(gather3_output_tensors_per_device[0].buffer_address())
             allreduce_config.set_remote_data_addr(intermediate_tensors_per_device[0].buffer_address())
+
+        # AllGather config is built lazily inside the per-device loop (once, using device 0's
+        # reference CB addresses) since it needs the resolved L1 address of gather3_scratch_cb.
+        allgather_config = None
 
         per_device_contexts = []
 
@@ -582,25 +635,28 @@ class PostSDPA:
                     ("mcast3_data_receiver_semaphore", mcast3_data_receiver_semaphore_id),
                     ("mcast3_dst_cb", matmul5_in0_cb),
                     ("mcast3_dst_num_pages", mcast3_dst_num_pages),
-                    # Matmul5
+                    # Matmul5 (KNSlicedMatmul)
                     ("matmul5_in0", matmul5_in0_cb),
                     ("matmul5_in1", matmul5_in1_cb),
                     ("matmul5_out", matmul5_out_cb),
-                    ("matmul5_k_num_tiles", matmul5_k_num_tiles),
                     ("matmul5_out_w_per_core", matmul5_out_w_per_core),
-                    # Gather3 sender (destination = sender core 11,9)
+                    ("matmul5_k_per_core", matmul5_k_per_core),
+                    ("matmul5_act_total_tiles", matmul5_act_total_tiles),
+                    # GatherReduce3 sender (destination = sender core 11,9)
                     ("gather3_dest_noc_x", sender_dest_noc_core.x),
                     ("gather3_dest_noc_y", sender_dest_noc_core.y),
                     ("gather3_data_size_bytes", gather3_data_size_bytes),
-                    ("gather3_receiver_semaphore_id", gather3_noc0_receiver_semaphore_id),
+                    ("gather3_receiver_semaphore_addr", gather3_noc0_receiver_semaphore_id),
                     ("gather3_src_cb", matmul5_out_cb),
                     ("gather3_src_num_pages", gather3_src_num_pages),
-                    ("gather3_sender_grid_start_x", 0),
-                    ("gather3_sender_grid_start_y", 0),
-                    ("gather3_sender_grid_end_x", 0),
-                    ("gather3_sender_grid_end_y", 0),
-                    ("gather3_row_major", 1),
-                    ("gather3_receiver_data_addr", gather3_receiver_data_addr),
+                    # Grid args unused when UsePerCoreSenderIdx=true, but required for struct init
+                    ("gather3_grid_start_x", 0),
+                    ("gather3_grid_start_y", 0),
+                    ("gather3_grid_end_x", 0),
+                    ("gather3_grid_end_y", 0),
+                    ("gather3_half_num_cores", matmul5_half_num_cores),
+                    ("gather3_dst_cb_id", gather3_scratch_cb),
+                    ("gather3_half_size_bytes", gather3_half_size_bytes),
                 ]
 
                 # Add SDPA NCRISC compile-time args when enabled
@@ -656,13 +712,13 @@ class PostSDPA:
                     ("mcast3_src_num_pages", mcast3_src_num_pages),
                     ("mcast3_dst_cb", matmul5_in0_cb),
                     ("mcast3_is_part_of_receiver_grid", mcast3_is_part_of_receiver_grid),
-                    # Gather3 receiver
+                    # GatherReduce3 receiver (on sender core 11,9)
                     ("gather3_noc0_num_senders", gather3_noc0_num_senders),
                     ("gather3_noc1_num_senders", gather3_noc1_num_senders),
                     ("gather3_noc0_receiver_semaphore_id", gather3_noc0_receiver_semaphore_id),
                     ("gather3_noc1_receiver_semaphore_id", gather3_noc1_receiver_semaphore_id),
-                    ("gather3_dst_cb", gather3_dst_cb),
-                    ("gather3_dst_num_pages", gather3_dst_num_pages),
+                    ("gather3_dst_cb", gather3_scratch_cb),
+                    ("gather3_dst_num_tiles", gather3_dst_num_tiles),
                 ]
 
                 # Add SDPA BRISC compile-time args when enabled
@@ -708,12 +764,17 @@ class PostSDPA:
                     ("matmul4_out", matmul4_out_cb),
                     ("matmul4_k_num_tiles", matmul4_k_num_tiles),
                     ("matmul4_out_w_per_core", matmul4_out_w_per_core),
-                    # Matmul5
+                    # Matmul5 (KNSlicedMatmul)
                     ("matmul5_in0", matmul5_in0_cb),
                     ("matmul5_in1", matmul5_in1_cb),
                     ("matmul5_out", matmul5_out_cb),
-                    ("matmul5_k_num_tiles", matmul5_k_num_tiles),
                     ("matmul5_out_w_per_core", matmul5_out_w_per_core),
+                    ("matmul5_k_per_core", matmul5_k_per_core),
+                    ("matmul5_act_total_tiles", matmul5_act_total_tiles),
+                    # GatherReduce3 compute
+                    ("gather3_scratch_cb", gather3_scratch_cb),
+                    ("gather3_out_cb", gather3_out_cb),
+                    ("gather3_dst_num_tiles", gather3_dst_num_tiles),
                 ]
 
                 # Add SDPA TRISC compile-time args when enabled
@@ -741,6 +802,21 @@ class PostSDPA:
                 ncrisc_named_compile_time_args.extend(allreduce_config.get_ncrisc_named_ct_args(coord))
                 brisc_named_compile_time_args.extend(allreduce_config.get_brisc_named_ct_args(coord))
                 trisc_named_compile_time_args.extend(allreduce_config.get_trisc_named_ct_args(coord))
+
+                # TP4 outer-dim: residual NOC copy params (receiver core reads its row slice)
+                # input source: residual tensor on gather core (= receiver core itself).
+                input_noc_coord = gather_dest_noc_core
+                residual_byte_offset = row * per_device_out_tiles * tile_1x32_size
+                residual_copy_size = per_device_out_tiles * tile_1x32_size
+                residual_copy_named_compile_time_args = [
+                    ("residual_byte_offset", residual_byte_offset),
+                    ("residual_copy_size", residual_copy_size),
+                    ("residual_cb_id", ccl_residual_cb),
+                    ("residual_num_tiles", gather3_dst_num_tiles),
+                    ("input_noc_coord_x", input_noc_coord.x),
+                    ("input_noc_coord_y", input_noc_coord.y),
+                ]
+                ncrisc_named_compile_time_args.extend(residual_copy_named_compile_time_args)
 
                 # ========================================================================
                 # Circular buffer descriptors
@@ -837,18 +913,68 @@ class PostSDPA:
                         format_descriptors=[matmul5_out_cb_format],
                     )
 
-                # CB 51: gather3 output = CCL local data (backed by gather3_output_tensor)
-                gather3_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    gather3_dst_cb, gather3_output_tensor_device
+                # CB 51: GatherReduce3 scratch (2× size — holds both halves before reduction,
+                # also reused as AllGather transport scratch).
+                # Overlapped into kv_cache when available; otherwise standalone on sender core.
+                gather3_scratch_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=gather3_scratch_cb,
+                    data_format=data_format,
+                    page_size=tile_32x32_size,
+                    tile=ttnn.TileDescriptor(TILE_32x32),
                 )
-                gather3_dst_cb_descriptor.format_descriptors = [
+                if sdpa_kv_cache_buffer_device is not None:
+                    gather3_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                        gather3_scratch_cb,
+                        sdpa_kv_cache_buffer_device,
+                        address_offset=running_address_offset,
+                        total_size=2 * ccl_cb_total_size,
+                    )
+                    gather3_scratch_cb_descriptor.format_descriptors = [gather3_scratch_cb_format]
+                    running_address_offset += gather3_scratch_cb_descriptor.total_size
+                else:
+                    gather3_scratch_cb_descriptor = ttnn.CBDescriptor(
+                        total_size=2 * ccl_cb_total_size,
+                        core_ranges=sender_core_grid,
+                        format_descriptors=[gather3_scratch_cb_format],
+                    )
+
+                # CB 52: GatherReduce3 output = CCL local data (backed by gather3_output_tensor)
+                gather3_out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    gather3_out_cb, gather3_output_tensor_device
+                )
+                gather3_out_cb_descriptor.format_descriptors = [
                     ttnn.CBFormatDescriptor(
-                        buffer_index=gather3_dst_cb,
+                        buffer_index=gather3_out_cb,
                         data_format=data_format,
                         page_size=tile_32x32_size,
                         tile=ttnn.TileDescriptor(TILE_32x32),
                     )
                 ]
+
+                # AllGather config (no-ownership mode) — scratch lives in gather3_scratch_cb,
+                # output in output_tensor.  Built once using device-0 addresses; addresses
+                # are uniform across devices (same L1 layout).
+                if allgather_config is None and ccl_enabled:
+                    allgather_config = AllGatherConfig(
+                        mesh_device=mesh_device,
+                        cluster_axis=allgather_cluster_axis,
+                        num_links=allgather_num_links,
+                        slice_size_bytes=allgather_slice_size_bytes,
+                        scratch_base_addr=ttnn.get_cb_address(gather3_scratch_cb_descriptor),
+                        output_addr=output_tensors_per_device[0].buffer_address(),
+                        handoff_sem_addr=allgather_handoff_sem_addr,
+                        recv_sem_addr=allgather_recv_sem_addr,
+                        gather_noc_core=gather_dest_noc_core,
+                        transport_noc_core=sender_dest_noc_core,
+                        output_cb_id=ccl_output_cb,
+                        output_num_tiles=gather3_dst_num_tiles,
+                    )
+
+                # Extend CT args with allgather schema + named.  Must be after allgather_config exists.
+                if ccl_enabled:
+                    ncrisc_named_compile_time_args.extend(allgather_config.get_fused_ncrisc_named_ct_args(coord))
+                    brisc_named_compile_time_args.extend(allgather_config.get_fused_brisc_named_ct_args(coord))
+                    trisc_named_compile_time_args.extend(allgather_config.get_fused_trisc_named_ct_args(coord))
 
                 cb_list = [
                     matmul4_in0_cb_descriptor,
@@ -858,7 +984,8 @@ class PostSDPA:
                     matmul5_in0_cb_descriptor,
                     matmul5_in1_cb_descriptor,
                     matmul5_out_cb_descriptor,
-                    gather3_dst_cb_descriptor,
+                    gather3_scratch_cb_descriptor,
+                    gather3_out_cb_descriptor,
                 ]
 
                 # CCL CBs: fused op owns all CCL CB descriptors (no-ownership mode)
@@ -1169,6 +1296,9 @@ class PostSDPA:
                 # non-rectangular kv_b2 grid offset calculation (UsePerCoreSenderIdx=true)
                 # gather3_sender_idx: each matmul5 core needs a unique index for
                 # non-rectangular o_proj grid offset calculation (UsePerCoreSenderIdx=true)
+                gather3_noc_idx_per_core = _get_gather_noc_idx_per_core(
+                    mesh_device, coord, matmul5_active_core_grid, sender_core
+                )
                 per_core_compile_time_descriptors = [
                     PerCoreCompileTimeDescriptor(
                         named_compile_time_arg="gather2_sender_idx",
@@ -1180,18 +1310,41 @@ class PostSDPA:
                         core_values=gather3_sender_idx_per_core,
                         other_value=0,
                     ),
+                    PerCoreCompileTimeDescriptor(
+                        named_compile_time_arg="gather3_noc_idx",
+                        core_values=gather3_noc_idx_per_core,
+                        other_value=0,
+                    ),
+                    PerCoreCompileTimeDescriptor(
+                        named_compile_time_arg="matmul5_k_offset",
+                        core_values=matmul5_k_offset_per_core,
+                        other_value=0,
+                    ),
                 ]
 
                 # ========================================================================
                 # Pre-compute CCL runtime args (fabric setup deferred to op())
                 # ========================================================================
+                # Receiver NCRISC common RT args: allreduce (6 items) + output tensor addr
+                # (index 6, for AllGather output) + residual input L1 addr (index 7, for NOC copy).
+                residual_input_l1_addr = (
+                    residual_tensors_per_device[device_idx].buffer_address()
+                    if ccl_enabled and residual_tensor_mesh is not None
+                    else 0
+                )
+                receiver_ncrisc_common_rt_args = list(allreduce_config.get_receiver_ncrisc_common_rt_args(coord)) + [
+                    output_tensors_per_device[device_idx].buffer_address() if ccl_enabled else 0,
+                    residual_input_l1_addr,
+                ]
+
                 ccl_ctx = {
                     "allreduce_config": allreduce_config,
+                    "allgather_config": allgather_config,
                     "sender_core": sender_core,
                     "receiver_core": gather_core,
                     "sender_ncrisc_common_rt_args": allreduce_config.get_sender_ncrisc_common_rt_args(coord),
                     "sender_brisc_common_rt_args": allreduce_config.get_sender_brisc_common_rt_args(coord),
-                    "receiver_ncrisc_common_rt_args": allreduce_config.get_receiver_ncrisc_common_rt_args(coord),
+                    "receiver_ncrisc_common_rt_args": receiver_ncrisc_common_rt_args,
                 }
 
                 # ========================================================================
@@ -1568,23 +1721,40 @@ class PostSDPA:
             # ==================================================================
             ccl = ctx["ccl"]
             ccl_sender_core = ccl["sender_core"]
+            allreduce_config = ccl["allreduce_config"]
+            allgather_config = ccl["allgather_config"]
             sender_group = kernel_result.get_group_by_arg("is_allreduce_sender_core", 1)
             receiver_group = kernel_result.get_group_by_arg("is_allreduce_receiver_core", 1)
 
             if sender_group is not None:
+                # Sender NCRISC: per-core = [allreduce fabric count] + allreduce fabric + allgather transport.
+                # Kernel reads the count first, then sets per_core_rta_start_idx past the allreduce fabric.
+                allreduce_ncrisc_pc_args = list(
+                    allreduce_config.get_ncrisc_per_core_rt_args(coord, program, ccl_sender_core)
+                )
+                sender_ncrisc_pc_args = [len(allreduce_ncrisc_pc_args)] + allreduce_ncrisc_pc_args
+                if allgather_config is not None:
+                    sender_ncrisc_pc_args.extend(
+                        allgather_config.get_transport_ncrisc_per_core_rt_args(coord, program, ccl_sender_core)
+                    )
                 sender_ncrisc_rt_args = ttnn.RuntimeArgs()
-                sender_ncrisc_rt_args[ccl_sender_core.x][ccl_sender_core.y] = ccl[
-                    "allreduce_config"
-                ].get_ncrisc_per_core_rt_args(coord, program, ccl_sender_core)
+                sender_ncrisc_rt_args[ccl_sender_core.x][ccl_sender_core.y] = sender_ncrisc_pc_args
                 program.kernels[sender_group.ncrisc_kernel_index].runtime_args = sender_ncrisc_rt_args
                 program.kernels[sender_group.ncrisc_kernel_index].common_runtime_args = ccl[
                     "sender_ncrisc_common_rt_args"
                 ]
 
+                # Sender BRISC: per-core = [allreduce fabric count] + allreduce fabric + allgather transport.
+                allreduce_brisc_pc_args = list(
+                    allreduce_config.get_brisc_per_core_rt_args(coord, program, ccl_sender_core)
+                )
+                sender_brisc_pc_args = [len(allreduce_brisc_pc_args)] + allreduce_brisc_pc_args
+                if allgather_config is not None:
+                    sender_brisc_pc_args.extend(
+                        allgather_config.get_transport_brisc_per_core_rt_args(coord, program, ccl_sender_core)
+                    )
                 sender_brisc_rt_args = ttnn.RuntimeArgs()
-                sender_brisc_rt_args[ccl_sender_core.x][ccl_sender_core.y] = ccl[
-                    "allreduce_config"
-                ].get_brisc_per_core_rt_args(coord, program, ccl_sender_core)
+                sender_brisc_rt_args[ccl_sender_core.x][ccl_sender_core.y] = sender_brisc_pc_args
                 program.kernels[sender_group.brisc_kernel_index].runtime_args = sender_brisc_rt_args
                 program.kernels[sender_group.brisc_kernel_index].common_runtime_args = ccl[
                     "sender_brisc_common_rt_args"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
@@ -23,7 +23,10 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import comp_pcc, skip_for_wormhole_b0
 from models.demos.deepseek_v3_b1.fused_ops.moe_routed_expert.op import MoeRoutedExpert
-from models.demos.deepseek_v3_b1.weights.transforms.attention import fuse_o_proj_gate_mm_norms
+from models.demos.deepseek_v3_b1.weights.transforms.attention import (
+    fuse_o_proj_gate_mm_norms,
+    fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a,
+)
 from models.demos.deepseek_v3_b1.weights.transforms.moe import create_moe_routed_expert_tensors
 
 
@@ -637,20 +640,27 @@ def test_moe_routed_expert_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_i
     # Mesh mapper for replication
     mesh_mapper = ttnn.ReplicateTensorToMesh(submesh)
 
-    # Gate matmul weights via overlapped tensor (fused with o_proj + gammas, matching production layout)
+    # Gate matmul weights via overlapped tensor (fused with o_proj + gammas + q_ab + kv_a,
+    # matching the TP4 production layout on the 4x2 mesh).
     mla_tp = submesh.shape[1]
     torch_o_proj_weights = torch.zeros((8192 * mla_tp, K), dtype=torch.bfloat16)
     torch_attn_norm = torch.zeros((1, K), dtype=torch.bfloat16)
     torch_q_norm = torch.zeros((1, 1536), dtype=torch.bfloat16)
     torch_kv_norm = torch.zeros((1, 512), dtype=torch.bfloat16)
     torch_ffn_norm = torch.zeros((1, K), dtype=torch.bfloat16)
-    o_norms = fuse_o_proj_gate_mm_norms(
+    torch_q_a_proj = torch.zeros((7168, 1536), dtype=torch.bfloat16)
+    torch_q_b_proj = torch.zeros((1536, 12288 * mla_tp), dtype=torch.bfloat16)
+    torch_kv_a_proj = torch.zeros((7168, 576), dtype=torch.bfloat16)
+    o_norms = fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
         torch_o_proj_weights,
         torch_gate_mm_weights,
         torch_attn_norm,
         torch_q_norm,
         torch_kv_norm,
         torch_ffn_norm,
+        torch_q_a_proj,
+        torch_q_b_proj,
+        torch_kv_a_proj,
         submesh,
     )
     ttnn_gate_mm_weights = o_norms["gate_mm"]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
@@ -23,10 +23,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import comp_pcc, skip_for_wormhole_b0
 from models.demos.deepseek_v3_b1.fused_ops.moe_routed_expert.op import MoeRoutedExpert
-from models.demos.deepseek_v3_b1.weights.transforms.attention import (
-    fuse_o_proj_gate_mm_norms,
-    fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a,
-)
+from models.demos.deepseek_v3_b1.weights.transforms.attention import fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a
 from models.demos.deepseek_v3_b1.weights.transforms.moe import create_moe_routed_expert_tensors
 
 
@@ -122,19 +119,28 @@ def test_moe_routed_expert(device, use_hardcoded_expert_index):
         f"Created mcast output tensor with shard shape ({M}, {K}) on {mcast_output_core_grid.num_cores()} cores"
     )
 
-    # Gate matmul weights via overlapped tensor (fused with o_proj + gammas, matching production layout)
-    torch_o_proj_weights = torch.zeros((8192, K), dtype=torch.bfloat16)
+    # Gate matmul weights via overlapped tensor (fused with o_proj + gammas + q_ab / kv_a, matching production layout)
+    torch_o_proj_weights = torch.zeros((16384, K), dtype=torch.bfloat16)
     torch_attn_norm = torch.zeros((1, K), dtype=torch.bfloat16)
     torch_q_norm = torch.zeros((1, 1536), dtype=torch.bfloat16)
     torch_kv_norm = torch.zeros((1, 512), dtype=torch.bfloat16)
     torch_ffn_norm = torch.zeros((1, K), dtype=torch.bfloat16)
-    o_norms = fuse_o_proj_gate_mm_norms(
+    # q_a/q_b/kv_a placeholders — not consumed by this test but required by the
+    # merged fuse.  1x1 mesh expects single-device shapes from the 4x2 layout:
+    # q_b_tp=1, so q_b is (1536, 12288) = (1536, 64 qnope + 64 qrope heads).
+    torch_q_a_proj_weights = torch.zeros((7168, 1536), dtype=torch.bfloat16)
+    torch_q_b_proj_weights = torch.zeros((1536, 12288), dtype=torch.bfloat16)
+    torch_kv_a_proj_weights = torch.zeros((7168, 576), dtype=torch.bfloat16)
+    o_norms = fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
         torch_o_proj_weights,
         torch_gate_mm_weights,
         torch_attn_norm,
         torch_q_norm,
         torch_kv_norm,
         torch_ffn_norm,
+        torch_q_a_proj_weights,
+        torch_q_b_proj_weights,
+        torch_kv_a_proj_weights,
         device,
     )
     ttnn_gate_mm_weights = o_norms["gate_mm"]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -27,6 +27,7 @@ from models.demos.deepseek_v3_b1.utils import deinterleave_kv_cache, generate_mm
 from models.demos.deepseek_v3_b1.weights.transforms.attention import (
     fuse_kv_b12,
     fuse_o_proj_gate_mm_norms,
+    fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a,
     fuse_q_ab_kv_a,
 )
 
@@ -388,13 +389,16 @@ def test_pre_sdpa(
         (QNOPE_OUT_DIM, num_tp * NUM_QNOPE_HEADS * QNOPE_HEAD_DIM), dtype=torch.bfloat16
     )
 
-    # DKV matmul weights (raw, unshuffled — fuse_q_ab_kv_a handles shard reordering)
+    # DKV matmul weights (raw, unshuffled — fuse handles shard reordering)
     torch_dkv_matmul_weights = generate_mm_weights(dkv_matmul_weights_shape, dtype=torch.bfloat16)
 
-    # Placeholder tensors for get_tt_o_proj_and_gate_mm_weights (not consumed by pre-SDPA)
+    # Placeholder tensors for o_proj/gate_mm/ffn_norm (not consumed by pre-SDPA)
     torch_o_proj_weights = torch.zeros((num_tp * 8192, 7168), dtype=torch.bfloat16)
     torch_gate_mm_weights = torch.zeros((7168, 256), dtype=torch.bfloat16)
     torch_ffn_norm = torch.zeros((1, 7168), dtype=torch.bfloat16)
+
+    # KV Cache Branch RMSNorm gamma (defined early so it can feed the fuse call)
+    torch_dkv_rmsnorm_gamma = torch.randn((1, KNOPE_DIM), dtype=torch.bfloat16)
 
     # ========================================================================
     # Create RoPE tensors (sin, cos, trans_mat)
@@ -442,17 +446,49 @@ def test_pre_sdpa(
     input_tensor_mesh = bcast_inputs.input_tensor_mesh
     intermediate_tensor_mesh = bcast_inputs.output_tensor_mesh
 
-    # Fused matmul1 (q_a_proj packed), matmul2 (q_b_proj shuffled), and DKV matmul (kv_a_proj)
-    # weights as overlapped tensors sharing a single L1 buffer via fuse_q_ab_kv_a.
-    qab_kva = fuse_q_ab_kv_a(
-        torch_matmul_weights,
-        torch_matmul2_weights_full_unshuffled,
-        torch_dkv_matmul_weights,
-        submesh,
-    )
-    matmul_weights_overlapped = qab_kva["q_a_proj"]
-    matmul2_weights_overlapped = qab_kva["q_b_proj"]
-    dkv_matmul_weights_overlapped = qab_kva["kv_a_proj"]
+    # Fuse o_proj (TP4 shuffled), gate_mm, norms, q_a / q_b / kv_a into a single
+    # per-core L1 buffer on 4x2; fall back to the split overlaps on 1x1.
+    if (mesh_rows, mesh_cols) == (4, 2):
+        fused = fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
+            torch_o_proj_weights,
+            torch_gate_mm_weights,
+            torch_gamma,
+            torch_rmsnorm2_gamma,
+            torch_dkv_rmsnorm_gamma,
+            torch_ffn_norm,
+            torch_matmul_weights,
+            torch_matmul2_weights_full_unshuffled,
+            torch_dkv_matmul_weights,
+            submesh,
+        )
+        matmul_weights_overlapped = fused["q_a_proj"]
+        matmul2_weights_overlapped = fused["q_b_proj"]
+        dkv_matmul_weights_overlapped = fused["kv_a_proj"]
+        gamma_overlapped = fused["attn_norm"]
+        rmsnorm2_gamma_overlapped = fused["q_norm"]
+        dkv_rmsnorm_gamma_overlapped = fused["kv_norm"]
+    else:
+        qab_kva = fuse_q_ab_kv_a(
+            torch_matmul_weights,
+            torch_matmul2_weights_full_unshuffled,
+            torch_dkv_matmul_weights,
+            submesh,
+        )
+        matmul_weights_overlapped = qab_kva["q_a_proj"]
+        matmul2_weights_overlapped = qab_kva["q_b_proj"]
+        dkv_matmul_weights_overlapped = qab_kva["kv_a_proj"]
+        o_norms = fuse_o_proj_gate_mm_norms(
+            torch_o_proj_weights,
+            torch_gate_mm_weights,
+            torch_gamma,
+            torch_rmsnorm2_gamma,
+            torch_dkv_rmsnorm_gamma,
+            torch_ffn_norm,
+            submesh,
+        )
+        gamma_overlapped = o_norms["attn_norm"]
+        rmsnorm2_gamma_overlapped = o_norms["q_norm"]
+        dkv_rmsnorm_gamma_overlapped = o_norms["kv_norm"]
 
     # Matmul3 / kv_b1_proj weights — fused with kv_b2_proj via fuse_kv_b12
     torch_matmul3_weights_flat = torch_matmul3_weights.reshape(num_tp * NUM_QNOPE_HEADS * QNOPE_HEAD_DIM, QNOPE_OUT_DIM)
@@ -556,23 +592,6 @@ def test_pre_sdpa(
         tile=trans_tile,
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
-
-    # KV Cache Branch RMSNorm gamma
-    torch_dkv_rmsnorm_gamma = torch.randn((1, KNOPE_DIM), dtype=torch.bfloat16)
-
-    # Fused o_proj, gate_mm, and RMSNorm gammas — we only need the 3 gamma overlapped views.
-    o_norms = fuse_o_proj_gate_mm_norms(
-        torch_o_proj_weights,
-        torch_gate_mm_weights,
-        torch_gamma,
-        torch_rmsnorm2_gamma,
-        torch_dkv_rmsnorm_gamma,
-        torch_ffn_norm,
-        submesh,
-    )
-    gamma_overlapped = o_norms["attn_norm"]
-    rmsnorm2_gamma_overlapped = o_norms["q_norm"]
-    dkv_rmsnorm_gamma_overlapped = o_norms["kv_norm"]
 
     # KRoPE cos/sin: DRAM INTERLEAVED (each krope core reads its width slice)
     krope_num_cores = kv_cache_branch_rope_crs.num_cores()

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -26,9 +26,7 @@ from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import (
 from models.demos.deepseek_v3_b1.utils import deinterleave_kv_cache, generate_mm_weights
 from models.demos.deepseek_v3_b1.weights.transforms.attention import (
     fuse_kv_b12,
-    fuse_o_proj_gate_mm_norms,
     fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a,
-    fuse_q_ab_kv_a,
 )
 
 
@@ -392,8 +390,10 @@ def test_pre_sdpa(
     # DKV matmul weights (raw, unshuffled — fuse handles shard reordering)
     torch_dkv_matmul_weights = generate_mm_weights(dkv_matmul_weights_shape, dtype=torch.bfloat16)
 
-    # Placeholder tensors for o_proj/gate_mm/ffn_norm (not consumed by pre-SDPA)
-    torch_o_proj_weights = torch.zeros((num_tp * 8192, 7168), dtype=torch.bfloat16)
+    # Placeholder tensors for o_proj/gate_mm/ffn_norm (not consumed by pre-SDPA).
+    # o_proj full logical shape; pack_o_proj_weights_tp4_shuffled extracts the
+    # mesh-position (0, 0) slice internally for 1x1.
+    torch_o_proj_weights = torch.zeros((16384, 7168), dtype=torch.bfloat16)
     torch_gate_mm_weights = torch.zeros((7168, 256), dtype=torch.bfloat16)
     torch_ffn_norm = torch.zeros((1, 7168), dtype=torch.bfloat16)
 
@@ -447,48 +447,26 @@ def test_pre_sdpa(
     intermediate_tensor_mesh = bcast_inputs.output_tensor_mesh
 
     # Fuse o_proj (TP4 shuffled), gate_mm, norms, q_a / q_b / kv_a into a single
-    # per-core L1 buffer on 4x2; fall back to the split overlaps on 1x1.
-    if (mesh_rows, mesh_cols) == (4, 2):
-        fused = fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
-            torch_o_proj_weights,
-            torch_gate_mm_weights,
-            torch_gamma,
-            torch_rmsnorm2_gamma,
-            torch_dkv_rmsnorm_gamma,
-            torch_ffn_norm,
-            torch_matmul_weights,
-            torch_matmul2_weights_full_unshuffled,
-            torch_dkv_matmul_weights,
-            submesh,
-        )
-        matmul_weights_overlapped = fused["q_a_proj"]
-        matmul2_weights_overlapped = fused["q_b_proj"]
-        dkv_matmul_weights_overlapped = fused["kv_a_proj"]
-        gamma_overlapped = fused["attn_norm"]
-        rmsnorm2_gamma_overlapped = fused["q_norm"]
-        dkv_rmsnorm_gamma_overlapped = fused["kv_norm"]
-    else:
-        qab_kva = fuse_q_ab_kv_a(
-            torch_matmul_weights,
-            torch_matmul2_weights_full_unshuffled,
-            torch_dkv_matmul_weights,
-            submesh,
-        )
-        matmul_weights_overlapped = qab_kva["q_a_proj"]
-        matmul2_weights_overlapped = qab_kva["q_b_proj"]
-        dkv_matmul_weights_overlapped = qab_kva["kv_a_proj"]
-        o_norms = fuse_o_proj_gate_mm_norms(
-            torch_o_proj_weights,
-            torch_gate_mm_weights,
-            torch_gamma,
-            torch_rmsnorm2_gamma,
-            torch_dkv_rmsnorm_gamma,
-            torch_ffn_norm,
-            submesh,
-        )
-        gamma_overlapped = o_norms["attn_norm"]
-        rmsnorm2_gamma_overlapped = o_norms["q_norm"]
-        dkv_rmsnorm_gamma_overlapped = o_norms["kv_norm"]
+    # per-core L1 buffer.  Same call for 4x2 (production) and 1x1 (single-device
+    # simulating mesh position (0, 0) of the 4x2 layout).
+    fused = fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
+        torch_o_proj_weights,
+        torch_gate_mm_weights,
+        torch_gamma,
+        torch_rmsnorm2_gamma,
+        torch_dkv_rmsnorm_gamma,
+        torch_ffn_norm,
+        torch_matmul_weights,
+        torch_matmul2_weights_full_unshuffled,
+        torch_dkv_matmul_weights,
+        submesh,
+    )
+    matmul_weights_overlapped = fused["q_a_proj"]
+    matmul2_weights_overlapped = fused["q_b_proj"]
+    dkv_matmul_weights_overlapped = fused["kv_a_proj"]
+    gamma_overlapped = fused["attn_norm"]
+    rmsnorm2_gamma_overlapped = fused["q_norm"]
+    dkv_rmsnorm_gamma_overlapped = fused["kv_norm"]
 
     # Matmul3 / kv_b1_proj weights — fused with kv_b2_proj via fuse_kv_b12
     torch_matmul3_weights_flat = torch_matmul3_weights.reshape(num_tp * NUM_QNOPE_HEADS * QNOPE_HEAD_DIM, QNOPE_OUT_DIM)

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -41,11 +41,8 @@ from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
     GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
     KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
     O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC,
-    QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
 )
 
-Q_AB_KV_A_SPEC = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
-O_PROJ_GATE_MM_NORMS_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 MERGED_TP4_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.tp4_merged_fusion_group_spec()
 KV_B12_SPEC = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 GATE_UP_SPEC = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
@@ -561,9 +558,10 @@ def split_kv_b_proj(kv_b_proj: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor
     return kv_b1, kv_b2
 
 
-# Per-TP attention tensor dimensions (match *_SingleDeviceOverlapSpec configs for single device)
+# Per-TP attention tensor dimensions: mla_tp=1 simulates a single device in the
+# 4x2 mesh, so we trim the TP-sharded dims of q_b/kv_b to one mesh position's
+# slice.  o_proj uses pack_o_proj_weights_tp4_shuffled which slices internally.
 _MLA_TP1_Q_B_WIDTH = 12288
-_MLA_TP1_O_PROJ_HEIGHT = 8192
 _MLA_TP1_KV_B1_HEIGHT = 8192
 _MLA_TP1_KV_B2_WIDTH = 8192
 
@@ -669,14 +667,14 @@ def prepare_attention_weights(
     move_to_device: bool = False,
     cache_config: CacheConfig | None = None,
 ) -> AttentionWeights:
-    """Prepare attention fusion groups for one layer (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)."""
+    """Prepare attention fusion groups for one layer (merged TP4 buffer + kv_b12)."""
     if cache_config is None:
         cache_config = CacheConfig.ephemeral(move_to_device=move_to_device)
     mla_tp, _ = _tp_factors(device)
     mesh_shape = (device.shape[0], device.shape[1]) if device.get_num_devices() > 1 else (1, 1)
 
     logger.debug(
-        "Converting attention fusion groups for layer {} (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)",
+        "Converting attention fusion groups for layer {} (merged TP4 buffer + kv_b12)",
         layer_idx,
     )
     t0 = time.perf_counter()
@@ -716,176 +714,52 @@ def prepare_attention_weights(
     kv_b1_proj = kv_views["kv_b1_proj"]
     kv_b2_proj = kv_views["kv_b2_proj"]
 
-    # -- mla_tp == 2: merged buffer (o_proj + gate_mm + norms + q_ab + kv_a) --
-    if mla_tp == 2:
-        q_ab_keys = (q_a_key, q_b_key, kv_a_key)
+    # -- merged buffer (o_proj + gate_mm + norms + q_ab + kv_a) --
+    # Single path for both mla_tp=1 (single-device simulating mesh position (0,0)
+    # of the 4x2 layout) and mla_tp=2 (full 4x2 mesh).  pack_o_proj_weights_tp4_shuffled
+    # and preprocess_q_ab_kv_a handle the mesh-dependent slicing internally.
+    q_ab_keys = (q_a_key, q_b_key, kv_a_key)
 
-        def _preprocess_merged(t: dict[str, torch.Tensor], *, include_gate: bool) -> dict[str, torch.Tensor]:
-            o_proj = t[o_proj_key].T.contiguous()
-            o_proj = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.pack_o_proj_weights_tp4_shuffled(o_proj)
-            if include_gate:
-                gate_mm = t[gate_key].T.contiguous()
-            else:
-                gate_mm = torch.zeros(D.HIDDEN_SIZE, D.GATE_NUM_INDICES, dtype=torch.bfloat16, device=o_proj.device)
-            q_a = t[q_a_key].T.contiguous()
-            q_b = deinterleave_q_b_proj(t[q_b_key])
-            kv_a = t[kv_a_key].T.contiguous()
-            q_ab_kv_a = preprocess_q_ab_kv_a(q_a, q_b, kv_a, mesh_shape)
-            return {
-                "o_proj": o_proj,
-                "gate_mm": gate_mm,
-                "attn_norm": t[attn_norm_key].unsqueeze(0),
-                "q_norm": t[q_norm_key].unsqueeze(0),
-                "kv_norm": t[kv_norm_key].unsqueeze(0),
-                "ffn_norm": t[ffn_norm_key].unsqueeze(0),
-                **q_ab_kv_a,
-            }
-
-        if is_moe:
-            gate_key = _key(layer_idx, "mlp.gate.weight")
-            merged_src = (o_proj_key, gate_key, attn_norm_key, q_norm_key, kv_norm_key, ffn_norm_key) + q_ab_keys
-            merged_fp = cache_config.context.fingerprint(
-                source=SourceTensorSelection(names=merged_src),
-                target=MERGED_TP4_SPEC,
-            )
-            merged_views = cache_config.cache.get_or_create(
-                merged_fp,
-                device,
-                preprocess=lambda t: _preprocess_merged(t, include_gate=True),
-                raw_tensors=lambda: {k: state_dict[k] for k in merged_src},
-            )
-            if not isinstance(merged_views, dict):
-                raise TypeError("expected dict[str, OverlappedTensor] for merged cache entry")
-
-            _bias_key = _key(layer_idx, "mlp.gate.e_score_correction_bias")
-            target = _gate_bias_target(layer_idx)
-            fingerprint = cache_config.context.fingerprint(
-                source=SourceTensorSelection(names=(_bias_key,)),
-                target=target,
-            )
-            gate_bias_tt = cache_config.cache.get_or_create(
-                fingerprint,
-                device,
-                preprocess=lambda t: {target.name: t[_bias_key].reshape(16, 16).T.contiguous().to(torch.bfloat16)},
-                raw_tensors=lambda: {_bias_key: state_dict[_bias_key]},
-            )
-            if not isinstance(gate_bias_tt, ttnn.Tensor):
-                raise TypeError("expected ttnn.Tensor for gate_bias cache entry")
-
-            logger.debug(
-                "Attention fusion groups (MoE, merged) for layer {} in {:.3f}s",
-                layer_idx,
-                time.perf_counter() - t0,
-            )
-            return AttentionWeights(
-                q_a_proj=merged_views["q_a_proj"],
-                q_b_proj=merged_views["q_b_proj"],
-                kv_a_proj=merged_views["kv_a_proj"],
-                o_proj=merged_views["o_proj"],
-                gate_mm=merged_views["gate_mm"],
-                attn_norm=merged_views["attn_norm"],
-                q_norm=merged_views["q_norm"],
-                kv_norm=merged_views["kv_norm"],
-                ffn_norm=merged_views["ffn_norm"],
-                kv_b1_proj=kv_b1_proj,
-                kv_b2_proj=kv_b2_proj,
-                gate_bias=gate_bias_tt,
-            )
-
-        # Dense merged path
-        merged_src_dense = (o_proj_key, attn_norm_key, q_norm_key, kv_norm_key, ffn_norm_key) + q_ab_keys
-        merged_fp_dense = cache_config.context.fingerprint(
-            source=SourceTensorSelection(names=merged_src_dense),
-            target=MERGED_TP4_SPEC,
+    def _preprocess_merged(t: dict[str, torch.Tensor], *, include_gate: bool) -> dict[str, torch.Tensor]:
+        o_proj = t[o_proj_key].T.contiguous()
+        o_proj = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.pack_o_proj_weights_tp4_shuffled(
+            o_proj, mesh_shape=mesh_shape
         )
-        merged_views = cache_config.cache.get_or_create(
-            merged_fp_dense,
-            device,
-            preprocess=lambda t: _preprocess_merged(t, include_gate=False),
-            raw_tensors=lambda: {k: state_dict[k] for k in merged_src_dense},
-        )
-        if not isinstance(merged_views, dict):
-            raise TypeError("expected dict[str, OverlappedTensor] for merged cache entry")
-
-        logger.debug(
-            "Attention fusion groups (dense, merged) for layer {} in {:.3f}s",
-            layer_idx,
-            time.perf_counter() - t0,
-        )
-        return AttentionWeights(
-            q_a_proj=merged_views["q_a_proj"],
-            q_b_proj=merged_views["q_b_proj"],
-            kv_a_proj=merged_views["kv_a_proj"],
-            o_proj=merged_views["o_proj"],
-            gate_mm=None,
-            attn_norm=merged_views["attn_norm"],
-            q_norm=merged_views["q_norm"],
-            kv_norm=merged_views["kv_norm"],
-            ffn_norm=merged_views["ffn_norm"],
-            kv_b1_proj=kv_b1_proj,
-            kv_b2_proj=kv_b2_proj,
-            gate_bias=None,
-        )
-
-    # -- mla_tp == 1: separate q_ab_kv_a and o_proj fusion groups --
-    def _preprocess_q_ab_kv_a(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        if include_gate:
+            gate_mm = t[gate_key].T.contiguous()
+        else:
+            gate_mm = torch.zeros(D.HIDDEN_SIZE, D.GATE_NUM_INDICES, dtype=torch.bfloat16, device=o_proj.device)
         q_a = t[q_a_key].T.contiguous()
         q_b = deinterleave_q_b_proj(t[q_b_key])
-        kv_a = t[kv_a_key].T.contiguous()
-        if q_b.shape[1] == _MLA_TP1_Q_B_WIDTH * 2:
+        if mla_tp == 1 and q_b.shape[1] == _MLA_TP1_Q_B_WIDTH * 2:
             q_b = q_b[:, :_MLA_TP1_Q_B_WIDTH].contiguous()
-        return preprocess_q_ab_kv_a(q_a, q_b, kv_a, mesh_shape)
-
-    q_ab_fp = cache_config.context.fingerprint(
-        source=SourceTensorSelection(names=(q_a_key, q_b_key, kv_a_key)),
-        target=Q_AB_KV_A_SPEC,
-    )
-    q_ab_views = cache_config.cache.get_or_create(
-        q_ab_fp,
-        device,
-        preprocess=_preprocess_q_ab_kv_a,
-        raw_tensors=lambda: {k: state_dict[k] for k in (q_a_key, q_b_key, kv_a_key)},
-    )
-    if not isinstance(q_ab_views, dict):
-        raise TypeError("expected dict[str, OverlappedTensor] for q_ab_kv_a cache entry")
-    q_a_proj = q_ab_views["q_a_proj"]
-    q_b_proj = q_ab_views["q_b_proj"]
-    kv_a_proj = q_ab_views["kv_a_proj"]
+        kv_a = t[kv_a_key].T.contiguous()
+        q_ab_kv_a = preprocess_q_ab_kv_a(q_a, q_b, kv_a, mesh_shape)
+        return {
+            "o_proj": o_proj,
+            "gate_mm": gate_mm,
+            "attn_norm": t[attn_norm_key].unsqueeze(0),
+            "q_norm": t[q_norm_key].unsqueeze(0),
+            "kv_norm": t[kv_norm_key].unsqueeze(0),
+            "ffn_norm": t[ffn_norm_key].unsqueeze(0),
+            **q_ab_kv_a,
+        }
 
     if is_moe:
         gate_key = _key(layer_idx, "mlp.gate.weight")
-
-        def _preprocess_o_proj_moe(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-            o_proj = t[o_proj_key].T.contiguous()
-            gate_mm = t[gate_key].T.contiguous()
-            attn_norm = t[attn_norm_key].unsqueeze(0)
-            q_norm = t[q_norm_key].unsqueeze(0)
-            kv_norm = t[kv_norm_key].unsqueeze(0)
-            ffn_norm = t[ffn_norm_key].unsqueeze(0)
-            if o_proj.shape[0] == _MLA_TP1_O_PROJ_HEIGHT * 2:
-                o_proj = o_proj[:_MLA_TP1_O_PROJ_HEIGHT, :].contiguous()
-            return {
-                "o_proj": o_proj,
-                "gate_mm": gate_mm,
-                "attn_norm": attn_norm,
-                "q_norm": q_norm,
-                "kv_norm": kv_norm,
-                "ffn_norm": ffn_norm,
-            }
-
-        o_src = (o_proj_key, gate_key, attn_norm_key, q_norm_key, kv_norm_key, ffn_norm_key)
-        o_fp = cache_config.context.fingerprint(
-            source=SourceTensorSelection(names=o_src),
-            target=O_PROJ_GATE_MM_NORMS_SPEC,
+        merged_src = (o_proj_key, gate_key, attn_norm_key, q_norm_key, kv_norm_key, ffn_norm_key) + q_ab_keys
+        merged_fp = cache_config.context.fingerprint(
+            source=SourceTensorSelection(names=merged_src),
+            target=MERGED_TP4_SPEC,
         )
-        o_views = cache_config.cache.get_or_create(
-            o_fp,
+        merged_views = cache_config.cache.get_or_create(
+            merged_fp,
             device,
-            preprocess=_preprocess_o_proj_moe,
-            raw_tensors=lambda: {k: state_dict[k] for k in o_src},
+            preprocess=lambda t: _preprocess_merged(t, include_gate=True),
+            raw_tensors=lambda: {k: state_dict[k] for k in merged_src},
         )
-        if not isinstance(o_views, dict):
-            raise TypeError("expected dict[str, OverlappedTensor] for o_proj_gate_mm_norms cache entry")
+        if not isinstance(merged_views, dict):
+            raise TypeError("expected dict[str, OverlappedTensor] for merged cache entry")
 
         _bias_key = _key(layer_idx, "mlp.gate.e_score_correction_bias")
         target = _gate_bias_target(layer_idx)
@@ -903,72 +777,55 @@ def prepare_attention_weights(
             raise TypeError("expected ttnn.Tensor for gate_bias cache entry")
 
         logger.debug(
-            "Attention fusion groups (MoE) for layer {} in {:.3f}s",
+            "Attention fusion groups (MoE, merged) for layer {} in {:.3f}s",
             layer_idx,
             time.perf_counter() - t0,
         )
         return AttentionWeights(
-            q_a_proj=q_a_proj,
-            q_b_proj=q_b_proj,
-            kv_a_proj=kv_a_proj,
-            o_proj=o_views["o_proj"],
-            gate_mm=o_views["gate_mm"],
-            attn_norm=o_views["attn_norm"],
-            q_norm=o_views["q_norm"],
-            kv_norm=o_views["kv_norm"],
-            ffn_norm=o_views["ffn_norm"],
+            q_a_proj=merged_views["q_a_proj"],
+            q_b_proj=merged_views["q_b_proj"],
+            kv_a_proj=merged_views["kv_a_proj"],
+            o_proj=merged_views["o_proj"],
+            gate_mm=merged_views["gate_mm"],
+            attn_norm=merged_views["attn_norm"],
+            q_norm=merged_views["q_norm"],
+            kv_norm=merged_views["kv_norm"],
+            ffn_norm=merged_views["ffn_norm"],
             kv_b1_proj=kv_b1_proj,
             kv_b2_proj=kv_b2_proj,
             gate_bias=gate_bias_tt,
         )
 
-    def _preprocess_o_proj_dense(t: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        o_proj = t[o_proj_key].T.contiguous()
-        attn_norm = t[attn_norm_key].unsqueeze(0)
-        q_norm = t[q_norm_key].unsqueeze(0)
-        kv_norm = t[kv_norm_key].unsqueeze(0)
-        ffn_norm = t[ffn_norm_key].unsqueeze(0)
-        if o_proj.shape[0] == _MLA_TP1_O_PROJ_HEIGHT * 2:
-            o_proj = o_proj[:_MLA_TP1_O_PROJ_HEIGHT, :].contiguous()
-        gate_mm = torch.zeros(D.HIDDEN_SIZE, D.GATE_NUM_INDICES, dtype=torch.bfloat16, device=o_proj.device)
-        return {
-            "o_proj": o_proj,
-            "gate_mm": gate_mm,
-            "attn_norm": attn_norm,
-            "q_norm": q_norm,
-            "kv_norm": kv_norm,
-            "ffn_norm": ffn_norm,
-        }
-
-    o_src_dense = (o_proj_key, attn_norm_key, q_norm_key, kv_norm_key, ffn_norm_key)
-    o_fp_dense = cache_config.context.fingerprint(
-        source=SourceTensorSelection(names=o_src_dense),
-        target=O_PROJ_GATE_MM_NORMS_SPEC,
+    # Dense merged path
+    merged_src_dense = (o_proj_key, attn_norm_key, q_norm_key, kv_norm_key, ffn_norm_key) + q_ab_keys
+    merged_fp_dense = cache_config.context.fingerprint(
+        source=SourceTensorSelection(names=merged_src_dense),
+        target=MERGED_TP4_SPEC,
     )
-    o_views = cache_config.cache.get_or_create(
-        o_fp_dense,
+    merged_views = cache_config.cache.get_or_create(
+        merged_fp_dense,
         device,
-        preprocess=_preprocess_o_proj_dense,
-        raw_tensors=lambda: {k: state_dict[k] for k in o_src_dense},
+        preprocess=lambda t: _preprocess_merged(t, include_gate=False),
+        raw_tensors=lambda: {k: state_dict[k] for k in merged_src_dense},
     )
-    if not isinstance(o_views, dict):
-        raise TypeError("expected dict[str, OverlappedTensor] for o_proj_gate_mm_norms cache entry")
+    if not isinstance(merged_views, dict):
+        raise TypeError("expected dict[str, OverlappedTensor] for merged cache entry")
 
     logger.debug(
-        "Attention fusion groups (dense) for layer {} in {:.3f}s",
+        "Attention fusion groups (dense, merged) for layer {} in {:.3f}s",
         layer_idx,
         time.perf_counter() - t0,
     )
     return AttentionWeights(
-        q_a_proj=q_a_proj,
-        q_b_proj=q_b_proj,
-        kv_a_proj=kv_a_proj,
-        o_proj=o_views["o_proj"],
+        q_a_proj=merged_views["q_a_proj"],
+        q_b_proj=merged_views["q_b_proj"],
+        kv_a_proj=merged_views["kv_a_proj"],
+        o_proj=merged_views["o_proj"],
         gate_mm=None,
-        attn_norm=o_views["attn_norm"],
-        q_norm=o_views["q_norm"],
-        kv_norm=o_views["kv_norm"],
-        ffn_norm=o_views["ffn_norm"],
+        attn_norm=merged_views["attn_norm"],
+        q_norm=merged_views["q_norm"],
+        kv_norm=merged_views["kv_norm"],
+        ffn_norm=merged_views["ffn_norm"],
         kv_b1_proj=kv_b1_proj,
         kv_b2_proj=kv_b2_proj,
         gate_bias=None,

--- a/models/demos/deepseek_v3_b1/weights/specs/overlap_configs.py
+++ b/models/demos/deepseek_v3_b1/weights/specs/overlap_configs.py
@@ -311,20 +311,34 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
     )
 
     @staticmethod
-    def pack_o_proj_weights_tp4_shuffled(o_proj_weights: torch.Tensor) -> torch.Tensor:
+    def pack_o_proj_weights_tp4_shuffled(
+        o_proj_weights: torch.Tensor, mesh_shape: tuple[int, int] = (4, 2)
+    ) -> torch.Tensor:
         """Pack full-mesh o_proj weights for ``tp_dim=(1, 0)`` plus ``shuffle_q_a`` layout.
 
         Input ``o_proj_weights`` has global shape ``(16384, 7168)``.  Each mesh device's
         ``(8192, 1792)`` slice is packed with
-        :meth:`QAB_KVA_PROJ_SingleDeviceOverlapSpec.shuffle_q_a` to ``(4096, 3584)`` and
-        written to the sub-rectangle that :func:`~weights.overlap.packing.overlap_tensors`
-        reads for that device when ``raw_tensor_shape=(8192, 14336)`` and ``tp_dim=(1, 0)``.
+        :meth:`QAB_KVA_PROJ_SingleDeviceOverlapSpec.shuffle_q_a` to ``(4096, 3584)``.
+
+        For ``mesh_shape=(4, 2)`` (production TP4), all eight per-device blocks are
+        written into a single ``(8192, 14336)`` buffer at the sub-rectangles that
+        :func:`~weights.overlap.packing.overlap_tensors` reads when
+        ``raw_tensor_shape=(8192, 14336)`` and ``tp_dim=(1, 0)``.
+
+        For ``mesh_shape=(1, 1)`` (single-device simulating mesh position (0, 0)),
+        only the ``(0, 0)`` block is packed and returned as ``(4096, 3584)`` —
+        i.e. exactly the per-device shard of the TP4 layout.
         """
         if tuple(o_proj_weights.shape) != (16384, 7168):
             raise ValueError(
                 f"pack_o_proj_weights_tp4_shuffled expects shape (16384, 7168), got {tuple(o_proj_weights.shape)}"
             )
+        if mesh_shape not in {(4, 2), (1, 1)}:
+            raise ValueError(f"pack_o_proj_weights_tp4_shuffled supports mesh (4,2) or (1,1), got {mesh_shape}")
         shuffle = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.shuffle_q_a
+        if mesh_shape == (1, 1):
+            block = o_proj_weights[:8192, :1792]
+            return shuffle(block)
         out = torch.empty((8192, 14336), dtype=o_proj_weights.dtype, device=o_proj_weights.device)
         for mesh_row in range(4):
             for mesh_col in range(2):

--- a/models/demos/deepseek_v3_b1/weights/transforms/attention.py
+++ b/models/demos/deepseek_v3_b1/weights/transforms/attention.py
@@ -190,15 +190,16 @@ def fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
     ``OverlappedTensor`` backed by its own per-core allocated tensor, avoiding
     lockstep L1 reservation on the ~115 cores used by the fused buffer.
 
-    Requires a **4×2** mesh.  ``o_proj_weights`` shape ``(16384, 7168)``.
+    Supports **4×2** (production) or **1×1** (single-device simulating mesh
+    position (0, 0) of the 4×2 layout).  ``o_proj_weights`` shape ``(16384, 7168)``.
     Must be the first per-core allocation on the device.
     """
     o_cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
     q_cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
-    mesh_shape = (device.shape[0], device.shape[1])
-    if mesh_shape != (4, 2):
+    mesh_shape = (device.shape[0], device.shape[1]) if device.get_num_devices() > 1 else (1, 1)
+    if mesh_shape not in {(4, 2), (1, 1)}:
         raise ValueError(
-            "fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a requires a 4x2 mesh; "
+            "fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a requires a 4x2 or 1x1 mesh; "
             f"got {mesh_shape[0]}x{mesh_shape[1]}"
         )
     if tuple(o_proj_weights.shape) != (16384, 7168):
@@ -214,7 +215,7 @@ def fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a(
     assert device_grid.y >= required_rows, f"Device grid needs at least {required_rows} rows, got {device_grid.y}"
     assert device_grid.x >= required_cols, f"Device grid needs at least {required_cols} cols, got {device_grid.x}"
 
-    o_packed = o_cfg.pack_o_proj_weights_tp4_shuffled(o_proj_weights)
+    o_packed = o_cfg.pack_o_proj_weights_tp4_shuffled(o_proj_weights, mesh_shape=mesh_shape)
     o_spec = replace(
         o_cfg.o_proj,
         raw_tensor_shape=tuple(o_packed.shape),


### PR DESCRIPTION
…duce + column all gather

Mirror the attention_block TP4 pipeline in post_sdpa: slice matmul5 along the inner dim, run GatherReduce3 on the sender core, then TP AllReduce with per-device tile/page overrides, and finish with a no-ownership column AllGather that reuses gather3_scratch_cb for transport scratch.  The receiver NCRISC now does an unconditional residual NOC copy from the gather core's residual slice.

Update test_pre_sdpa and test_moe_routed_expert (4x2 paths only) to use the combined fuse_o_proj_tp4_shuffled_gate_mm_norms_q_ab_kv_a overlap; 1x1 path keeps the split fuse calls.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=worktree-tp8-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-tp8-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=worktree-tp8-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:worktree-tp8-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=worktree-tp8-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-tp8-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=worktree-tp8-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-tp8-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=worktree-tp8-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-tp8-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=worktree-tp8-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-tp8-cleanup)