### PR TITLE
ds_prefill(ci): tt_prefill_transformer.py per-run per-layer PCC summaries, team shield migration, separate KV/PE thresholds

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -84,6 +84,11 @@ ttnn:
 shield:
   e2e:
     wh_llmbox: 45
+  demo:
+    bh_galaxy: 50
+    wh_llmbox_perf: 45
+    bh_loudbox: 45
+    bh_llmbox: 40
 
 # Former fabric + scaleout budgets merged under team scaleout (see tests/pipeline_reorg).
 scaleout:
@@ -151,12 +156,12 @@ models:
     bh_p300: 10
 
   demo:
-    wh_llmbox_perf: 200
+    wh_llmbox_perf: 1045
     wh_llmbox_perf_release: 1090
     wh_galaxy: 0
     wh_galaxy_perf: 150
     wh_galaxy_release: 345
-    bh_galaxy: 30
+    bh_galaxy: 0
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600
@@ -167,8 +172,8 @@ models:
     bh_p150b_civ2: 250
     bh_p150b_civ2_viommu: 50
     bh_deskbox: 250
-    bh_llmbox: 1200
-    bh_loudbox: 1200
+    bh_llmbox: 1160
+    bh_loudbox: 1155
 
     bh_p300: 800
     bh_quietbox_2: 250

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -140,6 +140,15 @@ jobs:
 
           echo "$CMD"
           eval "$CMD"
+      - name: Publish PCC summary
+        if: ${{ !cancelled() }}
+        run: |
+          PCC_DIR="/tmp/pcc_summaries"
+          if [ -d "$PCC_DIR" ]; then
+            for f in "$PCC_DIR"/pcc_summary_*.md; do
+              [ -f "$f" ] && cat "$f" >> "$GITHUB_STEP_SUMMARY"
+            done
+          fi
       - name: Save environment data
         id: save-environment-data
         if: ${{ !cancelled() && matrix.test-group.save-perf-data }}

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -19,6 +19,7 @@ Parametrized over:
 
 import gc
 import json
+import os
 
 import pytest
 import torch
@@ -397,13 +398,21 @@ def test_prefill_transformer(
         profiler.start("pcc_validation")
         if use_pretrained and input_source != "random":
             threshold = 0.97
+            kv_threshold = 0.96
+            pe_threshold = 0.99
         elif use_pretrained:
             threshold = 0.95
+            kv_threshold = threshold
+            pe_threshold = threshold
         elif n_routed_experts < 256:
             threshold = 0.985
+            kv_threshold = threshold
+            pe_threshold = threshold
         else:
             threshold = PCC_THRESHOLD  # 0.99
-        logger.info(f"PCC threshold: {threshold}")
+            kv_threshold = threshold
+            pe_threshold = threshold
+        logger.info(f"PCC threshold: {threshold}, KV: {kv_threshold}, PE: {pe_threshold}")
 
         # Load reference from cache if not already computed
         if ref_snapshots is None:
@@ -412,15 +421,17 @@ def test_prefill_transformer(
         # else: already computed by load_and_compute_layer_by_layer()
 
         # Per-stage PCC comparison
-        pcc_results = []
+        output_pcc = {}
+        kvpe_kv_pcc = {}
+        kvpe_pe_pcc = {}
         for (label, tt_host), ref_host in zip(tt_snapshots, ref_snapshots):
             try:
                 _, pcc = comp_pcc(ref_host.float(), tt_host.float())
                 logger.debug(f"{label:<20s}  PCC = {pcc:.6f}")
-                pcc_results.append((label, pcc))
+                output_pcc[label] = pcc
             except Exception as e:
                 logger.error(f"{label:<20s}  PCC comparison failed: {e}")
-                pcc_results.append((label, -1.0))
+                output_pcc[label] = -1.0
 
         # Per-layer KVPE PCC comparison — read back from external cache
         if do_return_kv:
@@ -443,26 +454,53 @@ def test_prefill_transformer(
                         tt_kvpe_layer[:, :, :, kv_lora_rank:].float(),
                     )
                     logger.info(f"{label:<20s}  KV PCC = {kv_pcc:.6f}, PE PCC = {pe_pcc:.6f}")
-                    pcc_results.append((f"{label}_kv", kv_pcc))
-                    pcc_results.append((f"{label}_pe", pe_pcc))
+                    kvpe_kv_pcc[f"{label}_kv"] = kv_pcc
+                    kvpe_pe_pcc[f"{label}_pe"] = pe_pcc
                 except Exception as e:
                     logger.error(f"{label:<20s}  KVPE PCC comparison failed: {e}")
-                    pcc_results.append((f"{label}_kv", -1.0))
-                    pcc_results.append((f"{label}_pe", -1.0))
+                    kvpe_kv_pcc[f"{label}_kv"] = -1.0
+                    kvpe_pe_pcc[f"{label}_pe"] = -1.0
 
         profiler.end("pcc_validation")
 
         # Summary table
-        logger.info(f"\n{'='*50}")
-        logger.info(f"{'Stage':<20s}  {'PCC':>10s}  {'Status':>8s}")
-        logger.info(f"{'-'*50}")
+        all_pcc_items = (
+            [(label, pcc, threshold) for label, pcc in output_pcc.items()]
+            + [(label, pcc, kv_threshold) for label, pcc in kvpe_kv_pcc.items()]
+            + [(label, pcc, pe_threshold) for label, pcc in kvpe_pe_pcc.items()]
+        )
+        logger.info(f"\n{'='*60}")
+        logger.info(f"{'Stage':<20s}  {'PCC':>10s}  {'Thresh':>8s}  {'Status':>8s}")
+        logger.info(f"{'-'*60}")
         failures = []
-        for label, pcc in pcc_results:
-            status = "PASS" if pcc > threshold else ("FAIL" if pcc >= 0 else "ERROR")
-            logger.info(f"{label:<20s}  {pcc:>10.6f}  {status:>8s}")
-            if pcc <= threshold:
+        for label, pcc, thresh in all_pcc_items:
+            status = "PASS" if pcc > thresh else ("FAIL" if pcc >= 0 else "ERROR")
+            logger.info(f"{label:<20s}  {pcc:>10.6f}  {thresh:>8.4f}  {status:>8s}")
+            if pcc <= thresh:
                 failures.append((label, pcc))
-        logger.info(f"{'='*50}")
+        logger.info(f"{'='*60}")
+
+        pcc_result = {
+            "pcc": (output_pcc, kvpe_kv_pcc, kvpe_pe_pcc),
+            "threshold": threshold,
+            "kv_threshold": kv_threshold,
+            "pe_threshold": pe_threshold,
+            "num_layers": num_layers,
+            "isl_total": isl_total,
+            "weight_type": weight_type,
+            "input_source": input_source,
+            "mesh_shape": mesh_shape,
+            "n_routed_experts": n_routed_experts,
+            "capacity_factor": capacity_factor,
+        }
+
+        try:
+            from models.demos.deepseek_v3_d_p.utils.pcc_plot_utils import generate_pcc_plots, write_pcc_summary
+
+            generate_pcc_plots(pcc_result, output_dir=os.getenv("PCC_PLOT_DIR", "/tmp/pcc_plots"))
+            write_pcc_summary(pcc_result, threshold=threshold)
+        except Exception as e:
+            logger.warning(f"Failed to generate PCC plots: {e}")
 
         # Store failures for deferred check (after timing report)
         has_pcc_failures = len(failures) > 0
@@ -495,6 +533,26 @@ def test_prefill_transformer(
     logger.info(f"{'='*60}")
     for key in profiler.times:
         logger.info(f"  {key}: {profiler.get(key) * 1000:.2f} ms")
+
+    # Append timing report to the per-run PCC summary file
+    try:
+        from pathlib import Path
+
+        summary_dir = Path(os.getenv("PCC_SUMMARY_DIR", "/tmp/pcc_summaries"))
+        from models.demos.deepseek_v3_d_p.utils.pcc_plot_utils import _build_run_name
+
+        run_name = _build_run_name(pcc_result)
+        summary_path = summary_dir / f"pcc_summary_{run_name}.md"
+        if summary_path.exists():
+            with open(summary_path, "a") as f:
+                f.write("\n\n### Timing Report\n\n")
+                f.write("| Stage | Time (ms) |\n")
+                f.write("|-------|-----------|\n")
+                for key in profiler.times:
+                    f.write(f"| {key} | {profiler.get(key) * 1000:.2f} |\n")
+            logger.info(f"Timing report appended to {summary_path}")
+    except Exception as e:
+        logger.warning(f"Failed to append timing report: {e}")
 
     # Restore original config
     DeepSeekV3Config.NUM_ROUTED_EXPERTS = orig_num_routed_experts

--- a/models/demos/deepseek_v3_d_p/utils/pcc_plot_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/pcc_plot_utils.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC visualization utilities for DeepSeek prefill transformer tests.
+
+Provides:
+- Matplotlib PNG plots of per-layer PCC values
+- Mermaid xychart-beta chart generation for GitHub Actions summaries
+- Summary file writer for CI integration
+"""
+
+import os
+from pathlib import Path
+
+from loguru import logger
+
+
+def _build_run_name(result: dict) -> str:
+    """Derive a short run name from result metadata."""
+    parts = []
+    if "num_layers" in result:
+        parts.append(f"{result['num_layers']}L")
+    if "isl_total" in result:
+        parts.append(f"isl{result['isl_total']}")
+    if "weight_type" in result:
+        parts.append(result["weight_type"])
+    if "input_source" in result:
+        parts.append(result["input_source"])
+    if "mesh_shape" in result:
+        ms = result["mesh_shape"]
+        if isinstance(ms, (list, tuple)):
+            parts.append(f"{ms[0]}x{ms[1]}")
+        else:
+            parts.append(str(ms))
+    if "n_routed_experts" in result:
+        parts.append(f"e{result['n_routed_experts']}")
+    if "capacity_factor" in result:
+        parts.append(f"cf{result['capacity_factor']}")
+    return "_".join(parts) if parts else "run"
+
+
+def generate_pcc_plots(result: dict, output_dir: str = "/tmp/pcc_plots") -> dict:
+    """
+    Generate Matplotlib PNG plots for PCC results.
+
+    Args:
+        result: Dict with 'pcc' tuple of (output_pcc, kvpe_kv_pcc, kvpe_pe_pcc) dicts,
+                plus metadata keys (num_layers, isl_total, weight_type, etc.)
+        output_dir: Directory to save PNG files.
+
+    Returns:
+        Stats dict with min/max/mean PCC values per category.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        logger.warning("matplotlib not available, skipping PNG plot generation")
+        return {}
+
+    output_pcc, kvpe_kv_pcc, kvpe_pe_pcc = result["pcc"]
+    run_name = _build_run_name(result)
+    threshold = result.get("threshold", 0.99)
+    kv_threshold = result.get("kv_threshold", threshold)
+    pe_threshold = result.get("pe_threshold", threshold)
+
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    stats = {}
+
+    # --- Subplot 1: Output PCC ---
+    has_output = len(output_pcc) > 0
+    has_kvpe = len(kvpe_kv_pcc) > 0 or len(kvpe_pe_pcc) > 0
+    n_subplots = (1 if has_output else 0) + (1 if has_kvpe else 0)
+
+    if n_subplots == 0:
+        logger.warning("No PCC data to plot")
+        return stats
+
+    fig, axes = plt.subplots(1, n_subplots, figsize=(7 * n_subplots, 5))
+    if n_subplots == 1:
+        axes = [axes]
+
+    ax_idx = 0
+
+    if has_output:
+        ax = axes[ax_idx]
+        ax_idx += 1
+        labels = list(output_pcc.keys())
+        values = np.array(list(output_pcc.values()))
+        x = np.arange(len(labels))
+
+        colors = ["red" if v <= threshold else "steelblue" for v in values]
+        ax.bar(x, values, color=colors, edgecolor="black", linewidth=0.3)
+        ax.axhline(y=threshold, color="orange", linestyle="--", linewidth=1.2, label=f"threshold={threshold}")
+        ax.set_xticks(x)
+        ax.set_xticklabels([_short_label(l) for l in labels], rotation=60, ha="right", fontsize=7)
+        ax.set_ylabel("PCC")
+        ax.set_title(f"Output PCC — {run_name}")
+        ax.legend(fontsize=8)
+        ax.set_ylim(min(values.min() - 0.01, threshold - 0.02), 1.005)
+
+        stats["output"] = {"min": float(values.min()), "max": float(values.max()), "mean": float(values.mean())}
+
+    if has_kvpe:
+        ax = axes[ax_idx]
+        kv_labels = list(kvpe_kv_pcc.keys())
+        kv_values = np.array(list(kvpe_kv_pcc.values())) if kvpe_kv_pcc else np.array([])
+        pe_labels = list(kvpe_pe_pcc.keys())
+        pe_values = np.array(list(kvpe_pe_pcc.values())) if kvpe_pe_pcc else np.array([])
+
+        n_kv = len(kv_labels)
+        n_pe = len(pe_labels)
+        n_total = max(n_kv, n_pe)
+        x = np.arange(n_total)
+        width = 0.35
+
+        if n_kv > 0:
+            kv_colors = ["red" if v <= kv_threshold else "steelblue" for v in kv_values]
+            ax.bar(
+                x[:n_kv] - width / 2, kv_values, width, color=kv_colors, edgecolor="black", linewidth=0.3, label="KV"
+            )
+        if n_pe > 0:
+            pe_colors = ["red" if v <= pe_threshold else "seagreen" for v in pe_values]
+            ax.bar(
+                x[:n_pe] + width / 2, pe_values, width, color=pe_colors, edgecolor="black", linewidth=0.3, label="PE"
+            )
+
+        ax.axhline(y=kv_threshold, color="orange", linestyle="--", linewidth=1.2, label=f"KV thresh={kv_threshold}")
+        if pe_threshold != kv_threshold:
+            ax.axhline(y=pe_threshold, color="purple", linestyle="--", linewidth=1.2, label=f"PE thresh={pe_threshold}")
+        combined_labels = kv_labels if n_kv >= n_pe else pe_labels
+        ax.set_xticks(x)
+        ax.set_xticklabels([_short_label(l) for l in combined_labels], rotation=60, ha="right", fontsize=7)
+        ax.set_ylabel("PCC")
+        ax.set_title(f"KVPE Cache PCC — {run_name}")
+        ax.legend(fontsize=8)
+
+        all_vals = np.concatenate([v for v in [kv_values, pe_values] if len(v) > 0])
+        min_thresh = min(kv_threshold, pe_threshold)
+        ax.set_ylim(min(all_vals.min() - 0.01, min_thresh - 0.02), 1.005)
+
+        if n_kv > 0:
+            stats["kv"] = {
+                "min": float(kv_values.min()),
+                "max": float(kv_values.max()),
+                "mean": float(kv_values.mean()),
+            }
+        if n_pe > 0:
+            stats["pe"] = {
+                "min": float(pe_values.min()),
+                "max": float(pe_values.max()),
+                "mean": float(pe_values.mean()),
+            }
+
+    plt.tight_layout()
+    png_path = out_path / f"pcc_{run_name}.png"
+    fig.savefig(png_path, dpi=150)
+    plt.close(fig)
+    logger.info(f"PCC plot saved to {png_path}")
+
+    return stats
+
+
+def _short_label(label: str) -> str:
+    """Convert e.g. 'layer_0' -> '0', 'layer_5_kvpe_kv' -> '5_kv', 'norm' -> 'norm'."""
+    label = label.replace("layer_", "").replace("_kvpe", "")
+    return label
+
+
+def generate_pcc_mermaid(result: dict, threshold: float = 0.99) -> str:
+    """
+    Generate Mermaid xychart-beta charts for PCC results.
+
+    Produces two charts:
+    1. Output PCC — single bar series (per-layer output + norm)
+    2. KVPE Cache PCC — two bar series (KV and PE) on shared layer x-axis
+
+    Args:
+        result: Dict with 'pcc' tuple and metadata.
+        threshold: PCC threshold for pass/fail.
+
+    Returns:
+        Markdown string with Mermaid chart blocks and summary table.
+    """
+    output_pcc, kvpe_kv_pcc, kvpe_pe_pcc = result["pcc"]
+    run_name = _build_run_name(result)
+    kv_threshold = result.get("kv_threshold", threshold)
+    pe_threshold = result.get("pe_threshold", threshold)
+
+    sections = []
+    sections.append(f"## PCC Results — {run_name}\n")
+
+    # Chart 1: Output PCC — red line + orange threshold
+    if output_pcc:
+        labels = list(output_pcc.keys())
+        values = list(output_pcc.values())
+        short_labels = [_short_label(l) for l in labels]
+
+        sections.append("### Output PCC\n")
+        sections.append("```mermaid")
+        sections.append(
+            "%%{init: {'theme': 'base', 'xyChart': {'width': 1600, 'height': 400}, 'themeVariables': {'xyChart': {'plotColorPalette': '#e74c3c, #e67e22'}}}}%%"
+        )
+        sections.append("xychart-beta")
+        sections.append(f'  title "Output PCC — {run_name}"')
+        sections.append(f"  x-axis [{', '.join(short_labels)}]")
+        sections.append(f'  y-axis "PCC" {_y_range(values, threshold)}')
+        sections.append(f"  line [{', '.join(f'{v:.4f}' for v in values)}]")
+        sections.append(f"  line [{', '.join(str(threshold) for _ in values)}]")
+        sections.append("```")
+        sections.append(f"> 🔴 Output PCC &nbsp; 🟠 Threshold ({threshold})\n")
+
+    # Chart 2: KVPE Cache PCC — green (KV) + blue (PE) lines + orange threshold
+    if kvpe_kv_pcc or kvpe_pe_pcc:
+        n_layers = max(len(kvpe_kv_pcc), len(kvpe_pe_pcc))
+        layer_labels = [str(i) for i in range(n_layers)]
+        kv_values = list(kvpe_kv_pcc.values())[:n_layers]
+        pe_values = list(kvpe_pe_pcc.values())[:n_layers]
+
+        all_vals = kv_values + pe_values
+
+        # Build palette: green for KV, blue for PE, orange for KV threshold, purple for PE threshold
+        palette_colors = []
+        if kv_values:
+            palette_colors.append("#2ecc71")
+        if pe_values:
+            palette_colors.append("#3498db")
+        palette_colors.append("#e67e22")
+        if kv_threshold != pe_threshold:
+            palette_colors.append("#9b59b6")
+
+        min_thresh = min(kv_threshold, pe_threshold)
+        sections.append("### KVPE Cache PCC\n")
+        sections.append("```mermaid")
+        sections.append(
+            "%%{init: {'theme': 'base', 'xyChart': {'width': 1600, 'height': 400}, 'themeVariables': {'xyChart': {'plotColorPalette': '"
+            + ", ".join(palette_colors)
+            + "'}}}}%%"
+        )
+        sections.append("xychart-beta")
+        sections.append(f'  title "KVPE Cache PCC — {run_name}"')
+        sections.append(f"  x-axis [{', '.join(layer_labels)}]")
+        sections.append(f'  y-axis "PCC" {_y_range(all_vals, min_thresh)}')
+        if kv_values:
+            sections.append(f"  line [{', '.join(f'{v:.4f}' for v in kv_values)}]")
+        if pe_values:
+            sections.append(f"  line [{', '.join(f'{v:.4f}' for v in pe_values)}]")
+        sections.append(f"  line [{', '.join(str(kv_threshold) for _ in range(n_layers))}]")
+        if kv_threshold != pe_threshold:
+            sections.append(f"  line [{', '.join(str(pe_threshold) for _ in range(n_layers))}]")
+        sections.append("```")
+        legend = f"> 🟢 KV Cache &nbsp; 🔵 PE Cache &nbsp; 🟠 KV Threshold ({kv_threshold})"
+        if kv_threshold != pe_threshold:
+            legend += f" &nbsp; 🟣 PE Threshold ({pe_threshold})"
+        sections.append(legend + "\n")
+
+    # Summary table — one row per layer with output, KV, and PE columns
+    # Build lookup dicts keyed by layer index
+    output_by_label = {_short_label(l): (pcc, threshold) for l, pcc in output_pcc.items()}
+    kv_by_idx = {i: (pcc, kv_threshold) for i, pcc in enumerate(kvpe_kv_pcc.values())}
+    pe_by_idx = {i: (pcc, pe_threshold) for i, pcc in enumerate(kvpe_pe_pcc.values())}
+
+    # Collect all row labels: output labels + any extra KV/PE layers
+    n_layers = max(len(kvpe_kv_pcc), len(kvpe_pe_pcc), 0)
+    row_labels = list(output_by_label.keys())
+    # Add layer indices not already covered by output labels
+    for i in range(n_layers):
+        if str(i) not in row_labels:
+            row_labels.append(str(i))
+
+    if row_labels:
+
+        def _cell(pcc, thresh):
+            status = "PASS" if pcc > thresh else ("FAIL" if pcc >= 0 else "ERROR")
+            icon = "✅" if status == "PASS" else "❌"
+            return f"{pcc:.4f}", str(thresh), f"{icon} {status}", pcc <= thresh
+
+        sections.append("### Summary\n")
+        sections.append(
+            "| Stage | PCC | Threshold | Status | KV PCC | KV Threshold | KV Status | PE PCC | PE Threshold | PE Status |"
+        )
+        sections.append(
+            "|-------|-----|-----------|--------|--------|--------------|-----------|--------|--------------|-----------|"
+        )
+        failures = 0
+        all_values = []
+        for label in row_labels:
+            # Output column
+            if label in output_by_label:
+                o_pcc, o_thresh = output_by_label[label]
+                o_val, o_th, o_st, o_fail = _cell(o_pcc, o_thresh)
+                all_values.append(o_pcc)
+                if o_fail:
+                    failures += 1
+            else:
+                o_val, o_th, o_st = "", "", ""
+
+            # KV column
+            idx = int(label) if label.isdigit() else -1
+            if idx in kv_by_idx:
+                kv_pcc, kv_th_val = kv_by_idx[idx]
+                kv_val, kv_th, kv_st, kv_fail = _cell(kv_pcc, kv_th_val)
+                all_values.append(kv_pcc)
+                if kv_fail:
+                    failures += 1
+            else:
+                kv_val, kv_th, kv_st = "", "", ""
+
+            # PE column
+            if idx in pe_by_idx:
+                pe_pcc, pe_th_val = pe_by_idx[idx]
+                pe_val, pe_th, pe_st, pe_fail = _cell(pe_pcc, pe_th_val)
+                all_values.append(pe_pcc)
+                if pe_fail:
+                    failures += 1
+            else:
+                pe_val, pe_th, pe_st = "", "", ""
+
+            sections.append(
+                f"| {label} | {o_val} | {o_th} | {o_st} | {kv_val} | {kv_th} | {kv_st} | {pe_val} | {pe_th} | {pe_st} |"
+            )
+
+        sections.append(
+            f"\n**Min PCC**: {min(all_values):.6f} | **Mean PCC**: {sum(all_values)/len(all_values):.6f} | **Failures**: {failures}/{len(all_values)}"
+        )
+
+    return "\n".join(sections)
+
+
+def _y_range(values: list, threshold: float) -> str:
+    """Compute y-axis range string for mermaid chart."""
+    min_val = min(min(values), threshold) - 0.02
+    return f"{max(0, min_val):.2f} --> 1.00"
+
+
+def write_pcc_summary(result: dict, threshold: float = 0.99, output_dir: str = None) -> Path:
+    """
+    Write PCC summary markdown (with Mermaid charts) to a per-run file.
+
+    Each run gets its own file named ``pcc_summary_{run_name}.md`` so that
+    multiple parameterized runs in CI don't overwrite each other.  The CI
+    publish step globs all files in the directory and concatenates them into
+    ``$GITHUB_STEP_SUMMARY``.
+
+    Args:
+        result: Dict with 'pcc' tuple and metadata.
+        threshold: PCC threshold for pass/fail.
+        output_dir: Directory for summary files.
+                    Defaults to PCC_SUMMARY_DIR env var or /tmp/pcc_summaries.
+
+    Returns:
+        Path to the written file.
+    """
+    if output_dir is None:
+        output_dir = os.getenv("PCC_SUMMARY_DIR", "/tmp/pcc_summaries")
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    run_name = _build_run_name(result)
+    path = out / f"pcc_summary_{run_name}.md"
+
+    content = generate_pcc_mermaid(result, threshold=threshold)
+    path.write_text(content)
+    logger.info(f"PCC summary written to {path}")
+
+    return path

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -40,7 +40,7 @@
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
     export NORM_OUTPUT_DIR=/tmp/ds_output_all_sources_new_ndshard # to deprecate
     export PCC_SUMMARY_DIR=/tmp/pcc_summaries
-    export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Reference-prefill
+    export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden-3bbdbfe4
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-prefill
     export HF_HOME=/tmp/hf_home # this is r/w path for huggingface, the actual model cache is in the read-only path defined by DEEPSEEK_V3_HF_MODEL
     export HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub # this is r/o path with the model

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -30,7 +30,29 @@
     bh_galaxy:
       timeout: 30
   owner_id: U08RL15T4N8
-  team: models
+  team: shield
+
+- name: "(Galaxy) DeepSeek Prefill Transformer PCC"
+  cmd: |
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
+    export MESH_DEVICE=TG
+    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+    export NORM_OUTPUT_DIR=/tmp/ds_output_all_sources_new_ndshard # to deprecate
+    export PCC_SUMMARY_DIR=/tmp/pcc_summaries
+    export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Reference-prefill
+    export TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-prefill
+    export HF_HOME=/tmp/hf_home # this is r/w path for huggingface, the actual model cache is in the read-only path defined by DEEPSEEK_V3_HF_MODEL
+    export HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub # this is r/o path with the model
+    pytest -xvs models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py \
+      -k 'pretrained and pcc and e256_cf32_host and mesh-8x4 and kv_cache and 1024 and 61 and abc' \
+      --tb=short
+  model: deepseek_prefill
+  skus:
+    bh_galaxy:
+      timeout: 20
+  owner_id: U08RL15T4N8
+  team: shield
 
 - name: "t3k_DeepSeek_PREFILL"
   cmd: |
@@ -46,7 +68,7 @@
     wh_llmbox_perf:
       timeout: 45
   owner_id: U08E1JCMAJF
-  team: models
+  team: shield
 
 - name: bh_lb_DeepSeek_PREFILL
   cmd: |
@@ -59,7 +81,7 @@
     bh_loudbox:
       timeout: 45
   owner_id: U08E1JCMAJF
-  team: models
+  team: shield
 
 - name: bh_qb_DeepSeek_PREFILL
   cmd: |
@@ -70,7 +92,7 @@
     bh_llmbox:
       timeout: 40
   owner_id: U08E1JCMAJF
-  team: models
+  team: shield
 
 # ============================================================================
 # DeepSeek V3 B1 Decode Tests (Blitz) - Blackhole P300


### PR DESCRIPTION
### Summary

Foundation work for #42621 (Relates to #42621)

Three improvements to the DeepSeek prefill CI infrastructure:

- **Per-run PCC summaries**: Replace flat `pcc_results` list with structured dicts keyed by `(layer, metric)`. Each test run writes its own summary JSON; the workflow step globs all summaries into `$GITHUB_STEP_SUMMARY`.
- **Team shield migration**: Move 5 `deepseek_prefill` tests from `team_models` to `team_shield` with matching time budgets.
- **Separate KV/PE thresholds**: Use KV=0.96 and PE=0.99 for pretrained non-random tests (previously a single threshold). Thin Mermaid x-axis labels for 61-layer runs to keep charts readable.

### Notes for reviewers

- The PCC summary format change is backwards-compatible — old-style flat lists still work but new runs produce structured dicts.
- Team shield time budgets were matched to existing team_models budgets.
- KV threshold (0.96) is intentionally lower than PE (0.99) based on observed PCC distributions across layers.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-ds-prefill-plot-and-ci-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-ds-prefill-plot-and-ci-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-ds-prefill-plot-and-ci-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-ds-prefill-plot-and-ci-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-ds-prefill-plot-and-ci-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-ds-prefill-plot-and-ci-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2604-ds-prefill-plot-and-ci-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2604-ds-prefill-plot-and-ci-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-ds-prefill-plot-and-ci-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-ds-prefill-plot-and-ci-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-ds-prefill-plot-and-ci-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-ds-prefill-plot-and-ci-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-ds-prefill-plot-and-ci-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-ds-prefill-plot-and-ci-v2)