### PR TITLE
Disable pytest-timeout during model tracing

### DIFF
--- a/model_tracer/generic_ops_tracer.py
+++ b/model_tracer/generic_ops_tracer.py
@@ -824,6 +824,13 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
     env = os.environ.copy()
     env["TTNN_OPERATION_TRACE_DIR"] = trace_dir
 
+    # Disable pytest-timeout during tracing.  Model tracing can legitimately
+    # take longer than the default pytest timeout (300 s) because it records
+    # every op invocation.  The GitHub Actions step-level timeout-minutes
+    # already guards against genuine hangs, so per-test timeouts are
+    # redundant and cause trace data loss.
+    env["PYTEST_TIMEOUT"] = "0"
+
     # Disable fast runtime mode to enable operation tracing
     # Fast mode skips the tracing decorator for performance
     env["TTNN_CONFIG_OVERRIDES"] = '{"enable_fast_runtime_mode": false}'


### PR DESCRIPTION
## Summary
- The default `pytest.ini` sets `timeout=300` (5 minutes) which causes large model traces (e.g. Llama-3.2-1B `performance-ci-1` variant) to be killed mid-trace, losing captured operation data
- Sets `PYTEST_TIMEOUT=0` in the tracer's subprocess environment to disable per-test timeouts during tracing
- The GitHub Actions step-level `timeout-minutes` already guards against genuine hangs, so per-test timeouts are redundant here

## Context
Observed in https://github.com/tenstorrent/tt-metal/actions/runs/24537421304/job/71736633968:
```
X test_demo_text[wormhole_b0-2-device_params0-False-performance-ci-1]
Failed: Timeout (>300.0s) from pytest-timeout.
```

## Test plan
- [ ] Re-run `ttnn run model trace` workflow with `llama-3.2-1b` model on this branch
- [ ] Verify the `performance-ci-1` variant no longer times out
- [ ] Verify trace data is fully captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aswin/fix-trace-pytest-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aswin/fix-trace-pytest-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aswin/fix-trace-pytest-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aswin/fix-trace-pytest-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aswin/fix-trace-pytest-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aswin/fix-trace-pytest-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aswin/fix-trace-pytest-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aswin/fix-trace-pytest-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aswin/fix-trace-pytest-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aswin/fix-trace-pytest-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aswin/fix-trace-pytest-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aswin/fix-trace-pytest-timeout)