### PR TITLE
Overlap untilization and dispatching of the input tensor for the dispatch module

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -39,7 +39,7 @@ def run_dispatch_op(mesh_device, use_l1_small):
     torch.manual_seed(42)
 
     seq_len_per_chip = 64
-    emb_dim = 128
+    emb_dim = 256
     num_routed_experts = 16
     num_experts_per_tok = 2
     capacity_factor = 2

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -99,6 +99,11 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])
+@pytest.mark.parametrize(
+    "input_layout",
+    [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    ids=["tile", "row_major"],
+)
 @pytest.mark.parametrize("verbose", [False])
 def test_ttnn_dispatch(
     mesh_device,
@@ -110,6 +115,7 @@ def test_ttnn_dispatch(
     num_links,
     topology,
     use_predictable_data,
+    input_layout,
     verbose,
     run_pcc_check,
 ):
@@ -168,7 +174,7 @@ def test_ttnn_dispatch(
     mesh_mapper_replicated = get_dispatch_input_mesh_mapper(mesh_device, sp_axis)
 
     tt_x = ttnn.from_torch(
-        x, mesh_mapper=mesh_mapper_replicated, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16
+        x, mesh_mapper=mesh_mapper_replicated, layout=input_layout, device=mesh_device, dtype=ttnn.bfloat16
     )
 
     tt_weights = ttnn.from_torch(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -214,7 +214,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 @pytest.mark.parametrize(
     "dispatched_buffer_layout",
     [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-    ids=["tile", "row_major"],
+    ids=["dispatched_buffer_tile", "dispatched_buffer_row_major"],
 )
 def test_ttnn_dispatch_combine(
     mesh_device,
@@ -287,7 +287,7 @@ def test_ttnn_dispatch_combine(
     tt_x = ttnn.from_torch(
         x,
         mesh_mapper=mesh_mapper_dispatch_inputs,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        layout=ttnn.TILE_LAYOUT,
         device=mesh_device,
         dtype=ttnn.bfloat16,
     )
@@ -575,7 +575,7 @@ def test_ttnn_dispatch_combine_overflow(
     tt_x = ttnn.from_torch(
         x,
         mesh_mapper=mesh_mapper_dispatch_inputs,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        layout=ttnn.TILE_LAYOUT,
         device=mesh_device,
         dtype=ttnn.bfloat16,
     )
@@ -679,7 +679,7 @@ def test_ttnn_dispatch_combine_overflow(
 @pytest.mark.parametrize(
     "dispatched_buffer_layout",
     [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-    ids=["tile", "row_major"],
+    ids=["dispatched_buffer_tile", "dispatched_buffer_row_major"],
 )
 def test_ttnn_dispatch_combine_top4(mesh_device, num_links, topology, dispatched_buffer_layout):
     """Regression test for num_experts_per_tok > 2 (previously caused hangs due to undersized CB buffering)."""

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -540,7 +540,7 @@ def test_ttnn_dispatch_combine_overflow(
     hang. After the fix, dispatch should complete (tokens silently dropped).
     """
     seq_len_per_chip = 256
-    emb_dim = 128
+    emb_dim = 256
     num_routed_experts = 16
     num_experts_per_tok = 2
     capacity_factor = 1

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -206,11 +206,7 @@ def _perf_param(op, worker_file, worker_test, topo, nlinks, expected_ns, op_filt
     model_name = f"deepseek_v3_{op}_{topo}_8_{nlinks}link"
     if layout != "tile":
         model_name += f"_{layout}"
-    # Only the combine worker has a layout parametrize (tile / row_major);
-    # dispatch has no such axis, so adding "and tile" would match nothing.
-    k_filter = f"perf_no_pcc and {worker_id} and random"
-    if op == "combine":
-        k_filter += f" and {layout}"
+    k_filter = f"perf_no_pcc and {worker_id} and random and {layout}"
     return (
         f"pytest models/demos/deepseek_v3_d_p/tests/pcc/{worker_file}::{worker_test} " f"-k '{k_filter}'",
         expected_ns,
@@ -230,8 +226,8 @@ def _perf_param(op, worker_file, worker_test, topo, nlinks, expected_ns, op_filt
 
 # CI set (BH LoudBox pipeline): keep small.
 _DISPATCH_PERF_PARAMS = [
-    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "linear", 2, 3_759_572, ""),
-    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, 2_630_604, ""),
+    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "linear", 2, 4_108_262, ""),
+    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, 3_683_084, ""),
 ]
 _COMBINE_PERF_PARAMS = [
     _perf_param(
@@ -250,8 +246,8 @@ _DISPATCH_PERF_PARAMS_FULL = [
     for topo, nlinks, expected in [
         ("linear", 1, 6_564_151),
         ("linear", 2, 3_907_070),
-        ("ring", 1, 4_329_141),
-        ("ring", 2, 2_640_502),
+        ("ring", 1, 5_392_448),
+        ("ring", 2, 3_690_830),
     ]
 ]
 _COMBINE_PERF_PARAMS_FULL = [
@@ -262,7 +258,7 @@ _COMBINE_PERF_PARAMS_FULL = [
         ("linear", 1, 5_767_986),
         ("linear", 2, 4_136_638),
         ("ring", 1, 4_968_952),
-        ("ring", 2, 2_975_783),
+        ("ring", 2, 3_136_810),
     ]
 ] + [
     _perf_param(

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -345,7 +345,6 @@ class TtMoe(LightweightModule):
         scores, indices, gate_logits, tt_expert_offsets, tt_expert_token_counts = self.gate(
             ttnn.view(x, (x.shape[0] * x.shape[1], x.shape[2]))
         )
-
         gate_logits = (
             ttnn.to_memory_config(gate_logits, ttnn.DRAM_MEMORY_CONFIG)
             if return_intermediates
@@ -402,7 +401,6 @@ class TtMoe(LightweightModule):
         # ========================================
         # Shared expert expects replicated input (full emb_dim)
         # Convert x to TILE_LAYOUT for shared expert
-
         logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
 
         shared_output = self.shared_expert(x)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -345,6 +345,7 @@ class TtMoe(LightweightModule):
         scores, indices, gate_logits, tt_expert_offsets, tt_expert_token_counts = self.gate(
             ttnn.view(x, (x.shape[0] * x.shape[1], x.shape[2]))
         )
+
         gate_logits = (
             ttnn.to_memory_config(gate_logits, ttnn.DRAM_MEMORY_CONFIG)
             if return_intermediates
@@ -401,6 +402,7 @@ class TtMoe(LightweightModule):
         # ========================================
         # Shared expert expects replicated input (full emb_dim)
         # Convert x to TILE_LAYOUT for shared expert
+
         logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
 
         shared_output = self.shared_expert(x)
@@ -410,7 +412,6 @@ class TtMoe(LightweightModule):
         # Step 2: Dispatch (enabled)
         # ========================================
         # Dispatch expects full emb_dim on each device (x already has this)
-        x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)  # to be overlaped with dispatch
         logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
         dispatched_buffer, metadata = self.dispatch_module(
             x,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -14,9 +14,11 @@ namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 
 void DispatchDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // Validate input tensor layouts are ROW_MAJOR
     TT_FATAL(
-        tensor_args.input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Input tensor must be ROW_MAJOR layout");
+        tensor_args.input_tensor.layout() == tt::tt_metal::Layout::TILE ||
+            tensor_args.input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
+        "Input tensor must be TILE or ROW_MAJOR layout, got {}",
+        tensor_args.input_tensor.layout());
     TT_FATAL(
         tensor_args.weights_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
         "Weights tensor must be ROW_MAJOR layout");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -15,11 +15,6 @@ namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 void DispatchDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     TT_FATAL(
-        tensor_args.input_tensor.layout() == tt::tt_metal::Layout::TILE ||
-            tensor_args.input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
-        "Input tensor must be TILE or ROW_MAJOR layout, got {}",
-        tensor_args.input_tensor.layout());
-    TT_FATAL(
         tensor_args.weights_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
         "Weights tensor must be ROW_MAJOR layout");
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -68,40 +68,10 @@ void create_tensor_cb(
 
 }  // namespace detail
 
-DispatchProgramFactory::cached_mesh_workload_t DispatchProgramFactory::create_mesh_workload(
-    const DispatchParams& operation_attributes,
-    const MeshCoordinateRangeSet& tensor_coords,
-    const DispatchInputs& tensor_args,
-    DispatchProgramFactory::tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, DispatchSharedVariables> shared_variables;
+namespace {
 
-    auto* mesh_device = tensor_args.input_tensor.device();
-
-    auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
-                                                                            : tt::tt_metal::BufferType::L1;
-    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
-        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
-    auto final_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
-        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
-    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
-
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(
-            operation_attributes,
-            coord,
-            tensor_args,
-            tensor_return_value,
-            tensor_coords,
-            init_barrier_semaphore,
-            final_barrier_semaphore);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
-
-ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFactory::create_at(
+// Tile-layout path: TILE inputs, fused untilize across sender + idle cores.
+ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_layout(
     const DispatchParams& operation_attributes,
     const MeshCoordinate& mesh_coordinate,
     const DispatchInputs& tensor_args,
@@ -124,7 +94,765 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     auto topology = operation_attributes.topology;
     log_debug(
         tt::LogOp,
-        "Creating prefill dispatch program for mesh coordinate: ({}, {}) with topology: {} num_links: {}",
+        "Creating prefill dispatch program (tile layout) for mesh coordinate: ({}, {}) with topology: {} num_links: {}",
+        mesh_coordinate[0],
+        mesh_coordinate[1],
+        topology,
+        num_links);
+
+    auto* mesh_device = input_tensor.device();
+    const auto& mesh_view = mesh_device->get_view();
+
+    auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+    uint32_t src_mesh_id = *src_fabric_node_id.mesh_id;
+    uint32_t src_chip_id = (uint32_t)src_fabric_node_id.chip_id;
+    uint32_t linearized_mesh_coord = ccl::common::get_linearized_index(mesh_coordinate, mesh_view);
+
+    log_debug(
+        tt::LogOp,
+        "\nCreating all to all dispatch program for mesh coordinate: ({}, {}) with mesh id: {} "
+        "chip id: {} linearized mesh coord: {}",
+        mesh_coordinate[0],
+        mesh_coordinate[1],
+        src_mesh_id,
+        src_chip_id,
+        linearized_mesh_coord);
+
+    auto worker_core_range_set = operation_attributes.worker_core_range_set;
+
+    auto subdevice_cores = corerange_to_cores(worker_core_range_set);
+    constexpr uint32_t MAX_WORKER_CORES = 4;
+    uint32_t effective_num_links = std::min(num_links, MAX_WORKER_CORES);
+    TT_FATAL(
+        subdevice_cores.size() >= effective_num_links,
+        "Not enough cores {} for {} links",
+        subdevice_cores.size(),
+        effective_num_links);
+
+    auto logical_volume = input_tensor.logical_shape().volume();
+    auto hidden_size = input_tensor.logical_shape()[-1];
+    auto tokens_per_device = logical_volume / hidden_size;
+
+    uint32_t num_cores = effective_num_links;
+
+    // ==================== Core layout: senders + idle groups ====================
+    // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
+    uint32_t sender_row_y = subdevice_cores.at(0).y;
+    std::vector<CoreCoord> all_row_cores;
+    for (const auto& core : subdevice_cores) {
+        if (core.y == sender_row_y) {
+            all_row_cores.push_back(core);
+        }
+    }
+    std::sort(
+        all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) { return a.x < b.x; });
+
+    uint32_t total_row_cores = static_cast<uint32_t>(all_row_cores.size());
+    TT_FATAL(
+        total_row_cores > num_cores,
+        "Same-row has only {} cores for {} senders — need at least one idle core per sender",
+        total_row_cores,
+        num_cores);
+
+    // Divide total_row_cores into num_cores groups.
+    // Within each group: center core = sender, surrounding cores = that sender's idle cores.
+    uint32_t base_group_size = total_row_cores / num_cores;
+    uint32_t extra_groups = total_row_cores % num_cores;
+
+    std::vector<CoreCoord> sender_cores;
+    sender_cores.reserve(num_cores);
+    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
+    std::vector<CoreCoord> all_idle_cores;
+    std::vector<uint32_t> idle_sender_map;
+
+    {
+        uint32_t pos = 0;
+        for (uint32_t s = 0; s < num_cores; s++) {
+            uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
+            uint32_t sender_offset = group_size / 2;
+            for (uint32_t j = 0; j < group_size; j++, pos++) {
+                if (j == sender_offset) {
+                    sender_cores.push_back(all_row_cores[pos]);
+                } else {
+                    sender_idle_groups[s].push_back(all_row_cores[pos]);
+                    all_idle_cores.push_back(all_row_cores[pos]);
+                    idle_sender_map.push_back(s);
+                }
+            }
+        }
+    }
+
+    uint32_t num_idle_cores = static_cast<uint32_t>(all_idle_cores.size());
+    TT_FATAL(
+        num_idle_cores >= num_cores,
+        "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
+        num_idle_cores,
+        num_cores);
+
+    // Build sender_core_grid and idle_core_grid CoreRangeSets
+    std::set<CoreRange> sender_ranges_set;
+    for (const auto& sc : sender_cores) {
+        sender_ranges_set.insert(CoreRange(sc));
+    }
+    auto sender_core_grid = CoreRangeSet(sender_ranges_set);
+
+    std::set<CoreRange> idle_ranges_set;
+    for (const auto& ic : all_idle_cores) {
+        idle_ranges_set.insert(CoreRange(ic));
+    }
+    CoreRangeSet idle_core_grid(idle_ranges_set);
+
+    // Combined grid for shared semaphores
+    std::set<CoreRange> sender_and_idle_ranges;
+    for (const auto& cr : sender_core_grid.ranges()) {
+        sender_and_idle_ranges.insert(cr);
+    }
+    for (const auto& cr : idle_core_grid.ranges()) {
+        sender_and_idle_ranges.insert(cr);
+    }
+    CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
+
+    log_debug(
+        tt::LogOp,
+        "Dispatch program: num_links: {} num_cores(senders): {} num_idle_cores: {} tokens_per_device: {}",
+        num_links,
+        num_cores,
+        num_idle_cores,
+        tokens_per_device);
+
+    constexpr uint32_t read_batch_size = 32;
+
+    const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
+    uint32_t total_batches = (tokens_per_device + read_batch_size - 1) / read_batch_size;
+
+    // ==================== Semaphores for inter-core sync ====================
+    // One data_ready + one start semaphore per sender (created on sender+idle grid)
+    std::vector<uint32_t> data_ready_semaphore_ids;
+    std::vector<uint32_t> start_semaphore_ids;
+    data_ready_semaphore_ids.reserve(num_cores);
+    start_semaphore_ids.reserve(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        data_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+        start_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+    }
+    // addr_ready semaphore: sender signals idle cores after writing receive buffer address
+    auto addr_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    // addr_value semaphore: holds the sender's c_18 L1 address (written via noc_async_write)
+    auto addr_value_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+    // mbox_ready semaphore (per sender): idle cores signal this after NOC-writing their mailbox address.
+    // Sender waits for count == num_idle_cores_in_group before reading its own scratch buffer.
+    std::vector<uint32_t> mbox_ready_semaphore_ids;
+    mbox_ready_semaphore_ids.reserve(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        mbox_ready_semaphore_ids.push_back(tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0));
+    }
+    // mbox_scratch_addr semaphore: sender writes its route-table scratch base address here and
+    // multicasts it to idle cores alongside addr_ready.  Idle cores read it after addr_ready fires,
+    // then NOC-write their mailbox L1 address into the sender's scratch slot (core_id * 4 offset).
+    auto mbox_scratch_addr_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_and_idle_grid, 0);
+
+    // ==================== Circular Buffers for IDLE cores ====================
+    // c_0: tiled input stripe (reader → compute)
+    detail::create_tensor_cb(
+        program,
+        idle_core_grid,
+        input_tensor,
+        /*buffering_factor=*/16,
+        /*cb_id=*/tt::CBIndex::c_0,
+        "idle_input_scratch");
+    // c_10: signal CB (reader → compute)
+    {
+        uint32_t signal_page_size = l1_alignment;
+        constexpr uint32_t signal_buffering = 2;
+        tt::tt_metal::CircularBufferConfig signal_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                signal_buffering * signal_page_size, {{tt::CBIndex::c_10, tt::DataFormat::UInt32}})
+                .set_page_size(tt::CBIndex::c_10, signal_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
+    }
+    // c_11: untilize output (compute → writer)
+    detail::create_tensor_cb(
+        program,
+        idle_core_grid,
+        output_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_11,
+        "idle_untilize_output");
+    // c_12: route table mailbox (sender writes before start_semaphore; writer reads after)
+    // Layout: [entry_count u32] [entry_0..N × 6 u32s each]
+    {
+        uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;
+        uint32_t mailbox_page_size = tt::round_up(
+            static_cast<uint32_t>(sizeof(uint32_t)) + max_route_entries * 6 * static_cast<uint32_t>(sizeof(uint32_t)),
+            l1_alignment);
+        tt::tt_metal::CircularBufferConfig mailbox_cb_config =
+            tt::tt_metal::CircularBufferConfig(mailbox_page_size, {{tt::CBIndex::c_12, tt::DataFormat::UInt32}})
+                .set_page_size(tt::CBIndex::c_12, mailbox_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, mailbox_cb_config);
+    }
+    // c_13: metadata scratch (idle writer builds metadata here before NOC-writing to DRAM)
+    detail::create_tensor_cb(
+        program,
+        idle_core_grid,
+        metadata_tensor,
+        /*buffering_factor=*/1,
+        /*cb_id=*/tt::CBIndex::c_13,
+        "idle_metadata_scratch");
+
+    // ==================== Circular Buffers for SENDER cores ====================
+    // c_0: tiled input stripe for self-untilize (reader → compute on sender)
+    // Double-buffered blocks of 8 tiles (compute processes 8 at a time)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        input_tensor,
+        /*buffering_factor=*/16,
+        /*cb_id=*/tt::CBIndex::c_0,
+        "sender_input_scratch");
+    // c_10: signal CB for self-untilize (reader → compute on sender)
+    {
+        uint32_t signal_page_size = l1_alignment;
+        constexpr uint32_t signal_buffering = 2;
+        tt::tt_metal::CircularBufferConfig sender_signal_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                signal_buffering * signal_page_size, {{tt::CBIndex::c_10, tt::DataFormat::UInt32}})
+                .set_page_size(tt::CBIndex::c_10, signal_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, sender_signal_cb_config);
+    }
+    // c_1: indices scratch
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        indices_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_1,
+        "indices_scratch");
+    // c_2: weights scratch
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        weights_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_2,
+        "weights_scratch");
+    // c_3: offsets (full tensor)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        offsets_tensor,
+        /*buffering_factor=*/detail::get_num_pages(offsets_tensor),
+        /*cb_id=*/tt::CBIndex::c_3,
+        "offsets_tensor");
+
+    // c_4, c_5, c_6: reader→writer CBs for (route_info, payload, metadata) per remote entry.
+    // The reader pushes all three per entry in lockstep, so small buffering (2) suffices
+    // for the writer to drain concurrently. No large buffering needed.
+    {
+        constexpr uint32_t rw_buffering = 2;
+
+        uint32_t route_info_page_size = l1_alignment;
+
+        tt::tt_metal::CircularBufferConfig route_info_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                rw_buffering * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_4, route_info_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
+
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            output_tensor,
+            /*buffering_factor=*/rw_buffering,
+            /*cb_id=*/tt::CBIndex::c_5,
+            "payload_for_writer");
+
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            metadata_tensor,
+            /*buffering_factor=*/rw_buffering,
+            /*cb_id=*/tt::CBIndex::c_6,
+            "metadata_for_writer");
+    }
+
+    // c_7: metadata_temp (reader-only, for constructing metadata locally)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        metadata_tensor,
+        /*buffering_factor=*/1,
+        /*cb_id=*/tt::CBIndex::c_7,
+        "metadata_temp_buffer");
+    // c_9: dispatch_table (full tensor)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        dispatch_table_tensor,
+        /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
+        /*cb_id=*/tt::CBIndex::c_9,
+        "dispatch_table_tensor");
+    // c_18: receive buffer for untilized data from idle cores
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        output_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_18,
+        "receive_untilized");
+    // c_19: route table scratch (sender builds local-expert route table here before NOC-writing to idle)
+    {
+        uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;
+        uint32_t mailbox_page_size = tt::round_up(
+            static_cast<uint32_t>(sizeof(uint32_t)) + max_route_entries * 6 * static_cast<uint32_t>(sizeof(uint32_t)),
+            l1_alignment);
+        tt::tt_metal::CircularBufferConfig route_table_cb_config =
+            tt::tt_metal::CircularBufferConfig(mailbox_page_size, {{tt::CBIndex::c_19, tt::DataFormat::UInt32}})
+                .set_page_size(tt::CBIndex::c_19, mailbox_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_table_cb_config);
+    }
+
+    const auto [neighbors, directions] =
+        ccl::common::get_neighbors(mesh_view, mesh_coordinate, topology, operation_attributes.axis);
+
+    // c_8: packet header CB for fabric sends
+    if (operation_attributes.num_links > 0) {
+        constexpr uint32_t num_packet_headers = 2;
+        auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
+        uint32_t packet_header_cb_size = num_packet_headers * packet_header_size_bytes;
+
+        tt::tt_metal::CircularBufferConfig packet_header_cb_config =
+            tt::tt_metal::CircularBufferConfig(packet_header_cb_size, {{tt::CBIndex::c_8, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_8, packet_header_size_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, packet_header_cb_config);
+    }
+
+    std::vector<uint32_t> dest_mesh_id, dest_chip_id;
+    for (const auto& coord : tensor_coords.coords()) {
+        auto dest_fabric_node_id = mesh_device->get_fabric_node_id(coord);
+        dest_mesh_id.push_back(*dest_fabric_node_id.mesh_id);
+        dest_chip_id.push_back((uint32_t)dest_fabric_node_id.chip_id);
+    }
+    log_debug(tt::LogOp, "dest_chip_id: {}", ccl::common::stringify(dest_chip_id));
+    log_debug(tt::LogOp, "dest_mesh_id: {}", ccl::common::stringify(dest_mesh_id));
+    log_debug(tt::LogOp, "directions: {}", ccl::common::stringify(directions));
+
+    auto fabric_max_packet_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+    log_debug(
+        tt::LogOp, "Fabric max packet size: {} bytes, L1 alignment: {} bytes", fabric_max_packet_size, l1_alignment);
+
+    // ==================== Compile-time args shared by sender reader and writer ====================
+    std::vector<uint32_t> compile_time_args = {
+        // CB IDs (10)
+        static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id (used by sender reader for self-untilize)
+        static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_indices_id
+        static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_weights_id
+        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
+        static_cast<uint32_t>(tt::CBIndex::c_4),  // cb_route_info_id
+        static_cast<uint32_t>(tt::CBIndex::c_5),  // cb_payload_for_writer_id
+        static_cast<uint32_t>(tt::CBIndex::c_6),  // cb_metadata_for_writer_id
+        static_cast<uint32_t>(tt::CBIndex::c_7),  // cb_metadata_temp_id
+        static_cast<uint32_t>(tt::CBIndex::c_8),  // cb_packet_header_id
+        static_cast<uint32_t>(tt::CBIndex::c_9),  // cb_dispatch_table_id
+
+        // Page counts (7)
+        detail::get_num_pages(input_tensor),
+        detail::get_num_pages(indices_tensor),
+        detail::get_num_pages(weights_tensor),
+        detail::get_num_pages(offsets_tensor),
+        detail::get_num_pages(output_tensor),
+        detail::get_num_pages(metadata_tensor),
+        detail::get_num_pages(dispatch_table_tensor),
+
+        // Page sizes (7)
+        detail::get_page_size(input_tensor),
+        detail::get_page_size(indices_tensor),
+        detail::get_page_size(weights_tensor),
+        detail::get_page_size(offsets_tensor),
+        detail::get_page_size(output_tensor),
+        detail::get_page_size(metadata_tensor),
+        detail::get_page_size(dispatch_table_tensor),
+
+        // Operation parameters (8)
+        mesh_view.num_devices(),  // num_devices
+        (uint32_t)hidden_size,
+        operation_attributes.experts_per_chip,
+        operation_attributes.num_routed_experts,
+        operation_attributes.num_experts_per_tok,
+        operation_attributes.metadata_len,
+        operation_attributes.max_dispatched_tokens_per_expert,
+        (uint32_t)tokens_per_device,
+
+        // Mesh information (5)
+        src_mesh_id,
+        src_chip_id,
+        mesh_view.num_rows(),
+        mesh_view.num_cols(),
+        linearized_mesh_coord,
+
+        // Aligned page sizes (7)
+        detail::get_aligned_page_size(input_tensor),
+        detail::get_aligned_page_size(indices_tensor),
+        detail::get_aligned_page_size(weights_tensor),
+        detail::get_aligned_page_size(offsets_tensor),
+        detail::get_aligned_page_size(output_tensor),
+        detail::get_aligned_page_size(metadata_tensor),
+        detail::get_aligned_page_size(dispatch_table_tensor),
+
+        // Fabric configuration (4)
+        (uint32_t)fabric_max_packet_size,
+        l1_alignment,
+        static_cast<uint32_t>(operation_attributes.num_links),
+        static_cast<uint32_t>(topology),
+
+        // Batch configuration (1)
+        read_batch_size,
+    };
+
+    // Append TensorAccessorArgs for all 7 tensors
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(weights_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(offsets_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dispatch_table_tensor.buffer()).append_to(compile_time_args);
+
+    std::map<std::string, std::string> fabric_defines;
+    if (operation_attributes.num_links > 0) {
+        fabric_defines["DEST_CHIP_ID"] = ccl::common::stringify(dest_chip_id);
+        fabric_defines["DEST_MESH_ID"] = ccl::common::stringify(dest_mesh_id);
+        fabric_defines["DIRECTIONS"] = ccl::common::stringify(directions);
+    }
+    if (operation_attributes.axis.has_value()) {
+        fabric_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
+    }
+
+    // ==================== Per-sender reader kernels ====================
+    // Each sender gets its own reader kernel with per-sender idle core count baked in.
+    auto reader_defines = fabric_defines;
+    reader_defines["IS_TILE_LAYOUT"] = "1";
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    reader_kernel_ids.reserve(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
+        uint32_t total_workers = k_s + 1;  // idle cores + sender itself
+        auto per_sender_compile_args = compile_time_args;
+        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id (receive buf)
+        per_sender_compile_args.push_back(
+            detail::get_aligned_page_size(output_tensor));  // aligned_row_major_input_page_size
+        per_sender_compile_args.push_back(k_s);             // num_idle_cores
+        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_10));  // cb_signal_id
+        per_sender_compile_args.push_back(total_workers);                             // total_workers
+        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_19));  // cb_route_table_scratch_id
+
+        CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
+        reader_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
+            "reader_dispatch.cpp",
+            single_sender_core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                .compile_args = per_sender_compile_args,
+                .defines = reader_defines}));
+    }
+
+    // ==================== Sender writer kernel (shared across all senders) ====================
+    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
+        "writer_dispatch.cpp",
+        sender_core_grid,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
+            .compile_args = compile_time_args,
+            .defines = fabric_defines});
+
+    // ==================== Idle core kernels ====================
+    // Reader and writer kernels run on the two data-movement RISCs of each idle core
+    // so that DRAM reads for the next batch overlap with the NOC write of the previous
+    // batch to the owning sender's receive buffer.
+    std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> writer_untilize_kernel_ids;
+    reader_untilize_kernel_ids.reserve(num_idle_cores);
+    writer_untilize_kernel_ids.reserve(num_idle_cores);
+    for (uint32_t j = 0; j < num_idle_cores; j++) {
+        uint32_t s = idle_sender_map[j];
+        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
+        // Compute local core_id within this sender's idle group
+        uint32_t local_core_id = 0;
+        for (uint32_t g = 0; g < k_s; g++) {
+            if (sender_idle_groups[s][g] == all_idle_cores[j]) {
+                local_core_id = g;
+                break;
+            }
+        }
+
+        uint32_t total_workers = k_s + 1;  // idle cores + sender itself
+
+        // Reader compile args (DRAM-read side)
+        std::vector<uint32_t> idle_reader_compile_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_input_id
+            static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+            (uint32_t)hidden_size,
+            detail::get_aligned_page_size(input_tensor),  // aligned_input_page_size
+            total_batches,
+            local_core_id,  // core_id within sender group
+            total_workers,  // batch stride (idle cores + sender)
+        };
+        // Append TensorAccessorArgs for input tensor only
+        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(idle_reader_compile_args);
+
+        // Writer compile args (NOC-write side)
+        std::vector<uint32_t> idle_writer_compile_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
+            read_batch_size,
+            detail::get_aligned_page_size(output_tensor),  // aligned_output_page_size
+            total_batches,
+            local_core_id,
+            total_workers,
+            // New: direct-DRAM-write support
+            static_cast<uint32_t>(tt::CBIndex::c_12),        // cb_mailbox_id
+            static_cast<uint32_t>(tt::CBIndex::c_13),        // cb_metadata_scratch_id
+            detail::get_aligned_page_size(metadata_tensor),  // aligned_metadata_page_size
+            operation_attributes.num_experts_per_tok,
+            operation_attributes.max_dispatched_tokens_per_expert,
+            linearized_mesh_coord,
+        };
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(idle_writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(idle_writer_compile_args);
+
+        CoreRangeSet single_idle_core({CoreRange(all_idle_cores[j])});
+        reader_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
+            "reader_untilize_dispatch.cpp",
+            single_idle_core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
+                .compile_args = idle_reader_compile_args}));
+
+        writer_untilize_kernel_ids.push_back(tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
+            "writer_untilize_dispatch.cpp",
+            single_idle_core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
+                .compile_args = idle_writer_compile_args}));
+    }
+
+    // Compute kernel on idle cores (same untilize kernel, unchanged)
+    tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
+        "untilize_dispatch.cpp",
+        idle_core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .compile_args = {
+                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+                static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
+                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+                (uint32_t)hidden_size,
+                read_batch_size,
+            }});
+
+    // Compute kernel on sender cores for self-untilize (output goes to c_18)
+    tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
+        "untilize_dispatch.cpp",
+        sender_core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .compile_args = {
+                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
+                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+                (uint32_t)hidden_size,
+                read_batch_size,
+            }});
+
+    // ==================== Pre-compute NOC coordinates ====================
+    std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;
+    for (const auto& sc : sender_cores) {
+        auto noc_coord = mesh_device->virtual_core_from_logical_core(sc, tt::CoreType::WORKER);
+        sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
+    }
+
+    // Per-sender multicast/idle info
+    struct SenderIdleCfg {
+        std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
+        uint32_t mcast_x_start = 0, mcast_y_start = 0, mcast_x_end = 0, mcast_y_end = 0;
+    };
+    std::vector<SenderIdleCfg> sender_idle_cfgs(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        bool first = true;
+        for (const auto& ic : sender_idle_groups[s]) {
+            auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
+            uint32_t nx = (uint32_t)noc.x, ny = (uint32_t)noc.y;
+            sender_idle_cfgs[s].idle_noc_coords.emplace_back(nx, ny);
+            if (first) {
+                sender_idle_cfgs[s].mcast_x_start = sender_idle_cfgs[s].mcast_x_end = nx;
+                sender_idle_cfgs[s].mcast_y_start = sender_idle_cfgs[s].mcast_y_end = ny;
+                first = false;
+            } else {
+                sender_idle_cfgs[s].mcast_x_start = std::min(sender_idle_cfgs[s].mcast_x_start, nx);
+                sender_idle_cfgs[s].mcast_x_end = std::max(sender_idle_cfgs[s].mcast_x_end, nx);
+                sender_idle_cfgs[s].mcast_y_start = std::min(sender_idle_cfgs[s].mcast_y_start, ny);
+                sender_idle_cfgs[s].mcast_y_end = std::max(sender_idle_cfgs[s].mcast_y_end, ny);
+            }
+        }
+    }
+
+    // ==================== Runtime args for sender cores ====================
+    std::vector<uint32_t> base_runtime_args = {
+        input_tensor.buffer()->address(),
+        indices_tensor.buffer()->address(),
+        weights_tensor.buffer()->address(),
+        offsets_tensor.buffer()->address(),
+        output_tensor.buffer()->address(),
+        metadata_tensor.buffer()->address(),
+        dispatch_table_tensor.buffer()->address(),
+        (uint32_t)cross_device_semaphore.address(),
+        (uint32_t)init_semaphore.address(),
+        0,                            // token_start_idx
+        (uint32_t)tokens_per_device,  // token_end_idx
+        0,                            // dispatch_core_idx (set per core)
+        num_cores,                    // num_dispatch_cores
+    };
+
+    uint32_t core_idx = 0;
+    for (const auto& sender_core : sender_cores) {
+        std::vector<uint32_t> reader_runtime_args = base_runtime_args;
+        std::vector<uint32_t> writer_runtime_args = base_runtime_args;
+
+        reader_runtime_args[11] = core_idx;  // dispatch_core_idx
+        writer_runtime_args[11] = core_idx;
+
+        // Inter-core sync args for reader
+        reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
+        reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
+        reader_runtime_args.push_back(addr_ready_semaphore_id);
+        reader_runtime_args.push_back(addr_value_semaphore_id);
+        reader_runtime_args.push_back(mbox_ready_semaphore_ids[core_idx]);
+        reader_runtime_args.push_back(mbox_scratch_addr_semaphore_id);
+
+        // Pass NOC coords of this sender's idle cores (for per-batch unicast start signal)
+        for (const auto& [noc_x, noc_y] : sender_idle_cfgs[core_idx].idle_noc_coords) {
+            reader_runtime_args.push_back(noc_x);
+            reader_runtime_args.push_back(noc_y);
+        }
+        // Bounding box for multicast of addr_value / addr_ready to the idle group
+        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_x_start);
+        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_y_start);
+        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_x_end);
+        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_y_end);
+
+        if (operation_attributes.num_links > 0) {
+            uint32_t core_link = core_idx % num_links;
+            for (const auto& neighbor_coordinate : neighbors) {
+                if (neighbor_coordinate[0] == mesh_coordinate[0] && neighbor_coordinate[1] == mesh_coordinate[1]) {
+                    continue;
+                }
+
+                log_debug(
+                    tt::LogOp,
+                    "Connection between mesh coord ({}, {}) and ({}, {}) at core {} link {}",
+                    mesh_coordinate[0],
+                    mesh_coordinate[1],
+                    neighbor_coordinate[0],
+                    neighbor_coordinate[1],
+                    sender_core,
+                    core_link);
+                tt::tt_fabric::append_fabric_connection_rt_args(
+                    src_fabric_node_id,
+                    mesh_device->get_fabric_node_id(neighbor_coordinate),
+                    core_link,
+                    program,
+                    sender_core,
+                    writer_runtime_args);
+            }
+        }
+
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[core_idx], sender_core, reader_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
+        core_idx++;
+    }
+
+    // ==================== Runtime args for idle cores ====================
+    // The sender's c_18 L1 address is communicated at runtime: sender uses noc_async_write
+    // to copy it to each idle core's addr_value_sem, then signals addr_ready_sem.
+    // Reader only needs the input tensor address; writer owns the sender-sync semaphores
+    // and NOC coords.
+    for (uint32_t j = 0; j < num_idle_cores; j++) {
+        uint32_t s = idle_sender_map[j];
+
+        std::vector<uint32_t> idle_reader_rt_args = {
+            input_tensor.buffer()->address(),
+        };
+        tt::tt_metal::SetRuntimeArgs(program, reader_untilize_kernel_ids[j], all_idle_cores[j], idle_reader_rt_args);
+
+        std::vector<uint32_t> idle_writer_rt_args = {
+            data_ready_semaphore_ids[s],
+            start_semaphore_ids[s],
+            sender_noc_coords[s].first,
+            sender_noc_coords[s].second,
+            addr_ready_semaphore_id,
+            addr_value_semaphore_id,
+            // New:
+            output_tensor.buffer()->address(),
+            metadata_tensor.buffer()->address(),
+            mbox_ready_semaphore_ids[s],
+            mbox_scratch_addr_semaphore_id,
+        };
+        tt::tt_metal::SetRuntimeArgs(program, writer_untilize_kernel_ids[j], all_idle_cores[j], idle_writer_rt_args);
+    }
+
+    return {
+        std::move(program),
+        {.reader_kernel_ids = std::move(reader_kernel_ids),
+         .writer_kernel_id = writer_kernel_id,
+         .reader_untilize_kernel_ids = std::move(reader_untilize_kernel_ids),
+         .writer_untilize_kernel_ids = std::move(writer_untilize_kernel_ids),
+         .cores = sender_cores,
+         .idle_cores = all_idle_cores,
+         .init_semaphore = init_semaphore,
+         .cross_device_semaphore = cross_device_semaphore,
+         .data_ready_semaphore_ids = std::move(data_ready_semaphore_ids),
+         .start_semaphore_ids = std::move(start_semaphore_ids)}};
+}
+
+// Row-major path: ROW_MAJOR inputs, single reader kernel per sender, no idle cores.
+ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_row_major(
+    const DispatchParams& operation_attributes,
+    const MeshCoordinate& mesh_coordinate,
+    const DispatchInputs& tensor_args,
+    DispatchProgramFactory::tensor_return_value_t& tensor_return_value,
+    const MeshCoordinateRangeSet& tensor_coords,
+    const GlobalSemaphore& init_semaphore,
+    const GlobalSemaphore& cross_device_semaphore) {
+    tt::tt_metal::Program program{};
+
+    auto input_tensor = tensor_args.input_tensor;
+    auto indices_tensor = tensor_args.indices_tensor;
+    auto weights_tensor = tensor_args.weights_tensor;
+    auto offsets_tensor = tensor_args.expert_offsets_tensor;
+    auto dispatch_table_tensor = tensor_args.expert_dispatch_table_tensor;
+
+    const auto& output_tensor = tensor_return_value.at(0);
+    const auto& metadata_tensor = tensor_return_value.at(1);
+
+    auto num_links = operation_attributes.num_links;
+    auto topology = operation_attributes.topology;
+    log_debug(
+        tt::LogOp,
+        "Creating prefill dispatch program (row-major) for mesh coordinate: ({}, {}) with topology: {} num_links: {}",
         mesh_coordinate[0],
         mesh_coordinate[1],
         topology,
@@ -382,6 +1110,8 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         fabric_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
     }
 
+    // Single reader kernel shared across all senders; store one handle per sender for
+    // uniform override_runtime_arguments iteration between tile and row-major paths.
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
@@ -392,6 +1122,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
             .compile_args = compile_time_args,
             .defines = fabric_defines});
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids(num_cores, reader_kernel_id);
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -462,11 +1193,81 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
 
     return {
         std::move(program),
-        {.reader_kernel_id = reader_kernel_id,
+        {.reader_kernel_ids = std::move(reader_kernel_ids),
          .writer_kernel_id = writer_kernel_id,
+         .reader_untilize_kernel_ids = {},
+         .writer_untilize_kernel_ids = {},
          .cores = sender_cores,
+         .idle_cores = {},
          .init_semaphore = init_semaphore,
-         .cross_device_semaphore = cross_device_semaphore}};
+         .cross_device_semaphore = cross_device_semaphore,
+         .data_ready_semaphore_ids = {},
+         .start_semaphore_ids = {}}};
+}
+
+}  // namespace
+
+DispatchProgramFactory::cached_mesh_workload_t DispatchProgramFactory::create_mesh_workload(
+    const DispatchParams& operation_attributes,
+    const MeshCoordinateRangeSet& tensor_coords,
+    const DispatchInputs& tensor_args,
+    DispatchProgramFactory::tensor_return_value_t& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, DispatchSharedVariables> shared_variables;
+
+    auto* mesh_device = tensor_args.input_tensor.device();
+
+    auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
+                                                                            : tt::tt_metal::BufferType::L1;
+    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
+        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
+    auto final_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(
+        mesh_device, operation_attributes.worker_core_range_set, 0, sem_buffer_type);
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
+
+    for (const auto& coord : tensor_coords.coords()) {
+        auto cached_program = create_at(
+            operation_attributes,
+            coord,
+            tensor_args,
+            tensor_return_value,
+            tensor_coords,
+            init_barrier_semaphore,
+            final_barrier_semaphore);
+        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
+        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
+    }
+    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
+}
+
+ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFactory::create_at(
+    const DispatchParams& operation_attributes,
+    const MeshCoordinate& mesh_coordinate,
+    const DispatchInputs& tensor_args,
+    DispatchProgramFactory::tensor_return_value_t& tensor_return_value,
+    const MeshCoordinateRangeSet& tensor_coords,
+    const GlobalSemaphore& init_semaphore,
+    const GlobalSemaphore& cross_device_semaphore) {
+    const bool is_tile_layout = tensor_args.input_tensor.layout() == tt::tt_metal::Layout::TILE;
+    log_info(tt::LogOp, "Prefill dispatch: input tensor is {} layout", is_tile_layout ? "TILE" : "ROW_MAJOR");
+    if (is_tile_layout) {
+        return create_at_tile_layout(
+            operation_attributes,
+            mesh_coordinate,
+            tensor_args,
+            tensor_return_value,
+            tensor_coords,
+            init_semaphore,
+            cross_device_semaphore);
+    }
+    return create_at_row_major(
+        operation_attributes,
+        mesh_coordinate,
+        tensor_args,
+        tensor_return_value,
+        tensor_coords,
+        init_semaphore,
+        cross_device_semaphore);
 }
 
 void DispatchProgramFactory::override_runtime_arguments(
@@ -474,17 +1275,19 @@ void DispatchProgramFactory::override_runtime_arguments(
     const DispatchParams& /*operation_attributes*/,
     const DispatchInputs& tensor_args,
     DispatchProgramFactory::tensor_return_value_t& tensor_return_value) {
+    const bool is_tile_layout = tensor_args.input_tensor.layout() == tt::tt_metal::Layout::TILE;
     for (auto& [range, program] : cached_workload.workload.get_programs()) {
         const auto& shared_variables = cached_workload.shared_variables.at(range);
-        const auto& reader_kernel_id = shared_variables.reader_kernel_id;
         const auto& writer_kernel_id = shared_variables.writer_kernel_id;
         const auto& cores = shared_variables.cores;
 
         const auto& output_tensor = tensor_return_value.at(0);
         const auto& metadata_tensor = tensor_return_value.at(1);
 
-        for (const auto& core : cores) {
-            auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
+        for (size_t s = 0; s < cores.size(); s++) {
+            const auto& core = cores[s];
+            auto& reader_runtime_args =
+                tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_ids[s], core);
             auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
 
             reader_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
@@ -506,6 +1309,20 @@ void DispatchProgramFactory::override_runtime_arguments(
             writer_runtime_args.at(6) = tensor_args.expert_dispatch_table_tensor.buffer()->address();
             writer_runtime_args.at(7) = (uint32_t)shared_variables.cross_device_semaphore.address();
             writer_runtime_args.at(8) = (uint32_t)shared_variables.init_semaphore.address();
+        }
+
+        // Idle cores only exist on the tile-layout path.
+        if (is_tile_layout) {
+            for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
+                auto& idle_reader_rt_args = tt::tt_metal::GetRuntimeArgs(
+                    program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
+                idle_reader_rt_args.at(0) = tensor_args.input_tensor.buffer()->address();
+
+                auto& idle_writer_rt_args = tt::tt_metal::GetRuntimeArgs(
+                    program, shared_variables.writer_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
+                idle_writer_rt_args.at(6) = output_tensor.buffer()->address();
+                idle_writer_rt_args.at(7) = metadata_tensor.buffer()->address();
+            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.hpp
@@ -15,11 +15,16 @@
 namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
 
 struct DispatchSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> writer_untilize_kernel_ids;
     std::vector<CoreCoord> cores;
+    std::vector<CoreCoord> idle_cores;
     GlobalSemaphore init_semaphore;          // Initialized in create_at()
     GlobalSemaphore cross_device_semaphore;  // Initialized in create_at()
+    std::vector<uint32_t> data_ready_semaphore_ids;
+    std::vector<uint32_t> start_semaphore_ids;
 };
 
 struct DispatchProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
@@ -46,14 +46,11 @@ void kernel_main() {
     uint32_t batch_counter = 0;
 
     while (true) {
-        DPRINT_DISPATCH << "Processing batch " << batch_counter << ENDL();
-
         cb_reserve_back(cb_untilize_id, read_batch_size);
         cb_wait_front(cb_signal_id, 1);
         uint32_t val = read_tile_value(cb_signal_id, 0, 0);
         cb_pop_front(cb_signal_id, 1);
         if (val == ROUTE_INFO_SENTINEL) {
-            DPRINT_DISPATCH << "Received sentinel, stopping" << ENDL();
             break;
         }
         for (uint32_t block = 0; block < num_blocks; block++) {
@@ -64,7 +61,6 @@ void kernel_main() {
 
         cb_push_back(cb_untilize_id, read_batch_size);
 
-        DPRINT_DISPATCH << "Processed batch " << batch_counter << ENDL();
         batch_counter++;
     }
     pack_untilize_uninit(cb_untilize_id);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/common.h"
+#include "api/compute/cb_api.h"
+#include "api/compute/pack_untilize.h"
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "api/debug/dprint.h"
+
+#define ENABLE_DISPATCH_DEBUG 0
+
+#if ENABLE_DISPATCH_DEBUG
+#define DPRINT_DISPATCH DPRINT
+#else
+#define DPRINT_DISPATCH \
+    if (0)              \
+    DebugPrinter()
+#endif
+
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
+// Compile-time args:
+//   0: cb_signal_id    - CB for reader->compute signaling (c_17)
+//   1: cb_untilize_id  - CB for compute untilized output (c_18)
+//   2: cb_in_id        - CB for untilize input tile data (c_0)
+//   3: hidden_size     - hidden dimension (e.g., 7168)
+//   4: read_batch_size - number of rows per untilize batch (32)
+void kernel_main() {
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_in_id = get_compile_time_arg_val(2);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(3);
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(4);
+
+    constexpr uint32_t block_ct_dim = 8;
+    constexpr uint32_t full_ct_dim = hidden_size / 32;
+    constexpr uint32_t num_blocks = full_ct_dim / block_ct_dim;
+
+    compute_kernel_hw_startup(cb_in_id, cb_untilize_id);
+    pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in_id, cb_untilize_id);
+
+    uint32_t batch_counter = 0;
+
+    while (true) {
+        DPRINT_DISPATCH << "Processing batch " << batch_counter << ENDL();
+
+        cb_reserve_back(cb_untilize_id, read_batch_size);
+        cb_wait_front(cb_signal_id, 1);
+        uint32_t val = read_tile_value(cb_signal_id, 0, 0);
+        cb_pop_front(cb_signal_id, 1);
+        if (val == ROUTE_INFO_SENTINEL) {
+            DPRINT_DISPATCH << "Received sentinel, stopping" << ENDL();
+            break;
+        }
+        for (uint32_t block = 0; block < num_blocks; block++) {
+            cb_wait_front(cb_in_id, block_ct_dim);
+            pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in_id, 1, cb_untilize_id, block);
+            cb_pop_front(cb_in_id, block_ct_dim);
+        }
+
+        cb_push_back(cb_untilize_id, read_batch_size);
+
+        DPRINT_DISPATCH << "Processed batch " << batch_counter << ENDL();
+        batch_counter++;
+    }
+    pack_untilize_uninit(cb_untilize_id);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -74,6 +74,7 @@ void kernel_main() {
     constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(38);
     constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(39);
     constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(40);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(41);
     constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(42);
     constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(43);
 
@@ -95,6 +96,25 @@ void kernel_main() {
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
     constexpr auto dispatch_table_args = TensorAccessorArgs<metadata_args.next_compile_time_args_offset()>();
 
+#ifdef IS_TILE_LAYOUT
+    // Reader-only compile-time args (appended after TensorAccessorArgs)
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset());
+    constexpr uint32_t aligned_row_major_input_page_size =
+        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 1);
+    constexpr uint32_t num_idle_cores =
+        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 3);
+    constexpr uint32_t total_workers =
+        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 4);
+    constexpr uint32_t cb_route_table_scratch_id =
+        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 5);
+
+    constexpr uint32_t tiles_per_row = hidden_size / 32;
+    constexpr uint32_t writer_page_size = aligned_row_major_input_page_size;
+#else
+    constexpr uint32_t writer_page_size = aligned_input_page_size;
+#endif
+
     // ===== Runtime Args =====
     uint32_t rt_args = 0;
     uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_args++);
@@ -112,6 +132,43 @@ void kernel_main() {
     uint32_t num_dispatch_cores = get_arg_val<uint32_t>(rt_args++);
     uint32_t core_mask = num_dispatch_cores - 1;
 
+#ifdef IS_TILE_LAYOUT
+    // Inter-core sync args
+    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t addr_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t addr_value_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mbox_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mbox_scratch_addr_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+
+    volatile tt_l1_ptr uint32_t* data_ready_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(data_ready_semaphore_id));
+    uint32_t start_sem_l1_offset = get_semaphore(start_semaphore_id);
+    uint32_t addr_ready_sem_l1_offset = get_semaphore(addr_ready_semaphore_id);
+    uint32_t addr_value_sem_l1_offset = get_semaphore(addr_value_semaphore_id);
+
+    // Read per-idle-core NOC addresses for per-batch start signaling (unicast)
+    // x/y kept separately to build idle_mailbox_noc_addrs after the mbox_ready rendezvous.
+    uint64_t idle_start_noc_addrs[num_idle_cores];
+    uint32_t idle_noc_xs[num_idle_cores];
+    uint32_t idle_noc_ys[num_idle_cores];
+    for (uint32_t c = 0; c < num_idle_cores; c++) {
+        idle_noc_xs[c] = get_arg_val<uint32_t>(rt_args++);
+        idle_noc_ys[c] = get_arg_val<uint32_t>(rt_args++);
+        idle_start_noc_addrs[c] = get_noc_addr(idle_noc_xs[c], idle_noc_ys[c], start_sem_l1_offset);
+    }
+
+    // Bounding box covering all idle cores in this sender's group (for multicast)
+    uint32_t mcast_x_start = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_y_start = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_x_end = get_arg_val<uint32_t>(rt_args++);
+    uint32_t mcast_y_end = get_arg_val<uint32_t>(rt_args++);
+    uint64_t mcast_addr_value_noc_addr =
+        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, addr_value_sem_l1_offset);
+    uint64_t mcast_addr_ready_noc_addr =
+        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, addr_ready_sem_l1_offset);
+#endif
+
 #ifdef AXIS
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
     constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
@@ -128,7 +185,11 @@ void kernel_main() {
 #endif
 
     DPRINT_DISPATCH << "Reader kernel: tokens=[" << token_start_idx << "," << token_end_idx << ")"
-                    << " dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores << ENDL();
+                    << " dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores
+#ifdef IS_TILE_LAYOUT
+                    << " num_idle_cores=" << num_idle_cores
+#endif
+                    << ENDL();
 
     // Read offsets into local scratch
     const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address);
@@ -155,24 +216,74 @@ void kernel_main() {
     // overwrites the same region at offsets [0, batch_count) without push/pop.
     // DRAM reads are batched to saturate DRAM bandwidth, while the L1-to-writer-CB
     // copies below are done one page at a time — this avoids CB FIFO pointer wrapping
-    // and measured faster in practice.
     cb_reserve_back(cb_indices_id, read_batch_size);
     uint32_t indices_base = get_write_ptr(cb_indices_id);
     cb_reserve_back(cb_weights_id, read_batch_size);
     uint32_t weights_base = get_write_ptr(cb_weights_id);
+
+#ifdef IS_TILE_LAYOUT
+    const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, aligned_indices_page_size);
+    const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address, aligned_weights_page_size);
+    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address, aligned_output_page_size);
+    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, aligned_metadata_page_size);
+#else
     cb_reserve_back(cb_input_id, read_batch_size);
     uint32_t input_base = get_write_ptr(cb_input_id);
-
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address);
     const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address);
     const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address);
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
+#endif
 
-    // Reserve metadata temp for constructing metadata locally
     cb_reserve_back(cb_metadata_temp_id, 1);
     uint32_t metadata_temp_addr = get_write_ptr(cb_metadata_temp_id);
 
+#ifdef IS_TILE_LAYOUT
+    uint32_t untilize_base = get_write_ptr(cb_untilize_id);
+    uint32_t rt_scratch_base = get_write_ptr(cb_route_table_scratch_id);
+
+    // Multicast two addresses to all idle cores in this sender's group before signaling addr_ready:
+    //   1. receive buffer address (c_18 base) → idle cores write untilized data here
+    //   2. route-table scratch base → idle cores NOC-write their mailbox L1 address into
+    //      slot [core_id * 4] of this buffer so the sender can read it locally (no NOC read).
+    volatile tt_l1_ptr uint32_t* addr_value_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr_value_sem_l1_offset);
+    *addr_value_ptr = untilize_base;
+    noc_async_write_multicast(addr_value_sem_l1_offset, mcast_addr_value_noc_addr, sizeof(uint32_t), num_idle_cores);
+
+    uint32_t mbox_scratch_addr_sem_l1_offset = get_semaphore(mbox_scratch_addr_semaphore_id);
+    volatile tt_l1_ptr uint32_t* mbox_scratch_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mbox_scratch_addr_sem_l1_offset);
+    *mbox_scratch_addr_ptr = rt_scratch_base;
+    uint64_t mcast_mbox_scratch_noc_addr =
+        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, mbox_scratch_addr_sem_l1_offset);
+    noc_async_write_multicast(
+        mbox_scratch_addr_sem_l1_offset, mcast_mbox_scratch_noc_addr, sizeof(uint32_t), num_idle_cores);
+    noc_async_write_barrier();
+    noc_semaphore_inc_multicast(mcast_addr_ready_noc_addr, 1, num_idle_cores);
+    noc_async_atomic_barrier();
+
+    // Wait for all idle cores to NOC-write their mailbox L1 addresses into rt_scratch_base.
+    // Because idle cores use noc_inline_dw_write (ordered before noc_semaphore_inc on the NOC),
+    // each slot is guaranteed to be visible in local L1 once mbox_ready reaches num_idle_cores.
+    volatile tt_l1_ptr uint32_t* mbox_ready_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(mbox_ready_semaphore_id));
+    noc_semaphore_wait(mbox_ready_sem_ptr, num_idle_cores);
+    noc_semaphore_set(mbox_ready_sem_ptr, 0);
+
+    // Read idle mailbox addresses directly from own L1 scratch — no NOC reads needed.
+    volatile tt_l1_ptr uint32_t* rt_scratch_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(rt_scratch_base);
+    uint64_t idle_mailbox_noc_addrs[num_idle_cores];
+    for (uint32_t c = 0; c < num_idle_cores; c++) {
+        idle_mailbox_noc_addrs[c] = get_noc_addr(idle_noc_xs[c], idle_noc_ys[c], rt_scratch_ptr[c]);
+    }
+
+    // Self-untilize setup: TensorAccessor for reading tiles from DRAM
+    const auto self_input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
+    constexpr uint32_t block_ct_dim = 8;
+    constexpr uint32_t num_tile_blocks = tiles_per_row / block_ct_dim;
+#else
     // Prefetch first batch of DRAM reads
     uint32_t first_batch_end =
         (token_start_idx + read_batch_size < token_end_idx) ? token_start_idx + read_batch_size : token_end_idx;
@@ -185,17 +296,145 @@ void kernel_main() {
         }
         noc_async_read_barrier();
     }
+#endif
 
-    // Main batch loop
-    for (uint32_t batch_start = token_start_idx; batch_start < token_end_idx; batch_start += read_batch_size) {
+    // ===== Unified batch loop =====
+    uint32_t total_batches = (token_end_idx - token_start_idx + read_batch_size - 1) / read_batch_size;
+    for (uint32_t B = 0; B < total_batches; B++) {
+        uint32_t batch_start = token_start_idx + B * read_batch_size;
         uint32_t batch_end =
             (batch_start + read_batch_size < token_end_idx) ? batch_start + read_batch_size : token_end_idx;
         uint32_t batch_count = batch_end - batch_start;
         bool batch_did_local_write = false;
 
+#ifdef IS_TILE_LAYOUT
+        // Batch prep: delegate to idle core, or self-untilize locally.
+        uint32_t C = B % total_workers;
+
+        if (C < num_idle_cores) {
+            // ---- Worker-batch: delegate to idle core C ----
+            // Read indices/weights before building the route table so routing
+            // decisions are known before we signal the idle core.
+            for (uint32_t t = 0; t < batch_count; t++) {
+                noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
+                noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
+            }
+            noc_async_read_barrier();
+
+            // Build local-expert route table into the route table scratch CB.
+            // Only LOCAL entries go in the mailbox; cross-device entries are
+            // handled by the sender's main routing loop as normal.
+            // We track per-expert offset increments locally to mirror the main
+            // loop without touching the shared offsets[] array.
+            uint32_t local_offset_delta[n_routed_experts] = {};
+            volatile tt_l1_ptr uint32_t* rt = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(rt_scratch_base);
+            uint32_t entry_count = 0;
+            bool has_non_local = false;
+
+            for (uint32_t t = 0; t < batch_count; t++) {
+                int32_t* indices_t = (int32_t*)(indices_base + t * aligned_indices_page_size);
+                uint16_t* weights_t = (uint16_t*)(weights_base + t * aligned_weights_page_size);
+                for (uint32_t k = 0; k < num_experts_per_tok; k++) {
+                    auto routed_expert = indices_t[k];
+                    if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
+                        continue;
+                    }
+                    auto expert_chip_og = expert_dispatch_table[routed_expert];
+                    if (expert_chip_og == -1) {
+                        continue;
+                    }
+                    // Mirror offset++ from main loop (covers both overflow and valid paths)
+                    uint32_t effective_offset = offsets[routed_expert] + local_offset_delta[routed_expert];
+                    local_offset_delta[routed_expert]++;
+
+                    if (effective_offset >= max_dispatched_tokens_per_expert) {
+                        continue;
+                    }
+                    auto expert_chip = device_begin_idx + expert_chip_og * device_stride;
+                    if (expert_chip != linearized_mesh_coord) {
+                        has_non_local = true;
+                        continue;  // cross-device: sender handles in main routing loop
+                    }
+                    auto expert_index_within_chip = (uint32_t)routed_expert % experts_per_chip;
+                    auto page_idx = expert_index_within_chip * max_dispatched_tokens_per_expert + effective_offset;
+
+                    uint32_t base = 1 + entry_count * 6;
+                    rt[base + 0] = t;
+                    rt[base + 1] = (uint32_t)page_idx;
+                    rt[base + 2] = batch_start + t;
+                    rt[base + 3] = k;
+                    rt[base + 4] = (uint32_t)routed_expert;
+                    rt[base + 5] = (uint32_t)(int32_t)(int16_t)weights_t[k];
+                    entry_count++;
+                }
+            }
+            // High bit signals the idle core whether to bulk-send back to us.
+            rt[0] = entry_count | (has_non_local ? 0x80000000u : 0u);
+
+            // Write route table to idle core's mailbox, then signal start.
+            uint32_t mailbox_write_bytes = sizeof(uint32_t) + entry_count * 6 * sizeof(uint32_t);
+            noc_async_write(rt_scratch_base, idle_mailbox_noc_addrs[C], mailbox_write_bytes);
+            noc_async_write_barrier();
+
+            noc_semaphore_inc(idle_start_noc_addrs[C], 1);
+            noc_async_atomic_barrier();
+
+            // Only wait if the idle core will actually send data back.
+            if (has_non_local) {
+                DPRINT_DISPATCH << "Waiting for idle core " << C << " batch " << B << ENDL();
+                noc_semaphore_wait(data_ready_sem_ptr, 1);
+                noc_semaphore_set(data_ready_sem_ptr, 0);
+                DPRINT_DISPATCH << "Got batch " << B << " from idle core " << C << ENDL();
+            }
+        } else {
+            // ---- Self-batch: read tiles, untilize locally, no NOC transfer ----
+            DPRINT_DISPATCH << "Self-untilize batch " << B << ENDL();
+            uint32_t tile_base_page = B * tiles_per_row;
+
+            // Signal compute to untilize (before streaming tiles so compute is ready)
+            cb_reserve_back(cb_signal_id, 1);
+            volatile tt_l1_ptr uint32_t* signal_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+            signal_ptr[0] = 0x00000000;
+            cb_push_back(cb_signal_id, 1);
+
+            // Stream tiles in blocks of 8 — compute consumes each block as it arrives
+            for (uint32_t blk = 0; blk < num_tile_blocks; blk++) {
+                cb_reserve_back(cb_input_id, block_ct_dim);
+                uint32_t blk_write_ptr = get_write_ptr(cb_input_id);
+                uint32_t blk_start = tile_base_page + blk * block_ct_dim;
+                for (uint32_t col = 0; col < block_ct_dim; col++) {
+                    noc_async_read_page(
+                        blk_start + col, self_input_addr_gen, blk_write_ptr + col * aligned_input_page_size);
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_input_id, block_ct_dim);
+            }
+
+            // Overlap reads with compute
+            for (uint32_t t = 0; t < batch_count; t++) {
+                noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
+                noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
+            }
+
+            // Wait for compute to finish (it writes untilized data into cb_untilize_id / c_18)
+            cb_wait_front(cb_untilize_id, read_batch_size);
+            noc_async_read_barrier();
+            DPRINT_DISPATCH << "Self-untilize batch " << B << " done" << ENDL();
+        }
+#endif
+
+        // ---- Common inner token loop ----
+#ifdef IS_TILE_LAYOUT
+        bool is_delegated_batch = (C < num_idle_cores);
+#endif
         for (uint32_t t = 0; t < batch_count; t++) {
             uint32_t token_idx = batch_start + t;
-            uint32_t input_scratch_addr = input_base + t * aligned_input_page_size;
+#ifdef IS_TILE_LAYOUT
+            uint32_t token_input_addr = untilize_base + t * writer_page_size;
+#else
+            uint32_t token_input_addr = input_base + t * aligned_input_page_size;
+#endif
             int32_t* indices = (int32_t*)(indices_base + t * aligned_indices_page_size);
             uint16_t* weights = (uint16_t*)(weights_base + t * aligned_weights_page_size);
 
@@ -222,25 +461,31 @@ void kernel_main() {
                 auto page_idx = expert_index_within_chip * max_dispatched_tokens_per_expert + offset;
 
                 if (expert_chip == linearized_mesh_coord) {
-                    volatile tt_l1_ptr int32_t* metadata =
-                        reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
-                    metadata[0] = linearized_mesh_coord;
-                    metadata[1] = token_idx;
-                    metadata[2] = k;
-                    metadata[3] = routed_expert;
-                    metadata[4] = static_cast<int16_t>(weights[k]);
+#ifdef IS_TILE_LAYOUT
+                    // For delegated batches the idle core's writer kernel handles
+                    // local DRAM writes directly; skip them here.
+                    if (!is_delegated_batch)
+#endif
+                    {
+                        volatile tt_l1_ptr int32_t* metadata =
+                            reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
+                        metadata[0] = linearized_mesh_coord;
+                        metadata[1] = token_idx;
+                        metadata[2] = k;
+                        metadata[3] = routed_expert;
+                        metadata[4] = static_cast<int16_t>(weights[k]);
 
-                    noc_async_write_page(page_idx, output_addr_gen, input_scratch_addr);
-                    noc_async_write_page(page_idx, metadata_addr_gen, metadata_temp_addr);
-                    noc_async_writes_flushed();
-                    batch_did_local_write = true;
+                        noc_async_write_page(page_idx, output_addr_gen, token_input_addr);
+                        noc_async_write_page(page_idx, metadata_addr_gen, metadata_temp_addr);
+                        noc_async_writes_flushed();
+                        batch_did_local_write = true;
+                    }
                 } else {
                     if constexpr (is_1d_topology<topology>()) {
                         uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
 
-                        // Push route info to writer
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -250,14 +495,12 @@ void kernel_main() {
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
 
-                        // Push payload to writer
                         cb_reserve_back(cb_payload_for_writer_id, 1);
                         uint32_t payload_dst = get_write_ptr(cb_payload_for_writer_id);
-                        noc_async_read(get_noc_addr(input_scratch_addr), payload_dst, aligned_input_page_size);
+                        noc_async_read(get_noc_addr(token_input_addr), payload_dst, writer_page_size);
                         noc_async_read_barrier();
                         cb_push_back(cb_payload_for_writer_id, 1);
 
-                        // Push metadata to writer
                         cb_reserve_back(cb_metadata_for_writer_id, 1);
                         volatile tt_l1_ptr int32_t* meta_dst =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(get_write_ptr(cb_metadata_for_writer_id));
@@ -274,6 +517,15 @@ void kernel_main() {
             }
         }
 
+#ifdef IS_TILE_LAYOUT
+        if (batch_did_local_write) {
+            noc_async_write_barrier();
+        }
+        // Release CB after self-batch so compute can reuse it next time
+        if (C >= num_idle_cores) {
+            cb_pop_front(cb_untilize_id, read_batch_size);
+        }
+#else
         // Issue next batch DRAM reads BEFORE write barrier to overlap read/write NOC channels
         uint32_t next_batch_start = batch_start + read_batch_size;
         bool has_next_batch = (next_batch_start < token_end_idx);
@@ -298,7 +550,17 @@ void kernel_main() {
         if (has_next_batch) {
             noc_async_read_barrier();
         }
+#endif
     }
+
+#ifdef IS_TILE_LAYOUT
+    // Signal compute to exit
+    cb_reserve_back(cb_signal_id, 1);
+    volatile tt_l1_ptr uint32_t* signal_sentinel =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+    signal_sentinel[0] = ROUTE_INFO_SENTINEL;
+    cb_push_back(cb_signal_id, 1);
+#endif
 
     // Push sentinel to signal writer that all dispatches are done
     cb_reserve_back(cb_route_info_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Reader kernel for idle (worker) cores in the dispatch op.
+// Pairs with writer_untilize_dispatch.cpp running on the other data-movement
+// RISC — this kernel focuses on streaming tiled input from DRAM so the writer
+// can overlap NOC-writes to the owning sender with the next batch's reads.
+//
+// Token batches are distributed round-robin across total_workers (k_s idle
+// cores + the sender itself). Core i processes batches i, i+total_workers, …
+//
+// For each assigned batch:
+//   1. Signal compute to start untilizing this batch (cb_signal_id).
+//   2. Read tiled input stripe from DRAM → cb_input_id, block_ct_dim tiles at a time.
+//
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+
+#define ENABLE_DISPATCH_DEBUG 0
+#if ENABLE_DISPATCH_DEBUG
+#define DPRINT_DISPATCH DPRINT
+#else
+#define DPRINT_DISPATCH \
+    if (0)              \
+    DebugPrinter()
+#endif
+
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
+void kernel_main() {
+    // ===== Compile-time args =====
+    constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(1);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(2);
+    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t total_batches = get_compile_time_arg_val(4);
+    constexpr uint32_t core_id = get_compile_time_arg_val(5);
+    constexpr uint32_t total_workers = get_compile_time_arg_val(6);
+    constexpr auto input_args = TensorAccessorArgs<7>();
+
+    constexpr uint32_t tiles_per_row = hidden_size / 32;
+    constexpr uint32_t block_ct_dim = 8;
+    constexpr uint32_t num_tile_blocks = tiles_per_row / block_ct_dim;
+
+    // ===== Runtime args =====
+    uint32_t input_tensor_address = get_arg_val<uint32_t>(0);
+
+    const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
+
+    DPRINT_DISPATCH << "Idle reader " << core_id << "/" << total_workers << " total_batches=" << total_batches
+                    << ENDL();
+
+    for (uint32_t batch_idx = core_id; batch_idx < total_batches; batch_idx += total_workers) {
+        uint32_t tile_base_page = batch_idx * tiles_per_row;
+
+        // 1. Signal compute to untilize this batch (before streaming tiles so compute is ready)
+        cb_reserve_back(cb_signal_id, 1);
+        volatile tt_l1_ptr uint32_t* signal_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+        signal_ptr[0] = 0x00000000;
+        cb_push_back(cb_signal_id, 1);
+
+        // 2. Stream tiled input stripe from DRAM in blocks of 8 tiles
+        for (uint32_t blk = 0; blk < num_tile_blocks; blk++) {
+            cb_reserve_back(cb_input_id, block_ct_dim);
+            uint32_t blk_write_ptr = get_write_ptr(cb_input_id);
+            uint32_t blk_start = tile_base_page + blk * block_ct_dim;
+            for (uint32_t col = 0; col < block_ct_dim; col++) {
+                noc_async_read_page(blk_start + col, input_addr_gen, blk_write_ptr + col * aligned_input_page_size);
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_input_id, block_ct_dim);
+        }
+
+        DPRINT_DISPATCH << "Idle reader " << core_id << " queued batch " << batch_idx << ENDL();
+    }
+
+    // Send sentinel to compute to break out of its loop
+    cb_reserve_back(cb_signal_id, 1);
+    volatile tt_l1_ptr uint32_t* signal_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
+    signal_ptr[0] = ROUTE_INFO_SENTINEL;
+    cb_push_back(cb_signal_id, 1);
+
+    DPRINT_DISPATCH << "Idle reader " << core_id << " done" << ENDL();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -51,9 +51,6 @@ void kernel_main() {
 
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
 
-    DPRINT_DISPATCH << "Idle reader " << core_id << "/" << total_workers << " total_batches=" << total_batches
-                    << ENDL();
-
     for (uint32_t batch_idx = core_id; batch_idx < total_batches; batch_idx += total_workers) {
         uint32_t tile_base_page = batch_idx * tiles_per_row;
 
@@ -75,8 +72,6 @@ void kernel_main() {
             noc_async_read_barrier();
             cb_push_back(cb_input_id, block_ct_dim);
         }
-
-        DPRINT_DISPATCH << "Idle reader " << core_id << " queued batch " << batch_idx << ENDL();
     }
 
     // Send sentinel to compute to break out of its loop
@@ -85,6 +80,4 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
     signal_ptr[0] = ROUTE_INFO_SENTINEL;
     cb_push_back(cb_signal_id, 1);
-
-    DPRINT_DISPATCH << "Idle reader " << core_id << " done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -110,9 +110,6 @@ void kernel_main() {
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
     uint32_t metadata_scratch_addr = get_write_ptr(cb_metadata_scratch_id);
 
-    DPRINT_DISPATCH << "Idle writer " << core_id << "/" << total_workers << " total_batches=" << total_batches
-                    << " recv_buf=" << sender_receive_buf_l1_addr << ENDL();
-
     for (uint32_t batch_idx = core_id; batch_idx < total_batches; batch_idx += total_workers) {
         // 1. Wait for compute to finish untilizing this batch
         cb_wait_front(cb_untilize_id, read_batch_size);
@@ -177,9 +174,5 @@ void kernel_main() {
 
         // 6. Release untilize CB
         cb_pop_front(cb_untilize_id, read_batch_size);
-
-        DPRINT_DISPATCH << "Idle writer " << core_id << " sent batch " << batch_idx << ENDL();
     }
-
-    DPRINT_DISPATCH << "Idle writer " << core_id << " done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Writer kernel for idle (worker) cores in the dispatch op.
+// Runs on the data-movement RISC opposite the reader so that the reader can
+// prefetch the next batch's DRAM tiles into cb_input_id while this kernel is
+// waiting for compute / the owning sender and performing the NOC write.
+//
+// Each idle core is permanently bound to ONE sender core (its owning sender).
+// Token batches are distributed round-robin across total_workers (k_s idle
+// cores + the sender itself).  Core i processes batches i, i+total_workers, …
+//
+// For each assigned batch:
+//   1. Wait for compute to finish (cb_wait_front on cb_untilize_id).
+//   2. Wait for the owning sender's "send now" signal (start_semaphore).
+//      The sender also writes a route table to cb_mailbox_id before signaling,
+//      so the table is ready to read immediately after the semaphore fires.
+//   3. For each local route entry in the mailbox: write output data and metadata
+//      directly to DRAM using NOC1, bypassing the sender entirely.
+//   4. Bulk-write the full untilized batch to the sender's receive buffer so
+//      the sender can forward cross-device tokens via the fabric writer.
+//   5. Signal the sender that data has landed (data_ready_semaphore).
+//   6. Release the untilize CB (cb_pop_front).
+//
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+
+#define ENABLE_DISPATCH_DEBUG 0
+#if ENABLE_DISPATCH_DEBUG
+#define DPRINT_DISPATCH DPRINT
+#else
+#define DPRINT_DISPATCH \
+    if (0)              \
+    DebugPrinter()
+#endif
+
+void kernel_main() {
+    // ===== Compile-time args =====
+    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(0);
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(1);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t total_batches = get_compile_time_arg_val(3);
+    constexpr uint32_t core_id = get_compile_time_arg_val(4);
+    constexpr uint32_t total_workers = get_compile_time_arg_val(5);
+    // New: direct-DRAM-write support
+    constexpr uint32_t cb_mailbox_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_metadata_scratch_id = get_compile_time_arg_val(7);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(8);
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(9);
+    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(10);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(11);
+    constexpr auto output_args = TensorAccessorArgs<12>();
+    constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
+
+    // ===== Runtime args =====
+    uint32_t rt_idx = 0;
+    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t addr_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t addr_value_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    // New:
+    uint32_t output_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t metadata_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t mbox_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t mbox_scratch_addr_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+
+    uint64_t sender_data_ready_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
+    volatile tt_l1_ptr uint32_t* start_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
+
+    // ===== Startup: receive buffer address exchange (existing) =====
+    volatile tt_l1_ptr uint32_t* addr_ready_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(addr_ready_semaphore_id));
+    noc_semaphore_wait(addr_ready_sem_ptr, 1);
+    noc_semaphore_set(addr_ready_sem_ptr, 0);
+    volatile tt_l1_ptr uint32_t* addr_value_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(addr_value_semaphore_id));
+    uint32_t sender_receive_buf_l1_addr = *addr_value_ptr;
+    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_receive_buf_l1_addr);
+
+    // ===== Startup: NOC-write mailbox L1 address into sender's scratch slot =====
+    // addr_ready also signals that the sender has multicast its rt_scratch_base into the
+    // mbox_scratch_addr semaphore slot on every core.  We read it here, then use
+    // noc_inline_dw_write to push our mailbox address into the sender's scratch buffer at
+    // slot [core_id * 4].  noc_inline_dw_write is ordered before the subsequent
+    // noc_semaphore_inc on the NOC, so the sender's local L1 read is safe after mbox_ready fires.
+    uint32_t mailbox_l1_addr = get_write_ptr(cb_mailbox_id);
+    volatile tt_l1_ptr uint32_t* mbox_scratch_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(mbox_scratch_addr_semaphore_id));
+    uint32_t sender_scratch_base = *mbox_scratch_addr_ptr;
+    uint64_t sender_scratch_slot_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, sender_scratch_base + core_id * sizeof(uint32_t));
+    noc_inline_dw_write(sender_scratch_slot_noc_addr, mailbox_l1_addr);
+    uint64_t sender_mbox_ready_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(mbox_ready_semaphore_id));
+    noc_semaphore_inc(sender_mbox_ready_noc_addr, 1);
+    noc_async_atomic_barrier();
+
+    // ===== Addr gens for direct DRAM writes =====
+    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
+    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
+    uint32_t metadata_scratch_addr = get_write_ptr(cb_metadata_scratch_id);
+
+    DPRINT_DISPATCH << "Idle writer " << core_id << "/" << total_workers << " total_batches=" << total_batches
+                    << " recv_buf=" << sender_receive_buf_l1_addr << ENDL();
+
+    for (uint32_t batch_idx = core_id; batch_idx < total_batches; batch_idx += total_workers) {
+        // 1. Wait for compute to finish untilizing this batch
+        cb_wait_front(cb_untilize_id, read_batch_size);
+
+        // 2. Wait for the sender's "send now" signal
+        //    The sender writes the route table to cb_mailbox_id before incrementing this semaphore,
+        //    so the table is guaranteed to be visible once we clear the semaphore.
+        noc_semaphore_wait(start_sem_ptr, 1);
+        noc_semaphore_set(start_sem_ptr, 0);
+
+        uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
+
+        // 3. Write local-expert tokens directly to DRAM (NOC1), skipping the sender.
+        //    Mailbox layout: [entry_count | has_non_local_flag (u32)] [entry_0..entry_N]
+        //    Each entry: token_t, page_idx, token_idx, k, routed_expert, weight (6 × u32)
+        //    High bit of mbox[0]: 1 = cross-device tokens exist → must bulk-send back to sender.
+        //                         0 = all local → skip bulk-send entirely.
+        volatile tt_l1_ptr uint32_t* mbox = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mailbox_l1_addr);
+        uint32_t raw = mbox[0];
+        bool has_non_local = (raw & 0x80000000u) != 0;
+        uint32_t entry_count = raw & 0x7FFFFFFFu;
+        for (uint32_t e = 0; e < entry_count; e++) {
+            uint32_t base = 1 + e * 6;
+            uint32_t token_t = mbox[base + 0];
+            uint32_t page_idx = mbox[base + 1];
+            int32_t token_idx = (int32_t)mbox[base + 2];
+            int32_t k = (int32_t)mbox[base + 3];
+            int32_t routed_exp = (int32_t)mbox[base + 4];
+            int16_t weight = (int16_t)mbox[base + 5];
+
+            uint32_t src_addr = untilize_read_ptr + token_t * aligned_output_page_size;
+
+            noc_async_write_page(page_idx, output_addr_gen, src_addr);
+
+            volatile tt_l1_ptr int32_t* meta = reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_scratch_addr);
+            meta[0] = (int32_t)linearized_mesh_coord;
+            meta[1] = token_idx;
+            meta[2] = k;
+            meta[3] = routed_exp;
+            meta[4] = (int32_t)weight;
+            noc_async_write_page(page_idx, metadata_addr_gen, metadata_scratch_addr);
+            noc_async_writes_flushed();
+        }
+
+        // 4. Bulk-write full untilized batch to sender's receive buffer (cross-device tokens).
+        //    Skipped entirely when all tokens are local — no round-trip to sender needed.
+        if (has_non_local) {
+            uint32_t off = 0;
+            while (off < total_transfer_size) {
+                uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
+                                     ? (uint32_t)NOC_MAX_BURST_SIZE
+                                     : (total_transfer_size - off);
+                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
+                off += chunk;
+            }
+            noc_async_write_barrier();
+
+            // 5. Signal the sender that all data has landed
+            noc_semaphore_inc(sender_data_ready_noc_addr, 1);
+            noc_async_atomic_barrier();
+        }
+
+        // 6. Release untilize CB
+        cb_pop_front(cb_untilize_id, read_batch_size);
+
+        DPRINT_DISPATCH << "Idle writer " << core_id << " sent batch " << batch_idx << ENDL();
+    }
+
+    DPRINT_DISPATCH << "Idle writer " << core_id << " done" << ENDL();
+}


### PR DESCRIPTION
Before, if tokens, which were the input of the dispatch module were in `TILE LAYOUT` - they had to be converted in `ROW_MAJOR` format. Since the untilization and dispatching was 2 separate sequential calls, there was room for improvement by overlapping these 2 operations.

What is changed:
- These two operations are now overlapped
- The input to the dispatch module can be both data in `ROW_MAJOR` and `TILE` layout
- Reserve one whole row of cores to do the untilization ; each core gets it set of the input tensor to untilize ; this approach parallelizes the work of untilizing the tensor, making the operation faster ; these additional cores don't do the sending to other cores, that part remains to be executed only from the sender cores


Tested on test_ttnn_moe.py
| Configuration | Latency / Components |
| :--- | :--- |
| **Mesh4x2-link-fused** | 6,233us |
| **Mesh4x2-2link-non-fused** | 4,837us + untilize (up to 5000us) |
| **Linear8-2link-fused** | 13,780us |
| **Linear8-2link-non-fused** | 14,442us + untilize (up to 5000us) |

bh e2e - https://github.com/tenstorrent/tt-metal/actions/runs/24955493303 ✅ 
galaxy deepseek prefill - https://github.com/tenstorrent/tt-metal/actions/runs/24955522139 ✅ 
t3k e2e - https://github.com/tenstorrent/tt-metal/actions/runs/24955504486 ✅ 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_newest)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/dispatch_newest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_newest)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/dispatch_newest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/dispatch_newest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/dispatch_newest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/dispatch_newest)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/dispatch_newest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/dispatch_newest)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/dispatch_newest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/dispatch_newest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/dispatch_newest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/dispatch_newest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/dispatch_newest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/dispatch_newest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/dispatch_newest)