### PR TITLE
Fix incorrect QSR code sequences for setting/clearing CSR bits

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -382,30 +382,18 @@ inline __attribute__((always_inline)) void setup_isr_csrs() {
 
 inline __attribute__((always_inline)) void enable_dfb_tile_isr() {
     // Enable ROCC interrupt in mie
-    uint64_t mie_val;
-    asm volatile("csrr %0, mie" : "=r"(mie_val));
-    mie_val |= (1 << 13);
-    asm volatile("csrrs zero, mie, %0" : : "r"(mie_val));
+    asm volatile("csrrs zero, mie, %0" : : "r"(1 << 13));
 
     // Enable MIE in mstatus
-    uint64_t mstatus_val;
-    asm volatile("csrr %0, mstatus" : "=r"(mstatus_val));
-    mstatus_val |= (1 << 3);
-    asm volatile("csrrs zero, mstatus, %0" : : "r"(mstatus_val));
+    asm volatile("csrrs zero, mstatus, %0" : : "r"(1 << 3));
 }
 
 inline __attribute__((always_inline)) void disable_dfb_tile_isr() {
     // Disable ROCC interrupt in mie
-    uint64_t mie_val;
-    asm volatile("csrr %0, mie" : "=r"(mie_val));
-    mie_val &= ~(1 << 13);
-    asm volatile("csrrc zero, mie, %0" : : "r"(mie_val));
+    asm volatile("csrrc zero, mie, %0" : : "r"(1 << 13));
 
     // Disable MIE in mstatus
-    uint64_t mstatus_val;
-    asm volatile("csrr %0, mstatus" : "=r"(mstatus_val));
-    mstatus_val &= ~(1 << 3);
-    asm volatile("csrrc zero, mstatus, %0" : : "r"(mstatus_val));
+    asm volatile("csrrc zero, mstatus, %0" : : "r"(1 << 3));
 }
 
 #endif  // !defined(COMPILE_FOR_TRISC)


### PR DESCRIPTION
### Summary
CSRRC sequence was clobbering bits that were not intended to be clobbered; use CSRRC and CSRRS correctly.

### Notes for reviewers
This could also use CSRRCI and CSRRSI for bit 3 (not for bit 13), but this change should be good enough as is.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-csrrc-bug-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/qsr-csrrc-bug-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/qsr-csrrc-bug-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/qsr-csrrc-bug-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/qsr-csrrc-bug-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/qsr-csrrc-bug-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/qsr-csrrc-bug-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/qsr-csrrc-bug-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/qsr-csrrc-bug-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/qsr-csrrc-bug-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/qsr-csrrc-bug-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/qsr-csrrc-bug-fix)