### PR TITLE
tests/ttnn: skip test_from_torch_sharded_tilize_dispatch_core_overlap on slow dispatch

### DIFF
--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -1079,6 +1079,7 @@ def test_from_torch_large_tensor_type_conversion_row_major_l1(device, torch_dtyp
     assert_with_pcc(torch_tensor, result, 0.999)
 
 
+@skip_for_slow_dispatch()
 def test_from_torch_sharded_tilize_dispatch_core_overlap(device):
     """
     Regression test for tilize with a shard grid that extends beyond the compute


### PR DESCRIPTION
### Problem description

`test_from_torch_sharded_tilize_dispatch_core_overlap` validates that sharded tilize handles shard grids extending into dispatch core rows (`y=grid.y`) without placing kernels there. This is an inherently fast dispatch scenario — dispatch cores do not exist in slow dispatch mode, and `y=grid.y` is not a valid core at all, so the test crashes with:

```
No L1 bank exists for core (x=0,y=9)
```

The test has a `try/except` guard meant to catch this case, but it matches on `"No core coordinate"` and `"out of range"` — neither of which matches the actual error string.

### What changed

Added `@skip_for_slow_dispatch()` decorator (already imported in this file) — same pattern used for other FD-only tests in this module.

### Checklist
- [x] Test skips cleanly on WH ttsim (slow dispatch)
- [x] Test still runs on fast dispatch silicon (the scenario it was written for)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/skip-dispatch-core-overlap-test-on-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/skip-dispatch-core-overlap-test-on-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/skip-dispatch-core-overlap-test-on-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/skip-dispatch-core-overlap-test-on-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/skip-dispatch-core-overlap-test-on-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/skip-dispatch-core-overlap-test-on-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/skip-dispatch-core-overlap-test-on-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/skip-dispatch-core-overlap-test-on-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/skip-dispatch-core-overlap-test-on-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/skip-dispatch-core-overlap-test-on-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/skip-dispatch-core-overlap-test-on-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/skip-dispatch-core-overlap-test-on-sd)