### PR TITLE
[Quasar AI codegen] Add Quasar SFPU fill kernel

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -190,6 +190,14 @@ class DISABLE_SRC_ZERO_FLAG(TemplateParameter):
 
 
 @dataclass
+class FILL_BITCAST(TemplateParameter):
+    enabled: bool = False
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool fill_bitcast = {str(self.enabled).lower()};"
+
+
+@dataclass
 class MATH_FIDELITY(TemplateParameter):
     math_fidelity: MathFidelity
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# AI-generated — run_id: 2026-04-02_fill_quasar_7aeae992
+
+from typing import List
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
+from helpers.llk_params import (
+    DataCopyType,
+    DestAccumulation,
+    ImpliedMathFormat,
+    MathOperation,
+    UnpackerEngine,
+    format_dict,
+)
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    FILL_BITCAST,
+    IMPLIED_MATH_FORMAT,
+    MATH_OP,
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+)
+from helpers.utils import passed_test
+
+# Fill constant value (must match the C++ test)
+FILL_CONST_VALUE = 5.0
+
+
+def prepare_fill_inputs(
+    src_A: torch.Tensor,
+    src_B: torch.Tensor,
+    input_format: DataFormat,
+    output_format: DataFormat,
+) -> torch.Tensor:
+    """
+    Prepare input tensor for fill operation.
+
+    Fill overwrites all destination values with a constant, so the input values
+    don't affect the output. We still need valid input data for the unpack stage
+    to function correctly. Use simple values within a safe range.
+    """
+    input_torch_format = format_dict[input_format]
+
+    # Fill ignores input data, but we need valid values for unpack infrastructure.
+    # Use a simple range that is safe for all float formats.
+    src_A_float = src_A.to(torch.float32)
+    src_A_float = torch.clamp(src_A_float, -100.0, 100.0)
+    result = src_A_float.to(input_torch_format)
+
+    return result
+
+
+def _is_invalid_quasar_combination(
+    fmt: FormatConfig, dest_acc: DestAccumulation
+) -> bool:
+    """
+    Check if format combination is invalid for Quasar.
+
+    Args:
+        fmt: Format configuration with input and output formats
+        dest_acc: Destination accumulation mode
+
+    Returns:
+        True if the combination is invalid, False otherwise
+    """
+    in_fmt = fmt.input_format
+    out_fmt = fmt.output_format
+
+    # Quasar packer does not support non-Float32 to Float32 conversion when dest_acc=No
+    if (
+        in_fmt != DataFormat.Float32
+        and out_fmt == DataFormat.Float32
+        and dest_acc == DestAccumulation.No
+    ):
+        return True
+
+    # Quasar SFPU with Float32 input and Float16 output requires dest_acc=Yes
+    if (
+        in_fmt == DataFormat.Float32
+        and out_fmt == DataFormat.Float16
+        and dest_acc == DestAccumulation.No
+    ):
+        return True
+
+    # Integer and float cannot be mixed in input->output
+    if in_fmt.is_integer() != out_fmt.is_integer():
+        return True
+
+    return False
+
+
+def generate_sfpu_fill_combinations(
+    formats_list: List[FormatConfig],
+):
+    """
+    Generate SFPU fill test combinations.
+
+    Args: Input-output format pairs
+
+    Returns: List of (format, dest_acc, implied_math_format, input_dimensions) tuples
+    """
+    combinations = []
+
+    for fmt in formats_list:
+        in_fmt = fmt.input_format
+
+        dest_acc_modes = (
+            (DestAccumulation.Yes,)
+            if in_fmt.is_32_bit()
+            else (DestAccumulation.No, DestAccumulation.Yes)
+        )
+        for dest_acc in dest_acc_modes:
+            # Skip invalid format combinations for Quasar
+            if _is_invalid_quasar_combination(fmt, dest_acc):
+                continue
+
+            for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]:
+                for input_dimensions in [[32, 32], [64, 64], [32, 64]]:
+                    combinations.append(
+                        (fmt, dest_acc, implied_math_format, input_dimensions)
+                    )
+
+    return combinations
+
+
+# Float fill variant format list
+# Note: Tf32 excluded — no PyTorch equivalent in format_dict
+# Note: MxFp8R/MxFp8P excluded — no existing quasar SFPU test uses MX formats;
+#       MX + dest_acc=No triggers unpack_to_dest path that fails for MX data
+SFPU_FILL_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16,
+        DataFormat.Float16_b,
+        DataFormat.Float32,
+    ]
+)
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_implied_math_input_dims=generate_sfpu_fill_combinations(
+        SFPU_FILL_FORMATS
+    ),
+)
+def test_sfpu_fill_quasar(formats_dest_acc_implied_math_input_dims):
+    """
+    Test fill operation on Quasar architecture.
+
+    Fills destination register with a constant value (5.0f) and verifies
+    against the golden reference where every element equals the fill constant.
+    """
+    (formats, dest_acc, implied_math_format, input_dimensions) = (
+        formats_dest_acc_implied_math_input_dims[0]
+    )
+
+    # Set seed for reproducibility
+    torch.manual_seed(42)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        sfpu=True,
+    )
+
+    # Prepare inputs with safe ranges (fill ignores input, but unpack needs valid data)
+    src_A = prepare_fill_inputs(
+        src_A, src_B, formats.input_format, formats.output_format
+    )
+
+    num_faces = 4
+
+    generate_golden = get_golden_generator(UnarySFPUGolden)
+    golden_tensor = generate_golden(
+        MathOperation.Fill,
+        src_A,
+        formats.output_format,
+        dest_acc,
+        formats.input_format,
+        input_dimensions,
+    )
+
+    # unpack_to_dest works only when format bit-width matches Dest mode
+    unpack_to_dest = formats.input_format.is_32_bit() == (
+        dest_acc == DestAccumulation.Yes
+    )
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_fill_quasar_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=MathOperation.Fill),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            FILL_BITCAST(enabled=False),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_A,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    # Verify results match golden
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"
+
+
+# Bitcast fill: exercises _calculate_fill_bitcast_ which loads full 32-bit value
+# via SFPLOADI LOWER + UPPER, then stores with DEFAULT mode.
+SFPU_FILL_BITCAST_FORMATS = input_output_formats(
+    [
+        DataFormat.Float32,
+        DataFormat.Float16_b,
+    ]
+)
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_implied_math_input_dims=generate_sfpu_fill_combinations(
+        SFPU_FILL_BITCAST_FORMATS
+    ),
+)
+def test_sfpu_fill_bitcast_quasar(formats_dest_acc_implied_math_input_dims):
+    """
+    Test bitcast fill operation on Quasar architecture.
+
+    Uses _calculate_fill_bitcast_ which loads the full 32-bit pattern explicitly
+    (LOWER + UPPER) instead of the FLOATB shortcut used by float fill.
+    """
+    (formats, dest_acc, implied_math_format, input_dimensions) = (
+        formats_dest_acc_implied_math_input_dims[0]
+    )
+
+    torch.manual_seed(42)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        sfpu=True,
+    )
+
+    src_A = prepare_fill_inputs(
+        src_A, src_B, formats.input_format, formats.output_format
+    )
+
+    num_faces = 4
+
+    generate_golden = get_golden_generator(UnarySFPUGolden)
+    golden_tensor = generate_golden(
+        MathOperation.Fill,
+        src_A,
+        formats.output_format,
+        dest_acc,
+        formats.input_format,
+        input_dimensions,
+    )
+
+    unpack_to_dest = formats.input_format.is_32_bit() == (
+        dest_acc == DestAccumulation.Yes
+    )
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_fill_quasar_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=MathOperation.Fill),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            FILL_BITCAST(enabled=True),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_A,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+// AI-generated — run_id: 2026-04-02_fill_quasar_7aeae992
+
+#include <cstdint>
+#include <cstring>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id = 0;
+    const std::uint32_t num_tiles   = params.TILE_CNT;
+
+    if (unpack_to_dest)
+    {
+        // Unpacking to DEST directly
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    buffer_descriptor_u bd_val = {0};
+
+    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    if (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0);
+
+    if (unpack_to_dest)
+    {
+        _llk_unpack_dest_dvalid_section_done_();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "experimental/ckernel_sfpu_fill.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_math_eltwise_unary_sfpu_common.h"
+#include "params.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    // Setup dvalid for MATH kernel
+    if (unpack_to_dest)
+    {
+        // Chain must match UNPACK's chain: {UNPACK, SFPU, PACK}
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    DataFormat src_format = static_cast<DataFormat>(formats.math);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+    const std::uint32_t num_sfpu_iterations = params.TEST_FACE_R_DIM / ckernel::math::SFP_ROWS;
+
+    if (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+
+        // Datacopy all tiles from SRC to DEST
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(num_rows, i);
+        }
+
+        _llk_math_set_dvalid_<p_cleardvalid::FPU>();
+    }
+
+    _llk_math_eltwise_unary_sfpu_init_();
+
+    // Convert fill constant (5.0f) to uint32_t bit pattern for SFPU
+    constexpr float fill_value_float = 5.0f;
+    std::uint32_t fill_value_bits;
+    std::memcpy(&fill_value_bits, &fill_value_float, sizeof(fill_value_bits));
+
+    // Apply SFPU fill to all tiles
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        if (fill_bitcast)
+        {
+            _llk_math_eltwise_unary_sfpu_params_<false>(ckernel::sfpu::_calculate_fill_bitcast_, i, num_sfpu_iterations, fill_value_bits);
+        }
+        else
+        {
+            _llk_math_eltwise_unary_sfpu_params_<false>(ckernel::sfpu::_calculate_fill_, i, num_sfpu_iterations, fill_value_bits);
+        }
+    }
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU>();
+
+    // Wait for all operations to complete
+    wait_sfpu_idle();
+    wait_fpu_idle();
+    wait_mop_idle();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    std::uint32_t const buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
+
+    // Setup dvalid for PACK
+    if (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+    _llk_pack_init_(buf_desc_id, num_tiles_per_pack);
+    _llk_pack_(params.DST_INDEX, 0);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+#endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -66,7 +66,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if (unpack_to_dest)
     {
-        _llk_unpack_dest_dvalid_section_done_();
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
     }
 }
 
@@ -121,7 +121,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_eltwise_unary_datacopy_(num_rows, i);
         }
 
-        _llk_math_set_dvalid_<p_cleardvalid::FPU>();
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
     }
 
     _llk_math_eltwise_unary_sfpu_init_();
@@ -136,15 +136,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         if (fill_bitcast)
         {
-            _llk_math_eltwise_unary_sfpu_params_<false>(ckernel::sfpu::_calculate_fill_bitcast_, i, num_sfpu_iterations, fill_value_bits);
+            _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_fill_bitcast_, i, num_sfpu_iterations, fill_value_bits);
         }
         else
         {
-            _llk_math_eltwise_unary_sfpu_params_<false>(ckernel::sfpu::_calculate_fill_, i, num_sfpu_iterations, fill_value_bits);
+            _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_fill_, i, num_sfpu_iterations, fill_value_bits);
         }
     }
 
-    _llk_math_set_dvalid_<p_cleardvalid::SFPU>();
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
 
     // Wait for all operations to complete
     wait_sfpu_idle();

--- a/tt_metal/tt-llk/tt_llk_quasar/PR1574_review_comments.md
+++ b/tt_metal/tt-llk/tt_llk_quasar/PR1574_review_comments.md
@@ -1,0 +1,45 @@
+# Review Comments from tenstorrent/tt-llk#1574
+
+Migrated from: https://github.com/tenstorrent/tt-llk/pull/1574
+
+## Unresolved / Carry-forward Comments
+
+### [fvranicTT] on `tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_fill.h` (magic numbers)
+> There are sfpi constants that we could use instead of the magic numbers `sfpi::SFPLOADI_MOD0_LOWER` (for 10) and `sfpi::SFPLOADI_MOD0_UPPER` (8). It'd be nice to teach the AI to use them.
+
+Additional comments from fvranicTT on same file:
+- Use `sfpi::SFPLOADI_MOD0_USHORT` (2) and `static_cast<std::uint16_t>(value)`.
+- Use `sfpi::SFPLOADI_MOD0_FLOATB` instead of magic numbers.
+
+**⚠️ ACTION NEEDED:** Replace magic number constants in fill kernel with named sfpi constants.
+
+---
+
+### [fvranicTT] on `tests/sources/quasar/sfpu_fill_quasar_test.cpp:113`
+> Since this test should be testing SFPU kernel, I think it's perfectly OK to just use unpack to dest and there's no need to use datacopy. This would simplify test logic in both Python and C++.
+
+**Response (rtawfik01):** sounds good to me!
+
+**⚠️ ACTION NEEDED:** Simplify test to use unpack-to-dest instead of datacopy.
+
+---
+
+### [Copilot] on `tests/python_tests/quasar/test_sfpu_fill_quasar.py` (artifact reference)
+> The comment references `codegen/artifacts/fill_phase1_spec.md`, but that file/path doesn't exist in this repo. Please update or remove the reference.
+
+---
+
+### [Copilot] on `tests/python_tests/quasar/test_sfpu_fill_quasar.py` (int/bitcast coverage)
+> Test is limited to "Phase 1: Float fill only", but the kernel also has integer-fill and bitcast-fill paths. Add basic functional coverage for those modes or clarify they're out of scope.
+
+---
+
+### [Copilot] on `tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_fill.h` (bitcast comment accuracy)
+> The comment says the bitcast path "stores with implied format, preserving all 32 bits", but `p_sfpu::sfpmem::DEFAULT` may truncate/round when the implied format isn't FP32. Adjust the comment to match actual instruction behavior.
+
+---
+
+### [nvelickovicTT] on `tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_fill.h:19`
+> This function seems like an overkill. It's a one-liner.
+
+**⚠️ ACTION NEEDED:** Consider inlining the helper function if it's genuinely a one-liner.

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_fill.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_fill.h
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+// AI-generated — run_id: 2026-04-02_fill_quasar_7aeae992
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+// Store fill constant (already loaded in LREG0) to dest for 2 rows
+inline void _calculate_fill_sfp_rows_()
+{
+    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+}
+
+// Fill dest with a constant float value
+// value: FP32 bit pattern as uint32_t (caller converts float to bits)
+inline void _calculate_fill_(const int iterations, const std::uint32_t value)
+{
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_FLOATB, (value >> 16));
+
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        _calculate_fill_sfp_rows_();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();
+    }
+}
+
+// Fill dest with a constant integer value
+// STORE_MODE: p_sfpu::sfpmem::INT32 (full 32-bit) or p_sfpu::sfpmem::UINT16 (16-bit unsigned)
+// value: integer bit pattern as uint32_t
+template <std::uint32_t STORE_MODE>
+inline void _calculate_fill_int_(const int iterations, const std::uint32_t value)
+{
+    // Load fill value into LREG1 (once, before loop)
+    if constexpr (STORE_MODE == p_sfpu::sfpmem::INT32)
+    {
+        TT_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_LOWER, (value & 0xFFFF));
+        TT_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_UPPER, ((value >> 16) & 0xFFFF));
+    }
+    else if constexpr (STORE_MODE == p_sfpu::sfpmem::UINT16)
+    {
+        TT_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, (value & 0xFFFF));
+    }
+
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, 0, 0);
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();
+    }
+}
+
+// Fill dest with a raw 32-bit value (bitcast fill)
+// value_bit_mask: raw 32-bit pattern; stored via DEFAULT mode, so the implied
+// format (FP16A/FP16B/FP32) determines whether bits are truncated or preserved.
+inline void _calculate_fill_bitcast_(const int iterations, const std::uint32_t value_bit_mask)
+{
+    // Load full 32-bit value into LREG0 (once, before loop)
+    TT_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, (value_bit_mask & 0xFFFF));
+    TT_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, ((value_bit_mask >> 16) & 0xFFFF));
+
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        _calculate_fill_sfp_rows_();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -69,7 +69,8 @@ enum class SfpuType : std::uint32_t
     add,
     square,
     sigmoid,
-    silu
+    silu,
+    fill
 };
 
 enum class DstSync : std::uint8_t


### PR DESCRIPTION
### Summary
Port of Quasar SFPU `fill` kernel from tenstorrent/tt-llk#1574.

Quasar was missing a tile-fill SFPU kernel. This ports the Blackhole implementation to Quasar, supporting float, integer, and bitcast fill modes. The kernel is placed in `experimental/` as it is AI-generated and not yet validated for production use.

Changes:
- `tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_fill.h` — fill kernel (float_fill, int_fill, bitcast_fill)
- `tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h` — adds `fill` to `SfpuType` enum
- `tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp`
- `tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py`
- `tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py` — adds `FILL_BITCAST` variant

### Notes for reviewers
Unresolved review comments from the original tt-llk PR are captured in `tt_metal/tt-llk/tt_llk_quasar/PR1574_review_comments.md`. Key open items:
- Magic number constants in the fill kernel should be replaced with named `sfpi::SFPLOADI_MOD0_*` constants.
- Test currently covers only float-fill path; integer-fill and bitcast-fill paths need coverage.
- Test uses datacopy; reviewer consensus was to simplify to unpack-to-dest instead.
- A one-liner helper function may be worth inlining.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-fill-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/quasar-fill-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/quasar-fill-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/quasar-fill-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/quasar-fill-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/quasar-fill-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/quasar-fill-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/quasar-fill-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/quasar-fill-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/quasar-fill-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/quasar-fill-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/quasar-fill-kernel)