### PR TITLE
ds_prefill ops: extract and insert

### DIFF
--- a/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_prefill_extract.py
+++ b/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_prefill_extract.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ttnn.experimental.deepseek_prefill.extract.
+
+Verifies constraint rejection as well as the functional behavior: for a given
+global_expert_id, the op copies global_tensor[start : start + ceil_tile(counts), :]
+into the first rows of an output tensor shaped
+[max_dispatched_tokens_per_expert, hidden_dim].
+"""
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+GLOBAL_ROWS = 64
+HIDDEN_DIM = 128
+NUM_EXPERTS = 8
+GLOBAL_EXPERT_ID = 0
+MAX_TOKENS = 32
+TILE = 32
+
+
+def _ceil_to_tile(n):
+    return ((n + TILE - 1) // TILE) * TILE
+
+
+def _make_global(
+    device, *, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, shape=(GLOBAL_ROWS, HIDDEN_DIM), memory_config=None
+):
+    torch_tensor = torch.zeros(shape, dtype=torch.float32)
+    return ttnn.from_torch(
+        torch_tensor,
+        device=device,
+        dtype=dtype,
+        layout=layout,
+        memory_config=memory_config if memory_config is not None else ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _make_index(device, *, dtype=ttnn.uint32, shape=(NUM_EXPERTS,), memory_config=None):
+    torch_tensor = torch.zeros(shape, dtype=torch.int32)
+    return ttnn.from_torch(
+        torch_tensor,
+        device=device,
+        dtype=dtype,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=memory_config if memory_config is not None else ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _run(global_tensor, start, counts, global_expert_id=GLOBAL_EXPERT_ID, max_tokens=MAX_TOKENS):
+    return ttnn.experimental.deepseek_prefill.extract(
+        global_tensor,
+        start,
+        counts,
+        global_expert_id=global_expert_id,
+        max_dispatched_tokens_per_expert=max_tokens,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Valid inputs should succeed.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_inputs_1d_index(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS,))
+    out = _run(g, s, c)
+    assert out is not None
+
+
+def test_valid_inputs_2d_index_first_dim_one(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(1, NUM_EXPERTS))
+    c = _make_index(device, shape=(1, NUM_EXPERTS))
+    out = _run(g, s, c)
+    assert out is not None
+
+
+# ---------------------------------------------------------------------------
+# Global tensor constraints.
+# ---------------------------------------------------------------------------
+
+
+def test_global_tensor_wrong_dtype(device):
+    g = _make_global(device, dtype=ttnn.bfloat16)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_global_tensor_must_be_2d(device):
+    g = _make_global(device, shape=(1, GLOBAL_ROWS, HIDDEN_DIM))
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_global_tensor_must_be_dram_interleaved(device):
+    g = _make_global(device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+# ---------------------------------------------------------------------------
+# Start tensor constraints.
+# ---------------------------------------------------------------------------
+
+
+def test_start_wrong_dtype(device):
+    g = _make_global(device)
+    s = _make_index(device, dtype=ttnn.uint16)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_start_must_be_dram_interleaved(device):
+    g = _make_global(device)
+    s = _make_index(device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_start_2d_first_dim_not_one(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(2, NUM_EXPERTS))
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_start_3d_rejected(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(1, 1, NUM_EXPERTS))
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+# ---------------------------------------------------------------------------
+# Counts tensor constraints (same as start tensor).
+# ---------------------------------------------------------------------------
+
+
+def test_counts_wrong_dtype(device):
+    g = _make_global(device)
+    s = _make_index(device)
+    c = _make_index(device, dtype=ttnn.uint16)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_counts_must_be_dram_interleaved(device):
+    g = _make_global(device)
+    s = _make_index(device)
+    c = _make_index(device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_counts_2d_first_dim_not_one(device):
+    g = _make_global(device)
+    s = _make_index(device)
+    c = _make_index(device, shape=(2, NUM_EXPERTS))
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_counts_3d_rejected(device):
+    g = _make_global(device)
+    s = _make_index(device)
+    c = _make_index(device, shape=(1, 1, NUM_EXPERTS))
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+# ---------------------------------------------------------------------------
+# Cross-tensor and scalar constraints.
+# ---------------------------------------------------------------------------
+
+
+def test_start_and_counts_last_dim_mismatch_1d(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS + 1,))
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_start_and_counts_last_dim_mismatch_2d(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(1, NUM_EXPERTS))
+    c = _make_index(device, shape=(1, NUM_EXPERTS + 1))
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_start_and_counts_last_dim_mismatch_mixed_rank(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(1, NUM_EXPERTS + 1))
+    with pytest.raises(RuntimeError):
+        _run(g, s, c)
+
+
+def test_global_expert_id_equal_to_last_dim_rejected(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS,))
+    with pytest.raises(RuntimeError):
+        _run(g, s, c, global_expert_id=NUM_EXPERTS)
+
+
+def test_global_expert_id_beyond_last_dim_rejected(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS,))
+    with pytest.raises(RuntimeError):
+        _run(g, s, c, global_expert_id=NUM_EXPERTS + 5)
+
+
+def test_global_expert_id_max_valid_accepted(device):
+    g = _make_global(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS,))
+    out = _run(g, s, c, global_expert_id=NUM_EXPERTS - 1)
+    assert out is not None
+
+
+# ---------------------------------------------------------------------------
+# max_dispatched_tokens_per_expert constraints.
+# ---------------------------------------------------------------------------
+
+
+def test_max_tokens_zero_rejected(device):
+    g = _make_global(device)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c, max_tokens=0)
+
+
+def test_max_tokens_not_tile_aligned_rejected(device):
+    g = _make_global(device)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, s, c, max_tokens=17)
+
+
+# ---------------------------------------------------------------------------
+# Functional: output[:ceil_tile(counts), :] == global[start:start+ceil_tile(counts), :].
+# ---------------------------------------------------------------------------
+
+
+def _make_index_from_values(device, values):
+    torch_tensor = torch.tensor(values, dtype=torch.int32)
+    return ttnn.from_torch(
+        torch_tensor,
+        device=device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _make_global_from_torch(device, torch_tensor):
+    return ttnn.from_torch(
+        torch_tensor,
+        device=device,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+@pytest.mark.parametrize(
+    "starts, counts, expert_id, max_tokens",
+    [
+        ([0, 32, 64, 96], [32, 32, 32, 32], 0, 32),
+        ([0, 32, 64, 96], [32, 32, 32, 32], 2, 64),  # output is larger than slice
+        ([0, 64, 96, 128], [32, 17, 32, 5], 1, 32),  # counts rounds up 17 -> 32 tile-rows
+        ([0, 64, 96, 128], [32, 17, 32, 5], 3, 64),  # counts rounds up 5 -> 32 tile-rows, output padded
+        ([0, 32, 64, 96], [96, 32, 32, 32], 0, 128),  # full slice, output padded
+    ],
+)
+def test_extract_matches_torch_slice(device, starts, counts, expert_id, max_tokens):
+    hidden_dim = 128
+    global_rows = _ceil_to_tile(max(s + c for s, c in zip(starts, counts)) + TILE)
+
+    torch.manual_seed(0)
+    global_torch = torch.randn(global_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+    g = _make_global_from_torch(device, global_torch)
+    s = _make_index_from_values(device, starts)
+    c = _make_index_from_values(device, counts)
+
+    out = _run(g, s, c, global_expert_id=expert_id, max_tokens=max_tokens)
+    out_torch = ttnn.to_torch(out)
+
+    assert out_torch.shape == (
+        max_tokens,
+        hidden_dim,
+    ), f"expected shape ({max_tokens}, {hidden_dim}), got {out_torch.shape}"
+    rows = _ceil_to_tile(counts[expert_id])
+    # Compare against bfp8_b-quantized source (tile-level kernel copy is bit-exact).
+    global_quantized = ttnn.to_torch(g)
+    expected = global_quantized[starts[expert_id] : starts[expert_id] + rows, :]
+    torch.testing.assert_close(out_torch[:rows, :].float(), expected.float(), atol=0.0, rtol=0.0)
+    # PCC against the original (pre-quantization) bfloat16 source: bfp8_b quantization
+    # should preserve correlation well above 0.999.
+    original = global_torch[starts[expert_id] : starts[expert_id] + rows, :]
+    assert_with_pcc(original.float(), out_torch[:rows, :].float(), pcc=0.999)
+
+
+def test_extract_2d_indices_matches_torch_slice(device):
+    hidden_dim = 64
+    starts = [0, 32, 96]
+    counts = [32, 48, 32]
+    expert_id = 1
+    max_tokens = 64
+    global_rows = 160
+
+    torch.manual_seed(1)
+    global_torch = torch.randn(global_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+    g = _make_global_from_torch(device, global_torch)
+
+    s_torch = torch.tensor([starts], dtype=torch.int32)
+    c_torch = torch.tensor([counts], dtype=torch.int32)
+    s = ttnn.from_torch(
+        s_torch, device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    c = ttnn.from_torch(
+        c_torch, device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    out = _run(g, s, c, global_expert_id=expert_id, max_tokens=max_tokens)
+    out_torch = ttnn.to_torch(out)
+
+    assert out_torch.shape == (max_tokens, hidden_dim)
+    rows = _ceil_to_tile(counts[expert_id])
+    # Compare against bfp8_b-quantized source (tile-level kernel copy is bit-exact).
+    global_quantized = ttnn.to_torch(g)
+    expected = global_quantized[starts[expert_id] : starts[expert_id] + rows, :]
+    torch.testing.assert_close(out_torch[:rows, :].float(), expected.float(), atol=0.0, rtol=0.0)
+    # PCC against the original (pre-quantization) bfloat16 source.
+    original = global_torch[starts[expert_id] : starts[expert_id] + rows, :]
+    assert_with_pcc(original.float(), out_torch[:rows, :].float(), pcc=0.999)

--- a/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_prefill_insert.py
+++ b/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_prefill_insert.py
@@ -1,0 +1,464 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ttnn.experimental.deepseek_prefill.insert.
+
+Verifies constraint rejection as well as the functional behavior: for a given
+global_expert_id, the op copies local_tensor[:ceil_tile(counts), :] into
+global_tensor[start : start + ceil_tile(counts), :] in place and returns a
+handle to global_tensor.
+"""
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+GLOBAL_ROWS = 128
+HIDDEN_DIM = 64
+LOCAL_ROWS = 64
+NUM_EXPERTS = 8
+GLOBAL_EXPERT_ID = 0
+TILE = 32
+
+
+def _ceil_to_tile(n):
+    return ((n + TILE - 1) // TILE) * TILE
+
+
+def _make_global(
+    device, *, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, shape=(GLOBAL_ROWS, HIDDEN_DIM), memory_config=None
+):
+    torch_tensor = torch.zeros(shape, dtype=torch.float32)
+    return ttnn.from_torch(
+        torch_tensor,
+        device=device,
+        dtype=dtype,
+        layout=layout,
+        memory_config=memory_config if memory_config is not None else ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _make_local(
+    device, *, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, shape=(LOCAL_ROWS, HIDDEN_DIM), memory_config=None
+):
+    torch_tensor = torch.zeros(shape, dtype=torch.float32)
+    return ttnn.from_torch(
+        torch_tensor,
+        device=device,
+        dtype=dtype,
+        layout=layout,
+        memory_config=memory_config if memory_config is not None else ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _make_index(device, *, dtype=ttnn.uint32, shape=(NUM_EXPERTS,), memory_config=None):
+    torch_tensor = torch.zeros(shape, dtype=torch.int32)
+    return ttnn.from_torch(
+        torch_tensor,
+        device=device,
+        dtype=dtype,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=memory_config if memory_config is not None else ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _run(global_tensor, local_tensor, start, counts, global_expert_id=GLOBAL_EXPERT_ID):
+    return ttnn.experimental.deepseek_prefill.insert(
+        global_tensor,
+        local_tensor,
+        start,
+        counts,
+        global_expert_id=global_expert_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Valid inputs should succeed.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_inputs_1d_index(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS,))
+    out = _run(g, l, s, c)
+    assert out is not None
+
+
+def test_valid_inputs_2d_index_first_dim_one(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(1, NUM_EXPERTS))
+    c = _make_index(device, shape=(1, NUM_EXPERTS))
+    out = _run(g, l, s, c)
+    assert out is not None
+
+
+# ---------------------------------------------------------------------------
+# Global tensor constraints.
+# ---------------------------------------------------------------------------
+
+
+def test_global_tensor_wrong_dtype(device):
+    g = _make_global(device, dtype=ttnn.bfloat16)
+    l = _make_local(device)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_global_tensor_must_be_2d(device):
+    g = _make_global(device, shape=(1, GLOBAL_ROWS, HIDDEN_DIM))
+    l = _make_local(device)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_global_tensor_must_be_dram_interleaved(device):
+    g = _make_global(device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    l = _make_local(device)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+# ---------------------------------------------------------------------------
+# Local tensor constraints (same static invariants as global).
+# ---------------------------------------------------------------------------
+
+
+def test_local_tensor_wrong_dtype(device):
+    g = _make_global(device)
+    l = _make_local(device, dtype=ttnn.bfloat16)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_local_tensor_must_be_2d(device):
+    g = _make_global(device)
+    l = _make_local(device, shape=(1, LOCAL_ROWS, HIDDEN_DIM))
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_local_tensor_must_be_dram_interleaved(device):
+    g = _make_global(device)
+    l = _make_local(device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_local_tensor_hidden_dim_must_match_global(device):
+    g = _make_global(device, shape=(GLOBAL_ROWS, HIDDEN_DIM))
+    l = _make_local(device, shape=(LOCAL_ROWS, HIDDEN_DIM * 2))
+    s = _make_index(device)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+# ---------------------------------------------------------------------------
+# Start tensor constraints.
+# ---------------------------------------------------------------------------
+
+
+def test_start_wrong_dtype(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, dtype=ttnn.uint16)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_start_must_be_dram_interleaved(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_start_2d_first_dim_not_one(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(2, NUM_EXPERTS))
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_start_3d_rejected(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(1, 1, NUM_EXPERTS))
+    c = _make_index(device)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+# ---------------------------------------------------------------------------
+# Counts tensor constraints (same as start tensor).
+# ---------------------------------------------------------------------------
+
+
+def test_counts_wrong_dtype(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device)
+    c = _make_index(device, dtype=ttnn.uint16)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_counts_must_be_dram_interleaved(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device)
+    c = _make_index(device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_counts_2d_first_dim_not_one(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device)
+    c = _make_index(device, shape=(2, NUM_EXPERTS))
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_counts_3d_rejected(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device)
+    c = _make_index(device, shape=(1, 1, NUM_EXPERTS))
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+# ---------------------------------------------------------------------------
+# Cross-tensor and scalar constraints.
+# ---------------------------------------------------------------------------
+
+
+def test_start_and_counts_last_dim_mismatch_1d(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS + 1,))
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_start_and_counts_last_dim_mismatch_2d(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(1, NUM_EXPERTS))
+    c = _make_index(device, shape=(1, NUM_EXPERTS + 1))
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_start_and_counts_last_dim_mismatch_mixed_rank(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(1, NUM_EXPERTS + 1))
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c)
+
+
+def test_global_expert_id_equal_to_last_dim_rejected(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS,))
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c, global_expert_id=NUM_EXPERTS)
+
+
+def test_global_expert_id_beyond_last_dim_rejected(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS,))
+    with pytest.raises(RuntimeError):
+        _run(g, l, s, c, global_expert_id=NUM_EXPERTS + 5)
+
+
+def test_global_expert_id_max_valid_accepted(device):
+    g = _make_global(device)
+    l = _make_local(device)
+    s = _make_index(device, shape=(NUM_EXPERTS,))
+    c = _make_index(device, shape=(NUM_EXPERTS,))
+    out = _run(g, l, s, c, global_expert_id=NUM_EXPERTS - 1)
+    assert out is not None
+
+
+# ---------------------------------------------------------------------------
+# Functional: global[start:start+ceil_tile(counts), :] == local[:ceil_tile(counts), :].
+# Rest of global_tensor is left untouched.
+# ---------------------------------------------------------------------------
+
+
+def _make_index_from_values(device, values):
+    return ttnn.from_torch(
+        torch.tensor(values, dtype=torch.int32),
+        device=device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _to_tile_bfp8(device, torch_tensor):
+    return ttnn.from_torch(
+        torch_tensor,
+        device=device,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+@pytest.mark.parametrize(
+    "starts, counts, expert_id, global_rows, local_rows, hidden_dim",
+    [
+        ([0, 32, 64, 96], [32, 32, 32, 32], 0, 128, 32, 64),
+        ([0, 32, 64, 96], [32, 32, 32, 32], 2, 128, 64, 64),
+        ([0, 64, 96, 128], [32, 17, 32, 5], 1, 256, 32, 64),  # counts rounds 17 → 32
+        ([0, 64, 96, 128], [32, 40, 32, 32], 1, 256, 64, 64),  # counts rounds 40 → 64
+        ([0, 32, 64, 96], [96, 32, 32, 32], 0, 256, 128, 64),  # counts rounds 96 → 96
+    ],
+)
+def test_insert_copies_slice(device, starts, counts, expert_id, global_rows, local_rows, hidden_dim):
+    torch.manual_seed(0)
+    global_torch = torch.randn(global_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+    local_torch = torch.randn(local_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+
+    g = _to_tile_bfp8(device, global_torch)
+    l = _to_tile_bfp8(device, local_torch)
+    # Snapshot bfp8_b-quantized inputs for comparison (kernel copy is bit-exact at tile level).
+    global_q = ttnn.to_torch(g).clone()
+    local_q = ttnn.to_torch(l)
+    s = _make_index_from_values(device, starts)
+    c = _make_index_from_values(device, counts)
+
+    out = _run(g, l, s, c, global_expert_id=expert_id)
+    out_torch = ttnn.to_torch(out)
+
+    # Build reference from the quantized inputs and overwrite the slice.
+    rows = _ceil_to_tile(counts[expert_id])
+    start = starts[expert_id]
+    expected = global_q.clone()
+    expected[start : start + rows, :] = local_q[:rows, :]
+
+    # Shape preserved (in-place).
+    assert out_torch.shape == global_torch.shape, f"shape changed: {out_torch.shape} vs {global_torch.shape}"
+    # Full tensor must match the reference everywhere (both inside and outside the slice).
+    torch.testing.assert_close(out_torch.float(), expected.float(), atol=0.0, rtol=0.0)
+    # PCC against the original (pre-quantization) bfloat16 reference.
+    original = global_torch.clone()
+    original[start : start + rows, :] = local_torch[:rows, :]
+    assert_with_pcc(original.float(), out_torch.float(), pcc=0.999)
+
+
+def test_insert_is_in_place(device):
+    """Inserting one expert's slice must leave other rows untouched, and the
+    returned tensor must reflect all accumulated inserts (in-place contract)."""
+    torch.manual_seed(0)
+    global_rows, local_rows, hidden_dim = 128, 64, 64
+    global_torch = torch.randn(global_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+    local_a = torch.randn(local_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+    local_b = torch.randn(local_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+
+    g = _to_tile_bfp8(device, global_torch)
+    # Snapshot bfp8_b-quantized global before any insert.
+    initial_g = ttnn.to_torch(g).clone()
+    l_a = _to_tile_bfp8(device, local_a)
+    l_b = _to_tile_bfp8(device, local_b)
+    local_a_q = ttnn.to_torch(l_a)
+    local_b_q = ttnn.to_torch(l_b)
+    s = _make_index_from_values(device, [0, 32, 64, 96])
+    c = _make_index_from_values(device, [32, 32, 32, 32])
+
+    # Insert two disjoint slices back-to-back.
+    _run(g, l_a, s, c, global_expert_id=0)
+    out = _run(g, l_b, s, c, global_expert_id=2)
+    out_torch = ttnn.to_torch(out)
+
+    expected = initial_g.clone()
+    expected[0:32, :] = local_a_q[:32, :]
+    expected[64:96, :] = local_b_q[:32, :]
+
+    assert out_torch.shape == global_torch.shape
+    torch.testing.assert_close(out_torch.float(), expected.float(), atol=0.0, rtol=0.0)
+    # PCC against the original (pre-quantization) bfloat16 reference.
+    original = global_torch.clone()
+    original[0:32, :] = local_a[:32, :]
+    original[64:96, :] = local_b[:32, :]
+    assert_with_pcc(original.float(), out_torch.float(), pcc=0.999)
+
+
+def test_insert_2d_indices_matches_torch_slice(device):
+    global_rows = 160
+    local_rows = 64
+    hidden_dim = 64
+    starts = [0, 32, 96]
+    counts = [32, 48, 32]
+    expert_id = 1
+
+    torch.manual_seed(1)
+    global_torch = torch.randn(global_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+    local_torch = torch.randn(local_rows, hidden_dim, dtype=torch.float32).to(torch.bfloat16)
+
+    g = _to_tile_bfp8(device, global_torch)
+    l = _to_tile_bfp8(device, local_torch)
+    global_q = ttnn.to_torch(g).clone()
+    local_q = ttnn.to_torch(l)
+    s = ttnn.from_torch(
+        torch.tensor([starts], dtype=torch.int32),
+        device=device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    c = ttnn.from_torch(
+        torch.tensor([counts], dtype=torch.int32),
+        device=device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    out = _run(g, l, s, c, global_expert_id=expert_id)
+    out_torch = ttnn.to_torch(out)
+
+    rows = _ceil_to_tile(counts[expert_id])
+    expected = global_q.clone()
+    expected[starts[expert_id] : starts[expert_id] + rows, :] = local_q[:rows, :]
+
+    assert out_torch.shape == global_torch.shape
+    torch.testing.assert_close(out_torch.float(), expected.float(), atol=0.0, rtol=0.0)
+    # PCC against the original (pre-quantization) bfloat16 reference.
+    original = global_torch.clone()
+    original[starts[expert_id] : starts[expert_id] + rows, :] = local_torch[:rows, :]
+    assert_with_pcc(original.float(), out_torch.float(), pcc=0.999)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -303,6 +303,8 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/plusone/plusone_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
@@ -721,6 +723,8 @@ target_link_libraries(
         TTNN::Ops::Experimental::DeepSeekPrefill::Combine
         TTNN::Ops::Experimental::DeepSeekPrefill::MaskedBincount
         TTNN::Ops::Experimental::DeepSeekPrefill::OffsetCumsum
+        TTNN::Ops::Experimental::DeepSeekPrefill::Extract
+        TTNN::Ops::Experimental::DeepSeekPrefill::Insert
         TTNN::Ops::Experimental::PagedCache
         TTNN::Ops::Experimental::PlusOne
         TTNN::Ops::Experimental::Reduction
@@ -973,6 +977,8 @@ add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/dispatch)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/combine)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum)
+add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/extract)
+add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/insert)
 add_subdirectory(cpp/ttnn/operations/experimental/padded_slice)
 add_subdirectory(cpp/ttnn/operations/experimental/paged_cache)
 add_subdirectory(cpp/ttnn/operations/experimental/plusone)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/CMakeLists.txt
@@ -1,0 +1,51 @@
+add_library(ttnn_op_experimental_deepseek_prefill_extract ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::DeepSeekPrefill::Extract ALIAS ttnn_op_experimental_deepseek_prefill_extract)
+
+target_precompile_headers(ttnn_op_experimental_deepseek_prefill_extract REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_deepseek_prefill_extract)
+
+set_target_properties(
+    ttnn_op_experimental_deepseek_prefill_extract
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+file(GLOB_RECURSE kernels device/kernels/*)
+
+target_sources(
+    ttnn_op_experimental_deepseek_prefill_extract
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
+    PRIVATE
+        device/extract_device_operation.cpp
+        device/extract_program_factory.cpp
+        extract.cpp
+)
+
+target_include_directories(ttnn_op_experimental_deepseek_prefill_extract PRIVATE ${FixmeOpIncDirs})
+target_link_libraries(
+    ttnn_op_experimental_deepseek_prefill_extract
+    PRIVATE
+        TT::Metalium
+        TTNN::Core
+)
+
+install(
+    TARGETS
+        ttnn_op_experimental_deepseek_prefill_extract
+    FILE_SET
+    kernels
+        DESTINATION
+            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract
+        COMPONENT ttnn-runtime
+)
+
+install(TARGETS ttnn_op_experimental_deepseek_prefill_extract LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_device_operation.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "extract_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract {
+
+namespace {
+
+bool is_dram_interleaved(const ttnn::Tensor& tensor) {
+    const auto& mem_cfg = tensor.memory_config();
+    return mem_cfg.buffer_type() == tt::tt_metal::BufferType::DRAM &&
+           mem_cfg.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
+}
+
+void validate_index_tensor(const ttnn::Tensor& tensor, const std::string& name) {
+    TT_FATAL(tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
+    TT_FATAL(tensor.buffer() != nullptr, "{} must have a buffer", name);
+    TT_FATAL(tensor.dtype() == tt::tt_metal::DataType::UINT32, "{} must be UINT32, got {}", name, tensor.dtype());
+    TT_FATAL(
+        tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "{} must be ROW_MAJOR layout, got {}", name, tensor.layout());
+    TT_FATAL(is_dram_interleaved(tensor), "{} must be DRAM interleaved", name);
+
+    const auto& shape = tensor.logical_shape();
+    const auto rank = shape.rank();
+    const bool valid_1d = rank == 1;
+    const bool valid_2d = rank == 2 && shape[0] == 1;
+    TT_FATAL(valid_1d || valid_2d, "{} must be 1D or 2D with first dimension == 1, got shape {}", name, shape);
+}
+
+}  // namespace
+
+// Host-side validation covers only static invariants (dtypes, layouts,
+// shape relationships, tile alignment of host-known scalars). The two
+// *data-dependent* bounds below are checked on-device at runtime inside the
+// reader/writer kernels:
+//   * start[id] + ceil_tile(counts[id]) <= global_rows — slice stays inside
+//     global_tensor.
+//   * ceil_tile(counts[id]) <= max_dispatched_tokens_per_expert — slice fits
+//     in the output tensor.
+// Host can't check these here without reading device-resident start/counts,
+// which we deliberately avoid (op must be device-local for multi-device mesh
+// use — each device may have its own start/counts values).
+//
+// NOT CHECKED anywhere (caller's contract):
+//   * start[id] + counts[id] <= start[id + 1] — this expert's slice does not
+//     overlap the next expert's slice. Enforcing this would require reading
+//     the adjacent expert's metadata, which breaks the "single global_expert_id,
+//     no cross-expert state" contract. Upstream code laying out the dispatch
+//     buffer is responsible for honoring this invariant.
+void ExtractDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& global_tensor = tensor_args.global_tensor;
+    const auto& start = tensor_args.start;
+    const auto& counts = tensor_args.counts;
+
+    // Global tensor validation: 2D, BFLOAT8_B, TILE layout, DRAM interleaved, on device.
+    TT_FATAL(global_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "global_tensor must be on device");
+    TT_FATAL(global_tensor.buffer() != nullptr, "global_tensor must have a buffer");
+    TT_FATAL(
+        global_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
+        "global_tensor must be BFLOAT8_B, got {}",
+        global_tensor.dtype());
+    TT_FATAL(
+        global_tensor.layout() == tt::tt_metal::Layout::TILE,
+        "global_tensor must be TILE layout, got {}",
+        global_tensor.layout());
+    TT_FATAL(is_dram_interleaved(global_tensor), "global_tensor must be DRAM interleaved");
+    TT_FATAL(
+        global_tensor.logical_shape().rank() == 2,
+        "global_tensor must be 2D, got rank {}",
+        global_tensor.logical_shape().rank());
+
+    // start and counts tensors share the same constraints.
+    validate_index_tensor(start, "start");
+    validate_index_tensor(counts, "counts");
+
+    // Last dimension of start and counts must match.
+    const auto start_last_dim = start.logical_shape()[-1];
+    const auto counts_last_dim = counts.logical_shape()[-1];
+    TT_FATAL(
+        start_last_dim == counts_last_dim,
+        "start and counts must have the same last dimension, got start={} and counts={}",
+        start_last_dim,
+        counts_last_dim);
+
+    // global_expert_id must index into counts' last dimension.
+    TT_FATAL(
+        operation_attributes.global_expert_id < counts_last_dim,
+        "global_expert_id ({}) must be in the range [0, {}] (counts last dimension - 1)",
+        operation_attributes.global_expert_id,
+        counts_last_dim - 1);
+
+    // Tile-alignment checks.
+    const uint32_t tile_height = tt::constants::TILE_HEIGHT;
+    const uint32_t tile_width = tt::constants::TILE_WIDTH;
+    const auto global_rows = global_tensor.logical_shape()[0];
+    const auto hidden_dim = global_tensor.logical_shape()[-1];
+    TT_FATAL(
+        global_rows % tile_height == 0,
+        "global_tensor rows/tokens ({}) must be a multiple of TILE_HEIGHT ({})",
+        global_rows,
+        tile_height);
+    TT_FATAL(
+        hidden_dim % tile_width == 0,
+        "global_tensor hidden_dim ({}) must be a multiple of TILE_WIDTH ({})",
+        hidden_dim,
+        tile_width);
+    TT_FATAL(operation_attributes.max_dispatched_tokens_per_expert > 0, "max_dispatched_tokens_per_expert must be > 0");
+    TT_FATAL(
+        operation_attributes.max_dispatched_tokens_per_expert % tile_height == 0,
+        "max_dispatched_tokens_per_expert ({}) must be a multiple of TILE_HEIGHT ({})",
+        operation_attributes.max_dispatched_tokens_per_expert,
+        tile_height);
+}
+
+void ExtractDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
+    // Empty for now.
+}
+
+ExtractDeviceOperation::spec_return_value_t ExtractDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& global_tensor = tensor_args.global_tensor;
+    const auto hidden_dim = global_tensor.logical_shape()[-1];
+    // Output shape: [max_dispatched_tokens_per_expert, hidden_dim], TILE layout,
+    // BFLOAT8_B, DRAM interleaved. Kernels fill only the first
+    // ceil_tile(counts[global_expert_id]) rows/tokens; the rest is undefined.
+    const ttnn::Shape output_shape({operation_attributes.max_dispatched_tokens_per_expert, hidden_dim});
+    const auto mem_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    return TensorSpec(
+        output_shape,
+        tt::tt_metal::TensorLayout(
+            global_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), mem_config));
+}
+
+ExtractDeviceOperation::tensor_return_value_t ExtractDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.global_tensor.device());
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract
+
+namespace ttnn::prim {
+
+ttnn::Tensor prefill_extract(
+    const ttnn::Tensor& global_tensor,
+    const ttnn::Tensor& start,
+    const ttnn::Tensor& counts,
+    uint32_t global_expert_id,
+    uint32_t max_dispatched_tokens_per_expert) {
+    using OperationType = ttnn::operations::experimental::deepseek_prefill::extract::ExtractDeviceOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .global_expert_id = global_expert_id, .max_dispatched_tokens_per_expert = max_dispatched_tokens_per_expert},
+        OperationType::tensor_args_t{.global_tensor = global_tensor, .start = start, .counts = counts});
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_device_operation.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <variant>
+
+#include "extract_types.hpp"
+#include "extract_program_factory.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract {
+
+struct ExtractDeviceOperation {
+    using operation_attributes_t = ExtractParams;
+    using tensor_args_t = ExtractInputs;
+    using spec_return_value_t = ttnn::TensorSpec;
+    using tensor_return_value_t = ttnn::Tensor;
+    using program_factory_t = std::variant<ExtractProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract
+
+namespace ttnn::prim {
+
+ttnn::Tensor prefill_extract(
+    const ttnn::Tensor& global_tensor,
+    const ttnn::Tensor& start,
+    const ttnn::Tensor& counts,
+    uint32_t global_expert_id,
+    uint32_t max_dispatched_tokens_per_expert);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_program_factory.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "extract_program_factory.hpp"
+
+#include <cstdint>
+#include <utility>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract {
+
+ExtractProgramFactory::cached_program_t ExtractProgramFactory::create(
+    const ExtractParams& operation_attributes, const ExtractInputs& tensor_args, Tensor& tensor_return_value) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    const auto& global_tensor = tensor_args.global_tensor;
+    const auto& start = tensor_args.start;
+    const auto& counts = tensor_args.counts;
+    Tensor& output_tensor = tensor_return_value;
+
+    constexpr uint32_t tile_width = tt::constants::TILE_WIDTH;
+    const auto hidden_dim = global_tensor.logical_shape()[-1];
+    const auto global_rows = global_tensor.logical_shape()[0];
+    const uint32_t tiles_per_row = hidden_dim / tile_width;
+    // Total tiles available in global_tensor — passed to the reader so it can
+    // assert (at runtime) that start[id] + ceil_tile(counts[id]) stays within
+    // the tensor bounds.
+    const uint32_t global_num_tiles = (global_rows / tt::constants::TILE_HEIGHT) * tiles_per_row;
+    // Maximum tiles we're allowed to emit into the output — passed to both
+    // kernels so they can assert ceil_tile(counts[id]) <= max_dispatched_tokens_per_expert.
+    const uint32_t max_output_tiles =
+        (operation_attributes.max_dispatched_tokens_per_expert / tt::constants::TILE_HEIGHT) * tiles_per_row;
+
+    // NOTE: We do NOT verify the inter-expert layout invariant
+    //   start[id] + counts[id] <= start[id + 1]
+    // i.e. that one expert's slice doesn't bleed into the next expert's slice
+    // in global_tensor. That's the caller's contract to uphold. Enforcing it
+    // would require reading start/counts host-side (which we explicitly avoid
+    // to keep the op device-local across a mesh) or cross-iteration state in
+    // the kernels. The bounds checks below cover only "stay inside global_tensor"
+    // and "stay inside the output tensor".
+
+    auto* global_buffer = global_tensor.buffer();
+    auto* start_buffer = start.buffer();
+    auto* counts_buffer = counts.buffer();
+    auto* output_buffer = output_tensor.buffer();
+
+    const tt::DataFormat tile_data_format = tt::tt_metal::datatype_to_dataformat_converter(global_tensor.dtype());
+    const uint32_t single_tile_size = tt::tile_size(tile_data_format);
+
+    const uint32_t start_page_size = start_buffer->aligned_page_size();
+    const uint32_t counts_page_size = counts_buffer->aligned_page_size();
+    const tt::DataFormat idx_data_format = tt::tt_metal::datatype_to_dataformat_converter(start.dtype());
+
+    // Single-core implementation: reader streams tiles, writer drains them.
+    const CoreCoord core{0, 0};
+    const CoreRange core_range{core, core};
+    const CoreRangeSet core_range_set{core_range};
+
+    constexpr uint32_t cb_tile = tt::CBIndex::c_0;
+    constexpr uint32_t cb_start_scratch = tt::CBIndex::c_1;
+    constexpr uint32_t cb_counts_scratch_reader = tt::CBIndex::c_2;
+    constexpr uint32_t cb_counts_scratch_writer = tt::CBIndex::c_3;
+
+    // Deep pipeline so the reader can race ahead of the writer (and vice versa)
+    // without stalling on cb_reserve_back / cb_wait_front. Each tile is small
+    // (e.g. ~1 KB for bfp8_b) so even 32 slots is only ~32 KB of L1.
+    constexpr uint32_t tile_buffering = 32;
+    tt::tt_metal::CircularBufferConfig cb_tile_config =
+        tt::tt_metal::CircularBufferConfig(tile_buffering * single_tile_size, {{cb_tile, tile_data_format}})
+            .set_page_size(cb_tile, single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_tile_config);
+
+    tt::tt_metal::CircularBufferConfig cb_start_config =
+        tt::tt_metal::CircularBufferConfig(start_page_size, {{cb_start_scratch, idx_data_format}})
+            .set_page_size(cb_start_scratch, start_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_start_config);
+
+    tt::tt_metal::CircularBufferConfig cb_counts_reader_config =
+        tt::tt_metal::CircularBufferConfig(counts_page_size, {{cb_counts_scratch_reader, idx_data_format}})
+            .set_page_size(cb_counts_scratch_reader, counts_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_counts_reader_config);
+
+    tt::tt_metal::CircularBufferConfig cb_counts_writer_config =
+        tt::tt_metal::CircularBufferConfig(counts_page_size, {{cb_counts_scratch_writer, idx_data_format}})
+            .set_page_size(cb_counts_scratch_writer, counts_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_counts_writer_config);
+
+    // Reader compile-time args: CB ids, scalars, then TensorAccessorArgs for global/start/counts.
+    std::vector<uint32_t> reader_compile_time_args = {
+        cb_tile,
+        cb_start_scratch,
+        cb_counts_scratch_reader,
+        operation_attributes.global_expert_id,
+        tiles_per_row,
+        global_num_tiles,
+        max_output_tiles,
+    };
+    tt::tt_metal::TensorAccessorArgs(global_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(counts_buffer).append_to(reader_compile_time_args);
+
+    // Writer compile-time args: CB ids, scalars, then TensorAccessorArgs for output/counts.
+    std::vector<uint32_t> writer_compile_time_args = {
+        cb_tile,
+        cb_counts_scratch_writer,
+        operation_attributes.global_expert_id,
+        tiles_per_row,
+        max_output_tiles,
+    };
+    tt::tt_metal::TensorAccessorArgs(output_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(counts_buffer).append_to(writer_compile_time_args);
+
+    auto reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/reader_extract.cpp",
+        core_range_set,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    auto writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/writer_extract.cpp",
+        core_range_set,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    tt::tt_metal::SetRuntimeArgs(
+        program, reader_kernel_id, core, {global_buffer->address(), start_buffer->address(), counts_buffer->address()});
+    tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, {output_buffer->address(), counts_buffer->address()});
+
+    return cached_program_t{
+        std::move(program),
+        {.reader_kernel_id = reader_kernel_id, .writer_kernel_id = writer_kernel_id, .cores = {core}}};
+}
+
+void ExtractProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const ExtractParams& /*operation_attributes*/,
+    const ExtractInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    auto& program = cached_program.program;
+    const auto reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+    const auto writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
+    const auto& cores = cached_program.shared_variables.cores;
+
+    const uint32_t global_addr = tensor_args.global_tensor.buffer()->address();
+    const uint32_t start_addr = tensor_args.start.buffer()->address();
+    const uint32_t counts_addr = tensor_args.counts.buffer()->address();
+    const uint32_t output_addr = tensor_return_value.buffer()->address();
+
+    for (const auto& core : cores) {
+        auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
+        reader_args[0] = global_addr;
+        reader_args[1] = start_addr;
+        reader_args[2] = counts_addr;
+
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
+        writer_args[0] = output_addr;
+        writer_args[1] = counts_addr;
+    }
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_program_factory.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include "extract_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract {
+
+struct ExtractSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    std::vector<CoreCoord> cores;
+};
+
+struct ExtractProgramFactory {
+    using shared_variables_t = ExtractSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const ExtractParams& operation_attributes, const ExtractInputs& tensor_args, Tensor& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const ExtractParams& operation_attributes,
+        const ExtractInputs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_types.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract {
+
+struct ExtractParams {
+    uint32_t global_expert_id;
+    uint32_t max_dispatched_tokens_per_expert;
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("global_expert_id", "max_dispatched_tokens_per_expert");
+
+    auto attribute_values() const { return std::forward_as_tuple(global_expert_id, max_dispatched_tokens_per_expert); }
+};
+
+struct ExtractInputs {
+    Tensor global_tensor;
+    Tensor start;
+    Tensor counts;
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/reader_extract.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/reader_extract.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reader kernel for the deepseek_prefill::extract op.
+// Reads start[global_expert_id] and counts[global_expert_id] from DRAM at
+// runtime, then streams ceil_tile(counts) * tiles_per_row tiles from
+// global_tensor (starting at row/token `start`) into the reader→writer CB.
+//
+// Reads are issued in batches so that multiple tiles are in flight on the NOC
+// at the same time (one barrier per batch instead of per tile).
+//
+// Bounds we check at runtime:
+//   * start[id] + ceil_tile(counts[id]) fits inside global_tensor.
+//   * ceil_tile(counts[id]) fits inside the output tensor (capped by
+//     max_dispatched_tokens_per_expert).
+//
+// Bounds we DO NOT check (caller's contract):
+//   * start[id] + counts[id] <= start[id + 1] — i.e. this expert's slice does
+//     not overlap the next expert's slice in global_tensor. Verifying this
+//     would require reading the adjacent expert's start/counts, which
+//     contradicts the op's per-device contract (each device operates on a
+//     single global_expert_id with no cross-expert state). Upstream code that
+//     lays out the dispatch buffer is responsible for honoring this
+//     invariant.
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
+
+constexpr uint32_t TILE_HEIGHT = 32;
+constexpr uint32_t READ_BATCH = 8;  // tiles per NOC barrier; must be <= CB depth.
+
+void kernel_main() {
+    const uint32_t global_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_addr = get_arg_val<uint32_t>(1);
+    const uint32_t counts_addr = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_tile = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(2);
+    constexpr uint32_t global_expert_id = get_compile_time_arg_val(3);
+    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(4);
+    // Upper bounds used for runtime asserts (see comment block above).
+    constexpr uint32_t global_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t max_output_tiles = get_compile_time_arg_val(6);
+
+    constexpr uint32_t global_accessor_offset = 7;
+    constexpr auto global_args = TensorAccessorArgs<global_accessor_offset>();
+    const auto global_accessor = TensorAccessor(global_args, global_addr, get_tile_size(cb_tile));
+
+    constexpr uint32_t start_accessor_offset = global_args.next_compile_time_args_offset();
+    constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
+    const auto start_accessor = TensorAccessor(start_args, start_addr);
+
+    constexpr uint32_t counts_accessor_offset = start_args.next_compile_time_args_offset();
+    constexpr auto counts_args = TensorAccessorArgs<counts_accessor_offset>();
+    const auto counts_accessor = TensorAccessor(counts_args, counts_addr);
+
+    // Fetch whole start and counts tensors (small, 1 page each) into L1 scratch.
+    const uint32_t start_l1 = get_write_ptr(cb_start_scratch);
+    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
+    noc_async_read_page(0, start_accessor, start_l1);
+    noc_async_read_page(0, counts_accessor, counts_l1);
+    noc_async_read_barrier();
+
+    const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
+    const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
+    const uint32_t start_value = start_ptr[global_expert_id];
+    const uint32_t counts_value = counts_ptr[global_expert_id];
+    const uint32_t counts_rounded_up = ((counts_value + TILE_HEIGHT - 1) / TILE_HEIGHT) * TILE_HEIGHT;
+    const uint32_t num_tile_rows = counts_rounded_up / TILE_HEIGHT;
+    const uint32_t num_tiles = num_tile_rows * tiles_per_row;
+    const uint32_t start_tile_idx = (start_value / TILE_HEIGHT) * tiles_per_row;
+
+    // Runtime bounds checks. Note: inter-expert layout invariant
+    // (start[id] + counts[id] <= start[id + 1]) is NOT enforced — see file
+    // header comment.
+    ASSERT(start_tile_idx + num_tiles <= global_num_tiles);
+    ASSERT(num_tiles <= max_output_tiles);
+
+    const uint32_t tile_bytes = get_tile_size(cb_tile);
+
+    uint32_t tile_idx = start_tile_idx;
+    const uint32_t end_tile_idx = start_tile_idx + num_tiles;
+    while (tile_idx < end_tile_idx) {
+        const uint32_t remaining = end_tile_idx - tile_idx;
+        const uint32_t batch = remaining < READ_BATCH ? remaining : READ_BATCH;
+
+        cb_reserve_back(cb_tile, batch);
+        uint32_t l1_write_addr = get_write_ptr(cb_tile);
+        for (uint32_t i = 0; i < batch; ++i) {
+            noc_async_read_tile(tile_idx + i, global_accessor, l1_write_addr);
+            l1_write_addr += tile_bytes;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_tile, batch);
+
+        tile_idx += batch;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/writer_extract.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/writer_extract.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Writer kernel for the deepseek_prefill::extract op.
+// Reads counts[global_expert_id] from DRAM at runtime to determine how many
+// tiles to drain from the reader→writer CB and write to the output tensor.
+//
+// Writes are issued in batches so multiple tiles are in flight on the NOC at
+// the same time (one barrier per batch instead of per tile).
+//
+// Bounds we check at runtime:
+//   * ceil_tile(counts[id]) fits inside the output tensor (capped by
+//     max_dispatched_tokens_per_expert).
+//
+// Bounds we DO NOT check (caller's contract):
+//   * start[id] + counts[id] <= start[id + 1] — i.e. this expert's slice does
+//     not overlap the next expert's slice in global_tensor. The writer doesn't
+//     touch global_tensor so this bound is the reader's domain; see
+//     reader_extract.cpp for the full rationale.
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
+
+constexpr uint32_t TILE_HEIGHT = 32;
+constexpr uint32_t WRITE_BATCH = 8;  // tiles per NOC barrier; must be <= CB depth.
+
+void kernel_main() {
+    const uint32_t output_addr = get_arg_val<uint32_t>(0);
+    const uint32_t counts_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t cb_tile = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(1);
+    constexpr uint32_t global_expert_id = get_compile_time_arg_val(2);
+    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);
+    // Upper bound used for runtime assert (see comment block above).
+    constexpr uint32_t max_output_tiles = get_compile_time_arg_val(4);
+
+    constexpr uint32_t output_accessor_offset = 5;
+    constexpr auto output_args = TensorAccessorArgs<output_accessor_offset>();
+    const auto output_accessor = TensorAccessor(output_args, output_addr, get_tile_size(cb_tile));
+
+    constexpr uint32_t counts_accessor_offset = output_args.next_compile_time_args_offset();
+    constexpr auto counts_args = TensorAccessorArgs<counts_accessor_offset>();
+    const auto counts_accessor = TensorAccessor(counts_args, counts_addr);
+
+    // Fetch the counts tensor (small, 1 page) into L1 scratch.
+    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
+    noc_async_read_page(0, counts_accessor, counts_l1);
+    noc_async_read_barrier();
+
+    const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
+    const uint32_t counts_value = counts_ptr[global_expert_id];
+    const uint32_t counts_rounded_up = ((counts_value + TILE_HEIGHT - 1) / TILE_HEIGHT) * TILE_HEIGHT;
+    const uint32_t num_tile_rows = counts_rounded_up / TILE_HEIGHT;
+    const uint32_t num_tiles = num_tile_rows * tiles_per_row;
+
+    // Runtime bounds check. Note: inter-expert layout invariant
+    // (start[id] + counts[id] <= start[id + 1]) is NOT enforced — see file
+    // header comment.
+    ASSERT(num_tiles <= max_output_tiles);
+
+    const uint32_t tile_bytes = get_tile_size(cb_tile);
+
+    uint32_t tile_idx = 0;
+    while (tile_idx < num_tiles) {
+        const uint32_t remaining = num_tiles - tile_idx;
+        const uint32_t batch = remaining < WRITE_BATCH ? remaining : WRITE_BATCH;
+
+        cb_wait_front(cb_tile, batch);
+        uint32_t l1_read_addr = get_read_ptr(cb_tile);
+        for (uint32_t i = 0; i < batch; ++i) {
+            noc_async_write_tile(tile_idx + i, output_accessor, l1_read_addr);
+            l1_read_addr += tile_bytes;
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_tile, batch);
+
+        tile_idx += batch;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "extract.hpp"
+#include "device/extract_device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract {
+
+ttnn::Tensor extract(
+    const ttnn::Tensor& global_tensor,
+    const ttnn::Tensor& start,
+    const ttnn::Tensor& counts,
+    uint32_t global_expert_id,
+    uint32_t max_dispatched_tokens_per_expert) {
+    return ttnn::prim::prefill_extract(
+        global_tensor, start, counts, global_expert_id, max_dispatched_tokens_per_expert);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract {
+
+ttnn::Tensor extract(
+    const ttnn::Tensor& global_tensor,
+    const ttnn::Tensor& start,
+    const ttnn::Tensor& counts,
+    uint32_t global_expert_id,
+    uint32_t max_dispatched_tokens_per_expert);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract
+
+namespace ttnn {
+using operations::experimental::deepseek_prefill::extract::extract;
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "extract_nanobind.hpp"
+
+#include <cstdint>
+
+#include <nanobind/nanobind.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "extract.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract::detail {
+
+void bind_extract(nb::module_& mod) {
+    ttnn::bind_function<"extract", "ttnn.experimental.deepseek_prefill.">(
+        mod,
+        R"doc(
+            Extract operation for DeepSeek prefill MoE.
+
+            Each device independently reads start[global_expert_id] and counts[global_expert_id]
+            from its own DRAM and copies
+            global_tensor[start : start + ceil_tile(counts), :]
+            into the first rows/tokens of the output tensor.
+
+            The output has shape [max_dispatched_tokens_per_expert, hidden_dim]; rows/tokens beyond
+            ceil_tile(counts[global_expert_id]) are left uninitialized.
+
+            Args:
+                global_tensor (ttnn.Tensor): 2D BFLOAT8_B TILE-layout DRAM interleaved tensor.
+                start (ttnn.Tensor): 1D tensor (or 2D with first dim == 1) of UINT32,
+                    DRAM interleaved, giving the per-expert starting row/token offsets.
+                counts (ttnn.Tensor): 1D tensor (or 2D with first dim == 1) of UINT32,
+                    DRAM interleaved, giving the per-expert row/token counts.
+                global_expert_id (int): UINT32 scalar selecting which expert's slice to extract.
+                max_dispatched_tokens_per_expert (int): Host-known upper bound on the number of
+                    rows/tokens that can be extracted per expert. Must be a multiple of TILE_HEIGHT (32).
+                    Defines the output tensor's row/token dimension.
+
+            Returns:
+                ttnn.Tensor: [max_dispatched_tokens_per_expert, hidden_dim] BFLOAT8_B TILE-layout
+                    DRAM tensor. Valid rows/tokens are in [0, ceil_tile(counts[global_expert_id])).
+        )doc",
+        &ttnn::operations::experimental::deepseek_prefill::extract::extract,
+        nb::arg("global_tensor").noconvert(),
+        nb::arg("start").noconvert(),
+        nb::arg("counts").noconvert(),
+        nb::kw_only(),
+        nb::arg("global_expert_id"),
+        nb::arg("max_dispatched_tokens_per_expert"));
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract::detail
+
+namespace ttnn::operations::experimental::deepseek_prefill::detail {
+
+void bind_extract(::nanobind::module_& mod) { extract::detail::bind_extract(mod); }
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::extract::detail {
+namespace nb = nanobind;
+void bind_extract(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::deepseek_prefill::extract::detail
+
+namespace ttnn::operations::experimental::deepseek_prefill::detail {
+void bind_extract(::nanobind::module_& mod);
+}  // namespace ttnn::operations::experimental::deepseek_prefill::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/CMakeLists.txt
@@ -1,0 +1,51 @@
+add_library(ttnn_op_experimental_deepseek_prefill_insert ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::DeepSeekPrefill::Insert ALIAS ttnn_op_experimental_deepseek_prefill_insert)
+
+target_precompile_headers(ttnn_op_experimental_deepseek_prefill_insert REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_deepseek_prefill_insert)
+
+set_target_properties(
+    ttnn_op_experimental_deepseek_prefill_insert
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+file(GLOB_RECURSE kernels device/kernels/*)
+
+target_sources(
+    ttnn_op_experimental_deepseek_prefill_insert
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
+    PRIVATE
+        device/insert_device_operation.cpp
+        device/insert_program_factory.cpp
+        insert.cpp
+)
+
+target_include_directories(ttnn_op_experimental_deepseek_prefill_insert PRIVATE ${FixmeOpIncDirs})
+target_link_libraries(
+    ttnn_op_experimental_deepseek_prefill_insert
+    PRIVATE
+        TT::Metalium
+        TTNN::Core
+)
+
+install(
+    TARGETS
+        ttnn_op_experimental_deepseek_prefill_insert
+    FILE_SET
+    kernels
+        DESTINATION
+            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert
+        COMPONENT ttnn-runtime
+)
+
+install(TARGETS ttnn_op_experimental_deepseek_prefill_insert LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_device_operation.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "insert_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert {
+
+namespace {
+
+bool is_dram_interleaved(const ttnn::Tensor& tensor) {
+    const auto& mem_cfg = tensor.memory_config();
+    return mem_cfg.buffer_type() == tt::tt_metal::BufferType::DRAM &&
+           mem_cfg.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
+}
+
+void validate_index_tensor(const ttnn::Tensor& tensor, const std::string& name) {
+    TT_FATAL(tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
+    TT_FATAL(tensor.buffer() != nullptr, "{} must have a buffer", name);
+    TT_FATAL(tensor.dtype() == tt::tt_metal::DataType::UINT32, "{} must be UINT32, got {}", name, tensor.dtype());
+    TT_FATAL(
+        tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "{} must be ROW_MAJOR layout, got {}", name, tensor.layout());
+    TT_FATAL(is_dram_interleaved(tensor), "{} must be DRAM interleaved", name);
+
+    const auto& shape = tensor.logical_shape();
+    const auto rank = shape.rank();
+    const bool valid_1d = rank == 1;
+    const bool valid_2d = rank == 2 && shape[0] == 1;
+    TT_FATAL(valid_1d || valid_2d, "{} must be 1D or 2D with first dimension == 1, got shape {}", name, shape);
+}
+
+void validate_data_tensor(const ttnn::Tensor& tensor, const std::string& name) {
+    TT_FATAL(tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
+    TT_FATAL(tensor.buffer() != nullptr, "{} must have a buffer", name);
+    TT_FATAL(tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "{} must be BFLOAT8_B, got {}", name, tensor.dtype());
+    TT_FATAL(tensor.layout() == tt::tt_metal::Layout::TILE, "{} must be TILE layout, got {}", name, tensor.layout());
+    TT_FATAL(is_dram_interleaved(tensor), "{} must be DRAM interleaved", name);
+    TT_FATAL(tensor.logical_shape().rank() == 2, "{} must be 2D, got rank {}", name, tensor.logical_shape().rank());
+}
+
+}  // namespace
+
+// Host-side validation covers only static invariants (dtypes, layouts, shape
+// relationships, tile alignment of host-known scalars). Two *data-dependent*
+// bounds are checked on-device at runtime inside the reader/writer kernels:
+//   * start[id] + ceil_tile(counts[id]) <= global_rows — slice stays inside
+//     global_tensor.
+//   * ceil_tile(counts[id]) <= local_rows — kernel doesn't over-read local_tensor.
+// Host can't check these here without reading device-resident start/counts,
+// which we deliberately avoid (op must be device-local for multi-device mesh
+// use — each device may have its own start/counts values).
+//
+// NOT CHECKED anywhere (caller's contract):
+//   * start[id] + counts[id] <= start[id + 1] — this expert's slice does not
+//     overlap the next expert's slice. Enforcing this would require reading
+//     the adjacent expert's metadata, which breaks the "single global_expert_id,
+//     no cross-expert state" contract. Upstream code laying out the dispatch
+//     buffer is responsible for honoring this invariant.
+void InsertDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& global_tensor = tensor_args.global_tensor;
+    const auto& local_tensor = tensor_args.local_tensor;
+    const auto& start = tensor_args.start;
+    const auto& counts = tensor_args.counts;
+
+    // global_tensor / local_tensor validation: 2D, BFLOAT8_B, TILE, DRAM interleaved.
+    validate_data_tensor(global_tensor, "global_tensor");
+    validate_data_tensor(local_tensor, "local_tensor");
+
+    // Hidden dim must match between the two data tensors.
+    const auto global_hidden_dim = global_tensor.logical_shape()[-1];
+    const auto local_hidden_dim = local_tensor.logical_shape()[-1];
+    TT_FATAL(
+        global_hidden_dim == local_hidden_dim,
+        "local_tensor hidden_dim ({}) must match global_tensor hidden_dim ({})",
+        local_hidden_dim,
+        global_hidden_dim);
+
+    // start and counts tensors share the same constraints.
+    validate_index_tensor(start, "start");
+    validate_index_tensor(counts, "counts");
+
+    // Last dimension of start and counts must match.
+    const auto start_last_dim = start.logical_shape()[-1];
+    const auto counts_last_dim = counts.logical_shape()[-1];
+    TT_FATAL(
+        start_last_dim == counts_last_dim,
+        "start and counts must have the same last dimension, got start={} and counts={}",
+        start_last_dim,
+        counts_last_dim);
+
+    // global_expert_id must index into counts' last dimension.
+    TT_FATAL(
+        operation_attributes.global_expert_id < counts_last_dim,
+        "global_expert_id ({}) must be in the range [0, {}] (counts last dimension - 1)",
+        operation_attributes.global_expert_id,
+        counts_last_dim - 1);
+
+    // Tile-alignment checks.
+    const uint32_t tile_height = tt::constants::TILE_HEIGHT;
+    const uint32_t tile_width = tt::constants::TILE_WIDTH;
+    const auto global_rows = global_tensor.logical_shape()[0];
+    const auto local_rows = local_tensor.logical_shape()[0];
+    TT_FATAL(
+        global_rows % tile_height == 0,
+        "global_tensor rows/tokens ({}) must be a multiple of TILE_HEIGHT ({})",
+        global_rows,
+        tile_height);
+    TT_FATAL(
+        global_hidden_dim % tile_width == 0,
+        "global_tensor hidden_dim ({}) must be a multiple of TILE_WIDTH ({})",
+        global_hidden_dim,
+        tile_width);
+    TT_FATAL(
+        local_rows % tile_height == 0,
+        "local_tensor rows/tokens ({}) must be a multiple of TILE_HEIGHT ({})",
+        local_rows,
+        tile_height);
+    TT_FATAL(local_rows > 0, "local_tensor must have at least one tile row/token");
+}
+
+void InsertDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
+    // Empty for now.
+}
+
+InsertDeviceOperation::spec_return_value_t InsertDeviceOperation::compute_output_specs(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    // The op is in-place: the output is global_tensor.
+    return tensor_args.global_tensor.tensor_spec();
+}
+
+InsertDeviceOperation::tensor_return_value_t InsertDeviceOperation::create_output_tensors(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    // In-place: reuse global_tensor. No new DRAM allocation.
+    return tensor_args.global_tensor;
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert
+
+namespace ttnn::prim {
+
+ttnn::Tensor prefill_insert(
+    const ttnn::Tensor& global_tensor,
+    const ttnn::Tensor& local_tensor,
+    const ttnn::Tensor& start,
+    const ttnn::Tensor& counts,
+    uint32_t global_expert_id) {
+    using OperationType = ttnn::operations::experimental::deepseek_prefill::insert::InsertDeviceOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{.global_expert_id = global_expert_id},
+        OperationType::tensor_args_t{
+            .global_tensor = global_tensor, .local_tensor = local_tensor, .start = start, .counts = counts});
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_device_operation.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <variant>
+
+#include "insert_types.hpp"
+#include "insert_program_factory.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert {
+
+struct InsertDeviceOperation {
+    using operation_attributes_t = InsertParams;
+    using tensor_args_t = InsertInputs;
+    using spec_return_value_t = ttnn::TensorSpec;
+    using tensor_return_value_t = ttnn::Tensor;
+    using program_factory_t = std::variant<InsertProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert
+
+namespace ttnn::prim {
+
+ttnn::Tensor prefill_insert(
+    const ttnn::Tensor& global_tensor,
+    const ttnn::Tensor& local_tensor,
+    const ttnn::Tensor& start,
+    const ttnn::Tensor& counts,
+    uint32_t global_expert_id);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_program_factory.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "insert_program_factory.hpp"
+
+#include <cstdint>
+#include <utility>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert {
+
+InsertProgramFactory::cached_program_t InsertProgramFactory::create(
+    const InsertParams& operation_attributes, const InsertInputs& tensor_args, Tensor& tensor_return_value) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    const auto& global_tensor = tensor_args.global_tensor;
+    const auto& local_tensor = tensor_args.local_tensor;
+    const auto& start = tensor_args.start;
+    const auto& counts = tensor_args.counts;
+    // tensor_return_value is the same handle as global_tensor (see
+    // create_output_tensors). We still use its buffer address in runtime args
+    // via the framework — here we go directly through global_tensor because
+    // it is the authoritative source.
+    (void)tensor_return_value;
+
+    constexpr uint32_t tile_width = tt::constants::TILE_WIDTH;
+    const auto hidden_dim = global_tensor.logical_shape()[-1];
+    const auto global_rows = global_tensor.logical_shape()[0];
+    const auto local_rows = local_tensor.logical_shape()[0];
+    const uint32_t tiles_per_row = hidden_dim / tile_width;
+    // Upper bounds used for runtime asserts in the kernels.
+    const uint32_t global_num_tiles = (global_rows / tt::constants::TILE_HEIGHT) * tiles_per_row;
+    const uint32_t local_num_tiles = (local_rows / tt::constants::TILE_HEIGHT) * tiles_per_row;
+
+    // NOTE: We do NOT verify the inter-expert layout invariant
+    //   start[id] + counts[id] <= start[id + 1]
+    // i.e. that one expert's slice doesn't overwrite the next expert's slice
+    // in global_tensor. That's the caller's contract. Enforcing it would
+    // require reading start/counts host-side (which we explicitly avoid to
+    // keep the op device-local across a mesh) or cross-iteration state in the
+    // kernels. The bounds checks below cover only "stay inside global_tensor"
+    // and "stay inside local_tensor".
+
+    auto* global_buffer = global_tensor.buffer();
+    auto* local_buffer = local_tensor.buffer();
+    auto* start_buffer = start.buffer();
+    auto* counts_buffer = counts.buffer();
+
+    const tt::DataFormat tile_data_format = tt::tt_metal::datatype_to_dataformat_converter(global_tensor.dtype());
+    const uint32_t single_tile_size = tt::tile_size(tile_data_format);
+
+    const uint32_t start_page_size = start_buffer->aligned_page_size();
+    const uint32_t counts_page_size = counts_buffer->aligned_page_size();
+    const tt::DataFormat idx_data_format = tt::tt_metal::datatype_to_dataformat_converter(start.dtype());
+
+    // Single-core implementation: reader streams tiles from local, writer
+    // drains them into global at the expert's start offset.
+    const CoreCoord core{0, 0};
+    const CoreRange core_range{core, core};
+    const CoreRangeSet core_range_set{core_range};
+
+    constexpr uint32_t cb_tile = tt::CBIndex::c_0;
+    constexpr uint32_t cb_counts_scratch_reader = tt::CBIndex::c_1;
+    constexpr uint32_t cb_start_scratch_writer = tt::CBIndex::c_2;
+    constexpr uint32_t cb_counts_scratch_writer = tt::CBIndex::c_3;
+
+    // Deep tile pipeline — same rationale as in extract: decouple reader from
+    // writer jitter. Each tile is ~1 KB for bfp8_b so 32 slots is ~32 KB of L1.
+    constexpr uint32_t tile_buffering = 32;
+    tt::tt_metal::CircularBufferConfig cb_tile_config =
+        tt::tt_metal::CircularBufferConfig(tile_buffering * single_tile_size, {{cb_tile, tile_data_format}})
+            .set_page_size(cb_tile, single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_tile_config);
+
+    tt::tt_metal::CircularBufferConfig cb_counts_reader_config =
+        tt::tt_metal::CircularBufferConfig(counts_page_size, {{cb_counts_scratch_reader, idx_data_format}})
+            .set_page_size(cb_counts_scratch_reader, counts_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_counts_reader_config);
+
+    tt::tt_metal::CircularBufferConfig cb_start_writer_config =
+        tt::tt_metal::CircularBufferConfig(start_page_size, {{cb_start_scratch_writer, idx_data_format}})
+            .set_page_size(cb_start_scratch_writer, start_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_start_writer_config);
+
+    tt::tt_metal::CircularBufferConfig cb_counts_writer_config =
+        tt::tt_metal::CircularBufferConfig(counts_page_size, {{cb_counts_scratch_writer, idx_data_format}})
+            .set_page_size(cb_counts_scratch_writer, counts_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, cb_counts_writer_config);
+
+    // Reader compile-time args: CB ids, scalars, then TensorAccessorArgs for local/counts.
+    std::vector<uint32_t> reader_compile_time_args = {
+        cb_tile,
+        cb_counts_scratch_reader,
+        operation_attributes.global_expert_id,
+        tiles_per_row,
+        local_num_tiles,
+    };
+    tt::tt_metal::TensorAccessorArgs(local_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(counts_buffer).append_to(reader_compile_time_args);
+
+    // Writer compile-time args: CB ids, scalars, then TensorAccessorArgs for global/start/counts.
+    std::vector<uint32_t> writer_compile_time_args = {
+        cb_tile,
+        cb_start_scratch_writer,
+        cb_counts_scratch_writer,
+        operation_attributes.global_expert_id,
+        tiles_per_row,
+        global_num_tiles,
+    };
+    tt::tt_metal::TensorAccessorArgs(global_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(counts_buffer).append_to(writer_compile_time_args);
+
+    auto reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/reader_insert.cpp",
+        core_range_set,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    auto writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/writer_insert.cpp",
+        core_range_set,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, {local_buffer->address(), counts_buffer->address()});
+    tt::tt_metal::SetRuntimeArgs(
+        program, writer_kernel_id, core, {global_buffer->address(), start_buffer->address(), counts_buffer->address()});
+
+    return cached_program_t{
+        std::move(program),
+        {.reader_kernel_id = reader_kernel_id, .writer_kernel_id = writer_kernel_id, .cores = {core}}};
+}
+
+void InsertProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const InsertParams& /*operation_attributes*/,
+    const InsertInputs& tensor_args,
+    Tensor& /*tensor_return_value*/) {
+    auto& program = cached_program.program;
+    const auto reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+    const auto writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
+    const auto& cores = cached_program.shared_variables.cores;
+
+    const uint32_t global_addr = tensor_args.global_tensor.buffer()->address();
+    const uint32_t local_addr = tensor_args.local_tensor.buffer()->address();
+    const uint32_t start_addr = tensor_args.start.buffer()->address();
+    const uint32_t counts_addr = tensor_args.counts.buffer()->address();
+
+    for (const auto& core : cores) {
+        auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
+        reader_args[0] = local_addr;
+        reader_args[1] = counts_addr;
+
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
+        writer_args[0] = global_addr;
+        writer_args[1] = start_addr;
+        writer_args[2] = counts_addr;
+    }
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_program_factory.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include "insert_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert {
+
+struct InsertSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    std::vector<CoreCoord> cores;
+};
+
+struct InsertProgramFactory {
+    using shared_variables_t = InsertSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const InsertParams& operation_attributes, const InsertInputs& tensor_args, Tensor& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const InsertParams& operation_attributes,
+        const InsertInputs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_types.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert {
+
+struct InsertParams {
+    uint32_t global_expert_id;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("global_expert_id");
+
+    auto attribute_values() const { return std::forward_as_tuple(global_expert_id); }
+};
+
+struct InsertInputs {
+    Tensor global_tensor;
+    Tensor local_tensor;
+    Tensor start;
+    Tensor counts;
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/reader_insert.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/reader_insert.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reader kernel for the deepseek_prefill::insert op.
+// Reads counts[global_expert_id] from DRAM at runtime, then streams
+// ceil_tile(counts) * tiles_per_row tiles from the *front* of local_tensor
+// into the reader→writer CB.
+//
+// Reads are issued in batches so that multiple tiles are in flight on the NOC
+// at the same time (one barrier per batch instead of per tile).
+//
+// Bounds we check at runtime:
+//   * ceil_tile(counts[id]) fits inside local_tensor — i.e. we don't over-read.
+//
+// Bounds we DO NOT check (caller's contract):
+//   * start[id] + counts[id] <= start[id + 1] — see file header in
+//     insert_device_operation.cpp for rationale.
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
+
+constexpr uint32_t TILE_HEIGHT = 32;
+constexpr uint32_t READ_BATCH = 8;  // tiles per NOC barrier; must be <= CB depth.
+
+void kernel_main() {
+    const uint32_t local_addr = get_arg_val<uint32_t>(0);
+    const uint32_t counts_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t cb_tile = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(1);
+    constexpr uint32_t global_expert_id = get_compile_time_arg_val(2);
+    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);
+    constexpr uint32_t local_num_tiles = get_compile_time_arg_val(4);
+
+    constexpr uint32_t local_accessor_offset = 5;
+    constexpr auto local_args = TensorAccessorArgs<local_accessor_offset>();
+    const auto local_accessor = TensorAccessor(local_args, local_addr, get_tile_size(cb_tile));
+
+    constexpr uint32_t counts_accessor_offset = local_args.next_compile_time_args_offset();
+    constexpr auto counts_args = TensorAccessorArgs<counts_accessor_offset>();
+    const auto counts_accessor = TensorAccessor(counts_args, counts_addr);
+
+    // Fetch the counts tensor (small, 1 page) into L1 scratch.
+    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
+    noc_async_read_page(0, counts_accessor, counts_l1);
+    noc_async_read_barrier();
+
+    const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
+    const uint32_t counts_value = counts_ptr[global_expert_id];
+    const uint32_t counts_rounded_up = ((counts_value + TILE_HEIGHT - 1) / TILE_HEIGHT) * TILE_HEIGHT;
+    const uint32_t num_tile_rows = counts_rounded_up / TILE_HEIGHT;
+    const uint32_t num_tiles = num_tile_rows * tiles_per_row;
+
+    // Runtime bounds check: slice must fit inside local_tensor.
+    ASSERT(num_tiles <= local_num_tiles);
+
+    const uint32_t tile_bytes = get_tile_size(cb_tile);
+
+    uint32_t tile_idx = 0;
+    while (tile_idx < num_tiles) {
+        const uint32_t remaining = num_tiles - tile_idx;
+        const uint32_t batch = remaining < READ_BATCH ? remaining : READ_BATCH;
+
+        cb_reserve_back(cb_tile, batch);
+        uint32_t l1_write_addr = get_write_ptr(cb_tile);
+        for (uint32_t i = 0; i < batch; ++i) {
+            noc_async_read_tile(tile_idx + i, local_accessor, l1_write_addr);
+            l1_write_addr += tile_bytes;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_tile, batch);
+
+        tile_idx += batch;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/writer_insert.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/writer_insert.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Writer kernel for the deepseek_prefill::insert op.
+// Reads start[global_expert_id] and counts[global_expert_id] from DRAM at
+// runtime, then drains ceil_tile(counts) * tiles_per_row tiles from the
+// reader→writer CB into global_tensor starting at tile index
+// (start / TILE_HEIGHT) * tiles_per_row.
+//
+// Writes are issued in batches so multiple tiles are in flight on the NOC at
+// the same time (one barrier per batch instead of per tile).
+//
+// Bounds we check at runtime:
+//   * start[id] + ceil_tile(counts[id]) fits inside global_tensor.
+//
+// Bounds we DO NOT check (caller's contract):
+//   * start[id] + counts[id] <= start[id + 1] — see file header in
+//     insert_device_operation.cpp for rationale.
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
+
+constexpr uint32_t TILE_HEIGHT = 32;
+constexpr uint32_t WRITE_BATCH = 8;  // tiles per NOC barrier; must be <= CB depth.
+
+void kernel_main() {
+    const uint32_t global_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_addr = get_arg_val<uint32_t>(1);
+    const uint32_t counts_addr = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_tile = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(2);
+    constexpr uint32_t global_expert_id = get_compile_time_arg_val(3);
+    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(4);
+    constexpr uint32_t global_num_tiles = get_compile_time_arg_val(5);
+
+    constexpr uint32_t global_accessor_offset = 6;
+    constexpr auto global_args = TensorAccessorArgs<global_accessor_offset>();
+    const auto global_accessor = TensorAccessor(global_args, global_addr, get_tile_size(cb_tile));
+
+    constexpr uint32_t start_accessor_offset = global_args.next_compile_time_args_offset();
+    constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
+    const auto start_accessor = TensorAccessor(start_args, start_addr);
+
+    constexpr uint32_t counts_accessor_offset = start_args.next_compile_time_args_offset();
+    constexpr auto counts_args = TensorAccessorArgs<counts_accessor_offset>();
+    const auto counts_accessor = TensorAccessor(counts_args, counts_addr);
+
+    // Fetch start and counts tensors (small, 1 page each) into L1 scratch.
+    const uint32_t start_l1 = get_write_ptr(cb_start_scratch);
+    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
+    noc_async_read_page(0, start_accessor, start_l1);
+    noc_async_read_page(0, counts_accessor, counts_l1);
+    noc_async_read_barrier();
+
+    const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
+    const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
+    const uint32_t start_value = start_ptr[global_expert_id];
+    const uint32_t counts_value = counts_ptr[global_expert_id];
+    const uint32_t counts_rounded_up = ((counts_value + TILE_HEIGHT - 1) / TILE_HEIGHT) * TILE_HEIGHT;
+    const uint32_t num_tile_rows = counts_rounded_up / TILE_HEIGHT;
+    const uint32_t num_tiles = num_tile_rows * tiles_per_row;
+    const uint32_t start_tile_idx = (start_value / TILE_HEIGHT) * tiles_per_row;
+
+    // Runtime bounds check: slice must stay inside global_tensor.
+    ASSERT(start_tile_idx + num_tiles <= global_num_tiles);
+
+    const uint32_t tile_bytes = get_tile_size(cb_tile);
+
+    uint32_t offset = 0;
+    while (offset < num_tiles) {
+        const uint32_t remaining = num_tiles - offset;
+        const uint32_t batch = remaining < WRITE_BATCH ? remaining : WRITE_BATCH;
+
+        cb_wait_front(cb_tile, batch);
+        uint32_t l1_read_addr = get_read_ptr(cb_tile);
+        for (uint32_t i = 0; i < batch; ++i) {
+            noc_async_write_tile(start_tile_idx + offset + i, global_accessor, l1_read_addr);
+            l1_read_addr += tile_bytes;
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_tile, batch);
+
+        offset += batch;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "insert.hpp"
+#include "device/insert_device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert {
+
+ttnn::Tensor insert(
+    const ttnn::Tensor& global_tensor,
+    const ttnn::Tensor& local_tensor,
+    const ttnn::Tensor& start,
+    const ttnn::Tensor& counts,
+    uint32_t global_expert_id) {
+    return ttnn::prim::prefill_insert(global_tensor, local_tensor, start, counts, global_expert_id);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert {
+
+ttnn::Tensor insert(
+    const ttnn::Tensor& global_tensor,
+    const ttnn::Tensor& local_tensor,
+    const ttnn::Tensor& start,
+    const ttnn::Tensor& counts,
+    uint32_t global_expert_id);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert
+
+namespace ttnn {
+using operations::experimental::deepseek_prefill::insert::insert;
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert_nanobind.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "insert_nanobind.hpp"
+
+#include <cstdint>
+
+#include <nanobind/nanobind.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "insert.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert::detail {
+
+void bind_insert(nb::module_& mod) {
+    ttnn::bind_function<"insert", "ttnn.experimental.deepseek_prefill.">(
+        mod,
+        R"doc(
+            Insert operation for DeepSeek prefill MoE — inverse of extract.
+
+            Each device independently reads start[global_expert_id] and
+            counts[global_expert_id] from its own DRAM and copies the first
+            ceil_tile(counts[global_expert_id]) rows/tokens of local_tensor into
+            global_tensor[start : start + ceil_tile(counts), :].
+
+            The op writes in place into global_tensor and returns a handle to
+            that same tensor (no new allocation).
+
+            Args:
+                global_tensor (ttnn.Tensor): 2D BFLOAT8_B TILE-layout DRAM interleaved
+                    tensor that the slice is written into.
+                local_tensor (ttnn.Tensor): 2D BFLOAT8_B TILE-layout DRAM interleaved
+                    tensor providing the source rows/tokens. Must have the same hidden_dim
+                    as global_tensor.
+                start (ttnn.Tensor): 1D tensor (or 2D with first dim == 1) of UINT32,
+                    DRAM interleaved, giving the per-expert starting row/token offsets in
+                    global_tensor.
+                counts (ttnn.Tensor): 1D tensor (or 2D with first dim == 1) of UINT32,
+                    DRAM interleaved, giving the per-expert row/token counts.
+                global_expert_id (int): UINT32 scalar selecting which expert's slice
+                    to write.
+
+            Returns:
+                ttnn.Tensor: The same global_tensor handle, now with the slice
+                    written into [start, start + ceil_tile(counts)).
+        )doc",
+        &ttnn::operations::experimental::deepseek_prefill::insert::insert,
+        nb::arg("global_tensor").noconvert(),
+        nb::arg("local_tensor").noconvert(),
+        nb::arg("start").noconvert(),
+        nb::arg("counts").noconvert(),
+        nb::kw_only(),
+        nb::arg("global_expert_id"));
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert::detail
+
+namespace ttnn::operations::experimental::deepseek_prefill::detail {
+
+void bind_insert(::nanobind::module_& mod) { insert::detail::bind_insert(mod); }
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert_nanobind.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::insert::detail {
+namespace nb = nanobind;
+void bind_insert(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::deepseek_prefill::insert::detail
+
+namespace ttnn::operations::experimental::deepseek_prefill::detail {
+void bind_insert(::nanobind::module_& mod);
+}  // namespace ttnn::operations::experimental::deepseek_prefill::detail

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -68,6 +68,8 @@
 #include "ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/post_combine_reduce_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/insert/insert_nanobind.hpp"
 #include "ttnn/operations/experimental/generic/patchable_generic_op_nanobind.hpp"
 
 namespace ttnn::operations::experimental {
@@ -156,6 +158,8 @@ void py_module(nb::module_& mod) {
     deepseek_prefill::detail::bind_dispatch(mod);
     deepseek_prefill::detail::bind_combine(mod);
     deepseek_prefill::detail::bind_routed_expert_ffn(mod);
+    deepseek_prefill::detail::bind_extract(mod);
+    deepseek_prefill::detail::bind_insert(mod);
 
     deepseek_moe_post_combine_tilize::detail::bind_deepseek_moe_post_combine_tilize(mod);
     // Fused generic op with source-descriptor-based override


### PR DESCRIPTION
## Summary

Adds two new device-local ops under `ttnn.experimental.deepseek_prefill` for moving per-expert slices between a local staging tensor and a global dispatch buffer. Both ops read their per-expert metadata (`start`, `counts`) from DRAM at runtime so each chip operates independently — no host involvement in a mesh.

- **`extract(global, start, counts, *, global_expert_id, max_dispatched_tokens_per_expert)`** — copies `global[start[id] : start[id] + ceil_tile(counts[id]), :]` into the first rows of a freshly allocated `[max_dispatched_tokens_per_expert, hidden_dim]` output.
- **`insert(global, local, start, counts, *, global_expert_id)`** — inverse of extract; copies `local[:ceil_tile(counts[id]), :]` into `global[start[id] : start[id] + ceil_tile(counts[id]), :]` in place and returns a handle to the same `global`.

Both ops are single-core, tile-aligned, and use a deep (32-slot) reader→writer CB with 8-tile NOC batching for throughput. Kernel-side `ASSERT`s guard against per-expert slices exceeding the relevant tensor bounds; the inter-expert overlap invariant (`start[i] + counts[i] <= start[i+1]`) is explicitly the caller's contract and is documented in the code.

## Test plan

- [x] `pytest tests/ttnn/unit_tests/operations/deepseek/test_deepseek_prefill_extract.py` — 28 tests (constraint rejection + functional PCC across parametrized cases)
- [x] `pytest tests/ttnn/unit_tests/operations/deepseek/test_deepseek_prefill_insert.py` — 32 tests (constraint rejection + functional PCC including in-place back-to-back inserts)
- [x] Full `pytest tests/ttnn/unit_tests/operations/deepseek/` suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbajraktari/ds_prefill_extract_and_insert_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbajraktari/ds_prefill_extract_and_insert_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fbajraktari/ds_prefill_extract_and_insert_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fbajraktari/ds_prefill_extract_and_insert_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbajraktari/ds_prefill_extract_and_insert_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbajraktari/ds_prefill_extract_and_insert_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbajraktari/ds_prefill_extract_and_insert_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbajraktari/ds_prefill_extract_and_insert_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbajraktari/ds_prefill_extract_and_insert_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbajraktari/ds_prefill_extract_and_insert_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbajraktari/ds_prefill_extract_and_insert_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbajraktari/ds_prefill_extract_and_insert_ops)