### PR TITLE
Improve AI-friendliness of Metal 2.0 host APIs

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -16,7 +16,14 @@
 
 namespace tt::tt_metal::experimental::metal2_host_api {
 
+// A name identifying a DataflowBufferSpec within a ProgramSpec.
+//
+// CONVENTION: define names as `constexpr const char*` constants, e.g.:
+//   constexpr const char* INPUT_DFB = "input_dfb";
+//   DataflowBufferSpec{.unique_id = INPUT_DFB, ...};
+// This way, cross-reference validity is checked at compile time.
 using DFBSpecName = std::string;
+
 enum class DFBAccessPattern { STRIDED, BLOCKED, CONTIGUOUS };
 
 struct DataflowBufferSpec {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -21,7 +21,7 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // CONVENTION: define names as `constexpr const char*` constants, e.g.:
 //   constexpr const char* INPUT_DFB = "input_dfb";
 //   DataflowBufferSpec{.unique_id = INPUT_DFB, ...};
-// This way, cross-reference validity is checked at compile time.
+// Reusing a single constant helps catch typos and errors at compile time.
 using DFBSpecName = std::string;
 
 enum class DFBAccessPattern { STRIDED, BLOCKED, CONTIGUOUS };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -54,7 +54,12 @@ struct DataMovementConfiguration {
     std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
 };
 
-using KernelSpecID = uint32_t;
+// A name identifying a KernelSpec within a ProgramSpec.
+//
+// CONVENTION: define names as `constexpr const char*` constants, e.g.:
+//   constexpr const char* READER_KERNEL = "reader";
+//   KernelSpec{.unique_id = READER_KERNEL, ...};
+// This way, cross-reference validity is checked at compile time.
 using KernelSpecName = std::string;
 
 struct KernelSpec {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -83,7 +83,10 @@ struct KernelSpec {
     // Threading
     // Number of kernel threads (this can be specified globally or per-node)
     uint8_t num_threads = 1;
-    using ThreadNodeMap = std::unordered_map<Nodes, uint8_t>;  // node -> number of kernel threads
+    // Optional per-node thread count specification (overrides global num_threads)
+    // This is currently unsupported, and an open question if we ever want to support it.
+    using NodeSpecificThreadCount = std::pair<Nodes, uint8_t>;  // {node, num_threads}
+    using ThreadNodeMap = std::vector<NodeSpecificThreadCount>;
     std::optional<ThreadNodeMap> thread_node_map = std::nullopt;
 
     // Kernel type (methods)

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -96,12 +96,10 @@ struct KernelSpec {
     struct CompilerOptions {
         using IncludePaths = std::vector<std::string>;
         using Defines = std::vector<std::pair<std::string, std::string>>;
-        using Macros = std::vector<std::string>;
         using OptLevel = tt::tt_metal::KernelBuildOptLevel;
 
         IncludePaths include_paths;         // -I <path>
         Defines defines;                    // -D <name>=<value>
-        Macros macros;                      // -M <macro>
         OptLevel opt_level = OptLevel::O2;  // -O<level>
         // Can add more options here as needed
     };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -59,7 +59,7 @@ struct DataMovementConfiguration {
 // CONVENTION: define names as `constexpr const char*` constants, e.g.:
 //   constexpr const char* READER_KERNEL = "reader";
 //   KernelSpec{.unique_id = READER_KERNEL, ...};
-// This way, cross-reference validity is checked at compile time.
+// Reusing a single constant helps catch typos and errors at compile time.
 using KernelSpecName = std::string;
 
 struct KernelSpec {
@@ -87,7 +87,7 @@ struct KernelSpec {
     // This is currently unsupported, and an open question if we ever want to support it.
     using NodeSpecificThreadCount = std::pair<Nodes, uint8_t>;  // {node, num_threads}
     using ThreadNodeMap = std::vector<NodeSpecificThreadCount>;
-    std::optional<ThreadNodeMap> thread_node_map = std::nullopt;
+    std::optional<ThreadNodeMap> node_specific_thread_counts = std::nullopt;
 
     // Kernel type (methods)
     bool is_dm_kernel() const { return std::holds_alternative<DataMovementConfiguration>(config_spec); }

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -17,8 +17,17 @@
 
 namespace tt::tt_metal::experimental::metal2_host_api {
 
-using WorkerSpecName = std::string;
+// A name identifying a ProgramSpec within a MeshWorkload.
+//
+// CONVENTION: define names as `constexpr const char*` constants, e.g.:
+//   constexpr const char* MATMUL_PROGRAM = "matmul";
+//   ProgramSpec{.program_id = MATMUL_PROGRAM, ...};
+// This way, cross-reference validity is checked at compile time.
 using ProgramSpecName = std::string;
+
+// A name identifying a WorkerSpec within a ProgramSpec.
+// CONVENTION: define names as `constexpr const char*` constants (see above).
+using WorkerSpecName = std::string;
 
 //------------------------------------------------
 // ProgramSpec & WorkerSpec

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -22,7 +22,7 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // CONVENTION: define names as `constexpr const char*` constants, e.g.:
 //   constexpr const char* MATMUL_PROGRAM = "matmul";
 //   ProgramSpec{.program_id = MATMUL_PROGRAM, ...};
-// This way, cross-reference validity is checked at compile time.
+// Reusing a single constant helps catch typos and errors at compile time.
 using ProgramSpecName = std::string;
 
 // A name identifying a WorkerSpec within a ProgramSpec.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -19,7 +19,7 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // CONVENTION: define names as `constexpr const char*` constants, e.g.:
 //   constexpr const char* DONE_FLAG = "done_flag";
 //   SemaphoreSpec{.unique_id = DONE_FLAG, ...};
-// This way, cross-reference validity is checked at compile time.
+// Reusing a single constant helps catch typos and errors at compile time.
 using SemaphoreSpecName = std::string;
 
 struct SemaphoreSpec {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -14,6 +14,12 @@
 
 namespace tt::tt_metal::experimental::metal2_host_api {
 
+// A name identifying a SemaphoreSpec within a ProgramSpec.
+//
+// CONVENTION: define names as `constexpr const char*` constants, e.g.:
+//   constexpr const char* DONE_FLAG = "done_flag";
+//   SemaphoreSpec{.unique_id = DONE_FLAG, ...};
+// This way, cross-reference validity is checked at compile time.
 using SemaphoreSpecName = std::string;
 
 struct SemaphoreSpec {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -441,10 +441,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.compiler_options.include_paths.empty(),
             "KernelSpec '{}' specifies include_paths -- this feature is not yet implemented. (Coming soon!)",
             kernel.unique_id);
-        TT_FATAL(
-            kernel.compiler_options.macros.empty(),
-            "KernelSpec '{}' specifies macros -- this feature is not yet implemented.",
-            kernel.unique_id);
     }
 
     // Validate no per-node thread maps are used (not yet implemented)

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -446,8 +446,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate no per-node thread maps are used (not yet implemented)
     for (const auto& kernel : spec.kernels) {
         TT_FATAL(
-            !kernel.thread_node_map.has_value(),
-            "KernelSpec '{}' specifies thread_node_map, but per-node thread counts are not implemented.",
+            !kernel.node_specific_thread_counts.has_value(),
+            "KernelSpec '{}' specifies node_specific_thread_counts, but per-node thread counts are not implemented.",
             kernel.unique_id);
     }
 


### PR DESCRIPTION
### Summary
This PR makes some minor changes to the Metal 2.0 host API surface, intended to make it more AI-friendly. The recommendations come from Claude Opus 4.6.

Minor changes:

- **Encourage the use of symbols for string identifiers**: Add a small comment block above each string identifier, locally recommending a symbol-based design pattern. This improves AI (and human) friendliness by converting runtime errors (immediate `TT_FATAL` in legality checks) to compile time errors.
- **Remove unnecessary `macros` from `CompilerOptions`**: This doesn't align with the familiar `-I`, `-O`, `-D` semantics, and it's superfluous with `defines`.
- **Improve clarify of (unsupported) `thread_node_map`**: Added clarifying comments, rename, and make it a vector<pair<>>

### Background

AI-specific API design guidelines:
- API clarity for humans and AIs alike is mostly the same thing, but...
- Locality matters more to API. Prefer more general inline comments to including info in examples, docs, etc.
- Compile-time error checking is strongly preferred to runtime errors. True for humans also, but more important for AI authors.

## Additional TO-DOs

Additional AI-inspired API improvements (to follow in subsequent PRs):
 - **Make WorkerSpec optional**: Reduces the potential error surface.
 - **Add strong typing wherever possible**: Converts runtime arguments to compiler time errors, though at a slight determinent to API readability.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/claudes-api-feedback2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/claudes-api-feedback2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/claudes-api-feedback2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/claudes-api-feedback2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/claudes-api-feedback2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/claudes-api-feedback2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/claudes-api-feedback2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/claudes-api-feedback2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/claudes-api-feedback2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/claudes-api-feedback2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/claudes-api-feedback2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/claudes-api-feedback2)