### PR TITLE
[Cleanup]: Remove CAS on QSR assert/sanitize

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -100,16 +100,21 @@ static void RunTest(
                     }
                     break;
                 case HalProcessorClassType::COMPUTE:
-                    // TODO: Watcher features are temporarily skipped on Quasar until basic runtime bring-up is complete
                     if (is_quasar) {
-                        GTEST_SKIP() << "Compute kernel watcher tests skipped on Quasar until TRISC runtime bring-up "
-                                        "is complete";
+                        assert_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
+                            program_,
+                            kernel,
+                            logical_core,
+                            tt::tt_metal::experimental::quasar::QuasarComputeConfig{
+                                .num_threads_per_cluster = 1,
+                                .defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
+                    } else {
+                        assert_kernel = CreateKernel(
+                            program_,
+                            kernel,
+                            logical_core,
+                            ComputeConfig{.defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
                     }
-                    assert_kernel = CreateKernel(
-                        program_,
-                        kernel,
-                        logical_core,
-                        ComputeConfig{.defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
                     break;
                 default: TT_THROW("Unsupported processor class type for TENSIX");
             }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -8,6 +8,7 @@
 #include "experimental/endpoints.h"
 #include "internal/firmware_common.h"
 #include "api/compile_time_args.h"
+#include "internal/hw_thread.h"
 #if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
 #include "internal/ethernet/tunneling.h"
 #endif
@@ -19,7 +20,7 @@
  * */
 void kernel_main() {
 #if defined(COMPILE_FOR_DM)
-    uint32_t cpu_index = get_my_thread_id();
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
 
 #if defined(TEST_MULTI_DM_SANITIZE_RACE)
     // Having explicit sync barrier helps stress test CAS in sanitize.h since
@@ -35,7 +36,7 @@ void kernel_main() {
 #else
     // Single DM test: only specified dm_id executes, others exit early
     constexpr uint32_t dm_id = get_compile_time_arg_val(0);
-    if (cpu_index != dm_id) {
+    if (thread_idx != dm_id) {
         return;
     }
 #endif
@@ -53,8 +54,8 @@ void kernel_main() {
     std::uint32_t buffer_size = get_arg_val<uint32_t>(7);
 
 #if defined(COMPILE_FOR_DM) && defined(TEST_MULTI_DM_SANITIZE_RACE)
-    buffer_dst_addr = (multi_dm_base_addr | static_cast<uint32_t>(cpu_index));
-    buffer_size = (multi_dm_base_size | static_cast<uint32_t>(cpu_index));
+    buffer_dst_addr = (multi_dm_base_addr | static_cast<uint32_t>(thread_idx));
+    buffer_size = (multi_dm_base_size | static_cast<uint32_t>(thread_idx));
 #endif
 
     bool use_inline_dw_write = static_cast<bool>(get_arg_val<uint32_t>(8));

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -58,14 +58,13 @@ void kernel_main() {
     }
 #else
 #if defined(COMPILE_FOR_TRISC)
-    // Signal TRISC completion via subordinate_sync map using hw_thread_idx
-    uint32_t hw_idx = internal_::get_hw_thread_idx();
 #if defined(ARCH_QUASAR)
+    uint32_t hw_idx = internal_::get_hw_thread_idx();
     volatile tt_l1_ptr uint8_t* const trisc_run =
         &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))->subordinate_sync.map[hw_idx];
 #else
-    volatile tt_l1_ptr uint8_t* const trisc_run =
-        &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE))->subordinate_sync.map[hw_idx];
+    volatile tt_l1_ptr uint8_t * const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE))
+        ->subordinate_sync.map[COMPILE_FOR_TRISC + 1];  // first entry is for NCRISC
 #endif
     *trisc_run = RUN_SYNC_MSG_DONE;
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -32,6 +32,7 @@ void kernel_main() {
 #if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
     (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
     (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
+    (defined(UCK_CHLKC_ISOLATE_SFPU) and defined(TRISC3)) or \
     (defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DRISC) or defined(COMPILE_FOR_DM))
     WATCHER_RING_BUFFER_PUSH(a);
     WATCHER_RING_BUFFER_PUSH(b);
@@ -57,8 +58,15 @@ void kernel_main() {
     }
 #else
 #if defined(COMPILE_FOR_TRISC)
-    volatile tt_l1_ptr uint8_t * const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE))
-        ->subordinate_sync.map[COMPILE_FOR_TRISC + 1];  // first entry is for NCRISC
+    // Signal TRISC completion via subordinate_sync map using hw_thread_idx
+    uint32_t hw_idx = internal_::get_hw_thread_idx();
+#if defined(ARCH_QUASAR)
+    volatile tt_l1_ptr uint8_t* const trisc_run =
+        &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))->subordinate_sync.map[hw_idx];
+#else
+    volatile tt_l1_ptr uint8_t* const trisc_run =
+        &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE))->subordinate_sync.map[hw_idx];
+#endif
     *trisc_run = RUN_SYNC_MSG_DONE;
 #endif
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -61,7 +61,7 @@ void kernel_main() {
 #if defined(ARCH_QUASAR)
     uint32_t hw_idx = internal_::get_hw_thread_idx();
     volatile tt_l1_ptr uint8_t* const trisc_run =
-        &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))->subordinate_sync.map[hw_idx];
+        &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE))->subordinate_sync.map[hw_idx];
 #else
     volatile tt_l1_ptr uint8_t * const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE))
         ->subordinate_sync.map[COMPILE_FOR_TRISC + 1];  // first entry is for NCRISC

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -30,7 +30,7 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
     {
         v->line_num = line_num;
         v->which = internal_::get_hw_thread_idx();
-        if (assert_type == DebugAssertHwFault) {  // only vslid on Quasar
+        if (assert_type == DebugAssertHwFault) {  // only valid on Quasar
             uint64_t mcause;
             uint64_t mtval;
             uint64_t mepc;

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -6,16 +6,13 @@
 
 #include "internal/debug/watcher_common.h"
 #include "internal/hw_thread.h"
-
-#if defined(ARCH_QUASAR)
-#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
-#endif
+#include "risc_common.h"
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT) && !defined(FORCE_WATCHER_OFF)
 
-//  - for Quasar, multiple DMs share assert_status area and we're fine of just getiting info for one of the asserts.
-//    To be multi-thread safe, CAS is used; address is remapped from uncached to
-//    cached L1 (LR/SC requires cache coherence), then flushed to make writes visible to host
+//  - for Quasar, multiple DMs and TRISCs share assert_status; only the first to assert records its
+//    metadata via a dedicated claim field atomically claimed (amoswap on the cached L1 alias).
+//    Writes are flushed to make them visible to host.
 inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type = DebugAssertTripped) {
     // Write the line number into the memory mailbox for host to read.
     debug_assert_msg_t tt_l1_ptr* v = GET_MAILBOX_ADDRESS_DEV(watcher.assert_status);
@@ -25,9 +22,8 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
     if (addr >= MEM_L1_UNCACHED_BASE) {
         v = reinterpret_cast<debug_assert_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
     }
-    uint16_t expected = DebugAssertOK;
-    if (__atomic_compare_exchange_n(
-            &v->tripped, &expected, DebugAssertWriteInProgress, false, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED))
+    uint32_t old = __atomic_exchange_n(&v->claim, 0xDEADBEEF, __ATOMIC_ACQ_REL);
+    if (!old)
 #else
     if (v->tripped == DebugAssertOK)
 #endif
@@ -45,12 +41,9 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
             v->hw_fault_info = mtval << 32 | (mcause & 0xffffffff);  // mtval is the faulting address or instruction
         }
         v->tripped = assert_type;
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
         // Flush 64B cache line to L1 so host sees all fields via NOC; fence ensures completion
-        // TODO: Replace with flush_l2_cache_line() once available
-        volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
-        *flush_reg = reinterpret_cast<uintptr_t>(v);
-        asm volatile("fence" ::: "memory");
+        flush_l2_cache_line(reinterpret_cast<uintptr_t>(v));
 #endif
     }
 

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -263,7 +263,7 @@ struct debug_assert_msg_t {
     volatile uint16_t line_num;
     volatile uint8_t tripped;
     volatile uint8_t which;
-    volatile uint32_t claim;  // CODEGEN:skip
+    volatile uint32_t claim;
     volatile uint64_t hw_fault_info;
 };
 

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -257,15 +257,13 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeEthSrcL1AddrOverflow = 15,
     DebugSanitizeEthDestL1AddrOverflow = 16,
     DebugSanitizeCBOutOfBounds = 17,
-    // Applicable only on Quasar: multiple DMs share one NOC, so CAS is used to prevent race conditions
-    // This transient value indicates a DM is writing error metadata, host should ignore
-    DebugSanitizeWriteInProgress = 0xDEAD,
 };
 
 struct debug_assert_msg_t {
     volatile uint16_t line_num;
     volatile uint8_t tripped;
     volatile uint8_t which;
+    volatile uint32_t claim;  // CODEGEN:skip
     volatile uint64_t hw_fault_info;
 };
 
@@ -279,9 +277,6 @@ enum debug_assert_type_t {
     DebugAssertRtaOutOfBounds = 8,
     DebugAssertCrtaOutOfBounds = 9,
     DebugAssertHwFault = 10,
-    // Applicable only on Quasar: multiple DMs share one NOC, so CAS is used to prevent race conditions
-    // This transient value indicates a DM is writing error metadata, host should ignore
-    DebugAssertWriteInProgress = 0xFF,
 };
 
 enum debug_transaction_type_t { TransactionRead = 0, TransactionWrite = 1, TransactionAtomic = 2, TransactionNumTypes };

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -262,6 +262,7 @@ inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
 //  - this isn't racy between riscvs so long as each gets their own noc_index as is the case on WH/BH
 //  - for Quasar, multiple DMs share one NOC and may race to report errors; a static lock in the
 //    DM firmware's shared .bss is atomically claimed (amoswap) so only the first writer proceeds.
+//    A static suffices since TRISCs never reach this code, avoiding a mailbox struct size increase.
 //    Metadata is written to the cached L1 alias of the mailbox, then flushed to make it visible to host.
 void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     uint8_t noc_id,

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -33,10 +33,7 @@
 #if !defined(WATCHER_DISABLE_CB_SANITIZE)
 #include "internal/circular_buffer_interface.h"
 #endif
-
-#if defined(ARCH_QUASAR)
-#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
-#endif
+#include "risc_common.h"
 
 // A couple defines for specifying read/write and multi/unicast
 #define DEBUG_SANITIZE_NOC_READ true
@@ -263,8 +260,9 @@ inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
 // Note:
 //  - this isn't racy w/ the host so long as return_code is written last
 //  - this isn't racy between riscvs so long as each gets their own noc_index as is the case on WH/BH
-//  - for Quasar, multiple DMs share one NOC so CAS is used; address is remapped from uncached to
-//    cached L1 (LR/SC requires cache coherence), then flushed to make writes visible to host
+//  - for Quasar, multiple DMs share one NOC and may race to report errors; a static lock in the
+//    DM firmware's shared .bss is atomically claimed (amoswap) so only the first writer proceeds.
+//    Metadata is written to the cached L1 alias of the mailbox, then flushed to make it visible to host.
 void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     uint8_t noc_id,
     uint64_t noc_addr,
@@ -287,9 +285,9 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     if (addr >= MEM_L1_UNCACHED_BASE) {
         san = reinterpret_cast<volatile debug_sanitize_addr_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
     }
-    uint16_t expected = DebugSanitizeOK;
-    if (__atomic_compare_exchange_n(
-            &san->return_code, &expected, DebugSanitizeWriteInProgress, false, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED))
+    static volatile uint32_t s_sanitize_lock = 0;
+    uint32_t old = __atomic_exchange_n(&s_sanitize_lock, 0xDEADBEEFu, __ATOMIC_ACQ_REL);
+    if (!old)
 #else
     if (san->return_code == DebugSanitizeOK)
 #endif
@@ -302,12 +300,9 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
         san->is_write = (dir == DEBUG_SANITIZE_NOC_WRITE);
         san->is_target = (which_core == DEBUG_SANITIZE_NOC_TARGET);
         san->return_code = return_code;
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
         // Flush 64B cache line to L1 so host sees all fields via NOC; fence ensures completion
-        // TODO: Replace with flush_l2_cache_line() once available
-        volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
-        *flush_reg = reinterpret_cast<uintptr_t>(san);
-        asm volatile("fence" ::: "memory");
+        flush_l2_cache_line(reinterpret_cast<uintptr_t>(san));
 #endif
     }
 

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -17,7 +17,6 @@
 #include "stream_io_map.h"
 #include "tensix.h"
 #include "tensix_neo_reg.h"
-#include "api/debug/assert.h"
 
 #define NOC_X(x) NOC_0_X(noc_index, noc_size_x, (x))
 #define NOC_Y(y) NOC_0_Y(noc_index, noc_size_y, (y))
@@ -315,6 +314,10 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
     // No-op for non-DM cores on Quasar
 }
 #endif  // ARCH_QUASAR && !COMPILE_FOR_DM
+
+// Included here (rather than at the top of the file) so that assert_and_hang()
+// sees flush_l2_cache_line() in scope on ARCH_QUASAR + COMPILE_FOR_DM builds.
+#include "api/debug/assert.h"
 
 template <bool enable = true>
 inline __attribute__((always_inline)) void set_l1_data_cache() {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -753,9 +753,6 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (NOC transaction overflows a circular buffer).";
             break;
-        case dev_msgs::DebugSanitizeWriteInProgress:
-            // Quasar: DM is atomically writing error metadata; ignore until complete
-            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",
@@ -779,8 +776,7 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
 
 void WatcherDeviceReader::Core::DumpAssertStatus() const {
     auto assert_status = mbox_data_.watcher().assert_status();
-    if (assert_status.tripped() == dev_msgs::DebugAssertOK ||
-        assert_status.tripped() == dev_msgs::DebugAssertWriteInProgress) {
+    if (assert_status.tripped() == dev_msgs::DebugAssertOK) {
         if (assert_status.line_num() != DEBUG_SANITIZE_SENTINEL_OK_16 ||
             assert_status.which() != DEBUG_SANITIZE_SENTINEL_OK_8) {
             TT_THROW(


### PR DESCRIPTION
### Summary
RISC-V LR/SC (Zalrsc extension) is not supported on `tt-qsr32` and is difficult to support on tt-sim. We replace `__atomic_compare_exchange_n` with `__atomic_exchange_n` (Zaamo extension) for first-writer-wins locking in watcher sanitize and assert paths.
                       
Additional changes/cleanup:  
1. Add TRISC support for watcher assert tests (previously skipped on Quasar)                                                                                                                
2. Replace raw `L2_FLUSH_ADDR` register direct access with `flush_l2_cache_line()` now that the API exists                                                                                           
3. Replace `get_my_thread_id()` with `internal_::get_hw_thread_idx()` in kernel test code

### Notes for reviewers
- `assert.h`: uses a dedicated `claim` field added to `debug_assert_msg_t` (fills existing 4-byte alignment padding between `which` and `hw_fault_info`, so zero additional size cost). The claim field lives in the mailbox (which is shared L1 memory accessible to all threads - DMs and TRISCs).                                                                                                                                                                                        
- `sanitize.h`: uses a `static` variable in DM firmware's `.bss`. This is because only DMs contend for sanitize metadata write access and using a static variable avoids adding a claim field to `debug_sanitize_addr_msg_t` (which would increase base firmware L1 usage size).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/quasar_change_cas_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/quasar_change_cas_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/quasar_change_cas_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/quasar_change_cas_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/quasar_change_cas_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/quasar_change_cas_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/quasar_change_cas_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/quasar_change_cas_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/quasar_change_cas_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/quasar_change_cas_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/quasar_change_cas_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/quasar_change_cas_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/quasar_change_cas_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/quasar_change_cas_asserts)