### PR TITLE
Remove 32-element alignment constraint from RM typecast

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -605,12 +605,12 @@ def test_typecast_legacy_sharded_shard_size_not_tile_aligned(device):
 @pytest.mark.parametrize(
     "shape",
     [
-        [120, 104],           # width=104, not divisible by 32 (WAN 480p per-device shard)
+        [120, 104],  # width=104, not divisible by 32 (WAN 480p per-device shard)
         [81, 120, 104],
         [3, 81, 120, 104],
         [1, 3, 81, 120, 104],
-        [10, 40],             # width=40, not divisible by 32
-        [5, 8],               # width=8, less than one tile row
+        [10, 40],  # width=40, not divisible by 32
+        [5, 8],  # width=8, less than one tile row
     ],
 )
 def test_typecast_rm_non_aligned_width(shape, device):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -602,6 +602,34 @@ def test_typecast_legacy_sharded_shard_size_not_tile_aligned(device):
     assert torch.equal(npu_result, expected)
 
 
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [120, 104],           # width=104, not divisible by 32 (WAN 480p per-device shard)
+        [81, 120, 104],
+        [3, 81, 120, 104],
+        [1, 3, 81, 120, 104],
+        [10, 40],             # width=40, not divisible by 32
+        [5, 8],               # width=8, less than one tile row
+    ],
+)
+def test_typecast_rm_non_aligned_width(shape, device):
+    """ROW_MAJOR bfloat16→uint8 typecast with width not divisible by 32."""
+    torch.manual_seed(42)
+    torch_input = (torch.rand(shape) * 200).to(torch.bfloat16)
+    expected = torch_input.to(torch.uint8)
+
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    result = ttnn.to_torch(ttnn.typecast(input_tensor, ttnn.uint8))
+    assert torch.equal(result, expected), f"mismatch for shape {shape}"
+
+
 def test_typecast_rm_chunked_program_cache(device):
     """Regression: program cache hit on ROW_MAJOR typecast must not hang when num_rows % num_cores != 0."""
     torch.manual_seed(0)

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp
@@ -10,14 +10,11 @@ void kernel_main() {
     const uint32_t start_row_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t full_chunk_size_bytes = get_compile_time_arg_val(1);      // CB page (padded to 32-elem boundary)
-    constexpr uint32_t full_chunks_per_row = get_compile_time_arg_val(2);
-    constexpr uint32_t partial_chunk_size_bytes = get_compile_time_arg_val(3);   // CB page (padded to 32-elem boundary)
-    constexpr uint32_t partial_chunks_per_row = get_compile_time_arg_val(4);     // 0 or 1
-    // index 5: row_page_size_bytes consumed by TensorAccessorArgs
-    constexpr uint32_t actual_full_chunk_size_bytes = get_compile_time_arg_val(6);
-    constexpr uint32_t actual_partial_chunk_size_bytes = get_compile_time_arg_val(7);
-    constexpr auto src_args = TensorAccessorArgs<8>();
+    constexpr uint32_t full_chunks_per_row = get_compile_time_arg_val(1);
+    constexpr uint32_t partial_chunks_per_row = get_compile_time_arg_val(2);  // 0 or 1
+    constexpr uint32_t full_chunk_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t partial_chunk_size_bytes = get_compile_time_arg_val(4);
+    constexpr auto src_args = TensorAccessorArgs<5>();
 
     constexpr uint32_t onepage = 1;
 
@@ -31,20 +28,11 @@ void kernel_main() {
             cb_reserve_back(cb_id_in, onepage);
             const uint32_t l1_write_addr = get_write_ptr(cb_id_in);
 
-            const uint32_t byte_offset = chunk_idx * actual_full_chunk_size_bytes;
+            const uint32_t byte_offset = chunk_idx * full_chunk_size_bytes;
             const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_read(chunk_noc_addr, l1_write_addr, actual_full_chunk_size_bytes);
+            noc_async_read(chunk_noc_addr, l1_write_addr, full_chunk_size_bytes);
 
             noc_async_read_barrier();
-            // Zero-fill any padding bytes so the unpacker sees complete 32-element tile rows
-            // within the CB page and never reads across a page boundary.
-            if constexpr (full_chunk_size_bytes > actual_full_chunk_size_bytes) {
-                volatile uint8_t* pad =
-                    reinterpret_cast<volatile uint8_t*>(l1_write_addr + actual_full_chunk_size_bytes);
-                for (uint32_t i = 0; i < full_chunk_size_bytes - actual_full_chunk_size_bytes; ++i) {
-                    pad[i] = 0;
-                }
-            }
             cb_push_back(cb_id_in, onepage);
         }
 
@@ -53,18 +41,11 @@ void kernel_main() {
             cb_reserve_back(cb_id_in, onepage);
             const uint32_t l1_write_addr = get_write_ptr(cb_id_in);
 
-            const uint32_t byte_offset = full_chunks_per_row * actual_full_chunk_size_bytes;
+            const uint32_t byte_offset = full_chunks_per_row * full_chunk_size_bytes;
             const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_read(chunk_noc_addr, l1_write_addr, actual_partial_chunk_size_bytes);
+            noc_async_read(chunk_noc_addr, l1_write_addr, partial_chunk_size_bytes);
 
             noc_async_read_barrier();
-            if constexpr (partial_chunk_size_bytes > actual_partial_chunk_size_bytes) {
-                volatile uint8_t* pad =
-                    reinterpret_cast<volatile uint8_t*>(l1_write_addr + actual_partial_chunk_size_bytes);
-                for (uint32_t i = 0; i < partial_chunk_size_bytes - actual_partial_chunk_size_bytes; ++i) {
-                    pad[i] = 0;
-                }
-            }
             cb_push_back(cb_id_in, onepage);
         }
     }

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp
@@ -10,15 +10,17 @@ void kernel_main() {
     const uint32_t start_row_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t full_chunk_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t full_chunk_size_bytes = get_compile_time_arg_val(1);      // CB page (padded to 32-elem boundary)
     constexpr uint32_t full_chunks_per_row = get_compile_time_arg_val(2);
-    constexpr uint32_t partial_chunk_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t partial_chunks_per_row = get_compile_time_arg_val(4);  // 0 or 1
-    constexpr auto src_args = TensorAccessorArgs<6>();
+    constexpr uint32_t partial_chunk_size_bytes = get_compile_time_arg_val(3);   // CB page (padded to 32-elem boundary)
+    constexpr uint32_t partial_chunks_per_row = get_compile_time_arg_val(4);     // 0 or 1
+    // index 5: row_page_size_bytes consumed by TensorAccessorArgs
+    constexpr uint32_t actual_full_chunk_size_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t actual_partial_chunk_size_bytes = get_compile_time_arg_val(7);
+    constexpr auto src_args = TensorAccessorArgs<8>();
 
     constexpr uint32_t onepage = 1;
 
-    // Create TensorAccessor with row page size (buffer's actual layout)
     const auto s = TensorAccessor(src_args, src_addr);
 
     const uint32_t end_row_id = start_row_id + num_rows;
@@ -29,11 +31,20 @@ void kernel_main() {
             cb_reserve_back(cb_id_in, onepage);
             const uint32_t l1_write_addr = get_write_ptr(cb_id_in);
 
-            const uint32_t byte_offset = chunk_idx * full_chunk_size_bytes;
+            const uint32_t byte_offset = chunk_idx * actual_full_chunk_size_bytes;
             const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_read(chunk_noc_addr, l1_write_addr, full_chunk_size_bytes);
+            noc_async_read(chunk_noc_addr, l1_write_addr, actual_full_chunk_size_bytes);
 
             noc_async_read_barrier();
+            // Zero-fill any padding bytes so the unpacker sees complete 32-element tile rows
+            // within the CB page and never reads across a page boundary.
+            if constexpr (full_chunk_size_bytes > actual_full_chunk_size_bytes) {
+                volatile uint8_t* pad =
+                    reinterpret_cast<volatile uint8_t*>(l1_write_addr + actual_full_chunk_size_bytes);
+                for (uint32_t i = 0; i < full_chunk_size_bytes - actual_full_chunk_size_bytes; ++i) {
+                    pad[i] = 0;
+                }
+            }
             cb_push_back(cb_id_in, onepage);
         }
 
@@ -42,11 +53,18 @@ void kernel_main() {
             cb_reserve_back(cb_id_in, onepage);
             const uint32_t l1_write_addr = get_write_ptr(cb_id_in);
 
-            const uint32_t byte_offset = full_chunks_per_row * full_chunk_size_bytes;
+            const uint32_t byte_offset = full_chunks_per_row * actual_full_chunk_size_bytes;
             const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_read(chunk_noc_addr, l1_write_addr, partial_chunk_size_bytes);
+            noc_async_read(chunk_noc_addr, l1_write_addr, actual_partial_chunk_size_bytes);
 
             noc_async_read_barrier();
+            if constexpr (partial_chunk_size_bytes > actual_partial_chunk_size_bytes) {
+                volatile uint8_t* pad =
+                    reinterpret_cast<volatile uint8_t*>(l1_write_addr + actual_partial_chunk_size_bytes);
+                for (uint32_t i = 0; i < partial_chunk_size_bytes - actual_partial_chunk_size_bytes; ++i) {
+                    pad[i] = 0;
+                }
+            }
             cb_push_back(cb_id_in, onepage);
         }
     }

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp
@@ -10,14 +10,11 @@ void kernel_main() {
     const uint32_t start_row_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t full_chunk_size_bytes = get_compile_time_arg_val(1);     // CB page (padded, unused directly)
-    constexpr uint32_t full_chunks_per_row = get_compile_time_arg_val(2);
-    constexpr uint32_t partial_chunk_size_bytes = get_compile_time_arg_val(3);  // CB page (padded, unused directly)
-    constexpr uint32_t partial_chunks_per_row = get_compile_time_arg_val(4);    // 0 or 1
-    // index 5: row_page_size_bytes consumed by TensorAccessorArgs
-    constexpr uint32_t actual_full_chunk_size_bytes = get_compile_time_arg_val(6);
-    constexpr uint32_t actual_partial_chunk_size_bytes = get_compile_time_arg_val(7);
-    constexpr auto dst_args = TensorAccessorArgs<8>();
+    constexpr uint32_t full_chunks_per_row = get_compile_time_arg_val(1);
+    constexpr uint32_t partial_chunks_per_row = get_compile_time_arg_val(2);  // 0 or 1
+    constexpr uint32_t full_chunk_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t partial_chunk_size_bytes = get_compile_time_arg_val(4);
+    constexpr auto dst_args = TensorAccessorArgs<5>();
 
     constexpr uint32_t onepage = 1;
 
@@ -31,9 +28,9 @@ void kernel_main() {
             cb_wait_front(cb_id_out, onepage);
             const uint32_t l1_read_addr = get_read_ptr(cb_id_out);
 
-            const uint32_t byte_offset = chunk_idx * actual_full_chunk_size_bytes;
+            const uint32_t byte_offset = chunk_idx * full_chunk_size_bytes;
             const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_write(l1_read_addr, chunk_noc_addr, actual_full_chunk_size_bytes);
+            noc_async_write(l1_read_addr, chunk_noc_addr, full_chunk_size_bytes);
 
             noc_async_writes_flushed();
             cb_pop_front(cb_id_out, onepage);
@@ -44,9 +41,9 @@ void kernel_main() {
             cb_wait_front(cb_id_out, onepage);
             const uint32_t l1_read_addr = get_read_ptr(cb_id_out);
 
-            const uint32_t byte_offset = full_chunks_per_row * actual_full_chunk_size_bytes;
+            const uint32_t byte_offset = full_chunks_per_row * full_chunk_size_bytes;
             const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_write(l1_read_addr, chunk_noc_addr, actual_partial_chunk_size_bytes);
+            noc_async_write(l1_read_addr, chunk_noc_addr, partial_chunk_size_bytes);
 
             noc_async_writes_flushed();
             cb_pop_front(cb_id_out, onepage);

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp
@@ -10,15 +10,17 @@ void kernel_main() {
     const uint32_t start_row_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t full_chunk_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t full_chunk_size_bytes = get_compile_time_arg_val(1);     // CB page (padded, unused directly)
     constexpr uint32_t full_chunks_per_row = get_compile_time_arg_val(2);
-    constexpr uint32_t partial_chunk_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t partial_chunks_per_row = get_compile_time_arg_val(4);  // 0 or 1
-    constexpr auto dst_args = TensorAccessorArgs<6>();
+    constexpr uint32_t partial_chunk_size_bytes = get_compile_time_arg_val(3);  // CB page (padded, unused directly)
+    constexpr uint32_t partial_chunks_per_row = get_compile_time_arg_val(4);    // 0 or 1
+    // index 5: row_page_size_bytes consumed by TensorAccessorArgs
+    constexpr uint32_t actual_full_chunk_size_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t actual_partial_chunk_size_bytes = get_compile_time_arg_val(7);
+    constexpr auto dst_args = TensorAccessorArgs<8>();
 
     constexpr uint32_t onepage = 1;
 
-    // Create TensorAccessor using layout/aligned_page_size metadata carried in TensorAccessorArgs.
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     const uint32_t end_row_id = start_row_id + num_rows;
@@ -29,9 +31,9 @@ void kernel_main() {
             cb_wait_front(cb_id_out, onepage);
             const uint32_t l1_read_addr = get_read_ptr(cb_id_out);
 
-            const uint32_t byte_offset = chunk_idx * full_chunk_size_bytes;
+            const uint32_t byte_offset = chunk_idx * actual_full_chunk_size_bytes;
             const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_write(l1_read_addr, chunk_noc_addr, full_chunk_size_bytes);
+            noc_async_write(l1_read_addr, chunk_noc_addr, actual_full_chunk_size_bytes);
 
             noc_async_writes_flushed();
             cb_pop_front(cb_id_out, onepage);
@@ -42,9 +44,9 @@ void kernel_main() {
             cb_wait_front(cb_id_out, onepage);
             const uint32_t l1_read_addr = get_read_ptr(cb_id_out);
 
-            const uint32_t byte_offset = full_chunks_per_row * full_chunk_size_bytes;
+            const uint32_t byte_offset = full_chunks_per_row * actual_full_chunk_size_bytes;
             const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_write(l1_read_addr, chunk_noc_addr, partial_chunk_size_bytes);
+            noc_async_write(l1_read_addr, chunk_noc_addr, actual_partial_chunk_size_bytes);
 
             noc_async_writes_flushed();
             cb_pop_front(cb_id_out, onepage);

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
@@ -100,11 +100,6 @@ void TypecastDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             args.sub_core_grids.has_value() == false,
             "Typecast operation does not support sub_core_grids when input tensor is in Row-Major layout.");
-        TT_FATAL(
-            input_tensor.padded_shape()[-1] % 32 == 0,
-            "Typecast operation requires Row-Major input tensor's padded shape to be multiple of 32. "
-            "Padded shape: {}",
-            input_tensor.padded_shape());
     }
 
     const TensorMemoryLayout& input_tensor_memory_layout = input_tensor.memory_config().memory_layout();

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
@@ -17,10 +17,14 @@ using namespace tt::constants;
 
 namespace {
 struct ChunkSizeConfig {
-    uint32_t input_full_chunk_size_bytes;
-    uint32_t output_full_chunk_size_bytes;
-    uint32_t input_partial_chunk_size_bytes;
-    uint32_t output_partial_chunk_size_bytes;
+    uint32_t input_full_chunk_size_bytes;          // actual bytes read from DRAM per full chunk
+    uint32_t output_full_chunk_size_bytes;         // actual bytes written to DRAM per full chunk
+    uint32_t input_partial_chunk_size_bytes;       // actual bytes read from DRAM for partial chunk
+    uint32_t output_partial_chunk_size_bytes;      // actual bytes written to DRAM for partial chunk
+    uint32_t padded_input_full_chunk_size_bytes;   // CB page size (rounded up to 32-element boundary)
+    uint32_t padded_output_full_chunk_size_bytes;  // CB page size (rounded up to 32-element boundary)
+    uint32_t padded_input_partial_chunk_size_bytes;
+    uint32_t padded_output_partial_chunk_size_bytes;
     uint32_t full_chunks_per_row;
     uint32_t partial_chunks_per_row;
 };
@@ -30,9 +34,15 @@ ChunkSizeConfig calculate_chunk_config(
     constexpr uint32_t max_elements_per_chunk = 1024;
     const uint32_t elements_per_full_chunk = std::min(max_elements_per_chunk, row_width_elements);
 
-    // Calculate chunk sizes in bytes (logical size, not including padding)
+    // Actual chunk sizes in bytes (for DRAM reads/writes)
     const uint32_t input_full_chunk_size_bytes = elements_per_full_chunk * input_element_size;
     const uint32_t output_full_chunk_size_bytes = elements_per_full_chunk * output_element_size;
+
+    // CB page sizes: round up to next multiple of 32 elements so the unpacker always
+    // sees complete 32-element tile rows and never reads across a CB page boundary.
+    const uint32_t padded_full_elements = tt::align(elements_per_full_chunk, 32u);
+    const uint32_t padded_input_full_chunk_size_bytes = padded_full_elements * input_element_size;
+    const uint32_t padded_output_full_chunk_size_bytes = padded_full_elements * output_element_size;
 
     // Calculate how many chunks per row
     const uint32_t full_chunks_per_row = row_width_elements / elements_per_full_chunk;
@@ -40,12 +50,19 @@ ChunkSizeConfig calculate_chunk_config(
     const uint32_t partial_chunks_per_row = (remainder > 0) ? 1 : 0;
     const uint32_t input_partial_chunk_size_bytes = remainder * input_element_size;
     const uint32_t output_partial_chunk_size_bytes = remainder * output_element_size;
+    const uint32_t padded_partial_elements = remainder > 0 ? tt::align(remainder, 32u) : 0u;
+    const uint32_t padded_input_partial_chunk_size_bytes = padded_partial_elements * input_element_size;
+    const uint32_t padded_output_partial_chunk_size_bytes = padded_partial_elements * output_element_size;
 
     return ChunkSizeConfig{
         .input_full_chunk_size_bytes = input_full_chunk_size_bytes,
         .output_full_chunk_size_bytes = output_full_chunk_size_bytes,
         .input_partial_chunk_size_bytes = input_partial_chunk_size_bytes,
         .output_partial_chunk_size_bytes = output_partial_chunk_size_bytes,
+        .padded_input_full_chunk_size_bytes = padded_input_full_chunk_size_bytes,
+        .padded_output_full_chunk_size_bytes = padded_output_full_chunk_size_bytes,
+        .padded_input_partial_chunk_size_bytes = padded_input_partial_chunk_size_bytes,
+        .padded_output_partial_chunk_size_bytes = padded_output_partial_chunk_size_bytes,
         .full_chunks_per_row = full_chunks_per_row,
         .partial_chunks_per_row = partial_chunks_per_row,
     };
@@ -89,6 +106,10 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
     const uint32_t output_full_chunk_size_bytes = chunk_config.output_full_chunk_size_bytes;
     const uint32_t input_partial_chunk_size_bytes = chunk_config.input_partial_chunk_size_bytes;
     const uint32_t output_partial_chunk_size_bytes = chunk_config.output_partial_chunk_size_bytes;
+    const uint32_t padded_input_full_chunk_size_bytes = chunk_config.padded_input_full_chunk_size_bytes;
+    const uint32_t padded_output_full_chunk_size_bytes = chunk_config.padded_output_full_chunk_size_bytes;
+    const uint32_t padded_input_partial_chunk_size_bytes = chunk_config.padded_input_partial_chunk_size_bytes;
+    const uint32_t padded_output_partial_chunk_size_bytes = chunk_config.padded_output_partial_chunk_size_bytes;
     const uint32_t full_chunks_per_row = chunk_config.full_chunks_per_row;
     const uint32_t partial_chunks_per_row = chunk_config.partial_chunks_per_row;
 
@@ -105,34 +126,41 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
 
     tt::tt_metal::CircularBufferConfig cb_input_config =
         tt::tt_metal::CircularBufferConfig(
-            num_input_pages * input_full_chunk_size_bytes, {{input_cb_index, cb_data_format_input}})
-            .set_page_size(input_cb_index, input_full_chunk_size_bytes);
+            num_input_pages * padded_input_full_chunk_size_bytes, {{input_cb_index, cb_data_format_input}})
+            .set_page_size(input_cb_index, padded_input_full_chunk_size_bytes);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
 
     tt::tt_metal::CircularBufferConfig cb_output_config =
         tt::tt_metal::CircularBufferConfig(
-            num_output_pages * output_full_chunk_size_bytes, {{output_cb_index, cb_data_format_output}})
-            .set_page_size(output_cb_index, output_full_chunk_size_bytes);
+            num_output_pages * padded_output_full_chunk_size_bytes, {{output_cb_index, cb_data_format_output}})
+            .set_page_size(output_cb_index, padded_output_full_chunk_size_bytes);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
     // Create compile-time args for unified kernels (handle both full and partial chunks)
+    // Indices 0-5 are CB/chunk config; 6-7 are actual DRAM read/write sizes (may differ from
+    // padded CB page sizes when row_width is not a multiple of 32 elements).
+    // TensorAccessorArgs start at index 8.
     std::vector<uint32_t> reader_compile_time_args = {
-        input_cb_index,                  // cb_id_in
-        input_full_chunk_size_bytes,     // full_chunk_size_bytes
-        full_chunks_per_row,             // full_chunks_per_row
-        input_partial_chunk_size_bytes,  // partial_chunk_size_bytes
-        partial_chunks_per_row,          // partial_chunks_per_row (0 or 1)
-        src_buffer->page_size()          // row_page_size_bytes
+        input_cb_index,                          // 0: cb_id_in
+        padded_input_full_chunk_size_bytes,      // 1: full_chunk_size_bytes (CB page, 32-element aligned)
+        full_chunks_per_row,                     // 2: full_chunks_per_row
+        padded_input_partial_chunk_size_bytes,   // 3: partial_chunk_size_bytes (CB page, 32-element aligned)
+        partial_chunks_per_row,                  // 4: partial_chunks_per_row (0 or 1)
+        src_buffer->page_size(),                 // 5: row_page_size_bytes (for TensorAccessor)
+        input_full_chunk_size_bytes,             // 6: actual_full_chunk_size_bytes (DRAM read size)
+        input_partial_chunk_size_bytes,          // 7: actual_partial_chunk_size_bytes (DRAM read size)
     };
     tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
-        output_cb_index,                  // cb_id_out
-        output_full_chunk_size_bytes,     // full_chunk_size_bytes
-        full_chunks_per_row,              // full_chunks_per_row
-        output_partial_chunk_size_bytes,  // partial_chunk_size_bytes
-        partial_chunks_per_row,           // partial_chunks_per_row (0 or 1)
-        dst_buffer->page_size()           // row_page_size_bytes
+        output_cb_index,                          // 0: cb_id_out
+        padded_output_full_chunk_size_bytes,      // 1: full_chunk_size_bytes (CB page, 32-element aligned)
+        full_chunks_per_row,                      // 2: full_chunks_per_row
+        padded_output_partial_chunk_size_bytes,   // 3: partial_chunk_size_bytes (CB page, 32-element aligned)
+        partial_chunks_per_row,                   // 4: partial_chunks_per_row (0 or 1)
+        dst_buffer->page_size(),                  // 5: row_page_size_bytes (for TensorAccessor)
+        output_full_chunk_size_bytes,             // 6: actual_full_chunk_size_bytes (DRAM write size)
+        output_partial_chunk_size_bytes,          // 7: actual_partial_chunk_size_bytes (DRAM write size)
     };
     tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
@@ -23,8 +23,6 @@ struct ChunkSizeConfig {
     uint32_t output_partial_chunk_size_bytes;      // actual bytes written to DRAM for partial chunk
     uint32_t padded_input_full_chunk_size_bytes;   // CB page size (rounded up to 32-element boundary)
     uint32_t padded_output_full_chunk_size_bytes;  // CB page size (rounded up to 32-element boundary)
-    uint32_t padded_input_partial_chunk_size_bytes;
-    uint32_t padded_output_partial_chunk_size_bytes;
     uint32_t full_chunks_per_row;
     uint32_t partial_chunks_per_row;
 };
@@ -38,8 +36,7 @@ ChunkSizeConfig calculate_chunk_config(
     const uint32_t input_full_chunk_size_bytes = elements_per_full_chunk * input_element_size;
     const uint32_t output_full_chunk_size_bytes = elements_per_full_chunk * output_element_size;
 
-    // CB page sizes: round up to next multiple of 32 elements so the unpacker always
-    // sees complete 32-element tile rows and never reads across a CB page boundary.
+    // CB page sizes: round up to next multiple of 32 elements for the unpacker.
     const uint32_t padded_full_elements = tt::align(elements_per_full_chunk, 32u);
     const uint32_t padded_input_full_chunk_size_bytes = padded_full_elements * input_element_size;
     const uint32_t padded_output_full_chunk_size_bytes = padded_full_elements * output_element_size;
@@ -50,9 +47,6 @@ ChunkSizeConfig calculate_chunk_config(
     const uint32_t partial_chunks_per_row = (remainder > 0) ? 1 : 0;
     const uint32_t input_partial_chunk_size_bytes = remainder * input_element_size;
     const uint32_t output_partial_chunk_size_bytes = remainder * output_element_size;
-    const uint32_t padded_partial_elements = remainder > 0 ? tt::align(remainder, 32u) : 0u;
-    const uint32_t padded_input_partial_chunk_size_bytes = padded_partial_elements * input_element_size;
-    const uint32_t padded_output_partial_chunk_size_bytes = padded_partial_elements * output_element_size;
 
     return ChunkSizeConfig{
         .input_full_chunk_size_bytes = input_full_chunk_size_bytes,
@@ -61,8 +55,6 @@ ChunkSizeConfig calculate_chunk_config(
         .output_partial_chunk_size_bytes = output_partial_chunk_size_bytes,
         .padded_input_full_chunk_size_bytes = padded_input_full_chunk_size_bytes,
         .padded_output_full_chunk_size_bytes = padded_output_full_chunk_size_bytes,
-        .padded_input_partial_chunk_size_bytes = padded_input_partial_chunk_size_bytes,
-        .padded_output_partial_chunk_size_bytes = padded_output_partial_chunk_size_bytes,
         .full_chunks_per_row = full_chunks_per_row,
         .partial_chunks_per_row = partial_chunks_per_row,
     };
@@ -108,8 +100,6 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
     const uint32_t output_partial_chunk_size_bytes = chunk_config.output_partial_chunk_size_bytes;
     const uint32_t padded_input_full_chunk_size_bytes = chunk_config.padded_input_full_chunk_size_bytes;
     const uint32_t padded_output_full_chunk_size_bytes = chunk_config.padded_output_full_chunk_size_bytes;
-    const uint32_t padded_input_partial_chunk_size_bytes = chunk_config.padded_input_partial_chunk_size_bytes;
-    const uint32_t padded_output_partial_chunk_size_bytes = chunk_config.padded_output_partial_chunk_size_bytes;
     const uint32_t full_chunks_per_row = chunk_config.full_chunks_per_row;
     const uint32_t partial_chunks_per_row = chunk_config.partial_chunks_per_row;
 
@@ -136,31 +126,21 @@ TypecastRowMajorChunkedProgramFactory::cached_program_t TypecastRowMajorChunkedP
             .set_page_size(output_cb_index, padded_output_full_chunk_size_bytes);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
-    // Create compile-time args for unified kernels (handle both full and partial chunks)
-    // Indices 0-5 are CB/chunk config; 6-7 are actual DRAM read/write sizes (may differ from
-    // padded CB page sizes when row_width is not a multiple of 32 elements).
-    // TensorAccessorArgs start at index 8.
     std::vector<uint32_t> reader_compile_time_args = {
-        input_cb_index,                          // 0: cb_id_in
-        padded_input_full_chunk_size_bytes,      // 1: full_chunk_size_bytes (CB page, 32-element aligned)
-        full_chunks_per_row,                     // 2: full_chunks_per_row
-        padded_input_partial_chunk_size_bytes,   // 3: partial_chunk_size_bytes (CB page, 32-element aligned)
-        partial_chunks_per_row,                  // 4: partial_chunks_per_row (0 or 1)
-        src_buffer->page_size(),                 // 5: row_page_size_bytes (for TensorAccessor)
-        input_full_chunk_size_bytes,             // 6: actual_full_chunk_size_bytes (DRAM read size)
-        input_partial_chunk_size_bytes,          // 7: actual_partial_chunk_size_bytes (DRAM read size)
+        input_cb_index,                  // 0: cb_id_in
+        full_chunks_per_row,             // 1: full_chunks_per_row
+        partial_chunks_per_row,          // 2: partial_chunks_per_row (0 or 1)
+        input_full_chunk_size_bytes,     // 3: full_chunk_size_bytes (DRAM read size)
+        input_partial_chunk_size_bytes,  // 4: partial_chunk_size_bytes (DRAM read size)
     };
     tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
-        output_cb_index,                          // 0: cb_id_out
-        padded_output_full_chunk_size_bytes,      // 1: full_chunk_size_bytes (CB page, 32-element aligned)
-        full_chunks_per_row,                      // 2: full_chunks_per_row
-        padded_output_partial_chunk_size_bytes,   // 3: partial_chunk_size_bytes (CB page, 32-element aligned)
-        partial_chunks_per_row,                   // 4: partial_chunks_per_row (0 or 1)
-        dst_buffer->page_size(),                  // 5: row_page_size_bytes (for TensorAccessor)
-        output_full_chunk_size_bytes,             // 6: actual_full_chunk_size_bytes (DRAM write size)
-        output_partial_chunk_size_bytes,          // 7: actual_partial_chunk_size_bytes (DRAM write size)
+        output_cb_index,                  // 0: cb_id_out
+        full_chunks_per_row,              // 1: full_chunks_per_row
+        partial_chunks_per_row,           // 2: partial_chunks_per_row (0 or 1)
+        output_full_chunk_size_bytes,     // 3: full_chunk_size_bytes (DRAM write size)
+        output_partial_chunk_size_bytes,  // 4: partial_chunk_size_bytes (DRAM write size)
     };
     tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 


### PR DESCRIPTION
The TypecastRowMajorChunkedProgramFactory required the tensor's last dimension to be a multiple of 32, because the hardware unpacker reads in 32-element tile-row granularity and would cross CB page boundaries for non-aligned widths (e.g. 104 elements from 832/8 mesh sharding).

Fix: pad each CB page to the next multiple of 32 elements in the factory (so the unpacker always stays within the page), zero-fill the extra bytes in L1 after the NOC read in the reader kernel (so garbage data isn't fed to the compute LLK), and write only the actual element count back to DRAM in the writer kernel.

This fixes a TT_FATAL in the WAN 480p pipeline where width 104 (=832/8) is not divisible by 32.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/rm_typecast_align)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/rm_typecast_align)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=cglagovich/rm_typecast_align)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cglagovich/rm_typecast_align)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/rm_typecast_align)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/rm_typecast_align)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/rm_typecast_align)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/rm_typecast_align)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/rm_typecast_align)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/rm_typecast_align)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/rm_typecast_align)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/rm_typecast_align)