### PR TITLE
Fix missing tile size variable declarations in gather writer kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
@@ -45,6 +45,10 @@ void kernel_main() {
     // Output tensor config
     const auto output_tensor_dram = TensorAccessor(output_tensor_args, output_tensor_buffer_addr);
 
+    // Tile size in bytes for input and output tensors
+    constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
+    constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
+
     experimental::Noc noc;
     experimental::CircularBuffer input_cb(input_tensor_cb_index);
     experimental::CircularBuffer output_cb(output_tensor_cb_index);

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
@@ -53,6 +53,10 @@ void kernel_main() {
     // Output tensor config
     const auto output_tensor_dram = TensorAccessor(output_tensor_args, output_tensor_buffer_addr);
 
+    // Tile size in bytes for input and output tensors
+    constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
+    constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
+
     experimental::Noc noc;
     experimental::CircularBuffer input_cb(input_tensor_cb_index);
     experimental::CircularBuffer output_cb(output_tensor_cb_index);


### PR DESCRIPTION
## Summary

This PR fixes compilation errors in gather writer kernels by adding missing variable declarations that were accidentally removed during the Device 2.0 API migration in PR #42663.

## Issue

The following variables are used but not declared in the gather writer kernels:
- `input_tensor_tile_size_bytes` 
- `output_tensor_tile_size_bytes`

These are used in `noc.async_read()` and `noc.async_write()` calls but their declarations were missing.

## Fix

Added the missing declarations:
```cpp
constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
```

## Affected Files
- `ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp`
- `ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp`

## Root Cause

As acknowledged in PR #42663's commit message:
> "The original PR was correct, but during merge conflict resolution with main, the input_tensor_tile_size_bytes and output_tensor_tile_size_bytes variable declarations were accidentally removed from two gather writer kernels while their usages were retained."

## Test Plan
- [x] Build passes with these fixes - works locally
- [x] Run gather tests: `pytest tests/ttnn/unit_tests/operations/data_movement/test_gather.py` - passes locally
- [x] Check previously failing sanity check models-unit-tests is passing. -passing, see below (other failures in sanity tests are unrelated to this or the original PR)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/gather-writer-tile-size-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/gather-writer-tile-size-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/gather-writer-tile-size-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/gather-writer-tile-size-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/gather-writer-tile-size-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/gather-writer-tile-size-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/gather-writer-tile-size-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/gather-writer-tile-size-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/gather-writer-tile-size-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/gather-writer-tile-size-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/gather-writer-tile-size-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/gather-writer-tile-size-only)