### PR TITLE
Standardize dispatch and combine perf test for Deepseek prefill

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -114,6 +114,7 @@ jobs:
               pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py -vvv --tb=short --timeout=900
               pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py -k "2x4 and layer0 and device" -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_grouped_topk.py -k "realistic" -vvv --tb=short
+              pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -m models_device_performance_bare_metal -vvv --tb=short --timeout=900
             timeout: 60
             test-type: loudbox
             owner_id: U08E1JCMAJF # Marko Bezulj

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -16,9 +16,12 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    MAX_PAYLOAD_SIZE_BH,
+    MAX_PAYLOAD_SIZE_WH,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -42,9 +45,10 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 
 
 @pytest.mark.parametrize(
-    "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, capacity_factor",
+    "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, capacity_factor, run_pcc_check",
     [
-        (128, 7 * 1024, 16, 4, 2),
+        pytest.param(128, 7 * 1024, 16, 4, 2, True, id="pcc"),
+        pytest.param(3200, 7168, 64, 2, 2, False, id="perf_no_pcc"),
     ],
 )
 @pytest.mark.parametrize(
@@ -193,6 +197,106 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-4x2"),
             id="mesh-2x4",
         ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_WH),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="perf-linear-8-1link-7k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_WH),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="perf-linear-8-2link-7k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_BH),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=[
+                pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+                pytest.mark.skipif(not is_blackhole(), reason="14K payload exceeds Wormhole hardware limit"),
+            ],
+            id="perf-linear-8-1link-14k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_BH),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=[
+                pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+                pytest.mark.skipif(not is_blackhole(), reason="14K payload exceeds Wormhole hardware limit"),
+            ],
+            id="perf-linear-8-2link-14k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_WH),
+            },
+            1,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="perf-ring-8-1link-7k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_WH),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="perf-ring-8-2link-7k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_BH),
+            },
+            1,
+            ttnn.Topology.Ring,
+            marks=[
+                pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+                pytest.mark.skipif(not is_blackhole(), reason="14K payload exceeds Wormhole hardware limit"),
+            ],
+            id="perf-ring-8-1link-14k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_BH),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=[
+                pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+                pytest.mark.skipif(not is_blackhole(), reason="14K payload exceeds Wormhole hardware limit"),
+            ],
+            id="perf-ring-8-2link-14k",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -207,6 +311,7 @@ def test_ttnn_combine(
     num_links,
     topology,
     use_predictable_data,
+    run_pcc_check,
 ):
     """Test TTNN combine operation in isolation using torch reference inputs."""
     torch.manual_seed(42)
@@ -357,6 +462,11 @@ def test_ttnn_combine(
         tt_dispatched_metadata,
         tt_expert_token_counts,
     )
+
+    if not run_pcc_check:
+        ttnn.synchronize_device(mesh_device)
+        logger.debug("Skipping PCC validation (run_pcc_check=False)")
+        return
 
     # Step 6: Convert ttnn output to torch for comparison
     mesh_composer = get_ep_mesh_composer(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -15,8 +15,11 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    MAX_PAYLOAD_SIZE_BH,
+    MAX_PAYLOAD_SIZE_WH,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -88,9 +91,10 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 
 
 @pytest.mark.parametrize(
-    "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, capacity_factor",
+    "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, capacity_factor, run_pcc_check",
     [
-        (32, 7168, 16, 4, 2),
+        pytest.param(32, 7168, 16, 4, 2, True, id="pcc"),
+        pytest.param(3200, 7168, 64, 2, 2, False, id="perf_no_pcc"),
     ],
 )
 @pytest.mark.parametrize(
@@ -239,6 +243,106 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-4x2"),
             id="mesh-2x4",
         ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_WH),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="perf-linear-8-1link-7k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_WH),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="perf-linear-8-2link-7k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_BH),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=[
+                pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+                pytest.mark.skipif(not is_blackhole(), reason="14K payload exceeds Wormhole hardware limit"),
+            ],
+            id="perf-linear-8-1link-14k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_BH),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=[
+                pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+                pytest.mark.skipif(not is_blackhole(), reason="14K payload exceeds Wormhole hardware limit"),
+            ],
+            id="perf-linear-8-2link-14k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_WH),
+            },
+            1,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="perf-ring-8-1link-7k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_WH),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="perf-ring-8-2link-7k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_BH),
+            },
+            1,
+            ttnn.Topology.Ring,
+            marks=[
+                pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+                pytest.mark.skipif(not is_blackhole(), reason="14K payload exceeds Wormhole hardware limit"),
+            ],
+            id="perf-ring-8-1link-14k",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE_BH),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=[
+                pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+                pytest.mark.skipif(not is_blackhole(), reason="14K payload exceeds Wormhole hardware limit"),
+            ],
+            id="perf-ring-8-2link-14k",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -255,6 +359,7 @@ def test_ttnn_dispatch(
     topology,
     use_predictable_data,
     verbose,
+    run_pcc_check,
 ):
     """Test TTNN dispatch operation against PyTorch reference."""
     torch.manual_seed(42)
@@ -383,6 +488,11 @@ def test_ttnn_dispatch(
     tt_dispatched, tt_metadata = tt_dispatch_module(
         tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
     )
+
+    if not run_pcc_check:
+        ttnn.synchronize_device(mesh_device)
+        logger.debug("Skipping PCC validation (run_pcc_check=False)")
+        return
 
     # Run torch reference for all EP ranks at once
     torch_dispatched, torch_metadata = torch_dispatch_module(x, weights, indices, expert_offsets)

--- a/models/demos/deepseek_v3_d_p/tests/perf/summarize_device_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/summarize_device_perf.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Summarize DeepSeek V3 dispatch/combine device perf reports.
+
+Reads the small `device_perf_<model>_<setting>_<YYYY_MM_DD>.csv` files that
+`prep_device_perf_report` drops in the tt-metal working directory after each
+call to `run_model_device_perf_test_with_merge`, then prints the same
+cross-config comparison tables (Ring vs Linear, 2L vs 1L, 14K vs 7K) that
+the old hand-rolled perf test logged inline.
+
+Usage:
+    python summarize_device_perf.py                              # scan tt-metal/
+    python summarize_device_perf.py PATH [PATH ...]              # specific files or dirs
+    python summarize_device_perf.py --date 2026_04_20             # restrict by date stamp
+    python summarize_device_perf.py --latest                      # keep only the newest file per config
+
+Each CSV's `Model` column is expected to match:
+    deepseek_v3_(dispatch|combine)_(linear|ring)_<ndev>_<nlinks>link_<payload>
+
+`payload` is the literal suffix used when constructing the model_name
+(e.g. `7k`, `14k`). Unknown filenames are skipped with a warning.
+"""
+
+import argparse
+import math
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+MODEL_RE = re.compile(
+    r"deepseek_v3_(?P<op>dispatch|combine)_"
+    r"(?P<topo>linear|ring)_"
+    r"(?P<ndev>\d+)_"
+    r"(?P<nlinks>\d+)link_"
+    r"(?P<payload>\d+k)",
+    re.IGNORECASE,
+)
+
+DEFAULT_ROOT = Path(__file__).resolve().parents[5]  # tt-metal/
+
+
+def _parse_model(model: str):
+    m = MODEL_RE.search(model)
+    if not m:
+        return None
+    return {
+        "op": m.group("op").lower(),
+        "topo": m.group("topo").capitalize(),
+        "ndev": int(m.group("ndev")),
+        "nlinks": int(m.group("nlinks")),
+        "payload": m.group("payload").lower(),
+    }
+
+
+def _iter_csv_paths(paths, date_filter):
+    """Expand each path: if it's a file, yield it; if a dir, yield every device_perf_*.csv inside."""
+    for p in paths:
+        p = Path(p)
+        if p.is_file():
+            yield p
+        elif p.is_dir():
+            pattern = f"device_perf_*{date_filter}*.csv" if date_filter else "device_perf_*.csv"
+            yield from sorted(p.glob(pattern))
+        else:
+            print(f"[warn] {p}: not found, skipping", file=sys.stderr)
+
+
+def _collect(csv_paths, keep_latest):
+    """Return {(op, topo, ndev, nlinks, payload): (ns, csv_path)}."""
+    per_config = {}
+    for csv in csv_paths:
+        try:
+            df = pd.read_csv(csv, skipinitialspace=True)
+        except Exception as exc:
+            print(f"[warn] {csv}: cannot read ({exc}), skipping", file=sys.stderr)
+            continue
+        if df.empty or "Model" not in df.columns or "AVG DEVICE KERNEL DURATION [ns]" not in df.columns:
+            print(f"[warn] {csv}: missing expected columns, skipping", file=sys.stderr)
+            continue
+        model = str(df["Model"].iloc[0])
+        info = _parse_model(model)
+        if info is None:
+            print(f"[warn] {csv}: model {model!r} does not match expected pattern, skipping", file=sys.stderr)
+            continue
+        try:
+            ns = float(df["AVG DEVICE KERNEL DURATION [ns]"].iloc[0])
+        except (TypeError, ValueError) as exc:
+            print(f"[warn] {csv}: cannot parse duration ({exc}), skipping", file=sys.stderr)
+            continue
+        key = (info["topo"], info["ndev"], info["nlinks"], info["payload"])
+        # Index by (topo, ndev, nlinks, payload) then op → ns, keeping newest file when asked.
+        bucket = per_config.setdefault(key, {})
+        prev = bucket.get(info["op"])
+        if prev is None or (keep_latest and csv.stat().st_mtime > prev[1]):
+            bucket[info["op"]] = (ns, csv.stat().st_mtime)
+    # Collapse to ns only.
+    return {key: {op: ns for op, (ns, _) in ops.items()} for key, ops in per_config.items()}
+
+
+def _fmt_us(ns):
+    if ns is None or (isinstance(ns, float) and math.isnan(ns)):
+        return "     N/A "
+    return f"{ns / 1000:>9.1f}"
+
+
+def _fmt_speedup(a, b):
+    if (
+        a is None
+        or b is None
+        or not a
+        or not b
+        or (isinstance(a, float) and math.isnan(a))
+        or (isinstance(b, float) and math.isnan(b))
+        or b == 0
+    ):
+        return "     N/A "
+    return f"{a / b:>9.2f}x"
+
+
+def _print_per_config(results):
+    print(f"\n{'=' * 72}")
+    print("  Per-config device kernel duration (μs)")
+    print(f"{'=' * 72}")
+    print(f"  {'Config':<30} {'Dispatch':>10} {'Combine':>10} {'Total':>10}")
+    print(f"  {'-' * 30} {'-' * 10} {'-' * 10} {'-' * 10}")
+    for (topo, ndev, nlinks, payload), ops in sorted(results.items()):
+        d = ops.get("dispatch")
+        c = ops.get("combine")
+        total = (d or 0) + (c or 0) if (d is not None or c is not None) else None
+        label = f"{topo}-{ndev} {nlinks}L {payload}"
+        print(f"  {label:<30} {_fmt_us(d)} {_fmt_us(c)} {_fmt_us(total)}")
+
+
+def _print_speedups(results):
+    header_printed = False
+
+    def _header():
+        nonlocal header_printed
+        if not header_printed:
+            print(f"\n  {'Speedup (base / fast)':<30} {'Dispatch':>10} {'Combine':>10}")
+            print(f"  {'-' * 30} {'-' * 10} {'-' * 10}")
+            header_printed = True
+
+    payloads = sorted({k[3] for k in results})
+    ndevs = sorted({k[1] for k in results})
+
+    for ndev in ndevs:
+        for nlinks in (1, 2):
+            for ps in payloads:
+                lin = results.get(("Linear", ndev, nlinks, ps))
+                ring = results.get(("Ring", ndev, nlinks, ps))
+                if lin and ring:
+                    _header()
+                    label = f"Ring/Lin {ndev}dev {nlinks}L {ps}"
+                    print(
+                        f"  {label:<30} "
+                        f"{_fmt_speedup(lin.get('dispatch'), ring.get('dispatch'))} "
+                        f"{_fmt_speedup(lin.get('combine'), ring.get('combine'))}"
+                    )
+
+    for ndev in ndevs:
+        for topo in ("Linear", "Ring"):
+            for ps in payloads:
+                one = results.get((topo, ndev, 1, ps))
+                two = results.get((topo, ndev, 2, ps))
+                if one and two:
+                    _header()
+                    label = f"2L/1L {topo[:3]} {ndev}dev {ps}"
+                    print(
+                        f"  {label:<30} "
+                        f"{_fmt_speedup(one.get('dispatch'), two.get('dispatch'))} "
+                        f"{_fmt_speedup(one.get('combine'), two.get('combine'))}"
+                    )
+
+    if "14k" in payloads and "7k" in payloads:
+        for ndev in ndevs:
+            for topo in ("Linear", "Ring"):
+                for nlinks in (1, 2):
+                    small = results.get((topo, ndev, nlinks, "7k"))
+                    large = results.get((topo, ndev, nlinks, "14k"))
+                    if small and large:
+                        _header()
+                        label = f"14K/7K {topo[:3]} {ndev}dev {nlinks}L"
+                        print(
+                            f"  {label:<30} "
+                            f"{_fmt_speedup(small.get('dispatch'), large.get('dispatch'))} "
+                            f"{_fmt_speedup(small.get('combine'), large.get('combine'))}"
+                        )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "paths",
+        nargs="*",
+        help=f"CSV files or directories to scan. Default: tt-metal root ({DEFAULT_ROOT}).",
+    )
+    ap.add_argument(
+        "--date",
+        default="",
+        help="Only include files whose name contains this date stamp (e.g. 2026_04_20).",
+    )
+    ap.add_argument(
+        "--latest",
+        action="store_true",
+        help="When multiple CSVs describe the same config, keep only the newest.",
+    )
+    args = ap.parse_args()
+
+    paths = [Path(p) for p in args.paths] if args.paths else [DEFAULT_ROOT]
+    csvs = list(_iter_csv_paths(paths, args.date))
+    if not csvs:
+        print(f"No device_perf_*.csv files found under: {', '.join(str(p) for p in paths)}", file=sys.stderr)
+        sys.exit(1)
+
+    results = _collect(csvs, args.latest)
+    if not results:
+        print("No matching configs found in the supplied CSVs.", file=sys.stderr)
+        sys.exit(1)
+
+    _print_per_config(results)
+    _print_speedups(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3_d_p/tests/perf/summarize_device_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/summarize_device_perf.py
@@ -213,7 +213,18 @@ def main():
     )
     args = ap.parse_args()
 
-    paths = [Path(p) for p in args.paths] if args.paths else [DEFAULT_ROOT]
+    # Contain user-supplied paths to the tt-metal workspace root. Prevents
+    # accidental/malicious scans of unrelated filesystem locations.
+    allowed_root = DEFAULT_ROOT.resolve()
+    paths = []
+    for raw in args.paths or [allowed_root]:
+        resolved = Path(raw).resolve()
+        try:
+            resolved.relative_to(allowed_root)
+        except ValueError:
+            ap.error(f"path {raw!r} is outside the allowed root {allowed_root}")
+        paths.append(resolved)
+
     csvs = list(_iter_csv_paths(paths, args.date))
     if not csvs:
         print(f"No device_perf_*.csv files found under: {', '.join(str(p) for p in paths)}", file=sys.stderr)

--- a/models/demos/deepseek_v3_d_p/tests/perf/summarize_device_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/summarize_device_perf.py
@@ -27,6 +27,7 @@ Each CSV's `Model` column is expected to match:
 
 import argparse
 import math
+import os
 import re
 import sys
 from pathlib import Path
@@ -215,15 +216,13 @@ def main():
 
     # Contain user-supplied paths to the tt-metal workspace root. Prevents
     # accidental/malicious scans of unrelated filesystem locations.
-    allowed_root = DEFAULT_ROOT.resolve()
+    allowed_root = str(DEFAULT_ROOT.resolve())
     paths = []
-    for raw in args.paths or [allowed_root]:
-        resolved = Path(raw).resolve()
-        try:
-            resolved.relative_to(allowed_root)
-        except ValueError:
+    for raw in args.paths or ["."]:
+        resolved = os.path.abspath(os.path.join(allowed_root, str(raw)))
+        if not (resolved == allowed_root or resolved.startswith(allowed_root + os.sep)):
             ap.error(f"path {raw!r} is outside the allowed root {allowed_root}")
-        paths.append(resolved)
+        paths.append(Path(resolved))
 
     csvs = list(_iter_csv_paths(paths, args.date))
     if not csvs:

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -223,8 +223,8 @@ def _perf_param(op, worker_file, worker_test, topo, nlinks, payload, expected_ns
 
 # CI set (BH LoudBox pipeline): keep small.
 _DISPATCH_PERF_PARAMS = [
-    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "linear", 2, "7k", 3_526_102, ""),
-    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, "7k", 2_823_079, ""),
+    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "linear", 2, "7k", 3_576_087, ""),
+    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, "7k", 2_804_940, ""),
 ]
 _COMBINE_PERF_PARAMS = [
     _perf_param(
@@ -234,11 +234,11 @@ _COMBINE_PERF_PARAMS = [
         "linear",
         2,
         "7k",
-        4_335_384,
+        4_435_146,
         "CombineDeviceOperation",
     ),
     _perf_param(
-        "combine", "test_prefill_combine.py", "test_ttnn_combine", "ring", 2, "7k", 3_113_945, "CombineDeviceOperation"
+        "combine", "test_prefill_combine.py", "test_ttnn_combine", "ring", 2, "7k", 3_017_923, "CombineDeviceOperation"
     ),
 ]
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -41,11 +41,23 @@ def merge_device_rows(df):
       Uses MAX duration across devices (critical path bottleneck)
 
     Args:
-        df: pandas DataFrame with profiler data
+        df: pandas DataFrame with profiler data. The DEVICE KERNEL DURATION
+            column may arrive as object dtype if Tracy wrote non-numeric
+            placeholders; it is coerced to float here so downstream NaN
+            handling works regardless.
 
     Returns:
-        DataFrame with merged rows
+        DataFrame with merged rows.
+
+    Raises:
+        pytest.fail: if any device's op sequence diverges from the others,
+            since the merged totals would otherwise silently compare
+            apples-to-oranges.
     """
+    duration_col = "DEVICE KERNEL DURATION [ns]"
+    df = df.copy()
+    df[duration_col] = pd.to_numeric(df[duration_col], errors="coerce")
+
     block_by_device = defaultdict(list)
 
     for _, row in df.iterrows():
@@ -68,10 +80,13 @@ def merge_device_rows(df):
                 if op_name is None:
                     op_name = current_op_name
                 elif op_name != current_op_name:
-                    logger.warning(f"Mismatched operations: {op_name} vs {current_op_name}")
+                    pytest.fail(
+                        f"Mismatched ops across devices at merge index: "
+                        f"device {device_id} has {current_op_name!r}, expected {op_name!r}"
+                    )
                 blocks.append((device_id, current_block))
             else:
-                logger.warning(f"Device {device_id} missing operation at this index")
+                pytest.fail(f"Device {device_id} is missing an op during merge (truncated trace?)")
 
         if not blocks:
             continue
@@ -82,18 +97,16 @@ def merge_device_rows(df):
 
         if is_collective:
             device_kernel_durations = [
-                d["DEVICE KERNEL DURATION [ns]"]
-                for _, d in blocks
-                if "DEVICE KERNEL DURATION [ns]" in d and not math.isnan(d["DEVICE KERNEL DURATION [ns]"])
+                d[duration_col] for _, d in blocks if duration_col in d and not math.isnan(d[duration_col])
             ]
             average_duration = (
                 sum(device_kernel_durations) / len(device_kernel_durations) if device_kernel_durations else float("nan")
             )
             base_block = blocks[0][1].copy()
-            base_block["DEVICE KERNEL DURATION [ns]"] = average_duration
+            base_block[duration_col] = average_duration
             merged_blocks.append(base_block)
         else:
-            max_duration_block = max(blocks, key=lambda x: x[1].get("DEVICE KERNEL DURATION [ns]", 0))
+            max_duration_block = max(blocks, key=lambda x: x[1].get(duration_col, 0))
             merged_blocks.append(max_duration_block[1])
 
     return pd.DataFrame(merged_blocks)
@@ -120,7 +133,19 @@ def run_model_device_perf_test_with_merge(
     `op_filter`, if set, restricts the measurement to rows whose OP CODE
     contains the given substring — useful when the worker pytest runs more
     than one op and only one of them is under test.
+
+    Only `num_iterations=1` is supported today. `run_device_perf` can run
+    multiple iterations and average them, but this helper rereads only the
+    latest ops CSV and rewrites the averaged metric from that single file —
+    mixing that with a multi-iteration average would produce inconsistent
+    numbers. Extending to N>1 requires merging across per-iteration CSVs.
     """
+    if num_iterations != 1:
+        pytest.fail(
+            f"run_model_device_perf_test_with_merge currently supports num_iterations=1 only "
+            f"(got {num_iterations}); per-iteration CSV merging is not implemented."
+        )
+
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
     inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
 
@@ -141,7 +166,8 @@ def run_model_device_perf_test_with_merge(
 
     if op_filter:
         df = df[df["OP CODE"].str.contains(op_filter, na=False)]
-        assert not df.empty, f"op_filter={op_filter!r} matched no rows in {filename}"
+        if df.empty:
+            pytest.fail(f"op_filter={op_filter!r} matched no rows in {filename}")
         logger.info(f"Rows after op_filter={op_filter!r}: {len(df)}")
 
     logger.info(f"Device rows before merge: {len(df)}")

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -3,462 +3,379 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Performance test for dispatch and combine operations.
+Device performance tests for DeepSeek V3 MoE dispatch and combine operations.
 
-TODO: Refactor to use run_model_device_perf_test_with_merge from models.perf.device_perf_utils
-once it is upstreamed from mbezulj/2603-moe-glx-perf-test branch. Also add perf test to BH LB CI pipeline.
+Measures device kernel duration for dispatch and combine separately on 8-chip
+linear and ring topologies (2 links, 7K payload). Each perf case spawns a
+worker pytest at a parametrize id whose config ends in `perf_no_pcc`; those
+workers skip PCC validation and run the op under test with the same
+production-format inputs it would see in the end-to-end MoE pipeline.
+`run_model_device_perf_test_with_merge` merges the per-device rows
+in the Tracy CSV into per-op totals; `op_filter` isolates the combine op
+when the worker also emits a preceding dispatch.
 
-Measures device-side kernel durations via the Tracy device profiler for
-dispatch and combine operations across Linear vs Ring topologies.
-
-Usage:
-    # Run on 8-chip linear:
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -k "linear-8" -s
-
-    # Run on 8-chip ring:
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -k "ring-8" -s
-
-    # Run all configurations:
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -s
-
-    # Run linear-8, 1-link configs (both payload sizes; 14K variant auto-skips on Wormhole):
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -k "linear-8 and 1link" -s
-
-Device profiling requires these environment variables to be set before device open:
-    TT_METAL_DEVICE_PROFILER=1          (required)
-    TT_METAL_PROFILER_MID_RUN_DUMP=1    (required)
-    TT_METAL_PROFILER_CPP_POST_PROCESS=1 (required)
-    TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES=1  (optional, suppresses file output)
-
-Durations are read programmatically through ttnn.ReadDeviceProfiler().
+TODO: `run_model_device_perf_test_with_merge` and `merge_device_rows` are
+duplicated here pending a follow-up PR that moves them into
+`models/perf/device_perf_utils.py`.
 """
 
-import os
+import math
+from collections import defaultdict
 
+import pandas as pd
 import pytest
 from loguru import logger
+from tracy.process_model_log import get_latest_ops_log_filename
 
-import ttnn
-from models.common.utility_functions import is_blackhole
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    MAX_PAYLOAD_SIZE_BH,
-    MAX_PAYLOAD_SIZE_WH,
-    ExpertMapping,
-    compute_constants,
-    create_fabric_router_config,
-    extract_mesh_config,
-    get_dispatch_input_mesh_mapper,
-    get_ep_mesh_mapper,
-    get_gate_outputs,
-    initialize_test_inputs,
-)
-from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
-from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
 
-WARMUP_ITERS = 2
-MEASURE_ITERS = 5
-assert MEASURE_ITERS % 2 == 1, "MEASURE_ITERS must be odd for _median to return the exact median"
 
-SEQ_LEN_PER_CHIP = 3200
-EMB_DIM = 7168
-NUM_ROUTED_EXPERTS = 64
-NUM_EXPERTS_PER_TOK = 2
-CAPACITY_FACTOR = 2
+def merge_device_rows(df):
+    """
+    Merge multi-device operation rows into single rows.
 
-# Key analysis names from the device profiler (see cpp_device_analyses.json).
-DEVICE_KERNEL_DURATION = "DEVICE KERNEL DURATION [ns]"
+    For collective operations (AllGather, ReduceScatter, AllReduce, Matmul_RS):
+      Uses AVERAGE duration across devices (synchronized operations)
 
-_REQUIRED_PROFILER_ENV_VARS = [
-    "TT_METAL_DEVICE_PROFILER",
-    "TT_METAL_PROFILER_MID_RUN_DUMP",
-    "TT_METAL_PROFILER_CPP_POST_PROCESS",
+    For non-collective operations:
+      Uses MAX duration across devices (critical path bottleneck)
+
+    Args:
+        df: pandas DataFrame with profiler data
+
+    Returns:
+        DataFrame with merged rows
+    """
+    block_by_device = defaultdict(list)
+
+    for _, row in df.iterrows():
+        op_name = row["OP CODE"]
+        op_type = row["OP TYPE"]
+        if op_type == "tt_dnn_device":
+            device_id = int(row["DEVICE ID"])
+            block_by_device[device_id].append((op_name, row.to_dict()))
+
+    device_ids = sorted(block_by_device.keys())
+    merged_blocks = []
+
+    while device_ids and max(len(block_by_device[device_id]) for device_id in device_ids) > 0:
+        blocks = []
+        op_name = None
+
+        for device_id in device_ids:
+            if len(block_by_device[device_id]) > 0:
+                current_op_name, current_block = block_by_device[device_id].pop(0)
+                if op_name is None:
+                    op_name = current_op_name
+                elif op_name != current_op_name:
+                    logger.warning(f"Mismatched operations: {op_name} vs {current_op_name}")
+                blocks.append((device_id, current_block))
+            else:
+                logger.warning(f"Device {device_id} missing operation at this index")
+
+        if not blocks:
+            continue
+
+        is_collective = (
+            "AllGather" in op_name or "ReduceScatter" in op_name or "AllReduce" in op_name or "Matmul_RS" in op_name
+        )
+
+        if is_collective:
+            device_kernel_durations = [
+                d["DEVICE KERNEL DURATION [ns]"]
+                for _, d in blocks
+                if "DEVICE KERNEL DURATION [ns]" in d and not math.isnan(d["DEVICE KERNEL DURATION [ns]"])
+            ]
+            average_duration = (
+                sum(device_kernel_durations) / len(device_kernel_durations) if device_kernel_durations else float("nan")
+            )
+            base_block = blocks[0][1].copy()
+            base_block["DEVICE KERNEL DURATION [ns]"] = average_duration
+            merged_blocks.append(base_block)
+        else:
+            max_duration_block = max(blocks, key=lambda x: x[1].get("DEVICE KERNEL DURATION [ns]", 0))
+            merged_blocks.append(max_duration_block[1])
+
+    return pd.DataFrame(merged_blocks)
+
+
+def run_model_device_perf_test_with_merge(
+    command: str,
+    expected_device_perf_ns_per_iteration: float,
+    subdir: str,
+    model_name: str,
+    num_iterations: int = 1,
+    batch_size: int = 1,
+    margin: float = 0.015,
+    comments: str = "",
+    op_filter: str = "",
+):
+    """
+    Run device performance test with multi-device row merging.
+
+    Extends `run_model_device_perf_test` with multi-chip row merging:
+    CCL ops are averaged across devices, non-CCL ops use the
+    slowest device's duration (critical path).
+
+    `op_filter`, if set, restricts the measurement to rows whose OP CODE
+    contains the given substring — useful when the worker pytest runs more
+    than one op and only one of them is under test.
+    """
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
+
+    post_processed_results = run_device_perf(
+        command, subdir=subdir, num_iterations=num_iterations, cols=cols, batch_size=batch_size
+    )
+
+    filename = get_latest_ops_log_filename(subdir)
+    df = pd.read_csv(filename)
+
+    total_rows = len(df)
+    device_rows_before_filter = len(df[df["OP TYPE"] == "tt_dnn_device"])
+
+    logger.info(f"CSV total rows: {total_rows}")
+    logger.info(f"Device operation rows: {device_rows_before_filter}")
+
+    df = df[df["OP TYPE"] == "tt_dnn_device"]
+
+    if op_filter:
+        df = df[df["OP CODE"].str.contains(op_filter, na=False)]
+        assert not df.empty, f"op_filter={op_filter!r} matched no rows in {filename}"
+        logger.info(f"Rows after op_filter={op_filter!r}: {len(df)}")
+
+    logger.info(f"Device rows before merge: {len(df)}")
+    df_merged = merge_device_rows(df)
+    logger.info(f"Device rows after merge: {len(df_merged)}")
+
+    if not df_merged.empty:
+        merged_kernel_durations = df_merged["DEVICE KERNEL DURATION [ns]"].dropna().tolist()
+        if merged_kernel_durations:
+            merged_sum_ns = sum(merged_kernel_durations)
+            logger.info(f"Merged operations count: {len(merged_kernel_durations)}")
+            logger.info(f"Merged sum (ns): {merged_sum_ns} ({merged_sum_ns / 1000:.1f} μs)")
+            logger.info(
+                f"Original post_processed_results[{inference_time_key}]: "
+                f"{post_processed_results.get(inference_time_key, 'N/A')}"
+            )
+            post_processed_results[inference_time_key] = merged_sum_ns
+
+    expected_perf_cols = {inference_time_key: expected_device_perf_ns_per_iteration}
+    expected_results = check_device_perf(
+        post_processed_results, margin=margin, expected_perf_cols=expected_perf_cols, assert_on_fail=True
+    )
+
+    prep_device_perf_report(
+        model_name=model_name,
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments=comments,
+    )
+
+
+def _perf_param(op, worker_file, worker_test, topo, nlinks, payload, expected_ns, op_filter, margin=0.03):
+    """Build one pytest.param tuple for the perf tests."""
+    worker_id = f"perf-{topo}-8-{nlinks}link-{payload}"
+    return (
+        f"pytest models/demos/deepseek_v3_d_p/tests/pcc/{worker_file}::{worker_test} "
+        f"-k 'perf_no_pcc and {worker_id} and random'",
+        expected_ns,
+        f"deepseek_v3_{op}",
+        f"deepseek_v3_{op}_{topo}_8_{nlinks}link_{payload}",
+        1,  # num_iterations
+        1,  # batch_size
+        margin,
+        f"{topo}-8-{nlinks}link-{payload.upper()}",
+        op_filter,
+    )
+
+
+# Baselines measured on BH LoudBox (bh-rb-01), seq_len=3200, emb=7168, experts=64, top-k=2.
+# Dispatch worker emits only DispatchDeviceOperation -> op_filter is empty.
+# Combine worker runs real dispatch + combine -> op_filter="CombineDeviceOperation".
+
+# CI set (BH LoudBox pipeline): keep small.
+_DISPATCH_PERF_PARAMS = [
+    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "linear", 2, "7k", 3_526_102, ""),
+    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, "7k", 2_823_079, ""),
+]
+_COMBINE_PERF_PARAMS = [
+    _perf_param(
+        "combine",
+        "test_prefill_combine.py",
+        "test_ttnn_combine",
+        "linear",
+        2,
+        "7k",
+        4_335_384,
+        "CombineDeviceOperation",
+    ),
+    _perf_param(
+        "combine", "test_prefill_combine.py", "test_ttnn_combine", "ring", 2, "7k", 3_113_945, "CombineDeviceOperation"
+    ),
 ]
 
-# Populated by test_dispatch_combine_perf; consumed by the print_summary fixture.
-_collected_results: list[dict] = []
-
-
-def _payload_label(payload_size: int) -> str:
-    return f"{payload_size // 1024}K"
-
-
-# ---------------------------------------------------------------------------
-# Device profiler helpers
-# ---------------------------------------------------------------------------
-
-
-def _check_profiler_env():
-    """Raise if the required profiler environment variables are not set."""
-    missing = [v for v in _REQUIRED_PROFILER_ENV_VARS if os.environ.get(v) != "1"]
-    if missing:
-        pytest.skip(
-            f"Device profiler not configured. Set these env vars before device open: "
-            f"{', '.join(f'{v}=1' for v in missing)}"
-        )
-
-
-def _read_device_duration(mesh_device, analysis_name: str = DEVICE_KERNEL_DURATION) -> float:
-    """Read device profiler and return the op duration (us) for the given analysis.
-
-    Calls ReadDeviceProfiler to flush profiler data, then reads the latest
-    programs.  Devices execute in parallel, so the duration is the max across
-    all devices (the slowest device determines the actual wall-clock time).
-    Within each device, program durations are summed (sequential programs).
-    """
-    ttnn.ReadDeviceProfiler(mesh_device)
-    latest = ttnn.get_latest_programs_perf_data()
-
-    if not latest:
-        pytest.fail("ReadDeviceProfiler returned no data -- is TT_METAL_DEVICE_PROFILER=1?")
-
-    # Sum program durations within each device, then take the max across devices.
-    max_device_dur = 0.0
-    for _device_id, programs in latest.items():
-        device_dur = 0.0
-        for program in programs:
-            analysis = program.program_analyses_results.get(analysis_name)
-            if analysis is not None:
-                device_dur += analysis.duration / 1000.0  # ns -> us
-        max_device_dur = max(max_device_dur, device_dur)
-    return max_device_dur
-
-
-def _measure_op(mesh_device, op_fn, num_iters: int) -> list[float]:
-    """Run *op_fn* for *num_iters* and return the device kernel duration (us) per iteration.
-
-    Each iteration: run op -> synchronize -> ReadDeviceProfiler -> max across devices.
-    """
-    iter_durations: list[float] = []
-    for _ in range(num_iters):
-        op_fn()
-        ttnn.synchronize_device(mesh_device)
-        iter_durations.append(_read_device_duration(mesh_device))
-    return iter_durations
-
-
-def _median(values: list[float]) -> float:
-    # MEASURE_ITERS is odd, so s[len(s)//2] is the exact median.
-    s = sorted(values)
-    return s[len(s) // 2]
-
-
-def _stats(times: list[float]) -> tuple[float, float, float, float]:
-    """Return (min, median, avg, max) for *times*."""
-    median = _median(times)
-    return min(times), median, sum(times) / len(times), max(times)
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module", autouse=True)
-def print_summary():
-    """Print a comparison summary table after all parametrized tests in this module complete."""
-    _collected_results.clear()
-    yield
-    if not _collected_results:
-        return
-
-    header = (
-        f"\n{'='*100}\n"
-        f"  COMPARISON SUMMARY  (device kernel duration, median us, {MEASURE_ITERS} iters after {WARMUP_ITERS} warmup)\n"
-        f"  seq_len={SEQ_LEN_PER_CHIP}, emb_dim={EMB_DIM}, experts={NUM_ROUTED_EXPERTS}, top-k={NUM_EXPERTS_PER_TOK}\n"
-        f"{'='*100}\n"
-        f"  {'Config':<30} {'Dispatch':>12} {'Combine':>12} {'Round-trip':>12}\n"
-        f"  {'-'*30} {'-'*12} {'-'*12} {'-'*12}"
+# Full matrix (heavy local/manual run): all 8-chip topo x num_links x payload combos.
+# 14k payloads run on Blackhole only (auto-skipped on Wormhole by the worker).
+# Placeholder expected=1 entries are for configs not yet baselined.
+_DISPATCH_PERF_PARAMS_FULL = [
+    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", topo, nlinks, payload, expected, "")
+    for topo, nlinks, payload, expected in [
+        ("linear", 1, "7k", 5_558_477),
+        ("linear", 2, "7k", 3_533_716),
+        ("linear", 1, "14k", 6_640_253),
+        ("linear", 2, "14k", 3_918_331),
+        ("ring", 1, "7k", 4_794_187),
+        ("ring", 2, "7k", 2_815_844),
+        ("ring", 1, "14k", 4_305_734),
+        ("ring", 2, "14k", 2_619_047),
+    ]
+]
+_COMBINE_PERF_PARAMS_FULL = [
+    _perf_param(
+        "combine",
+        "test_prefill_combine.py",
+        "test_ttnn_combine",
+        topo,
+        nlinks,
+        payload,
+        expected,
+        "CombineDeviceOperation",
     )
-    rows = []
-    for r in _collected_results:
-        rows.append(
-            f"  {r['config']:<30} {r['dispatch_med']:>12.1f} {r['combine_med']:>12.1f} {r['roundtrip_med']:>12.1f}"
-        )
-
-    speedup_lines = []
-    lookup: dict[tuple, dict] = {}
-    for r in _collected_results:
-        lookup[(r["num_devices"], r["topo"], r["num_links"], r["payload_size"])] = r
-
-    def fmt_speedup(base, fast):
-        d_sp = base["dispatch_med"] / fast["dispatch_med"] if fast["dispatch_med"] else 0
-        c_sp = base["combine_med"] / fast["combine_med"] if fast["combine_med"] else 0
-        r_sp = base["roundtrip_med"] / fast["roundtrip_med"] if fast["roundtrip_med"] else 0
-        return f"{d_sp:>12.2f}x {c_sp:>12.2f}x {r_sp:>12.2f}x"
-
-    seen_devices = sorted({r["num_devices"] for r in _collected_results})
-    seen_payloads = sorted({r["payload_size"] for r in _collected_results})
-
-    for ndev in seen_devices:
-        for ps in seen_payloads:
-            # Ring vs Linear comparison (same link count, same payload size)
-            for nlinks in (1, 2):
-                lin = lookup.get((ndev, "Linear", nlinks, ps))
-                ring = lookup.get((ndev, "Ring", nlinks, ps))
-                if lin and ring:
-                    label = f"Ring/Lin {ndev}dev {nlinks}L {_payload_label(ps)}"
-                    speedup_lines.append(f"  {label:<30} {fmt_speedup(lin, ring)}")
-            # 2-link vs 1-link comparison (same topology, same payload size)
-            for topo in ("Linear", "Ring"):
-                one = lookup.get((ndev, topo, 1, ps))
-                two = lookup.get((ndev, topo, 2, ps))
-                if one and two:
-                    label = f"2L/1L {topo[:3]} {ndev}dev {_payload_label(ps)}"
-                    speedup_lines.append(f"  {label:<30} {fmt_speedup(one, two)}")
-
-        # 14K vs 7K payload comparison (same topology, same link count)
-        for topo in ("Linear", "Ring"):
-            for nlinks in (1, 2):
-                small = lookup.get((ndev, topo, nlinks, MAX_PAYLOAD_SIZE_WH))
-                large = lookup.get((ndev, topo, nlinks, MAX_PAYLOAD_SIZE_BH))
-                if small and large:
-                    label = f"14K/7K {topo[:3]} {ndev}dev {nlinks}L"
-                    speedup_lines.append(f"  {label:<30} {fmt_speedup(small, large)}")
-
-    summary = "\n".join([header] + rows)
-    if speedup_lines:
-        summary += (
-            f"\n\n  {'Speedup':<30} {'Dispatch':>12} {'Combine':>12} {'Round-trip':>12}\n"
-            f"  {'-'*30} {'-'*12} {'-'*12} {'-'*12}\n" + "\n".join(speedup_lines)
-        )
-    summary += f"\n{'='*100}"
-    logger.info(summary)
+    for topo, nlinks, payload, expected in [
+        ("linear", 1, "7k", 5_995_117),
+        ("linear", 2, "7k", 4_313_204),
+        ("linear", 1, "14k", 5_952_111),
+        ("linear", 2, "14k", 4_194_514),
+        ("ring", 1, "7k", 5_136_507),
+        ("ring", 2, "7k", 3_083_027),
+        ("ring", 1, "14k", 4_513_822),
+        ("ring", 2, "14k", 2_889_739),
+    ]
+]
 
 
-# ---------------------------------------------------------------------------
-# Test parameters
-# ---------------------------------------------------------------------------
+def _ids_for(params):
+    # model_name (4th tuple element) like deepseek_v3_dispatch_linear_8_2link_7k -> linear-8-2link-7k
+    ids = []
+    for p in params:
+        mn = p[3]
+        mn = mn.removeprefix("deepseek_v3_dispatch_").removeprefix("deepseek_v3_combine_")
+        ids.append(mn.replace("_", "-"))
+    return ids
 
 
-def _make_params(mesh_shape, fabric_config, payload_size, num_links, topology, ring_or_linear):
-    """Build a single pytest.param entry.
-
-    Attaches requires_mesh_topology mark, and a skipif mark for 14K payloads
-    on non-Blackhole architectures (exceeds Wormhole hardware limit).
-    Test ID format: "{topology}-{ndev}-{nlinks}link-{payload_label}".
-    """
-    ps_label = _payload_label(payload_size)
-    marks = [pytest.mark.requires_mesh_topology(mesh_shape=mesh_shape, topology=ring_or_linear)]
-    if payload_size > MAX_PAYLOAD_SIZE_WH:
-        marks.append(
-            pytest.mark.skipif(
-                not is_blackhole(),
-                reason=f"14K payload exceeds Wormhole limit (MAX_PAYLOAD_SIZE_WH={MAX_PAYLOAD_SIZE_WH})",
-            )
-        )
-    ndev = mesh_shape[0] * mesh_shape[1]
-    return pytest.param(
-        mesh_shape,
-        {
-            "fabric_config": fabric_config,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=payload_size),
-        },
-        num_links,
-        topology,
-        payload_size,
-        marks=marks,
-        id=f"{ring_or_linear}-{ndev}-{num_links}link-{ps_label}",
-    )
-
-
-_TEST_PARAMS = []
-for mesh, fab_1d, fab_ring, topo_lin, topo_ring in [
-    ((4, 1), ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_1D_RING, ttnn.Topology.Linear, ttnn.Topology.Ring),
-    ((8, 1), ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_1D_RING, ttnn.Topology.Linear, ttnn.Topology.Ring),
-]:
-    for nlinks in (1, 2):
-        for ps in (MAX_PAYLOAD_SIZE_WH, MAX_PAYLOAD_SIZE_BH):
-            _TEST_PARAMS.append(_make_params(mesh, fab_1d, ps, nlinks, topo_lin, "linear"))
-            _TEST_PARAMS.append(_make_params(mesh, fab_ring, ps, nlinks, topo_ring, "ring"))
-
-
-# ---------------------------------------------------------------------------
-# Test
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology, payload_size",
-    _TEST_PARAMS,
-    indirect=["mesh_device", "device_params"],
+_PARAMS_HEADER = (
+    "command, expected_device_perf_ns_per_iteration, subdir, model_name, "
+    "num_iterations, batch_size, margin, comments, op_filter"
 )
-def test_dispatch_combine_perf(
-    mesh_device,
-    num_links,
-    topology,
-    payload_size,
+
+
+# --- CI (BH LoudBox pipeline) -------------------------------------------------
+
+
+@pytest.mark.parametrize(_PARAMS_HEADER, _DISPATCH_PERF_PARAMS, ids=_ids_for(_DISPATCH_PERF_PARAMS))
+@pytest.mark.models_device_performance_bare_metal
+def test_device_perf_dispatch(
+    command,
+    expected_device_perf_ns_per_iteration,
+    subdir,
+    model_name,
+    num_iterations,
+    batch_size,
+    margin,
+    comments,
+    op_filter,
 ):
-    _check_profiler_env()
-
-    num_devices = mesh_device.get_num_devices()
-    mesh_config = extract_mesh_config(mesh_device)
-    sp_axis = mesh_config.sp_axis
-    dispatch_group_size = mesh_config.dispatch_group_size
-    num_dispatch_groups = mesh_config.num_dispatch_groups
-
-    experts_per_chip, metadata_len, max_dispatched_tokens_per_expert = compute_constants(
-        SEQ_LEN_PER_CHIP, NUM_ROUTED_EXPERTS, NUM_EXPERTS_PER_TOK, num_devices, dispatch_group_size, CAPACITY_FACTOR
+    run_model_device_perf_test_with_merge(
+        command=command,
+        expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,
+        subdir=subdir,
+        model_name=model_name,
+        num_iterations=num_iterations,
+        batch_size=batch_size,
+        margin=margin,
+        comments=comments,
+        op_filter=op_filter,
     )
 
-    topo_name = "Ring" if topology == ttnn.Topology.Ring else "Linear"
-    ps_label = _payload_label(payload_size)
-    logger.info(
-        f"\n{'='*70}\n"
-        f"  PERF TEST: {topo_name} topology, {num_devices} devices, {num_links} link(s), payload={ps_label}\n"
-        f"  seq_len={SEQ_LEN_PER_CHIP}, emb_dim={EMB_DIM}, experts={NUM_ROUTED_EXPERTS}, top-k={NUM_EXPERTS_PER_TOK}\n"
-        f"  experts_per_chip={experts_per_chip}, max_tok_per_expert={max_dispatched_tokens_per_expert}\n"
-        f"  dispatch_group_size={dispatch_group_size}, num_dispatch_groups={num_dispatch_groups}\n"
-        f"{'='*70}"
+
+@pytest.mark.parametrize(_PARAMS_HEADER, _COMBINE_PERF_PARAMS, ids=_ids_for(_COMBINE_PERF_PARAMS))
+@pytest.mark.models_device_performance_bare_metal
+def test_device_perf_combine(
+    command,
+    expected_device_perf_ns_per_iteration,
+    subdir,
+    model_name,
+    num_iterations,
+    batch_size,
+    margin,
+    comments,
+    op_filter,
+):
+    run_model_device_perf_test_with_merge(
+        command=command,
+        expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,
+        subdir=subdir,
+        model_name=model_name,
+        num_iterations=num_iterations,
+        batch_size=batch_size,
+        margin=margin,
+        comments=comments,
+        op_filter=op_filter,
     )
 
-    x, weights, indices = initialize_test_inputs(
-        dispatch_group_size=dispatch_group_size,
-        seq_len_per_chip=SEQ_LEN_PER_CHIP,
-        emb_dim=EMB_DIM,
-        num_routed_experts=NUM_ROUTED_EXPERTS,
-        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
-        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
-        seed=42,
-        num_dispatch_groups=num_dispatch_groups,
+
+# --- Full matrix (manual/local) ----------------------------------------------
+# Not marked models_device_performance_bare_metal so they do not run in CI by default.
+
+
+@pytest.mark.parametrize(_PARAMS_HEADER, _DISPATCH_PERF_PARAMS_FULL, ids=_ids_for(_DISPATCH_PERF_PARAMS_FULL))
+def test_device_perf_dispatch_full(
+    command,
+    expected_device_perf_ns_per_iteration,
+    subdir,
+    model_name,
+    num_iterations,
+    batch_size,
+    margin,
+    comments,
+    op_filter,
+):
+    run_model_device_perf_test_with_merge(
+        command=command,
+        expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,
+        subdir=subdir,
+        model_name=model_name,
+        num_iterations=num_iterations,
+        batch_size=batch_size,
+        margin=margin,
+        comments=comments,
+        op_filter=op_filter,
     )
 
-    mesh_mapper_dispatch_inputs = get_dispatch_input_mesh_mapper(mesh_device, sp_axis)
 
-    tt_x = ttnn.from_torch(
-        x,
-        mesh_mapper=mesh_mapper_dispatch_inputs,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=mesh_device,
-        dtype=ttnn.bfloat16,
-    )
-    tt_weights = ttnn.from_torch(
-        weights,
-        mesh_mapper=mesh_mapper_dispatch_inputs,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=mesh_device,
-        dtype=ttnn.bfloat16,
-    )
-    tt_indices = ttnn.from_torch(
-        indices,
-        mesh_mapper=mesh_mapper_dispatch_inputs,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=mesh_device,
-        dtype=ttnn.int32,
-    )
-
-    expert_offsets, expert_token_counts, _ = get_gate_outputs(
-        indices,
-        dispatch_group_size,
-        NUM_ROUTED_EXPERTS,
-        experts_per_chip,
-        SEQ_LEN_PER_CHIP,
-        NUM_EXPERTS_PER_TOK,
-    )
-
-    expert_dispatch_table = ExpertMapping.create_dispatch_table(
-        num_routed_experts=NUM_ROUTED_EXPERTS,
-        dispatch_group_size=dispatch_group_size,
-        num_dispatch_groups=num_dispatch_groups,
-    )
-
-    tt_expert_offsets = TtDispatchModule.shard_expert_offsets(mesh_device, expert_offsets)
-    tt_expert_dispatch_table = TtDispatchModule.shard_expert_dispatch_table(mesh_device, expert_dispatch_table, sp_axis)
-
-    mesh_mapper_combine_counter = get_ep_mesh_mapper(mesh_device)
-    tt_expert_token_counts = ttnn.from_torch(
-        expert_token_counts,
-        mesh_mapper=mesh_mapper_combine_counter,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=mesh_device,
-        dtype=ttnn.int32,
-    )
-
-    tt_dispatch_module = TtDispatchModule(
-        mesh_device=mesh_device,
-        dispatch_group_size=dispatch_group_size,
-        experts_per_chip=experts_per_chip,
-        num_routed_experts=NUM_ROUTED_EXPERTS,
-        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
-        metadata_len=metadata_len,
-        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
-        seq_len_per_chip=SEQ_LEN_PER_CHIP,
-        emb_dim=EMB_DIM,
-        cluster_axis=sp_axis,
-        num_links=num_links,
-        topology=topology,
-    )
-
-    tt_combine_module = TtCombineModule(
-        mesh_device=mesh_device,
-        dispatch_group_size=dispatch_group_size,
-        num_dispatch_groups=num_dispatch_groups,
-        experts_per_chip=experts_per_chip,
-        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
-        seq_len_per_chip=SEQ_LEN_PER_CHIP,
-        cluster_axis=sp_axis,
-        num_links=num_links,
-        topology=topology,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        init_zeros=True,
-    )
-
-    # Warmup (no profiler reads)
-    for _ in range(WARMUP_ITERS):
-        tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
-            tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
-        )
-        tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
-        ttnn.synchronize_device(mesh_device)
-
-    # Flush any warmup profiler data
-    ttnn.ReadDeviceProfiler(mesh_device)
-
-    # Measure dispatch (device kernel duration per iteration)
-    def run_dispatch():
-        nonlocal tt_dispatched_buffer, tt_metadata
-        tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
-            tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
-        )
-
-    def run_combine():
-        nonlocal tt_output
-        tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
-
-    def run_roundtrip():
-        run_dispatch()
-        run_combine()
-
-    dispatch_durations = _measure_op(mesh_device, run_dispatch, MEASURE_ITERS)
-    combine_durations = _measure_op(mesh_device, run_combine, MEASURE_ITERS)
-    roundtrip_durations = _measure_op(mesh_device, run_roundtrip, MEASURE_ITERS)
-
-    d_min, d_med, d_avg, d_max = _stats(dispatch_durations)
-    c_min, c_med, c_avg, c_max = _stats(combine_durations)
-    r_min, r_med, r_avg, r_max = _stats(roundtrip_durations)
-
-    config_label = f"{topo_name}-{num_devices} ({num_links}L {ps_label})"
-    logger.info(
-        f"\n{'='*70}\n"
-        f"  RESULTS: {topo_name} | {num_devices} devices | {num_links} link(s) | payload={ps_label}\n"
-        f"  Device kernel durations ({MEASURE_ITERS} iters after {WARMUP_ITERS} warmup)\n"
-        f"{'='*70}\n"
-        f"  {'Operation':<20} {'Min (us)':>12} {'Median (us)':>12} {'Avg (us)':>12} {'Max (us)':>12}\n"
-        f"  {'-'*20} {'-'*12} {'-'*12} {'-'*12} {'-'*12}\n"
-        f"  {'Dispatch':<20} {d_min:>12.1f} {d_med:>12.1f} {d_avg:>12.1f} {d_max:>12.1f}\n"
-        f"  {'Combine':<20} {c_min:>12.1f} {c_med:>12.1f} {c_avg:>12.1f} {c_max:>12.1f}\n"
-        f"  {'Dispatch+Combine':<20} {r_min:>12.1f} {r_med:>12.1f} {r_avg:>12.1f} {r_max:>12.1f}\n"
-        f"{'='*70}"
-    )
-
-    _collected_results.append(
-        {
-            "config": config_label,
-            "topo": topo_name,
-            "num_devices": num_devices,
-            "num_links": num_links,
-            "payload_size": payload_size,
-            "dispatch_med": d_med,
-            "combine_med": c_med,
-            "roundtrip_med": r_med,
-        }
+@pytest.mark.parametrize(_PARAMS_HEADER, _COMBINE_PERF_PARAMS_FULL, ids=_ids_for(_COMBINE_PERF_PARAMS_FULL))
+def test_device_perf_combine_full(
+    command,
+    expected_device_perf_ns_per_iteration,
+    subdir,
+    model_name,
+    num_iterations,
+    batch_size,
+    margin,
+    comments,
+    op_filter,
+):
+    run_model_device_perf_test_with_merge(
+        command=command,
+        expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,
+        subdir=subdir,
+        model_name=model_name,
+        num_iterations=num_iterations,
+        batch_size=batch_size,
+        margin=margin,
+        comments=comments,
+        op_filter=op_filter,
     )


### PR DESCRIPTION
### Summary
Performance tests for dispatch and combine for Deepseek prefill were focused on comparsion of different configurations. They were not in CI, and not enforcing any metric comparisons. Additionally they used custom code for perf measurements.

The tests were added to CI, migrated to a more standard framework, perf targets were added and old config comparison was pulled out into a separate script to run after the perf test. It remains out of CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ianastasijevic/deepseek_prefill_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ianastasijevic/deepseek_prefill_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ianastasijevic/deepseek_prefill_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ianastasijevic/deepseek_prefill_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ianastasijevic/deepseek_prefill_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ianastasijevic/deepseek_prefill_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ianastasijevic/deepseek_prefill_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ianastasijevic/deepseek_prefill_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ianastasijevic/deepseek_prefill_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ianastasijevic/deepseek_prefill_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ianastasijevic/deepseek_prefill_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ianastasijevic/deepseek_prefill_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ianastasijevic/deepseek_prefill_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ianastasijevic/deepseek_prefill_perf)
- [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ianastasijevic%2Fdeepseek_prefill_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml)