### PR TITLE
ds_prefill (cache perf)

### DIFF
--- a/models/demos/deepseek_v3_d_p/README.md
+++ b/models/demos/deepseek_v3_d_p/README.md
@@ -8,3 +8,7 @@ This directory will contain the implementation of prefill stage for DeepSeek V3 
 - **`TT_DS_PREFILL_TTNN_CACHE`** — Directory for cached TTNN weight tensors (`.tensorbin` files). First run writes cache, subsequent runs load directly. Defaults to `{model_path}/tensor_cache_{arch}_{num_devices}dev/`.
 - **`TT_DS_PREFILL_HOST_REF_CACHE`** — Directory for cached host reference snapshots used in PCC validation. Defaults to `/tmp/deepseek_v3_transformer_ref_cache`.
 - **`TT_DS_PREFILL_INFINITEBENCH_CACHE`** — Directory for cached InfiniteBench prompt data. Defaults to `/tmp/deepseek_v3_transformer_inputs`.
+
+## Weight Loading and TTNN Cache
+
+See [tt/WEIGHTS_AND_CACHE.md](tt/WEIGHTS_AND_CACHE.md) for the weight loading contract that every TT module implements.

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
@@ -11,6 +11,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CACHE_DIR = Path("/tmp/DS_PREFILL_embedding")
@@ -22,6 +23,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
+    report_and_clear()
 
 
 @pytest.mark.parametrize(
@@ -79,6 +81,7 @@ def test_embedding_weights_cold_warm_cache(mesh_device, device_params):
     output1 = to_torch_concat(output1_tt)
 
     # === Path 2: Cold Cache ===
+    init_checker(CACHE_DIR)
     assert not TtParallelEmbedding.check_cache_complete(CACHE_DIR), "Cache should be empty before build"
 
     profiler.clear()
@@ -92,6 +95,7 @@ def test_embedding_weights_cold_warm_cache(mesh_device, device_params):
     )
     profiler.end("build_cache")
 
+    init_checker(CACHE_DIR)
     assert TtParallelEmbedding.check_cache_complete(CACHE_DIR), "Cache should be complete after build"
 
     profiler.start("cold_load")

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -26,10 +28,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 2),
+            (2, 4),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -79,6 +81,8 @@ def test_embedding_weights_cold_warm_cache(mesh_device, device_params):
     # === Path 2: Cold Cache ===
     assert not TtParallelEmbedding.check_cache_complete(CACHE_DIR), "Cache should be empty before build"
 
+    profiler.clear()
+    profiler.start("build_cache")
     TtParallelEmbedding.build_ttnn_cache(
         torch_weight,
         vocab_size,
@@ -86,9 +90,11 @@ def test_embedding_weights_cold_warm_cache(mesh_device, device_params):
         mesh_device,
         CACHE_DIR,
     )
+    profiler.end("build_cache")
 
     assert TtParallelEmbedding.check_cache_complete(CACHE_DIR), "Cache should be complete after build"
 
+    profiler.start("cold_load")
     emb_cold = TtParallelEmbedding(
         mesh_device,
         vocab_size,
@@ -96,10 +102,12 @@ def test_embedding_weights_cold_warm_cache(mesh_device, device_params):
         torch_weight=None,
         weight_cache_path=CACHE_DIR,
     )
+    profiler.end("cold_load")
     output2_tt = emb_cold(token_ids_tt)
     output2 = to_torch_concat(output2_tt)
 
     # === Path 3: Warm Cache ===
+    profiler.start("warm_load")
     emb_warm = TtParallelEmbedding(
         mesh_device,
         vocab_size,
@@ -107,18 +115,21 @@ def test_embedding_weights_cold_warm_cache(mesh_device, device_params):
         torch_weight=None,
         weight_cache_path=CACHE_DIR,
     )
+    profiler.end("warm_load")
     output3_tt = emb_warm(token_ids_tt)
     output3 = to_torch_concat(output3_tt)
 
     # === Validation ===
-    from loguru import logger
-
     passed_cold, pcc_cold = comp_pcc(output1, output2)
     passed_warm, pcc_warm = comp_pcc(output1, output3)
 
     logger.info(f"Embedding Cache Test:")
     logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
     logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
 
     assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
@@ -28,10 +28,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 4),
+            (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -26,10 +28,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 2),
+            (2, 4),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -84,15 +86,19 @@ def test_ffn_weights_cold_warm_cache(mesh_device, device_params):
     # === Path 2: Cold Cache ===
     assert not TtFfn.check_cache_complete(CACHE_DIR, "ffn"), "Cache should be empty before build"
 
+    profiler.clear()
+    profiler.start("build_cache")
     TtFfn.build_ttnn_cache(
         torch_weights,
         mesh_device,
         CACHE_DIR,
         "ffn",
     )
+    profiler.end("build_cache")
 
     assert TtFfn.check_cache_complete(CACHE_DIR, "ffn"), "Cache should be complete after build"
 
+    profiler.start("cold_load")
     ffn_cold = TtFfn(
         mesh_device,
         torch_weights=None,
@@ -100,10 +106,12 @@ def test_ffn_weights_cold_warm_cache(mesh_device, device_params):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="ffn",
     )
+    profiler.end("cold_load")
     output2_tt = ffn_cold(x_tt)
     output2 = to_torch_concat(output2_tt)
 
     # === Path 3: Warm Cache ===
+    profiler.start("warm_load")
     ffn_warm = TtFfn(
         mesh_device,
         torch_weights=None,
@@ -111,18 +119,20 @@ def test_ffn_weights_cold_warm_cache(mesh_device, device_params):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="ffn",
     )
+    profiler.end("warm_load")
     output3_tt = ffn_warm(x_tt)
     output3 = to_torch_concat(output3_tt)
 
     # === Validation ===
-    from loguru import logger
-
     passed_cold, pcc_cold = comp_pcc(output1, output2)
     passed_warm, pcc_warm = comp_pcc(output1, output3)
 
     logger.info(f"FFN Cache Test:")
     logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
     logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
 
     assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
@@ -11,6 +11,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CACHE_DIR = Path("/tmp/DS_PREFILL_ffn")
@@ -22,6 +23,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
+    report_and_clear()
 
 
 @pytest.mark.parametrize(
@@ -84,6 +86,7 @@ def test_ffn_weights_cold_warm_cache(mesh_device, device_params):
     output1 = to_torch_concat(output1_tt)
 
     # === Path 2: Cold Cache ===
+    init_checker(CACHE_DIR)
     assert not TtFfn.check_cache_complete(CACHE_DIR, "ffn"), "Cache should be empty before build"
 
     profiler.clear()
@@ -96,6 +99,7 @@ def test_ffn_weights_cold_warm_cache(mesh_device, device_params):
     )
     profiler.end("build_cache")
 
+    init_checker(CACHE_DIR)
     assert TtFfn.check_cache_complete(CACHE_DIR, "ffn"), "Cache should be complete after build"
 
     profiler.start("cold_load")

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
@@ -28,10 +28,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 4),
+            (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
@@ -12,6 +12,7 @@ import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, create_gate_weights, get_sp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_testing, get_input_mem_config
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -25,7 +26,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
-    # Keep cache for debugging if test fails
+    report_and_clear()
 
 
 def create_gate_input(config, mesh_device):
@@ -112,6 +113,7 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     output1 = to_torch_gate(scores1)
 
     # === Path 2: Cold Cache (build + load) ===
+    init_checker(CACHE_DIR)
     assert not TtMoEGatePrefill.check_cache_complete(CACHE_DIR, "gate"), "Cache should be empty before build"
 
     # Build cache
@@ -133,6 +135,7 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         raise
     profiler.end("build_cache")
 
+    init_checker(CACHE_DIR)
     assert TtMoEGatePrefill.check_cache_complete(CACHE_DIR, "gate"), "Cache should be complete after build"
 
     # Load from cold cache

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
@@ -51,10 +51,10 @@ def create_gate_input(config, mesh_device):
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 4),
+            (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
@@ -9,6 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, create_gate_weights, get_sp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
 from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_testing, get_input_mem_config
@@ -50,10 +51,10 @@ def create_gate_input(config, mesh_device):
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 2),
+            (2, 4),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -115,6 +116,8 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
 
     # Build cache
     logger.info(f"Building cache to {CACHE_DIR}")
+    profiler.clear()
+    profiler.start("build_cache")
     try:
         TtMoEGatePrefill.build_ttnn_cache(
             torch_weight=gate_w,
@@ -128,10 +131,12 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     except Exception as e:
         logger.error(f"Cache building failed: {e}")
         raise
+    profiler.end("build_cache")
 
     assert TtMoEGatePrefill.check_cache_complete(CACHE_DIR, "gate"), "Cache should be complete after build"
 
     # Load from cold cache
+    profiler.start("cold_load")
     gate_cold = TtMoEGatePrefill(
         config,
         mesh_device,
@@ -142,10 +147,12 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="gate",
     )
+    profiler.end("cold_load")
     scores2, indices2, logits2, offsets2, counts2 = gate_cold(x)
     output2 = to_torch_gate(scores2)
 
     # === Path 3: Warm Cache (reuse existing cache) ===
+    profiler.start("warm_load")
     gate_warm = TtMoEGatePrefill(
         config,
         mesh_device,
@@ -156,6 +163,7 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="gate",
     )
+    profiler.end("warm_load")
     scores3, indices3, logits3, offsets3, counts3 = gate_warm(x)
     output3 = to_torch_gate(scores3)
 
@@ -166,6 +174,9 @@ def test_gate_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     logger.info(f"Gate Cache Test ({gate_mode}):")
     logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
     logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
 
     assert passed_cold, f"Cold cache mismatch ({gate_mode}): PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch ({gate_mode}): PCC={pcc_warm}"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
@@ -30,10 +30,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 4),
+            (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
@@ -28,10 +30,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 2),
+            (2, 4),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -144,6 +146,8 @@ def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only):
     # === Path 2: Cold Cache ===
     assert not ttMLA.check_cache_complete(CACHE_DIR, f"layer_{layer_idx}.mla"), "Cache should be empty before build"
 
+    profiler.clear()
+    profiler.start("build_cache")
     ttMLA.build_ttnn_cache(
         state_dict,
         CACHE_DIR,
@@ -154,9 +158,11 @@ def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only):
         sp_axis,
         tp_axis,
     )
+    profiler.end("build_cache")
 
     assert ttMLA.check_cache_complete(CACHE_DIR, f"layer_{layer_idx}.mla"), "Cache should be complete after build"
 
+    profiler.start("cold_load")
     mla_cold = ttMLA(
         config,
         {},
@@ -167,10 +173,12 @@ def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only):
         tp_axis=tp_axis,
         weight_cache_path=CACHE_DIR,
     )
+    profiler.end("cold_load")
     output2_tt = mla_cold.forward(x_tt, rope_tensors, tt_kvpe_cache)
     output2 = to_torch_concat(output2_tt)
 
     # === Path 3: Warm Cache ===
+    profiler.start("warm_load")
     mla_warm = ttMLA(
         config,
         {},
@@ -181,18 +189,20 @@ def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only):
         tp_axis=tp_axis,
         weight_cache_path=CACHE_DIR,
     )
+    profiler.end("warm_load")
     output3_tt = mla_warm.forward(x_tt, rope_tensors, tt_kvpe_cache)
     output3 = to_torch_concat(output3_tt)
 
     # === Validation ===
-    from loguru import logger
-
     passed_cold, pcc_cold = comp_pcc(output1, output2)
     passed_warm, pcc_warm = comp_pcc(output1, output3)
 
     logger.info(f"MLA Cache Test:")
     logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
     logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
 
     assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
@@ -12,6 +12,7 @@ import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -24,6 +25,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
+    report_and_clear()
 
 
 @pytest.mark.parametrize(
@@ -144,6 +146,7 @@ def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only):
     output1 = to_torch_concat(output1_tt)
 
     # === Path 2: Cold Cache ===
+    init_checker(CACHE_DIR)
     assert not ttMLA.check_cache_complete(CACHE_DIR, f"layer_{layer_idx}.mla"), "Cache should be empty before build"
 
     profiler.clear()
@@ -160,6 +163,7 @@ def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only):
     )
     profiler.end("build_cache")
 
+    init_checker(CACHE_DIR)
     assert ttMLA.check_cache_complete(CACHE_DIR, f"layer_{layer_idx}.mla"), "Cache should be complete after build"
 
     profiler.start("cold_load")

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -9,6 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     compute_constants,
     create_gate_weights,
@@ -37,10 +38,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 2),
+            (2, 4),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -146,6 +147,8 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     ), "Cache should be empty before build"
 
     logger.info(f"Building cache to {CACHE_DIR}...")
+    profiler.clear()
+    profiler.start("build_cache")
     TtMoe.build_ttnn_cache(
         gate_weights=gate_weights,
         routed_expert_weights=routed_expert_weights,
@@ -159,12 +162,14 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         cache_path=CACHE_DIR,
         layer_idx=0,
     )
+    profiler.end("build_cache")
 
     assert TtMoe.check_cache_complete(
         CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip
     ), "Cache should be complete after build"
 
     logger.info("Path 2: Creating TtMoe from cold cache...")
+    profiler.start("cold_load")
     moe_cold = TtMoe(
         mesh_device=mesh_device,
         dispatch_group_size=dispatch_group_size,
@@ -190,6 +195,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         weight_cache_path=CACHE_DIR,
         layer_idx=0,
     )
+    profiler.end("cold_load")
     output2_tt, _ = moe_cold(create_input(), return_intermediates=False)
     output2 = to_torch_tp(output2_tt)
     logger.info(f"Output2 shape: {output2.shape}, min={output2.min():.4f}, max={output2.max():.4f}")
@@ -200,6 +206,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
 
     # === Path 3: Warm Cache (reuse existing cache) ===
     logger.info("Path 3: Creating TtMoe from warm cache...")
+    profiler.start("warm_load")
     moe_warm = TtMoe(
         mesh_device=mesh_device,
         dispatch_group_size=dispatch_group_size,
@@ -225,6 +232,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         weight_cache_path=CACHE_DIR,
         layer_idx=0,
     )
+    profiler.end("warm_load")
     output3_tt, _ = moe_warm(create_input(), return_intermediates=False)
     output3 = to_torch_tp(output3_tt)
     logger.info(f"Output3 shape: {output3.shape}, min={output3.min():.4f}, max={output3.max():.4f}")
@@ -236,6 +244,9 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     logger.info(f"MoE Cache Test:")
     logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
     logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
 
     # MoE integration test should achieve high PCC like component tests
     # Using GateComputeMode.DEVICE ensures gate runs on device (not host fallback)

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -20,6 +20,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
 )
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CACHE_DIR = Path("/tmp/DS_PREFILL_moe")
@@ -32,6 +33,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
+    report_and_clear()
 
 
 @pytest.mark.parametrize(
@@ -142,6 +144,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     ttnn.synchronize_device(mesh_device)
 
     # === Path 2: Cold Cache (build + load) ===
+    init_checker(CACHE_DIR)
     assert not TtMoe.check_cache_complete(
         CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip
     ), "Cache should be empty before build"
@@ -164,6 +167,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     )
     profiler.end("build_cache")
 
+    init_checker(CACHE_DIR)
     assert TtMoe.check_cache_complete(
         CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip
     ), "Cache should be complete after build"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -38,10 +38,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 4),
+            (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
@@ -11,6 +11,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CACHE_DIR = Path("/tmp/DS_PREFILL_rms_norm")
@@ -22,6 +23,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
+    report_and_clear()
 
 
 @pytest.mark.parametrize(
@@ -83,6 +85,7 @@ def test_rms_norm_weights_cold_warm_cache(mesh_device, device_params):
     output1 = to_torch_concat(output1_tt)
 
     # === Path 2: Cold Cache ===
+    init_checker(CACHE_DIR)
     assert not TtDistributedRmsNorm.check_cache_complete(CACHE_DIR, "rms_norm"), "Cache should be empty before build"
 
     profiler.clear()
@@ -96,6 +99,7 @@ def test_rms_norm_weights_cold_warm_cache(mesh_device, device_params):
     )
     profiler.end("build_cache")
 
+    init_checker(CACHE_DIR)
     assert TtDistributedRmsNorm.check_cache_complete(CACHE_DIR, "rms_norm"), "Cache should be complete after build"
 
     profiler.start("cold_load")

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -26,10 +28,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 2),
+            (2, 4),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -83,6 +85,8 @@ def test_rms_norm_weights_cold_warm_cache(mesh_device, device_params):
     # === Path 2: Cold Cache ===
     assert not TtDistributedRmsNorm.check_cache_complete(CACHE_DIR, "rms_norm"), "Cache should be empty before build"
 
+    profiler.clear()
+    profiler.start("build_cache")
     TtDistributedRmsNorm.build_ttnn_cache(
         torch_weight,
         emb_dim,
@@ -90,9 +94,11 @@ def test_rms_norm_weights_cold_warm_cache(mesh_device, device_params):
         CACHE_DIR,
         "rms_norm",
     )
+    profiler.end("build_cache")
 
     assert TtDistributedRmsNorm.check_cache_complete(CACHE_DIR, "rms_norm"), "Cache should be complete after build"
 
+    profiler.start("cold_load")
     norm_cold = TtDistributedRmsNorm(
         mesh_device,
         emb_dim,
@@ -100,10 +106,12 @@ def test_rms_norm_weights_cold_warm_cache(mesh_device, device_params):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="rms_norm",
     )
+    profiler.end("cold_load")
     output2_tt = norm_cold(x_tt)
     output2 = to_torch_concat(output2_tt)
 
     # === Path 3: Warm Cache ===
+    profiler.start("warm_load")
     norm_warm = TtDistributedRmsNorm(
         mesh_device,
         emb_dim,
@@ -111,18 +119,20 @@ def test_rms_norm_weights_cold_warm_cache(mesh_device, device_params):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="rms_norm",
     )
+    profiler.end("warm_load")
     output3_tt = norm_warm(x_tt)
     output3 = to_torch_concat(output3_tt)
 
     # === Validation ===
-    from loguru import logger
-
     passed_cold, pcc_cold = comp_pcc(output1, output2)
     passed_warm, pcc_warm = comp_pcc(output1, output3)
 
     logger.info(f"RMS Norm Cache Test:")
     logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
     logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
 
     assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
@@ -28,10 +28,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 4),
+            (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
@@ -34,10 +34,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 4),
+            (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     compute_constants,
     extract_mesh_config,
@@ -32,10 +34,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 2),
+            (2, 4),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -110,8 +112,6 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
     weights_dtype = ttnn.bfloat4_b
 
     # === Path 1: From Weights ===
-    from loguru import logger
-
     logger.info(f"Test params: experts_per_chip={experts_per_chip}, max_tokens={max_dispatched_tokens_per_expert}")
     logger.info(f"Dimensions: emb_dim={emb_dim}, hidden_dim={hidden_dim}")
     logger.info(f"dispatched_buffer_tt.shape={dispatched_buffer_tt.shape}")
@@ -135,6 +135,8 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
     ), "Cache should be empty before build"
 
     logger.info(f"Building cache to {CACHE_DIR}")
+    profiler.clear()
+    profiler.start("build_cache")
     TtRoutedExpert.build_ttnn_cache(
         torch_weights,
         experts_per_chip,
@@ -143,11 +145,13 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
         CACHE_DIR,
         "routed_expert",
     )
+    profiler.end("build_cache")
 
     assert TtRoutedExpert.check_cache_complete(
         CACHE_DIR, "routed_expert", experts_per_chip
     ), "Cache should be complete after build"
 
+    profiler.start("cold_load")
     expert_cold = TtRoutedExpert(
         mesh_device,
         experts_per_chip,
@@ -159,10 +163,12 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="routed_expert",
     )
+    profiler.end("cold_load")
     output2_tt = expert_cold(dispatched_buffer_tt)
     output2 = to_torch_expert(output2_tt)
 
     # === Path 3: Warm Cache ===
+    profiler.start("warm_load")
     expert_warm = TtRoutedExpert(
         mesh_device,
         experts_per_chip,
@@ -174,12 +180,11 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="routed_expert",
     )
+    profiler.end("warm_load")
     output3_tt = expert_warm(dispatched_buffer_tt)
     output3 = to_torch_expert(output3_tt)
 
     # === Validation ===
-    from loguru import logger
-
     # Debug: check output stats
     logger.info(
         f"Output1 (from weights): shape={output1.shape}, min={output1.min():.4f}, max={output1.max():.4f}, mean={output1.mean():.4f}"
@@ -197,6 +202,9 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
     logger.info(f"Routed Expert Cache Test:")
     logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
     logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
 
     assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
@@ -17,6 +17,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     get_ep_mesh_mapper,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CACHE_DIR = Path("/tmp/DS_PREFILL_routed_expert")
@@ -28,6 +29,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
+    report_and_clear()
 
 
 @pytest.mark.parametrize(
@@ -130,6 +132,7 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
     output1 = to_torch_expert(output1_tt)
 
     # === Path 2: Cold Cache ===
+    init_checker(CACHE_DIR)
     assert not TtRoutedExpert.check_cache_complete(
         CACHE_DIR, "routed_expert", experts_per_chip
     ), "Cache should be empty before build"
@@ -147,6 +150,7 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
     )
     profiler.end("build_cache")
 
+    init_checker(CACHE_DIR)
     assert TtRoutedExpert.check_cache_complete(
         CACHE_DIR, "routed_expert", experts_per_chip
     ), "Cache should be complete after build"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
@@ -11,6 +11,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CACHE_DIR = Path("/tmp/DS_PREFILL_shared_expert")
@@ -22,6 +23,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
+    report_and_clear()
 
 
 @pytest.mark.parametrize(
@@ -85,6 +87,7 @@ def test_shared_expert_weights_cold_warm_cache(mesh_device, device_params):
     output1 = to_torch_concat(output1_tt)
 
     # === Path 2: Cold Cache ===
+    init_checker(CACHE_DIR)
     assert not TtSharedExpert.check_cache_complete(CACHE_DIR, "shared_expert"), "Cache should be empty before build"
 
     profiler.clear()
@@ -100,6 +103,7 @@ def test_shared_expert_weights_cold_warm_cache(mesh_device, device_params):
     )
     profiler.end("build_cache")
 
+    init_checker(CACHE_DIR)
     assert TtSharedExpert.check_cache_complete(CACHE_DIR, "shared_expert"), "Cache should be complete after build"
 
     profiler.start("cold_load")

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
@@ -28,10 +28,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 4),
+            (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -26,10 +28,10 @@ def cleanup_cache():
     "mesh_device, device_params",
     [
         pytest.param(
-            (2, 2),
+            (2, 4),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -85,6 +87,8 @@ def test_shared_expert_weights_cold_warm_cache(mesh_device, device_params):
     # === Path 2: Cold Cache ===
     assert not TtSharedExpert.check_cache_complete(CACHE_DIR, "shared_expert"), "Cache should be empty before build"
 
+    profiler.clear()
+    profiler.start("build_cache")
     TtSharedExpert.build_ttnn_cache(
         torch_weights,
         emb_dim,
@@ -94,9 +98,11 @@ def test_shared_expert_weights_cold_warm_cache(mesh_device, device_params):
         CACHE_DIR,
         "shared_expert",
     )
+    profiler.end("build_cache")
 
     assert TtSharedExpert.check_cache_complete(CACHE_DIR, "shared_expert"), "Cache should be complete after build"
 
+    profiler.start("cold_load")
     expert_cold = TtSharedExpert(
         mesh_device,
         emb_dim,
@@ -106,10 +112,12 @@ def test_shared_expert_weights_cold_warm_cache(mesh_device, device_params):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="shared_expert",
     )
+    profiler.end("cold_load")
     output2_tt = expert_cold(x_tt)
     output2 = to_torch_concat(output2_tt)
 
     # === Path 3: Warm Cache ===
+    profiler.start("warm_load")
     expert_warm = TtSharedExpert(
         mesh_device,
         emb_dim,
@@ -119,18 +127,20 @@ def test_shared_expert_weights_cold_warm_cache(mesh_device, device_params):
         weight_cache_path=CACHE_DIR,
         cache_name_prefix="shared_expert",
     )
+    profiler.end("warm_load")
     output3_tt = expert_warm(x_tt)
     output3 = to_torch_concat(output3_tt)
 
     # === Validation ===
-    from loguru import logger
-
     passed_cold, pcc_cold = comp_pcc(output1, output2)
     passed_warm, pcc_warm = comp_pcc(output1, output3)
 
     logger.info(f"Shared Expert Cache Test:")
     logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
     logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
 
     assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -199,6 +199,11 @@ def test_prefill_transformer(
 
     profiler.end("cache_check")
 
+    # Report cache check timing breakdown
+    from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import report_and_clear
+
+    report_and_clear()
+
     # --- Create input (needed early for reference computation) ---
     if input_source == "random":
         token_ids = torch.randint(0, config.vocab_size, (1, isl_total), dtype=torch.int64)
@@ -283,6 +288,10 @@ def test_prefill_transformer(
     profiler.end("weights_creation")
 
     # --- TT transformer ---
+    # Log program cache size BEFORE creation
+    cache_entries_before = mesh_device.num_program_cache_entries()
+    logger.info(f"Program cache entries BEFORE transformer creation: {cache_entries_before}")
+
     profiler.start("tt_transformer_creation")
     transformer = TtPrefillTransformer(
         mesh_device=mesh_device,
@@ -300,6 +309,12 @@ def test_prefill_transformer(
     )
     ttnn.ReadDeviceProfiler(mesh_device)
     ttnn.synchronize_device(mesh_device)
+
+    # Log program cache size AFTER creation
+    cache_entries_after = mesh_device.num_program_cache_entries()
+    logger.info(f"Program cache entries AFTER transformer creation: {cache_entries_after}")
+    logger.info(f"Program cache entries ADDED during creation: {cache_entries_after - cache_entries_before}")
+
     # --- Free memory immediately after transformer creation ---
     del state_dict
     gc.collect()

--- a/models/demos/deepseek_v3_d_p/tt/WEIGHTS_AND_CACHE.md
+++ b/models/demos/deepseek_v3_d_p/tt/WEIGHTS_AND_CACHE.md
@@ -24,3 +24,38 @@ With this, every TT module that holds weights follows the same 3-method pattern:
 
 
 Components implementing this pattern: `TtParallelEmbedding`, `TtDistributedRmsNorm`, `ttMLA`, `TtMoEGatePrefill`, `TtRoutedExpert`, `TtSharedExpert` (inherited by `TtFfn` as well). Note: the method signatures are not yet unified across modules — each component has different arguments reflecting its weight structure (single tensor, dict, list of dicts, state_dict, etc.).
+
+---
+
+## Cache Check Optimization
+
+### Problem
+The `check_cache_complete()` methods used `Path.glob()` to verify existence of `.tensorbin` files. Each glob scans the entire cache directory (~2303 files), taking ~24ms per call. With 2303 pattern checks: **2303 × 24ms = 56 seconds**.
+
+### Solution
+`utils/fast_cache_checker.py` replaces sequential glob calls with:
+1. Single `iterdir()` to build file set (~40ms)
+2. In-memory prefix/suffix matching (~0.03ms per pattern)
+
+**Result: 56s → 240ms (230× speedup)**
+
+---
+
+## Performance: tt_transformer_creation
+
+Benchmark: 61-layer transformer, 1024 seq len, 8×4 mesh (32 devices)
+
+| Scenario | tt_transformer_creation | Notes |
+|----------|------------------------|-------|
+| TTNN cache creation | ~465s | Building `.tensorbin` files to disk |
+| Cold OS page cache | ~435s | First run after reboot or `drop_caches` |
+| Warm OS page cache | ~42s | Subsequent runs (tensorbin files in RAM) |
+
+The 10× difference between cold and warm page cache is disk I/O: reading ~100GB of `.tensorbin` files from disk (~250MB/s) vs RAM.
+
+**For benchmarking**: Always run twice and report the second run (warm cache) as the representative time.
+
+To manually drop the OS page cache (requires root on host, not inside container):
+```bash
+echo 3 | sudo tee /proc/sys/vm/drop_caches
+```

--- a/models/demos/deepseek_v3_d_p/tt/WEIGHTS_AND_CACHE.md
+++ b/models/demos/deepseek_v3_d_p/tt/WEIGHTS_AND_CACHE.md
@@ -1,0 +1,26 @@
+# Weight Loading and TTNN Cache
+
+The `__init__` of each module uses a 3-way branch:
+
+```python
+if torch_weights is not None:
+    # Real weights provided — convert to TTNN, optionally write cache
+    weights = self._convert_and_cache_weights(torch_weights, ..., cache_path, device=mesh_device)
+elif weight_cache_path is not None:
+    # Cache-only — pass None weights, load from .tensorbin files
+    weights = self._convert_and_cache_weights(None, ..., cache_path, device=mesh_device)
+else:
+    # Testing without cache — random/dummy weights
+    ...
+```
+
+With this, every TT module that holds weights follows the same 3-method pattern:
+
+| Method | Type | Purpose |
+|---|---|---|
+| `check_cache_complete(cache_path, ...)` | `@staticmethod` | Returns `True` if all `.tensorbin` files exist for this component |
+| `build_ttnn_cache(torch_weights, ..., cache_path)` | `@staticmethod` | Writes `.tensorbin` cache to disk without touching device memory. Delegates to `_convert_and_cache_weights(..., device=None)` |
+| `_convert_and_cache_weights(torch_weights, ..., device)` | `@staticmethod` | Single workhorse that handles all weight paths. When `device=None` it builds cache; when `device=mesh_device` it loads to device. Accepts `None` for `torch_weights` — creates minimal `torch.empty()` placeholders with post-transform shapes, skipping expensive host operations (`torch.randn`, transpose, stacking, slicing). `ttnn.as_tensor` ignores the placeholder when a `.tensorbin` cache file exists |
+
+
+Components implementing this pattern: `TtParallelEmbedding`, `TtDistributedRmsNorm`, `ttMLA`, `TtMoEGatePrefill`, `TtRoutedExpert`, `TtSharedExpert` (inherited by `TtFfn` as well). Note: the method signatures are not yet unified across modules — each component has different arguments reflecting its weight structure (single tensor, dict, list of dicts, state_dict, etc.).

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -37,6 +37,159 @@ class ttMLA:
         return True
 
     @staticmethod
+    def _convert_and_cache_weights(
+        state_dict: dict | None,
+        mesh_device: ttnn.MeshDevice,
+        config,
+        layer_idx: int,
+        sp_axis: int = 0,
+        tp_axis: int = 1,
+        cache_path: Path | None = None,
+        device: ttnn.MeshDevice | None = None,
+    ) -> dict | None:
+        """
+        Shared logic for converting MLA weights to ttnn with caching.
+
+        Args:
+            state_dict: Weight dict, or None/empty for cache-only loading.
+            mesh_device: Mesh device reference
+            config: Model config with attention dimensions
+            layer_idx: Layer index for cache file naming
+            sp_axis: Sequence parallel axis
+            tp_axis: Tensor parallel axis
+            cache_path: Cache directory path
+            device: None for cache-only (build cache), mesh_device for load to device
+
+        Returns:
+            Dict of ttnn.Tensor if device is not None, else None
+        """
+        num_heads = config.num_attention_heads
+        kv_lora_rank = config.kv_lora_rank
+        qk_nope_head_dim = config.qk_nope_head_dim
+        qk_rope_head_dim = config.qk_rope_head_dim
+        v_head_dim = config.v_head_dim
+        q_lora_rank = config.q_lora_rank
+        hidden_size = config.hidden_size
+        qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+
+        def _cache_name(name):
+            return str(cache_path / f"layer_{layer_idx}.mla.{name}") if cache_path else None
+
+        # Prepare tensors — real weights or placeholders
+        if state_dict and "q_a_layernorm.weight" in state_dict:
+            q_a_ln = state_dict["q_a_layernorm.weight"].reshape(1, 1, -1, ttnn.TILE_SIZE)
+            kv_a_ln = state_dict["kv_a_layernorm.weight"].reshape(1, 1, -1, ttnn.TILE_SIZE)
+            q_a_proj = state_dict["q_a_proj.weight"].transpose(-2, -1)
+            q_b_proj = state_dict["q_b_proj.weight"].transpose(-2, -1)
+            kv_a_proj = state_dict["kv_a_proj_with_mqa.weight"].transpose(-2, -1)
+            kv_b = state_dict["kv_b_proj.weight"].reshape(1, num_heads, qk_nope_head_dim + v_head_dim, kv_lora_rank)
+            wkv_b1 = kv_b[..., :qk_nope_head_dim, :].transpose(-2, -1).transpose(-2, -1)
+            wkv_b2 = kv_b[..., qk_nope_head_dim:, :].transpose(-2, -1)
+            o_proj = state_dict["o_proj.weight"].transpose(-2, -1)
+        else:
+            q_a_ln = torch.empty(1, 1, q_lora_rank // ttnn.TILE_SIZE, ttnn.TILE_SIZE)
+            kv_a_ln = torch.empty(1, 1, kv_lora_rank // ttnn.TILE_SIZE, ttnn.TILE_SIZE)
+            q_a_proj = torch.empty(hidden_size, q_lora_rank)
+            q_b_proj = torch.empty(q_lora_rank, num_heads * qk_head_dim)
+            kv_a_proj = torch.empty(hidden_size, kv_lora_rank + qk_rope_head_dim)
+            wkv_b1 = torch.empty(1, num_heads, qk_nope_head_dim, kv_lora_rank)
+            wkv_b2 = torch.empty(1, num_heads, kv_lora_rank, v_head_dim)
+            o_proj = torch.empty(num_heads * v_head_dim, hidden_size)
+
+        # Mesh mappers
+        shard_dims_tp0 = [None, None]
+        shard_dims_tp0[tp_axis] = 0
+        mapper_tp0 = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims_tp0)
+        shard_dims_tp1 = [None, None]
+        shard_dims_tp1[tp_axis] = 1
+        shard_dims_tp1[sp_axis] = None
+        mapper_tp1 = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims_tp1)
+
+        mem = ttnn.DRAM_MEMORY_CONFIG if device else None
+
+        # 8 ttnn.as_tensor calls
+        result = {
+            "q_a_layernorm": ttnn.as_tensor(
+                q_a_ln,
+                device=device,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=mem,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                cache_file_name=_cache_name("q_a_layernorm"),
+            ),
+            "kv_a_layernorm": ttnn.as_tensor(
+                kv_a_ln,
+                device=device,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=mem,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                cache_file_name=_cache_name("kv_a_layernorm"),
+            ),
+            "q_a_proj": ttnn.as_tensor(
+                q_a_proj,
+                device=device,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=mem,
+                mesh_mapper=mapper_tp0,
+                cache_file_name=_cache_name("q_a_proj"),
+            ),
+            "q_b_proj": ttnn.as_tensor(
+                q_b_proj,
+                device=device,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=mem,
+                mesh_mapper=mapper_tp1,
+                cache_file_name=_cache_name("q_b_proj"),
+            ),
+            "kv_a_proj_with_mqa": ttnn.as_tensor(
+                kv_a_proj,
+                device=device,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=mem,
+                mesh_mapper=mapper_tp0,
+                cache_file_name=_cache_name("kv_a_proj_with_mqa"),
+            ),
+            "wkv_b1": ttnn.as_tensor(
+                wkv_b1,
+                device=device,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=mem,
+                mesh_mapper=mapper_tp1,
+                cache_file_name=_cache_name("wkv_b1"),
+            ),
+            "wkv_b2": ttnn.as_tensor(
+                wkv_b2,
+                device=device,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=mem,
+                mesh_mapper=mapper_tp1,
+                cache_file_name=_cache_name("wkv_b2"),
+            ),
+            "o_proj": ttnn.as_tensor(
+                o_proj,
+                device=device,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=mem,
+                mesh_mapper=mapper_tp0,
+                cache_file_name=_cache_name("o_proj"),
+            ),
+        }
+
+        if device is None:
+            for v in result.values():
+                del v
+            return None
+        return result
+
+    @staticmethod
     def build_ttnn_cache(
         state_dict: dict,
         cache_path: Path,
@@ -48,112 +201,8 @@ class ttMLA:
         tp_axis: int = 1,
     ):
         """Build TTNN cache for MLA weights using device=None (no device copy)."""
-
-        num_heads = config.num_attention_heads
-        kv_lora_rank = config.kv_lora_rank
-        qk_nope_head_dim = config.qk_nope_head_dim
-        v_head_dim = config.v_head_dim
-
-        def _cache_name(name):
-            return str(cache_path / f"layer_{layer_idx}.mla.{name}") if cache_path else None
-
-        # q_a_layernorm
-        q_a_ln_weight = state_dict["q_a_layernorm.weight"].reshape(1, 1, -1, ttnn.TILE_SIZE)
-        ttnn.as_tensor(
-            q_a_ln_weight,
-            device=None,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            cache_file_name=_cache_name("q_a_layernorm"),
-        )
-
-        # kv_a_layernorm
-        kv_a_ln_weight = state_dict["kv_a_layernorm.weight"].reshape(1, 1, -1, ttnn.TILE_SIZE)
-        ttnn.as_tensor(
-            kv_a_ln_weight,
-            device=None,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            cache_file_name=_cache_name("kv_a_layernorm"),
-        )
-
-        # q_a_proj
-        q_a_proj = state_dict["q_a_proj.weight"].transpose(-2, -1)
-        shard_dims = [None, None]
-        shard_dims[tp_axis] = 0
-        mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims)
-        ttnn.as_tensor(
-            q_a_proj,
-            device=None,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=mesh_mapper,
-            cache_file_name=_cache_name("q_a_proj"),
-        )
-
-        # q_b_proj
-        shard_dims[tp_axis] = 1
-        shard_dims[sp_axis] = None
-        mesh_mapper_q_b_proj = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims)
-        ttnn.as_tensor(
-            state_dict["q_b_proj.weight"].transpose(-2, -1),
-            device=None,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=mesh_mapper_q_b_proj,
-            cache_file_name=_cache_name("q_b_proj"),
-        )
-
-        # kv_a_proj_with_mqa
-        shard_dims[tp_axis] = 0
-        mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims)
-        ttnn.as_tensor(
-            state_dict["kv_a_proj_with_mqa.weight"].transpose(-2, -1),
-            device=None,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=mesh_mapper,
-            cache_file_name=_cache_name("kv_a_proj_with_mqa"),
-        )
-
-        # kv_b_proj - split into wkv_b1 and wkv_b2
-        kv_b_proj_weights = state_dict["kv_b_proj.weight"].reshape(
-            1, num_heads, qk_nope_head_dim + v_head_dim, kv_lora_rank
-        )
-        torch_weights_k = kv_b_proj_weights[..., :qk_nope_head_dim, :].transpose(-2, -1)
-        torch_weights_v = kv_b_proj_weights[..., qk_nope_head_dim:, :]
-
-        shard_dims[tp_axis] = 1
-        shard_dims[sp_axis] = None
-        ttnn.as_tensor(
-            torch_weights_k.transpose(-2, -1),
-            device=None,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=mesh_mapper_q_b_proj,
-            cache_file_name=_cache_name("wkv_b1"),
-        )
-        ttnn.as_tensor(
-            torch_weights_v.transpose(-2, -1),
-            device=None,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=mesh_mapper_q_b_proj,
-            cache_file_name=_cache_name("wkv_b2"),
-        )
-
-        # o_proj
-        shard_dims[tp_axis] = 0
-        mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims)
-        ttnn.as_tensor(
-            state_dict["o_proj.weight"].transpose(-2, -1),
-            device=None,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=mesh_mapper,
-            cache_file_name=_cache_name("o_proj"),
+        ttMLA._convert_and_cache_weights(
+            state_dict, mesh_device, config, layer_idx, sp_axis, tp_axis, cache_path, device=None
         )
 
     def __init__(
@@ -305,154 +354,25 @@ class ttMLA:
         )
 
         # Load weights to TT device
-        self._load_weights(state_dict)
-
-    def _cache_name(self, name: str) -> Optional[str]:
-        if self.weight_cache_path is None:
-            return None
-        return str(self.weight_cache_path / f"layer_{self.layer_idx}.mla.{name}")
-
-    def _load_weights(self, state_dict: dict[str, torch.Tensor]):
-        """
-        Load weights from state dict and convert to TT tensors.
-
-        Expected keys in state_dict (when weights provided):
-        - q_a_proj.weight, q_a_layernorm.weight
-        - q_b_proj.weight
-        - kv_a_proj_with_mqa.weight, kv_a_layernorm.weight
-        - kv_b_proj.weight
-        - o_proj.weight
-
-        If state_dict is empty, loads from cache using dummy tensors.
-        """
-
-        # Check if weights are provided (following TtMoe pattern)
-        if state_dict and "q_a_layernorm.weight" in state_dict:
-            # Weights provided - use direct access (all keys should exist)
-            q_a_ln_weight = state_dict["q_a_layernorm.weight"].reshape(1, 1, -1, ttnn.TILE_SIZE)
-            kv_a_ln_weight = state_dict["kv_a_layernorm.weight"].reshape(1, 1, -1, ttnn.TILE_SIZE)
-            q_a_proj = state_dict["q_a_proj.weight"].transpose(-2, -1)
-            q_b_proj_weight = state_dict["q_b_proj.weight"].transpose(-2, -1)
-            kv_a_proj_weight = state_dict["kv_a_proj_with_mqa.weight"].transpose(-2, -1)
-            kv_b_proj_weights = state_dict["kv_b_proj.weight"].reshape(
-                1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim, self.kv_lora_rank
-            )
-            o_proj_weight = state_dict["o_proj.weight"].transpose(-2, -1)
-        else:
-            # Cache-only mode - create dummy tensors with transposed dimensions (ignored when cache exists)
-            q_a_ln_weight = torch.empty(1, 1, self.qk_rope_head_dim, ttnn.TILE_SIZE)
-            kv_a_ln_weight = torch.empty(1, 1, self.kv_lora_rank, ttnn.TILE_SIZE)
-            q_a_proj = torch.empty(self.hidden_size, self.q_lora_rank)
-            q_b_proj_weight = torch.empty(self.q_lora_rank, self.qk_rope_head_dim * self.num_heads)
-            kv_a_proj_weight = torch.empty(self.hidden_size, self.kv_lora_rank + self.qk_rope_head_dim)
-            kv_b_proj_weights = torch.empty(
-                1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim, self.kv_lora_rank
-            )
-            o_proj_weight = torch.empty(self.num_heads * self.qk_rope_head_dim, self.hidden_size)
-
-        # Mesh Device = (sp x tp)
-        # Convert q_a_layernorm
-        self.q_a_layernorm_weight = ttnn.as_tensor(
-            q_a_ln_weight,
-            device=self.mesh_device,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-            cache_file_name=self._cache_name("q_a_layernorm"),
+        weights = self._convert_and_cache_weights(
+            state_dict,
+            mesh_device,
+            config,
+            layer_idx,
+            sp_axis,
+            tp_axis,
+            self.weight_cache_path,
+            device=mesh_device,
         )
-
-        # Convert kv_a_layernorm
-        self.kv_a_layernorm_weight = ttnn.as_tensor(
-            kv_a_ln_weight,
-            device=self.mesh_device,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-            cache_file_name=self._cache_name("kv_a_layernorm"),
-        )
-
-        # Convert q_a_proj
-        shard_dims = [None, None]
-        shard_dims[self.tp_axis] = 0
-        mesh_mapper = ttnn.ShardTensor2dMesh(
-            self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=shard_dims
-        )
-        self.q_a_proj_weight = ttnn.as_tensor(
-            q_a_proj,
-            device=self.mesh_device,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=mesh_mapper,
-            cache_file_name=self._cache_name("q_a_proj"),
-        )
-
-        # Convert q_b_proj
-        shard_dims[self.tp_axis] = 1
-        shard_dims[self.sp_axis] = None
-        mesh_mapper_q_b_proj = ttnn.ShardTensor2dMesh(
-            self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=shard_dims
-        )
-        self.q_b_proj_weight = ttnn.as_tensor(
-            q_b_proj_weight,
-            device=self.mesh_device,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=mesh_mapper_q_b_proj,
-            cache_file_name=self._cache_name("q_b_proj"),
-        )
-
-        # Convert kv_a_proj_with_mqa
-        self.kv_a_proj_with_mqa_weight = ttnn.as_tensor(
-            kv_a_proj_weight,
-            device=self.mesh_device,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=mesh_mapper,
-            cache_file_name=self._cache_name("kv_a_proj_with_mqa"),
-        )
-
-        # Convert kv_b_proj (split into k and v)
-        torch_weights_k = kv_b_proj_weights[..., : self.qk_nope_head_dim, :].transpose(-2, -1)
-        torch_weights_v = kv_b_proj_weights[..., self.qk_nope_head_dim :, :]
-
-        shard_dims[self.tp_axis] = 1
-        shard_dims[self.sp_axis] = None
-        self.wkv_b1_weight = ttnn.as_tensor(
-            torch_weights_k.transpose(-2, -1),
-            device=self.mesh_device,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=mesh_mapper_q_b_proj,
-            cache_file_name=self._cache_name("wkv_b1"),
-        )
-        self.wkv_b2_weight = ttnn.as_tensor(
-            torch_weights_v.transpose(-2, -1),
-            device=self.mesh_device,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=mesh_mapper_q_b_proj,
-            cache_file_name=self._cache_name("wkv_b2"),
-        )
-
-        # Convert o_proj
-        self.o_proj_weight = ttnn.as_tensor(
-            o_proj_weight,
-            device=self.mesh_device,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=mesh_mapper,
-            cache_file_name=self._cache_name("o_proj"),
-        )
-
-        logger.info(f"✓ Loaded {len(state_dict)} weights in MLA layer {self.layer_idx} to TT device")
+        self.q_a_layernorm_weight = weights["q_a_layernorm"]
+        self.kv_a_layernorm_weight = weights["kv_a_layernorm"]
+        self.q_a_proj_weight = weights["q_a_proj"]
+        self.q_b_proj_weight = weights["q_b_proj"]
+        self.kv_a_proj_with_mqa_weight = weights["kv_a_proj_with_mqa"]
+        self.wkv_b1_weight = weights["wkv_b1"]
+        self.wkv_b2_weight = weights["wkv_b2"]
+        self.o_proj_weight = weights["o_proj"]
+        logger.info(f"Loaded {len(weights)} weights in MLA layer {layer_idx}")
 
     @staticmethod
     def kv_cache_to_host(kvpe_cache: ttnn.Tensor, mesh_device: ttnn.MeshDevice, sp_axis: int = 0):

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -30,8 +30,10 @@ class ttMLA:
     @staticmethod
     def check_cache_complete(cache_path: Path, cache_name_prefix: str) -> bool:
         """Check if all 8 MLA weight cache files exist."""
+        from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
+
         for name in ttMLA.MLA_WEIGHT_NAMES:
-            if not list(cache_path.glob(f"{cache_name_prefix}.{name}*.tensorbin")):
+            if not pattern_exists(f"{cache_name_prefix}.{name}*.tensorbin", "MLA"):
                 logger.debug(f"TTNN cache missing: {cache_name_prefix}.{name}")
                 return False
         return True

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -133,7 +133,13 @@ class TtMoEGatePrefill(LightweightModule):
             return str(cache_path / f"{cache_name_prefix}.{name}")
 
         # Transpose weight from HF (n_experts, dim) to TTNN (dim, n_experts)
-        weight_for_ttnn = torch_weight.T
+        if torch_weight is not None:
+            weight_for_ttnn = torch_weight.T
+        else:
+            weight_for_ttnn = torch.empty(config.dim, config.n_routed_experts)
+
+        if torch_bias is None:
+            torch_bias = torch.empty(config.n_routed_experts)
 
         # Convert weight
         weight_tt = ttnn.as_tensor(
@@ -226,23 +232,31 @@ class TtMoEGatePrefill(LightweightModule):
         self.mesh_device = mesh_device
         self.fallback_mode = fallback_mode
 
-        # Handle cache-only case (weight=None, bias=None)
         if weight is not None and bias is not None:
-            torch_weight = weight
-            torch_bias = bias
+            weights = self._convert_and_cache_gate_weights(
+                weight, bias, config, mesh_device, weight_cache_path, cache_name_prefix, device=mesh_device
+            )
+        elif weight_cache_path is not None:
+            weights = self._convert_and_cache_gate_weights(
+                None, None, config, mesh_device, weight_cache_path, cache_name_prefix, device=mesh_device
+            )
         else:
-            # Dummy tensors for cache load (ignored when cache exists)
-            torch_weight = torch.zeros([config.n_routed_experts, config.dim])
-            torch_bias = torch.zeros([config.n_routed_experts])
-
-        # Use shared conversion method
-        weights = self._convert_and_cache_gate_weights(
-            torch_weight, torch_bias, config, mesh_device, weight_cache_path, cache_name_prefix, device=mesh_device
-        )
+            weights = self._convert_and_cache_gate_weights(
+                torch.zeros([config.n_routed_experts, config.dim]),
+                torch.zeros([config.n_routed_experts]),
+                config,
+                mesh_device,
+                None,
+                None,
+                device=mesh_device,
+            )
 
         self.weight = weights["weight"]
-
         bias_tt = weights["bias_unbroadcasted"]
+        torch_weight_fallback = weights["torch_weight"]
+        torch_bias_fallback = weights["torch_bias"]
+
+        # Broadcast bias for deepseek_grouped_gate kernel
         bias_torch = ttnn.to_torch(bias_tt)
         del bias_tt
         bias_broadcasted = bias_torch.repeat(config.sp_dim).view(config.sp_dim, -1)
@@ -258,10 +272,8 @@ class TtMoEGatePrefill(LightweightModule):
 
         # Torch copies for host fallback paths — keep in HF convention (n_experts, dim)
         if fallback_mode != GateComputeMode.DEVICE:
-            # Shared method already converts cached tensors to torch format
-            # Whether from provided weights or loaded from cache, these are correct
-            self.torch_weight = weights["torch_weight"]  # (n_experts, dim) - HF format
-            self.torch_bias = weights["torch_bias"]  # (n_experts,)
+            self.torch_weight = torch_weight_fallback  # (n_experts, dim) - HF format
+            self.torch_bias = torch_bias_fallback  # (n_experts,)
 
         # Reference model for host grouped-gate paths
         if fallback_mode in (GateComputeMode.HOST_GROUPED_GATE, GateComputeMode.HOST_ALL):
@@ -279,7 +291,6 @@ class TtMoEGatePrefill(LightweightModule):
                 hidden_size=config.dim,
             )
             self.reference_model = ReferenceMoEGate(self.ref_config, use_bitonic_sort=True)
-            # Use converted torch tensors (from cache or original weights)
             self.reference_model.weight.data = self.torch_weight  # (n_experts, dim)
             self.reference_model.e_score_correction_bias.data = self.torch_bias  # (n_experts,)
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -93,10 +93,12 @@ class TtMoEGatePrefill(LightweightModule):
     @staticmethod
     def check_cache_complete(cache_path: Path, cache_name_prefix: str) -> bool:
         """Check if gate weight and bias cache files exist."""
-        if not list(cache_path.glob(f"{cache_name_prefix}.weight*.tensorbin")):
+        from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
+
+        if not pattern_exists(f"{cache_name_prefix}.weight*.tensorbin", "MoEGate"):
             logger.debug(f"TTNN cache missing: {cache_name_prefix}.weight")
             return False
-        if not list(cache_path.glob(f"{cache_name_prefix}.e_score_correction_bias*.tensorbin")):
+        if not pattern_exists(f"{cache_name_prefix}.e_score_correction_bias*.tensorbin", "MoEGate"):
             logger.debug(f"TTNN cache missing: {cache_name_prefix}.e_score_correction_bias")
             return False
         return True

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py
@@ -29,6 +29,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 
 
 class TtPrefillTransformer(LightweightModule):
@@ -71,6 +72,9 @@ class TtPrefillTransformer(LightweightModule):
         if not cache_path or not cache_path.exists():
             logger.debug(f"TTNN cache path does not exist: {cache_path}")
             return False
+
+        # Initialize fast cache checker for this directory
+        init_checker(cache_path)
 
         # Embedding
         if not TtParallelEmbedding.check_cache_complete(cache_path):

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -46,25 +46,31 @@ class TtRoutedExpert(LightweightModule):
 
     @staticmethod
     def _convert_and_cache_expert_weights(
-        torch_weights: list[dict],
+        torch_weights: list[dict] | None,
         experts_per_chip: int,
         mesh_device: ttnn.MeshDevice,
         weights_dtype: ttnn.DataType,
         cache_path: Path | None,
         cache_name_prefix: str | None,
         device: ttnn.MeshDevice | None = None,
+        *,
+        emb_dim: int | None = None,
+        hidden_dim: int | None = None,
     ):
         """
         Shared logic for converting expert weights to ttnn with caching.
 
         Args:
-            torch_weights: List of 256 expert weight dicts
+            torch_weights: List of expert weight dicts, or None for cache-only loading.
+                When None, emb_dim and hidden_dim must be provided.
             experts_per_chip: Number of experts per chip (8 for 8x4 mesh)
             mesh_device: Mesh device reference
             weights_dtype: Weight data type
             cache_path: Cache directory
             cache_name_prefix: Prefix for cache files
             device: None for cache-only, mesh_device for cache+load
+            emb_dim: Required when torch_weights is None
+            hidden_dim: Required when torch_weights is None
 
         Returns:
             (gate_projs, up_projs, down_projs) if device is not None, else None
@@ -79,53 +85,58 @@ class TtRoutedExpert(LightweightModule):
         mesh_rows, mesh_cols = mesh_device.shape
         gate_tensors, up_tensors, down_tensors = [], [], []
 
-        for local_expert_idx in tqdm(
-            range(experts_per_chip), desc=f"Expert weights ({'cache' if device is None else 'device'})"
-        ):
-            gate_weights, up_weights, down_weights = ExpertMapping.gather_weights_for_mesh_distribution(
-                torch_weights, local_expert_idx, mesh_rows, mesh_cols, experts_per_chip
-            )
+        mode = "build-cache" if device is None else ("load-cache" if torch_weights is None else "convert")
+        for local_expert_idx in tqdm(range(experts_per_chip), desc=f"Expert weights ({mode})"):
+            if torch_weights is not None:
+                gate_weights, up_weights, down_weights = ExpertMapping.gather_weights_for_mesh_distribution(
+                    torch_weights, local_expert_idx, mesh_rows, mesh_cols, experts_per_chip
+                )
 
-            # Convert gate
-            stacked_gate = torch.stack([w.T.contiguous() for w in gate_weights], dim=0)
-            in_f, out_f = stacked_gate.shape[1], stacked_gate.shape[2]
-            stacked_gate = stacked_gate.reshape(mesh_rows, mesh_cols, in_f, out_f)
+                stacked_gate = torch.stack([w.T.contiguous() for w in gate_weights], dim=0)
+                in_f, out_f = stacked_gate.shape[1], stacked_gate.shape[2]
+                stacked_gate = stacked_gate.reshape(mesh_rows, mesh_cols, in_f, out_f)
+
+                stacked_up = torch.stack([w.T.contiguous() for w in up_weights], dim=0).reshape(
+                    mesh_rows, mesh_cols, in_f, out_f
+                )
+
+                stacked_down = torch.stack([w.T.contiguous() for w in down_weights], dim=0)
+                in_f_down, out_f_down = stacked_down.shape[1], stacked_down.shape[2]
+                stacked_down = stacked_down.reshape(mesh_rows, mesh_cols, in_f_down, out_f_down)
+            else:
+                assert emb_dim is not None and hidden_dim is not None
+                stacked_gate = torch.empty(mesh_rows, mesh_cols, emb_dim, hidden_dim)
+                stacked_up = torch.empty(mesh_rows, mesh_cols, emb_dim, hidden_dim)
+                stacked_down = torch.empty(mesh_rows, mesh_cols, hidden_dim, emb_dim)
+
+            mem = ttnn.DRAM_MEMORY_CONFIG if device else None
+            mapper = ExpertMapping.get_weights_mesh_mapper(mesh_device)
 
             gate_tt = ttnn.as_tensor(
                 stacked_gate,
-                mesh_mapper=ExpertMapping.get_weights_mesh_mapper(mesh_device),
+                mesh_mapper=mapper,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 dtype=weights_dtype,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG if device else None,
+                memory_config=mem,
                 cache_file_name=_cache_name(f"local_{local_expert_idx}_gate"),
-            )
-
-            # Convert up (same shape as gate)
-            stacked_up = torch.stack([w.T.contiguous() for w in up_weights], dim=0).reshape(
-                mesh_rows, mesh_cols, in_f, out_f
             )
             up_tt = ttnn.as_tensor(
                 stacked_up,
-                mesh_mapper=ExpertMapping.get_weights_mesh_mapper(mesh_device),
+                mesh_mapper=mapper,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 dtype=weights_dtype,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG if device else None,
+                memory_config=mem,
                 cache_file_name=_cache_name(f"local_{local_expert_idx}_up"),
             )
-
-            # Convert down (different shape: hidden_dim x emb_dim after transpose)
-            stacked_down = torch.stack([w.T.contiguous() for w in down_weights], dim=0)
-            in_f_down, out_f_down = stacked_down.shape[1], stacked_down.shape[2]  # Get actual down_proj dims
-            stacked_down = stacked_down.reshape(mesh_rows, mesh_cols, in_f_down, out_f_down)
             down_tt = ttnn.as_tensor(
                 stacked_down,
-                mesh_mapper=ExpertMapping.get_weights_mesh_mapper(mesh_device),
+                mesh_mapper=mapper,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 dtype=weights_dtype,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG if device else None,
+                memory_config=mem,
                 cache_file_name=_cache_name(f"local_{local_expert_idx}_down"),
             )
 
@@ -240,9 +251,30 @@ class TtRoutedExpert(LightweightModule):
                 f"experts_per_chip={experts_per_chip}), got {len(torch_weights)}"
             )
             logger.debug(f"Creating weights from provided torch tensors ({total_experts} experts)")
+            result = self._convert_and_cache_expert_weights(
+                torch_weights,
+                experts_per_chip,
+                self.mesh_device,
+                self.weights_dtype,
+                self.weight_cache_path,
+                self.cache_name_prefix,
+                device=self.mesh_device,
+            )
+        elif weight_cache_path is not None:
+            logger.debug(f"Loading weights from cache ({experts_per_chip} local experts)")
+            result = self._convert_and_cache_expert_weights(
+                None,
+                experts_per_chip,
+                self.mesh_device,
+                self.weights_dtype,
+                self.weight_cache_path,
+                self.cache_name_prefix,
+                device=self.mesh_device,
+                emb_dim=emb_dim,
+                hidden_dim=hidden_dim,
+            )
         else:
-            # Cache-only mode: create dummy tensors (ignored when cache exists)
-            logger.debug(f"Creating dummy tensors for cache loading ({total_experts} experts)")
+            logger.debug(f"Creating dummy tensors for testing ({total_experts} experts)")
             torch_weights = []
             for _ in range(total_experts):
                 torch_weights.append(
@@ -252,17 +284,15 @@ class TtRoutedExpert(LightweightModule):
                         "down_proj": torch.empty(emb_dim, hidden_dim),
                     }
                 )
-
-        # Use shared static method with device=mesh_device (works for both real weights and cache loading)
-        result = self._convert_and_cache_expert_weights(
-            torch_weights,
-            experts_per_chip,
-            self.mesh_device,
-            self.weights_dtype,
-            self.weight_cache_path,
-            self.cache_name_prefix,
-            device=self.mesh_device,
-        )
+            result = self._convert_and_cache_expert_weights(
+                torch_weights,
+                experts_per_chip,
+                self.mesh_device,
+                self.weights_dtype,
+                None,
+                None,
+                device=self.mesh_device,
+            )
         self.gate_projs, self.up_projs, self.down_projs = result
 
     def _cache_name(self, name: str) -> Optional[str]:

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -36,10 +36,12 @@ class TtRoutedExpert(LightweightModule):
     @staticmethod
     def check_cache_complete(cache_path: Path, cache_name_prefix: str, experts_per_chip: int) -> bool:
         """Check if all routed expert weight cache files exist."""
+        from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
+
         for local_expert_idx in range(experts_per_chip):
             for proj in ["gate", "up", "down"]:
                 pattern = f"{cache_name_prefix}.local_{local_expert_idx}_{proj}*.tensorbin"
-                if not list(cache_path.glob(pattern)):
+                if not pattern_exists(pattern, "RoutedExpert"):
                     logger.debug(f"TTNN cache missing: {cache_name_prefix}.local_{local_expert_idx}_{proj}")
                     return False
         return True

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -91,18 +91,24 @@ class TtSharedExpert(LightweightModule):
                 return None
             return str(cache_path / f"{cache_name_prefix}.{name}")
 
-        def _convert_projection(torch_weight, dims, name):
-            # Transpose from HF format [out, in] to TTNN format [in, out]
-            torch_weight_t = torch_weight.T.contiguous()
+        # Prepare post-transpose tensors
+        if torch_weights is not None:
+            gate_w = torch_weights["gate_proj"].T.contiguous()
+            up_w = torch_weights["up_proj"].T.contiguous()
+            down_w = torch_weights["down_proj"].T.contiguous()
+        else:
+            gate_w = torch.empty(emb_dim, hidden_dim)
+            up_w = torch.empty(emb_dim, hidden_dim)
+            down_w = torch.empty(hidden_dim, emb_dim)
 
+        def _to_ttnn(tensor, dims, name):
             mesh_mapper = ttnn.ShardTensor2dMesh(
                 mesh_device,
                 mesh_shape=mesh_device.shape,
                 dims=dims,
             )
-
-            tt_weight = ttnn.as_tensor(
-                torch_weight_t,
+            return ttnn.as_tensor(
+                tensor,
                 mesh_mapper=mesh_mapper,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
@@ -111,12 +117,9 @@ class TtSharedExpert(LightweightModule):
                 cache_file_name=_cache_name(name),
             )
 
-            return tt_weight
-
-        # Convert all 3 projections
-        gate_tt = _convert_projection(torch_weights["gate_proj"], (None, -1), "gate_proj")
-        up_tt = _convert_projection(torch_weights["up_proj"], (None, -1), "up_proj")
-        down_tt = _convert_projection(torch_weights["down_proj"], (None, -2), "down_proj")
+        gate_tt = _to_ttnn(gate_w, (None, -1), "gate_proj")
+        up_tt = _to_ttnn(up_w, (None, -1), "up_proj")
+        down_tt = _to_ttnn(down_w, (None, -2), "down_proj")
 
         if device is None:
             # Cache built, free host tensors
@@ -191,9 +194,23 @@ class TtSharedExpert(LightweightModule):
         # Create sharded weights
         if torch_weights is not None:
             logger.debug("Creating weights from provided torch tensors")
-            # Use shared static method with device=mesh_device
             weights = self._convert_and_cache_weights(
                 torch_weights,
+                emb_dim,
+                hidden_dim,
+                mesh_device,
+                self.weights_dtype,
+                weight_cache_path,
+                cache_name_prefix,
+                device=mesh_device,
+            )
+            self.gate_proj = weights["gate"]
+            self.up_proj = weights["up"]
+            self.down_proj = weights["down"]
+        elif weight_cache_path is not None:
+            logger.debug("Loading weights from cache")
+            weights = self._convert_and_cache_weights(
+                None,
                 emb_dim,
                 hidden_dim,
                 mesh_device,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -52,8 +52,10 @@ class TtSharedExpert(LightweightModule):
     @staticmethod
     def check_cache_complete(cache_path: Path, cache_name_prefix: str) -> bool:
         """Check if all shared expert weight cache files exist."""
+        from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
+
         for proj in ["gate_proj", "up_proj", "down_proj"]:
-            if not list(cache_path.glob(f"{cache_name_prefix}.{proj}*.tensorbin")):
+            if not pattern_exists(f"{cache_name_prefix}.{proj}*.tensorbin", "SharedExpert"):
                 logger.debug(f"TTNN cache missing: {cache_name_prefix}.{proj}")
                 return False
         return True

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -75,7 +75,10 @@ class TtDistributedRmsNorm(LightweightModule):
             ttnn.Tensor if device is not None, else None
         """
         # Reshape weight to [1, 1, emb_dim // 32, 32]
-        torch_weight_reshaped = torch_weight.reshape(1, 1, emb_dim // 32, 32)
+        if torch_weight is not None:
+            torch_weight_reshaped = torch_weight.reshape(1, 1, emb_dim // 32, 32)
+        else:
+            torch_weight_reshaped = torch.empty(1, 1, emb_dim // 32, 32)
 
         # Create mesh mapper: replicate across rows, shard dim 2 across cols
         mesh_mapper = ttnn.ShardTensor2dMesh(
@@ -180,6 +183,16 @@ class TtDistributedRmsNorm(LightweightModule):
         if torch_weight is not None:
             logger.debug("Creating weight from provided torch tensor")
             self.weight = self._create_sharded_weight_from_torch(torch_weight)
+        elif weight_cache_path is not None:
+            logger.debug("Loading weight from cache")
+            self.weight = self._convert_and_cache_weight(
+                None,
+                self.emb_dim,
+                self.mesh_device,
+                self.weight_cache_path,
+                self.cache_name_prefix,
+                device=self.mesh_device,
+            )
         else:
             logger.debug("Creating random sharded weight")
             self.weight = self._create_random_sharded_weight()

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -46,7 +46,9 @@ class TtDistributedRmsNorm(LightweightModule):
     @staticmethod
     def check_cache_complete(cache_path: Path, cache_name_prefix: str) -> bool:
         """Check if norm weight cache files exist."""
-        if not list(cache_path.glob(f"{cache_name_prefix}_weight*.tensorbin")):
+        from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
+
+        if not pattern_exists(f"{cache_name_prefix}_weight*.tensorbin", "RmsNorm"):
             logger.debug(f"TTNN cache missing: {cache_name_prefix}_weight")
             return False
         return True

--- a/models/demos/deepseek_v3_d_p/tt/tt_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_parallel_embedding.py
@@ -73,10 +73,13 @@ class TtParallelEmbedding(LightweightModule):
         Returns:
             ttnn.Tensor if device is not None, else None
         """
-        assert torch_weight.shape == (
-            vocab_size,
-            emb_dim,
-        ), f"Weight shape mismatch: got {torch_weight.shape}, expected ({vocab_size}, {emb_dim})"
+        if torch_weight is not None:
+            assert torch_weight.shape == (
+                vocab_size,
+                emb_dim,
+            ), f"Weight shape mismatch: got {torch_weight.shape}, expected ({vocab_size}, {emb_dim})"
+        else:
+            torch_weight = torch.empty(vocab_size, emb_dim)
 
         shard_dims = [None, None]
         shard_dims[tp_axis] = -1  # shard emb_dim across TP axis
@@ -98,6 +101,8 @@ class TtParallelEmbedding(LightweightModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG if device else None,
             cache_file_name=cache_file_name,
         )
+        if device is not None:
+            ttnn.synchronize_device(device)
 
         if device is None:
             del tt_weight
@@ -164,6 +169,17 @@ class TtParallelEmbedding(LightweightModule):
 
         if torch_weight is not None:
             self.weight = self._create_weight_from_torch(torch_weight)
+        elif weight_cache_path is not None:
+            self.weight = self._convert_and_cache_weight(
+                None,
+                self.vocab_size,
+                self.emb_dim,
+                self.mesh_device,
+                self.tp_axis,
+                self.dtype,
+                self.weight_cache_path,
+                device=self.mesh_device,
+            )
         else:
             self.weight = self._create_random_weight()
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_parallel_embedding.py
@@ -41,7 +41,9 @@ class TtParallelEmbedding(LightweightModule):
     @staticmethod
     def check_cache_complete(cache_path: Path) -> bool:
         """Check if embedding weight cache files exist."""
-        if not list(cache_path.glob("embed_weight*.tensorbin")):
+        from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
+
+        if not pattern_exists("embed_weight*.tensorbin", "Embedding"):
             logger.debug("TTNN cache missing: embed_weight")
             return False
         return True

--- a/models/demos/deepseek_v3_d_p/utils/fast_cache_checker.py
+++ b/models/demos/deepseek_v3_d_p/utils/fast_cache_checker.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fast cache completeness checker using single directory scan + in-memory pattern matching.
+
+Replaces sequential Path.glob() calls which each scan the entire directory (~24ms per call).
+For 2303 pattern checks: 2303 × 24ms = 56s with glob, vs 240ms with this approach (230x speedup).
+"""
+
+import time
+from collections import defaultdict
+from pathlib import Path
+
+from loguru import logger
+
+
+class FastCacheChecker:
+    """
+    Optimized cache file existence checker.
+
+    Instead of N sequential glob() calls (each ~24ms due to directory scan),
+    this does:
+    - 1 iterdir() to build file set (~40ms)
+    - N in-memory pattern matches (~0.03ms each)
+
+    Usage:
+        checker = FastCacheChecker(cache_path)
+        if checker.pattern_exists("layer_0.mla.q_a_proj*.tensorbin", "MLA"):
+            ...
+        checker.report()  # prints timing summary
+
+    Or as context manager:
+        with FastCacheChecker(cache_path) as checker:
+            checker.pattern_exists(...)
+        # auto-reports on exit
+    """
+
+    def __init__(self, cache_path: Path):
+        self.cache_path = cache_path
+        self._files: set[str] | None = None
+        self._timings: dict[str, list[tuple[str, float]]] = defaultdict(list)
+        self._iterdir_ms: float = 0.0
+
+    def _ensure_files_loaded(self) -> set[str]:
+        if self._files is None:
+            start = time.perf_counter()
+            self._files = set(f.name for f in self.cache_path.iterdir())
+            self._iterdir_ms = (time.perf_counter() - start) * 1000
+            logger.debug(f"FastCacheChecker: loaded {len(self._files)} files in {self._iterdir_ms:.1f}ms")
+        return self._files
+
+    def pattern_exists(self, pattern: str, component: str = "unknown") -> bool:
+        """Check if any file matches glob pattern (e.g., 'layer_0.mla.q_a_proj*.tensorbin')."""
+        files = self._ensure_files_loaded()
+
+        start = time.perf_counter()
+        if "*" in pattern:
+            prefix, suffix = pattern.split("*", 1)
+        else:
+            prefix, suffix = pattern, ""
+
+        result = any(f.startswith(prefix) and f.endswith(suffix) for f in files)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        self._timings[component].append((pattern, elapsed_ms))
+        return result
+
+    def report(self):
+        """Print timing summary."""
+        total_ms = self._iterdir_ms
+        total_calls = 0
+
+        logger.info(f"  iterdir: {self._iterdir_ms:.1f} ms ({len(self._files or [])} files)")
+        for component, timings in sorted(self._timings.items()):
+            comp_total = sum(t[1] for t in timings)
+            comp_count = len(timings)
+            total_ms += comp_total
+            total_calls += comp_count
+            logger.info(f"  {component}: {comp_count} checks, {comp_total:.2f} ms")
+        logger.info(f"  TOTAL: {total_calls} checks, {total_ms:.1f} ms ({total_ms / 1000:.3f} s)")
+
+    def clear(self):
+        """Clear cached state."""
+        self._timings.clear()
+        self._files = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.report()
+        self.clear()
+
+
+# Module-level singleton for backward compatibility with existing component code
+_checker: FastCacheChecker | None = None
+
+
+def init_checker(cache_path: Path):
+    """Initialize the global checker for a cache directory."""
+    global _checker
+    _checker = FastCacheChecker(cache_path)
+
+
+def pattern_exists(pattern: str, component: str = "unknown") -> bool:
+    """Check pattern using global checker. Must call init_checker() first."""
+    if _checker is None:
+        raise RuntimeError("Call init_checker(cache_path) before pattern_exists()")
+    return _checker.pattern_exists(pattern, component)
+
+
+def report_and_clear():
+    """Report timings and clear global checker."""
+    global _checker
+    if _checker:
+        _checker.report()
+        _checker.clear()
+        _checker = None


### PR DESCRIPTION
## Summary
- Each `_convert_and_cache_*` method now accepts `None` for `torch_weights`, creating minimal `torch.empty()` placeholders with post-transform shapes
- `ttnn.as_tensor` ignores the placeholder when a `.tensorbin` cache exists, skipping expensive host ops (`torch.randn`, transpose, stacking, slicing)
- MLA refactored: `build_ttnn_cache` and `__init__` both delegate to a single static `_convert_and_cache_weights`

Closes #42450


## Performance: tt_transformer_creation

Benchmark: 61-layer transformer, 1024 seq len, 8×4 mesh (32 devices)

| Scenario | tt_transformer_creation | Notes |
|----------|------------------------|-------|
| TTNN cache creation | ~465s | Building `.tensorbin` files to disk |
| Cold OS page cache | ~435s | First run after reboot or `drop_caches` |
| Warm OS page cache | ~42s | Subsequent runs (tensorbin files in RAM) |

## CI

| Pipeline | Status |
|---|---|
| Galaxy | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2604-cache-perf) |
| T3K e2e | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2604-cache-perf) |
| Blackhole e2e | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2604-cache-perf) |

## Warm cache load benchmarks (2x4 BH mesh)

| Component | Before (ms) | After (ms) | Speedup |
|---|---:|---:|---:|
| Embedding | 5,287 | 137 | **39x** |
| FFN | 2,264 | 35 | **65x** |
| MoE (composite) | 1,137 | 99 | **11x** |
| Routed Expert | 318 | 13 | **24x** |
| Shared Expert | 175 | 6 | **29x** |
| MLA | 190 | 191 | ~1x |
| Gate | 28 | 22 | ~1x |
| RMS Norm | 2 | 2 | ~1x |

## Test plan
- [x] All 8 cache unit tests pass with PCC 1.0
- [x] `test_prefill_block.py` passes (dense + MoE blocks, PCC 0.9927)
- [ ] Galaxy CI
- [ ] T3K e2e CI
- [ ] Blackhole e2e CI

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-cache-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-cache-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-cache-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-cache-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-cache-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-cache-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-cache-perf)