### PR TITLE
[Performance] Optimize DRAM-backed CQ push to write only the newly-pushed region

### DIFF
--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -552,6 +552,10 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
     uint32_t issue_q_wr_ptr = ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
 
+    // Capture before advancing: issue_fifo_wr_ptr points to the slot just written; after the advance below it points to
+    // the next slot.
+    const uint32_t wr_ptr_bytes = cq_interface.issue_fifo_wr_ptr << 4;
+
     if (cq_interface.issue_fifo_wr_ptr + push_size_16B >= cq_interface.issue_fifo_limit) {
         cq_interface.issue_fifo_wr_ptr = (cq_interface.cq_start + cq_interface.offset) >> 4;  // In 16B words
         cq_interface.issue_fifo_wr_toggle = not cq_interface.issue_fifo_wr_toggle;            // Flip the toggle
@@ -563,13 +567,13 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
         const uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
+        const uint32_t dram_target_addr = wr_ptr_bytes - this->channel_offset;
         ctx.get_cluster().write_dram_vec(
-            this->cq_sysmem_start + (cq_interface.offset - this->get_dram_region_base_addr() - this->channel_offset) +
-                cq_interface.cq_start,
-            this->get_issue_queue_size(cq_id),
+            this->cq_sysmem_start + (dram_target_addr - this->get_dram_region_base_addr()),
+            push_size_16B << 4,
             this->device_id,
             dram_channel,
-            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + cq_interface.cq_start);
+            dram_target_addr);
         ctx.get_cluster().write_dram_vec(
             &cq_interface.issue_fifo_wr_ptr,
             sizeof(uint32_t),


### PR DESCRIPTION
### Summary
Optimizes `issue_queue_push_back()` to write only the newly-pushed bytes to DRAM rather than the full queue when DRAM-backed CQs are being used.

The write pointer is now captured before advancing, allowing the DRAM target address to be computed directly from `wr_ptr_bytes` rather than reconstructed from `cq_start + offset` offsets. The write size changes from `get_issue_queue_size(cq_id)` to `push_size_16B << 4`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/optimize_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/optimize_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/optimize_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/optimize_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/optimize_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/optimize_dram_backed_cq)