### PR TITLE
Qwen3-32B: enable tuned fused AG+MM for FF2 prefill

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -755,54 +755,46 @@ class TtQwenModelArgs(TtModelArgs):
             #  Only used when seq_len >= 4096
             def prefill_ff2_minimal_matmul_config(seq_len):
                 """
-                Returns the best minimal matmul config for prefill FF2 based on sequence length.
-                Configurations are optimized based on sweep results.
+                Best minimal matmul config for prefill FF2 per sequence length.
+
+                Qwen3-32B FF2 shape constraints (8x4 mesh, shard dims (1, 0)):
+                  - K tiles per device = intermediate_dim / 8 / cluster_axis_1 / 32 = 25
+                    => K_block_size must divide 25 => K_block_size in {1, 5, 25}
+                  - N tiles per device = hidden_dim / cluster_axis_1 / 32 = 40
+                    => grid_x must divide 40 => grid_x in {1, 2, 4, 5, 8}
+                  - M tiles = seq_len / 32
+                    => grid_y must divide M => grid_y in divisors of (seq_len / 32)
+
+                Starting point (pre-sweep): same M/N/subblock shape as the tuned
+                Llama config (M=8/16, N=8, subblock=(1,4)) adapted to Qwen's
+                divisibility. A full Qwen-specific sweep is a separate task.
                 """
-                # Best configurations from sweep results for each M value
-                if seq_len <= 4096:
+                if seq_len <= 16384:
                     return ttnn.MinimalMatmulConfig(
                         M_block_size=8,
-                        K_block_size=8,
+                        K_block_size=5,
                         N_block_size=8,
-                        subblock_h=4,
-                        subblock_w=2,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 9),
-                    )
-                elif seq_len <= 16384:  # Both 8K and 16K share the same config
-                    return ttnn.MinimalMatmulConfig(
-                        M_block_size=8,
-                        K_block_size=8,
-                        N_block_size=8,
-                        subblock_h=2,
+                        subblock_h=1,
                         subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
-                    )
-                elif seq_len <= 32768:
-                    return ttnn.MinimalMatmulConfig(
-                        M_block_size=8,
-                        K_block_size=8,
-                        N_block_size=8,
-                        subblock_h=4,
-                        subblock_w=2,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
+                        compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
                     )
                 elif seq_len <= 65536:
                     return ttnn.MinimalMatmulConfig(
-                        M_block_size=8,
-                        K_block_size=8,
+                        M_block_size=16,
+                        K_block_size=5,
                         N_block_size=8,
-                        subblock_h=2,
+                        subblock_h=1,
                         subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
+                        compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
                     )
-                else:  # For seq_len >= 131072
+                else:  # 128k+
                     return ttnn.MinimalMatmulConfig(
-                        M_block_size=8,
-                        K_block_size=8,
+                        M_block_size=16,
+                        K_block_size=5,
                         N_block_size=8,
-                        subblock_h=2,
+                        subblock_h=1,
                         subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 9),
+                        compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
                     )
 
             self.model_config["PREFILL_FF2_MINIMAL_MATMUL_CONFIG"] = prefill_ff2_minimal_matmul_config

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -755,47 +755,28 @@ class TtQwenModelArgs(TtModelArgs):
             #  Only used when seq_len >= 4096
             def prefill_ff2_minimal_matmul_config(seq_len):
                 """
-                Best minimal matmul config for prefill FF2 per sequence length.
+                Qwen3-32B FF2 fused AG+MM config (WH Galaxy, 8x4 mesh, cluster_axis=1).
 
-                Qwen3-32B FF2 shape constraints (8x4 mesh, shard dims (1, 0)):
-                  - K tiles per device = intermediate_dim / 8 / cluster_axis_1 / 32 = 25
-                    => K_block_size must divide 25 => K_block_size in {1, 5, 25}
-                  - N tiles per device = hidden_dim / cluster_axis_1 / 32 = 40
-                    => grid_x must divide 40 => grid_x in {1, 2, 4, 5, 8}
-                  - M tiles = seq_len / 32
-                    => grid_y must divide M => grid_y in divisors of (seq_len / 32)
+                Tuned via tests/ttnn/unit_tests/operations/ccl/sweep_qwen3_ff2_agmm.py.
+                Winner at both 4k and 8k (end-to-end TTFT improvement vs non-fused):
+                  grid=(6,8), M=8, K=5, N=5, sub=(1,5)   -> +7.7% at 4k, +8.6% at 8k
 
-                Starting point (pre-sweep): same M/N/subblock shape as the tuned
-                Llama config (M=8/16, N=8, subblock=(1,4)) adapted to Qwen's
-                divisibility. A full Qwen-specific sweep is a separate task.
+                Key constraints (shape-derived, divisibility):
+                  K_block | K_tiles_per_device (= 25)        => K_block in {1, 5, 25}
+                  N_block | N_tiles            (= 40)
+                  sub_h * sub_w <= 8, sub_h | M_block, sub_w | N_block
+                  grid_x=6 forces num_links=3 (via line_all_gather_matmul auto-derive);
+                    grid_x in {2,4,8} hits a CCL core-range overlap bug, grid_x=5 loses
+                    bandwidth with num_links=1.
                 """
-                if seq_len <= 16384:
-                    return ttnn.MinimalMatmulConfig(
-                        M_block_size=8,
-                        K_block_size=5,
-                        N_block_size=8,
-                        subblock_h=1,
-                        subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
-                    )
-                elif seq_len <= 65536:
-                    return ttnn.MinimalMatmulConfig(
-                        M_block_size=16,
-                        K_block_size=5,
-                        N_block_size=8,
-                        subblock_h=1,
-                        subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
-                    )
-                else:  # 128k+
-                    return ttnn.MinimalMatmulConfig(
-                        M_block_size=16,
-                        K_block_size=5,
-                        N_block_size=8,
-                        subblock_h=1,
-                        subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
-                    )
+                return ttnn.MinimalMatmulConfig(
+                    M_block_size=8,
+                    K_block_size=5,
+                    N_block_size=5,
+                    subblock_h=1,
+                    subblock_w=5,
+                    compute_with_storage_grid_size=ttnn.CoreCoord(6, 8),
+                )
 
             self.model_config["PREFILL_FF2_MINIMAL_MATMUL_CONFIG"] = prefill_ff2_minimal_matmul_config
 

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -108,7 +108,7 @@ def get_supported_trace_region_size(request, mesh_device):
         },
         "Qwen3-32B": {
             "T3K": 90000000,
-            "TG": 96000000,
+            "TG": 200000000,
             "P150": 90000000,
             "P300": 90000000,
             "P150x4": 90000000,


### PR DESCRIPTION
Adds Qwen3-32B support on top of Teja's Llama fused AG+MM work (#41837).

## Changes (2 commits)
1. **Qwen FF2 MinimalMatmul config** (atupe) — routes Qwen's FF2 through the same fused path as Llama.
2. **Tuned fused AG+MM for Qwen FF2 prefill** (moritztng) — WH Galaxy tuned block-size config.

## Files touched
- `models/demos/llama3_70b_galaxy/tt/qwen_model_config.py` — `prefill_ff2_minimal_matmul_config` tuned to Qwen FF2 tile geometry (K=3200, N_per_device=1280). Winning config baked in as default:
  `MinimalMatmulConfig(M=8, K=5, N=5, sb=(1,5), grid=(6,8))`.
- `models/tt_transformers/demo/trace_region_config.py` — TG trace region for Qwen3-32B raised to 200 MB (prevents trace OOM during prefill).

## Key learnings folded into the config
- Qwen K_tiles_per_device=25 ⇒ `K_block` must divide 25 (Llama's 8 is invalid).
- `grid_x=6` yields `num_links=3, workers_per_link=2` and avoids the CCL core-overlap bug seen at `grid_x ∈ {2,4}`.
- `fp32_dest_acc_en=False` (model default) caps `subblock_h * subblock_w <= 4`.

## Measured impact (WH Galaxy, Qwen3-32B prefill)
FF2 op: ~7–9% faster at 4k/8k ISL vs. non-fused baseline, matching Llama's gains.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=moritztng/qwen_on_llama70b_agmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=moritztng/qwen_on_llama70b_agmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=moritztng/qwen_on_llama70b_agmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=moritztng/qwen_on_llama70b_agmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=moritztng/qwen_on_llama70b_agmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=moritztng/qwen_on_llama70b_agmm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moritztng/qwen_on_llama70b_agmm) |