### PR TITLE
tt_metal/graph: fix is_graph_capture_active() broken by ShmTrackingPr…

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
@@ -610,3 +610,21 @@ def test_duration_captured(device, mode):
 
     assert found_function_end_with_duration, "Expected function_end nodes to have duration"
     assert found_capture_end_with_duration, "Expected capture_end node to have duration"
+
+
+def test_graph_capture_inactive_with_open_device(device):
+    """Regression: is_graph_capture_active() must return False when a device is open but no
+    capture has been started, True during capture, and False again after end_graph_capture() —
+    regardless of any background processors registered on device open.
+    """
+    assert (
+        not ttnn.graph.is_graph_capture_active()
+    ), "is_graph_capture_active() should be False with an open device and no active capture"
+
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+    assert ttnn.graph.is_graph_capture_active(), "is_graph_capture_active() should be True during capture"
+
+    ttnn.graph.end_graph_capture()
+    assert (
+        not ttnn.graph.is_graph_capture_active()
+    ), "is_graph_capture_active() should be False after end_graph_capture()"

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -50,6 +50,10 @@ public:
 
     IGraphProcessor() = default;
 
+    // Returns false for background processors that are always
+    // registered but should not make is_graph_capture_active() return true.
+    virtual bool is_capture_processor() const { return true; }
+
     virtual void track_allocate(const tt::tt_metal::Buffer* /*buffer*/) {};
 
     virtual void track_deallocate(tt::tt_metal::Buffer* /*buffer*/) {};

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -51,7 +51,7 @@ public:
     IGraphProcessor() = default;
 
     // Returns false for background processors that are always
-    // registered but should not make is_graph_capture_active() return true.
+    // registered but should not make GraphTracker::is_enabled() return true.
     virtual bool is_capture_processor() const { return true; }
 
     virtual void track_allocate(const tt::tt_metal::Buffer* /*buffer*/) {};

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -4,6 +4,7 @@
 
 #include <graph_tracking.hpp>
 
+#include <algorithm>
 #include <nlohmann/json.hpp>
 #include <tt_stl/assert.hpp>
 
@@ -16,7 +17,9 @@ GraphTracker& GraphTracker::instance() {
     return tracker;
 }
 
-bool GraphTracker::is_enabled() const { return (not processors.empty()); }
+bool GraphTracker::is_enabled() const {
+    return std::any_of(processors.begin(), processors.end(), [](const auto& p) { return p->is_capture_processor(); });
+}
 
 void GraphTracker::push_processor(const std::shared_ptr<IGraphProcessor>& new_processor) {
     processors.push_back(new_processor);

--- a/tt_metal/impl/memory_tracking/shm_tracking_processor.hpp
+++ b/tt_metal/impl/memory_tracking/shm_tracking_processor.hpp
@@ -19,6 +19,10 @@ public:
     ShmTrackingProcessor();
     ~ShmTrackingProcessor() override = default;
 
+    // ShmTrackingProcessor is a permanent background processor; it must not
+    // cause is_graph_capture_active() to return true when no capture is in progress.
+    bool is_capture_processor() const override { return false; }
+
     void track_allocate(const Buffer* buffer) override;
     void track_deallocate(Buffer* buffer) override;
 


### PR DESCRIPTION
…ocessor

ShmTrackingProcessor is registered permanently in GraphTracker::processors when a device opens (commit a2db301fb65).  Because is_enabled() returned !processors.empty(), is_graph_capture_active() became permanently True, breaking every caller that used it to mean "is a user-initiated capture active?":

- ttnn/graph.py begin_graph_capture: never initialised _python_io_data or set _python_io_recording_enabled=True, so FastOperation never called track_function_start and Python-level op names vanished from the report.
- ttnn/graph.py end_graph_capture: never cleared _python_io_recording_enabled.
- conftest.py graph-capture fixture: skipped itself unconditionally.
- full_graph_capture finally block: fired on the happy path, spuriously calling _cpp_end_graph_capture after the capture had already ended.

Fix: add a virtual is_capture_processor() method to IGraphProcessor that returns true by default.  ShmTrackingProcessor overrides it to return false. GraphTracker::is_enabled() now returns true only when at least one capture processor is present, restoring the original semantics without touching any Python code.

The C++ fast-path guards (processors.empty()) in track_allocate, track_deallocate, track_function_start, etc. are intentionally left unchanged — ShmTrackingProcessor still receives all tracking events.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/shm-processor-not-a-capture-processor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/shm-processor-not-a-capture-processor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/shm-processor-not-a-capture-processor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/shm-processor-not-a-capture-processor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/shm-processor-not-a-capture-processor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/shm-processor-not-a-capture-processor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/shm-processor-not-a-capture-processor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/shm-processor-not-a-capture-processor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/shm-processor-not-a-capture-processor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/shm-processor-not-a-capture-processor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/shm-processor-not-a-capture-processor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/shm-processor-not-a-capture-processor)