### PR TITLE
MatmulMultiCoreProgramFactory to pass accuracy params to kernels

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -1,7 +1,11 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/ttnn)
 
 add_library(test_common_utils STATIC)
-target_sources(test_common_utils PUBLIC common_test_utils.cpp)
+# PRIVATE so consumers that link `test_common_utils` don't also recompile this
+# source file into their own OBJECT library (which would produce duplicate
+# symbols when the final executable links both the OBJECT library and this
+# static lib).
+target_sources(test_common_utils PRIVATE common_test_utils.cpp)
 target_link_libraries(test_common_utils PRIVATE TTNN::CPP)
 tt_reuse_precompile_headers(test_common_utils TTNN::PCH)
 
@@ -49,6 +53,7 @@ target_link_libraries(
     unit_tests_ttnn_basic
     PRIVATE
         test_common_libs
+        test_common_utils
         TTNN::CPP
 )
 tt_reuse_precompile_headers(unit_tests_ttnn_basic TTNN::PCH)

--- a/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
@@ -5,10 +5,12 @@
 #include "common_test_utils.hpp"
 
 #include <cstddef>
-#include <stdexcept>
 #include <cmath>
+#include <limits>
 #include <variant>
 #include <vector>
+
+#include <gtest/gtest.h>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/core.hpp"
@@ -18,8 +20,9 @@
 namespace ttnn::test_utils {
 
 float pcc(const std::vector<float>& x, const std::vector<float>& y) {
+    EXPECT_EQ(x.size(), y.size()) << "pcc: input vectors must be the same length";
     if (x.size() != y.size()) {
-        throw std::invalid_argument("Vectors must be of the same length.");
+        return 0.0f;
     }
     int n = x.size();
     float mean_x = 0, mean_y = 0;
@@ -49,8 +52,10 @@ float pcc(const std::vector<float>& x, const std::vector<float>& y) {
 
 float relative_frobenius(
     const std::vector<float>& actual, const std::vector<float>& expected, bool& expected_norm_is_zero) {
+    EXPECT_EQ(actual.size(), expected.size()) << "relative_frobenius: input vectors must be the same length";
     if (actual.size() != expected.size()) {
-        throw std::invalid_argument("Vectors must be of the same length.");
+        expected_norm_is_zero = false;
+        return std::numeric_limits<float>::quiet_NaN();
     }
     // Use double accumulators: squaring + summing O(1e6) bf16-range values in float
     // loses precision quickly and can make the relative norm wander by several percent.
@@ -69,13 +74,58 @@ float relative_frobenius(
 
 AllcloseReport allclose_report(
     const std::vector<float>& actual, const std::vector<float>& expected, float rtol, float atol) {
+    EXPECT_EQ(actual.size(), expected.size()) << "allclose_report: input vectors must be the same length";
     if (actual.size() != expected.size()) {
-        throw std::invalid_argument("Vectors must be of the same length.");
+        return AllcloseReport{};
     }
     AllcloseReport report;
+    constexpr float inf = std::numeric_limits<float>::infinity();
     for (std::size_t i = 0; i < actual.size(); ++i) {
         const float a = actual[i];
         const float b = expected[i];
+
+        // Match torch.allclose(..., equal_nan=False) semantics for non-finite elements:
+        //   - matching same-sign infinities are close (+inf vs +inf, -inf vs -inf);
+        //   - any NaN is not close (NaN == anything is always false in IEEE 754);
+        //   - mismatched infinities and inf-vs-finite are not close.
+        // The regular tolerance formula below cannot handle these cases on its own:
+        // (inf - inf) is NaN, NaN propagates silently through every `>` comparison
+        // (NaN > x is always false), so without this guard a non-finite element would
+        // never be counted as a failure or surface in the worst-element diagnostics.
+        // For the failure cases we use an infinite sentinel diff/margin so the bad
+        // element wins every "worst" slot, while preserving the original a/b values
+        // in the diagnostic fields so the reader can see whether it was a NaN or an Inf.
+        if (!std::isfinite(a) || !std::isfinite(b)) {
+            if (a == b) {
+                // +inf vs +inf or -inf vs -inf: torch.allclose treats these as close.
+                // (NaN == NaN is always false, so NaNs cannot reach this branch.)
+                continue;
+            }
+            ++report.failures;
+            if (inf > report.worst_atol_diff) {
+                report.worst_atol_diff = inf;
+                report.worst_atol_index = i;
+                report.worst_atol_actual = a;
+                report.worst_atol_expected = b;
+            }
+            if (inf > report.worst_rtol_rel) {
+                report.worst_rtol_rel = inf;
+                report.worst_rtol_index = i;
+                report.worst_rtol_diff = inf;
+                report.worst_rtol_actual = a;
+                report.worst_rtol_expected = b;
+            }
+            if (inf > report.worst_margin) {
+                report.worst_margin = inf;
+                report.worst_margin_index = i;
+                report.worst_margin_diff = inf;
+                report.worst_margin_tol = 0.0f;
+                report.worst_margin_actual = a;
+                report.worst_margin_expected = b;
+            }
+            continue;
+        }
+
         const float diff = std::abs(a - b);
         const float tol = atol + rtol * std::abs(b);
         const float margin = diff - tol;
@@ -89,17 +139,13 @@ AllcloseReport allclose_report(
             report.worst_atol_actual = a;
             report.worst_atol_expected = b;
         }
-        // Skip near-zero expected values when computing relative error to avoid
-        // division noise from denormal-like tiny references.
-        if (std::abs(b) > 1e-6f) {
-            const float rel = diff / std::abs(b);
-            if (rel > report.worst_rtol_rel) {
-                report.worst_rtol_rel = rel;
-                report.worst_rtol_index = i;
-                report.worst_rtol_diff = diff;
-                report.worst_rtol_actual = a;
-                report.worst_rtol_expected = b;
-            }
+        const float rel = diff / std::abs(b);
+        if (rel > report.worst_rtol_rel) {
+            report.worst_rtol_rel = rel;
+            report.worst_rtol_index = i;
+            report.worst_rtol_diff = diff;
+            report.worst_rtol_actual = a;
+            report.worst_rtol_expected = b;
         }
         if (margin > report.worst_margin) {
             report.worst_margin = margin;
@@ -108,6 +154,45 @@ AllcloseReport allclose_report(
             report.worst_margin_tol = tol;
             report.worst_margin_actual = a;
             report.worst_margin_expected = b;
+        }
+    }
+    return report;
+}
+
+NonfiniteReport check_nonfinite_positions(const std::vector<float>& actual, const std::vector<float>& expected) {
+    EXPECT_EQ(actual.size(), expected.size()) << "check_nonfinite_positions: input vectors must be the same length";
+    if (actual.size() != expected.size()) {
+        return NonfiniteReport{};
+    }
+    NonfiniteReport report;
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        const float a = actual[i];
+        const float b = expected[i];
+        const bool a_is_nan = std::isnan(a);
+        const bool b_is_nan = std::isnan(b);
+        const bool a_is_inf = std::isinf(a);
+        const bool b_is_inf = std::isinf(b);
+
+        if (a_is_nan || b_is_nan || a_is_inf || b_is_inf) {
+            report.any_nonfinite = true;
+        }
+
+        // NaN positions must match exactly.
+        if (a_is_nan != b_is_nan) {
+            report.positions_match = false;
+            report.first_mismatch_index = i;
+            report.first_mismatch_actual = a;
+            report.first_mismatch_expected = b;
+            return report;
+        }
+        // Inf positions and signs must match exactly.  std::signbit picks +/- correctly
+        // for both +inf and -inf, so comparing it only when both are Inf is sufficient.
+        if (a_is_inf != b_is_inf || (a_is_inf && b_is_inf && std::signbit(a) != std::signbit(b))) {
+            report.positions_match = false;
+            report.first_mismatch_index = i;
+            report.first_mismatch_actual = a;
+            report.first_mismatch_expected = b;
+            return report;
         }
     }
     return report;

--- a/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "common_test_utils.hpp"
 
+#include <cstddef>
 #include <stdexcept>
 #include <cmath>
 #include <variant>
@@ -44,6 +45,72 @@ float pcc(const std::vector<float>& x, const std::vector<float>& y) {
     }
 
     return numerator / denominator;
+}
+
+float relative_frobenius(
+    const std::vector<float>& actual, const std::vector<float>& expected, bool& expected_norm_is_zero) {
+    if (actual.size() != expected.size()) {
+        throw std::invalid_argument("Vectors must be of the same length.");
+    }
+    // Use double accumulators: squaring + summing O(1e6) bf16-range values in float
+    // loses precision quickly and can make the relative norm wander by several percent.
+    double err_sq = 0.0;
+    double expected_sq = 0.0;
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        const double d = static_cast<double>(actual[i]) - static_cast<double>(expected[i]);
+        err_sq += d * d;
+        expected_sq += static_cast<double>(expected[i]) * static_cast<double>(expected[i]);
+    }
+    const double err_norm = std::sqrt(err_sq);
+    const double expected_norm = std::sqrt(expected_sq);
+    expected_norm_is_zero = (expected_norm == 0.0);
+    return static_cast<float>(expected_norm_is_zero ? err_norm : (err_norm / expected_norm));
+}
+
+AllcloseReport allclose_report(
+    const std::vector<float>& actual, const std::vector<float>& expected, float rtol, float atol) {
+    if (actual.size() != expected.size()) {
+        throw std::invalid_argument("Vectors must be of the same length.");
+    }
+    AllcloseReport report;
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        const float a = actual[i];
+        const float b = expected[i];
+        const float diff = std::abs(a - b);
+        const float tol = atol + rtol * std::abs(b);
+        const float margin = diff - tol;
+
+        if (margin > 0.0f) {
+            ++report.failures;
+        }
+        if (diff > report.worst_atol_diff) {
+            report.worst_atol_diff = diff;
+            report.worst_atol_index = i;
+            report.worst_atol_actual = a;
+            report.worst_atol_expected = b;
+        }
+        // Skip near-zero expected values when computing relative error to avoid
+        // division noise from denormal-like tiny references.
+        if (std::abs(b) > 1e-6f) {
+            const float rel = diff / std::abs(b);
+            if (rel > report.worst_rtol_rel) {
+                report.worst_rtol_rel = rel;
+                report.worst_rtol_index = i;
+                report.worst_rtol_diff = diff;
+                report.worst_rtol_actual = a;
+                report.worst_rtol_expected = b;
+            }
+        }
+        if (margin > report.worst_margin) {
+            report.worst_margin = margin;
+            report.worst_margin_index = i;
+            report.worst_margin_diff = diff;
+            report.worst_margin_tol = tol;
+            report.worst_margin_actual = a;
+            report.worst_margin_expected = b;
+        }
+    }
+    return report;
 }
 
 Tensor dispatch_ops_to_device(const Tensor& input_tensor, QueueId cq_id) {

--- a/tests/ttnn/unit_tests/gtests/common_test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/common_test_utils.hpp
@@ -12,7 +12,9 @@
 
 namespace ttnn::test_utils {
 
-// Pearson Correlation Coefficient for two float vectors
+// Pearson Correlation Coefficient for two float vectors.
+// Both vectors must be the same size; if not, records a non-fatal gtest failure
+// (EXPECT_EQ) and returns 0.0f without computing a correlation.
 float pcc(const std::vector<float>& x, const std::vector<float>& y);
 
 // Relative Frobenius norm of the difference: ||actual - expected||_F / ||expected||_F.
@@ -20,11 +22,13 @@ float pcc(const std::vector<float>& x, const std::vector<float>& y);
 // ||expected||_F is zero, falls back to the absolute Frobenius error and reports that
 // via the `expected_norm_is_zero` out-parameter so callers can word failure messages
 // appropriately ("Absolute" vs "Relative" Frobenius error).
+// Both vectors must be the same size; if not, records a non-fatal gtest failure
+// (EXPECT_EQ), sets `expected_norm_is_zero` to false, and returns NaN without computing
+// a Frobenius norm.
 float relative_frobenius(
     const std::vector<float>& actual, const std::vector<float>& expected, bool& expected_norm_is_zero);
 
-// Summary of an element-wise comparison between `actual` and `expected`, using
-// torch.allclose semantics: |actual[i] - expected[i]| <= atol + rtol * |expected[i]|.
+// Summary of an element-wise comparison between `actual` and `expected`.
 //
 // In addition to the failure count it records the worst elements by absolute error,
 // relative error and allclose margin so failures can be diagnosed without re-running
@@ -40,8 +44,7 @@ struct AllcloseReport {
     float worst_atol_actual = 0.0f;
     float worst_atol_expected = 0.0f;
 
-    // Worst element by relative error |actual[i] - expected[i]| / |expected[i]| among
-    // elements whose expected value is not near zero (|expected[i]| > 1e-6).
+    // Worst element by relative error |actual[i] - expected[i]| / |expected[i]|.
     std::size_t worst_rtol_index = 0;
     float worst_rtol_rel = 0.0f;
     float worst_rtol_diff = 0.0f;
@@ -59,10 +62,62 @@ struct AllcloseReport {
     float worst_margin_expected = 0.0f;
 };
 
-// Compute an AllcloseReport comparing `actual` against `expected` with torch.allclose
-// tolerance semantics (|a - b| <= atol + rtol * |b|).  Both vectors must be the same size.
+// Compute an AllcloseReport comparing `actual` against `expected` using
+// torch.allclose(..., equal_nan=False) semantics:
+//   - finite elements are close iff |a - b| <= atol + rtol * |b|;
+//   - matching same-sign infinities (+inf vs +inf, -inf vs -inf) are close;
+//   - any NaNs, mismatched infinities (+inf vs -inf), and inf-vs-finite are not close.
+// When a non-finite element is counted as a failure, it dominates every "worst"
+// slot (absolute, relative and margin) using infinite sentinel diff/margin values,
+// while the original `actual`/`expected` values are preserved in the diagnostic
+// fields so the reader can tell whether it was a NaN or an Inf.
+// Both vectors must be the same size; if not, records a non-fatal gtest failure
+// (EXPECT_EQ) and returns a default-constructed AllcloseReport (failures = 0, all
+// worst-element fields at their defaults) without inspecting any element.
 AllcloseReport allclose_report(
     const std::vector<float>& actual, const std::vector<float>& expected, float rtol, float atol);
+
+// Result of a non-finite position check between two vectors.  Records whether the
+// positions and signs of NaN/Inf elements agree, and the first index where they
+// don't when they don't.
+//
+// `positions_match` is true iff:
+//   - NaN appears at the same set of indices in both vectors, AND
+//   - Inf appears at the same set of indices in both vectors, AND
+//   - Inf signs agree at those indices.
+// When false, the `first_mismatch_*` fields describe the first index where the
+// disagreement occurs.
+//
+// See `check_nonfinite_positions` for the producer and the recommended caller pattern.
+struct NonfiniteReport {
+    bool positions_match = true;
+    // Whether either vector has any non-finite element (NaN or Inf).  When this is false,
+    // both vectors are all-finite and `positions_match` is trivially true.
+    bool any_nonfinite = false;
+    // First index where the non-finite-position rule above is violated.  Unspecified when
+    // `positions_match` is true.
+    std::size_t first_mismatch_index = 0;
+    float first_mismatch_actual = 0.0f;
+    float first_mismatch_expected = 0.0f;
+};
+
+// Pre-check for unexpected NaN/Inf values between `actual` and `expected`.  Mirrors
+// models/common/utility_functions.py::_comp_nonfinite.
+// Both vectors must be the same size; if not, records a non-fatal gtest failure
+// (EXPECT_EQ) and returns a default-constructed NonfiniteReport (positions_match = true,
+// any_nonfinite = false) without inspecting any element.
+//
+// Run before tolerance/correlation metrics (allclose_report, pcc, relative_frobenius)
+// so that an unexpected NaN/Inf produces a clear, dedicated failure. Examples:
+//   - `positions_match == false` is a more direct diagnosis than what allclose_report
+//     would produce: allclose_report will count a finite-vs-Inf element as a tolerance
+//     failure and report it via the "worst" slots, but the message reads like an ordinary
+//     out-of-tolerance miss rather than "the device produced a non-finite value here";
+//   - `any_nonfinite == true` lets callers skip pcc / relative_frobenius entirely.  Those
+//     metrics NaN-poison on any non-finite input (e.g. pcc evaluates inf - inf = NaN)
+//     even when the non-finites match positions and signs, so once `any_nonfinite` is true
+//     their numeric output is unreliable.
+NonfiniteReport check_nonfinite_positions(const std::vector<float>& actual, const std::vector<float>& expected);
 
 // Dispatches a series of elementwise arithmetic operations over a tensor to `cq_id`, according to the expression:
 // `output_tensor = - 32 * (input_tensor) + 128`

--- a/tests/ttnn/unit_tests/gtests/common_test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/common_test_utils.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <limits>
 #include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -12,6 +14,55 @@ namespace ttnn::test_utils {
 
 // Pearson Correlation Coefficient for two float vectors
 float pcc(const std::vector<float>& x, const std::vector<float>& y);
+
+// Relative Frobenius norm of the difference: ||actual - expected||_F / ||expected||_F.
+// Matches tests/ttnn/utils_for_testing.py::comp_relative_frobenius semantics: when
+// ||expected||_F is zero, falls back to the absolute Frobenius error and reports that
+// via the `expected_norm_is_zero` out-parameter so callers can word failure messages
+// appropriately ("Absolute" vs "Relative" Frobenius error).
+float relative_frobenius(
+    const std::vector<float>& actual, const std::vector<float>& expected, bool& expected_norm_is_zero);
+
+// Summary of an element-wise comparison between `actual` and `expected`, using
+// torch.allclose semantics: |actual[i] - expected[i]| <= atol + rtol * |expected[i]|.
+//
+// In addition to the failure count it records the worst elements by absolute error,
+// relative error and allclose margin so failures can be diagnosed without re-running
+// the test.  All `*_index` fields are flat offsets into the input vectors; callers
+// that want row/col coordinates should divide/modulo by the row stride themselves.
+struct AllcloseReport {
+    // Number of elements that violate |actual[i] - expected[i]| <= atol + rtol * |expected[i]|.
+    std::size_t failures = 0;
+
+    // Worst element by absolute error |actual[i] - expected[i]|.
+    std::size_t worst_atol_index = 0;
+    float worst_atol_diff = 0.0f;
+    float worst_atol_actual = 0.0f;
+    float worst_atol_expected = 0.0f;
+
+    // Worst element by relative error |actual[i] - expected[i]| / |expected[i]| among
+    // elements whose expected value is not near zero (|expected[i]| > 1e-6).
+    std::size_t worst_rtol_index = 0;
+    float worst_rtol_rel = 0.0f;
+    float worst_rtol_diff = 0.0f;
+    float worst_rtol_actual = 0.0f;
+    float worst_rtol_expected = 0.0f;
+
+    // Worst element by allclose margin: (|actual[i] - expected[i]|) - (atol + rtol * |expected[i]|).
+    // Positive margin means the element failed allclose; reporting this identifies the element
+    // most responsible for the failure.
+    std::size_t worst_margin_index = 0;
+    float worst_margin = -std::numeric_limits<float>::infinity();
+    float worst_margin_diff = 0.0f;
+    float worst_margin_tol = 0.0f;
+    float worst_margin_actual = 0.0f;
+    float worst_margin_expected = 0.0f;
+};
+
+// Compute an AllcloseReport comparing `actual` against `expected` with torch.allclose
+// tolerance semantics (|a - b| <= atol + rtol * |b|).  Both vectors must be the same size.
+AllcloseReport allclose_report(
+    const std::vector<float>& actual, const std::vector<float>& expected, float rtol, float atol);
 
 // Dispatches a series of elementwise arithmetic operations over a tensor to `cq_id`, according to the expression:
 // `output_tensor = - 32 * (input_tensor) + 128`

--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -26,6 +26,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_graph_query_op_constraints.cpp
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp
+    test_matmul_multicore.cpp
     test_reduction.cpp
     test_relational_int.cpp
     test_rsub_int.cpp

--- a/tests/ttnn/unit_tests/gtests/test_matmul_multicore.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_multicore.cpp
@@ -57,14 +57,14 @@ class MatmulMulticoreFixture : public TTNNFixtureWithSuiteDevice<MatmulMulticore
                                public testing::WithParamInterface<MatmulMulticoreParam> {};
 
 // Verify that MatmulMultiCoreProgramFactory produces accurate results.
-TEST_P(MatmulMulticoreFixture, ComputeKernelConfigIsForwarded) {
+TEST_P(MatmulMulticoreFixture, MatmulMulticoreAccuracy) {
     auto param = GetParam();
     const int M = param.M;
     const int K = param.K;
     const int N = param.N;
 
-    // Generate random float32 inputs using a fixed seed (matches torch.manual_seed(0)
-    // + torch.randn behaviour from Python regtests).
+    // Generate random float32 inputs using a fixed seed (similar to torch.randn behaviour
+    // from Python regtests).
     std::mt19937 rng(0);
     std::normal_distribution<float> dist(0.0f, 1.0f);
 
@@ -84,22 +84,21 @@ TEST_P(MatmulMulticoreFixture, ComputeKernelConfigIsForwarded) {
     // --- Device matmul ---
     auto& device = *device_;
 
-    const MemoryConfig l1_mem_cfg{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::L1};
-    const TensorLayout float32_l1_tile(DataType::FLOAT32, PageConfig(Layout::TILE), l1_mem_cfg);
+    const MemoryConfig mem_cfg{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const TensorLayout layout(DataType::FLOAT32, PageConfig(Layout::TILE), mem_cfg);
     const ttnn::QueueId cq = ttnn::QueueId(0);
 
     // Create input tensors on device via the host → device path used in other gtests.
-    const Tensor host_a = Tensor::from_vector(data_a, TensorSpec(ttnn::Shape({M, K}), float32_l1_tile));
-    const Tensor host_b = Tensor::from_vector(data_b, TensorSpec(ttnn::Shape({K, N}), float32_l1_tile));
-    const Tensor input_a = host_a.to_device(&device, l1_mem_cfg, cq);
-    const Tensor input_b = host_b.to_device(&device, l1_mem_cfg, cq);
+    const Tensor host_a = Tensor::from_vector(data_a, TensorSpec(ttnn::Shape({M, K}), layout));
+    const Tensor host_b = Tensor::from_vector(data_b, TensorSpec(ttnn::Shape({K, N}), layout));
+    const Tensor input_a = host_a.to_device(&device, mem_cfg, cq);
+    const Tensor input_b = host_b.to_device(&device, mem_cfg, cq);
 
     // HiFi3 + fp32_dest_acc_en to avoid known Wormhole HW bug #38306.
     const ttnn::ComputeKernelConfig compute_cfg{
         .math_fidelity = tt::tt_metal::MathFidelity::HiFi3,
         .math_approx_mode = false,
         .fp32_dest_acc_en = true,
-        .packer_l1_acc = true,
     };
 
     // Bypass the auto-selection logic and force MatmulMultiCoreProgramFactory,
@@ -111,7 +110,7 @@ TEST_P(MatmulMulticoreFixture, ComputeKernelConfigIsForwarded) {
         input_b,
         /*transpose_a=*/false,
         /*transpose_b=*/false,
-        l1_mem_cfg,
+        mem_cfg,
         /*dtype=*/std::nullopt,
         program_cfg,
         /*activation=*/std::nullopt,

--- a/tests/ttnn/unit_tests/gtests/test_matmul_multicore.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_multicore.cpp
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression test for MatmulMultiCoreProgramFactory (the simplest "fallback of last resort"
+// factory selected when no optimised mcast variant fits the device grid).
+// The test bypasses the auto-selection logic by explicitly passing a non-default
+// MatmulMultiCoreProgramConfig{} as the program_config, so it works regardless of
+// the device grid size or memory configuration.
+
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <vector>
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/shape.hpp>
+#include "common_test_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+namespace ttnn::operations::matmul::test {
+
+namespace {
+
+// Compute the CPU float32 reference: C = A * B (M x K) * (K x N) -> (M x N).
+// Uses i-k-j loop order for good cache locality on the innermost j loop.
+void cpu_matmul_f32(
+    const std::vector<float>& a, const std::vector<float>& b, std::vector<float>& c, int M, int K, int N) {
+    std::fill(c.begin(), c.end(), 0.0f);
+    for (int i = 0; i < M; ++i) {
+        for (int k = 0; k < K; ++k) {
+            float aik = a[i * K + k];
+            for (int j = 0; j < N; ++j) {
+                c[i * N + j] += aik * b[k * N + j];
+            }
+        }
+    }
+}
+
+}  // namespace
+
+struct MatmulMulticoreParam {
+    int M;
+    int K;
+    int N;
+};
+
+class MatmulMulticoreFixture : public TTNNFixtureWithSuiteDevice<MatmulMulticoreFixture>,
+                               public testing::WithParamInterface<MatmulMulticoreParam> {};
+
+// Verify that MatmulMultiCoreProgramFactory produces accurate results.
+TEST_P(MatmulMulticoreFixture, ComputeKernelConfigIsForwarded) {
+    auto param = GetParam();
+    const int M = param.M;
+    const int K = param.K;
+    const int N = param.N;
+
+    // Generate random float32 inputs using a fixed seed (matches torch.manual_seed(0)
+    // + torch.randn behaviour from Python regtests).
+    std::mt19937 rng(0);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+
+    std::vector<float> data_a(M * K);
+    std::vector<float> data_b(K * N);
+    for (float& v : data_a) {
+        v = dist(rng);
+    }
+    for (float& v : data_b) {
+        v = dist(rng);
+    }
+
+    // --- CPU float32 reference ---
+    std::vector<float> ref_c(M * N);
+    cpu_matmul_f32(data_a, data_b, ref_c, M, K, N);
+
+    // --- Device matmul ---
+    auto& device = *device_;
+
+    const MemoryConfig l1_mem_cfg{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::L1};
+    const TensorLayout float32_l1_tile(DataType::FLOAT32, PageConfig(Layout::TILE), l1_mem_cfg);
+    const ttnn::QueueId cq = ttnn::QueueId(0);
+
+    // Create input tensors on device via the host → device path used in other gtests.
+    const Tensor host_a = Tensor::from_vector(data_a, TensorSpec(ttnn::Shape({M, K}), float32_l1_tile));
+    const Tensor host_b = Tensor::from_vector(data_b, TensorSpec(ttnn::Shape({K, N}), float32_l1_tile));
+    const Tensor input_a = host_a.to_device(&device, l1_mem_cfg, cq);
+    const Tensor input_b = host_b.to_device(&device, l1_mem_cfg, cq);
+
+    // HiFi3 + fp32_dest_acc_en to avoid known Wormhole HW bug #38306.
+    const ttnn::ComputeKernelConfig compute_cfg{
+        .math_fidelity = tt::tt_metal::MathFidelity::HiFi3,
+        .math_approx_mode = false,
+        .fp32_dest_acc_en = true,
+        .packer_l1_acc = true,
+    };
+
+    // Bypass the auto-selection logic and force MatmulMultiCoreProgramFactory,
+    // regardless of the device grid size or memory configuration.
+    const MatmulProgramConfig program_cfg = MatmulMultiCoreProgramConfig{};
+
+    const Tensor output = ttnn::matmul(
+        input_a,
+        input_b,
+        /*transpose_a=*/false,
+        /*transpose_b=*/false,
+        l1_mem_cfg,
+        /*dtype=*/std::nullopt,
+        program_cfg,
+        /*activation=*/std::nullopt,
+        compute_cfg);
+
+    const std::vector<float> device_c = output.to_vector<float>();
+
+    // --- Validation ---
+    // Use the combination of allclose, relative Frobenius, and pcc checks,
+    // mirroring assert_numeric_metrics from tests/ttnn/utils_for_testing.py.
+    constexpr float rtol = 0.1f;
+    constexpr float atol = 0.108f;
+    // Relative Frobenius catches global error magnitude that individual
+    // allclose checks might miss when errors are widely distributed.
+    constexpr float frobenius_threshold = 0.002f;
+    constexpr float pcc_threshold = 0.9999f;
+    const ttnn::test_utils::AllcloseReport report = ttnn::test_utils::allclose_report(device_c, ref_c, rtol, atol);
+    bool expected_norm_is_zero = false;
+    const float frobenius = ttnn::test_utils::relative_frobenius(device_c, ref_c, expected_norm_is_zero);
+    const float pcc = ttnn::test_utils::pcc(device_c, ref_c);
+
+    // Format a diagnostic identifying the worst elements by absolute error,
+    // relative error and allclose margin.  Indexes are reported both as flat
+    // offsets and 2D (row, col) coordinates to make it easy to correlate with
+    // tile positions when debugging.
+    auto row_col = [&](size_t idx) {
+        return std::make_pair(idx / static_cast<size_t>(N), idx % static_cast<size_t>(N));
+    };
+    auto worst_summary = [&]() {
+        std::ostringstream os;
+        const auto [ar, ac] = row_col(report.worst_atol_index);
+        os << "\n  worst abs     : [" << ar << "," << ac << "] device=" << report.worst_atol_actual
+           << " ref=" << report.worst_atol_expected << " diff=" << report.worst_atol_diff;
+        const auto [rr, rc] = row_col(report.worst_rtol_index);
+        os << "\n  worst rel     : [" << rr << "," << rc << "] device=" << report.worst_rtol_actual
+           << " ref=" << report.worst_rtol_expected << " diff=" << report.worst_rtol_diff
+           << " rel_err=" << report.worst_rtol_rel;
+        const auto [mr, mc] = row_col(report.worst_margin_index);
+        os << "\n  worst allclose: [" << mr << "," << mc << "] device=" << report.worst_margin_actual
+           << " ref=" << report.worst_margin_expected << " diff=" << report.worst_margin_diff
+           << " tol=" << report.worst_margin_tol << " margin=" << report.worst_margin;
+        return os.str();
+    };
+
+    EXPECT_EQ(report.failures, 0u) << report.failures << " element(s) failed allclose(atol=" << atol
+                                   << ", rtol=" << rtol << "). Result had pcc=" << pcc
+                                   << ", relative_frobenius=" << frobenius << ";" << worst_summary();
+    EXPECT_LE(frobenius, frobenius_threshold)
+        << (expected_norm_is_zero ? "Absolute" : "Relative") << " Frobenius norm " << frobenius << " exceeds threshold "
+        << frobenius_threshold << ". Result had pcc=" << pcc << worst_summary();
+    EXPECT_GE(pcc, pcc_threshold) << "PCC " << pcc << " below threshold " << pcc_threshold
+                                  << ". Result had relative_frobenius=" << frobenius << worst_summary();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MatmulMulticoreTests,
+    MatmulMulticoreFixture,
+    ::testing::Values(MatmulMulticoreParam{2048, 2048, 2048}),
+    [](const testing::TestParamInfo<MatmulMulticoreParam>& info) {
+        return fmt::format("M{}_K{}_N{}", info.param.M, info.param.K, info.param.N);
+    });
+
+}  // namespace ttnn::operations::matmul::test

--- a/tests/ttnn/unit_tests/gtests/test_matmul_multicore.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_multicore.cpp
@@ -119,8 +119,36 @@ TEST_P(MatmulMulticoreFixture, MatmulMulticoreAccuracy) {
     const std::vector<float> device_c = output.to_vector<float>();
 
     // --- Validation ---
-    // Use the combination of allclose, relative Frobenius, and pcc checks,
-    // mirroring assert_numeric_metrics from tests/ttnn/utils_for_testing.py.
+    // Helper used by both the non-finite pre-check and the worst-element diagnostic below
+    // to map flat element indices back to (row, col) for easier correlation with tile
+    // positions when debugging.
+    auto row_col = [&](size_t idx) {
+        return std::make_pair(idx / static_cast<size_t>(N), idx % static_cast<size_t>(N));
+    };
+
+    // Pre-check: surface unexpected NaN/Inf cleanly before running the validation
+    // metrics below.  Mirrors models/common/utility_functions.py::_comp_nonfinite.
+    //
+    // Two complementary actions on the result, both aimed at preventing a cascade of
+    // confusing secondary failures from the metrics:
+    //   - If non-finite POSITIONS disagree, FAIL with a dedicated message.  Without
+    //     this, allclose_report would still flag these as failures (finite vs Inf is
+    //     out of tolerance), but as part of its generic "N elements failed allclose"
+    //     message rather than naming the actual symptom (a non-finite leaked).
+    //   - If at least one non-finite is present (even when positions match), skip
+    //     pcc and relative_frobenius below.  Both NaN-poison on any non-finite input
+    //     (e.g. pcc evaluates inf - inf = NaN in the mean-deviation step) and would
+    //     return NaN even when allclose_report correctly reports the result as close.
+    //     allclose_report itself runs unconditionally because it correctly treats
+    //     matching same-sign infinities as "close" per torch.allclose semantics.
+    const ttnn::test_utils::NonfiniteReport nf = ttnn::test_utils::check_nonfinite_positions(device_c, ref_c);
+    if (!nf.positions_match) {
+        const auto [r, c] = row_col(nf.first_mismatch_index);
+        FAIL() << "Non-finite values do not appear at the same positions in device output and CPU reference. "
+               << "First mismatch at flat index " << nf.first_mismatch_index << " (row=" << r << ", col=" << c
+               << "): device=" << nf.first_mismatch_actual << " ref=" << nf.first_mismatch_expected;
+    }
+
     constexpr float rtol = 0.1f;
     constexpr float atol = 0.108f;
     // Relative Frobenius catches global error magnitude that individual
@@ -128,17 +156,33 @@ TEST_P(MatmulMulticoreFixture, MatmulMulticoreAccuracy) {
     constexpr float frobenius_threshold = 0.002f;
     constexpr float pcc_threshold = 0.9999f;
     const ttnn::test_utils::AllcloseReport report = ttnn::test_utils::allclose_report(device_c, ref_c, rtol, atol);
+
+    // pcc and relative_frobenius are skipped when non-finites are present: see the
+    // pre-check comment above.
+    std::optional<float> frobenius_opt;
+    std::optional<float> pcc_opt;
     bool expected_norm_is_zero = false;
-    const float frobenius = ttnn::test_utils::relative_frobenius(device_c, ref_c, expected_norm_is_zero);
-    const float pcc = ttnn::test_utils::pcc(device_c, ref_c);
+    if (!nf.any_nonfinite) {
+        frobenius_opt = ttnn::test_utils::relative_frobenius(device_c, ref_c, expected_norm_is_zero);
+        pcc_opt = ttnn::test_utils::pcc(device_c, ref_c);
+    }
+
+    // Format a metric value for inclusion in an EXPECT_* failure message: numeric
+    // when computed, or a clear skip notice when omitted.
+    auto fmt_metric = [](const std::optional<float>& v) {
+        std::ostringstream os;
+        if (v) {
+            os << *v;
+        } else {
+            os << "(skipped: non-finite values present)";
+        }
+        return os.str();
+    };
 
     // Format a diagnostic identifying the worst elements by absolute error,
     // relative error and allclose margin.  Indexes are reported both as flat
     // offsets and 2D (row, col) coordinates to make it easy to correlate with
     // tile positions when debugging.
-    auto row_col = [&](size_t idx) {
-        return std::make_pair(idx / static_cast<size_t>(N), idx % static_cast<size_t>(N));
-    };
     auto worst_summary = [&]() {
         std::ostringstream os;
         const auto [ar, ac] = row_col(report.worst_atol_index);
@@ -156,19 +200,36 @@ TEST_P(MatmulMulticoreFixture, MatmulMulticoreAccuracy) {
     };
 
     EXPECT_EQ(report.failures, 0u) << report.failures << " element(s) failed allclose(atol=" << atol
-                                   << ", rtol=" << rtol << "). Result had pcc=" << pcc
-                                   << ", relative_frobenius=" << frobenius << ";" << worst_summary();
-    EXPECT_LE(frobenius, frobenius_threshold)
-        << (expected_norm_is_zero ? "Absolute" : "Relative") << " Frobenius norm " << frobenius << " exceeds threshold "
-        << frobenius_threshold << ". Result had pcc=" << pcc << worst_summary();
-    EXPECT_GE(pcc, pcc_threshold) << "PCC " << pcc << " below threshold " << pcc_threshold
-                                  << ". Result had relative_frobenius=" << frobenius << worst_summary();
+                                   << ", rtol=" << rtol << "). Result had pcc=" << fmt_metric(pcc_opt)
+                                   << ", relative_frobenius=" << fmt_metric(frobenius_opt) << ";" << worst_summary();
+    if (frobenius_opt) {
+        EXPECT_LE(*frobenius_opt, frobenius_threshold)
+            << (expected_norm_is_zero ? "Absolute" : "Relative") << " Frobenius norm " << *frobenius_opt
+            << " exceeds threshold " << frobenius_threshold << ". Result had pcc=" << fmt_metric(pcc_opt)
+            << worst_summary();
+    }
+    if (pcc_opt) {
+        EXPECT_GE(*pcc_opt, pcc_threshold)
+            << "PCC " << *pcc_opt << " below threshold " << pcc_threshold
+            << ". Result had relative_frobenius=" << fmt_metric(frobenius_opt) << worst_summary();
+    }
 }
 
+// Shapes:
+//   * {2048, 2048, 2048}: 64*64 = 4096 output tiles -- evenly divides any reasonable
+//     compute grid (8x8, 8x10, ...), so split_work_to_cores produces a single non-empty
+//     core_group_1 and an empty core_group_2.  Exercises the "primary" CreateKernel call.
+//   * {2080, 2048, 64}:   65*2  = 130 output tiles (2080 = 65*32 forces an odd Mt).
+//     130 = 2*5*13, so it cannot evenly divide grid sizes like 64 or 80, which forces
+//     split_work_to_cores to produce a non-empty core_group_2 and exercise the second
+//     CreateKernel call (where the same compute_kernel_config and throttle/stagger
+//     defines are forwarded to a different per-core tile count).  Keeps K=2048 so the
+//     accumulation depth -- and therefore the precision tolerances below -- match the
+//     primary shape.
 INSTANTIATE_TEST_SUITE_P(
     MatmulMulticoreTests,
     MatmulMulticoreFixture,
-    ::testing::Values(MatmulMulticoreParam{2048, 2048, 2048}),
+    ::testing::Values(MatmulMulticoreParam{2048, 2048, 2048}, MatmulMulticoreParam{2080, 2048, 64}),
     [](const testing::TestParamInfo<MatmulMulticoreParam>& info) {
         return fmt::format("M{}_K{}_N{}", info.param.M, info.param.K, info.param.N);
     });

--- a/ttnn/cpp/ttnn-nanobind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/core.cpp
@@ -52,7 +52,8 @@ void py_module_types(nb::module_& mod) {
     // Primary config class (ComputeKernelConfig is the canonical name, but we expose as WormholeComputeKernelConfig
     // for backward compatibility)
     nb::class_<ComputeKernelConfig>(mod, "WormholeComputeKernelConfig", R"doc(
-        Compute kernel configuration for Wormhole devices and also valid for Blackhole devices.
+        Compute kernel configuration for Wormhole devices. Note that ``BlackholeComputeKernelConfig``
+        is a type alias for the same class (``WormholeComputeKernelConfig``).
 
         Controls the precision/throughput trade-offs of the on-chip matrix engine and SFPU.
         Pass an instance of this class as the ``compute_kernel_config`` argument to ops such as

--- a/ttnn/cpp/ttnn-nanobind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/core.cpp
@@ -41,13 +41,35 @@ void py_module_types(nb::module_& mod) {
     )doc");
 
     // Unified ComputeKernelConfig - all architecture-specific names are now aliases
-    nb::class_<DeviceComputeKernelConfigPlaceholder>(mod, "DeviceComputeKernelConfig");
+    nb::class_<DeviceComputeKernelConfigPlaceholder>(mod, "DeviceComputeKernelConfig", R"doc(
+        Abstract base type used in op signatures to accept any architecture-specific compute kernel config.
+
+        Example concrete, instantiable class is :class:`ttnn.WormholeComputeKernelConfig`, which is valid for both
+        Wormhole and Blackhole devices. Construct one of the concrete classes and pass it wherever a
+        ``ttnn.DeviceComputeKernelConfig`` is expected.
+    )doc");
 
     // Primary config class (ComputeKernelConfig is the canonical name, but we expose as WormholeComputeKernelConfig
     // for backward compatibility)
-    nb::class_<ComputeKernelConfig>(mod, "WormholeComputeKernelConfig")
+    nb::class_<ComputeKernelConfig>(mod, "WormholeComputeKernelConfig", R"doc(
+        Compute kernel configuration for Wormhole devices and also valid for Blackhole devices.
+
+        Controls the precision/throughput trade-offs of the on-chip matrix engine and SFPU.
+        Pass an instance of this class as the ``compute_kernel_config`` argument to ops such as
+        :func:`ttnn.matmul`, :func:`ttnn.linear`, and others that accept a
+        :class:`ttnn.DeviceComputeKernelConfig`.
+
+        See the per-attribute docs below for what each field does, and
+        ``tech_reports/matrix_engine/matrix_engine.md`` for the full architectural background.
+    )doc")
         .def(
-            nb::init<tt::tt_metal::MathFidelity, bool, bool, bool, bool, ttnn::operations::compute_throttle_utils::ThrottleLevel>(),
+            nb::init<
+                tt::tt_metal::MathFidelity,
+                bool,
+                bool,
+                bool,
+                bool,
+                ttnn::operations::compute_throttle_utils::ThrottleLevel>(),
             nb::kw_only(),
             nb::arg("math_fidelity") = nb::cast(tt::tt_metal::MathFidelity::Invalid),
             nb::arg("math_approx_mode") = true,
@@ -55,12 +77,39 @@ void py_module_types(nb::module_& mod) {
             nb::arg("packer_l1_acc") = false,
             nb::arg("dst_full_sync_en") = false,
             nb::arg("throttle_level") = compute_throttle_utils::ThrottleLevel::NO_THROTTLE)
-        .def_rw("math_fidelity", &ComputeKernelConfig::math_fidelity)
-        .def_rw("math_approx_mode", &ComputeKernelConfig::math_approx_mode)
-        .def_rw("fp32_dest_acc_en", &ComputeKernelConfig::fp32_dest_acc_en)
-        .def_rw("packer_l1_acc", &ComputeKernelConfig::packer_l1_acc)
-        .def_rw("dst_full_sync_en", &ComputeKernelConfig::dst_full_sync_en)
-        .def_rw("throttle_level", &ComputeKernelConfig::throttle_level);
+        .def_rw("math_fidelity", &ComputeKernelConfig::math_fidelity, R"doc(
+            Controls the number of mantissa-bit passes through the 5b×7b multiplier array, trading
+            throughput for precision. See :class:`ttnn.MathFidelity` for the available values.
+        )doc")
+        .def_rw("math_approx_mode", &ComputeKernelConfig::math_approx_mode, R"doc(
+            When ``True``, SFPU ops that have an approximate variant (e.g. ``exp``, ``gelu``, ``sqrt``)
+            run in high-performance / lower-precision mode instead of high-precision / lower-performance mode.
+            Has no effect on ops that do not have an approximate variant.
+        )doc")
+        .def_rw("fp32_dest_acc_en", &ComputeKernelConfig::fp32_dest_acc_en, R"doc(
+            When ``True``, the FPU accumulates results into the math destination (DST) register in FP32
+            instead of BFLOAT16. This is required when the output dtype is ``FLOAT32`` and improves
+            numerical accuracy for intermediate accumulations.
+
+            Warning: enabling this halves the number of tiles that fit in DST. With ``DstSync::Half``,
+            BFLOAT16 holds 8 tiles while FP32 holds only 4.
+        )doc")
+        .def_rw("packer_l1_acc", &ComputeKernelConfig::packer_l1_acc, R"doc(
+            When ``True``, the packer reads the current value at the output SRAM address, adds the value
+            from DST, and writes the result back (in-place accumulation in SRAM). This is useful for
+            accumulating partial sums in higher precision circular buffer (e.g. FP32) across multiple kernel launches,
+            and then doing a final pack to a lower-precision circular buffer (e.g. BFLOAT16).
+        )doc")
+        .def_rw("dst_full_sync_en", &ComputeKernelConfig::dst_full_sync_en, R"doc(
+            When ``True``, the math and pack units synchronize over the full DST register rather than
+            the default half-DST split. Leave at ``False`` unless you explicitly need full-DST sync
+            semantics.
+        )doc")
+        .def_rw("throttle_level", &ComputeKernelConfig::throttle_level, R"doc(
+            Inserts NOP instructions into the compute kernel to reduce throughput and limit di/dt
+            (power-supply current transients) when running on large core grids. See
+            :class:`ttnn.ThrottleLevel` for the available levels and their throughput percentages.
+        )doc");
 }
 
 void py_module(nb::module_& mod) {

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -53,7 +53,16 @@ void tensor_mem_config_module_types(nb::module_& m_tensor) {
     export_enum<Layout>(m_tensor);
     export_enum<DataType>(m_tensor);
     export_enum<StorageType>(m_tensor);
-    export_enum<tt::tt_metal::MathFidelity>(m_tensor, "MathFidelity");
+    export_enum<tt::tt_metal::MathFidelity>(m_tensor, "MathFidelity", R"doc(
+        Number of mantissa-bit passes through the 5b×7b multiplier array.
+
+        Higher fidelity consumes more mantissa bits from each operand and therefore produces more
+        accurate results, at the cost of proportionally lower throughput. The matrix engine uses
+        5 bits (1 hidden + 4) from SrcA and 7 bits (1 hidden + 6) from SrcB per pass:
+
+        Note: ``reduce_max`` and elementwise ``add``/``sub`` are unaffected by this setting.
+        Elementwise ``mul`` and ``reduce_average``/``sum`` do respect this setting.
+    )doc");
     export_enum<TensorMemoryLayout>(m_tensor);
     export_enum<ShardOrientation>(m_tensor);
     // export_enum<ShardMode>(m_tensor);

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -60,6 +60,11 @@ void tensor_mem_config_module_types(nb::module_& m_tensor) {
         accurate results, at the cost of proportionally lower throughput. The matrix engine uses
         5 bits (1 hidden + 4) from SrcA and 7 bits (1 hidden + 6) from SrcB per pass:
 
+        - ``LoFi``  (1 pass):  SrcA uses the 4 MSB mantissa bits; SrcB uses the 6 MSB mantissa bits.
+        - ``HiFi2`` (2 passes): SrcA adds the next 4 LSB bits; SrcB keeps the 6 MSB bits.
+        - ``HiFi3`` (3 passes): SrcA keeps the 4 MSB bits; SrcB adds the next 6 LSB bits.
+        - ``HiFi4`` (4 passes): SrcA adds the next 4 LSB bits; SrcB keeps both 6 MSB and 6 LSB bits.
+
         Note: ``reduce_max`` and elementwise ``add``/``sub`` are unaffected by this setting.
         Elementwise ``mul`` and ``reduce_average``/``sum`` do respect this setting.
     )doc");

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -39,13 +39,15 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
     uint32_t in0_single_tile_size = tt::tile_size(in0_data_format);
     uint32_t in1_single_tile_size = tt::tile_size(in1_data_format);
     uint32_t output_single_tile_size = tt::tile_size(output_data_format);
-    tt::tt_metal::MathFidelity math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
 
     tt_metal::Buffer* src0_buffer = a.buffer();
     tt_metal::Buffer* src1_buffer = b.buffer();
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
     const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -135,7 +137,9 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
         core_group_1,
         tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,
-            .dst_full_sync_en = true,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
             .compile_args = compute_args_group_1,
             .named_compile_args = {
                 {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}}});
@@ -155,7 +159,9 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
             core_group_2,
             tt_metal::ComputeConfig{
                 .math_fidelity = math_fidelity,
-                .dst_full_sync_en = true,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .dst_full_sync_en = dst_full_sync_en,
+                .math_approx_mode = math_approx_mode,
                 .compile_args = compute_args_group_2,
                 .named_compile_args = {
                     {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}}});

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -3,10 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.hpp"
+#include <map>
+#include <string>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/operations/compute_throttle_utils.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 using namespace tt;
 using namespace tt::constants;
@@ -46,8 +50,16 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+    TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
+    const auto kernel_config =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
+    const auto math_fidelity = std::get<0>(kernel_config);
+    const auto math_approx_mode = std::get<1>(kernel_config);
+    const auto fp32_dest_acc_en = std::get<2>(kernel_config);
+    // packer_l1_acc (element 3 in the tuple) is not applicable, because the compute kernel doesn't have any
+    // intermediate accumulation.
+    const auto dst_full_sync_en = std::get<4>(kernel_config);
+
     const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -123,6 +135,15 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
         all_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, {{"cb_out", output_cb_index}}));
 
+    const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
+    // Forward stagger / throttle settings to the bmm compute kernel via preprocessor defines.
+    // Both helpers are no-ops on small core grids, so it is safe to always call them.
+    std::map<std::string, std::string> mm_kernel_defines;
+    ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
+        device->arch(), num_cores, mm_kernel_defines);
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+
     std::vector<uint32_t> compute_args_group_1 = {
         1,                                 // B
         1,                                 // Mt
@@ -141,6 +162,7 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
             .dst_full_sync_en = dst_full_sync_en,
             .math_approx_mode = math_approx_mode,
             .compile_args = compute_args_group_1,
+            .defines = mm_kernel_defines,
             .named_compile_args = {
                 {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}}});
 
@@ -163,6 +185,7 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
                 .dst_full_sync_en = dst_full_sync_en,
                 .math_approx_mode = math_approx_mode,
                 .compile_args = compute_args_group_2,
+                .defines = mm_kernel_defines,
                 .named_compile_args = {
                     {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}}});
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -51,14 +51,11 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
     tt::tt_metal::IDevice* device = a.device();
 
     TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
-    const auto kernel_config =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
-    const auto math_fidelity = std::get<0>(kernel_config);
-    const auto math_approx_mode = std::get<1>(kernel_config);
-    const auto fp32_dest_acc_en = std::get<2>(kernel_config);
-    // packer_l1_acc (element 3 in the tuple) is not applicable, because the compute kernel doesn't have any
-    // intermediate accumulation.
-    const auto dst_full_sync_en = std::get<4>(kernel_config);
+    // packer_l1_acc is not applicable, because the compute kernel doesn't have any
+    // intermediate accumulation. Silences compiler warnings.
+    (void)packer_l1_acc;
 
     const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
 

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -671,7 +671,7 @@ void py_module(nb::module_& mod) {
             dtype (ttnn.DataType): the data type of the output tensor. Defaults to `None`.
             program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
             activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
-            compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`. See :class:`ttnn.DeviceComputeKernelConfig` for the available fields and their meanings.
             core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
             optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
@@ -794,7 +794,7 @@ void py_module(nb::module_& mod) {
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
             activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
-            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`. See :class:`ttnn.DeviceComputeKernelConfig` for the available fields and their meanings.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
             optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of linear is to be written. Defaults to `None`.
@@ -858,7 +858,7 @@ void py_module(nb::module_& mod) {
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
             activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
-            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`. See :class:`ttnn.DeviceComputeKernelConfig` for the available fields and their meanings.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
             optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of linear is to be written. Defaults to `None`.
@@ -942,7 +942,7 @@ void py_module(nb::module_& mod) {
             memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType): the data type of the output tensor. Supported types: `ttnn.bfloat16`, `ttnn.float32`, `ttnn.bfloat8_b`  Defaults to `None` which means it will default to the highest precision of `input_tensor`, `mat1_tensor` or `mat2_tensor`.
             program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
-            compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`. See :class:`ttnn.DeviceComputeKernelConfig` for the available fields and their meanings.
             core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
             optional_output_tensor (ttnn.Tensor, optional): User-provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
@@ -989,7 +989,7 @@ void py_module(nb::module_& mod) {
             is_input_b_sparse (bool, optional): boolean indicating whether `input_tensor_b` is sparse. Defaults to `True`. Together with `is_input_a_sparse`, it determines how the sparsity tensor is interpreted. See the supported modes table below.
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
-            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`. See :class:`ttnn.DeviceComputeKernelConfig` for the available fields and their meanings.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
             optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.


### PR DESCRIPTION
### Summary
Closes #42511

`MatmulMultiCoreProgramFactory` wasn't passing `fp32_dest_acc_en` and other accuracy parameters that user specified to kernels. This resulted in accuracy issues even when user requested higher accuracy.

Changes made:
- Passed accuracy parameters down to kernels. Notable changes
  - MathFidelity was previously hard-coded to HiFi4; now it follows whatever the user (or the default-populated config) specifies.
  - dst_full_sync_en was previously hard-coded to true; now it follows whatever the user (or the default-populated config) specifies.
- Added CPP unit test that cathes the issue before the fix and passes after the fix. It's added as a CPP test rather than Python to guarantee that MatmulMultiCoreProgramFactory will be chosen (this factory is not exposed in Python, and we don't want to expose it).
- Added documentation for `DeviceComputeKernelConfig` and accuracy parameters to nanobind files, based on info in https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/matrix_engine/matrix_engine.md

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec_42511_factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec_42511_factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fplavec_42511_factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fplavec_42511_factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec_42511_factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec_42511_factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec_42511_factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec_42511_factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec_42511_factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec_42511_factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec_42511_factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec_42511_factory)