### PR TITLE
ds_prefill(add use_l1_small_for_semaphores to dispatch and combine)

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -122,6 +122,7 @@ jobs:
               pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc" --timeout 1800
               pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2 and pcc_check' -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/cache/ -vvv --tb=short
+              pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py -vvv --tb=short
             timeout: 25
             test-type: qb
             owner_id: U08E1JCMAJF # Marko Bezulj

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test that deepseek_prefill dispatch and combine global semaphores can be placed
+in L1_SMALL to prevent L1 fragmentation.
+
+Pattern (same as test_ccl_l1_small_semaphores.py):
+1. Allocate tensor_a in L1 (~80% full)
+2. Run dispatch+combine (creates global semaphores in L1 or L1_SMALL)
+3. Free all tensors (global semaphores persist in program cache)
+4. Try to allocate tensor_c in L1 (~100%)
+   - L1 semaphores  -> OOM (semaphores fragment L1)
+   - L1_SMALL sems  -> success (L1 is clean)
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    ExpertMapping,
+    compute_constants,
+    create_fabric_router_config,
+    extract_mesh_config,
+    get_dispatch_input_mesh_mapper,
+    get_gate_outputs,
+    get_max_payload_size,
+    initialize_test_inputs,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+from models.demos.deepseek_v3_d_p.utils.test_utils import print_l1_buffers, print_l1_small_buffers
+
+
+def run_dispatch_op(mesh_device, use_l1_small):
+    """Run dispatch op with small tensors in DRAM, creating 2 global semaphores."""
+    torch.manual_seed(42)
+
+    seq_len_per_chip = 64
+    emb_dim = 128
+    num_routed_experts = 16
+    num_experts_per_tok = 2
+    capacity_factor = 2
+
+    num_devices = mesh_device.get_num_devices()
+    mesh_config = extract_mesh_config(mesh_device)
+    sp_axis = mesh_config.sp_axis
+    dispatch_group_size = mesh_config.dispatch_group_size
+    num_dispatch_groups = mesh_config.num_dispatch_groups
+
+    experts_per_chip, metadata_len, max_dispatched_tokens_per_expert = compute_constants(
+        seq_len_per_chip, num_routed_experts, num_experts_per_tok, num_devices, dispatch_group_size, capacity_factor
+    )
+
+    x, weights, indices = initialize_test_inputs(
+        dispatch_group_size=dispatch_group_size,
+        seq_len_per_chip=seq_len_per_chip,
+        emb_dim=emb_dim,
+        num_routed_experts=num_routed_experts,
+        num_experts_per_tok=num_experts_per_tok,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    mesh_mapper = get_dispatch_input_mesh_mapper(mesh_device, sp_axis)
+
+    tt_x = ttnn.from_torch(
+        x, mesh_mapper=mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16
+    )
+    tt_weights = ttnn.from_torch(
+        weights, mesh_mapper=mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16
+    )
+    tt_indices = ttnn.from_torch(
+        indices, mesh_mapper=mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.int32
+    )
+
+    expert_dispatch_table = ExpertMapping.create_dispatch_table(
+        num_routed_experts=num_routed_experts,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    expert_offsets, expert_token_counts, _ = get_gate_outputs(
+        indices,
+        dispatch_group_size,
+        num_routed_experts,
+        experts_per_chip,
+        seq_len_per_chip,
+        num_experts_per_tok,
+        expert_dispatch_table=expert_dispatch_table,
+    )
+
+    ep_mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_device.shape, dims=(1, 0))
+    tt_expert_offsets = ttnn.from_torch(
+        expert_offsets,
+        mesh_mapper=ep_mesh_mapper,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.int32,
+    )
+    tt_expert_token_counts = ttnn.from_torch(
+        expert_token_counts,
+        mesh_mapper=ep_mesh_mapper,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.int32,
+    )
+    tt_expert_dispatch_table = TtDispatchModule.shard_expert_dispatch_table(mesh_device, expert_dispatch_table, sp_axis)
+
+    dispatched_buffer, dispatch_metadata = ttnn.experimental.deepseek_prefill.dispatch(
+        input_tensor=tt_x,
+        weights_tensor=tt_weights,
+        indices_tensor=tt_indices,
+        expert_offsets_tensor=tt_expert_offsets,
+        expert_dispatch_table_tensor=tt_expert_dispatch_table,
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_routed_experts=num_routed_experts,
+        num_experts_per_tok=num_experts_per_tok,
+        metadata_len=metadata_len,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        cluster_axis=sp_axis,
+        num_links=1,
+        topology=ttnn.Topology.Linear,
+        use_l1_small_for_semaphores=use_l1_small,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Return tensors for combine, plus intermediates to deallocate
+    return (
+        dispatched_buffer,
+        dispatch_metadata,
+        tt_expert_token_counts,
+        dispatch_group_size,
+        experts_per_chip,
+        num_experts_per_tok,
+        seq_len_per_chip,
+        sp_axis,
+        [tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table],
+    )
+
+
+def run_combine_op(
+    mesh_device,
+    dispatched_buffer,
+    dispatch_metadata,
+    tt_expert_token_counts,
+    dispatch_group_size,
+    experts_per_chip,
+    num_experts_per_tok,
+    seq_len_per_chip,
+    sp_axis,
+    use_l1_small,
+):
+    """Run combine op using dispatch outputs, creating 1 global semaphore."""
+    output = ttnn.experimental.deepseek_prefill.combine(
+        dispatched_buffer,
+        dispatch_metadata,
+        tt_expert_token_counts,
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_experts_per_tok=num_experts_per_tok,
+        seq_len_per_chip=seq_len_per_chip,
+        cluster_axis=sp_axis,
+        num_links=1,
+        topology=ttnn.Topology.Linear,
+        init_zeros=True,
+        use_l1_small_for_semaphores=use_l1_small,
+    )
+    ttnn.synchronize_device(mesh_device)
+    return output
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+                "l1_small_size": 512,
+            },
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
+            id="linear-4x1",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("ccl_op", ["dispatch", "combine"])
+@pytest.mark.parametrize("use_l1_small", [False, True], ids=["l1_default", "l1_small"])
+def test_deepseek_prefill_l1_small_semaphores(mesh_device, device_params, ccl_op, use_l1_small):
+    """Test that dispatch/combine semaphores can be placed in L1_SMALL to prevent L1 fragmentation."""
+
+    compute_grid = mesh_device.compute_with_storage_grid_size()
+    num_worker_cores = compute_grid.x * compute_grid.y
+    logger.info(f"Compute grid: {compute_grid.x}x{compute_grid.y} = {num_worker_cores} cores")
+
+    # Tensor A: 0.8MB * num_worker_cores in L1
+    tensor_a_bytes = int(0.8 * 1024 * 1024) * num_worker_cores
+    tensor_a_elements = tensor_a_bytes // 2  # bfloat16
+    tensor_a_cols = tensor_a_elements // 32
+    logger.info(f"Tensor A: shape [1, 1, 32, {tensor_a_cols}], {tensor_a_bytes} bytes total")
+
+    tensor_a = ttnn.from_torch(
+        torch.randn(1, 1, 32, tensor_a_cols),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    print_l1_buffers(mesh_device, f"before_{ccl_op}")
+    print_l1_small_buffers(mesh_device, f"before_{ccl_op}")
+
+    # Run the op(s) — global semaphores are created in L1 or L1_SMALL
+    logger.info(f"Running {ccl_op} with use_l1_small_for_semaphores={use_l1_small}")
+
+    tensors_to_free = []
+
+    # Run dispatch to produce tensors (needed by both dispatch and combine tests).
+    # Always use the same l1_small flag so dispatch semaphores don't pollute L1.
+    (
+        dispatched_buffer,
+        dispatch_metadata,
+        tt_expert_token_counts,
+        dispatch_group_size,
+        experts_per_chip,
+        num_experts_per_tok,
+        seq_len_per_chip,
+        sp_axis,
+        dispatch_intermediates,
+    ) = run_dispatch_op(mesh_device, use_l1_small)
+    tensors_to_free.extend(dispatch_intermediates)
+
+    if ccl_op == "combine":
+        combine_output = run_combine_op(
+            mesh_device,
+            dispatched_buffer,
+            dispatch_metadata,
+            tt_expert_token_counts,
+            dispatch_group_size,
+            experts_per_chip,
+            num_experts_per_tok,
+            seq_len_per_chip,
+            sp_axis,
+            use_l1_small,
+        )
+        tensors_to_free.append(combine_output)
+
+    tensors_to_free.extend([dispatched_buffer, dispatch_metadata, tt_expert_token_counts])
+
+    print_l1_buffers(mesh_device, f"after_{ccl_op}")
+    print_l1_small_buffers(mesh_device, f"after_{ccl_op}")
+
+    # Free tensor A and all op tensors
+    tensor_a.deallocate(True)
+    for t in tensors_to_free:
+        t.deallocate(True)
+
+    print_l1_buffers(mesh_device, "before_tensor_c")
+    print_l1_small_buffers(mesh_device, "before_tensor_c")
+
+    # Tensor C: 1.0MB * num_worker_cores in L1
+    # With L1 semaphores: should fail (OOM — semaphores fragment L1)
+    # With L1_SMALL semaphores: should succeed (semaphores in L1_SMALL, L1 is clean)
+    tensor_c_bytes = int(1.0 * 1024 * 1024) * num_worker_cores
+    tensor_c_elements = tensor_c_bytes // 2
+    tensor_c_cols = tensor_c_elements // 32
+    logger.info(f"Tensor C: shape [1, 1, 32, {tensor_c_cols}], {tensor_c_bytes} bytes total")
+
+    if not use_l1_small:
+        with pytest.raises(RuntimeError):
+            ttnn.from_torch(
+                torch.randn(1, 1, 32, tensor_c_cols),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
+    else:
+        ttnn.from_torch(
+            torch.randn(1, 1, 32, tensor_c_cols),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        print_l1_buffers(mesh_device, "after_tensor_c")
+        print_l1_small_buffers(mesh_device, "after_tensor_c")

--- a/models/demos/deepseek_v3_d_p/utils/test_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/test_utils.py
@@ -12,6 +12,24 @@ from loguru import logger
 import ttnn
 
 
+def print_buffers(device, name, buffer_type):
+    buffers = ttnn._ttnn.reports.get_buffers(device)
+    filtered_buffers = [buf for buf in buffers if buf.buffer_type == buffer_type]
+    for i, buf in enumerate(filtered_buffers):
+        logger.warning(
+            f"{buffer_type} [{name}] Buffer {i}: addr={buf.address}, "
+            f"size={buf.max_size_per_bank}, layout={buf.buffer_layout}"
+        )
+
+
+def print_l1_buffers(device, name):
+    print_buffers(device, name, ttnn.BufferType.L1)
+
+
+def print_l1_small_buffers(device, name):
+    print_buffers(device, name, ttnn.BufferType.L1_SMALL)
+
+
 def adjust_shapes_for_testing(config, mesh_device):
     """Scale TP dimension for smaller meshes. sp_dim (per-device seq len) is always correct."""
     _, n_tp_devices = mesh_device.shape

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
@@ -25,7 +25,8 @@ ttnn::Tensor combine(
     std::optional<uint32_t> cluster_axis,
     std::optional<uint32_t> num_links,
     std::optional<tt::tt_fabric::Topology> topology,
-    bool init_zeros) {
+    bool init_zeros,
+    bool use_l1_small_for_semaphores) {
     // Get device and subdevice info
     auto* mesh_device = dispatched_buffer.device();
     auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
@@ -67,7 +68,8 @@ ttnn::Tensor combine(
         usable_topology,
         memory_config_,
         subdevice_core_range_set,
-        init_zeros);
+        init_zeros,
+        use_l1_small_for_semaphores);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.hpp
@@ -24,7 +24,8 @@ ttnn::Tensor combine(
     std::optional<uint32_t> cluster_axis = 0,
     std::optional<uint32_t> num_links = 1,
     std::optional<tt::tt_fabric::Topology> topology = tt::tt_fabric::Topology::Linear,
-    bool init_zeros = true);
+    bool init_zeros = true,
+    bool use_l1_small_for_semaphores = false);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine_nanobind.cpp
@@ -71,7 +71,8 @@ void bind_combine(nb::module_& mod) {
         nb::arg("cluster_axis") = nb::none(),
         nb::arg("num_links") = 1,
         nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear),
-        nb::arg("init_zeros") = true);
+        nb::arg("init_zeros") = true,
+        nb::arg("use_l1_small_for_semaphores") = false);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
@@ -116,7 +116,8 @@ ttnn::Tensor prefill_combine(
     tt::tt_fabric::Topology topology,
     const ttnn::MemoryConfig& memory_config,
     const CoreRangeSet& worker_core_range_set,
-    bool init_zeros) {
+    bool init_zeros,
+    bool use_l1_small_for_semaphores) {
     using OperationType = ttnn::operations::experimental::deepseek_prefill::combine::CombineDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -129,7 +130,8 @@ ttnn::Tensor prefill_combine(
             .topology = topology,
             .output_mem_config = memory_config,
             .worker_core_range_set = worker_core_range_set,
-            .init_zeros = init_zeros},
+            .init_zeros = init_zeros,
+            .use_l1_small_for_semaphores = use_l1_small_for_semaphores},
         OperationType::tensor_args_t{
             .dispatched_buffer = dispatched_buffer,
             .dispatched_metadata = dispatched_metadata,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.hpp
@@ -41,5 +41,6 @@ ttnn::Tensor prefill_combine(
     tt::tt_fabric::Topology topology,
     const ttnn::MemoryConfig& memory_config,
     const CoreRangeSet& worker_core_range_set,
-    bool init_zeros);
+    bool init_zeros,
+    bool use_l1_small_for_semaphores = false);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -78,8 +78,10 @@ CombineProgramFactory::cached_mesh_workload_t CombineProgramFactory::create_mesh
 
     auto* mesh_device = tensor_args.dispatched_buffer.device();
 
-    auto init_barrier_semaphore =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, operation_attributes.worker_core_range_set, 0);
+    auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
+                                                                            : tt::tt_metal::BufferType::L1;
+    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
+        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
 
     for (const auto& coord : tensor_coords.coords()) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_types.hpp
@@ -23,6 +23,7 @@ struct CombineParams {
     MemoryConfig output_mem_config;
     CoreRangeSet worker_core_range_set;
     bool init_zeros;
+    bool use_l1_small_for_semaphores = false;
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "dispatch_group_size",
@@ -34,7 +35,8 @@ struct CombineParams {
         "topology",
         "output_mem_config",
         "worker_core_range_set",
-        "init_zeros");
+        "init_zeros",
+        "use_l1_small_for_semaphores");
 
     auto attribute_values() const {
         return std::forward_as_tuple(
@@ -47,7 +49,8 @@ struct CombineParams {
             topology,
             output_mem_config,
             worker_core_range_set,
-            init_zeros);
+            init_zeros,
+            use_l1_small_for_semaphores);
     };
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -142,7 +142,8 @@ prefill_dispatch(
     uint32_t num_links,
     tt::tt_fabric::Topology topology,
     const ttnn::MemoryConfig& memory_config,
-    const CoreRangeSet& worker_core_range_set) {
+    const CoreRangeSet& worker_core_range_set,
+    bool use_l1_small_for_semaphores) {
     using OperationType = ttnn::operations::experimental::deepseek_prefill::dispatch::DispatchDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -156,7 +157,8 @@ prefill_dispatch(
             .num_links = num_links,
             .topology = topology,
             .output_mem_config = memory_config,
-            .worker_core_range_set = worker_core_range_set},
+            .worker_core_range_set = worker_core_range_set,
+            .use_l1_small_for_semaphores = use_l1_small_for_semaphores},
         OperationType::tensor_args_t{
             .input_tensor = input_tensor,
             .weights_tensor = weights_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
@@ -60,5 +60,6 @@ prefill_dispatch(
     uint32_t num_links,
     tt::tt_fabric::Topology topology,
     const ttnn::MemoryConfig& memory_config,
-    const CoreRangeSet& worker_core_range_set);
+    const CoreRangeSet& worker_core_range_set,
+    bool use_l1_small_for_semaphores = false);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -78,10 +78,12 @@ DispatchProgramFactory::cached_mesh_workload_t DispatchProgramFactory::create_me
 
     auto* mesh_device = tensor_args.input_tensor.device();
 
-    auto init_barrier_semaphore =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, operation_attributes.worker_core_range_set, 0);
-    auto final_barrier_semaphore =
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, operation_attributes.worker_core_range_set, 0);
+    auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
+                                                                            : tt::tt_metal::BufferType::L1;
+    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
+        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
+    auto final_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
+        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
 
     for (const auto& coord : tensor_coords.coords()) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_types.hpp
@@ -24,6 +24,7 @@ struct DispatchParams {
     tt::tt_fabric::Topology topology;
     MemoryConfig output_mem_config;
     CoreRangeSet worker_core_range_set;
+    bool use_l1_small_for_semaphores = false;
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "dispatch_group_size",
@@ -36,7 +37,8 @@ struct DispatchParams {
         "num_links",
         "topology",
         "output_mem_config",
-        "worker_core_range_set");
+        "worker_core_range_set",
+        "use_l1_small_for_semaphores");
 
     auto attribute_values() const {
         return std::forward_as_tuple(
@@ -50,7 +52,8 @@ struct DispatchParams {
             num_links,
             topology,
             output_mem_config,
-            worker_core_range_set);
+            worker_core_range_set,
+            use_l1_small_for_semaphores);
     };
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
@@ -28,7 +28,8 @@ std::array<ttnn::Tensor, 2> dispatch(
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
     std::optional<uint32_t> cluster_axis,
     std::optional<uint32_t> num_links,
-    std::optional<tt::tt_fabric::Topology> topology) {
+    std::optional<tt::tt_fabric::Topology> topology,
+    bool use_l1_small_for_semaphores) {
     auto* mesh_device = input_tensor.device();
     auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
     auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
@@ -71,7 +72,8 @@ std::array<ttnn::Tensor, 2> dispatch(
         num_links_,
         usable_topology,
         memory_config_,
-        subdevice_core_range_set);
+        subdevice_core_range_set,
+        use_l1_small_for_semaphores);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
@@ -29,7 +29,8 @@ std::array<ttnn::Tensor, 2> dispatch(
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id = std::nullopt,
     std::optional<uint32_t> cluster_axis = 0,
     std::optional<uint32_t> num_links = 1,
-    std::optional<tt::tt_fabric::Topology> topology = tt::tt_fabric::Topology::Linear);
+    std::optional<tt::tt_fabric::Topology> topology = tt::tt_fabric::Topology::Linear,
+    bool use_l1_small_for_semaphores = false);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
@@ -83,7 +83,8 @@ void bind_dispatch(nb::module_& mod) {
         nb::arg("subdevice_id") = nb::none(),
         nb::arg("cluster_axis") = nb::none(),
         nb::arg("num_links") = 1,
-        nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear));
+        nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear),
+        nb::arg("use_l1_small_for_semaphores") = false);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch::detail


### PR DESCRIPTION
### Summary

Threads `bool use_l1_small_for_semaphores = false` through Dispatch (2 semaphores) and Combine (1 semaphore) call chains, allowing global semaphores to be allocated in L1_SMALL instead of L1 to prevent fragmentation.

### Notes for reviewers

Same pattern as AllGather/ReduceScatter (#42637) — the flag is propagated down to `create_global_semaphore` where the buffer type switches between `BufferType::L1` and `BufferType::L1_SMALL`.

The test `test_dispatch_combine_l1_small_semaphores.py` validates that with L1 semaphores a subsequent large L1 allocation fails (fragmentation), while with L1_SMALL semaphores it succeeds.

### Fragmentation demo (local run, Blackhole 8-chip)

**Setup**: 110 cores (11x10 grid), tensor A occupies 839680 B per L1 bank starting at addr 732672. After CCL op, try allocating tensor C requiring 1048576 B per bank (bank size 1461248 B).

<details>
<summary><b>dispatch — L1 semaphores (default): OOM</b></summary>

```
L1 [before_dispatch] Buffer 0: addr=732672, size=839680  (tensor A)

L1 [after_dispatch]  Buffer 0: addr=732544, size=4       (semaphore)
L1 [after_dispatch]  Buffer 1: addr=732608, size=4       (semaphore)
L1 [after_dispatch]  Buffer 2: addr=732672, size=839680  (tensor A)

L1 [before_tensor_c] Buffer 0: addr=732544, size=4      (semaphore)
L1 [before_tensor_c] Buffer 1: addr=732608, size=4      (semaphore)

TT_FATAL: Out of Memory: Not enough space to allocate 115343360 B L1 buffer
  across 110 banks, each bank needs 1048576 B, but largest free block: 839680 B
  (2 semaphore buffers sit between base and tensor A → fragment the free space)
```
</details>

<details>
<summary><b>dispatch — L1_SMALL semaphores: OK</b></summary>

```
L1       [before_dispatch] Buffer 0: addr=732672, size=839680  (tensor A)

L1       [after_dispatch]  Buffer 0: addr=732672, size=839680  (tensor A, untouched)
L1_SMALL [after_dispatch]  Buffer 0: addr=1572800, size=4     (semaphore)
L1_SMALL [after_dispatch]  Buffer 1: addr=1572736, size=4     (semaphore)

L1_SMALL [before_tensor_c] Buffer 0: addr=1572800, size=4    (semaphore)
L1_SMALL [before_tensor_c] Buffer 1: addr=1572736, size=4    (semaphore)

Tensor C allocation succeeds!
  (L1 free space is contiguous — semaphores live in separate L1_SMALL region)
```
</details>

<details>
<summary><b>combine — L1 semaphores (default): OOM</b></summary>

```
L1 [before_combine] Buffer 0: addr=732672, size=839680  (tensor A)

L1 [after_combine]  Buffer 0: addr=732672, size=839680  (tensor A)
L1 [after_combine]  Buffer 1: addr=732480, size=4       (semaphore — combine)
L1 [after_combine]  Buffer 2: addr=732544, size=4       (semaphore — dispatch)
L1 [after_combine]  Buffer 3: addr=732608, size=4       (semaphore — dispatch)

L1 [before_tensor_c] Buffer 0: addr=732480, size=4      (semaphore)
L1 [before_tensor_c] Buffer 1: addr=732544, size=4      (semaphore)
L1 [before_tensor_c] Buffer 2: addr=732608, size=4      (semaphore)

TT_FATAL: Out of Memory: Not enough space to allocate 115343360 B L1 buffer
  across 110 banks, each bank needs 1048576 B, but largest free block: 839680 B
  (3 semaphore buffers fragment the free space below tensor A)
```
</details>

<details>
<summary><b>combine — L1_SMALL semaphores: OK</b></summary>

```
L1       [before_combine] Buffer 0: addr=732672, size=839680  (tensor A)

L1       [after_combine]  Buffer 0: addr=732672, size=839680  (tensor A, untouched)
L1_SMALL [after_combine]  Buffer 0: addr=1572672, size=4     (semaphore — combine)
L1_SMALL [after_combine]  Buffer 1: addr=1572736, size=4     (semaphore — dispatch)
L1_SMALL [after_combine]  Buffer 2: addr=1572800, size=4     (semaphore — dispatch)

L1_SMALL [before_tensor_c] Buffer 0: addr=1572672, size=4   (semaphore)
L1_SMALL [before_tensor_c] Buffer 1: addr=1572736, size=4   (semaphore)
L1_SMALL [before_tensor_c] Buffer 2: addr=1572800, size=4   (semaphore)

Tensor C allocation succeeds!
  (L1 free space is contiguous — semaphores live in separate L1_SMALL region)
```
</details>

4 passed in 11.78s

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-dispatch-combine-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-dispatch-combine-l1-small)
