### PR TITLE
[tt-train] Use tt::tt_metal type names in SDPA FW compute config.

### DIFF
--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp
@@ -514,9 +514,9 @@ SDPAForwardProgramFactory::cached_program_t SDPAForwardProgramFactory::create(
     // copy_tile from these CBs bypasses SrcA and DMAs directly to DST at full FP32.
     // Only SFPU operations (mul_binary_tile, etc.) may be used on data loaded this way.
     auto create_unpack_to_dest_mode = []() {
-        std::vector<UnpackToDestMode> mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-        mode[kPrevMmOutCbIndex] = UnpackToDestMode::UnpackToDestFp32;
-        mode[kCurMmOutCbIndex] = UnpackToDestMode::UnpackToDestFp32;
+        std::vector<tt::tt_metal::UnpackToDestMode> mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+        mode[kPrevMmOutCbIndex] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        mode[kCurMmOutCbIndex] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         return mode;
     };
 
@@ -540,7 +540,7 @@ SDPAForwardProgramFactory::cached_program_t SDPAForwardProgramFactory::create(
             kComputeKernelPath,
             all_cores,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
+                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                 .fp32_dest_acc_en = true,
                 .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                 .math_approx_mode = false,
@@ -565,7 +565,7 @@ SDPAForwardProgramFactory::cached_program_t SDPAForwardProgramFactory::create(
             kComputeKernelPath,
             core_group_1,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
+                .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                 .fp32_dest_acc_en = true,
                 .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                 .math_approx_mode = false,
@@ -589,7 +589,7 @@ SDPAForwardProgramFactory::cached_program_t SDPAForwardProgramFactory::create(
                 kComputeKernelPath,
                 core_group_2,
                 tt::tt_metal::ComputeConfig{
-                    .math_fidelity = MathFidelity::HiFi4,
+                    .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
                     .fp32_dest_acc_en = true,
                     .unpack_to_dest_mode = create_unpack_to_dest_mode(),
                     .math_approx_mode = false,


### PR DESCRIPTION
### Summary
Use `tt::tt_metal::MathFidelity` and `tt::tt_metal::UnpackToDestMode` to fix warnings.

### Example
```bash
/proj_sw/user_dev/.../tt_metal/api/tt-metalium/base_types.hpp:52:26: note: 'UnpackToDestMode' has been explicitly marked deprecated here
/proj_sw/user_dev/.../tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp:543:46: warning: 'MathFidelity' is deprecated: Use tt::tt_metal::MathFidelity [-Wdeprecated-declarations]
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecated-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/fix-tt-train-deprecated-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecated-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/fix-tt-train-deprecated-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecated-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/fix-tt-train-deprecated-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecated-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/fix-tt-train-deprecated-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecated-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/fix-tt-train-deprecated-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecated-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/fix-tt-train-deprecated-types)
