### PR TITLE
Remove split_dispatch_page_preamble_size

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -125,7 +125,6 @@ void DispatchKernel::GenerateStaticConfigs() {
 
         static_config_.my_downstream_cb_sem_id = 0;  // unused
 
-        static_config_.split_dispatch_page_preamble_size = 0;        // unused
         static_config_.prefetch_h_max_credits = 0;                   // unused prefetch_downstream_buffer_pages
 
         static_config_.packed_write_max_unicast_sub_cmds =
@@ -178,7 +177,6 @@ void DispatchKernel::GenerateStaticConfigs() {
 
         static_config_.my_downstream_cb_sem_id = 0;  // Unused
 
-        static_config_.split_dispatch_page_preamble_size = 0;
         static_config_.prefetch_h_max_credits = my_dispatch_constants.prefetch_d_buffer_pages();
         static_config_.packed_write_max_unicast_sub_cmds =
             device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
@@ -209,7 +207,6 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.completion_queue_base_addr = 0;
         static_config_.completion_queue_size = 0;
 
-        static_config_.split_dispatch_page_preamble_size = 0;
         static_config_.prefetch_h_max_credits = my_dispatch_constants.prefetch_d_buffer_pages();
         static_config_.my_downstream_cb_sem_id = tt_metal::CreateSemaphore(
             *program_, logical_core_, my_dispatch_constants.prefetch_d_buffer_pages(), GetCoreType());
@@ -492,7 +489,6 @@ void DispatchKernel::CreateKernel() {
         {"DOWNSTREAM_CB_SIZE", std::to_string(dependent_config_.downstream_cb_size.value())},
         {"MY_DOWNSTREAM_CB_SEM_ID", std::to_string(static_config_.my_downstream_cb_sem_id.value())},
         {"DOWNSTREAM_CB_SEM_ID", std::to_string(dependent_config_.downstream_cb_sem_id.value())},
-        {"SPLIT_DISPATCH_PAGE_PREAMBLE_SIZE", std::to_string(static_config_.split_dispatch_page_preamble_size.value())},
         {"SPLIT_PREFETCH", std::to_string(dependent_config_.split_prefetch.value())},
         {"PREFETCH_H_NOC_XY", std::to_string(dependent_config_.prefetch_h_noc_xy.value())},
         {"PREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR",

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -30,7 +30,6 @@ struct dispatch_static_config_t {
 
     std::optional<uint32_t> my_downstream_cb_sem_id;
 
-    std::optional<uint32_t> split_dispatch_page_preamble_size;  // 14
     std::optional<uint32_t> prefetch_h_max_credits;             // Used if split_prefetch is true
 
     std::optional<uint32_t> packed_write_max_unicast_sub_cmds;  // 19

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -37,7 +37,6 @@ constexpr uint32_t downstream_cb_base = DOWNSTREAM_CB_BASE;
 constexpr uint32_t downstream_cb_size = DOWNSTREAM_CB_SIZE;
 constexpr uint32_t my_downstream_cb_sem_id = MY_DOWNSTREAM_CB_SEM_ID;
 constexpr uint32_t downstream_cb_sem_id = DOWNSTREAM_CB_SEM_ID;
-constexpr uint32_t split_dispatch_page_preamble_size = SPLIT_DISPATCH_PAGE_PREAMBLE_SIZE;
 constexpr uint32_t split_prefetch = SPLIT_PREFETCH;
 constexpr uint32_t prefetch_h_noc_xy = PREFETCH_H_NOC_XY;
 constexpr uint32_t prefetch_h_local_downstream_sem_addr = PREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR;
@@ -382,10 +381,7 @@ CBWriter<my_downstream_cb_sem_id, 0, 0, 0> dispatch_h_cb_writer{};
 // Relay, potentially through the mux/dmux/tunneller path
 // Code below sends 1 page worth of data except at the end of a cmd
 // This means the downstream buffers are always page aligned, simplifies wrap handling
-template <uint32_t preamble_size>
 void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
-    static_assert(preamble_size == 0, "Dispatcher preamble size must be 0. This is not supported anymore with Fabric");
-
     // DPRINT << "relay_to_next_cb: " << data_ptr << " " << dispatch_cb_reader.cb_fence << " " << wlength << ENDL();
     // DEVICE_PRINT("relay_to_next_cb: data_ptr {} dispatch_cb_reader.cb_fence {} wlength {}\n", data_ptr,
     // dispatch_cb_reader.cb_fence, wlength);
@@ -411,8 +407,8 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
 
             uint32_t xfer_size;
             bool not_end_of_cmd;
-            if (length > dispatch_cb_page_size - preamble_size) {
-                xfer_size = dispatch_cb_page_size - preamble_size;
+            if (length > dispatch_cb_page_size) {
+                xfer_size = dispatch_cb_page_size;
                 not_end_of_cmd = true;
             } else {
                 xfer_size = length;
@@ -420,14 +416,6 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
             }
             length -= xfer_size;
 
-            if constexpr (preamble_size > 0) {
-                uint32_t flag;
-                relay_client.write_inline<my_noc_index>(
-                    get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr),
-                    xfer_size + preamble_size + not_end_of_cmd);
-                downstream_cb_data_ptr += preamble_size;
-                ASSERT(downstream_cb_data_ptr < downstream_cb_end);
-            }
             // Get a page if needed
             if (xfer_size > dispatch_cb_reader.available_bytes(data_ptr)) {
                 dispatch_cb_reader.get_cb_page_and_release_pages(data_ptr, [&](bool will_wrap) {
@@ -478,7 +466,7 @@ void process_write_host_d() {
     uint64_t length = cmd->write_linear_host.length;
     uint32_t data_ptr = cmd_ptr;
 
-    relay_to_next_cb<split_dispatch_page_preamble_size>(data_ptr, length);
+    relay_to_next_cb(data_ptr, length);
 }
 
 void relay_write_h() {
@@ -486,10 +474,10 @@ void relay_write_h() {
     uint64_t length = sizeof(CQDispatchCmdLarge) + cmd->write_linear.length;
     uint32_t data_ptr = cmd_ptr;
 
-    relay_to_next_cb<split_dispatch_page_preamble_size>(data_ptr, length);
+    relay_to_next_cb(data_ptr, length);
 }
 
-void process_exec_buf_end_d() { relay_to_next_cb<split_dispatch_page_preamble_size>(cmd_ptr, sizeof(CQDispatchCmd)); }
+void process_exec_buf_end_d() { relay_to_next_cb(cmd_ptr, sizeof(CQDispatchCmd)); }
 
 // Note that for non-paged writes, the number of writes per page is always 1
 // This means each noc_write frees up a page
@@ -1308,7 +1296,7 @@ re_run_command:
             // DPRINT << "dispatch terminate\n";
             // DEVICE_PRINT("dispatch terminate\n");
             if (is_d_variant && !is_h_variant) {
-                relay_to_next_cb<split_dispatch_page_preamble_size>(cmd_ptr, sizeof(CQDispatchCmd));
+                relay_to_next_cb(cmd_ptr, sizeof(CQDispatchCmd));
             }
             cmd_ptr += sizeof(CQDispatchCmd);
             done = true;
@@ -1430,8 +1418,6 @@ void kernel_main() {
             -NOC_STREAM_READ_REG(index, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)
                 << REMOTE_DEST_BUF_WORDS_FREE_INC);
     }
-
-    static_assert(is_d_variant || split_dispatch_page_preamble_size == 0);
 
     uint32_t l1_cache[l1_cache_elements_rounded];
 


### PR DESCRIPTION
### Summary

Closes #31733

With Fabric, split dispatch preamble size is no longer supported. This PR removes the variable from the dispatch config and refactors cq_dispatch to remove usage of it.

### Notes for reviewers
A static assert within cq_dispatch required `preamble_size == 0`, so no behavior changes are implicated with this change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT-31733-remove-dispach-preamble-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT-31733-remove-dispach-preamble-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anashTT-31733-remove-dispach-preamble-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anashTT-31733-remove-dispach-preamble-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT-31733-remove-dispach-preamble-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT-31733-remove-dispach-preamble-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT-31733-remove-dispach-preamble-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT-31733-remove-dispach-preamble-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT-31733-remove-dispach-preamble-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT-31733-remove-dispach-preamble-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT-31733-remove-dispach-preamble-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT-31733-remove-dispach-preamble-size)