### PR TITLE
Optimize back to back tokens for deepseek

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_one_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_one_b1.hpp
@@ -337,6 +337,28 @@ struct ReduceToOneB1 {
 
             // ROOT1: gather all shards to output tensor; each worker sends its shard downstream
             if constexpr (CTArgs::device_role == MESH_ROOT1) {
+                // Notify the aggregator (or persistent forwarder) that this worker is done.
+                // Issued between socket_notify_receiver and socket_barrier in the socket branch
+                // so the downstream consumer can wake up while we wait for the socket ack.
+                auto signal_aggregator = [&]() __attribute__((always_inline)) {
+                    if (args.persistent_enable != 0) {
+                        volatile tt_l1_ptr uint32_t* agg_sem_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.agg_sem_l1_addr);
+                        noc_semaphore_wait_min(agg_sem_ptr, CTArgs::total_num_workers - 1);
+                        noc_semaphore_set(agg_sem_ptr, 0);
+
+                        uint64_t fc_sem = get_noc_addr(
+                            args.persistent_dst_noc_x, args.persistent_dst_noc_y, args.persistent_dst_sem_addr);
+                        noc_semaphore_inc(fc_sem, 1);
+                        noc_async_atomic_barrier();
+                    } else if (args.agg_sem_l1_addr != 0) {
+                        uint64_t agg_sem_noc =
+                            get_noc_addr(args.agg_core_noc_x, args.agg_core_noc_y, args.agg_sem_l1_addr);
+                        noc_semaphore_inc(agg_sem_noc, 1);
+                        noc_async_atomic_barrier();
+                    }
+                };
+
                 if constexpr (CTArgs::enable_downstream_socket) {
                     constexpr uint32_t useful_per_shard = CTArgs::agg_output_size_bytes / CTArgs::total_num_workers;
                     if (args.socket_config_addr != 0) {
@@ -358,6 +380,7 @@ struct ReduceToOneB1 {
 
                         socket_push_pages(sender_socket, 1);
                         socket_notify_receiver(sender_socket);
+                        signal_aggregator();
                         socket_barrier(sender_socket);
                         update_socket_config(sender_socket);
                     }
@@ -369,21 +392,7 @@ struct ReduceToOneB1 {
                     uint32_t src_addr = get_read_ptr(CTArgs::scratch_cb);
                     noc_async_write<CTArgs::payload_size_bytes>(src_addr, dst_noc_addr_0, CTArgs::payload_size_bytes);
                     noc_async_write_barrier();
-                }
-                if (args.persistent_enable != 0) {
-                    volatile tt_l1_ptr uint32_t* agg_sem_ptr =
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.agg_sem_l1_addr);
-                    noc_semaphore_wait_min(agg_sem_ptr, CTArgs::total_num_workers - 1);
-                    noc_semaphore_set(agg_sem_ptr, 0);
-
-                    uint64_t fc_sem = get_noc_addr(
-                        args.persistent_dst_noc_x, args.persistent_dst_noc_y, args.persistent_dst_sem_addr);
-                    noc_semaphore_inc(fc_sem, 1);
-                    noc_async_atomic_barrier();
-                } else if (args.agg_sem_l1_addr != 0) {
-                    uint64_t agg_sem_noc = get_noc_addr(args.agg_core_noc_x, args.agg_core_noc_y, args.agg_sem_l1_addr);
-                    noc_semaphore_inc(agg_sem_noc, 1);
-                    noc_async_atomic_barrier();
+                    signal_aggregator();
                 }
 
                 cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);


### PR DESCRIPTION
### Summary
We were unnecessarily stalling waiting for pipeline core to acknowledge that it had forwarded the data on the reduce to one worker cores before we signalled the fabric core. We can signal the fabric core after data has been sent to the pipeline core.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/b2b)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/b2b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/b2b)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/b2b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/b2b)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/b2b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/b2b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/b2b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/b2b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/b2b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/b2b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/b2b)