### PR TITLE
[Quasar AI codegen] Add Quasar SFPU trigonometry kernel

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_trigonometry_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_trigonometry_quasar.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# AI-generated — run_id: 2026-04-02_trigonometry_quasar_e1448d06
+
+from dataclasses import dataclass
+from typing import List
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
+from helpers.llk_params import (
+    DataCopyType,
+    DestAccumulation,
+    ImpliedMathFormat,
+    MathOperation,
+    UnpackerEngine,
+    format_dict,
+)
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+    TemplateParameter,
+)
+from helpers.utils import passed_test
+
+# Operation type constants matching the C++ SFPU_OP_TYPE dispatch:
+# 0 = sine, 1 = cosine, 2 = acosh, 3 = asinh, 4 = atanh
+TRIG_OP_SINE = 0
+TRIG_OP_COSINE = 1
+TRIG_OP_ACOSH = 2
+TRIG_OP_ASINH = 3
+TRIG_OP_ATANH = 4
+
+# Map from operation type integer to MathOperation for golden reference
+TRIG_OP_TO_MATH_OP = {
+    TRIG_OP_SINE: MathOperation.Sin,
+    TRIG_OP_COSINE: MathOperation.Cos,
+    TRIG_OP_ACOSH: MathOperation.Acosh,
+    TRIG_OP_ASINH: MathOperation.Asinh,
+    TRIG_OP_ATANH: MathOperation.Atanh,
+}
+
+TRIG_OP_NAMES = {
+    TRIG_OP_SINE: "Sine",
+    TRIG_OP_COSINE: "Cosine",
+    TRIG_OP_ACOSH: "Acosh",
+    TRIG_OP_ASINH: "Asinh",
+    TRIG_OP_ATANH: "Atanh",
+}
+
+
+@dataclass
+class SFPU_OP_TYPE_PARAM(TemplateParameter):
+    """Custom template parameter for trigonometry operation type dispatch."""
+
+    op_type: int = 0
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr int SFPU_OP_TYPE = {self.op_type};"
+
+
+def prepare_trig_inputs(
+    src_A: torch.Tensor,
+    op_type: int,
+    input_format: DataFormat,
+    output_format: DataFormat,
+) -> torch.Tensor:
+    """
+    Prepare input tensor for trigonometry operations with safe value ranges.
+
+    Each trig operation has different valid input domains:
+    - sine: [-10, 10]
+    - cosine: [-10, 10]
+    - acosh: [1.0, 10.0]
+    - asinh: [-10, 10]
+    - atanh: [-0.95, 0.95]
+
+    Args:
+        src_A: Source tensor A (raw stimuli in [0, 1) range)
+        op_type: Trig operation type constant
+        input_format: Input data format
+        output_format: Output data format
+
+    Returns:
+        Prepared tensor with safe values for the operation
+    """
+    torch_format = format_dict[input_format]
+
+    if op_type == TRIG_OP_SINE:
+        # sine: [-10, 10]
+        min_val = -10.0
+        max_val = 10.0
+        src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
+        src_A = src_A.to(torch_format)
+    elif op_type == TRIG_OP_COSINE:
+        # cosine: [-10, 10]
+        min_val = -10.0
+        max_val = 10.0
+        src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
+        src_A = src_A.to(torch_format)
+    elif op_type == TRIG_OP_ACOSH:
+        # acosh: domain is [1.0, inf), use [1.0, 10.0] for safe range
+        # Use uniform distribution in [1.0, 10.0] to get good coverage
+        min_val = 1.0
+        max_val = 10.0
+        src_A = min_val + src_A.to(torch.float32).abs() * (max_val - min_val)
+        src_A = torch.clamp(src_A, min_val, max_val)
+        src_A = src_A.to(torch_format)
+    elif op_type == TRIG_OP_ASINH:
+        # asinh: [-10, 10]
+        min_val = -10.0
+        max_val = 10.0
+        src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
+        src_A = src_A.to(torch_format)
+    elif op_type == TRIG_OP_ATANH:
+        # atanh: domain is (-1, 1), use [-0.95, 0.95] for safe range
+        min_val = -0.95
+        max_val = 0.95
+        src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
+        src_A = torch.clamp(src_A, min_val, max_val)
+        src_A = src_A.to(torch_format)
+
+    return src_A
+
+
+def _is_invalid_quasar_combination(
+    fmt: FormatConfig, dest_acc: DestAccumulation
+) -> bool:
+    """
+    Check if format combination is invalid for Quasar.
+
+    Args:
+        fmt: Format configuration with input and output formats
+        dest_acc: Destination accumulation mode
+
+    Returns:
+        True if the combination is invalid, False otherwise
+    """
+    in_fmt = fmt.input_format
+    out_fmt = fmt.output_format
+
+    # Quasar packer does not support non-Float32 to Float32 conversion when dest_acc=No
+    if (
+        in_fmt != DataFormat.Float32
+        and out_fmt == DataFormat.Float32
+        and dest_acc == DestAccumulation.No
+    ):
+        return True
+
+    # Quasar SFPU with Float32 input and Float16 output requires dest_acc=Yes
+    if (
+        in_fmt == DataFormat.Float32
+        and out_fmt == DataFormat.Float16
+        and dest_acc == DestAccumulation.No
+    ):
+        return True
+
+    return False
+
+
+def generate_sfpu_trig_combinations(
+    formats_list: List[FormatConfig],
+):
+    """
+    Generate SFPU trigonometry test combinations.
+
+    Args: Input-output format pairs
+
+    Returns: List of (format, dest_acc, implied_math_format, input_dimensions, op_type) tuples
+    """
+    combinations = []
+
+    for fmt in formats_list:
+        in_fmt = fmt.input_format
+
+        dest_acc_modes = (
+            (DestAccumulation.Yes,)
+            if in_fmt.is_32_bit()
+            else (DestAccumulation.No, DestAccumulation.Yes)
+        )
+        for dest_acc in dest_acc_modes:
+            # Skip invalid format combinations for Quasar
+            if _is_invalid_quasar_combination(fmt, dest_acc):
+                continue
+
+            for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]:
+                for input_dimensions in [[32, 32]]:
+                    for op_type in [
+                        TRIG_OP_SINE,
+                        TRIG_OP_COSINE,
+                        TRIG_OP_ACOSH,
+                        TRIG_OP_ASINH,
+                        TRIG_OP_ATANH,
+                    ]:
+                        combinations.append(
+                            (
+                                fmt,
+                                dest_acc,
+                                implied_math_format,
+                                input_dimensions,
+                                op_type,
+                            )
+                        )
+
+    return combinations
+
+
+SFPU_TRIG_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16,
+        DataFormat.Float32,
+        DataFormat.Float16_b,
+    ]
+)
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_implied_math_input_dims_op=generate_sfpu_trig_combinations(
+        SFPU_TRIG_FORMATS
+    ),
+)
+def test_sfpu_trigonometry_quasar(formats_dest_acc_implied_math_input_dims_op):
+    """
+    Test trigonometric SFPU operations (sine, cosine, acosh, asinh, atanh) on Quasar architecture.
+
+    Uses a compile-time SFPU_OP_TYPE integer for dispatch since SfpuType enum
+    does not include trigonometry operations.
+    """
+    (formats, dest_acc, implied_math_format, input_dimensions, op_type) = (
+        formats_dest_acc_implied_math_input_dims_op[0]
+    )
+
+    op_name = TRIG_OP_NAMES[op_type]
+    math_op = TRIG_OP_TO_MATH_OP[op_type]
+
+    # Set seed for reproducibility
+    torch.manual_seed(42)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        sfpu=False,
+    )
+
+    # Prepare inputs with operation-specific safe ranges
+    src_A = prepare_trig_inputs(
+        src_A, op_type, formats.input_format, formats.output_format
+    )
+
+    num_faces = 4
+
+    generate_golden = get_golden_generator(UnarySFPUGolden)
+    golden_tensor = generate_golden(
+        math_op,
+        src_A,
+        formats.output_format,
+        dest_acc,
+        formats.input_format,
+        input_dimensions,
+    )
+
+    # unpack_to_dest works only when format bit-width matches Dest mode
+    unpack_to_dest = formats.input_format.is_32_bit() == (
+        dest_acc == DestAccumulation.Yes
+    )
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_trigonometry_quasar_test.cpp",
+        formats,
+        templates=[
+            SFPU_OP_TYPE_PARAM(op_type=op_type),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_A,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    # Verify results match golden
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), f"Result tensor and golden tensor are not of the same length for {op_name}"
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), f"Assert against golden failed for {op_name}"

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_trigonometry_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_trigonometry_quasar_test.cpp
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+// AI-generated — run_id: 2026-04-02_trigonometry_quasar_e1448d06
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id          = 0;
+    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+
+    if (unpack_to_dest)
+    {
+        // Unpacking to DEST directly
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    buffer_descriptor_u bd_val = {0};
+
+    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    if (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0);
+
+    if (unpack_to_dest)
+    {
+        _llk_unpack_dest_dvalid_section_done_();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "experimental/ckernel_sfpu_trigonometry.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_math_eltwise_unary_sfpu_common.h"
+#include "params.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+// Operation type constants (since SfpuType enum doesn't include trig operations)
+// 0 = sine, 1 = cosine, 2 = acosh, 3 = asinh, 4 = atanh
+
+inline void call_trig_operation(int tile_idx, int num_sfpu_iterations)
+{
+    if constexpr (SFPU_OP_TYPE == 0)
+    {
+        // sine: takes runtime iterations parameter
+        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_sine_<true>, tile_idx, num_sfpu_iterations);
+    }
+    else if constexpr (SFPU_OP_TYPE == 1)
+    {
+        // cosine: takes runtime iterations parameter
+        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_cosine_<true>, tile_idx, num_sfpu_iterations);
+    }
+    else if constexpr (SFPU_OP_TYPE == 2)
+    {
+        // acosh: ITERATIONS is template-only (default 8), no runtime iterations param
+        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_acosh_<true>, tile_idx);
+    }
+    else if constexpr (SFPU_OP_TYPE == 3)
+    {
+        // asinh: ITERATIONS is template-only (default 8), no runtime iterations param
+        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_asinh_<true>, tile_idx);
+    }
+    else if constexpr (SFPU_OP_TYPE == 4)
+    {
+        // atanh: extra is_fp32_dest_acc_en template param, ITERATIONS template-only, no runtime param
+        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_atanh_<true, is_fp32_dest_acc_en>, tile_idx);
+    }
+}
+
+inline void init_trig_operation()
+{
+    if constexpr (SFPU_OP_TYPE == 2 || SFPU_OP_TYPE == 3)
+    {
+        // acosh and asinh need inverse hyperbolic init
+        _init_inverse_hyperbolic_<true>();
+    }
+    else if constexpr (SFPU_OP_TYPE == 4)
+    {
+        // atanh needs its own init
+        _init_atanh_<true>();
+    }
+}
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    // Setup dvalid for MATH kernel
+    if (unpack_to_dest)
+    {
+        // Chain must match UNPACK's chain: {UNPACK, SFPU, PACK}
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    DataFormat src_format = static_cast<DataFormat>(formats.math);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+    std::uint32_t num_sfpu_iterations = params.TEST_FACE_R_DIM / ckernel::math::SFP_ROWS;
+
+    if (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+
+        // Datacopy all tiles from SRC to DEST
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(num_rows, i);
+        }
+
+        _llk_math_set_dvalid_<p_cleardvalid::FPU>();
+    }
+
+    _llk_math_eltwise_unary_sfpu_init_();
+    init_trig_operation();
+
+    // Apply trigonometric SFPU operation to all tiles
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        call_trig_operation(i, num_sfpu_iterations);
+    }
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU>();
+
+    // Wait for all operations to complete
+    wait_sfpu_idle();
+    wait_fpu_idle();
+    wait_mop_idle();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    std::uint32_t const buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
+
+    // Setup dvalid for PACK
+    if (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+    _llk_pack_init_(buf_desc_id, num_tiles_per_pack);
+    _llk_pack_(params.DST_INDEX, 0);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+#endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_trigonometry_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_trigonometry_quasar_test.cpp
@@ -95,27 +95,27 @@ inline void call_trig_operation(int tile_idx, int num_sfpu_iterations)
     if constexpr (SFPU_OP_TYPE == 0)
     {
         // sine: takes runtime iterations parameter
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_sine_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_sine_<true>, tile_idx, num_sfpu_iterations);
     }
     else if constexpr (SFPU_OP_TYPE == 1)
     {
         // cosine: takes runtime iterations parameter
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_cosine_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_cosine_<true>, tile_idx, num_sfpu_iterations);
     }
     else if constexpr (SFPU_OP_TYPE == 2)
     {
         // acosh: ITERATIONS is template-only (default 8), no runtime iterations param
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_acosh_<true>, tile_idx);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_acosh_<true>, tile_idx);
     }
     else if constexpr (SFPU_OP_TYPE == 3)
     {
         // asinh: ITERATIONS is template-only (default 8), no runtime iterations param
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_asinh_<true>, tile_idx);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_asinh_<true>, tile_idx);
     }
     else if constexpr (SFPU_OP_TYPE == 4)
     {
         // atanh: extra is_fp32_dest_acc_en template param, ITERATIONS template-only, no runtime param
-        _llk_math_eltwise_unary_sfpu_params_<false>(_calculate_atanh_<true, is_fp32_dest_acc_en>, tile_idx);
+        _llk_math_eltwise_unary_sfpu_params_(_calculate_atanh_<true, is_fp32_dest_acc_en>, tile_idx);
     }
 }
 
@@ -166,7 +166,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_eltwise_unary_datacopy_(num_rows, i);
         }
 
-        _llk_math_set_dvalid_<p_cleardvalid::FPU>();
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
     }
 
     _llk_math_eltwise_unary_sfpu_init_();
@@ -178,7 +178,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         call_trig_operation(i, num_sfpu_iterations);
     }
 
-    _llk_math_set_dvalid_<p_cleardvalid::SFPU>();
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
 
     // Wait for all operations to complete
     wait_sfpu_idle();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_trigonometry_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_trigonometry_quasar_test.cpp
@@ -65,7 +65,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if (unpack_to_dest)
     {
-        _llk_unpack_dest_dvalid_section_done_();
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/PR1600_review_comments.md
+++ b/tt_metal/tt-llk/tt_llk_quasar/PR1600_review_comments.md
@@ -1,0 +1,50 @@
+# Review Comments from tenstorrent/tt-llk#1600
+
+Migrated from: https://github.com/tenstorrent/tt-llk/pull/1600
+
+## Unresolved / Carry-forward Comments
+
+### [Copilot] on `ckernel_sfpu_trigonometry.h:121` (_calculate_sine_ ITERATIONS)
+> `_calculate_sine_` declares a template parameter `ITERATIONS` but the function uses the runtime `iterations` argument instead, leaving `ITERATIONS` unused. Either remove `ITERATIONS` from the template parameters or switch the loop bound to `ITERATIONS` (and drop the runtime argument).
+
+**⚠️ ACTION NEEDED:** Resolve unused template parameter `ITERATIONS` vs runtime `iterations`.
+
+---
+
+### [Copilot / nvelickovicTT] on `ckernel_sfpu_trigonometry.h:224` (_calculate_cosine_ ITERATIONS)
+> Same issue as sine — `ITERATIONS` template parameter is declared but `iterations` runtime argument is used.
+
+**Response (nvelickovicTT):** "I guess there is no need for both ITERATIONS and iterations. That is something the AI reviewer could check easily."
+
+**⚠️ ACTION NEEDED:** Same fix as sine — unify to one iteration control.
+
+---
+
+### [Copilot] on `ckernel_sfpu_trigonometry.h:340` (_calculate_acosh_ runtime iterations)
+> `_calculate_acosh_` hard-codes iteration count via `ITERATIONS` template parameter (default 8) without a runtime `iterations` argument. If `TEST_FACE_R_DIM` ever changes from default (16), this will process wrong number of rows. Add runtime `iterations` parameter or static assertion.
+
+---
+
+### [Copilot] on `ckernel_sfpu_trigonometry.h:383` (_calculate_asinh_ runtime iterations)
+> Same as acosh — inconsistent with other Quasar SFPU entrypoints that take a runtime `iterations` argument.
+
+---
+
+### [nvelickovicTT] on `ckernel_sfpu_trigonometry.h:470` (_calculate_atanh_ ITERATIONS)
+> Not consistent where it places iteration parameter.
+
+**⚠️ ACTION NEEDED:** Make all 5 trig functions consistent in how they handle iteration count (either all use runtime `iterations` or all use compile-time `ITERATIONS`).
+
+---
+
+### [Copilot] on `tests/python_tests/quasar/test_sfpu_trigonometry_quasar.py:133` (boundary coverage)
+> Test input generation intentionally clamps values to "safe" domains (acosh to [1,10], atanh to [-0.95, 0.95]), meaning domain-handling branches are never exercised. Add targeted test cases for boundary and out-of-domain values.
+
+**⚠️ ACTION NEEDED:** Add boundary/out-of-domain test cases for acosh and atanh.
+
+---
+
+### [nvelickovicTT] on `ckernel_sfpu_trigonometry.h:475` (llk_defs.h entry)
+> Should this also make changes in llk_defs.h file? Or is it not needed?
+
+**⚠️ ACTION NEEDED:** Clarify whether trig ops need a `SfpuType` enum entry. If yes, add them to `llk_defs.h`.

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_trigonometry.h
@@ -1,0 +1,475 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+// AI-generated — run_id: 2026-04-02_trigonometry_quasar_e1448d06
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_ops.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// Calculates sine using Maclaurin series with range reduction for SFP_ROWS (2 rows).
+// Algorithm: range reduce x to [-pi, pi] via x/pi → round → subtract → scale by pi,
+// then apply sin(x) = x - x^3/3! + x^5/5! - x^7/7! [+ x^9/9! - x^11/11!].
+// Conditional sign flip for odd half-periods.
+template <bool APPROXIMATION_MODE>
+inline void _calculate_sine_sfp_rows_()
+{
+    // 1. Load from Dest
+    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+
+    // 2. Range reduction: scale by 1/pi = 0.318309886... (0x3EA2F983)
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3EA2);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0xF983);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+
+    // FP32 → signed INT16 (round to nearest even)
+    TTI_SFP_STOCH_RND(p_sfpu::sfp_stochrnd_rnd_mod::NearEven, 0, 0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::sfp_stochrnd_mod::FP32_TO_INT16);
+
+    // Save integer for odd/even test
+    TTI_SFPMOV(p_sfpu::LREG2, p_sfpu::LREG3, 0);
+
+    // INT32 (sign-mag) → FP32
+    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG4, 0);
+
+    // Fractional = (x/pi) - round(x/pi), using SFPADD with mod1=2 (negate VC)
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG4, p_sfpu::LREG1, 2);
+
+    // Multiply fractional by pi = 3.14159265... (0x40490FDB) → val in [-pi, pi]
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x4049);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x0FDB);
+    TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+
+    // 3. Maclaurin series: sin(x) = x - x^3/3! + x^5/5! - x^7/7! [+ x^9/9! - x^11/11!]
+    // LREG1 = val (preserved), LREG0 = power term, LREG5 = output
+    TTI_SFPMOV(p_sfpu::LREG1, p_sfpu::LREG5, 0); // output = x
+    TTI_SFPMOV(p_sfpu::LREG1, p_sfpu::LREG0, 0); // tmp = x
+
+    // x^3/3!: tmp = tmp*val*val, output += (-1/6)*tmp
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0xBE2A); // -1/6 = 0xBE2AAAAB
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0xAAAB);
+    TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+    // x^5/5!: tmp = tmp*val*val, output += (1/120)*tmp
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3C08); // 1/120 = 0x3C088888
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x8888);
+    TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+    // x^7/7!: tmp = tmp*val*val, output += (-1/5040)*tmp
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0xB950); // -1/5040 = 0xB9500CFA
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x0CFA);
+    TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+    // Full precision: x^9/9! and x^11/11! terms
+    if constexpr (!APPROXIMATION_MODE)
+    {
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3638); // 1/362880 = 0x3638EE91
+        TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0xEE91);
+        TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0xB2D7); // -1/39916800 = 0xB2D72D88
+        TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x2D88);
+        TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+    }
+
+    // 4. Odd/even test + conditional sign flip
+    // Load integer mask 0x00000001 into LREG0
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x0000);
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0001);
+
+    // AND: LREG0 = LREG0 & LREG3 → isolate bit 0 of saved integer
+    TTI_SFPAND(p_sfpu::LREG3, p_sfpu::LREG0);
+
+    // CC test: set flags where LREG0 == 0 (EVEN half-periods), then complement for ODD
+    TTI_SFPSETCC(0, p_sfpu::LREG0, 0x6);
+    TTI_SFPCOMPC;
+    TTI_SFPMOV(p_sfpu::LREG5, p_sfpu::LREG5, 1); // Negate output for ODD lanes (mod1=1)
+    TTI_SFPENCC(0, 0);                           // Clear CC result
+
+    // 5. Store result
+    TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, 0);
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void _calculate_sine_(const int iterations)
+{
+    TTI_SFPENCC(1, 2); // Enable CC mode
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        _calculate_sine_sfp_rows_<APPROXIMATION_MODE>();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();
+    }
+    TTI_SFPENCC(0, 2); // Disable CC mode
+}
+
+// Calculates cosine using Maclaurin series with range reduction for SFP_ROWS (2 rows).
+// Algorithm: range reduce x to [-pi, pi] via x/pi -> round -> subtract -> scale by pi,
+// then apply cos(x) = 1 - x^2/2! + x^4/4! - x^6/6! [+ x^8/8! - x^10/10!].
+// Conditional sign flip for odd half-periods.
+template <bool APPROXIMATION_MODE>
+inline void _calculate_cosine_sfp_rows_()
+{
+    // 1. Load from Dest
+    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+
+    // 2. Range reduction: scale by 1/pi = 0.318309886... (0x3EA2F983)
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3EA2);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0xF983);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+
+    // FP32 -> signed INT16 (round to nearest even)
+    TTI_SFP_STOCH_RND(p_sfpu::sfp_stochrnd_rnd_mod::NearEven, 0, 0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::sfp_stochrnd_mod::FP32_TO_INT16);
+
+    // Save integer for odd/even test
+    TTI_SFPMOV(p_sfpu::LREG2, p_sfpu::LREG3, 0);
+
+    // INT32 (sign-mag) -> FP32
+    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG4, 0);
+
+    // Fractional = (x/pi) - round(x/pi), using SFPADD with mod1=2 (negate VC)
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG4, p_sfpu::LREG1, 2);
+
+    // Multiply fractional by pi = 3.14159265... (0x40490FDB) -> val in [-pi, pi]
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x4049);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x0FDB);
+    TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+
+    // 3. Maclaurin series: cos(x) = 1 - x^2/2! + x^4/4! - x^6/6! [+ x^8/8! - x^10/10!]
+    // LREG1 = val (preserved), LREG0 = power term, LREG5 = output
+    TTI_SFPMOV(p_sfpu::LCONST_1, p_sfpu::LREG5, 0);                               // output = 1.0
+    TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0); // tmp = x^2
+
+    // x^2/2!: output += (-0.5)*tmp
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0xBF00); // -0.5 = 0xBF000000
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+    TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+    // x^4/4!: tmp = tmp*val*val, output += (1/24)*tmp
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3D2A); // 1/24 = 0x3D2AAAAB
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0xAAAB);
+    TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+    // x^6/6!: tmp = tmp*val*val, output += (-1/720)*tmp
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0xBAB6); // -1/720 = 0xBAB60B61
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x0B61);
+    TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+    // Full precision: x^8/8! and x^10/10! terms
+    if constexpr (!APPROXIMATION_MODE)
+    {
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x37D0); // 1/40320 = 0x37D00D01
+        TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x0D01);
+        TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0xB493); // -1/3628800 = 0xB493F27E
+        TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0xF27E);
+        TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+    }
+
+    // 4. Odd/even test + conditional sign flip
+    // Load integer mask 0x00000001 into LREG0
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x0000);
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0001);
+
+    // AND: LREG0 = LREG0 & LREG3 -> isolate bit 0 of saved integer
+    TTI_SFPAND(p_sfpu::LREG3, p_sfpu::LREG0);
+
+    // CC test: set flags where LREG0 == 0 (EVEN half-periods), then complement for ODD
+    TTI_SFPSETCC(0, p_sfpu::LREG0, 0x6);
+    TTI_SFPCOMPC;
+    TTI_SFPMOV(p_sfpu::LREG5, p_sfpu::LREG5, 1); // Negate output for ODD lanes (mod1=1)
+    TTI_SFPENCC(0, 0);                           // Clear CC result
+
+    // 5. Store result
+    TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, 0);
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void _calculate_cosine_(const int iterations)
+{
+    TTI_SFPENCC(1, 2); // Enable CC mode
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        _calculate_cosine_sfp_rows_<APPROXIMATION_MODE>();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();
+    }
+    TTI_SFPENCC(0, 2); // Disable CC mode
+}
+
+// Helper: computes ln(x) for x > 0 using exponent extraction + polynomial approximation.
+// Convention: input FP32 in LREG0, output ln(x) in LREG5. Trashes LREG1-LREG4.
+// Preserves LREG0, LREG6, LREG7.
+inline void _calculate_log_body_()
+{
+    // Step 1: Extract biased exponent via right-shift by 23
+    TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG1, 0);         // LREG1 = input copy
+    TTI_SFPSHFT(0xFE9, p_sfpu::LREG0, p_sfpu::LREG1, 1); // LREG1 = input >> 23 (logical), mod1=ARG_IMM
+    // Mask to 8 bits to remove sign bit that shifted down
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, 0x0000);
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, 0x00FF); // mask = 0x000000FF
+    TTI_SFPAND(p_sfpu::LREG2, p_sfpu::LREG1);                       // LREG1 = biased exponent (0-255)
+
+    // Step 2: Unbiased exponent = biased - 127 (two's complement)
+    TTI_SFPIADD(0xF81, p_sfpu::LREG1, p_sfpu::LREG1, 5); // LREG1 -= 127, mod1=ARG_IMM|CC_NONE
+
+    // Convert two's complement to sign-magnitude for SFPCAST
+    TTI_SFPMOV(p_sfpu::LREG1, p_sfpu::LREG2, 0);       // LREG2 = save two's comp value (for sign)
+    TTI_SFPABS(p_sfpu::LREG1, p_sfpu::LREG1, 0);       // LREG1 = |exponent| (2's comp abs, mod1=0)
+    TTI_SFPSETSGN(0, p_sfpu::LREG1, p_sfpu::LREG2, 0); // LREG2 = {sign from LREG2} | {mag from LREG1}
+    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG1, 0);      // LREG1 = float(exponent) as signed FP32
+
+    // Step 3: Normalize mantissa to [1,2) by replacing exponent with 127
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, 0x007F);
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, 0xFFFF); // mantissa mask = 0x007FFFFF
+    TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG3, 0);                    // LREG3 = input copy
+    TTI_SFPAND(p_sfpu::LREG2, p_sfpu::LREG3);                       // LREG3 &= 0x007FFFFF (mantissa bits only)
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, 0x3F80);
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, 0x0000); // exp bias = 0x3F800000
+    TTI_SFPOR(p_sfpu::LREG2, p_sfpu::LREG3);                        // LREG3 = x_norm in [1.0, 2.0)
+
+    // Step 4: 3rd-order polynomial: ln(x_norm) = x*(x*(x*A - B) + C) - D
+    // A=0.1417 (0x3E111CD0), B=0.8689 (0x3F5E712A), C=2.3099 (0x4013D4E2), D=1.5827 (0x3FCA94C9)
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3E11);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x1CD0);               // A
+    TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG5, 0); // LREG5 = x*A
+
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3F5E);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x712A);               // B
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, p_sfpu::LREG5, 2); // LREG5 = x*A - B
+
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x4013);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0xD4E2);            // C
+    TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG5, p_sfpu::LREG4, p_sfpu::LREG5, 0); // LREG5 = x*(x*A-B) + C
+
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3FCA);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x94C9);            // D
+    TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG5, p_sfpu::LREG4, p_sfpu::LREG5, 2); // LREG5 = x*(x*(x*A-B)+C) - D
+
+    // Step 5: Combine: ln(x) = exponent * ln(2) + series_result
+    // ln(2) = 0.692871 (0x3F315FFE)
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3F31);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x5FFE);
+    TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LREG4, p_sfpu::LREG5, p_sfpu::LREG5, 0); // LREG5 = exp*ln2 + series
+
+    // Step 6: Handle base case: if input == 0, result = -infinity
+    TTI_SFPSETCC(0, p_sfpu::LREG0, 0x6);                            // CC set where input == 0
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_UPPER, 0xFF80); // -Inf upper (conditional)
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, 0x0000); // -Inf lower (conditional)
+    TTI_SFPENCC(0, 0);                                              // Clear CC
+    // Result: LREG5 = ln(LREG0)
+}
+
+template <bool APPROXIMATION_MODE>
+inline void _init_inverse_hyperbolic_()
+{
+    // No-op on Quasar: sqrt uses hardware SFPNONLINEAR, log body loads constants inline.
+}
+
+// Calculates acosh(x) = ln(x + sqrt(x^2 - 1)) with domain checks for SFP_ROWS.
+// Uses compute-then-patch: compute general case for all lanes, then overwrite x==1 and x<1 lanes.
+template <bool APPROXIMATION_MODE>
+inline void _calculate_acosh_sfp_rows_()
+{
+    // Load input x from Dest
+    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+    TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG6, 0); // LREG6 = save original input
+
+    // General case (x > 1): acosh(x) = ln(x + sqrt(x^2 - 1))
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);    // LREG1 = x^2
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG1, 2); // LREG1 = x^2 - 1
+    TTI_SFPNONLINEAR(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE);       // LREG1 = sqrt(x^2 - 1)
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG6, p_sfpu::LREG0, 0);    // LREG0 = sqrt(x^2-1) + x
+    _calculate_log_body_();                                                          // LREG5 = ln(sqrt(x^2-1) + x)
+
+    // Patch x == 1 lanes: acosh(1) = 0
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG6, p_sfpu::LCONST_1, p_sfpu::LREG0, 2); // LREG0 = x - 1.0
+    TTI_SFPSETCC(0, p_sfpu::LREG0, 0x6);                                             // CC where (x - 1.0) == 0
+    TTI_SFPMOV(p_sfpu::LCONST_0, p_sfpu::LREG5, 0);                                  // result = 0.0 for x == 1 lanes
+    TTI_SFPENCC(0, 0);                                                               // Clear CC
+
+    // Patch x < 1 lanes: acosh(x<1) = NaN
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x3F80); // 1.0f upper
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0000); // 1.0f lower
+    TTI_SFPGT(0, p_sfpu::LREG6, p_sfpu::LREG0, 0x1);                // CC set where 1.0 > x (i.e., x < 1.0)
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_UPPER, 0x7FC0); // NaN upper (conditional)
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, 0x0000); // NaN lower (conditional)
+    TTI_SFPENCC(0, 0);                                              // Clear CC
+
+    // Store result
+    TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, 0);
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void _calculate_acosh_()
+{
+    TTI_SFPENCC(1, 2); // Enable CC mode
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        _calculate_acosh_sfp_rows_<APPROXIMATION_MODE>();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();
+    }
+    TTI_SFPENCC(0, 2); // Disable CC mode
+}
+
+// Calculates asinh(x) = sign(x) * ln(|x| + sqrt(x^2 + 1)) for SFP_ROWS.
+template <bool APPROXIMATION_MODE>
+inline void _calculate_asinh_sfp_rows_()
+{
+    // Load input x from Dest
+    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+    TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG6, 0); // LREG6 = save original input for sign
+
+    // x^2
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+    // x^2 + 1
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG1, 0);
+    // sqrt(x^2 + 1)
+    TTI_SFPNONLINEAR(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE);
+    // |x|
+    TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG0, 1); // mod1=1 for FP32/sign-magnitude abs
+    // sqrt(x^2 + 1) + |x|
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+    // ln(sqrt(x^2 + 1) + |x|) — input in LREG0, output in LREG5
+    _calculate_log_body_();
+
+    // Conditional sign flip: if original x < 0, negate result
+    TTI_SFPSETCC(0, p_sfpu::LREG6, 0);           // CC where original x < 0
+    TTI_SFPMOV(p_sfpu::LREG5, p_sfpu::LREG5, 1); // Negate result where CC set (mod1=1)
+    TTI_SFPENCC(0, 0);                           // Clear CC
+
+    // Store result
+    TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, 0);
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void _calculate_asinh_()
+{
+    TTI_SFPENCC(1, 2); // Enable CC mode
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        _calculate_asinh_sfp_rows_<APPROXIMATION_MODE>();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();
+    }
+    TTI_SFPENCC(0, 2); // Disable CC mode
+}
+
+// No-op init for atanh: Quasar reciprocal uses hardware SFPNONLINEAR, no setup needed.
+template <bool APPROXIMATION_MODE>
+inline void _init_atanh_()
+{
+}
+
+// Calculates atanh(x) = 0.5 * ln((1+x) / (1-x)) with domain checks for SFP_ROWS.
+// Uses compute-then-patch: compute general case for all lanes, then patch |x|==1 with +/-Inf
+// and |x|>1 with NaN.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void _calculate_atanh_sfp_rows_()
+{
+    // Step 1: Load input and save original x for sign patching at end
+    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+    TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG6, 0); // LREG6 = original x (preserved across log body)
+
+    // Step 2: Compute |x| and save for domain checks after log body
+    TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG7, 1); // LREG7 = |x| (mod1=1 for FP32/sign-mag abs)
+
+    // Step 3: Compute general case: 0.5 * ln((1+x) / (1-x))
+    // num = 1.0 + x
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LCONST_1, p_sfpu::LREG0, p_sfpu::LREG1, 0); // LREG1 = 1.0 + x
+    // den = 1.0 - x
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LCONST_1, p_sfpu::LREG0, p_sfpu::LREG2, 2); // LREG2 = 1.0 - x (mod1=2)
+
+    // recip_den = 1/(1-x) via hardware approximation
+    TTI_SFPNONLINEAR(p_sfpu::LREG2, p_sfpu::LREG3, p_sfpnonlinear::RECIP_MODE); // LREG3 = approx 1/(1-x)
+
+    // Fix sign: SFPSETSGN(0, VC=LREG3, VD=LREG2, 0) -> LREG2 = {sign from LREG2} | {mag from LREG3}
+    TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
+
+    // Optional FP16b truncation for precision in non-FP32 non-approx mode
+    if constexpr (!(is_fp32_dest_acc_en || APPROXIMATION_MODE))
+    {
+        TTI_SFP_STOCH_RND(p_sfpu::sfp_stochrnd_rnd_mod::NearEven, 0, 0, p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::sfp_stochrnd_mod::FP32_TO_FP16B);
+    }
+
+    // ratio = (1+x) * recip(1-x) = (1+x) / (1-x)
+    TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG0, 0); // LREG0 = ratio
+
+    // ln(ratio) via _calculate_log_body_(): input LREG0, output LREG5, trashes LREG1-4
+    _calculate_log_body_();
+
+    // result = 0.5 * ln(ratio)
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_UPPER, 0x3F00);               // 0.5f upper (0x3F000000)
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);               // 0.5f lower
+    TTI_SFPMUL(p_sfpu::LREG5, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG5, 0); // LREG5 = 0.5 * ln
+
+    // Step 4: Patch |x| == 1 lanes with +/-Inf
+    // Compute 1.0 - |x| and check if zero
+    TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LCONST_1, p_sfpu::LREG7, p_sfpu::LREG0, 2); // LREG0 = 1.0 - |x|
+    TTI_SFPSETCC(0, p_sfpu::LREG0, 0x6);                                             // CC where (1.0 - |x|) == 0, i.e., |x| == 1
+    // Load +Inf into LREG5 (CC-gated: only affects |x|==1 lanes)
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_UPPER, 0x7F80); // +Inf upper
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, 0x0000); // +Inf lower
+    // Apply sign from original x: copy x to LREG0, then setsgn(Inf, x) via LREG0
+    TTI_SFPMOV(p_sfpu::LREG6, p_sfpu::LREG0, 0);       // LREG0 = original x (CC-gated)
+    TTI_SFPSETSGN(0, p_sfpu::LREG5, p_sfpu::LREG0, 0); // LREG0 = {sign(x)} | {mag(+Inf)}
+    TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG5, 0);       // LREG5 = signed Inf (CC-gated)
+    TTI_SFPENCC(0, 0);                                 // Clear CC
+
+    // Step 5: Patch |x| > 1 lanes with NaN
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x3F80); // 1.0f upper
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0000); // 1.0f lower
+    // SFPGT(0, C=LREG0, D=LREG7, 0x1): sets CC where LREG7(|x|) > LREG0(1.0), i.e., |x| > 1
+    TTI_SFPGT(0, p_sfpu::LREG0, p_sfpu::LREG7, 0x1);
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_UPPER, 0x7FC0); // NaN upper (conditional)
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, 0x0000); // NaN lower (conditional)
+    TTI_SFPENCC(0, 0);                                              // Clear CC
+
+    // Step 6: Store result
+    TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, 0);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void _calculate_atanh_()
+{
+    TTI_SFPENCC(1, 2); // Enable CC mode
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        _calculate_atanh_sfp_rows_<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();
+    }
+    TTI_SFPENCC(0, 2); // Disable CC mode
+}
+
+} // namespace sfpu
+} // namespace ckernel


### PR DESCRIPTION
### Summary
Port of Quasar SFPU trigonometry kernels from tenstorrent/tt-llk#1600.

Quasar was missing trig SFPU kernels. This ports sine, cosine, acosh, asinh, and atanh from Blackhole using Maclaurin series (sin/cos) and logarithmic identities (inverse hyperbolics). Magic numbers are replaced with named `sfpi::SFPLOADI_MOD0_*` constants. The kernel is placed in `experimental/` as it is AI-generated and not yet validated for production use.

Changes:
- `tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/ckernel_sfpu_trigonometry.h` — 5 ops, 475 lines
- `tt_metal/tt-llk/tests/sources/quasar/sfpu_trigonometry_quasar_test.cpp` — compile-time `SFPU_OP_TYPE` dispatch
- `tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_trigonometry_quasar.py` — Float16/Float16_b/Float32 coverage

### Notes for reviewers
Unresolved review comments from the original tt-llk PR are captured in `tt_metal/tt-llk/tt_llk_quasar/PR1600_review_comments.md`. Key open items:
- `ITERATIONS` template parameter vs runtime `iterations` argument is inconsistent across the 5 functions — should be unified.
- acosh/atanh tests only cover "safe" input domains; boundary and out-of-domain values (NaN, ±Inf) are not tested.
- Open question: should trig ops get `SfpuType` enum entries in `llk_defs.h`?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-trigonometry-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/quasar-trigonometry-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/quasar-trigonometry-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/quasar-trigonometry-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/quasar-trigonometry-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/quasar-trigonometry-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/quasar-trigonometry-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/quasar-trigonometry-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/quasar-trigonometry-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/quasar-trigonometry-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/quasar-trigonometry-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/quasar-trigonometry-kernel)