### PR TITLE
Revert changes to d2d_exchange related to new teardown setup

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange.cpp
@@ -20,6 +20,18 @@ constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(7);
 constexpr bool use_fabric_on_receiver = get_compile_time_arg_val(8);
 constexpr bool use_fabric_on_sender = get_compile_time_arg_val(9);
 
+FORCE_INLINE bool socket_wait_for_pages_with_termination(
+    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
+    constexpr uint32_t termination_value = 1;
+    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
+        invalidate_l1_cache();
+        if (termination_semaphore[0] == termination_value) {
+            return false;
+        }
+    }
+    return true;
+}
+
 FORCE_INLINE void write_data_to_local_core_with_ack(
     SocketSenderInterface& sender_socket, uint32_t l1_read_addr, uint64_t dst_addr, uint32_t page_size) {
     noc_async_write(l1_read_addr, dst_addr, page_size);
@@ -178,12 +190,9 @@ void kernel_main() {
     }
 
     while (true) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == 1) {
-            break;
-        }
         socket_reserve_pages(sender_socket, 1);
-        while (!socket_wait_for_pages(receiver_socket, 1)) {
+        if (!socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
+            break;
         }
 
         auto l1_read_addr = receiver_socket.read_ptr;


### PR DESCRIPTION
### Summary
We want to implement a new teardown procedure for deepseek, but tests were not updated to follow the new setup. Revert changes to d2d_exchange for now.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/d2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/d2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/d2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/d2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/d2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/d2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/d2d)