### PR TITLE
Fix nullptr deref. for remote TTDevices in get_physical_slot()

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <optional>
 #include <tt_stl/fmt.hpp>
 #include "tt_cluster.hpp"
 #include "llrt/rtoptions.hpp"
@@ -722,7 +723,11 @@ std::optional<int> Cluster::get_physical_slot(ChipId chip) const {
         log_warning(tt::LogDevice, "get_physical_slot is not supported for non-silicon devices");
         return std::nullopt;
     }
-    return this->driver_->get_chip(chip)->get_tt_device()->get_pci_device()->get_device_info().physical_slot;
+    auto pci_device = this->driver_->get_tt_device(chip)->get_pci_device();
+    if (pci_device == nullptr) {
+        return std::nullopt;
+    }
+    return pci_device->get_device_info().physical_slot;
 }
 
 void Cluster::deassert_risc_reset_at_core(

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -723,7 +723,7 @@ std::optional<int> Cluster::get_physical_slot(ChipId chip) const {
         log_warning(tt::LogDevice, "get_physical_slot is not supported for non-silicon devices");
         return std::nullopt;
     }
-    auto pci_device = this->driver_->get_tt_device(chip)->get_pci_device();
+    umd::PCIDevice* pci_device = this->driver_->get_tt_device(chip)->get_pci_device();
     if (pci_device == nullptr) {
         return std::nullopt;
     }


### PR DESCRIPTION
### Summary
Fix nullptr deref. for remote TTDevices in get_physical_slot(). UMD after githash [`efa03cf`](https://github.com/tenstorrent/tt-umd/commit/efa03cfe8cdd1c3a71704289b46d061fb039c22a) does not have remote TTDevices anymore. TTDevices do not always have a linked PCIDevice. 

### Notes for reviewers
Similar issues may arise in these chained expressions across llrt. This one is a quick fix to unblock an UMD bump.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aleksamarkovic/physicalslotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aleksamarkovic/physicalslotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aleksamarkovic/physicalslotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aleksamarkovic/physicalslotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aleksamarkovic/physicalslotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aleksamarkovic/physicalslotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aleksamarkovic/physicalslotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aleksamarkovic/physicalslotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aleksamarkovic/physicalslotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aleksamarkovic/physicalslotfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aleksamarkovic/physicalslotfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aleksamarkovic/physicalslotfix)