### PR TITLE
SDPA: make lightweight mask gate compile-time

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1439,10 +1439,11 @@ void apply_causal_mask_lightweight(
 
 /**
  * Context for lightweight mask application in ring joint SDPA.
- * All mask tiles reside in a single CB. A default-constructed instance disables lightweight masking.
+ * All mask tiles reside in a single CB. This struct stores the pre-resolved mask metadata used when
+ * lightweight masking is enabled; enablement itself is controlled by the `lightweight_mask_enabled`
+ * template parameter(s), not by default-constructing this context.
  */
 struct LightweightMaskContext {
-    bool enabled = false;
     bool is_causal = false;                  // True only on ring_iter 0 for causal configs
     uint32_t neginf_tile_idx = 0;            // Index of -inf tile in the mask CB
     uint32_t causal_diag_tile_idx = 0;       // Index of causal diagonal tile in the mask CB
@@ -1587,6 +1588,7 @@ enum SDPAType {
  * @tparam is_chunked - Whether query is chunked
  * @tparam scale_fp32 - FP32 scale factor
  * @tparam sliding_window_size - Sliding window attention size
+ * @tparam lightweight_mask_enabled - Enables the lightweight mask path (compile-time gated)
  *
  * Runtime Parameters:
  * @param Skt - Sequence length in tiles
@@ -1660,7 +1662,8 @@ template <
     bool use_joint_mask,
     bool is_chunked,
     uint32_t scale_fp32,
-    uint32_t sliding_window_size>
+    uint32_t sliding_window_size,
+    bool lightweight_mask_enabled = false>
 void sdpa_inner_loop(
     const uint32_t Skt,
     const uint32_t qk_in0_block_w,
@@ -1859,7 +1862,7 @@ void sdpa_inner_loop(
             if (apply_mask) {
                 /* QK += MASK */
                 reconfig_data_format(cb_qk_im, cb_mask_in);
-                if (lw_mask.enabled) {
+                if constexpr (lightweight_mask_enabled) {
                     // Re-enter reserved state on cb_qk_im so the lightweight mask can be stamped in-place.
                     // matmul_blocks above already pushed the QK tiles, so tiles_received has been bumped;
                     // without the pop+push cycle below, reduce_c's cb_wait_front would return immediately
@@ -2142,7 +2145,8 @@ template <
     bool use_padded_mask,
     bool is_chunked,
     uint32_t scale_fp32,
-    uint32_t sliding_window_size>
+    uint32_t sliding_window_size,
+    bool lightweight_mask_enabled = false>
 void sdpa_standard(
     const uint32_t Skt,
     const uint32_t qk_in0_block_w,
@@ -2199,7 +2203,8 @@ void sdpa_standard(
         false,  // use_joint_mask (not used)
         is_chunked,
         scale_fp32,
-        sliding_window_size>(
+        sliding_window_size,
+        lightweight_mask_enabled>(
         Skt,
         qk_in0_block_w,
         qk_subblock_w,
@@ -2391,7 +2396,8 @@ template <
     uint32_t NH,
     uint32_t DHt,
     uint32_t vDHt,
-    uint32_t scale_fp32>
+    uint32_t scale_fp32,
+    bool lightweight_mask_enabled = false>
 void sdpa_ring(
     const uint32_t qk_in0_block_w,
     const uint32_t qk_subblock_w,
@@ -2464,8 +2470,9 @@ void sdpa_ring(
         false,  // use_joint_mask (not used)
         false,  // is_chunked (not used)
         scale_fp32,
-        0>(  // sliding_window_size (not used)
-        0,   // Skt (not used)
+        0,  // sliding_window_size (not used)
+        lightweight_mask_enabled>(
+        0,  // Skt (not used)
         qk_in0_block_w,
         qk_subblock_w,
         qk_subblock_h,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1344,7 +1344,8 @@ template <
     bool uniform_dataformat = false,
     uint32_t cb_normalized_out = 0,
     uint32_t cb_sum_out = 0,
-    uint32_t cb_sum_in = 0>
+    uint32_t cb_sum_in = 0,
+    bool lightweight_mask_enabled = false>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1452,11 +1453,13 @@ void sdpa_ring_v2(
 
             // Resolve lightweight mask params for partial tile masking
             uint32_t lw_partial_tile_idx = 0;
-            if (apply_mask && lw_mask.enabled) {
-                if (is_global_n_mask_chunk) {
-                    lw_partial_tile_idx = lw_mask.global_n_partial_tile_idx;
-                } else if (is_joint_n_mask_chunk) {
-                    lw_partial_tile_idx = lw_mask.joint_l_partial_tile_idx;
+            if constexpr (lightweight_mask_enabled) {
+                if (apply_mask) {
+                    if (is_global_n_mask_chunk) {
+                        lw_partial_tile_idx = lw_mask.global_n_partial_tile_idx;
+                    } else if (is_joint_n_mask_chunk) {
+                        lw_partial_tile_idx = lw_mask.joint_l_partial_tile_idx;
+                    }
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
@@ -162,7 +162,6 @@ void kernel_main() {
 
         // Build lightweight mask context for this ring iteration
         LightweightMaskContext lw_mask;
-        lw_mask.enabled = needs_lightweight_mask;
         lw_mask.neginf_tile_idx = neginf_tile_idx;
         lw_mask.local_n_padded_tiles = local_n_padded_tiles;
         lw_mask.joint_n_padded_tiles = joint_n_padded_tiles;
@@ -208,7 +207,8 @@ void kernel_main() {
                 uniform_dataformat,
                 cb_out,  // cb_normalized_out — output goes directly to cb_out
                 cb_sum_out,
-                cb_sum_in>(
+                cb_sum_in,
+                needs_lightweight_mask>(
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,
@@ -228,7 +228,17 @@ void kernel_main() {
                 q_per_core,
                 lw_mask);
         } else {
-            sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, NH, DHt, DHt, scale_fp32>(
+            sdpa_ring<
+                cb_qk_im,
+                cb_identity_scale_in,
+                cb_scale_in,
+                Sq_chunk_t,
+                Sk_chunk_t,
+                NH,
+                DHt,
+                DHt,
+                scale_fp32,
+                needs_lightweight_mask>(
                 qk_in0_block_w,
                 qk_subblock_w,
                 qk_subblock_h,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -180,7 +180,6 @@ void kernel_main() {
 
         // Build lightweight mask context for this ring iteration
         LightweightMaskContext lw_mask;
-        lw_mask.enabled = needs_lightweight_mask;
         lw_mask.is_causal = (ring_iter == 0 ? is_causal : false);
         lw_mask.neginf_tile_idx = neginf_tile_idx;
         lw_mask.causal_diag_tile_idx = causal_diag_tile_idx;
@@ -228,7 +227,8 @@ void kernel_main() {
                 uniform_dataformat,
                 cb_out,  // cb_normalized_out — output goes directly to cb_out
                 cb_sum_out,
-                cb_sum_in>(
+                cb_sum_in,
+                needs_lightweight_mask>(
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,
@@ -256,7 +256,17 @@ void kernel_main() {
             }
             bool skip_first_half_q = (ring_index >= ring_id ? false : is_balanced);
 
-            sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, NH, DHt, vDHt, scale_fp32>(
+            sdpa_ring<
+                cb_qk_im,
+                cb_identity_scale_in,
+                cb_scale_in,
+                Sq_chunk_t,
+                Sk_chunk_t,
+                NH,
+                DHt,
+                vDHt,
+                scale_fp32,
+                needs_lightweight_mask>(
                 qk_in0_block_w,
                 qk_subblock_w,
                 qk_subblock_h,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -160,7 +160,6 @@ void kernel_main() {
 
         LightweightMaskContext lw_mask;
         if constexpr (use_lightweight_causal_mask) {
-            lw_mask.enabled = true;
             lw_mask.is_causal = true;
             lw_mask.neginf_tile_idx = 0;
             lw_mask.causal_diag_tile_idx = 1;
@@ -190,7 +189,8 @@ void kernel_main() {
                         use_padded_mask,
                         is_chunked,
                         scale_fp32,
-                        sliding_window_size>(
+                        sliding_window_size,
+                        use_lightweight_causal_mask>(
                         Skt,
                         qk_in0_block_w,
                         qk_subblock_w,


### PR DESCRIPTION
Promote LightweightMaskContext::enabled from a runtime field to a lightweight_mask_enabled template parameter on sdpa_inner_loop, sdpa_standard, sdpa_ring, and sdpa_ring_v2. All three call sites (sdpa.cpp, ring_joint_sdpa.cpp, exp_ring_joint_sdpa.cpp) already compute the flag as a constexpr, so the masking branch can be discarded via if constexpr — shrinking kernel code size on non-masked configs.

## Test plan

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/runs/24675022881)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/runs/24675108400)
- [ ] [![Nightly tt-metal L2 tests (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/causal_mask_code_size_fix)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dnijemcevic/causal_mask_code_size_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dnijemcevic/causal_mask_code_size_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/causal_mask_code_size_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dnijemcevic/causal_mask_code_size_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dnijemcevic/causal_mask_code_size_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dnijemcevic/causal_mask_code_size_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dnijemcevic/causal_mask_code_size_fix)