### PR TITLE
ds_prefill(moe): remove gate_input_mem_config to_memory_config

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -31,7 +31,6 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_intermediates import TtMoEInterm
 from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
-from models.demos.deepseek_v3_d_p.utils.test_utils import get_input_mem_config
 
 
 class TtMoe(LightweightModule):
@@ -222,8 +221,6 @@ class TtMoe(LightweightModule):
             weight_cache_path=weight_cache_path,
             cache_name_prefix=f"layer_{layer_idx}.gate",
         )
-        self.gate_input_mem_config = get_input_mem_config(gate_config, mesh_device.shape)
-
         logger.debug(f"Initializing TtMoe")
         logger.debug(f"  mesh_device.shape={mesh_device.shape}")
         logger.debug(f"  dispatch_group_size={dispatch_group_size}, num_dispatch_groups={num_dispatch_groups}")
@@ -334,12 +331,9 @@ class TtMoe(LightweightModule):
         # Reshape 3D -> 2D for gate: (batch, seq, emb) -> (batch*seq, emb)
         x_for_gate = ttnn.reshape(x, (x.shape[0] * x.shape[1], x.shape[2]))
         x_for_gate = ttnn.to_layout(x_for_gate, ttnn.TILE_LAYOUT)
-        if self.gate_input_mem_config is not None:
-            # TODO: check perf loss for x_for_gate in DRAM vs to_memory_config(gate_input_mem_config)
-            x_for_gate = ttnn.to_memory_config(x_for_gate, self.gate_input_mem_config)
 
         scores, indices, gate_logits, tt_expert_offsets, tt_expert_token_counts = self.gate(x_for_gate)
-        ttnn.deallocate(x_for_gate)  # x_for_gate is L1 height sharded and no longer needed.
+        ttnn.deallocate(x_for_gate)  # x_for_gate is no longer needed.
         gate_logits = (
             ttnn.to_memory_config(gate_logits, ttnn.DRAM_MEMORY_CONFIG)
             if return_intermediates


### PR DESCRIPTION
## Summary

Closes #42618

Profiling showed that `ttnn.to_memory_config(x_for_gate, gate_input_mem_config)` (DRAM interleaved → L1 height-sharded) costs more than it saves. Remove it and keep `x_for_gate` in DRAM interleaved for the gate matmul.

## Per-Op Breakdown (gate → step0 window)

| OP Code | With `to_memory_config` | Without (DRAM) | Delta |
|---|---|---|---|
| TilizeDeviceOperation | 255 μs | 252 μs | -3 μs |
| **InterleavedToShardedDeviceOperation** | **115 μs** | **N/A** | **-115 μs** |
| **MatmulDeviceOperation** (3200x7168x256) | **217 μs** (39.2% FLOPs) | **264 μs** (32.1% FLOPs) | +47 μs |
| DeepseekGroupedGateDeviceOperation | 58 μs | 58 μs | 0 |
| AllBroadcastDeviceOperation | 27 μs | 20 μs | -7 μs |
| Other ops | ~94 μs | ~98 μs | +4 μs |

### Summary

| Metric | With `to_memory_config` | Without (DRAM) | Delta |
|---|---|---|---|
| **Total device time** | **769 μs** | **692 μs** | **-77 μs (10% faster)** |
| Device op count | 15 | 14 | -1 |
| Matmul FLOPs util | 39.2% | 32.1% | -7.1 pp |
| Matmul DRAM BW | 17 GB/s | 187 GB/s | +170 GB/s |

### Analysis

The sharding cost (115 μs) outweighs the matmul speedup (47 μs), yielding a net saving of 77 μs by staying in DRAM interleaved.

## Notes for reviewers

- Only `tt_moe.py` is changed — removed the import, attribute creation, and conditional block
- The `get_input_mem_config` function in `test_utils.py` is still used by test files (`test_gate_cache.py`, `test_moe_gate_prefill2d.py`)

## CI Pipelines

[![Galaxy DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch%3Ambezulj%2F2604-gate_input_mem_config)
[![T3K e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch%3Ambezulj%2F2604-gate_input_mem_config)
[![SP Release DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch%3Ambezulj%2F2604-gate_input_mem_config)
[![BH e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Ambezulj%2F2604-gate_input_mem_config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-gate_input_mem_config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-gate_input_mem_config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-gate_input_mem_config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-gate_input_mem_config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-gate_input_mem_config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-gate_input_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-gate_input_mem_config)