### PR TITLE
Bug fix: Restore missing SD tests lost during runtime pipeline reorg

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -109,11 +109,11 @@ runtime:
     bh_quietbox: 5
     bh_loudbox: 5
   unit:
-    wh_n150_civ2: 152
-    wh_n300_civ2: 50
-    bh_p150b_civ2: 147
+    wh_n150_civ2: 174
+    wh_n300_civ2: 72
+    bh_p150b_civ2: 169
     bh_p150b_civ2_viommu: 5
-    bh_p100a_civ2_viommu: 50
+    bh_p100a_civ2_viommu: 72
     bh_quietbox: 20
     wh_galaxy: 35
   integration:

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -50,7 +50,7 @@
 
 # --- Data Movement Tests ---
 - name: runtime_data_movement
-  cmd: ./build/test/tt_metal/unit_tests_data_movement --gtest_filter='-*NIGHTLY_*'
+  cmd: ./build/test/tt_metal/unit_tests_data_movement --gtest_filter='-*NIGHTLY_*:*NocEstimator*'
   skus:
     wh_n150_civ2:
       timeout: 8
@@ -177,18 +177,26 @@
 # Slow Dispatch Tests (TT_METAL_SLOW_DISPATCH_MODE=1 set per-command)
 # =============================================================================
 
-# --- Core API Tests (SD) ---
+# --- Core API + per-core allocation Tests (SD) ---
 - name: runtime_sd_api
-  cmd: TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_api
+  cmd: |
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_api
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_per_core_allocation
+    if [ "$ARCH_NAME" = "blackhole" ]; then
+      TT_METAL_SLOW_DISPATCH_MODE=1 \
+        TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 \
+        ./build/test/tt_metal/unit_tests_api \
+        --gtest_filter='BlackholeSingleCardFixture.DramKernel*'
+    fi
   skus:
     wh_n150_civ2:
-      timeout: 15
+      timeout: 20
     wh_n300_civ2:
-      timeout: 15
+      timeout: 20
     bh_p150b_civ2:
-      timeout: 15
+      timeout: 20
     bh_p100a_civ2_viommu:
-      timeout: 15
+      timeout: 20
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
@@ -210,26 +218,61 @@
 # --- Debug Tools, Device, Dispatch (SD) ---
 - name: runtime_sd_debug_tools_device_dispatch
   cmd: |
-    export TT_METAL_SLOW_DISPATCH_MODE=1
-    ./build/test/tt_metal/unit_tests_debug_tools
-    ./build/test/tt_metal/unit_tests_inspector
-    ./build/test/tt_metal/unit_tests_device
-    ./build/test/tt_metal/unit_tests_dispatch
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_debug_tools
+    if [ "$ARCH_NAME" = "blackhole" ]; then
+      TT_METAL_SLOW_DISPATCH_MODE=1 \
+        TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 \
+        ./build/test/tt_metal/unit_tests_debug_tools \
+        --gtest_filter='*Drisc*:*Dram*Print*'
+    fi
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_inspector
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_device
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_dispatch
   skus:
     wh_n150_civ2:
-      timeout: 15
+      timeout: 17
     wh_n300_civ2:
-      timeout: 15
+      timeout: 17
     bh_p150b_civ2:
-      timeout: 15
+      timeout: 17
     bh_p100a_civ2_viommu:
-      timeout: 15
+      timeout: 17
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
 # --- LLK Tests (SD) ---
 - name: runtime_sd_llk
   cmd: TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_llk
+  skus:
+    wh_n150_civ2:
+      timeout: 10
+    wh_n300_civ2:
+      timeout: 10
+    bh_p150b_civ2:
+      timeout: 10
+    bh_p100a_civ2_viommu:
+      timeout: 10
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
+# --- Legacy Tests (SD) ---
+- name: runtime_sd_legacy
+  cmd: TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_legacy --gtest_shuffle --gtest_filter='-*NIGHTLY_*'
+  skus:
+    wh_n150_civ2:
+      timeout: 5
+    wh_n300_civ2:
+      timeout: 5
+    bh_p150b_civ2:
+      timeout: 5
+    bh_p100a_civ2_viommu:
+      timeout: 5
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
+# --- Eager C++ Tests (SD) ---
+- name: runtime_sd_eager
+  cmd: TT_METAL_SLOW_DISPATCH_MODE=1 python3 tests/scripts/run_tt_eager.py --dispatch-mode slow
   skus:
     wh_n150_civ2:
       timeout: 10


### PR DESCRIPTION
## Summary

**Type: Bug fix**

- Restores 5 Slow Dispatch tests that were inadvertently dropped when `sd-unit-tests` (calling `build-and-unit-tests.yaml`) was removed from `tt-metal-l2-nightly.yaml` during the runtime pipeline reorganization (#40962).
- Excludes `*NocEstimator*` from `runtime_data_movement` gtest filter to match the data movement team's own exclusion and prevent CI timeouts (#39869).
- Updates time budgets to account for the additional SD test time (+22 min per SKU).

## What was missing

| # | Test | Where added | Notes |
|---|---|---|---|
| 1 | `unit_tests_per_core_allocation` | `runtime_sd_api` | Was in group 1 of old SD pipeline |
| 2 | `TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 unit_tests_api --gtest_filter=BlackholeSingleCardFixture.DramKernel*` | `runtime_sd_api` | BH conditional |
| 3 | `TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 unit_tests_debug_tools --gtest_filter=*Drisc*:*Dram*Print*` | `runtime_sd_debug_tools_device_dispatch` | BH conditional |
| 4 | `run_tt_eager.py --dispatch-mode slow` (8 C++ eager test binaries) | New job `runtime_sd_eager` | From `run_cpp_unit_tests.sh` |
| 5 | `unit_tests_legacy` in SD mode | New job `runtime_sd_legacy` | Ran outside if/else in `run_cpp_unit_tests.sh` |

## NocEstimator exclusion

`runtime_data_movement` filter updated from `'-*NIGHTLY_*'` to `'-*NIGHTLY_*:*NocEstimator*'`. These tests lack the `NIGHTLY_` prefix so they were running in our FD pipeline and timing out. The DM team already excludes them in their own pipeline (`tm-data-movement-wrapper.yaml`). See #39869.

## Time budget changes (`runtime.unit`)

| SKU | Old (min) | New (min) | Delta |
|---|---|---|---|
| `wh_n150_civ2` | 152 | 174 | +22 |
| `wh_n300_civ2` | 50 | 72 | +22 |
| `bh_p150b_civ2` | 147 | 169 | +22 |
| `bh_p100a_civ2_viommu` | 50 | 72 | +22 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-missing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/runtime-pipeline-missing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-missing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/runtime-pipeline-missing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-missing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/runtime-pipeline-missing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-missing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/runtime-pipeline-missing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-missing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/runtime-pipeline-missing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-missing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/runtime-pipeline-missing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-missing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/runtime-pipeline-missing-tests)