### PR TITLE
Make `WorkerSpec` optional in Metal 2.0 host APIs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -561,16 +561,52 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
 // SECTION 3: WorkerSpec Validation Tests
 // ============================================================================
 
-TEST_F(ProgramSpecTestQuasar, MissingWorkerSpecsFails) {
-    // Gen2 requires WorkerSpecs
-    NodeCoord node{0, 0};
+TEST_F(ProgramSpecTestQuasar, MissingWorkerSpecsInfersWorkers) {
+    // If the user omits WorkerSpecs, they get inferred from kernel/DFB/semaphore
+    // target_nodes. An otherwise-valid spec should create successfully.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.workers = std::nullopt;
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, InferredWorkersPartitionByCoverage) {
+    // Two kernels on disjoint node ranges should produce two inferred WorkerSpecs.
+    // If inference gets this wrong (e.g., merges nodes with differing coverage),
+    // downstream validation will fail.
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.program_id = "multi_region";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
-    spec.kernels = {kernel};
-    // spec.workers is NOT set (nullopt)
+    spec.kernels = {MakeMinimalDMKernel("kernel_a", node_a), MakeMinimalDMKernel("kernel_b", node_b)};
+    // spec.workers left unset -> inference should yield one worker per node.
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, InferredWorkerWithDFBOnlyNodeFails) {
+    // If a DFB targets a node that no kernel covers, the inferred worker for
+    // that node has no kernels, which fails validation.
+    NodeCoord kernel_node{0, 0};
+    NodeCoord dfb_extra_node{1, 0};
+    NodeRangeSet dfb_nodes{
+        std::vector<NodeRange>{NodeRange{kernel_node, kernel_node}, NodeRange{dfb_extra_node, dfb_extra_node}}};
+
+    ProgramSpec spec;
+    spec.program_id = "dfb_only_node";
+
+    auto producer = MakeMinimalDMKernel("producer", kernel_node);
+    auto consumer = MakeMinimalDMKernel("consumer", kernel_node);
+    auto dfb = MakeMinimalDFB("dfb", dfb_nodes);
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    // spec.workers left unset.
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -572,8 +572,10 @@ TEST_F(ProgramSpecTestQuasar, MissingWorkerSpecsInfersWorkers) {
 
 TEST_F(ProgramSpecTestQuasar, InferredWorkersPartitionByCoverage) {
     // Two kernels on disjoint node ranges should produce two inferred WorkerSpecs.
-    // If inference gets this wrong (e.g., merges nodes with differing coverage),
-    // downstream validation will fail.
+    // This is a black-box check: if inference wrongly produced a single worker
+    // covering both nodes, ValidateProgramSpec's "kernel target_nodes must contain
+    // worker target_nodes" rule would reject it (each kernel only covers one of
+    // the two nodes). So NO_THROW implies inference partitioned correctly.
     NodeCoord node_a{0, 0};
     NodeCoord node_b{1, 0};
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -33,7 +33,8 @@ using WorkerSpecName = std::string;
 // ProgramSpec & WorkerSpec
 //------------------------------------------------
 
-// WorkerSpec describes the configuration of a worker node
+// WorkerSpec describes the specific configuration of a worker node,
+// (kernels, DFBs, and semaphores) and the set of nodes it applies to.
 struct WorkerSpec {
     // Worker type identifier
     WorkerSpecName unique_id;
@@ -59,11 +60,10 @@ struct ProgramSpec {
     std::vector<SemaphoreSpec> semaphores;
 
     // (Optional) Worker specifications.
-    // If std::nullopt, workers are inferred automatically from kernel/DFB/semaphore
-    // target_nodes fields (nodes with identical coverage become one inferred WorkerSpec,
-    // named "inferred_worker@<node_range_set>").
-    // User-supplied workers let you assign readable names, and act as a redundant sanity
-    // check on which nodes each entity covers.
+    // Providing WorkerSpecs explicitly improves the readability of the
+    // ProgramSpec and results in clearer error messaging.
+    // If left as std::nullopt, the runtime automatically infers WorkerSpecs
+    // based on the target_nodes fields of the kernel, DFB and semaphore specs.
     std::optional<std::vector<WorkerSpec>> workers = std::nullopt;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -58,9 +58,12 @@ struct ProgramSpec {
     std::vector<DataflowBufferSpec> dataflow_buffers;
     std::vector<SemaphoreSpec> semaphores;
 
-    // Worker specifications (optional on Gen1, required on Gen2+)
-    // This info is redundant, but improves clarity and messaging.
-    // (Done to simplify porting from ProgramDescriptor.)
+    // (Optional) Worker specifications.
+    // If std::nullopt, workers are inferred automatically from kernel/DFB/semaphore
+    // target_nodes fields (nodes with identical coverage become one inferred WorkerSpec,
+    // named "inferred_worker@<node_range_set>").
+    // User-supplied workers let you assign readable names, and act as a redundant sanity
+    // check on which nodes each entity covers.
     std::optional<std::vector<WorkerSpec>> workers = std::nullopt;
 };
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <unordered_set>
 
+#include <fmt/format.h>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program.hpp>
@@ -339,6 +340,68 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 }
 
 // ----------------------------------------------------------------------------
+// Default Inference (optional inputs -> explicit)
+// ----------------------------------------------------------------------------
+//
+// Some optional parameters in the ProgramSpec are automatically inferred by the
+// runtime if the user doesn't specify them explicitly:
+//   - WorkerSpecs
+//   - Gen1 DM kernel configuration (TODO)
+//
+//
+// Infer WorkerSpecs from kernels, DFBs, and semaphores.
+std::vector<WorkerSpec> InferWorkers(const ProgramSpec& spec) {
+    using CoverageSig = std::tuple<std::set<KernelSpecName>, std::set<DFBSpecName>, std::set<SemaphoreSpecName>>;
+
+    std::map<NodeCoord, CoverageSig> node_to_sig;
+
+    // Compute coverage signatures for each node mentioned in any target_nodes field.
+    auto for_each_node = [&](const std::variant<NodeCoord, NodeRange, NodeRangeSet>& target_nodes, auto&& fn) {
+        const NodeRangeSet range_set = to_node_range_set(target_nodes);
+        for (const NodeRange& range : range_set.ranges()) {
+            for (const NodeCoord& node : range) {
+                fn(node);
+            }
+        }
+    };
+
+    // Accumulate coverage signatures from kernels, DFBs, and semaphores.
+    for (const KernelSpec& kernel : spec.kernels) {
+        for_each_node(
+            kernel.target_nodes, [&](const NodeCoord& n) { std::get<0>(node_to_sig[n]).insert(kernel.unique_id); });
+    }
+    for (const DataflowBufferSpec& dfb : spec.dataflow_buffers) {
+        for_each_node(dfb.target_nodes, [&](const NodeCoord& n) { std::get<1>(node_to_sig[n]).insert(dfb.unique_id); });
+    }
+    for (const SemaphoreSpec& sem : spec.semaphores) {
+        for_each_node(sem.target_nodes, [&](const NodeCoord& n) { std::get<2>(node_to_sig[n]).insert(sem.unique_id); });
+    }
+
+    // Group nodes by coverage signature.
+    std::map<CoverageSig, std::vector<NodeCoord>> sig_to_nodes;
+    for (const auto& [node, sig] : node_to_sig) {
+        sig_to_nodes[sig].push_back(node);
+    }
+
+    // Build one WorkerSpec per signature.
+    // Inferred unique_ids have the form "inferred_worker@<node_range_set>"
+    // (so auto-generated status is explicit in error messages).
+    std::vector<WorkerSpec> workers;
+    workers.reserve(sig_to_nodes.size());
+    for (const auto& [sig, nodes] : sig_to_nodes) {
+        NodeRangeSet nrs = NodeRangeSet(ttsl::Span<const NodeCoord>(nodes)).merge_ranges();
+        workers.push_back(WorkerSpec{
+            .unique_id = fmt::format("inferred_worker@{}", nrs),
+            .kernels = std::vector<KernelSpecName>(std::get<0>(sig).begin(), std::get<0>(sig).end()),
+            .dataflow_buffers = std::vector<DFBSpecName>(std::get<1>(sig).begin(), std::get<1>(sig).end()),
+            .semaphores = std::vector<SemaphoreSpecName>(std::get<2>(sig).begin(), std::get<2>(sig).end()),
+            .target_nodes = nrs,
+        });
+    }
+    return workers;
+}
+
+// ----------------------------------------------------------------------------
 // ValidateNodeBounds: Node coordinate bounds checking
 // ----------------------------------------------------------------------------
 //
@@ -634,12 +697,9 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate WorkerSpecs
     //////////////////////////////
 
-    // WorkerSpecs are now required for all architectures.
-    // NOTE: WorkerSpec data is strictly redundant, but improves clarity and messaging.
-    //       If it's hated, we can make it optional, and derive the WorkerSpec if absent.
-    //       (Only on WH/BH though, I definitely want to require it on Quasar.)
-    TT_FATAL(spec.workers.has_value(), "Workers are required");
-    const auto& workers = spec.workers.value();
+    // By contract, MakeProgramFromSpec runs InferWorkers before validation, so
+    // spec.workers is always populated here — either by the user or by inference.
+    const auto& workers = *spec.workers;
     TT_FATAL(!workers.empty(), "At least one WorkerSpec is required");
 
     // WorkerSpecs may not overlap in their target nodes
@@ -1350,13 +1410,23 @@ std::set<experimental::quasar::QuasarComputeProcessor> GetComputeProcessorSet(Co
 // Public Entry Point
 // ============================================================================
 
-Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
-    log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.program_id);
+Program MakeProgramFromSpec(const ProgramSpec& user_spec, bool skip_validation) {
+    log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", user_spec.program_id);
 
-    // Step 1a: Collect derived data (builds lookup tables, checks structural invariants)
+    // Step 1a: Copy the spec and infer defaults for any optional fields the user
+    // left unspecified. After this, `spec` is guaranteed to have workers populated.
+    // NOTE: We copy before CollectSpecData because the collected data caches
+    // pointers into spec.kernels; downstream maps (kernel_to_risc_mask) are keyed
+    // by those same pointers, so `collected` and the solver must see the same spec.
+    ProgramSpec spec = user_spec;
+    if (!spec.workers.has_value()) {
+        spec.workers = InferWorkers(spec);
+    }
+
+    // Step 1b: Collect derived data (builds lookup tables, checks structural invariants)
     CollectedSpecData collected = CollectSpecData(spec);
 
-    // Step 1b: Validate semantic rules (can be skipped for trusted inputs)
+    // Step 1c: Validate semantic rules (can be skipped for trusted inputs)
     if (!skip_validation) {
         ValidateProgramSpec(spec, collected);
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -340,22 +340,20 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 }
 
 // ----------------------------------------------------------------------------
-// Default Inference (optional inputs -> explicit)
+// InferWorkers: Populate spec.workers if not supplied by the user
 // ----------------------------------------------------------------------------
 //
-// Some optional parameters in the ProgramSpec are automatically inferred by the
-// runtime if the user doesn't specify them explicitly:
-//   - WorkerSpecs
-//   - Gen1 DM kernel configuration (TODO)
-//
-//
-// Infer WorkerSpecs from kernels, DFBs, and semaphores.
+// If WorkerSpecs are not supplied by the user, infer them from the
+// ProgramSpec's kernel/DFB/semaphore target_nodes fields.
 std::vector<WorkerSpec> InferWorkers(const ProgramSpec& spec) {
-    using CoverageSig = std::tuple<std::set<KernelSpecName>, std::set<DFBSpecName>, std::set<SemaphoreSpecName>>;
+    // NodeContents: the kernels, DFBs, and semaphores on a given node are its "signature"
+    // Nodes with the same NodeContents can be grouped together into the same WorkerSpec
+    using NodeContents = std::tuple<std::set<KernelSpecName>, std::set<DFBSpecName>, std::set<SemaphoreSpecName>>;
 
-    std::map<NodeCoord, CoverageSig> node_to_sig;
+    std::map<NodeCoord, NodeContents> node_contents_map;
 
-    // Compute coverage signatures for each node mentioned in any target_nodes field.
+    // Visit every node in a std::variant<NodeCoord, NodeRange, NodeRangeSet>
+    // TODO: Why the heck do we always deal with this silly variant? Why not just NodeRangeSet everywhere?
     auto for_each_node = [&](const std::variant<NodeCoord, NodeRange, NodeRangeSet>& target_nodes, auto&& fn) {
         const NodeRangeSet range_set = to_node_range_set(target_nodes);
         for (const NodeRange& range : range_set.ranges()) {
@@ -365,27 +363,30 @@ std::vector<WorkerSpec> InferWorkers(const ProgramSpec& spec) {
         }
     };
 
-    // Accumulate coverage signatures from kernels, DFBs, and semaphores.
+    // Populate the NodeContents for every node (mentioned somewhere in the ProgramSpec)
     for (const KernelSpec& kernel : spec.kernels) {
-        for_each_node(
-            kernel.target_nodes, [&](const NodeCoord& n) { std::get<0>(node_to_sig[n]).insert(kernel.unique_id); });
+        for_each_node(kernel.target_nodes, [&](const NodeCoord& n) {
+            std::get<0>(node_contents_map[n]).insert(kernel.unique_id);
+        });
     }
     for (const DataflowBufferSpec& dfb : spec.dataflow_buffers) {
-        for_each_node(dfb.target_nodes, [&](const NodeCoord& n) { std::get<1>(node_to_sig[n]).insert(dfb.unique_id); });
+        for_each_node(
+            dfb.target_nodes, [&](const NodeCoord& n) { std::get<1>(node_contents_map[n]).insert(dfb.unique_id); });
     }
     for (const SemaphoreSpec& sem : spec.semaphores) {
-        for_each_node(sem.target_nodes, [&](const NodeCoord& n) { std::get<2>(node_to_sig[n]).insert(sem.unique_id); });
+        for_each_node(
+            sem.target_nodes, [&](const NodeCoord& n) { std::get<2>(node_contents_map[n]).insert(sem.unique_id); });
     }
 
-    // Group nodes by coverage signature.
-    std::map<CoverageSig, std::vector<NodeCoord>> sig_to_nodes;
-    for (const auto& [node, sig] : node_to_sig) {
+    // Group nodes by NodeContents signature
+    std::map<NodeContents, std::vector<NodeCoord>> sig_to_nodes;
+    for (const auto& [node, sig] : node_contents_map) {
         sig_to_nodes[sig].push_back(node);
     }
 
-    // Build one WorkerSpec per signature.
+    // Build one WorkerSpec per NodeContents signature.
     // Inferred unique_ids have the form "inferred_worker@<node_range_set>"
-    // (so auto-generated status is explicit in error messages).
+    // (this makes the auto-inference obvious in error messaging).
     std::vector<WorkerSpec> workers;
     workers.reserve(sig_to_nodes.size());
     for (const auto& [sig, nodes] : sig_to_nodes) {
@@ -697,9 +698,15 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate WorkerSpecs
     //////////////////////////////
 
-    // By contract, MakeProgramFromSpec runs InferWorkers before validation, so
-    // spec.workers is always populated here — either by the user or by inference.
-    const auto& workers = *spec.workers;
+    // spec.workers is ALWAYS populated at this point.
+    // Either the user provided it, or runtime inferred it in a previous step.
+    //
+    // TODO: This isn't a user-facing error! A user-facing error is actionable to the user,
+    // it says "hey, your input was malformed, fix it". This is a developer-facing, active
+    // documentation of the code's assumptions.
+    // We REALLY shouldn't be using TT_FATAL for both flavors.
+    TT_FATAL(spec.workers.has_value(), "Interal Error: spec.workers must be populated.");
+    const auto& workers = spec.workers.value();
     TT_FATAL(!workers.empty(), "At least one WorkerSpec is required");
 
     // WorkerSpecs may not overlap in their target nodes
@@ -1413,15 +1420,23 @@ std::set<experimental::quasar::QuasarComputeProcessor> GetComputeProcessorSet(Co
 Program MakeProgramFromSpec(const ProgramSpec& user_spec, bool skip_validation) {
     log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", user_spec.program_id);
 
-    // Step 1a: Copy the spec and infer defaults for any optional fields the user
-    // left unspecified. After this, `spec` is guaranteed to have workers populated.
-    // NOTE: We copy before CollectSpecData because the collected data caches
-    // pointers into spec.kernels; downstream maps (kernel_to_risc_mask) are keyed
-    // by those same pointers, so `collected` and the solver must see the same spec.
-    ProgramSpec spec = user_spec;
-    if (!spec.workers.has_value()) {
-        spec.workers = InferWorkers(spec);
+    // Step 1a: Infer missing fields (required, but "opt in" for the user)
+    //    - WorkerSpecs
+    //   - Gen1 DM kernel configs (TODO - upcoming PR)
+
+    // For now, just make a full copy of the ProgramSpec if inference is required.
+    // This is simple, but wasteful -- specs can be large, and inference will
+    // only fill in a few spare fields.
+    // TODO: Optimize this. We can maintain a separate "inference results" struct,
+    // and plumb that through the rest of the code alongside the user's spec.
+
+    std::optional<ProgramSpec> inferred_spec;
+    // If we need to infer some fields, for now just suck it up and copy everything.
+    if (!user_spec.workers.has_value()) {
+        inferred_spec = user_spec;
+        inferred_spec->workers = InferWorkers(*inferred_spec);
     }
+    const ProgramSpec& spec = inferred_spec.has_value() ? *inferred_spec : user_spec;
 
     // Step 1b: Collect derived data (builds lookup tables, checks structural invariants)
     CollectedSpecData collected = CollectSpecData(spec);


### PR DESCRIPTION
### Summary
This PR implements an AI-friendliness API recommendation from Claude Opus 4.6.

Metal 2.0 host API has a new `WorkerSpec` field. The information provided by `WorkerSpec` is technically redundant, but it greatly improves the usability of error messages and the readability of host code.  Previously, I had made `WorkerSpec` a mandatory field to encourage its use on Quasar, where the threaded kernel programming model makes it most useful.

The PR makes the `WorkerSpec` field optional and auto-infers it if absent. This decreases the potential error surface for an AI user.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/claudes-api-feedback4)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/claudes-api-feedback4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/claudes-api-feedback4)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/claudes-api-feedback4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/claudes-api-feedback4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/claudes-api-feedback4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/claudes-api-feedback4)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/claudes-api-feedback4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/claudes-api-feedback4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/claudes-api-feedback4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/claudes-api-feedback4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/claudes-api-feedback4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/claudes-api-feedback4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/claudes-api-feedback4)