### PR TITLE
[Bug fix]: Reduce memory footprint of g_dfb_interface on trisc2

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
@@ -52,7 +52,7 @@ inline void llk_pack_init(const std::uint32_t pack_output) {
 template <bool out_of_order_output, bool untilize>
 inline std::uint32_t get_output_tile_index(std::uint8_t output_id, std::uint32_t output_tile_index) {
     std::uint32_t l1_tile_index;
-    LocalDFBInterface& local_dfb_interface = g_dfb_interface[output_id];
+    LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(output_id);
     if constexpr (out_of_order_output) {
         // Use the write tile index to track position within DFB
         l1_tile_index =
@@ -137,7 +137,7 @@ inline void llk_pack_hw_configure(const std::uint32_t pack_output) {
 
         // TODO: with multiple TCs are there multiple descriptors?
         buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B = g_dfb_interface[i].tc_slots[0].base_addr;
+        bd_val.f.l1_addr_16B = get_local_dfb_interface(i).tc_slots[0].base_addr;
         bd_val.f.format = static_cast<std::uint8_t>(l1_data_format);
         bd_val.f.x_dim = ckernel::trisc::FACE_C_DIM;
         bd_val.f.y_dim = pack_tile_face_r_dim[i];

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
@@ -80,7 +80,7 @@ inline void llk_pack_untilize(
     // merging adjacent face-columns into a single output row. Hence we use R_DIM_FACES instead of num_faces for L1
     // strides
     const std::uint32_t y_stride = full_ct_dim * R_DIM_FACES * face_r_dim;
-    LocalDFBInterface& local_dfb_interface = g_dfb_interface[output_id];
+    LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(output_id);
     const std::uint32_t base_l1 = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx * R_DIM_FACES * face_r_dim;
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -56,8 +56,8 @@ inline void llk_unpack_AB(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const LocalDFBInterface& local_dfb_interface_a = g_dfb_interface[operandA_id];
-    const LocalDFBInterface& local_dfb_interface_b = g_dfb_interface[operandB_id];
+    const LocalDFBInterface& local_dfb_interface_a = get_local_dfb_interface(operandA_id);
+    const LocalDFBInterface& local_dfb_interface_b = get_local_dfb_interface(operandB_id);
 
     const std::uint32_t l1_tile_idx_a =
         local_dfb_interface_a.tc_slots[local_dfb_interface_a.tc_idx].rd_entry_idx + tile_index_a;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -73,8 +73,8 @@ inline void llk_unpack_AB_matmul(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const LocalDFBInterface& local_dfb_interface_a = g_dfb_interface[operandA_id];
-    const LocalDFBInterface& local_dfb_interface_b = g_dfb_interface[operandB_id];
+    const LocalDFBInterface& local_dfb_interface_a = get_local_dfb_interface(operandA_id);
+    const LocalDFBInterface& local_dfb_interface_b = get_local_dfb_interface(operandB_id);
 
     const std::uint32_t l1_tile_idx_0 =
         local_dfb_interface_a.tc_slots[local_dfb_interface_a.tc_idx].rd_entry_idx + tile_index_a;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -52,8 +52,8 @@ inline void llk_unpack_AB_reduce(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const LocalDFBInterface& local_dfb_interface_a = g_dfb_interface[operandA_id];
-    const LocalDFBInterface& local_dfb_interface_b = g_dfb_interface[operandB_id];
+    const LocalDFBInterface& local_dfb_interface_a = get_local_dfb_interface(operandA_id);
+    const LocalDFBInterface& local_dfb_interface_b = get_local_dfb_interface(operandB_id);
 
     const std::uint32_t l1_tile_index_a =
         local_dfb_interface_a.tc_slots[local_dfb_interface_a.tc_idx].rd_entry_idx + tile_index_a;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -41,8 +41,9 @@ inline void llk_unpack_A_init(const std::uint32_t operand) {
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
     const std::uint32_t operand_id = get_operand_id(operand);
     // Number of tiles the read pointer has advanced from DFB base
+    const LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(operand_id);
     const std::uint32_t l1_tile_index =
-        g_dfb_interface[operand_id].tc_slots[g_dfb_interface[operand_id].tc_idx].rd_entry_idx + tile_index;
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx + tile_index;
 
     WAYPOINT("UPAW");
     _llk_unpack_unary_operand_<p_unpacr::UNP_A>(l1_tile_index);
@@ -63,7 +64,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
 inline void llk_unpack_A_block(
     const std::uint32_t operand, const std::uint32_t start_tile_index, const std::uint32_t ntiles) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    const LocalDFBInterface& local_dfb_interface = g_dfb_interface[operand_id];
+    const LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(operand_id);
     std::uint32_t l1_tile_index =
         local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx + start_tile_index;
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -39,7 +39,7 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
 
         // TODO: with multiple TCs are there multiple descriptors?
         buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B = g_dfb_interface[i].tc_slots[0].base_addr;
+        bd_val.f.l1_addr_16B = get_local_dfb_interface(i).tc_slots[0].base_addr;
         bd_val.f.format = static_cast<std::uint8_t>(l1_data_format);
         bd_val.f.x_dim = ckernel::trisc::FACE_C_DIM;
         bd_val.f.y_dim = unpack_tile_face_r_dim[i];

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io.h
@@ -6,3 +6,45 @@
 #include <cstdint>
 
 #include "internal/circular_buffer_interface.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
+
+#if defined(COMPILE_FOR_TRISC) && (defined(UCK_CHLKC_PACK) || defined(UCK_CHLKC_UNPACK))
+// Used by pack and unpack to advance DFB rd/wr tile offsets and the tile counter pointer
+//
+// Pack updates wr_entry_idx / wr_offset
+// Unpack updates rd_entry_idx / rd_offset
+inline void dfb_advance_slot(
+    LocalDFBInterface& intf,
+    DFBTCSlot& slot,
+    std::uint32_t num_tiles) {
+    const std::uint32_t num_words = num_tiles * intf.stride_size;
+
+    std::uint32_t entry_idx;
+    std::uint32_t offset;
+#if defined(UCK_CHLKC_PACK)
+    entry_idx = slot.wr_entry_idx;
+    offset = slot.wr_offset;
+#elif defined(UCK_CHLKC_UNPACK)
+    entry_idx = slot.rd_entry_idx;
+    offset = slot.rd_offset;
+#endif
+
+    entry_idx += num_tiles * static_cast<std::uint32_t>(intf.stride_size_tiles);
+    offset += num_words;
+    if (offset >= slot.ring_size) {
+        offset = 0;
+        entry_idx = slot.base_entry_idx;
+    }
+
+#if defined(UCK_CHLKC_PACK)
+    slot.wr_entry_idx = static_cast<std::uint16_t>(entry_idx);
+    slot.wr_offset = static_cast<std::uint16_t>(offset);
+#elif defined(UCK_CHLKC_UNPACK)
+    slot.rd_entry_idx = static_cast<std::uint16_t>(entry_idx);
+    slot.rd_offset = static_cast<std::uint16_t>(offset);
+#endif
+
+    intf.tc_idx = (intf.tc_idx + 1) % intf.num_tcs_to_rr;
+}
+
+#endif

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
@@ -9,6 +9,7 @@
 #include "ckernel_trisc_common.h"
 #include "internal/circular_buffer_interface.h"
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
+#include "llk_io.h"
 
 /**
  * @brief  Wait for num_tiles of free space in the dataflow buffer
@@ -16,7 +17,7 @@
  * @param num_tiles: Number of tiles of free space to wait for in dataflow buffer
  */
 inline void llk_wait_for_free_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
-    LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
+    LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(dfb_id);
     uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
     TT_WAIT_FREE(ckernel::p_stall::STALL_PACK, num_tiles, tc_id);
 }
@@ -29,25 +30,12 @@ inline void llk_wait_for_free_tiles(const std::int32_t dfb_id, const std::int32_
 // Push N tiles to stream buffer (increment write pointer)
 template <std::uint8_t PACK_SEL = 0x1>
 inline void llk_push_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
-    LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
-    uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+    LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(dfb_id);
+    auto& slot = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx];
+    uint32_t tc_id = dfb::get_counter_id(slot.packed_tile_counter);
     // Update the tile counters values
     TT_PUSH_TILES(PACK_SEL, num_tiles, tc_id);
 
-    const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
-
-    local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx +=
-        num_tiles * local_dfb_interface.stride_size_tiles;
-    local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr += num_words;
     local_dfb_interface.wr_entry_ptr = 0;
-
-    if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr >=
-        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {
-        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr =
-            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_addr;
-        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx =
-            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_entry_idx;
-    }
-
-    local_dfb_interface.tc_idx = (local_dfb_interface.tc_idx + 1) % local_dfb_interface.num_tcs_to_rr;
+    dfb_advance_slot(local_dfb_interface, slot, num_tiles);
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -9,6 +9,7 @@
 #include "ckernel_trisc_common.h"
 #include "internal/circular_buffer_interface.h"
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
+#include "llk_io.h"
 
 /**
  * @brief  Wait for num_tiles available in the incoming dataflow buffer
@@ -16,7 +17,7 @@
  * @param num_tiles: Number of tiles to wait for in dataflow buffer
  */
 inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_tiles) {
-    LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
+    LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(dfb_id);
     uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
 
     TT_WAIT_TILES(ckernel::p_stall::STALL_UNPACK, num_tiles, tc_id);
@@ -29,25 +30,12 @@ inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_ti
  */
 template <std::uint8_t UNPACK_SEL = 0x3>
 inline void llk_pop_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
-    LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
-    uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+    LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(dfb_id);
+    auto& slot = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx];
+    uint32_t tc_id = dfb::get_counter_id(slot.packed_tile_counter);
 
     // Wait until selected unpackers are reading from L1
     TT_POP_TILES(UNPACK_SEL, num_tiles, tc_id);
 
-    // Update the DFB buffer information
-    const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
-
-    local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx +=
-        num_tiles * local_dfb_interface.stride_size_tiles;
-    local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr += num_words;
-    if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr >=
-        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {
-        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr =
-            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_addr;
-        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx =
-            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_entry_idx;
-    }
-
-    local_dfb_interface.tc_idx = (local_dfb_interface.tc_idx + 1) % local_dfb_interface.num_tcs_to_rr;
+    dfb_advance_slot(local_dfb_interface, slot, num_tiles);
 }

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -50,7 +50,12 @@ uint8_t my_relative_x_ __attribute__((used));
 uint8_t my_relative_y_ __attribute__((used));
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
+#if defined(UCK_CHLKC_PACK)
+thread_local LocalDFBInterface g_dfb_interface[dfb::MAX_ACTIVE_DFBS_PACK] __attribute__((used));
+thread_local uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS] __attribute__((used));
+#else
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
+#endif
 #endif
 
 namespace ckernel {

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -19,7 +19,7 @@
 namespace experimental {
 
 inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id)
-    : local_dfb_interface_(g_dfb_interface[logical_dfb_id]), logical_dfb_id_(logical_dfb_id) {}
+    : local_dfb_interface_(get_local_dfb_interface(logical_dfb_id)), logical_dfb_id_(logical_dfb_id) {}
 
 inline uint32_t DataflowBuffer::get_entry_size() const { return local_dfb_interface_.entry_size; }
 
@@ -157,13 +157,29 @@ inline void DataflowBuffer::finish_impl() {
 }
 
 inline uint32_t DataflowBuffer::get_write_ptr_impl() const {
-    // return byte address (wr_ptr is 16B address on Gen1XX)
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+    return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr +
+           local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_offset;
+#elif !defined(COMPILE_FOR_TRISC)
     return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr;
+#else
+    // Unpack TRISC does not use wr_ptr; return ring base for any accidental caller.
+    ASSERT(false);
+    return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+#endif
 }
 
 inline uint32_t DataflowBuffer::get_read_ptr_impl() const {
-    // return byte address (rd_ptr is 16B address on Gen1XX)
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+    return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr +
+           local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_offset;
+#elif !defined(COMPILE_FOR_TRISC)
     return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr;
+#else
+    // Pack TRISC does not use rd_ptr; return ring base for any accidental caller.
+    ASSERT(false);
+    return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+#endif
 }
 
 #ifndef COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -15,6 +15,8 @@ enum AccessPattern : uint8_t {
 };
 
 constexpr uint8_t NUM_DFBS = 32;
+// Pack TRISC stores only active logical DFBs in a compact local array to reduce local-memory pressure.
+constexpr uint8_t MAX_ACTIVE_DFBS_PACK = 16;
 
 constexpr uint8_t NUM_TENSIX = 4;
 constexpr uint8_t NUM_TILE_COUNTERS_PER_TENSIX = 32;

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -35,6 +35,9 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
     uint32_t num_dfbs =
         local_dfb_mask;  // kernel config holds local_cb_mask but it gets hijacked to hold number of dfbs
     volatile uint8_t* base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+    uint8_t compact_dfb_count = 0;
+#endif
 
     // each RISC populates its own g_dfb_interface entry
     for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
@@ -56,7 +59,16 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + risc_index;
 
             // Populate LocalDFBInterface from combined dfb_initializer_t + dfb_initializer_per_risc_t
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+            ASSERT(compact_dfb_count < dfb::MAX_ACTIVE_DFBS_PACK);
+            // Pack TRISC has smaller local memory so the LocalDFBInterface is tightly packed and a
+            // second lookup table is needed to map the logical DFB ID to the tightly packed index.
+            const uint8_t compact_dfb_id = compact_dfb_count++;
+            g_dfb_logical_to_compact[logical_dfb_id] = compact_dfb_id;
+            LocalDFBInterface& dfb_interface = g_dfb_interface[compact_dfb_id];
+#else
             LocalDFBInterface& dfb_interface = g_dfb_interface[logical_dfb_id];
+#endif
 
             // DPRINT << "risc_index: " << static_cast<uint32_t>(risc_index) << ENDL();
             // DEVICE_PRINT("risc_index: {}\n", static_cast<uint32_t>(risc_index));
@@ -66,34 +78,53 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
 
             // Address fields are in bytes on host; convert to 16B units on TRISC (cb_addr_shift=4), keep bytes on DM
             // (cb_addr_shift=0)
-            dfb_interface.entry_size = init_ptr->entry_size >> cb_addr_shift;
-            // DPRINT << "entry_size: " << static_cast<uint32_t>(dfb_interface.entry_size) << ENDL();
-            dfb_interface.stride_size = dfb_interface.entry_size * init_ptr->stride_in_entries;
-            // DPRINT << "stride_size: " << static_cast<uint32_t>(dfb_interface.stride_size) << ENDL();
 #ifdef COMPILE_FOR_TRISC
-            dfb_interface.stride_size_tiles = init_ptr->stride_in_entries;
+            dfb_interface.entry_size = static_cast<uint16_t>(init_ptr->entry_size >> cb_addr_shift);
+            dfb_interface.stride_size = static_cast<uint16_t>(
+                static_cast<uint32_t>(dfb_interface.entry_size) * static_cast<uint32_t>(init_ptr->stride_in_entries));
+            dfb_interface.stride_size_tiles = static_cast<uint8_t>(init_ptr->stride_in_entries);
+#if defined(UCK_CHLKC_PACK)
             dfb_interface.wr_entry_ptr = 0;
+#else
+            dfb_interface.tensix_trisc_mask = static_cast<uint8_t>(init_ptr->risc_mask_bits.tensix_trisc_mask);
+#endif
+#else
+            dfb_interface.entry_size = init_ptr->entry_size >> cb_addr_shift;
+            dfb_interface.stride_size = dfb_interface.entry_size * init_ptr->stride_in_entries;
 #endif
 
             for (uint8_t i = 0; i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
                 uint32_t base = per_risc_ptr->base_addr[i] >> cb_addr_shift;
+                uint32_t limit_s = per_risc_ptr->limit[i] >> cb_addr_shift;
+                // ring_size (TRISC): linear span limit_s - base for this TC—the same bound legacy wr_ptr/rd_ptr used.
+                // In STRIDED layouts that span includes other producers' interleaved entries between this TC's tiles.
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
                 dfb_interface.tc_slots[i].base_addr = base;
-                dfb_interface.tc_slots[i].limit = per_risc_ptr->limit[i] >> cb_addr_shift;
+                dfb_interface.tc_slots[i].wr_offset = 0;
+                dfb_interface.tc_slots[i].ring_size = static_cast<uint16_t>(limit_s - base);
+                dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
+                dfb_interface.tc_slots[i].base_entry_idx = static_cast<uint16_t>(
+                    (base - dfb_interface.tc_slots[0].base_addr) / dfb_interface.entry_size);
+                dfb_interface.tc_slots[i].wr_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
+#elif defined(COMPILE_FOR_TRISC)
+                dfb_interface.tc_slots[i].base_addr = base;
+                dfb_interface.tc_slots[i].rd_offset = 0;
+                dfb_interface.tc_slots[i].ring_size = static_cast<uint16_t>(limit_s - base);
+                dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
+                dfb_interface.tc_slots[i].base_entry_idx = static_cast<uint16_t>(
+                    (base - dfb_interface.tc_slots[0].base_addr) / dfb_interface.entry_size);
+                dfb_interface.tc_slots[i].rd_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
+#else
+                dfb_interface.tc_slots[i].base_addr = base;
+                dfb_interface.tc_slots[i].limit = limit_s;
                 dfb_interface.tc_slots[i].rd_ptr = base;
                 dfb_interface.tc_slots[i].wr_ptr = base;
                 dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
-#ifdef COMPILE_FOR_TRISC
-                dfb_interface.tc_slots[i].base_entry_idx =
-                    (base - dfb_interface.tc_slots[0].base_addr) / dfb_interface.entry_size;
-                dfb_interface.tc_slots[i].rd_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
-                dfb_interface.tc_slots[i].wr_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
 #endif
             }
 
             dfb_interface.tc_idx = 0;
-#ifdef COMPILE_FOR_TRISC
-            dfb_interface.tensix_trisc_mask = init_ptr->risc_mask_bits.tensix_trisc_mask;
-#else
+#ifndef COMPILE_FOR_TRISC
             dfb_interface.broadcast_tc = per_risc_ptr->num_tcs_and_init.broadcast_tc;
 #endif
 

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -15,24 +15,74 @@ struct LocalDFBInterface;
 struct TxnDFBDescriptor;
 
 // Global DFB interface array
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+extern thread_local LocalDFBInterface g_dfb_interface[dfb::MAX_ACTIVE_DFBS_PACK];
+extern thread_local uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS];
+#else
 extern thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS];
+#endif
 #ifndef COMPILE_FOR_TRISC
 // TODO: make this a constant when we clean up number of txn ids
 extern volatile TxnDFBDescriptor g_txn_dfb_descriptor[32];
 extern RemapperAPI g_remapper_configurator;
 #endif
 
-// Per–tile-counter slot
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+
+struct DFBTCSlot {
+    uint32_t base_addr;
+    uint16_t wr_offset;
+    uint16_t ring_size;
+    uint16_t wr_entry_idx;
+    uint16_t base_entry_idx;
+    dfb::PackedTileCounter packed_tile_counter;
+} __attribute__((packed));
+
+struct LocalDFBInterface {
+    uint16_t entry_size;
+    uint16_t stride_size;
+    uint16_t wr_entry_ptr;
+    uint8_t stride_size_tiles;
+    uint8_t num_tcs_to_rr;
+    uint8_t tc_idx;
+    DFBTCSlot tc_slots[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
+} __attribute__((packed));
+
+static_assert(sizeof(DFBTCSlot) == 13, "DFBTCSlot (pack TRISC) size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 61, "LocalDFBInterface (pack TRISC) size is incorrect");
+
+#elif defined(COMPILE_FOR_TRISC)
+
+struct DFBTCSlot {
+    uint32_t base_addr;
+    uint16_t rd_offset;
+    uint16_t ring_size;
+    uint16_t rd_entry_idx;
+    uint16_t base_entry_idx;
+    dfb::PackedTileCounter packed_tile_counter;
+} __attribute__((packed));
+
+struct LocalDFBInterface {
+    uint16_t entry_size;
+    uint16_t stride_size;
+    uint8_t stride_size_tiles;
+    uint8_t num_tcs_to_rr;
+    uint8_t tc_idx;
+    uint8_t tensix_trisc_mask;
+    DFBTCSlot tc_slots[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
+} __attribute__((packed));
+
+static_assert(sizeof(DFBTCSlot) == 13, "DFBTCSlot (unpack TRISC) size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 60, "LocalDFBInterface (unpack TRISC) size is incorrect");
+
+#else
+
+// Per–tile-counter slot (DM)
 struct DFBTCSlot {
     uint32_t rd_ptr;
     uint32_t wr_ptr;
     uint32_t base_addr;
     uint32_t limit;
-#ifdef COMPILE_FOR_TRISC
-    uint16_t rd_entry_idx;
-    uint16_t wr_entry_idx;
-    uint16_t base_entry_idx;
-#endif
     dfb::PackedTileCounter packed_tile_counter;
 } __attribute__((packed));
 
@@ -41,27 +91,31 @@ struct LocalDFBInterface {
     uint32_t entry_size;
     uint32_t stride_size;
 
-#ifdef COMPILE_FOR_TRISC
-    uint32_t stride_size_tiles; // used by triscs to calculate tile offset from base L1 address
-    uint16_t wr_entry_ptr;
-#endif
-
     uint8_t num_tcs_to_rr;
     uint8_t tc_idx;
 
-#ifdef COMPILE_FOR_TRISC
-    uint8_t tensix_trisc_mask;  // which TRISC(s) use this DFB (bit N = trisc N); for runtime gate on TRISC
-#else
     uint8_t txn_ids[dfb::NUM_TXN_IDS];
     uint8_t
         num_entries_per_txn_id;
     uint8_t num_entries_per_txn_id_per_tc;
     uint8_t num_txn_ids;
-    uint8_t broadcast_tc;       // DM-DM BLOCKED producer: post to all TCs instead of round-robin
-#endif
+    uint8_t broadcast_tc;  // DM-DM BLOCKED producer: post to all TCs instead of round-robin
 
     DFBTCSlot tc_slots[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
 } __attribute__((packed));
+
+static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 86, "LocalDFBInterface size is incorrect");
+
+#endif
+
+inline LocalDFBInterface& get_local_dfb_interface(uint32_t logical_dfb_id) {
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+    return g_dfb_interface[g_dfb_logical_to_compact[logical_dfb_id]];
+#else
+    return g_dfb_interface[logical_dfb_id];
+#endif
+}
 
 // Holds metadata for transaction ID based ISR handling
 // It is used by the ISR to understand which tile counters need to update which credits (post/ack)
@@ -73,11 +127,3 @@ struct TxnDFBDescriptor {
         uint8_t tiles_to_ack;
     } __attribute__((packed));
 };
-
-#ifdef COMPILE_FOR_TRISC
-static_assert(sizeof(DFBTCSlot) == 23, "DFBTCSlot size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 109, "LocalDFBInterface size is incorrect");
-#else
-static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 86, "LocalDFBInterface size is incorrect");
-#endif

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -745,6 +745,37 @@ void ProgramImpl::finalize_single_dfb_config(
         "Both producer and consumer cannot be Tensix-only RISCs - at least one DM RISC is required to initialize tile "
         "counters");
 
+    // TRISC pack/unpack store ring extent in uint16_t L1-aligned units; host must reject oversized rings.
+    if (MetalContext::instance().hal().has_tile_counter_registers()) {
+        const bool tensix_on_dfb =
+            has_tensix_risc(config.producer_risc_mask) || has_tensix_risc(config.consumer_risc_mask);
+        if (tensix_on_dfb && dfb->capacity > 0) {
+            const uint64_t ring_bytes =
+                dfb->entry_size * (dfb->stride_in_entries * (dfb->capacity - 1U) + 1U);
+            const uint32_t l1_align = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+            TT_FATAL(
+                ring_bytes % l1_align == 0,
+                "DFB {}: ring size in bytes ({}) must be a multiple of L1 alignment ({})",
+                dfb->id,
+                ring_bytes,
+                l1_align);
+            const uint64_t ring_trisc_units = ring_bytes / l1_align;
+            TT_FATAL(
+                ring_trisc_units > 0U,
+                "DFB {}: TRISC ring extent is zero L1 units (ring_bytes={}, align={})",
+                dfb->id,
+                ring_bytes,
+                l1_align);
+            TT_FATAL(
+                ring_trisc_units < 65536U,
+                "DFB {}: TRISC ring extent ({} L1 units of {} bytes) exceeds uint16_t; reduce capacity, stride, or "
+                "entry_size",
+                dfb->id,
+                ring_trisc_units,
+                l1_align);
+        }
+    }
+
     dfb->risc_mask = config.producer_risc_mask | config.consumer_risc_mask;
 
     // DM-DM BLOCKED: producer broadcasts to N TCs (one per consumer) instead of using remapper.


### PR DESCRIPTION
### Summary
Packer has smaller local mem size compared to trisc0/3. the g_dfb_interface array was overflowing this 2K region. This PR reduces the mem footprint by removing rd ptr/tile index metadata from Packer and wr ptr/tile index metadata from Unpackers. 

Also keeping g_dfb_interface tightly packed on trisc by adding lookup table from logical dfb ID to a tightly packed idx. 

### Notes for reviewers
Currently set a max of 16 logical DFBs to be tracked in Packer. I think this should be sufficient but can revisit this.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/trisc2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/trisc2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/trisc2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/trisc2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/trisc2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/trisc2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/trisc2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/trisc2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/trisc2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/trisc2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/trisc2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/trisc2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/trisc2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/trisc2)