### PR TITLE
Make kernel source a std::variant with strongly typed options

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -34,8 +34,7 @@ inline KernelSpec MakeMinimalDMKernel(
     const std::string& name, const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes, uint8_t num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
-        .source = MINIMAL_KERNEL_SOURCE,
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .target_nodes = nodes,
         .num_threads = num_threads,
         .config_spec =
@@ -52,8 +51,7 @@ inline KernelSpec MakeMinimalGen1DMKernel(
     tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0) {
     return KernelSpec{
         .unique_id = name,
-        .source = MINIMAL_KERNEL_SOURCE,
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .target_nodes = nodes,
         .num_threads = 1,
         .config_spec =
@@ -71,8 +69,7 @@ inline KernelSpec MakeMinimalComputeKernel(
     const std::string& name, const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes, uint8_t num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
-        .source = MINIMAL_KERNEL_SOURCE,
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .target_nodes = nodes,
         .num_threads = num_threads,
         .config_spec = ComputeConfiguration{},

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -985,8 +985,7 @@ TEST_F(ProgramSpecTestQuasar, SourceCodeKernelSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Change to inline source code
-    spec.kernels[0].source = "void kernel_main() {}";
-    spec.kernels[0].source_type = KernelSpec::SourceType::SOURCE_CODE;
+    spec.kernels[0].source = KernelSpec::SourceCode{"void kernel_main() {}"};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1269,8 +1268,7 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
     // Demonstrates constructing KernelSpec with designated initializers
     KernelSpec dm_kernel{
         .unique_id = "my_dm_kernel",
-        .source = "void kernel_main() {}",
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{"void kernel_main() {}"},
         .target_nodes = NodeCoord{0, 0},
         .num_threads = 2,
         .config_spec =
@@ -1285,8 +1283,7 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
 
     KernelSpec compute_kernel{
         .unique_id = "my_compute_kernel",
-        .source = "void kernel_main() {}",
-        .source_type = KernelSpec::SourceType::SOURCE_CODE,
+        .source = KernelSpec::SourceCode{"void kernel_main() {}"},
         .target_nodes = NodeRange{{0, 0}, {1, 1}},
         .num_threads = 4,
         .compiler_options =
@@ -1369,8 +1366,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
             {
                 KernelSpec{
                     .unique_id = "producer",
-                    .source = "void kernel_main() {}",
-                    .source_type = KernelSpec::SourceType::SOURCE_CODE,
+                    .source = KernelSpec::SourceCode{"void kernel_main() {}"},
                     .target_nodes = NodeCoord{0, 0},
                     .dfb_bindings =
                         {
@@ -1388,8 +1384,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                 },
                 KernelSpec{
                     .unique_id = "consumer",
-                    .source = "void kernel_main() {}",
-                    .source_type = KernelSpec::SourceType::SOURCE_CODE,
+                    .source = KernelSpec::SourceCode{"void kernel_main() {}"},
                     .target_nodes = NodeCoord{0, 0},
                     .dfb_bindings =
                         {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -97,14 +97,14 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
 
     // Producer: BRISC reads from DRAM → DFB
     auto producer = MakeMinimalGen1DMKernel("producer", node, DataMovementProcessor::RISCV_0);
-    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp";
-    producer.source_type = KernelSpec::SourceType::FILE_PATH;
+    producer.source =
+        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp"};
     producer.runtime_arguments_schema.num_runtime_args_per_node = {{node, 3}};
 
     // Consumer: NCRISC reads DFB → DRAM
     auto consumer = MakeMinimalGen1DMKernel("consumer", node, DataMovementProcessor::RISCV_1);
-    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
-    consumer.source_type = KernelSpec::SourceType::FILE_PATH;
+    consumer.source =
+        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp"};
     consumer.runtime_arguments_schema.num_runtime_args_per_node = {{node, 3}};
 
     // DFB: both kernels bind it, with different local accessor names

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -70,10 +71,16 @@ struct KernelSpec {
     // Kernel identifier: used to reference this kernel within the ProgramSpec
     KernelSpecName unique_id;
 
-    // Kernel source
-    std::string source;
-    enum class SourceType { FILE_PATH, SOURCE_CODE };
-    SourceType source_type = SourceType::FILE_PATH;
+    // Kernel source: either a path to a source file, or the source code itself.
+    // (Wrapper types disambiguate the string-constructible variant alternatives,
+    // ensuring compile-time enforcement.)
+    struct SourceFilePath {
+        std::filesystem::path path;
+    };
+    struct SourceCode {
+        std::string code;
+    };
+    std::variant<SourceFilePath, SourceCode> source;
 
     // Target nodes
     // The logical coordinates for the set of device nodes on which the kernel will run

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -93,8 +93,8 @@ struct KernelSpec {
     // Optional per-node thread count specification (overrides global num_threads)
     // This is currently unsupported, and an open question if we ever want to support it.
     using NodeSpecificThreadCount = std::pair<Nodes, uint8_t>;  // {node, num_threads}
-    using ThreadNodeMap = std::vector<NodeSpecificThreadCount>;
-    std::optional<ThreadNodeMap> node_specific_thread_counts = std::nullopt;
+    using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
+    std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
 
     // Kernel type (methods)
     bool is_dm_kernel() const { return std::holds_alternative<DataMovementConfiguration>(config_spec); }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1156,10 +1156,13 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
 // ----------------------------------------------------------------------------
 
 KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
-    KernelSource::SourceType source_type = (kernel_spec.source_type == KernelSpec::SourceType::FILE_PATH)
-                                               ? KernelSource::SourceType::FILE_PATH
-                                               : KernelSource::SourceType::SOURCE_CODE;
-    return KernelSource(kernel_spec.source, source_type);
+    // Source file path
+    if (auto* p = std::get_if<KernelSpec::SourceFilePath>(&kernel_spec.source)) {
+        return KernelSource(p->path.string(), KernelSource::SourceType::FILE_PATH);
+    } else {  // Source code
+        const auto& c = std::get<KernelSpec::SourceCode>(kernel_spec.source);
+        return KernelSource(c.code, KernelSource::SourceType::SOURCE_CODE);
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1156,13 +1156,20 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
 // ----------------------------------------------------------------------------
 
 KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
-    // Source file path
-    if (auto* p = std::get_if<KernelSpec::SourceFilePath>(&kernel_spec.source)) {
-        return KernelSource(p->path.string(), KernelSource::SourceType::FILE_PATH);
-    } else {  // Source code
-        const auto& c = std::get<KernelSpec::SourceCode>(kernel_spec.source);
-        return KernelSource(c.code, KernelSource::SourceType::SOURCE_CODE);
-    }
+    return std::visit(
+        [&](const auto& src) -> KernelSource {
+            using T = std::decay_t<decltype(src)>;
+            if constexpr (std::is_same_v<T, KernelSpec::SourceFilePath>) {
+                TT_FATAL(!src.path.empty(), "KernelSpec '{}' has empty source file path", kernel_spec.unique_id);
+                return KernelSource(src.path.string(), KernelSource::SourceType::FILE_PATH);
+            } else if constexpr (std::is_same_v<T, KernelSpec::SourceCode>) {
+                TT_FATAL(!src.code.empty(), "KernelSpec '{}' has empty inline source code", kernel_spec.unique_id);
+                return KernelSource(src.code, KernelSource::SourceType::SOURCE_CODE);
+            } else {
+                static_assert(!sizeof(T*), "Unhandled KernelSpec::source alternative");
+            }
+        },
+        kernel_spec.source);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
This is a small Metal 2.0 host API change. It is designed to improve API usability for an AI user.

The kernel source can be specified either as a filepath or string: 

- **Previously**: a single `kernel_source` string field, with a separate enum field to disambiguate its meaning. This style is clunky -- more importantly, it can trip up an AI author.
- [Replacement](https://github.com/tenstorrent/tt-metal/pull/42729): a single `std::variant` field. This forces the user to declare their intent at the point of assignment. I had to add type wrappers to the `std::filesystem::path` and `std::string` variant options (because `std::filesystem::path` is constructible from string)

### Background

AI-specific API design guidelines:
- Compile-time error checking is strongly preferred to runtime errors. True for humans also, but more important for AI authors.

## Additional TO-DOs

Additional AI-inspired API improvements (to follow in subsequent PRs):
 - **Make WorkerSpec optional**: Reduces the potential error surface.
 - **Add strong typing wherever possible**: Converts runtime arguments to compiler time errors, though at a slight detriment to API readability.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/claudes-api-feedback3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/claudes-api-feedback3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/claudes-api-feedback3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/claudes-api-feedback3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/claudes-api-feedback3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/claudes-api-feedback3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/claudes-api-feedback3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/claudes-api-feedback3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/claudes-api-feedback3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/claudes-api-feedback3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/claudes-api-feedback3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/claudes-api-feedback3)