### PR TITLE
gather: fix missing tile_size_bytes declarations in writer kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
@@ -40,9 +40,11 @@ void kernel_main() {
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
+    constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
     const auto input_tensor_dram = TensorAccessor(input_tensor_args, input_tensor_buffer_addr);
 
     // Output tensor config
+    constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
     const auto output_tensor_dram = TensorAccessor(output_tensor_args, output_tensor_buffer_addr);
 
     // Tile size in bytes for input and output tensors

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
@@ -48,9 +48,11 @@ void kernel_main() {
     constexpr uint32_t one_tile = 1;
 
     // Input tensor config
+    constexpr uint32_t input_tensor_tile_size_bytes = get_tile_size(input_tensor_cb_index);
     const auto input_tensor_dram = TensorAccessor(input_tensor_args, input_tensor_buffer_addr);
 
     // Output tensor config
+    constexpr uint32_t output_tensor_tile_size_bytes = get_tile_size(output_tensor_cb_index);
     const auto output_tensor_dram = TensorAccessor(output_tensor_args, output_tensor_buffer_addr);
 
     // Tile size in bytes for input and output tensors


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #42663 (commit `50970dc`). During merge conflict resolution, the `input_tensor_tile_size_bytes` and `output_tensor_tile_size_bytes` `constexpr` declarations were accidentally dropped from both gather writer kernels, while their usages in `noc.async_read`/`noc.async_write` calls were retained. This caused a compile failure:

```
error: 'input_tensor_tile_size_bytes' was not declared in this scope
error: 'output_tensor_tile_size_bytes' was not declared in this scope
```

**Files fixed:**
- `gather_writer_single_row_single_core.cpp`
- `gather_writer_single_row_multi_core.cpp`

**Fix:** Add `constexpr uint32_t {input,output}_tensor_tile_size_bytes = get_tile_size({input,output}_tensor_cb_index);` in the tensor config section, matching the pattern already used in the reader kernels.

## Test plan
- [ ] WH ttsim `gather` op tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/fix-gather-writer-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-gather-writer-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/fix-gather-writer-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/fix-gather-writer-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/fix-gather-writer-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-gather-writer-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/fix-gather-writer-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-gather-writer-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/fix-gather-writer-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-gather-writer-tile-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/fix-gather-writer-tile-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-gather-writer-tile-size)