### PR TITLE
Improve FillPadDeviceOperation performance

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
@@ -12,7 +12,7 @@ from models.common.utility_functions import torch_random, run_for_wormhole_b0
 
 def assert_quality(expected_tensor, actual_tensor):
     # fill_implicit_tile_padding is bit-exact for integer dtypes and deterministic for float paths.
-    # For float outputs we use tight ULP checks (with nonfinite support); for integers we require exact equality.
+    # For float outputs we use tight ULP checks (with nonfinite support); for integers we require equality.
     if actual_tensor.dtype == torch.float32 or actual_tensor.dtype == torch.bfloat16:
         assert_with_ulp(expected_tensor, actual_tensor, ulp_threshold=1, allow_nonfinite=True)
     else:

--- a/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
@@ -6,8 +6,17 @@ import pytest
 import torch
 import ttnn
 import math
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_allclose, assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_equal
 from models.common.utility_functions import torch_random, run_for_wormhole_b0
+
+
+def assert_quality(expected_tensor, actual_tensor):
+    # fill_implicit_tile_padding is bit-exact for integer dtypes and deterministic for float paths.
+    # For float outputs we use tight ULP checks (with nonfinite support); for integers we require exact equality.
+    if actual_tensor.dtype == torch.float32 or actual_tensor.dtype == torch.bfloat16:
+        assert_with_ulp(expected_tensor, actual_tensor, ulp_threshold=1, allow_nonfinite=True)
+    else:
+        assert_equal(expected_tensor, actual_tensor)
 
 
 def create_nd_padded_tiled_tensor(shape, tile_size, fill_value, dtype):
@@ -43,10 +52,6 @@ def create_nd_padded_tiled_tensor(shape, tile_size, fill_value, dtype):
 
     return tensor, padded_tensor
 
-
-import pytest
-import torch
-import ttnn
 
 ttnn_dtype_to_torch_dtype = {
     ttnn.uint16: torch.int16,
@@ -99,16 +104,7 @@ def test_fill_pad_float(
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=output_mem_config)
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
-    if dtype == ttnn.bfloat16:
-        # bf16 tilize/untilize path introduces rounding (~4 bf16 ULPs)
-        assert_with_ulp(
-            padded_torch_tensor.to(torch.bfloat16),
-            padded_torch_output_tensor.to(torch.bfloat16),
-            ulp_threshold=4,
-            allow_nonfinite=True,
-        )
-    else:
-        assert_equal(padded_torch_tensor, padded_torch_output_tensor)
+    assert_quality(padded_torch_tensor, padded_torch_output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -154,7 +150,8 @@ def test_fill_pad_bfloat8_b(
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=output_mem_config)
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
-    assert_allclose(padded_torch_tensor, padded_torch_output_tensor, rtol=0.05, atol=0.025)
+    # bfloat8_b is a reduced-precision format; keep PCC-based validation for stability.
+    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -265,7 +262,7 @@ def test_fill_pad_complex_sharding(device, fill_value, shape, shard_scheme, dtyp
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
-    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor, 0.99)
+    assert_quality(padded_torch_tensor, padded_torch_output_tensor)
 
 
 @pytest.mark.parametrize("fill_value", [1])
@@ -277,7 +274,6 @@ def test_fill_pad_complex_sharding(device, fill_value, shape, shard_scheme, dtyp
         (17, 17),
         (17, 1),
         (16, 16),
-        (17, 17),
         (31, 31),
         (33, 33),
         (97, 97),
@@ -291,7 +287,7 @@ def test_fill_pad_complex_sharding(device, fill_value, shape, shard_scheme, dtyp
         ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint32, ttnn.int32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.uint32, ttnn.int32])
 def test_fill_pad_sharded(device, fill_value, shape, shard_scheme, dtype):
     torch.manual_seed(1234)
     torch_input_tensor, padded_torch_tensor = create_nd_padded_tiled_tensor(
@@ -338,4 +334,4 @@ def test_fill_pad_sharded(device, fill_value, shape, shard_scheme, dtype):
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
-    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor, 0.99)
+    assert_quality(padded_torch_tensor, padded_torch_output_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
@@ -12,6 +12,17 @@ namespace ttnn::prim {
 
 using namespace tt::tt_metal;
 
+FillPadDeviceOperation::program_factory_t FillPadDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    // L1-sharded: each core processes its own shard (no cross-core NOC).
+    // DRAM interleaved / DRAM-sharded (rare): fall through to the regular factory.
+    if (input.is_sharded() && input.memory_config().is_l1()) {
+        return FillPadL1ShardedProgramFactory{};
+    }
+    return FillPadProgramFactory{};
+}
+
 void FillPadDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp
@@ -16,7 +16,9 @@ struct FillPadDeviceOperation {
     using tensor_args_t = FillPadInputs;
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
-    using program_factory_t = std::variant<FillPadProgramFactory>;
+    using program_factory_t = std::variant<FillPadProgramFactory, FillPadL1ShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -3,129 +3,286 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fill_pad_program_factory.hpp"
-#include "ttnn/operations/core/core.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/operations/data_movement/common/common.hpp"
-#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
+#include <algorithm>
+#include <bit>
 
 namespace ttnn::prim {
-
-using namespace ttnn::operations::data_movement;
 
 FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     const FillPadParams& operation_attributes, const FillPadInputs& tensor_args, Tensor& /*tensor_return_value*/) {
     const Tensor& input_tensor = tensor_args.input;
+    TT_FATAL(
+        !input_tensor.is_sharded() || !input_tensor.memory_config().is_l1(),
+        "FillPadProgramFactory called with L1-sharded tensor; use FillPadL1ShardedProgramFactory");
+    TT_FATAL(
+        detail::data_type_to_size.contains(input_tensor.dtype()),
+        "FillPadProgramFactory: unsupported dtype {}",
+        input_tensor.dtype());
+
     const float fill_value = operation_attributes.fill_value;
     tt::tt_metal::IDevice* device = input_tensor.device();
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-
     tt::tt_metal::Buffer* tens_buffer = input_tensor.buffer();
-    TT_ASSERT(tens_buffer != nullptr, "Input buffer should be allocated on device!");
+    TT_FATAL(tens_buffer != nullptr, "Input buffer should be allocated on device!");
 
     const uint32_t input_element_size_bytes = detail::data_type_to_size.at(input_tensor.dtype());
-    const uint32_t cb_page_size = (input_element_size_bytes * tt::constants::FACE_HEIGHT) + sizeof(uint16_t);
+    const uint32_t tile_bytes = tt::tile_size(cb_data_format);
+
     const uint32_t height = input_tensor.logical_shape()[-2];
     const uint32_t width = input_tensor.logical_shape()[-1];
+    const uint32_t N_slices = input_tensor.logical_shape().rank() > 2 ? input_tensor.logical_shape()[-3] : 1u;
 
-    const uint32_t problem_size = input_tensor.logical_shape()[-3];
+    const uint32_t tile_height = input_tensor.tensor_spec().tile().get_height();
+    const uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
+
+    const uint32_t H_tiles = tt::div_up(height, tile_height);
+    const uint32_t W_tiles = tt::div_up(width, tile_width);
+    const uint32_t H_mod32 = height % tile_height;
+    const uint32_t W_mod32 = width % tile_width;
+    const uint32_t has_right_pad = W_mod32 != 0;
+    const uint32_t has_bottom_pad = H_mod32 != 0;
+
+    const bool is_float_type =
+        (input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32);
+    const bool is_fp32 = (input_tensor.dtype() == DataType::FLOAT32);
+    const bool is_uint32 = (input_tensor.dtype() == DataType::UINT32);
+    const bool is_int32 = (input_tensor.dtype() == DataType::INT32);
+    // 32-bit integer types need fp32_dest_acc_en so DST holds full 32-bit values
+    // and where_tile<UInt32/Int32> can use INT32-mode SFPLOAD/SFPSTORE correctly.
+    const bool need_fp32_dest_acc = is_fp32 || is_uint32 || is_int32;
+    // Float types: raw bit pattern of fill_value for fill_tile_bitcast.
+    // Integer types: packed native bit pattern for fill_tile_int.
+    const uint32_t fill_bits =
+        is_float_type ? std::bit_cast<uint32_t>(fill_value) : detail::pack_fill_value(input_tensor.dtype(), fill_value);
 
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     const uint32_t num_cores_x = compute_with_storage_grid_size.x;
     const uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
+    // Unified border-tile split across all slices.
+    //   R = rows per slice in the right block (H_tiles-1 if both pads, else H_tiles).
+    //   C = cols per slice in the bottom block (W_tiles-1 if both pads, else W_tiles).
+    // The global tile-index space is three contiguous blocks:
+    //   [0, T_right)                 – right-column border tiles
+    //   [T_right, T_right+T_bottom)  – bottom-row border tiles (incl. corner if !has_right_pad)
+    //   [..., total_work)            – corner tiles (only when has_right_pad && has_bottom_pad)
+    const uint32_t R = has_right_pad ? (has_bottom_pad ? (H_tiles - 1u) : H_tiles) : 0u;
+    const uint32_t C = has_bottom_pad ? (has_right_pad ? (W_tiles - 1u) : W_tiles) : 0u;
+    const uint32_t T_right = has_right_pad ? (N_slices * R) : 0u;
+    const uint32_t T_bottom = has_bottom_pad ? (N_slices * C) : 0u;
+    const uint32_t T_corner = (has_right_pad && has_bottom_pad) ? N_slices : 0u;
+    const uint32_t total_work = T_right + T_bottom + T_corner;
+
     const auto
-        [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
-            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, problem_size);
+        [num_cores, all_cores, core_group_1, core_group_2, num_work_per_core_group_1, num_work_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, total_work);
     const uint32_t g1_numcores = core_group_1.num_cores();
 
-    constexpr uint32_t src0_cb_index = tt::CBIndex::c_0;
-    const tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(cb_page_size * 2, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, cb_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    // ---- Circular buffers ----
+    constexpr uint32_t cb_data_in_idx = tt::CBIndex::c_0;
+    constexpr uint32_t cb_right_mask_idx = tt::CBIndex::c_1;
+    constexpr uint32_t cb_bot_mask_idx = tt::CBIndex::c_2;
+    constexpr uint32_t cb_data_out_idx = tt::CBIndex::c_16;
 
-    const bool src_is_dram = tens_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-
-    // pack bf16 vals
-    uint32_t packed_fill_value = 0;
-    if (input_tensor.dtype() == DataType::BFLOAT16) {
-        packed_fill_value = pack_two_bfloat16_into_uint32({bfloat16(fill_value), bfloat16(fill_value)});
-    } else if (input_tensor.dtype() == DataType::UINT16) {
-        packed_fill_value = pack_two_uint16_into_uint32({fill_value, fill_value});
-    } else if (input_tensor.dtype() == DataType::FLOAT32) {
-        packed_fill_value = std::bit_cast<uint32_t>(fill_value);
-    } else {
-        packed_fill_value = static_cast<std::uint32_t>(fill_value);
+    // CB[0]: data in, double-buffered (reader → compute)
+    {
+        const tt::tt_metal::CircularBufferConfig cb_config =
+            tt::tt_metal::CircularBufferConfig(tile_bytes * 2, {{cb_data_in_idx, cb_data_format}})
+                .set_page_size(cb_data_in_idx, tile_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
     }
 
-    const uint32_t padded_height = tt::div_up(height, tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;
-    const uint32_t padded_width = tt::div_up(width, tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;
-    const uint32_t tiles_per_2d_tensor =
-        padded_height / tt::constants::TILE_HEIGHT * padded_width / tt::constants::TILE_HEIGHT;
-    const uint32_t tiles_per_tile_row = padded_width / tt::constants::TILE_HEIGHT;
-
-    const bool sharded = input_tensor.memory_config().memory_layout() != TensorMemoryLayout::INTERLEAVED;
-
-    std::vector<uint32_t> writer_compile_time_args = {
-        static_cast<std::uint32_t>(src0_cb_index),
-        static_cast<std::uint32_t>(src_is_dram),
-        static_cast<std::uint32_t>(packed_fill_value),
-        static_cast<std::uint32_t>(input_element_size_bytes),
-        static_cast<std::uint32_t>(height),
-        static_cast<std::uint32_t>(width),
-        static_cast<std::uint32_t>(padded_height),
-        static_cast<std::uint32_t>(padded_width),
-        static_cast<std::uint32_t>(tiles_per_2d_tensor),
-        static_cast<std::uint32_t>(tiles_per_tile_row),
-        static_cast<std::uint32_t>(tt::constants::TILE_HEIGHT),
-        static_cast<std::uint32_t>(tt::constants::FACE_HEIGHT)};
-
-    std::map<std::string, std::string> compute_defines;
-    if (sharded) {
-        shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_time_args);
-        compute_defines["SHARDED"] = "1";
-    } else {
-        tt::tt_metal::TensorAccessorArgs(*tens_buffer).append_to(writer_compile_time_args);
+    // CB[1]: right mask, capacity=1 (writer → compute, persistent; only when has_right_pad)
+    if (has_right_pad) {
+        const tt::tt_metal::CircularBufferConfig cb_config =
+            tt::tt_metal::CircularBufferConfig(tile_bytes, {{cb_right_mask_idx, cb_data_format}})
+                .set_page_size(cb_right_mask_idx, tile_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
     }
+
+    // CB[2]: bottom mask, capacity=1 (writer → compute, persistent; only when has_bottom_pad)
+    if (has_bottom_pad) {
+        const tt::tt_metal::CircularBufferConfig cb_config =
+            tt::tt_metal::CircularBufferConfig(tile_bytes, {{cb_bot_mask_idx, cb_data_format}})
+                .set_page_size(cb_bot_mask_idx, tile_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+    }
+
+    // CB[16]: data out, double-buffered (compute → writer)
+    {
+        const tt::tt_metal::CircularBufferConfig cb_config =
+            tt::tt_metal::CircularBufferConfig(tile_bytes * 2, {{cb_data_out_idx, cb_data_format}})
+                .set_page_size(cb_data_out_idx, tile_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+    }
+
+    // ---- Kernel defines ----
+    std::map<std::string, std::string> kernel_defines;
+    kernel_defines["MASK_ELEM_UINT"] = (input_element_size_bytes == 2) ? "uint16_t" : "uint32_t";
+    kernel_defines["MASK_VALUE"] = is_fp32 ? "0x3F800000u" : is_float_type ? "0x3F80u" : "1u";
+    kernel_defines["FILL_PAD_DATA_FMT"] = detail::get_where_data_fmt(input_tensor.dtype());
+    if (!is_float_type) {
+        kernel_defines["FILL_PAD_FILL_DATA_FMT"] = detail::get_fill_int_fmt(input_tensor.dtype());
+    }
+    kernel_defines["FILL_PAD_FILL_FN"] = is_float_type ? "fill_tile_bitcast" : "fill_tile_int<FILL_PAD_FILL_DATA_FMT>";
+    kernel_defines["FILL_PAD_FILL_ARG"] = "fill_bits";
+
+    // ---- Reader CT args ----
+    // [0] W_tiles, [1] H_tiles, [2] N_slices, [3] has_right_pad, [4] has_bottom_pad,
+    // [5] W_mod32, [6] H_mod32, [7] elem_size, [8] fill_bits (unused by reader), [9] cb_data_in_idx=0,
+    // [10+] accessor args
+    std::vector<uint32_t> reader_ct = {
+        W_tiles,
+        H_tiles,
+        N_slices,
+        has_right_pad,
+        has_bottom_pad,
+        W_mod32,
+        H_mod32,
+        input_element_size_bytes,
+        fill_bits,
+        static_cast<uint32_t>(cb_data_in_idx),
+    };
+    tt::tt_metal::TensorAccessorArgs(*tens_buffer).append_to(reader_ct);
+
+    // ---- Writer CT args ----
+    // [0] W_tiles, [1] H_tiles, [2] N_slices, [3] has_right_pad, [4] has_bottom_pad,
+    // [5] W_mod32, [6] H_mod32,
+    // [7] cb_right_mask=1, [8] cb_bot_mask=2, [9] cb_data_out=16,
+    // [10+] accessor args
+    std::vector<uint32_t> writer_ct = {
+        W_tiles,
+        H_tiles,
+        N_slices,
+        has_right_pad,
+        has_bottom_pad,
+        W_mod32,
+        H_mod32,
+        static_cast<uint32_t>(cb_right_mask_idx),
+        static_cast<uint32_t>(cb_bot_mask_idx),
+        static_cast<uint32_t>(cb_data_out_idx),
+    };
+    tt::tt_metal::TensorAccessorArgs(*tens_buffer).append_to(writer_ct);
+
+    // ---- Compute CT args (no accessor args) ----
+    // [0] W_tiles, [1] H_tiles, [2] has_right_pad, [3] has_bottom_pad,
+    // [4] elem_size, [5] fill_bits, [6] cb_data_in=0, [7] cb_right_mask=1,
+    // [8] cb_bot_mask=2, [9] cb_data_out=16
+    const std::vector<uint32_t> compute_ct = {
+        W_tiles,
+        H_tiles,
+        has_right_pad,
+        has_bottom_pad,
+        input_element_size_bytes,
+        fill_bits,
+        static_cast<uint32_t>(cb_data_in_idx),
+        static_cast<uint32_t>(cb_right_mask_idx),
+        static_cast<uint32_t>(cb_bot_mask_idx),
+        static_cast<uint32_t>(cb_data_out_idx),
+    };
+
+    // ---- Kernel creation ----
+    const tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct, kernel_defines));
 
     const tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp",
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig(
-            writer_compile_time_args, compute_defines));  // writer only for in-place operation
+        tt::tt_metal::WriterDataMovementConfig(writer_ct, kernel_defines));
 
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (is_fp32) {
+        unpack_to_dest_mode[cb_data_in_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[cb_right_mask_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[cb_bot_mask_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    const tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp",
+        all_cores,
+        tt::tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = need_fp32_dest_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .compile_args = compute_ct,
+            .defines = kernel_defines,
+        });
+
+    // ---- Per-core runtime args ----
+    // Each core's global range [work_start, work_start + num_work) is intersected with the three
+    // global blocks to produce per-phase (start, num) pairs. Phases with num==0 are skipped in the
+    // kernels.
     const std::vector<CoreCoord> cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
-    std::vector<uint32_t> writer_runtime_args = {
-        static_cast<std::uint32_t>(tens_buffer->address()),
-        static_cast<std::uint32_t>(cb_page_size),
-        static_cast<std::uint32_t>(0),
-        static_cast<std::uint32_t>(0)};
-
-    uint32_t tile_offset = 0;
+    uint32_t work_start = 0;
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores[i];
-        const uint32_t local_num_2d_tensors =
-            i < g1_numcores ? num_blocks_per_core_group_1 : num_blocks_per_core_group_2;
-        {
-            writer_runtime_args[2] = tile_offset;
-            writer_runtime_args[3] = local_num_2d_tensors;
-            if (sharded) {
-                shard_builder::extend_sharding_run_time_args(input_tensor, writer_runtime_args);
-            }
-            tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-        }
+        const uint32_t num_work = (i < g1_numcores) ? num_work_per_core_group_1 : num_work_per_core_group_2;
 
-        tile_offset += local_num_2d_tensors * tiles_per_2d_tensor;
+        // Intersect [work_start, work_start + num_work) with the three global blocks.
+        const uint32_t work_end = work_start + num_work;
+        auto intersect = [work_start, work_end](
+                             uint32_t block_start, uint32_t block_size, uint32_t& out_start, uint32_t& out_num) {
+            if (block_size == 0u) {
+                out_start = 0u;
+                out_num = 0u;
+                return;
+            }
+            const uint32_t block_end = block_start + block_size;
+            const uint32_t lo = std::max(work_start, block_start);
+            const uint32_t hi = std::min(work_end, block_end);
+            if (lo >= hi) {
+                out_start = 0u;
+                out_num = 0u;
+            } else {
+                out_start = lo - block_start;
+                out_num = hi - lo;
+            }
+        };
+
+        uint32_t start_right = 0, num_right = 0;
+        uint32_t start_bottom = 0, num_bottom = 0;
+        uint32_t start_corner = 0, num_corner = 0;
+        intersect(0u, T_right, start_right, num_right);
+        intersect(T_right, T_bottom, start_bottom, num_bottom);
+        intersect(T_right + T_bottom, T_corner, start_corner, num_corner);
+
+        const std::vector<uint32_t> rt_args = {
+            static_cast<uint32_t>(tens_buffer->address()),
+            start_right,
+            num_right,
+            start_bottom,
+            num_bottom,
+            start_corner,
+            num_corner,
+        };
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, rt_args);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, rt_args);
+
+        // Compute RT: per-phase counts; starts are not needed (CBs are FIFO).
+        tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, {num_right, num_bottom, num_corner});
+
+        work_start = work_end;
     }
 
     return cached_program_t{
-        std::move(program), shared_variables_t{.writer_kernel_id = writer_kernel_id, .cores = cores}};
+        std::move(program),
+        shared_variables_t{
+            .reader_kernel_id = reader_kernel_id,
+            .writer_kernel_id = writer_kernel_id,
+            .compute_kernel_id = compute_kernel_id,
+            .cores = cores,
+        }};
 }
 
 void FillPadProgramFactory::override_runtime_arguments(
@@ -137,14 +294,369 @@ void FillPadProgramFactory::override_runtime_arguments(
     tt::tt_metal::Buffer* tens_buffer = input_tensor.buffer();
 
     tt::tt_metal::Program& program = cached_program.program;
+    const tt::tt_metal::KernelHandle reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
     const tt::tt_metal::KernelHandle writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
     const auto& cores = cached_program.shared_variables.cores;
 
+    auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
     auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
 
     for (const auto& core : cores) {
-        auto& runtime_args = writer_runtime_args[core.x][core.y];
-        runtime_args[0] = tens_buffer->address();
+        reader_runtime_args[core.x][core.y][0] = tens_buffer->address();
+        writer_runtime_args[core.x][core.y][0] = tens_buffer->address();
+    }
+}
+
+FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory::create(
+    const FillPadParams& operation_attributes, const FillPadInputs& tensor_args, Tensor& /*tensor_return_value*/) {
+    const Tensor& input_tensor = tensor_args.input;
+    TT_FATAL(
+        input_tensor.is_sharded() && input_tensor.memory_config().is_l1(),
+        "FillPadL1ShardedProgramFactory requires an L1-sharded input tensor");
+    TT_FATAL(
+        detail::data_type_to_size.contains(input_tensor.dtype()),
+        "FillPadL1ShardedProgramFactory: unsupported dtype {}",
+        input_tensor.dtype());
+
+    const float fill_value = operation_attributes.fill_value;
+
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    const tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::tt_metal::Buffer* tens_buffer = input_tensor.buffer();
+    TT_FATAL(tens_buffer != nullptr, "Input buffer should be allocated on device!");
+
+    const uint32_t input_element_size_bytes = detail::data_type_to_size.at(input_tensor.dtype());
+    const uint32_t tile_bytes = tt::tile_size(cb_data_format);
+
+    const uint32_t height = input_tensor.logical_shape()[-2];
+    const uint32_t width = input_tensor.logical_shape()[-1];
+    const uint32_t N_slices = input_tensor.logical_shape().rank() > 2 ? input_tensor.logical_shape()[-3] : 1u;
+
+    TT_FATAL(N_slices == 1, "FillPadL1ShardedProgramFactory: N_slices > 1 not yet supported (got {})", N_slices);
+
+    const uint32_t tile_height = input_tensor.tensor_spec().tile().get_height();
+    const uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
+
+    const uint32_t H_tiles = tt::div_up(height, tile_height);
+    const uint32_t W_tiles_tensor = tt::div_up(width, tile_width);
+    const uint32_t W_mod32 = width % tile_width;
+    const uint32_t H_mod32 = height % tile_height;
+    const uint32_t has_right_pad = W_mod32 != 0;
+    const uint32_t has_bottom_pad = H_mod32 != 0;
+
+    // ---- Shard geometry ----
+    const auto layout = input_tensor.memory_config().memory_layout();
+    const tt::tt_metal::ShardSpec& shard_spec = input_tensor.shard_spec().value();
+    const bool rm_orientation = (shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+    const tt::tt_metal::ShardSpecBuffer& buf_shard_spec = tens_buffer->shard_spec();
+    const auto [pages_per_shard_y, pages_per_shard_x] = buf_shard_spec.shape_in_pages();
+    const uint32_t W_tiles = pages_per_shard_x;  // shard width in tiles (CT arg for kernels)
+
+    // Ordered shard cores — same ordering used by generate_buffer_page_mapping.
+    const std::vector<CoreCoord> all_shard_cores = corerange_to_cores(shard_spec.grid, std::nullopt, rm_orientation);
+    const CoreRange bb = shard_spec.grid.bounding_box();
+    const uint32_t num_cols = bb.end_coord.x - bb.start_coord.x + 1;
+    const uint32_t num_rows = bb.end_coord.y - bb.start_coord.y + 1;
+
+    // ---- Per-core properties ----
+    // Each core's (row, col) in the shard grid determines h_start and w_start, which in turn
+    // determine whether it touches the right or bottom edge of the tensor.
+    //   HEIGHT_SHARDED: row=i, col=0  (full-width shards; all touch the right edge)
+    //   WIDTH_SHARDED:  row=0, col=i  (full-height shards; all touch the bottom edge)
+    //   BLOCK_SHARDED:  row/col from 2-D grid layout
+    struct ShardCoreInfo {
+        CoreCoord coord;
+        uint32_t shard_H_tiles;
+        uint32_t rp;  // has_right_pad for this core (CT binary selector)
+        uint32_t bp;  // has_bottom_pad for this core (CT binary selector for compute)
+        uint32_t num_work;
+        uint32_t local_valid_w;    // min(pages_per_shard_x, W_tiles_tensor - w_start)
+        uint32_t local_right_col;  // local_valid_w - 1; right-border tile's column within this shard
+    };
+
+    std::vector<ShardCoreInfo> active;
+
+    for (uint32_t i = 0; i < static_cast<uint32_t>(all_shard_cores.size()); ++i) {
+        uint32_t row, col;
+        if (layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            row = i;
+            col = 0;
+        } else if (layout == TensorMemoryLayout::WIDTH_SHARDED) {
+            row = 0;
+            col = i;
+        } else {  // BLOCK_SHARDED
+            if (rm_orientation) {
+                row = i / num_cols;
+                col = i % num_cols;
+            } else {
+                col = i / num_rows;
+                row = i % num_rows;
+            }
+        }
+
+        const uint32_t h_start = row * pages_per_shard_y;
+        const uint32_t w_start = col * pages_per_shard_x;
+
+        if (h_start >= H_tiles || w_start >= W_tiles_tensor) {
+            continue;  // core's shard is outside the valid tile range
+        }
+
+        const uint32_t shard_h = std::min(pages_per_shard_y, H_tiles - h_start);
+        const uint32_t core_rp = (has_right_pad && w_start + pages_per_shard_x >= W_tiles_tensor) ? 1u : 0u;
+        const uint32_t core_bp = (has_bottom_pad && h_start + pages_per_shard_y >= H_tiles) ? 1u : 0u;
+        const uint32_t nw = core_bp ? 1u : (core_rp ? shard_h : 0u);
+        const uint32_t local_valid_w = std::min(pages_per_shard_x, W_tiles_tensor - w_start);
+        const uint32_t local_right_col = local_valid_w - 1u;
+
+        active.push_back({all_shard_cores[i], shard_h, core_rp, core_bp, nw, local_valid_w, local_right_col});
+    }
+
+    TT_FATAL(!active.empty(), "FillPadL1ShardedProgramFactory: no active shard cores");
+
+    // ---- Build kernel groups ----
+    // Reader/writer: binary key = rp (has_right_pad); has_bottom_pad_core is RT.
+    // Compute: binary key = (rp, bp, H_tiles, effective_W).
+    //   For bp=0 (Mode A), H_tiles is unused — all bp=0 cores share a binary with H=pages_per_shard_y.
+    //   For bp=1 (Mode B), H_tiles drives right_rows = H_tiles - 1; use actual shard height.
+    //   effective_W = local_valid_w; equals pages_per_shard_x for fully-packed shards, less for
+    //   partially-filled rightmost shards (W_tiles_tensor % pages_per_shard_x != 0).
+    struct ComputeKey {
+        uint32_t rp, bp, H, effective_W;
+        bool operator<(const ComputeKey& o) const {
+            if (rp != o.rp) {
+                return rp < o.rp;
+            }
+            if (bp != o.bp) {
+                return bp < o.bp;
+            }
+            if (H != o.H) {
+                return H < o.H;
+            }
+            return effective_W < o.effective_W;
+        }
+    };
+
+    std::array<std::vector<CoreRange>, 2> rw_ranges;
+    std::map<ComputeKey, std::vector<CoreRange>> compute_ranges;
+
+    for (const auto& ci : active) {
+        rw_ranges[ci.rp].emplace_back(ci.coord, ci.coord);
+        const uint32_t key_H = ci.bp ? ci.shard_H_tiles : pages_per_shard_y;
+        compute_ranges[{ci.rp, ci.bp, key_H, ci.local_valid_w}].emplace_back(ci.coord, ci.coord);
+    }
+
+    // All-active CoreRangeSet for CB creation.
+    std::vector<CoreRange> all_active_vec;
+    for (const auto& ci : active) {
+        all_active_vec.emplace_back(ci.coord, ci.coord);
+    }
+    const CoreRangeSet all_active_set(all_active_vec);
+
+    const bool is_float_type =
+        (input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32);
+    const bool is_fp32 = (input_tensor.dtype() == DataType::FLOAT32);
+    const bool is_uint32 = (input_tensor.dtype() == DataType::UINT32);
+    const bool is_int32 = (input_tensor.dtype() == DataType::INT32);
+    const bool need_fp32_dest_acc = is_fp32 || is_uint32 || is_int32;
+    const uint32_t fill_bits =
+        is_float_type ? std::bit_cast<uint32_t>(fill_value) : detail::pack_fill_value(input_tensor.dtype(), fill_value);
+
+    // ---- CB indices ----
+    constexpr uint32_t cb_data_in_idx = tt::CBIndex::c_0;
+    constexpr uint32_t cb_right_mask_idx = tt::CBIndex::c_1;
+    constexpr uint32_t cb_bot_mask_idx = tt::CBIndex::c_2;
+    constexpr uint32_t cb_data_out_idx = tt::CBIndex::c_16;
+
+    // ---- Circular buffers (all active cores) ----
+    {
+        const tt::tt_metal::CircularBufferConfig cb_config =
+            tt::tt_metal::CircularBufferConfig(tile_bytes * 2, {{cb_data_in_idx, cb_data_format}})
+                .set_page_size(cb_data_in_idx, tile_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_active_set, cb_config);
+    }
+    if (has_right_pad) {
+        const tt::tt_metal::CircularBufferConfig cb_config =
+            tt::tt_metal::CircularBufferConfig(tile_bytes, {{cb_right_mask_idx, cb_data_format}})
+                .set_page_size(cb_right_mask_idx, tile_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_active_set, cb_config);
+    }
+    if (has_bottom_pad) {
+        const tt::tt_metal::CircularBufferConfig cb_config =
+            tt::tt_metal::CircularBufferConfig(tile_bytes, {{cb_bot_mask_idx, cb_data_format}})
+                .set_page_size(cb_bot_mask_idx, tile_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_active_set, cb_config);
+    }
+    {
+        const tt::tt_metal::CircularBufferConfig cb_config =
+            tt::tt_metal::CircularBufferConfig(tile_bytes * 2, {{cb_data_out_idx, cb_data_format}})
+                .set_page_size(cb_data_out_idx, tile_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_active_set, cb_config);
+    }
+
+    // ---- Kernel defines ----
+    std::map<std::string, std::string> kernel_defines;
+    kernel_defines["MASK_ELEM_UINT"] = (input_element_size_bytes == 2) ? "uint16_t" : "uint32_t";
+    kernel_defines["MASK_VALUE"] = is_fp32 ? "0x3F800000u" : is_float_type ? "0x3F80u" : "1u";
+    kernel_defines["FILL_PAD_DATA_FMT"] = detail::get_where_data_fmt(input_tensor.dtype());
+    if (!is_float_type) {
+        kernel_defines["FILL_PAD_FILL_DATA_FMT"] = detail::get_fill_int_fmt(input_tensor.dtype());
+    }
+    kernel_defines["FILL_PAD_FILL_FN"] = is_float_type ? "fill_tile_bitcast" : "fill_tile_int<FILL_PAD_FILL_DATA_FMT>";
+    kernel_defines["FILL_PAD_FILL_ARG"] = "fill_bits";
+
+    // ---- Reader kernels (one per has_right_pad value) ----
+    // CT: [0] W_tiles, [1] has_right_pad, [2] elem_size, [3] cb_data_in
+    std::array<tt::tt_metal::KernelHandle, 2> reader_kernel_ids = {0, 0};
+    for (uint32_t rp = 0; rp <= 1; ++rp) {
+        if (rw_ranges[rp].empty()) {
+            continue;
+        }
+        const std::vector<uint32_t> reader_ct = {
+            W_tiles, rp, input_element_size_bytes, static_cast<uint32_t>(cb_data_in_idx)};
+        reader_kernel_ids[rp] = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp",
+            CoreRangeSet(rw_ranges[rp]),
+            tt::tt_metal::ReaderDataMovementConfig(reader_ct, kernel_defines));
+    }
+
+    // ---- Writer kernels (one per has_right_pad value) ----
+    // CT: [0] W_tiles, [1] has_right_pad, [2] W_mod32, [3] H_mod32,
+    //     [4] cb_right_mask, [5] cb_bot_mask, [6] cb_data_out
+    std::array<tt::tt_metal::KernelHandle, 2> writer_kernel_ids = {0, 0};
+    for (uint32_t rp = 0; rp <= 1; ++rp) {
+        if (rw_ranges[rp].empty()) {
+            continue;
+        }
+        const std::vector<uint32_t> writer_ct = {
+            W_tiles,
+            rp,
+            W_mod32,
+            H_mod32,
+            static_cast<uint32_t>(cb_right_mask_idx),
+            static_cast<uint32_t>(cb_bot_mask_idx),
+            static_cast<uint32_t>(cb_data_out_idx)};
+        writer_kernel_ids[rp] = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp",
+            CoreRangeSet(rw_ranges[rp]),
+            tt::tt_metal::WriterDataMovementConfig(writer_ct, kernel_defines));
+    }
+
+    // ---- Compute kernel unpack-to-dest mode ----
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (is_fp32) {
+        unpack_to_dest_mode[cb_data_in_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[cb_right_mask_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[cb_bot_mask_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    // ---- Compute kernels (one per (rp, bp, H_tiles, effective_W) group) ----
+    // CT: [0] W_tiles (= effective_W for this group), [1] H_tiles, [2] has_right_pad, [3] has_bottom_pad,
+    //     [4] elem_size, [5] fill_bits, [6] cb_data_in, [7] cb_right_mask,
+    //     [8] cb_bot_mask, [9] cb_data_out
+    std::map<ComputeKey, tt::tt_metal::KernelHandle> compute_kernel_map;
+    std::vector<tt::tt_metal::KernelHandle> compute_kernel_ids_vec;
+    for (auto& [key, ranges] : compute_ranges) {
+        const std::vector<uint32_t> compute_ct = {
+            key.effective_W,
+            key.H,
+            key.rp,
+            key.bp,
+            input_element_size_bytes,
+            fill_bits,
+            static_cast<uint32_t>(cb_data_in_idx),
+            static_cast<uint32_t>(cb_right_mask_idx),
+            static_cast<uint32_t>(cb_bot_mask_idx),
+            static_cast<uint32_t>(cb_data_out_idx)};
+        const tt::tt_metal::KernelHandle h = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp",
+            CoreRangeSet(ranges),
+            tt::tt_metal::ComputeConfig{
+                .fp32_dest_acc_en = need_fp32_dest_acc,
+                .unpack_to_dest_mode = unpack_to_dest_mode,
+                .compile_args = compute_ct,
+                .defines = kernel_defines});
+        compute_kernel_map[key] = h;
+        compute_kernel_ids_vec.push_back(h);
+    }
+
+    // ---- Per-core runtime args ----
+    // RT layout: [0] buf_addr, [1] shard_H_tiles, [2] has_bottom_pad_core, [3] num_work,
+    //            [4] local_right_col
+    const uint32_t buf_addr = static_cast<uint32_t>(tens_buffer->address());
+    std::vector<CoreCoord> active_coords;
+    std::vector<uint32_t> active_rp;
+
+    for (const auto& ci : active) {
+        const std::vector<uint32_t> rt = {buf_addr, ci.shard_H_tiles, ci.bp, ci.num_work, ci.local_right_col};
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[ci.rp], ci.coord, rt);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_ids[ci.rp], ci.coord, rt);
+
+        // Compute RT: (num_right, num_bottom, num_corner) per the unified phase layout.
+        // The sharded reader/writer push tiles in the same order (right, bottom, corner),
+        // so these counts let the shared compute kernel process them in lock-step.
+        uint32_t num_right = 0, num_bottom = 0, num_corner = 0;
+        if (ci.bp == 0u) {
+            // Mode A: right-column tiles only (only cores with rp=1 have work).
+            num_right = ci.rp ? ci.shard_H_tiles : 0u;
+        } else if (ci.rp) {
+            // Mode B with right pad: right strip (H-1) + bottom non-corner (local_valid_w-1) + corner.
+            num_right = ci.shard_H_tiles - 1u;
+            num_bottom = ci.local_valid_w - 1u;  // = local_right_col
+            num_corner = 1u;
+        } else {
+            // Mode B, bottom pad only: full bottom row of this shard.
+            num_bottom = ci.local_valid_w;
+        }
+        const uint32_t key_H = ci.bp ? ci.shard_H_tiles : pages_per_shard_y;
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            compute_kernel_map.at({ci.rp, ci.bp, key_H, ci.local_valid_w}),
+            ci.coord,
+            {num_right, num_bottom, num_corner});
+        active_coords.push_back(ci.coord);
+        active_rp.push_back(ci.rp);
+    }
+
+    return cached_program_t{
+        std::move(program),
+        shared_variables_t{
+            .reader_kernel_ids = reader_kernel_ids,
+            .writer_kernel_ids = writer_kernel_ids,
+            .compute_kernel_ids = std::move(compute_kernel_ids_vec),
+            .active_cores = std::move(active_coords),
+            .active_core_rp = std::move(active_rp),
+        }};
+}
+
+void FillPadL1ShardedProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const FillPadParams& /*operation_attributes*/,
+    const FillPadInputs& tensor_args,
+    Tensor& /*tensor_return_value*/) {
+    const uint32_t buf_addr = static_cast<uint32_t>(tensor_args.input.buffer()->address());
+
+    tt::tt_metal::Program& program = cached_program.program;
+    const auto& sv = cached_program.shared_variables;
+
+    for (uint32_t rp = 0; rp <= 1; ++rp) {
+        if (sv.reader_kernel_ids[rp] == 0) {
+            continue;
+        }
+        auto& rrt = GetRuntimeArgs(program, sv.reader_kernel_ids[rp]);
+        auto& wrt = GetRuntimeArgs(program, sv.writer_kernel_ids[rp]);
+        for (uint32_t i = 0; i < sv.active_cores.size(); ++i) {
+            if (sv.active_core_rp[i] != rp) {
+                continue;
+            }
+            const CoreCoord& core = sv.active_cores[i];
+            rrt[core.x][core.y][0] = buf_addr;
+            wrt[core.x][core.y][0] = buf_addr;
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -7,8 +7,10 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 #include <algorithm>
 #include <bit>
+#include <fmt/format.h>
 
 namespace ttnn::prim {
 
@@ -45,8 +47,8 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     const uint32_t W_tiles = tt::div_up(width, tile_width);
     const uint32_t H_mod32 = height % tile_height;
     const uint32_t W_mod32 = width % tile_width;
-    const uint32_t has_right_pad = W_mod32 != 0;
-    const uint32_t has_bottom_pad = H_mod32 != 0;
+    const bool has_right_pad = W_mod32 != 0;
+    const bool has_bottom_pad = H_mod32 != 0;
 
     const bool is_float_type =
         (input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32);
@@ -58,24 +60,23 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     const bool need_fp32_dest_acc = is_fp32 || is_uint32 || is_int32;
     // Float types: raw bit pattern of fill_value for fill_tile_bitcast.
     // Integer types: packed native bit pattern for fill_tile_int.
-    const uint32_t fill_bits =
-        is_float_type ? std::bit_cast<uint32_t>(fill_value) : detail::pack_fill_value(input_tensor.dtype(), fill_value);
+    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(input_tensor.dtype(), fill_value);
 
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     const uint32_t num_cores_x = compute_with_storage_grid_size.x;
     const uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
     // Unified border-tile split across all slices.
-    //   R = rows per slice in the right block (H_tiles-1 if both pads, else H_tiles).
-    //   C = cols per slice in the bottom block (W_tiles-1 if both pads, else W_tiles).
+    //   right_slice_stride  = rows per slice in the right block (H_tiles-1 if both pads, else H_tiles).
+    //   bottom_slice_stride = cols per slice in the bottom block (W_tiles-1 if both pads, else W_tiles).
     // The global tile-index space is three contiguous blocks:
     //   [0, T_right)                 – right-column border tiles
     //   [T_right, T_right+T_bottom)  – bottom-row border tiles (incl. corner if !has_right_pad)
     //   [..., total_work)            – corner tiles (only when has_right_pad && has_bottom_pad)
-    const uint32_t R = has_right_pad ? (has_bottom_pad ? (H_tiles - 1u) : H_tiles) : 0u;
-    const uint32_t C = has_bottom_pad ? (has_right_pad ? (W_tiles - 1u) : W_tiles) : 0u;
-    const uint32_t T_right = has_right_pad ? (N_slices * R) : 0u;
-    const uint32_t T_bottom = has_bottom_pad ? (N_slices * C) : 0u;
+    const uint32_t right_slice_stride = has_right_pad ? (has_bottom_pad ? (H_tiles - 1u) : H_tiles) : 0u;
+    const uint32_t bottom_slice_stride = has_bottom_pad ? (has_right_pad ? (W_tiles - 1u) : W_tiles) : 0u;
+    const uint32_t T_right = has_right_pad ? (N_slices * right_slice_stride) : 0u;
+    const uint32_t T_bottom = has_bottom_pad ? (N_slices * bottom_slice_stride) : 0u;
     const uint32_t T_corner = (has_right_pad && has_bottom_pad) ? N_slices : 0u;
     const uint32_t total_work = T_right + T_bottom + T_corner;
 
@@ -128,7 +129,7 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     kernel_defines["MASK_VALUE"] = is_fp32 ? "0x3F800000u" : is_float_type ? "0x3F80u" : "1u";
     kernel_defines["FILL_PAD_DATA_FMT"] = detail::get_where_data_fmt(input_tensor.dtype());
     if (!is_float_type) {
-        kernel_defines["FILL_PAD_FILL_DATA_FMT"] = detail::get_fill_int_fmt(input_tensor.dtype());
+        kernel_defines["FILL_PAD_FILL_DATA_FMT"] = fmt::format("DataFormat::{}", cb_data_format);
     }
     kernel_defines["FILL_PAD_FILL_FN"] = is_float_type ? "fill_tile_bitcast" : "fill_tile_int<FILL_PAD_FILL_DATA_FMT>";
     kernel_defines["FILL_PAD_FILL_ARG"] = "fill_bits";
@@ -229,33 +230,34 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
         const CoreCoord& core = cores[i];
         const uint32_t num_work = (i < g1_numcores) ? num_work_per_core_group_1 : num_work_per_core_group_2;
 
-        // Intersect [work_start, work_start + num_work) with the three global blocks.
+        // Intersect this core's work range with each phase block and return the
+        // block-relative (start, count) pair of tiles assigned to this core.
         const uint32_t work_end = work_start + num_work;
-        auto intersect = [work_start, work_end](
-                             uint32_t block_start, uint32_t block_size, uint32_t& out_start, uint32_t& out_num) {
-            if (block_size == 0u) {
-                out_start = 0u;
-                out_num = 0u;
-                return;
-            }
-            const uint32_t block_end = block_start + block_size;
-            const uint32_t lo = std::max(work_start, block_start);
-            const uint32_t hi = std::min(work_end, block_end);
-            if (lo >= hi) {
-                out_start = 0u;
-                out_num = 0u;
-            } else {
-                out_start = lo - block_start;
-                out_num = hi - lo;
-            }
-        };
+        auto clip_to_phase_block =
+            [work_start, work_end](uint32_t block_start, uint32_t block_size, uint32_t& out_start, uint32_t& out_num) {
+                if (block_size == 0u) {
+                    out_start = 0u;
+                    out_num = 0u;
+                    return;
+                }
+                const uint32_t block_end = block_start + block_size;
+                const uint32_t lo = std::max(work_start, block_start);
+                const uint32_t hi = std::min(work_end, block_end);
+                if (lo >= hi) {
+                    out_start = 0u;
+                    out_num = 0u;
+                } else {
+                    out_start = lo - block_start;
+                    out_num = hi - lo;
+                }
+            };
 
         uint32_t start_right = 0, num_right = 0;
         uint32_t start_bottom = 0, num_bottom = 0;
         uint32_t start_corner = 0, num_corner = 0;
-        intersect(0u, T_right, start_right, num_right);
-        intersect(T_right, T_bottom, start_bottom, num_bottom);
-        intersect(T_right + T_bottom, T_corner, start_corner, num_corner);
+        clip_to_phase_block(0u, T_right, start_right, num_right);
+        clip_to_phase_block(T_right, T_bottom, start_bottom, num_bottom);
+        clip_to_phase_block(T_right + T_bottom, T_corner, start_corner, num_corner);
 
         const std::vector<uint32_t> rt_args = {
             static_cast<uint32_t>(tens_buffer->address()),
@@ -342,8 +344,8 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     const uint32_t W_tiles_tensor = tt::div_up(width, tile_width);
     const uint32_t W_mod32 = width % tile_width;
     const uint32_t H_mod32 = height % tile_height;
-    const uint32_t has_right_pad = W_mod32 != 0;
-    const uint32_t has_bottom_pad = H_mod32 != 0;
+    const bool has_right_pad = W_mod32 != 0;
+    const bool has_bottom_pad = H_mod32 != 0;
 
     // ---- Shard geometry ----
     const auto layout = input_tensor.memory_config().memory_layout();
@@ -368,8 +370,8 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     struct ShardCoreInfo {
         CoreCoord coord;
         uint32_t shard_H_tiles;
-        uint32_t rp;  // has_right_pad for this core (CT binary selector)
-        uint32_t bp;  // has_bottom_pad for this core (CT binary selector for compute)
+        uint32_t has_right_pad;   // per-core right-edge flag (CT binary selector)
+        uint32_t has_bottom_pad;  // per-core bottom-edge flag (CT binary selector for compute)
         uint32_t num_work;
         uint32_t local_valid_w;    // min(pages_per_shard_x, W_tiles_tensor - w_start)
         uint32_t local_right_col;  // local_valid_w - 1; right-border tile's column within this shard
@@ -403,32 +405,34 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
         }
 
         const uint32_t shard_h = std::min(pages_per_shard_y, H_tiles - h_start);
-        const uint32_t core_rp = (has_right_pad && w_start + pages_per_shard_x >= W_tiles_tensor) ? 1u : 0u;
-        const uint32_t core_bp = (has_bottom_pad && h_start + pages_per_shard_y >= H_tiles) ? 1u : 0u;
-        const uint32_t nw = core_bp ? 1u : (core_rp ? shard_h : 0u);
+        const uint32_t core_has_right_pad = (has_right_pad && w_start + pages_per_shard_x >= W_tiles_tensor) ? 1u : 0u;
+        const uint32_t core_has_bottom_pad = (has_bottom_pad && h_start + pages_per_shard_y >= H_tiles) ? 1u : 0u;
+        const uint32_t nw = core_has_bottom_pad ? 1u : (core_has_right_pad ? shard_h : 0u);
         const uint32_t local_valid_w = std::min(pages_per_shard_x, W_tiles_tensor - w_start);
         const uint32_t local_right_col = local_valid_w - 1u;
 
-        active.push_back({all_shard_cores[i], shard_h, core_rp, core_bp, nw, local_valid_w, local_right_col});
+        active.push_back(
+            {all_shard_cores[i], shard_h, core_has_right_pad, core_has_bottom_pad, nw, local_valid_w, local_right_col});
     }
 
     TT_FATAL(!active.empty(), "FillPadL1ShardedProgramFactory: no active shard cores");
 
     // ---- Build kernel groups ----
-    // Reader/writer: binary key = rp (has_right_pad); has_bottom_pad_core is RT.
-    // Compute: binary key = (rp, bp, H_tiles, effective_W).
-    //   For bp=0 (Mode A), H_tiles is unused — all bp=0 cores share a binary with H=pages_per_shard_y.
-    //   For bp=1 (Mode B), H_tiles drives right_rows = H_tiles - 1; use actual shard height.
+    // Reader/writer: binary key = has_right_pad; has_bottom_pad_core is RT.
+    // Compute: binary key = (has_right_pad, has_bottom_pad, H_tiles, effective_W).
+    //   For has_bottom_pad=0 (Mode A), H_tiles is unused — all such cores share a binary
+    //   with H=pages_per_shard_y.
+    //   For has_bottom_pad=1 (Mode B), H_tiles drives right_rows = H_tiles - 1; use actual shard height.
     //   effective_W = local_valid_w; equals pages_per_shard_x for fully-packed shards, less for
     //   partially-filled rightmost shards (W_tiles_tensor % pages_per_shard_x != 0).
     struct ComputeKey {
-        uint32_t rp, bp, H, effective_W;
+        uint32_t has_right_pad, has_bottom_pad, H, effective_W;
         bool operator<(const ComputeKey& o) const {
-            if (rp != o.rp) {
-                return rp < o.rp;
+            if (has_right_pad != o.has_right_pad) {
+                return has_right_pad < o.has_right_pad;
             }
-            if (bp != o.bp) {
-                return bp < o.bp;
+            if (has_bottom_pad != o.has_bottom_pad) {
+                return has_bottom_pad < o.has_bottom_pad;
             }
             if (H != o.H) {
                 return H < o.H;
@@ -441,9 +445,9 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     std::map<ComputeKey, std::vector<CoreRange>> compute_ranges;
 
     for (const auto& ci : active) {
-        rw_ranges[ci.rp].emplace_back(ci.coord, ci.coord);
-        const uint32_t key_H = ci.bp ? ci.shard_H_tiles : pages_per_shard_y;
-        compute_ranges[{ci.rp, ci.bp, key_H, ci.local_valid_w}].emplace_back(ci.coord, ci.coord);
+        rw_ranges[ci.has_right_pad].emplace_back(ci.coord, ci.coord);
+        const uint32_t key_H = ci.has_bottom_pad ? ci.shard_H_tiles : pages_per_shard_y;
+        compute_ranges[{ci.has_right_pad, ci.has_bottom_pad, key_H, ci.local_valid_w}].emplace_back(ci.coord, ci.coord);
     }
 
     // All-active CoreRangeSet for CB creation.
@@ -459,8 +463,7 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     const bool is_uint32 = (input_tensor.dtype() == DataType::UINT32);
     const bool is_int32 = (input_tensor.dtype() == DataType::INT32);
     const bool need_fp32_dest_acc = is_fp32 || is_uint32 || is_int32;
-    const uint32_t fill_bits =
-        is_float_type ? std::bit_cast<uint32_t>(fill_value) : detail::pack_fill_value(input_tensor.dtype(), fill_value);
+    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(input_tensor.dtype(), fill_value);
 
     // ---- CB indices ----
     constexpr uint32_t cb_data_in_idx = tt::CBIndex::c_0;
@@ -500,7 +503,7 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     kernel_defines["MASK_VALUE"] = is_fp32 ? "0x3F800000u" : is_float_type ? "0x3F80u" : "1u";
     kernel_defines["FILL_PAD_DATA_FMT"] = detail::get_where_data_fmt(input_tensor.dtype());
     if (!is_float_type) {
-        kernel_defines["FILL_PAD_FILL_DATA_FMT"] = detail::get_fill_int_fmt(input_tensor.dtype());
+        kernel_defines["FILL_PAD_FILL_DATA_FMT"] = fmt::format("DataFormat::{}", cb_data_format);
     }
     kernel_defines["FILL_PAD_FILL_FN"] = is_float_type ? "fill_tile_bitcast" : "fill_tile_int<FILL_PAD_FILL_DATA_FMT>";
     kernel_defines["FILL_PAD_FILL_ARG"] = "fill_bits";
@@ -508,16 +511,16 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     // ---- Reader kernels (one per has_right_pad value) ----
     // CT: [0] W_tiles, [1] has_right_pad, [2] elem_size, [3] cb_data_in
     std::array<tt::tt_metal::KernelHandle, 2> reader_kernel_ids = {0, 0};
-    for (uint32_t rp = 0; rp <= 1; ++rp) {
-        if (rw_ranges[rp].empty()) {
+    for (uint32_t rp_idx = 0; rp_idx <= 1; ++rp_idx) {
+        if (rw_ranges[rp_idx].empty()) {
             continue;
         }
         const std::vector<uint32_t> reader_ct = {
-            W_tiles, rp, input_element_size_bytes, static_cast<uint32_t>(cb_data_in_idx)};
-        reader_kernel_ids[rp] = tt::tt_metal::CreateKernel(
+            W_tiles, rp_idx, input_element_size_bytes, static_cast<uint32_t>(cb_data_in_idx)};
+        reader_kernel_ids[rp_idx] = tt::tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp",
-            CoreRangeSet(rw_ranges[rp]),
+            CoreRangeSet(rw_ranges[rp_idx]),
             tt::tt_metal::ReaderDataMovementConfig(reader_ct, kernel_defines));
     }
 
@@ -525,22 +528,22 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     // CT: [0] W_tiles, [1] has_right_pad, [2] W_mod32, [3] H_mod32,
     //     [4] cb_right_mask, [5] cb_bot_mask, [6] cb_data_out
     std::array<tt::tt_metal::KernelHandle, 2> writer_kernel_ids = {0, 0};
-    for (uint32_t rp = 0; rp <= 1; ++rp) {
-        if (rw_ranges[rp].empty()) {
+    for (uint32_t rp_idx = 0; rp_idx <= 1; ++rp_idx) {
+        if (rw_ranges[rp_idx].empty()) {
             continue;
         }
         const std::vector<uint32_t> writer_ct = {
             W_tiles,
-            rp,
+            rp_idx,
             W_mod32,
             H_mod32,
             static_cast<uint32_t>(cb_right_mask_idx),
             static_cast<uint32_t>(cb_bot_mask_idx),
             static_cast<uint32_t>(cb_data_out_idx)};
-        writer_kernel_ids[rp] = tt::tt_metal::CreateKernel(
+        writer_kernel_ids[rp_idx] = tt::tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp",
-            CoreRangeSet(rw_ranges[rp]),
+            CoreRangeSet(rw_ranges[rp_idx]),
             tt::tt_metal::WriterDataMovementConfig(writer_ct, kernel_defines));
     }
 
@@ -553,7 +556,7 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
         unpack_to_dest_mode[cb_bot_mask_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
 
-    // ---- Compute kernels (one per (rp, bp, H_tiles, effective_W) group) ----
+    // ---- Compute kernels (one per (has_right_pad, has_bottom_pad, H_tiles, effective_W) group) ----
     // CT: [0] W_tiles (= effective_W for this group), [1] H_tiles, [2] has_right_pad, [3] has_bottom_pad,
     //     [4] elem_size, [5] fill_bits, [6] cb_data_in, [7] cb_right_mask,
     //     [8] cb_bot_mask, [9] cb_data_out
@@ -563,8 +566,8 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
         const std::vector<uint32_t> compute_ct = {
             key.effective_W,
             key.H,
-            key.rp,
-            key.bp,
+            key.has_right_pad,
+            key.has_bottom_pad,
             input_element_size_bytes,
             fill_bits,
             static_cast<uint32_t>(cb_data_in_idx),
@@ -589,21 +592,22 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
     //            [4] local_right_col
     const uint32_t buf_addr = static_cast<uint32_t>(tens_buffer->address());
     std::vector<CoreCoord> active_coords;
-    std::vector<uint32_t> active_rp;
+    std::vector<uint32_t> active_has_right_pad;
 
     for (const auto& ci : active) {
-        const std::vector<uint32_t> rt = {buf_addr, ci.shard_H_tiles, ci.bp, ci.num_work, ci.local_right_col};
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[ci.rp], ci.coord, rt);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_ids[ci.rp], ci.coord, rt);
+        const std::vector<uint32_t> rt = {
+            buf_addr, ci.shard_H_tiles, ci.has_bottom_pad, ci.num_work, ci.local_right_col};
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_ids[ci.has_right_pad], ci.coord, rt);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_ids[ci.has_right_pad], ci.coord, rt);
 
         // Compute RT: (num_right, num_bottom, num_corner) per the unified phase layout.
         // The sharded reader/writer push tiles in the same order (right, bottom, corner),
         // so these counts let the shared compute kernel process them in lock-step.
         uint32_t num_right = 0, num_bottom = 0, num_corner = 0;
-        if (ci.bp == 0u) {
-            // Mode A: right-column tiles only (only cores with rp=1 have work).
-            num_right = ci.rp ? ci.shard_H_tiles : 0u;
-        } else if (ci.rp) {
+        if (ci.has_bottom_pad == 0u) {
+            // Mode A: right-column tiles only (only cores with has_right_pad=1 have work).
+            num_right = ci.has_right_pad ? ci.shard_H_tiles : 0u;
+        } else if (ci.has_right_pad) {
             // Mode B with right pad: right strip (H-1) + bottom non-corner (local_valid_w-1) + corner.
             num_right = ci.shard_H_tiles - 1u;
             num_bottom = ci.local_valid_w - 1u;  // = local_right_col
@@ -612,14 +616,14 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
             // Mode B, bottom pad only: full bottom row of this shard.
             num_bottom = ci.local_valid_w;
         }
-        const uint32_t key_H = ci.bp ? ci.shard_H_tiles : pages_per_shard_y;
+        const uint32_t key_H = ci.has_bottom_pad ? ci.shard_H_tiles : pages_per_shard_y;
         tt::tt_metal::SetRuntimeArgs(
             program,
-            compute_kernel_map.at({ci.rp, ci.bp, key_H, ci.local_valid_w}),
+            compute_kernel_map.at({ci.has_right_pad, ci.has_bottom_pad, key_H, ci.local_valid_w}),
             ci.coord,
             {num_right, num_bottom, num_corner});
         active_coords.push_back(ci.coord);
-        active_rp.push_back(ci.rp);
+        active_has_right_pad.push_back(ci.has_right_pad);
     }
 
     return cached_program_t{
@@ -629,7 +633,7 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
             .writer_kernel_ids = writer_kernel_ids,
             .compute_kernel_ids = std::move(compute_kernel_ids_vec),
             .active_cores = std::move(active_coords),
-            .active_core_rp = std::move(active_rp),
+            .active_core_has_right_pad = std::move(active_has_right_pad),
         }};
 }
 
@@ -643,14 +647,14 @@ void FillPadL1ShardedProgramFactory::override_runtime_arguments(
     tt::tt_metal::Program& program = cached_program.program;
     const auto& sv = cached_program.shared_variables;
 
-    for (uint32_t rp = 0; rp <= 1; ++rp) {
-        if (sv.reader_kernel_ids[rp] == 0) {
+    for (uint32_t rp_idx = 0; rp_idx <= 1; ++rp_idx) {
+        if (sv.reader_kernel_ids[rp_idx] == 0) {
             continue;
         }
-        auto& rrt = GetRuntimeArgs(program, sv.reader_kernel_ids[rp]);
-        auto& wrt = GetRuntimeArgs(program, sv.writer_kernel_ids[rp]);
+        auto& rrt = GetRuntimeArgs(program, sv.reader_kernel_ids[rp_idx]);
+        auto& wrt = GetRuntimeArgs(program, sv.writer_kernel_ids[rp_idx]);
         for (uint32_t i = 0; i < sv.active_cores.size(); ++i) {
-            if (sv.active_core_rp[i] != rp) {
+            if (sv.active_core_has_right_pad[i] != rp_idx) {
                 continue;
             }
             const CoreCoord& core = sv.active_cores[i];

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -452,6 +452,7 @@ FillPadL1ShardedProgramFactory::cached_program_t FillPadL1ShardedProgramFactory:
 
     // All-active CoreRangeSet for CB creation.
     std::vector<CoreRange> all_active_vec;
+    all_active_vec.reserve(active.size());
     for (const auto& ci : active) {
         all_active_vec.emplace_back(ci.coord, ci.coord);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -6,29 +6,105 @@
 
 #include "fill_pad_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <array>
+#include <bit>
 
 namespace ttnn::prim::detail {
 
-const std::map<ttnn::DataType, uint32_t> data_type_to_size = {
+inline const std::map<ttnn::DataType, uint32_t> data_type_to_size = {
     {ttnn::DataType::BFLOAT16, 2},
     {ttnn::DataType::FLOAT32, 4},
     {ttnn::DataType::UINT16, 2},
     {ttnn::DataType::UINT32, 4},
     {ttnn::DataType::INT32, 4},
-    {ttnn::DataType::UINT8, 1},
 };
+
+// Packs fill_value into the uint32 bit pattern expected by the reader/compute kernels.
+// For 2-byte types both halves of the 32-bit word carry the same 16-bit value;
+// for 4-byte types the full 32-bit pattern is used.
+inline uint32_t pack_fill_value(ttnn::DataType dtype, float fill_value) {
+    switch (dtype) {
+        case ttnn::DataType::BFLOAT16: {
+            const uint16_t bits = static_cast<uint16_t>(std::bit_cast<uint32_t>(fill_value) >> 16);
+            return (static_cast<uint32_t>(bits) << 16) | bits;
+        }
+        case ttnn::DataType::UINT16: {
+            const uint16_t bits = static_cast<uint16_t>(static_cast<int32_t>(fill_value) & 0xFFFF);
+            return (static_cast<uint32_t>(bits) << 16) | bits;
+        }
+        case ttnn::DataType::FLOAT32: return std::bit_cast<uint32_t>(fill_value);
+        default:  // UINT32, INT32
+            return static_cast<uint32_t>(static_cast<int32_t>(fill_value));
+    }
+}
+
+// DataFormat string for where_tile<> template parameter.
+inline std::string get_where_data_fmt(ttnn::DataType dtype) {
+    switch (dtype) {
+        case ttnn::DataType::FLOAT32: return "DataFormat::Float32";
+        case ttnn::DataType::UINT32: return "DataFormat::UInt32";
+        case ttnn::DataType::INT32: return "DataFormat::Int32";
+        default: return "DataFormat::Float16_b";  // BFLOAT16, UINT16
+    }
+}
+
+// DataFormat string for fill_tile_int<> template parameter (integer types only).
+inline std::string get_fill_int_fmt(ttnn::DataType dtype) {
+    switch (dtype) {
+        case ttnn::DataType::UINT32: return "DataFormat::UInt32";
+        case ttnn::DataType::INT32: return "DataFormat::Int32";
+        default: return "DataFormat::UInt16";  // UINT16
+    }
+}
 
 }  // namespace ttnn::prim::detail
 
 namespace ttnn::prim {
 
 struct FillPadSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id = 0;
     tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    tt::tt_metal::KernelHandle compute_kernel_id = 0;
     std::vector<CoreCoord> cores;
 };
 
+// Handles DRAM tensors (Interleaved + DRAM sharded).
+//
+// Work splitting is unified across three border-tile phases (right / bottom /
+// corner). All border tiles across all slices are enumerated into a single
+// global index space and handed to split_work_to_cores at tile granularity,
+// so 2D / small-N_slices shapes (e.g. 4097x4097) still fan out across the
+// full compute grid. Each core gets per-phase (start, num) pairs; phases
+// with num == 0 are skipped. A single compute kernel binary covers all cores
+// (CT has_right_pad / has_bottom_pad gate the phase branches at compile time).
 struct FillPadProgramFactory {
     using shared_variables_t = FillPadSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const FillPadParams& operation_attributes, const FillPadInputs& tensor_args, Tensor& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const FillPadParams& operation_attributes,
+        const FillPadInputs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+struct FillPadL1ShardedSharedVariables {
+    // Indexed by has_right_pad (0/1); 0 means that group is unused.
+    std::array<tt::tt_metal::KernelHandle, 2> reader_kernel_ids = {0, 0};
+    std::array<tt::tt_metal::KernelHandle, 2> writer_kernel_ids = {0, 0};
+    std::vector<tt::tt_metal::KernelHandle> compute_kernel_ids;
+    std::vector<CoreCoord> active_cores;
+    std::vector<uint32_t> active_core_rp;  // has_right_pad per active core (for override_runtime_arguments)
+};
+
+// Handles all L1-sharded tensors (HEIGHT_SHARDED, WIDTH_SHARDED, BLOCK_SHARDED).
+// Unlike `FillPadProgramFactory` which gives each core a comparable number of borders,
+// with FillPadL1ShardedProgramFactory, each core only processes its own local L1 data (no balancing).
+struct FillPadL1ShardedProgramFactory {
+    using shared_variables_t = FillPadL1ShardedSharedVariables;
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -19,41 +19,46 @@ inline const std::map<ttnn::DataType, uint32_t> data_type_to_size = {
     {ttnn::DataType::INT32, 4},
 };
 
-// Packs fill_value into the uint32 bit pattern expected by the reader/compute kernels.
-// For 2-byte types both halves of the 32-bit word carry the same 16-bit value;
-// for 4-byte types the full 32-bit pattern is used.
-inline uint32_t pack_fill_value(ttnn::DataType dtype, float fill_value) {
+// Packs `fill_value` into the uint32 bit pattern expected by the reader/compute kernels.
+// Width is deduced from the parameter type: 4-byte types take their raw bit pattern,
+// 2-byte integer types are duplicated across both halves of the 32-bit word.
+template <typename T>
+inline uint32_t pack_fill_value(T fill_value) {
+    static_assert(sizeof(T) == 2 || sizeof(T) == 4, "pack_fill_value: unsupported size");
+    if constexpr (sizeof(T) == 4) {
+        return std::bit_cast<uint32_t>(fill_value);
+    } else {
+        using U16 = std::uint16_t;
+        const uint32_t v = static_cast<uint32_t>(std::bit_cast<U16>(fill_value));
+        return (v << 16) | v;
+    }
+}
+
+// Dtype-directed wrapper used by both program factories. Chooses the native
+// fill type per dtype and packs it.
+// Float DataTypes (FLOAT32, BFLOAT16) keep the full float32 bit pattern — the
+// compute kernel reconstructs it via fill_tile_bitcast and the downstream
+// packer handles the bf16 narrowing.
+inline uint32_t pack_fill_value_for_dtype(ttnn::DataType dtype, float fill_value) {
     switch (dtype) {
-        case ttnn::DataType::BFLOAT16: {
-            const uint16_t bits = static_cast<uint16_t>(std::bit_cast<uint32_t>(fill_value) >> 16);
-            return (static_cast<uint32_t>(bits) << 16) | bits;
-        }
-        case ttnn::DataType::UINT16: {
-            const uint16_t bits = static_cast<uint16_t>(static_cast<int32_t>(fill_value) & 0xFFFF);
-            return (static_cast<uint32_t>(bits) << 16) | bits;
-        }
-        case ttnn::DataType::FLOAT32: return std::bit_cast<uint32_t>(fill_value);
-        default:  // UINT32, INT32
-            return static_cast<uint32_t>(static_cast<int32_t>(fill_value));
+        case ttnn::DataType::FLOAT32:
+        case ttnn::DataType::BFLOAT16: return pack_fill_value(fill_value);
+        case ttnn::DataType::UINT16: return pack_fill_value(static_cast<uint16_t>(fill_value));
+        case ttnn::DataType::UINT32: return pack_fill_value(static_cast<uint32_t>(fill_value));
+        case ttnn::DataType::INT32: return pack_fill_value(static_cast<int32_t>(fill_value));
+        default: TT_THROW("fill_pad: unsupported dtype"); return 0u;
     }
 }
 
 // DataFormat string for where_tile<> template parameter.
+// 2-byte types (BFLOAT16, UINT16) both collapse to Float16_b because that's the only
+// 2-byte where_tile<> SFPU variant exposed by the LLKs (matches the ternary_op pattern).
 inline std::string get_where_data_fmt(ttnn::DataType dtype) {
     switch (dtype) {
         case ttnn::DataType::FLOAT32: return "DataFormat::Float32";
         case ttnn::DataType::UINT32: return "DataFormat::UInt32";
         case ttnn::DataType::INT32: return "DataFormat::Int32";
         default: return "DataFormat::Float16_b";  // BFLOAT16, UINT16
-    }
-}
-
-// DataFormat string for fill_tile_int<> template parameter (integer types only).
-inline std::string get_fill_int_fmt(ttnn::DataType dtype) {
-    switch (dtype) {
-        case ttnn::DataType::UINT32: return "DataFormat::UInt32";
-        case ttnn::DataType::INT32: return "DataFormat::Int32";
-        default: return "DataFormat::UInt16";  // UINT16
     }
 }
 
@@ -97,7 +102,8 @@ struct FillPadL1ShardedSharedVariables {
     std::array<tt::tt_metal::KernelHandle, 2> writer_kernel_ids = {0, 0};
     std::vector<tt::tt_metal::KernelHandle> compute_kernel_ids;
     std::vector<CoreCoord> active_cores;
-    std::vector<uint32_t> active_core_rp;  // has_right_pad per active core (for override_runtime_arguments)
+    // has_right_pad per active core (for override_runtime_arguments)
+    std::vector<uint32_t> active_core_has_right_pad;
 };
 
 // Handles all L1-sharded tensors (HEIGHT_SHARDED, WIDTH_SHARDED, BLOCK_SHARDED).

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/eltwise_unary/where.h"
+
+ALWI void process_masked_tile(uint32_t cb_data_in, uint32_t cb_mask, uint32_t cb_data_out, uint32_t fill_bits) {
+    constexpr uint32_t CB_DATA_IN = 0;
+    constexpr uint32_t CB_DATA_PADDING = 1;
+    constexpr uint32_t CB_MASK = 2;
+    constexpr uint32_t CB_OUT = 2;  // reuse CB_MASK tile
+
+    cb_wait_front(cb_data_in, 1);
+    cb_reserve_back(cb_data_out, 1);
+    tile_regs_acquire();
+
+    copy_tile_to_dst_init_short(cb_data_in);
+    copy_tile(cb_data_in, 0, CB_DATA_IN);  // data → DST[0]
+
+    copy_tile_to_dst_init_short(cb_mask);
+    copy_tile(cb_mask, 0, CB_MASK);  // mask → DST[2]
+
+    fill_tile_init();
+    FILL_PAD_FILL_FN(CB_DATA_PADDING, FILL_PAD_FILL_ARG);  // fill → DST
+
+    where_tile_init();
+    where_tile<FILL_PAD_DATA_FMT>(CB_MASK, CB_DATA_PADDING, CB_DATA_IN, CB_OUT);  // if mask then padidng else in -> out
+
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(CB_OUT, cb_data_out);  // result is at DST[2]
+    tile_regs_release();
+
+    cb_pop_front(cb_data_in, 1);
+    cb_push_back(cb_data_out, 1);
+}
+
+// Corner tile: two sequential where_tile calls give (right_mask OR bot_mask) → fill.
+ALWI void process_corner_tile(
+    uint32_t cb_data_in, uint32_t cb_right_mask, uint32_t cb_bot_mask, uint32_t cb_data_out, uint32_t fill_bits) {
+    constexpr uint32_t CB_DATA_IN = 0;
+    constexpr uint32_t CB_DATA_PADDING = 1;
+    constexpr uint32_t CB_RIGHT_MASK = 2;
+    constexpr uint32_t CB_BOTTOM_MASK = 3;
+    constexpr uint32_t CB_OUT = 3;  // reuse CB_MASK tile
+
+    cb_wait_front(cb_data_in, 1);
+    cb_reserve_back(cb_data_out, 1);
+    tile_regs_acquire();
+
+    copy_tile_to_dst_init_short(cb_data_in);
+    copy_tile(cb_data_in, 0, CB_DATA_IN);  // data       → DST[0]
+
+    copy_tile_to_dst_init_short(cb_right_mask);
+    copy_tile(cb_right_mask, 0, CB_RIGHT_MASK);  // right_mask → DST[2]
+
+    copy_tile_to_dst_init_short(cb_bot_mask);
+    copy_tile(cb_bot_mask, 0, CB_BOTTOM_MASK);  // bot_mask   → DST[3]
+
+    fill_tile_init();
+    FILL_PAD_FILL_FN(CB_DATA_PADDING, FILL_PAD_FILL_ARG);  // fill → DST[1]
+
+    where_tile_init();
+    // Combine right and bottom mask into corner mask
+    where_tile<FILL_PAD_DATA_FMT>(
+        CB_RIGHT_MASK, CB_DATA_PADDING, CB_DATA_IN, CB_RIGHT_MASK);  // if mask then padidng else in -> out
+    where_tile<FILL_PAD_DATA_FMT>(
+        CB_BOTTOM_MASK, CB_DATA_PADDING, CB_RIGHT_MASK, CB_OUT);  // if mask then padidng else in -> out
+
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(CB_OUT, cb_data_out);  // final result is at DST[3]
+    tile_regs_release();
+
+    cb_pop_front(cb_data_in, 1);
+    cb_push_back(cb_data_out, 1);
+}
+
+void kernel_main() {
+    constexpr uint32_t W_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t H_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t has_right_pad = get_compile_time_arg_val(2);
+    constexpr uint32_t has_bottom_pad = get_compile_time_arg_val(3);
+    constexpr uint32_t elem_size = get_compile_time_arg_val(4);
+    constexpr uint32_t fill_bits_ct = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_data_in = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_right_mask = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_bot_mask = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_data_out = get_compile_time_arg_val(9);
+
+    // Per-phase tile counts. Phases with num == 0 are skipped. When the
+    // corresponding global has_*_pad CT is 0 the host always sets num to 0,
+    // so the if constexpr gating below removes the dead code path entirely.
+    const uint32_t num_right = get_arg_val<uint32_t>(0);
+    const uint32_t num_bottom = get_arg_val<uint32_t>(1);
+    const uint32_t num_corner = get_arg_val<uint32_t>(2);
+
+    if (num_right + num_bottom + num_corner == 0) {
+        return;
+    }
+
+    // Standard init for unary-style SFPU compute with one primary input CB.
+    unary_op_init_common(cb_data_in, cb_data_out);
+
+    // Wait for persistent mask tiles pushed once by the writer. They are popped
+    // once at cleanup; during the main loop they are reused persistently.
+    if constexpr (has_right_pad) {
+        cb_wait_front(cb_right_mask, 1);
+    }
+    if constexpr (has_bottom_pad) {
+        cb_wait_front(cb_bot_mask, 1);
+    }
+
+    // ---- Main loop: same tile ordering as reader and writer (right/bottom/corner) ----
+
+    if constexpr (has_right_pad) {
+        for (uint32_t i = 0; i < num_right; ++i) {
+            process_masked_tile(cb_data_in, cb_right_mask, cb_data_out, fill_bits_ct);
+        }
+    }
+    if constexpr (has_bottom_pad) {
+        for (uint32_t j = 0; j < num_bottom; ++j) {
+            process_masked_tile(cb_data_in, cb_bot_mask, cb_data_out, fill_bits_ct);
+        }
+    }
+    if constexpr (has_right_pad && has_bottom_pad) {
+        for (uint32_t k = 0; k < num_corner; ++k) {
+            process_corner_tile(cb_data_in, cb_right_mask, cb_bot_mask, cb_data_out, fill_bits_ct);
+        }
+    }
+
+    // Clean-up
+    if constexpr (has_right_pad) {
+        cb_pop_front(cb_right_mask, 1);
+    }
+    if constexpr (has_bottom_pad) {
+        cb_pop_front(cb_bot_mask, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_dataflow_common.hpp
@@ -4,18 +4,17 @@
 
 #pragma once
 
-static constexpr uint32_t FACE = 16;
-static constexpr uint32_t TILE = 32;
-
 /**
  * Write a mask tile into `p` using face layout.
  *
  * Positions where (gcol >= W_thresh OR grow >= H_thresh) receive `one_val`;
- * all other positions receive 0.
- * Pass TILE (32) for a threshold to disable that dimension's condition.
+ * all other positions receive 0. Pass TILE for a threshold to disable that
+ * dimension's condition. TILE is the edge length of the tile in elements;
+ * a 2x2 face layout is assumed (FACE = TILE / 2).
  */
-template <typename T, uint32_t W_thresh, uint32_t H_thresh>
+template <typename T, uint32_t W_thresh, uint32_t H_thresh, uint32_t TILE>
 static void generate_mask_tile(T* __restrict__ p, T one_val) {
+    constexpr uint32_t FACE = TILE / 2u;
     T zero_val = static_cast<T>(0);
     for (uint32_t fr = 0; fr < 2; fr++) {
         for (uint32_t fc = 0; fc < 2; fc++) {
@@ -29,4 +28,27 @@ static void generate_mask_tile(T* __restrict__ p, T one_val) {
             }
         }
     }
+}
+
+/**
+ * Reserve a single tile in `cb_right_mask`, write a right-edge mask
+ * (1 at gcol >= W_mod32, 0 elsewhere) and push it. Used by both the unified
+ * and sharded writer kernels during Phase 1.
+ */
+template <typename MASK_T, uint32_t W_mod32, uint32_t TILE, typename CB_T>
+static inline __attribute__((always_inline)) void push_right_mask_tile(CB_T& cb_right_mask, MASK_T one_val) {
+    cb_right_mask.reserve_back(1);
+    generate_mask_tile<MASK_T, W_mod32, TILE, TILE>(reinterpret_cast<MASK_T*>(cb_right_mask.get_write_ptr()), one_val);
+    cb_right_mask.push_back(1);
+}
+
+/**
+ * Reserve a single tile in `cb_bot_mask`, write a bottom-edge mask
+ * (1 at grow >= H_mod32, 0 elsewhere) and push it.
+ */
+template <typename MASK_T, uint32_t H_mod32, uint32_t TILE, typename CB_T>
+static inline __attribute__((always_inline)) void push_bottom_mask_tile(CB_T& cb_bot_mask, MASK_T one_val) {
+    cb_bot_mask.reserve_back(1);
+    generate_mask_tile<MASK_T, TILE, H_mod32, TILE>(reinterpret_cast<MASK_T*>(cb_bot_mask.get_write_ptr()), one_val);
+    cb_bot_mask.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_dataflow_common.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+static constexpr uint32_t FACE = 16;
+static constexpr uint32_t TILE = 32;
+
+/**
+ * Write a mask tile into `p` using face layout.
+ *
+ * Positions where (gcol >= W_thresh OR grow >= H_thresh) receive `one_val`;
+ * all other positions receive 0.
+ * Pass TILE (32) for a threshold to disable that dimension's condition.
+ */
+template <typename T, uint32_t W_thresh, uint32_t H_thresh>
+static void generate_mask_tile(T* __restrict__ p, T one_val) {
+    T zero_val = static_cast<T>(0);
+    for (uint32_t fr = 0; fr < 2; fr++) {
+        for (uint32_t fc = 0; fc < 2; fc++) {
+            const uint32_t face_base = (fr * 2u + fc) * FACE * FACE;
+            for (uint32_t r = 0; r < FACE; r++) {
+                const uint32_t grow = fr * FACE + r;
+                for (uint32_t c = 0; c < FACE; c++) {
+                    const uint32_t gcol = fc * FACE + c;
+                    p[face_base + r * FACE + c] = (gcol >= W_thresh || grow >= H_thresh) ? one_val : zero_val;
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_dataflow_common.hpp
@@ -13,7 +13,7 @@
  * a 2x2 face layout is assumed (FACE = TILE / 2).
  */
 template <typename T, uint32_t W_thresh, uint32_t H_thresh, uint32_t TILE>
-static void generate_mask_tile(T* __restrict__ p, T one_val) {
+void generate_mask_tile(T* __restrict__ p, T one_val) {
     constexpr uint32_t FACE = TILE / 2u;
     T zero_val = static_cast<T>(0);
     for (uint32_t fr = 0; fr < 2; fr++) {
@@ -36,7 +36,7 @@ static void generate_mask_tile(T* __restrict__ p, T one_val) {
  * and sharded writer kernels during Phase 1.
  */
 template <typename MASK_T, uint32_t W_mod32, uint32_t TILE, typename CB_T>
-static inline __attribute__((always_inline)) void push_right_mask_tile(CB_T& cb_right_mask, MASK_T one_val) {
+void push_right_mask_tile(CB_T& cb_right_mask, MASK_T one_val) {
     cb_right_mask.reserve_back(1);
     generate_mask_tile<MASK_T, W_mod32, TILE, TILE>(reinterpret_cast<MASK_T*>(cb_right_mask.get_write_ptr()), one_val);
     cb_right_mask.push_back(1);
@@ -47,7 +47,7 @@ static inline __attribute__((always_inline)) void push_right_mask_tile(CB_T& cb_
  * (1 at grow >= H_mod32, 0 elsewhere) and push it.
  */
 template <typename MASK_T, uint32_t H_mod32, uint32_t TILE, typename CB_T>
-static inline __attribute__((always_inline)) void push_bottom_mask_tile(CB_T& cb_bot_mask, MASK_T one_val) {
+void push_bottom_mask_tile(CB_T& cb_bot_mask, MASK_T one_val) {
     cb_bot_mask.reserve_back(1);
     generate_mask_tile<MASK_T, TILE, H_mod32, TILE>(reinterpret_cast<MASK_T*>(cb_bot_mask.get_write_ptr()), one_val);
     cb_bot_mask.push_back(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reads border tiles from the tensor (DRAM interleaved or sharded) into the
+ * double-buffered cb_tile_in. The writer (BRISC) applies the padding-fill mask
+ * in L1 and writes each tile back.
+ *
+ * Unified border-tile split. The host enumerates border tiles across all
+ * slices into three contiguous blocks (right / bottom / corner) and gives
+ * this core a per-phase (start, num) range inside each block:
+ *
+ *   Right phase  (num_right > 0 only when has_right_pad):
+ *     for each i in [start_right, start_right + num_right):
+ *       slice = i / R;  row = i % R
+ *       tile_id = slice * H_tiles * W_tiles + row * W_tiles + (W_tiles - 1)
+ *     where R = (H_tiles - 1) if has_bottom_pad else H_tiles.
+ *
+ *   Bottom phase (num_bottom > 0 only when has_bottom_pad):
+ *     for each j in [start_bottom, start_bottom + num_bottom):
+ *       slice = j / C;  col = j % C
+ *       tile_id = slice * H_tiles * W_tiles + (H_tiles - 1) * W_tiles + col
+ *     where C = (W_tiles - 1) if has_right_pad else W_tiles.
+ *
+ *   Corner phase (num_corner > 0 only when has_right_pad && has_bottom_pad):
+ *     for each k in [start_corner, start_corner + num_corner):
+ *       slice = k
+ *       tile_id = slice * H_tiles * W_tiles + (H_tiles - 1) * W_tiles + (W_tiles - 1)
+ *
+ * Tile ordering across the three phases must match fill_pad_writer.cpp and
+ * fill_pad_compute.cpp exactly (CBs are FIFO).
+ *
+ * CT args layout (common to reader and writer):
+ *   [0]  W_tiles
+ *   [1]  H_tiles
+ *   [2]  N_slices (unused here)
+ *   [3]  has_right_pad
+ *   [4]  has_bottom_pad
+ *   [5]  W_mod32 (unused here)
+ *   [6]  H_mod32 (unused here)
+ *   [7]  elem_size (2 or 4)
+ *   [8]  fill_bits (unused here)
+ *   [9]  CB_TILE_IN (= 0)
+ *   [10+] TensorAccessorArgs
+ *
+ * RT args:
+ *   [0]  buf_addr
+ *   [1]  start_right   [2]  num_right
+ *   [3]  start_bottom  [4]  num_bottom
+ *   [5]  start_corner  [6]  num_corner
+ */
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
+
+void kernel_main() {
+    constexpr uint32_t W_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t H_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t has_right_pad = get_compile_time_arg_val(3);
+    constexpr uint32_t has_bottom_pad = get_compile_time_arg_val(4);
+    constexpr uint32_t elem_size = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_tile_in_idx = get_compile_time_arg_val(9);
+
+    // Per-phase strides (meaningful only when the corresponding phase is active).
+    // Clamped to >= 1 so the compiler does not see a constexpr divide-by-zero in
+    // the dead-code branches (when H_tiles==1 or W_tiles==1 the host sets the
+    // matching num_* to 0 and the loop below never executes).
+    constexpr uint32_t R =
+        (has_right_pad != 0u) ? ((has_bottom_pad != 0u) ? ((H_tiles > 1u) ? (H_tiles - 1u) : 1u) : H_tiles) : 1u;
+    constexpr uint32_t C =
+        (has_bottom_pad != 0u) ? ((has_right_pad != 0u) ? ((W_tiles > 1u) ? (W_tiles - 1u) : 1u) : W_tiles) : 1u;
+
+    constexpr uint32_t tile_bytes = get_tile_size(cb_tile_in_idx);
+
+    const uint32_t buf_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_right = get_arg_val<uint32_t>(1);
+    const uint32_t num_right = get_arg_val<uint32_t>(2);
+    const uint32_t start_bottom = get_arg_val<uint32_t>(3);
+    const uint32_t num_bottom = get_arg_val<uint32_t>(4);
+    const uint32_t start_corner = get_arg_val<uint32_t>(5);
+    const uint32_t num_corner = get_arg_val<uint32_t>(6);
+
+    constexpr auto src_args = TensorAccessorArgs<10>();
+    const auto s = TensorAccessor(src_args, buf_addr, tile_bytes);
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_tile_in(cb_tile_in_idx);
+
+    // ---- Right phase ----
+    if constexpr (has_right_pad != 0u) {
+        for (uint32_t i = 0; i < num_right; ++i) {
+            const uint32_t g = start_right + i;
+            const uint32_t slice = g / R;
+            const uint32_t row = g - slice * R;
+            const uint32_t tile_id = slice * H_tiles * W_tiles + row * W_tiles + (W_tiles - 1u);
+            cb_tile_in.reserve_back(1);
+            noc.async_read(s, cb_tile_in, tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb_tile_in.push_back(1);
+        }
+    }
+
+    // ---- Bottom phase ----
+    if constexpr (has_bottom_pad != 0u) {
+        for (uint32_t j = 0; j < num_bottom; ++j) {
+            const uint32_t g = start_bottom + j;
+            const uint32_t slice = g / C;
+            const uint32_t col = g - slice * C;
+            const uint32_t tile_id = slice * H_tiles * W_tiles + (H_tiles - 1u) * W_tiles + col;
+            cb_tile_in.reserve_back(1);
+            noc.async_read(s, cb_tile_in, tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb_tile_in.push_back(1);
+        }
+    }
+
+    // ---- Corner phase ----
+    if constexpr (has_right_pad != 0u && has_bottom_pad != 0u) {
+        for (uint32_t k = 0; k < num_corner; ++k) {
+            const uint32_t slice = start_corner + k;
+            const uint32_t tile_id = slice * H_tiles * W_tiles + (H_tiles - 1u) * W_tiles + (W_tiles - 1u);
+            cb_tile_in.reserve_back(1);
+            noc.async_read(s, cb_tile_in, tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb_tile_in.push_back(1);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp
@@ -13,15 +13,15 @@
  *
  *   Right phase  (num_right > 0 only when has_right_pad):
  *     for each i in [start_right, start_right + num_right):
- *       slice = i / R;  row = i % R
+ *       slice = i / right_slice_stride;  row = i % right_slice_stride
  *       tile_id = slice * H_tiles * W_tiles + row * W_tiles + (W_tiles - 1)
- *     where R = (H_tiles - 1) if has_bottom_pad else H_tiles.
+ *     where right_slice_stride = (H_tiles - 1) if has_bottom_pad else H_tiles.
  *
  *   Bottom phase (num_bottom > 0 only when has_bottom_pad):
  *     for each j in [start_bottom, start_bottom + num_bottom):
- *       slice = j / C;  col = j % C
+ *       slice = j / bottom_slice_stride;  col = j % bottom_slice_stride
  *       tile_id = slice * H_tiles * W_tiles + (H_tiles - 1) * W_tiles + col
- *     where C = (W_tiles - 1) if has_right_pad else W_tiles.
+ *     where bottom_slice_stride = (W_tiles - 1) if has_right_pad else W_tiles.
  *
  *   Corner phase (num_corner > 0 only when has_right_pad && has_bottom_pad):
  *     for each k in [start_corner, start_corner + num_corner):
@@ -64,14 +64,14 @@ void kernel_main() {
     constexpr uint32_t elem_size = get_compile_time_arg_val(7);
     constexpr uint32_t cb_tile_in_idx = get_compile_time_arg_val(9);
 
-    // Per-phase strides (meaningful only when the corresponding phase is active).
+    // Per-phase slice strides (meaningful only when the corresponding phase is active).
     // Clamped to >= 1 so the compiler does not see a constexpr divide-by-zero in
     // the dead-code branches (when H_tiles==1 or W_tiles==1 the host sets the
     // matching num_* to 0 and the loop below never executes).
-    constexpr uint32_t R =
-        (has_right_pad != 0u) ? ((has_bottom_pad != 0u) ? ((H_tiles > 1u) ? (H_tiles - 1u) : 1u) : H_tiles) : 1u;
-    constexpr uint32_t C =
-        (has_bottom_pad != 0u) ? ((has_right_pad != 0u) ? ((W_tiles > 1u) ? (W_tiles - 1u) : 1u) : W_tiles) : 1u;
+    constexpr uint32_t right_slice_stride =
+        has_right_pad ? (has_bottom_pad ? ((H_tiles > 1u) ? (H_tiles - 1u) : 1u) : H_tiles) : 1u;
+    constexpr uint32_t bottom_slice_stride =
+        has_bottom_pad ? (has_right_pad ? ((W_tiles > 1u) ? (W_tiles - 1u) : 1u) : W_tiles) : 1u;
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_tile_in_idx);
 
@@ -90,35 +90,45 @@ void kernel_main() {
     experimental::CircularBuffer cb_tile_in(cb_tile_in_idx);
 
     // ---- Right phase ----
-    if constexpr (has_right_pad != 0u) {
+    // Maintain (slice, row) incrementally instead of dividing every iteration
+    // — RV32IM division is slow. Startup division runs at most once.
+    if constexpr (has_right_pad) {
+        uint32_t slice = num_right ? start_right / right_slice_stride : 0u;
+        uint32_t row = num_right ? start_right - slice * right_slice_stride : 0u;
         for (uint32_t i = 0; i < num_right; ++i) {
-            const uint32_t g = start_right + i;
-            const uint32_t slice = g / R;
-            const uint32_t row = g - slice * R;
             const uint32_t tile_id = slice * H_tiles * W_tiles + row * W_tiles + (W_tiles - 1u);
             cb_tile_in.reserve_back(1);
             noc.async_read(s, cb_tile_in, tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
             noc.async_read_barrier();
             cb_tile_in.push_back(1);
+            ++row;
+            if (row == right_slice_stride) {
+                row = 0;
+                ++slice;
+            }
         }
     }
 
     // ---- Bottom phase ----
-    if constexpr (has_bottom_pad != 0u) {
+    if constexpr (has_bottom_pad) {
+        uint32_t slice = num_bottom ? start_bottom / bottom_slice_stride : 0u;
+        uint32_t col = num_bottom ? start_bottom - slice * bottom_slice_stride : 0u;
         for (uint32_t j = 0; j < num_bottom; ++j) {
-            const uint32_t g = start_bottom + j;
-            const uint32_t slice = g / C;
-            const uint32_t col = g - slice * C;
             const uint32_t tile_id = slice * H_tiles * W_tiles + (H_tiles - 1u) * W_tiles + col;
             cb_tile_in.reserve_back(1);
             noc.async_read(s, cb_tile_in, tile_bytes, {.page_id = tile_id}, {.offset_bytes = 0});
             noc.async_read_barrier();
             cb_tile_in.push_back(1);
+            ++col;
+            if (col == bottom_slice_stride) {
+                col = 0;
+                ++slice;
+            }
         }
     }
 
     // ---- Corner phase ----
-    if constexpr (has_right_pad != 0u && has_bottom_pad != 0u) {
+    if constexpr (has_right_pad && has_bottom_pad) {
         for (uint32_t k = 0; k < num_corner; ++k) {
             const uint32_t slice = start_corner + k;
             const uint32_t tile_id = slice * H_tiles * W_tiles + (H_tiles - 1u) * W_tiles + (W_tiles - 1u);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_reader.cpp
@@ -52,9 +52,9 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/noc.h"
-#include "experimental/circular_buffer.h"
-#include "experimental/tensor.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     constexpr uint32_t W_tiles = get_compile_time_arg_val(0);
@@ -86,8 +86,8 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<10>();
     const auto s = TensorAccessor(src_args, buf_addr, tile_bytes);
 
-    experimental::Noc noc;
-    experimental::CircularBuffer cb_tile_in(cb_tile_in_idx);
+    Noc noc;
+    CircularBuffer cb_tile_in(cb_tile_in_idx);
 
     // ---- Right phase ----
     // Maintain (slice, row) incrementally instead of dividing every iteration

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reads border tiles from the local L1 shard into cb_data_in using NOC
+ * reads addressed to this core's own L1. No cross-core NOC access.
+ *
+ * CT args:
+ *   [0] W_tiles         – width of the shard in tiles (= full tensor width for HEIGHT_SHARDED)
+ *   [1] has_right_pad   – 1 if tensor width % 32 != 0
+ *   [2] elem_size       – 2 or 4 bytes per element
+ *   [3] cb_data_in_idx  – CB index for data-in (= 0)
+ *
+ * RT args:
+ *   [0] shard_l1_base_addr  – L1 base address of this core's shard buffer
+ *   [1] shard_H_tiles       – active height tiles in this shard
+ *   [2] has_bottom_pad_core – 1 if this is the last active shard and tensor has bottom padding
+ *   [3] num_work            – 0 → no border tiles on this core; >0 → work to do
+ *   [4] local_right_col     – local column index of the right-border tile within this shard
+ *                             (= W_tiles-1 for fully-packed shards; may be smaller for the
+ *                              rightmost shard when W_tiles_tensor % pages_per_shard_x != 0)
+ *
+ * Tile ordering matches fill_pad_compute.cpp exactly:
+ *   Mode A (has_bottom_pad_core == 0):
+ *     right column: (row, local_right_col) for row = 0..shard_H_tiles-1
+ *   Mode B (has_bottom_pad_core == 1):
+ *     right non-corner: (row, local_right_col) for row = 0..shard_H_tiles-2   [if has_right_pad]
+ *     bottom row:       (shard_H_tiles-1, col) for col = 0..local_right_col
+ */
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+
+void kernel_main() {
+    constexpr uint32_t W_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t has_right_pad = get_compile_time_arg_val(1);
+    constexpr uint32_t elem_size = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_data_in_idx = get_compile_time_arg_val(3);
+
+    constexpr uint32_t tile_bytes = get_tile_size(cb_data_in_idx);
+
+    const uint32_t shard_l1_base = get_arg_val<uint32_t>(0);
+    const uint32_t shard_H_tiles = get_arg_val<uint32_t>(1);
+    const uint32_t has_bottom_pad_core = get_arg_val<uint32_t>(2);
+    const uint32_t num_work = get_arg_val<uint32_t>(3);
+    const uint32_t local_right_col = get_arg_val<uint32_t>(4);
+
+    // get_noc_addr(addr) encodes the local core's physical NOC coordinates
+    // automatically — no need to call my_x[]/my_y[] directly.
+
+    constexpr uint32_t row_stride_bytes = W_tiles * tile_bytes;
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_data_in(cb_data_in_idx);
+
+    // Local-L1 self-read: no address-generator trait is applicable, so fall back
+    // to raw noc_async_read(get_noc_addr(addr), ...). CB reservations and the
+    // read barrier still go through the experimental API.
+
+    if (has_bottom_pad_core) {
+        // ---- Mode B: right non-corner tiles, then full bottom row ----
+
+        // Right non-corner tiles: rows 0..shard_H_tiles-2, col local_right_col.
+        // addr steps by row_stride_bytes each iter.
+        if constexpr (has_right_pad) {
+            uint32_t addr = shard_l1_base + local_right_col * tile_bytes;
+            for (uint32_t r = 0; r < shard_H_tiles - 1u; r++) {
+                cb_data_in.reserve_back(1);
+                noc_async_read(get_noc_addr(addr), cb_data_in.get_write_ptr(), tile_bytes);
+                noc.async_read_barrier();
+                cb_data_in.push_back(1);
+                addr += row_stride_bytes;
+            }
+        }
+
+        // Bottom row: all valid columns (including corner at col local_right_col).
+        // addr steps by tile_bytes each iter.
+        {
+            uint32_t addr = shard_l1_base + (shard_H_tiles - 1u) * row_stride_bytes;
+            for (uint32_t c = 0; c <= local_right_col; c++) {
+                cb_data_in.reserve_back(1);
+                noc_async_read(get_noc_addr(addr), cb_data_in.get_write_ptr(), tile_bytes);
+                noc.async_read_barrier();
+                cb_data_in.push_back(1);
+                addr += tile_bytes;
+            }
+        }
+
+    } else {
+        // ---- Mode A: right-column tiles only ----
+
+        if constexpr (has_right_pad) {
+            uint32_t addr = shard_l1_base + local_right_col * tile_bytes;
+            for (uint32_t r = 0; r < shard_H_tiles; r++) {
+                cb_data_in.reserve_back(1);
+                noc_async_read(get_noc_addr(addr), cb_data_in.get_write_ptr(), tile_bytes);
+                noc.async_read_barrier();
+                cb_data_in.push_back(1);
+                addr += row_stride_bytes;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_reader.cpp
@@ -30,8 +30,8 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/noc.h"
-#include "experimental/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t W_tiles = get_compile_time_arg_val(0);
@@ -52,8 +52,8 @@ void kernel_main() {
 
     constexpr uint32_t row_stride_bytes = W_tiles * tile_bytes;
 
-    experimental::Noc noc;
-    experimental::CircularBuffer cb_data_in(cb_data_in_idx);
+    Noc noc;
+    CircularBuffer cb_data_in(cb_data_in_idx);
 
     // Local-L1 self-read: no address-generator trait is applicable, so fall back
     // to raw noc_async_read(get_noc_addr(addr), ...). CB reservations and the

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp
@@ -66,17 +66,12 @@ void kernel_main() {
 
     // ---- Phase 1: generate and push mask tile(s) ----
     using mask_t = MASK_ELEM_UINT;
+    constexpr uint32_t TILE = 32;
     if constexpr (has_right_pad) {
-        cb_right_mask.reserve_back(1);
-        generate_mask_tile<mask_t, W_mod32, TILE>(
-            reinterpret_cast<mask_t*>(cb_right_mask.get_write_ptr()), static_cast<mask_t>(MASK_VALUE));
-        cb_right_mask.push_back(1);
+        push_right_mask_tile<mask_t, W_mod32, TILE>(cb_right_mask, static_cast<mask_t>(MASK_VALUE));
     }
     if (has_bottom_pad_core) {
-        cb_bot_mask.reserve_back(1);
-        generate_mask_tile<mask_t, TILE, H_mod32>(
-            reinterpret_cast<mask_t*>(cb_bot_mask.get_write_ptr()), static_cast<mask_t>(MASK_VALUE));
-        cb_bot_mask.push_back(1);
+        push_bottom_mask_tile<mask_t, H_mod32, TILE>(cb_bot_mask, static_cast<mask_t>(MASK_VALUE));
     }
 
     // ---- Phase 2: write-back loop ----

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Phase 1 – Mask generation (before main loop):
+ *   Same mask-tile generation as fill_pad_writer.cpp. Pushes right-mask and/or
+ *   bottom-mask tiles to their CBs once; the compute kernel reuses them persistently.
+ *
+ * Phase 2 – Write-back loop:
+ *   Reads masked tiles from CB[cb_data_out_idx] and writes them back to the
+ *   correct positions in this core's local L1 shard via NOC (local self-write).
+ *   No cross-core NOC access.
+ *
+ * CT args:
+ *   [0] W_tiles
+ *   [1] has_right_pad
+ *   [2] W_mod32        – width modulo 32 (right-mask threshold)
+ *   [3] H_mod32        – height modulo 32 (bottom-mask threshold)
+ *   [4] cb_right_mask_idx (= 1)
+ *   [5] cb_bot_mask_idx   (= 2)
+ *   [6] cb_data_out_idx   (= 16)
+ *
+ * RT args:
+ *   [0] shard_l1_base_addr
+ *   [1] shard_H_tiles
+ *   [2] has_bottom_pad_core
+ *   [3] num_work
+ *   [4] local_right_col – local column index of the right-border tile within this shard
+ *                         (= W_tiles-1 for fully-packed shards; may be smaller for the
+ *                          rightmost shard when W_tiles_tensor % pages_per_shard_x != 0)
+ *
+ * Tile ordering mirrors fill_pad_sharded_reader.cpp and fill_pad_compute.cpp exactly.
+ */
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "fill_pad_dataflow_common.hpp"
+
+void kernel_main() {
+    constexpr uint32_t W_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t has_right_pad = get_compile_time_arg_val(1);
+    constexpr uint32_t W_mod32 = get_compile_time_arg_val(2);
+    constexpr uint32_t H_mod32 = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_right_mask_idx = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_bot_mask_idx = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_data_out_idx = get_compile_time_arg_val(6);
+
+    constexpr uint32_t tile_bytes = get_tile_size(cb_data_out_idx);
+
+    const uint32_t shard_l1_base = get_arg_val<uint32_t>(0);
+    const uint32_t shard_H_tiles = get_arg_val<uint32_t>(1);
+    const uint32_t has_bottom_pad_core = get_arg_val<uint32_t>(2);
+    const uint32_t num_work = get_arg_val<uint32_t>(3);
+    const uint32_t local_right_col = get_arg_val<uint32_t>(4);
+
+    if (num_work == 0) {
+        return;
+    }
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_right_mask(cb_right_mask_idx);
+    experimental::CircularBuffer cb_bot_mask(cb_bot_mask_idx);
+    experimental::CircularBuffer cb_data_out(cb_data_out_idx);
+
+    // ---- Phase 1: generate and push mask tile(s) ----
+    using mask_t = MASK_ELEM_UINT;
+    if constexpr (has_right_pad) {
+        cb_right_mask.reserve_back(1);
+        generate_mask_tile<mask_t, W_mod32, TILE>(
+            reinterpret_cast<mask_t*>(cb_right_mask.get_write_ptr()), static_cast<mask_t>(MASK_VALUE));
+        cb_right_mask.push_back(1);
+    }
+    if (has_bottom_pad_core) {
+        cb_bot_mask.reserve_back(1);
+        generate_mask_tile<mask_t, TILE, H_mod32>(
+            reinterpret_cast<mask_t*>(cb_bot_mask.get_write_ptr()), static_cast<mask_t>(MASK_VALUE));
+        cb_bot_mask.push_back(1);
+    }
+
+    // ---- Phase 2: write-back loop ----
+    // Tiles arrive in the same order as the reader and compute kernels.
+    //
+    // Local-L1 self-write: no address-generator trait is applicable, so fall back
+    // to raw noc_async_write(..., get_noc_addr(addr), ...). CB wait/pop and the
+    // writes-flushed barrier still go through the experimental API.
+
+    if (has_bottom_pad_core) {
+        // ---- Mode B ----
+
+        // Step 1: right non-corner tiles (rows 0..shard_H_tiles-2, col local_right_col)
+        if constexpr (has_right_pad) {
+            for (uint32_t r = 0; r < shard_H_tiles - 1u; r++) {
+                const uint32_t dst = shard_l1_base + (r * W_tiles + local_right_col) * tile_bytes;
+                cb_data_out.wait_front(1);
+                noc_async_write(cb_data_out.get_read_ptr(), get_noc_addr(dst), tile_bytes);
+                noc.async_writes_flushed();
+                cb_data_out.pop_front(1);
+            }
+        }
+
+        // Step 2: bottom row
+        if constexpr (has_right_pad) {
+            // Non-corner bottom tiles: cols 0..local_right_col-1
+            for (uint32_t c = 0; c < local_right_col; c++) {
+                const uint32_t dst = shard_l1_base + ((shard_H_tiles - 1u) * W_tiles + c) * tile_bytes;
+                cb_data_out.wait_front(1);
+                noc_async_write(cb_data_out.get_read_ptr(), get_noc_addr(dst), tile_bytes);
+                noc.async_writes_flushed();
+                cb_data_out.pop_front(1);
+            }
+            // Corner tile: col local_right_col
+            const uint32_t dst = shard_l1_base + ((shard_H_tiles - 1u) * W_tiles + local_right_col) * tile_bytes;
+            cb_data_out.wait_front(1);
+            noc_async_write(cb_data_out.get_read_ptr(), get_noc_addr(dst), tile_bytes);
+            noc.async_writes_flushed();
+            cb_data_out.pop_front(1);
+        } else {
+            for (uint32_t c = 0; c <= local_right_col; c++) {
+                const uint32_t dst = shard_l1_base + ((shard_H_tiles - 1u) * W_tiles + c) * tile_bytes;
+                cb_data_out.wait_front(1);
+                noc_async_write(cb_data_out.get_read_ptr(), get_noc_addr(dst), tile_bytes);
+                noc.async_writes_flushed();
+                cb_data_out.pop_front(1);
+            }
+        }
+
+    } else {
+        // ---- Mode A: right-column tiles only ----
+
+        if constexpr (has_right_pad) {
+            for (uint32_t r = 0; r < shard_H_tiles; r++) {
+                const uint32_t dst = shard_l1_base + (r * W_tiles + local_right_col) * tile_bytes;
+                cb_data_out.wait_front(1);
+                noc_async_write(cb_data_out.get_read_ptr(), get_noc_addr(dst), tile_bytes);
+                noc.async_writes_flushed();
+                cb_data_out.pop_front(1);
+            }
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_sharded_writer.cpp
@@ -34,8 +34,8 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/noc.h"
-#include "experimental/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "fill_pad_dataflow_common.hpp"
 
 void kernel_main() {
@@ -59,10 +59,10 @@ void kernel_main() {
         return;
     }
 
-    experimental::Noc noc;
-    experimental::CircularBuffer cb_right_mask(cb_right_mask_idx);
-    experimental::CircularBuffer cb_bot_mask(cb_bot_mask_idx);
-    experimental::CircularBuffer cb_data_out(cb_data_out_idx);
+    Noc noc;
+    CircularBuffer cb_right_mask(cb_right_mask_idx);
+    CircularBuffer cb_bot_mask(cb_bot_mask_idx);
+    CircularBuffer cb_data_out(cb_data_out_idx);
 
     // ---- Phase 1: generate and push mask tile(s) ----
     using mask_t = MASK_ELEM_UINT;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
@@ -1,100 +1,147 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * Phase 1 – Mask generation (before the main loop):
+ *   Builds a "right mask" tile (if has_right_pad) and a "bottom mask" tile
+ *   (if has_bottom_pad) in face layout and pushes them to their respective
+ *   circular buffers. The compute kernel holds these tiles persistently
+ *   (never pops them) and uses them with where_tile to apply the fill.
+ *
+ *   Mask encoding (same DataFormat as the input tensor):
+ *     Float types  : 1.0 at padding positions, 0.0 elsewhere.
+ *     Integer types: integer 1 at padding positions, 0 elsewhere.
+ *
+ * Phase 2 – Write-back loop:
+ *   Reads masked tiles produced by the compute kernel from CB[16] and writes
+ *   them back to DRAM (or sharded L1). No masking is done here.
+ *
+ *   Three phase loops mirror fill_pad_reader.cpp's right / bottom / corner
+ *   phases, using the same per-phase (start, num) RT args so that reader,
+ *   compute and writer process tiles in lock-step.
+ *
+ * CT args layout:
+ *   [0]  W_tiles
+ *   [1]  H_tiles
+ *   [2]  N_slices (unused in the write loop)
+ *   [3]  has_right_pad
+ *   [4]  has_bottom_pad
+ *   [5]  W_mod32
+ *   [6]  H_mod32
+ *   [7]  cb_right_mask_idx  (= 1)
+ *   [8]  cb_bot_mask_idx    (= 2)
+ *   [9]  cb_data_out_idx    (= 16)
+ *   [10+] TensorAccessorArgs
+ *
+ * RT args:
+ *   [0]  buf_addr
+ *   [1]  start_right   [2]  num_right
+ *   [3]  start_bottom  [4]  num_bottom
+ *   [5]  start_corner  [6]  num_corner
+ */
+
 #include "api/dataflow/dataflow_api.h"
-#include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
-#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "fill_pad_dataflow_common.hpp"
+#include "experimental/tensor.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_id_0 = get_compile_time_arg_val(0);
-    constexpr bool tensor_in_dram = get_compile_time_arg_val(1) == 1;
-    const uint32_t fill_value = get_compile_time_arg_val(2);
-    const uint32_t element_size_bytes = get_compile_time_arg_val(3);
-    uint32_t logical_height = get_compile_time_arg_val(4);
-    uint32_t logical_width = get_compile_time_arg_val(5);
-    uint32_t padded_height = get_compile_time_arg_val(6);
-    uint32_t padded_width = get_compile_time_arg_val(7);
-    uint32_t tiles_per_2d_tensor = get_compile_time_arg_val(8);
-    uint32_t tiles_per_tile_row = get_compile_time_arg_val(9);
-    // hardware constraints
-    constexpr uint32_t tile_size = get_compile_time_arg_val(10);
-    constexpr uint32_t tile_hw = tile_size * tile_size;
-    constexpr uint32_t face_size = get_compile_time_arg_val(11);
-    constexpr uint32_t face_hw = face_size * face_size;
-    constexpr uint32_t alignment_adjustor = 16;
+    constexpr uint32_t W_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t H_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t has_right_pad = get_compile_time_arg_val(3);
+    constexpr uint32_t has_bottom_pad = get_compile_time_arg_val(4);
+    constexpr uint32_t W_mod32 = get_compile_time_arg_val(5);
+    constexpr uint32_t H_mod32 = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_right_mask_idx = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_bot_mask_idx = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_data_out_idx = get_compile_time_arg_val(9);
 
-    uint32_t rt_arg_ind = 0;
-    uint32_t dst_addr = get_arg_val<uint32_t>(rt_arg_ind++);
-    uint32_t cb_page_size = get_arg_val<uint32_t>(rt_arg_ind++);
-    uint32_t starting_tile_offset = get_arg_val<uint32_t>(rt_arg_ind++);
-    uint32_t num_2d_tensors = get_arg_val<uint32_t>(rt_arg_ind++);
+    // Per-phase strides (meaningful only when the corresponding phase is active).
+    // Clamped to >= 1 so the compiler does not see a constexpr divide-by-zero in
+    // the dead-code branches (when H_tiles==1 or W_tiles==1 the host sets the
+    // matching num_* to 0 and the loop below never executes).
+    constexpr uint32_t R =
+        (has_right_pad != 0u) ? ((has_bottom_pad != 0u) ? ((H_tiles > 1u) ? (H_tiles - 1u) : 1u) : H_tiles) : 1u;
+    constexpr uint32_t C =
+        (has_bottom_pad != 0u) ? ((has_right_pad != 0u) ? ((W_tiles > 1u) ? (W_tiles - 1u) : 1u) : W_tiles) : 1u;
 
-#ifdef SHARDED
-    using tensor_shard_info = ShardedInfo<
-        get_compile_time_arg_val(12),   // Memory layout
-        get_compile_time_arg_val(13),   // The number of sharding cores
-        get_compile_time_arg_val(14),   // The page size we offset each write to
-        get_compile_time_arg_val(15),   // The number of pages in each sharding row not including padding pages
-        get_compile_time_arg_val(16),   // This defines times when contiguous pages can't be calculated
-        get_compile_time_arg_val(17),   // pages_per_shard_x
-        get_compile_time_arg_val(18)>;  // pages_per_shard_y
+    constexpr uint32_t tile_bytes = get_tile_size(cb_data_out_idx);
 
-    const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(rt_arg_ind));
-    experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = dst_addr, .shard_array = mapping_table};
-#else
-    constexpr auto dst_args = TensorAccessorArgs<12>();
-    const auto s0 = TensorAccessor(dst_args, dst_addr);
-#endif
+    const uint32_t buf_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_right = get_arg_val<uint32_t>(1);
+    const uint32_t num_right = get_arg_val<uint32_t>(2);
+    const uint32_t start_bottom = get_arg_val<uint32_t>(3);
+    const uint32_t num_bottom = get_arg_val<uint32_t>(4);
+    const uint32_t start_corner = get_arg_val<uint32_t>(5);
+    const uint32_t num_corner = get_arg_val<uint32_t>(6);
 
-    // Reserve and push the fill value into the circular buffer
-    cb_reserve_back(cb_id_0, 1);
-    uint32_t l1_write_addr = get_write_ptr(cb_id_0);
-    volatile tt_l1_ptr uint32_t* l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr);
-    for (uint32_t i = 0; i < cb_page_size; i++) {
-        l1_ptr[i] = fill_value;
+    constexpr auto dst_args = TensorAccessorArgs<10>();
+    const auto s = TensorAccessor(dst_args, buf_addr, tile_bytes);
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_right_mask(cb_right_mask_idx);
+    experimental::CircularBuffer cb_bot_mask(cb_bot_mask_idx);
+    experimental::CircularBuffer cb_data_out(cb_data_out_idx);
+
+    // ---- Phase 1: generate and push mask tile(s) ----
+    using mask_t = MASK_ELEM_UINT;
+    if constexpr (has_right_pad) {
+        cb_right_mask.reserve_back(1);
+        generate_mask_tile<mask_t, W_mod32, TILE>(
+            reinterpret_cast<mask_t*>(cb_right_mask.get_write_ptr()), static_cast<mask_t>(MASK_VALUE));
+        cb_right_mask.push_back(1);
     }
-    cb_push_back(cb_id_0, 1);
+    if constexpr (has_bottom_pad) {
+        cb_bot_mask.reserve_back(1);
+        generate_mask_tile<mask_t, TILE, H_mod32>(
+            reinterpret_cast<mask_t*>(cb_bot_mask.get_write_ptr()), static_cast<mask_t>(MASK_VALUE));
+        cb_bot_mask.push_back(1);
+    }
 
-    auto fill_pad_2d_tensor = [&](const uint32_t& tile_offset) {
-        uint32_t start_col;
-        for (uint32_t row = 0; row < padded_height; row++) {
-            if (row < logical_height) {
-                start_col = logical_width;
-            } else {
-                start_col = 0;
-            }
-            uint32_t curr_tile = (row / tile_size) * tiles_per_tile_row + (start_col / tile_size) + tile_offset;
-            uint32_t r_f_offset = ((row % tile_size) / face_size) * 2 * face_hw + (row % face_size) * face_size;
-            uint32_t c_f_offset = ((start_col % tile_size) / face_size) * face_hw + (start_col % face_size);
-            uint32_t face_offset = r_f_offset + c_f_offset;
+    // ---- Phase 2: write-back loop ----
+    // Tiles arrive in the same order as the reader pushes them (right, bottom, corner).
 
-            for (uint32_t col = start_col; col < padded_width;) {
-                // so for each iteration of col, we will be writing at most 2 faces
-                uint64_t start_tile_noc_addr = s0.get_noc_addr(curr_tile);
-                uint32_t face = face_offset / (face_hw);
-
-                uint64_t dst_noc_addr = start_tile_noc_addr + face_offset * element_size_bytes;
-                uint32_t alignment_offset = dst_noc_addr % alignment_adjustor;
-                uint32_t elems_to_write = col % face_size == 0 ? face_size : face_size - (col % face_size);
-                uint32_t bytes_to_write = elems_to_write * element_size_bytes;
-                noc_async_write(l1_write_addr + alignment_offset, dst_noc_addr, bytes_to_write);
-                col += elems_to_write;
-                face_offset += elems_to_write;
-
-                if (face % 2 == 0) {
-                    face_offset += face_size * (face_size - 1);
-                } else {
-                    curr_tile++;
-                    face_offset -= face_size * (face_size + 1);
-                }
-            }
+    // Right phase
+    if constexpr (has_right_pad != 0u) {
+        for (uint32_t i = 0; i < num_right; ++i) {
+            const uint32_t g = start_right + i;
+            const uint32_t slice = g / R;
+            const uint32_t row = g - slice * R;
+            const uint32_t tile_id = slice * H_tiles * W_tiles + row * W_tiles + (W_tiles - 1u);
+            cb_data_out.wait_front(1);
+            noc.async_write(cb_data_out, s, tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
+            noc.async_writes_flushed();
+            cb_data_out.pop_front(1);
         }
-    };
-
-    for (uint32_t t = 0; t < num_2d_tensors; t++) {
-        fill_pad_2d_tensor(t * tiles_per_2d_tensor + starting_tile_offset);
     }
-    noc_async_write_barrier();
+
+    // Bottom phase
+    if constexpr (has_bottom_pad != 0u) {
+        for (uint32_t j = 0; j < num_bottom; ++j) {
+            const uint32_t g = start_bottom + j;
+            const uint32_t slice = g / C;
+            const uint32_t col = g - slice * C;
+            const uint32_t tile_id = slice * H_tiles * W_tiles + (H_tiles - 1u) * W_tiles + col;
+            cb_data_out.wait_front(1);
+            noc.async_write(cb_data_out, s, tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
+            noc.async_writes_flushed();
+            cb_data_out.pop_front(1);
+        }
+    }
+
+    // Corner phase
+    if constexpr (has_right_pad != 0u && has_bottom_pad != 0u) {
+        for (uint32_t k = 0; k < num_corner; ++k) {
+            const uint32_t slice = start_corner + k;
+            const uint32_t tile_id = slice * H_tiles * W_tiles + (H_tiles - 1u) * W_tiles + (W_tiles - 1u);
+            cb_data_out.wait_front(1);
+            noc.async_write(cb_data_out, s, tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
+            noc.async_writes_flushed();
+            cb_data_out.pop_front(1);
+        }
+    }
+
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -58,14 +58,14 @@ void kernel_main() {
     constexpr uint32_t cb_bot_mask_idx = get_compile_time_arg_val(8);
     constexpr uint32_t cb_data_out_idx = get_compile_time_arg_val(9);
 
-    // Per-phase strides (meaningful only when the corresponding phase is active).
+    // Per-phase slice strides (meaningful only when the corresponding phase is active).
     // Clamped to >= 1 so the compiler does not see a constexpr divide-by-zero in
     // the dead-code branches (when H_tiles==1 or W_tiles==1 the host sets the
     // matching num_* to 0 and the loop below never executes).
-    constexpr uint32_t R =
-        (has_right_pad != 0u) ? ((has_bottom_pad != 0u) ? ((H_tiles > 1u) ? (H_tiles - 1u) : 1u) : H_tiles) : 1u;
-    constexpr uint32_t C =
-        (has_bottom_pad != 0u) ? ((has_right_pad != 0u) ? ((W_tiles > 1u) ? (W_tiles - 1u) : 1u) : W_tiles) : 1u;
+    constexpr uint32_t right_slice_stride =
+        has_right_pad ? (has_bottom_pad ? ((H_tiles > 1u) ? (H_tiles - 1u) : 1u) : H_tiles) : 1u;
+    constexpr uint32_t bottom_slice_stride =
+        has_bottom_pad ? (has_right_pad ? ((W_tiles > 1u) ? (W_tiles - 1u) : 1u) : W_tiles) : 1u;
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_data_out_idx);
 
@@ -87,52 +87,56 @@ void kernel_main() {
 
     // ---- Phase 1: generate and push mask tile(s) ----
     using mask_t = MASK_ELEM_UINT;
+    constexpr uint32_t TILE = 32;
     if constexpr (has_right_pad) {
-        cb_right_mask.reserve_back(1);
-        generate_mask_tile<mask_t, W_mod32, TILE>(
-            reinterpret_cast<mask_t*>(cb_right_mask.get_write_ptr()), static_cast<mask_t>(MASK_VALUE));
-        cb_right_mask.push_back(1);
+        push_right_mask_tile<mask_t, W_mod32, TILE>(cb_right_mask, static_cast<mask_t>(MASK_VALUE));
     }
     if constexpr (has_bottom_pad) {
-        cb_bot_mask.reserve_back(1);
-        generate_mask_tile<mask_t, TILE, H_mod32>(
-            reinterpret_cast<mask_t*>(cb_bot_mask.get_write_ptr()), static_cast<mask_t>(MASK_VALUE));
-        cb_bot_mask.push_back(1);
+        push_bottom_mask_tile<mask_t, H_mod32, TILE>(cb_bot_mask, static_cast<mask_t>(MASK_VALUE));
     }
 
     // ---- Phase 2: write-back loop ----
     // Tiles arrive in the same order as the reader pushes them (right, bottom, corner).
 
-    // Right phase
-    if constexpr (has_right_pad != 0u) {
+    // Right phase. Maintain (slice, row) incrementally instead of dividing every iteration
+    // — RV32IM division is slow. Startup division runs at most once per kernel invocation.
+    if constexpr (has_right_pad) {
+        uint32_t slice = num_right ? start_right / right_slice_stride : 0u;
+        uint32_t row = num_right ? start_right - slice * right_slice_stride : 0u;
         for (uint32_t i = 0; i < num_right; ++i) {
-            const uint32_t g = start_right + i;
-            const uint32_t slice = g / R;
-            const uint32_t row = g - slice * R;
             const uint32_t tile_id = slice * H_tiles * W_tiles + row * W_tiles + (W_tiles - 1u);
             cb_data_out.wait_front(1);
             noc.async_write(cb_data_out, s, tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
             noc.async_writes_flushed();
             cb_data_out.pop_front(1);
+            ++row;
+            if (row == right_slice_stride) {
+                row = 0;
+                ++slice;
+            }
         }
     }
 
-    // Bottom phase
-    if constexpr (has_bottom_pad != 0u) {
+    // Bottom phase. Same incremental pattern as the right phase.
+    if constexpr (has_bottom_pad) {
+        uint32_t slice = num_bottom ? start_bottom / bottom_slice_stride : 0u;
+        uint32_t col = num_bottom ? start_bottom - slice * bottom_slice_stride : 0u;
         for (uint32_t j = 0; j < num_bottom; ++j) {
-            const uint32_t g = start_bottom + j;
-            const uint32_t slice = g / C;
-            const uint32_t col = g - slice * C;
             const uint32_t tile_id = slice * H_tiles * W_tiles + (H_tiles - 1u) * W_tiles + col;
             cb_data_out.wait_front(1);
             noc.async_write(cb_data_out, s, tile_bytes, {.offset_bytes = 0}, {.page_id = tile_id});
             noc.async_writes_flushed();
             cb_data_out.pop_front(1);
+            ++col;
+            if (col == bottom_slice_stride) {
+                col = 0;
+                ++slice;
+            }
         }
     }
 
     // Corner phase
-    if constexpr (has_right_pad != 0u && has_bottom_pad != 0u) {
+    if constexpr (has_right_pad && has_bottom_pad) {
         for (uint32_t k = 0; k < num_corner; ++k) {
             const uint32_t slice = start_corner + k;
             const uint32_t tile_id = slice * H_tiles * W_tiles + (H_tiles - 1u) * W_tiles + (W_tiles - 1u);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
@@ -42,10 +42,10 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/noc.h"
-#include "experimental/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 #include "fill_pad_dataflow_common.hpp"
-#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr uint32_t W_tiles = get_compile_time_arg_val(0);
@@ -80,10 +80,10 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<10>();
     const auto s = TensorAccessor(dst_args, buf_addr, tile_bytes);
 
-    experimental::Noc noc;
-    experimental::CircularBuffer cb_right_mask(cb_right_mask_idx);
-    experimental::CircularBuffer cb_bot_mask(cb_bot_mask_idx);
-    experimental::CircularBuffer cb_data_out(cb_data_out_idx);
+    Noc noc;
+    CircularBuffer cb_right_mask(cb_right_mask_idx);
+    CircularBuffer cb_bot_mask(cb_bot_mask_idx);
+    CircularBuffer cb_data_out(cb_data_out_idx);
 
     // ---- Phase 1: generate and push mask tile(s) ----
     using mask_t = MASK_ELEM_UINT;


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

FillPadDeviceOperation (ttnn.fill_implicit_tile_padding) fills tile padding with specified value. It is used for ops such as topk or sum. 
In tiny deepseek training, this operation is called indirectly, by topk and sum. It amounts to around ~40% of the MoE forward/backward pass. 

Looking at the fillpad implementation:
- It does everything in reader kernel. (no writer or compute kernel)
- Reader kernel makes heavy use of integer division/modulo. 
- Due to its work splitting strategy, on tiny deepseek shapes, it only uses 8 cores (instead of 110). 

#### Implementation

This PR refactors the implementation to use more cores, and leverage compute/writer kernels:

Basic idea: right-padding and bottom-padding are the same everywhere (for tiles in the borders). We can pre-generate a mask to determine which tile elements have to be replaced. Once mask tile has been generated, masking can easily be done on compute kernel through `where_tile` LLK. 

The new implementation works as follows:
- Reader kernel read data and sends to compute
- Writer kernel first generate masks, sends mask to compute, and then reads output from compute kernel and writes it back to destination address.
- Compute kernel receives masks from writer, and for every input from reader, applies `where_tile` LLK with the mask and sends output to writer. 

I've also tightened test thresholds: instead of testing against PCC, we use equality (except for block float, which are a special case).

#### Performance

In tiny deepseek training shapes, this changes reduces time spent on FillPadDeviceOperation by a factor of ~3 (c.f. table https://github.com/tenstorrent/tt-metal/pull/42859).  
It is also faster for most other shapes: 

Name | Shape | Average Duration [ms] | Speed-up
-- | -- | -- | --
main | [2048, 8] | 0.2067 | N/A
main | [8192, 1] | 0.80745 | N/A
main | [8192, 8191] | 0.34021 | N/A
main | [512, 511, 512] | 0.01284 | N/A
main | [512, 512, 496] | 0.21285 | N/A
main | [512, 512, 511] | 0.21227 | N/A
main | [8192, 32, 16] | 0.15773 | N/A
main | [8192, 32, 31] | 0.15812 | N/A
new | [2048, 8] | 0.00728 | x28.39
new | [8192, 1] | 0.00901 | x89.62
new | [8192, 8191] | 0.00861 | x39.51
new | [512, 511, 512] | 0.10149 | x0.13
new | [512, 512, 496] | 0.10644 | x2.00
new | [512, 512, 511] | 0.10575 | x2.01
new | [8192, 32, 16] | 0.09855 | x1.60
new | [8192, 32, 31] | 0.09733 | x1.62

Notes: 
- There is a performance regression for `[512, 511, 512]` (~134M elements), but it's worth noting that latency is still reasonable given the tensor size, and it's close to being a best case scenario for the implementation in main (good load balancing and few elements to fill per corner tile). 

- This also fixes the accuracy error in current fill pad implementation: #43792

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

- Tile-level balancing is not well suited for L1 tensors (we do not want to perform data-movement when not needed). For this reason, we have separate dataflow kernels for L1 tensors. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/perf-improvement-fill-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/perf-improvement-fill-pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmaurice/perf-improvement-fill-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmaurice/perf-improvement-fill-pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/perf-improvement-fill-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/perf-improvement-fill-pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/perf-improvement-fill-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/perf-improvement-fill-pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmaurice/perf-improvement-fill-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmaurice/perf-improvement-fill-pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/perf-improvement-fill-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/perf-improvement-fill-pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/perf-improvement-fill-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/perf-improvement-fill-pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/perf-improvement-fill-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/perf-improvement-fill-pad)