### PR TITLE
Quasar SFPU Binary Add and AddInt

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/pack.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/pack.py
@@ -36,7 +36,9 @@ def pack_fp32(torch_tensor):
     return torch_tensor.cpu().numpy().astype(np.float32).tobytes()
 
 
-def pack_int32(torch_tensor):
+def pack_int32(torch_tensor, twos_complement=False):
+    if twos_complement:
+        return torch_tensor.cpu().numpy().astype(np.int32).tobytes()
     # INT32 uses sign-magnitude format in hardware (not two's complement)
     # Format: bit 31 = sign, bits 30:0 = magnitude
     # Sign-magnitude INT32 cannot represent -2147483648, so clip to [min+1, max]
@@ -52,7 +54,9 @@ def pack_uint32(torch_tensor):
     return torch_tensor.cpu().numpy().astype(np.uint32).tobytes()
 
 
-def pack_int16(torch_tensor):
+def pack_int16(torch_tensor, twos_complement=False):
+    if twos_complement:
+        return torch_tensor.cpu().numpy().astype(np.int16).tobytes()
     # INT16 uses sign-magnitude format in hardware (not two's complement)
     # Format: bit 15 = sign, bits 14:0 = magnitude
     # Sign-magnitude INT16 cannot represent -32768, so clip to [min+1, max]
@@ -73,7 +77,9 @@ def pack_fp8_e4m3(torch_tensor):
     return fp32_array.astype(ml_dtypes.float8_e4m3fn).tobytes()
 
 
-def pack_int8(torch_tensor):
+def pack_int8(torch_tensor, twos_complement=False):
+    if twos_complement:
+        return torch_tensor.cpu().numpy().astype(np.int8).tobytes()
     # INT8 uses sign-magnitude format in hardware (not two's complement)
     # Format: bit 7 = sign, bits 6:0 = magnitude
     # Sign-magnitude INT8 cannot represent -128, so clip to [min+1, max]

--- a/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_config.py
@@ -78,6 +78,7 @@ class StimuliConfig:
         write_full_tiles: bool = False,
         use_dense_tile_dimensions: bool = False,
         operand_res_tile_size: int = None,
+        twos_complement: bool = False,
     ):
 
         # Fields init
@@ -99,6 +100,7 @@ class StimuliConfig:
         self.write_full_tiles = write_full_tiles
         self.use_dense_tile_dimensions = use_dense_tile_dimensions
         self.operand_res_tile_size = operand_res_tile_size
+        self.twos_complement = twos_complement
 
         # Hardware flags injected by TestConfig via set_use_srcs() / set_dest_acc()
         self.use_srcs = False
@@ -276,6 +278,7 @@ class StimuliConfig:
         location: str = "0,0",
         write_full_tiles: bool = False,
         use_srcs: bool = False,
+        twos_complement: bool = False,
     ):
         """
         Original backward-compatible write_matrix.
@@ -305,6 +308,8 @@ class StimuliConfig:
                 return pack_function(
                     buffer_tile, num_faces=num_faces, face_r_dim=face_r_dim
                 )
+            if twos_complement and pack_function in (pack_int32, pack_int16, pack_int8):
+                return pack_function(buffer_tile, twos_complement=True)
             return pack_function(buffer_tile)
 
         for ind in range(tile_count):
@@ -330,6 +335,7 @@ class StimuliConfig:
         tile_dimensions: list[int],
         location: str = "0,0",
         use_srcs: bool = False,
+        twos_complement: bool = False,
     ):
         """
         New write_matrix for variable tile dimensions with dense L1 data.
@@ -354,6 +360,8 @@ class StimuliConfig:
                 return pack_function(
                     buffer_tile, num_faces=num_faces, face_r_dim=face_r_dim
                 )
+            if twos_complement and pack_function in (pack_int32, pack_int16, pack_int8):
+                return pack_function(buffer_tile, twos_complement=True)
             return pack_function(buffer_tile)
 
         for ind in range(tile_count):
@@ -431,6 +439,7 @@ class StimuliConfig:
             location,
             self.write_full_tiles,
             use_srcs=self.use_srcs,
+            twos_complement=self.twos_complement,
         )
 
         StimuliConfig.write_matrix(
@@ -444,6 +453,7 @@ class StimuliConfig:
             location,
             self.write_full_tiles,
             use_srcs=self.use_srcs,
+            twos_complement=self.twos_complement,
         )
 
         if self.buffer_C is not None:
@@ -463,6 +473,7 @@ class StimuliConfig:
                 location,
                 self.write_full_tiles,
                 use_srcs=self.use_srcs,
+                twos_complement=self.twos_complement,
             )
 
     def _write_dense_tile_dimensions(self, location: str = "0,0"):
@@ -490,6 +501,7 @@ class StimuliConfig:
             self.tile_dimensions,
             location,
             use_srcs=self.use_srcs,
+            twos_complement=self.twos_complement,
         )
         StimuliConfig.write_matrix_w_tile_dimensions(
             self.buffer_B,
@@ -502,6 +514,7 @@ class StimuliConfig:
             self.tile_dimensions,
             location,
             use_srcs=self.use_srcs,
+            twos_complement=self.twos_complement,
         )
 
         if self.buffer_C is not None:
@@ -521,6 +534,7 @@ class StimuliConfig:
                 self.tile_dimensions,
                 location,
                 use_srcs=self.use_srcs,
+                twos_complement=self.twos_complement,
             )
 
     def collect_results(self, location="0,0"):
@@ -568,6 +582,7 @@ class StimuliConfig:
             tile_stride_bytes=stride_bytes,
             use_srcs=self.use_srcs,
             dest_acc=self._dest_acc_32b,
+            twos_complement=self.twos_complement,
         )
         return res_from_L1
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_generator.py
@@ -63,7 +63,7 @@ def generate_random_face(
     sfpu=True,
     face_r_dim=MAX_FACE_R_DIM,
     negative_values=False,
-    full_range=False,
+    full_2sc_int_range=False,
 ):
     size = face_r_dim * FACE_C_DIM  # face_r_dim rows × FACE_C_DIM columns
 
@@ -85,7 +85,7 @@ def generate_random_face(
                 # UInt32 is stored as torch.int64; use the actual uint32 range.
                 if stimuli_format == DataFormat.UInt32:
                     type_min, type_max = 0, 2**32 - 1
-                elif full_range:
+                elif full_2sc_int_range:
                     iinfo = torch.iinfo(dtype)
                     type_min = iinfo.min
                     type_max = iinfo.max
@@ -346,7 +346,7 @@ def _generate_source_tensor(
     sfpu: bool,
     negative_values: bool,
     sequential: bool,
-    full_range: bool = False,
+    full_2sc_int_range: bool = False,
 ) -> torch.Tensor:
     """
     Generate a source tensor with random or sequential values.
@@ -385,7 +385,7 @@ def _generate_source_tensor(
             sfpu=sfpu,
             face_r_dim=face_r_dim,
             negative_values=negative_values,
-            full_range=full_range,
+            full_2sc_int_range=full_2sc_int_range,
         )
         src.extend(face.tolist())
 
@@ -469,7 +469,7 @@ def generate_stimuli(
     output_format=None,
     sequential_A=False,
     sequential_B=False,
-    full_range=False,
+    full_2sc_int_range=False,
 ):
     """
     Generate stimuli data for testing - ORIGINAL backward-compatible version.
@@ -493,7 +493,7 @@ def generate_stimuli(
         output_format: Optional output format for MX range constraints
         sequential_A: If True, generate sequential values for src_A
         sequential_B: If True, generate sequential values for src_B
-        full_range: If True, use the full two's complement range for integer formats
+        full_2sc_int_range: If True, use the full two's complement range for integer formats
 
     Returns:
         tuple: (srcA_tensor, tile_cnt_A, srcB_tensor, tile_cnt_B)
@@ -516,7 +516,7 @@ def generate_stimuli(
         sfpu=sfpu,
         negative_values=negative_values,
         sequential=sequential_A,
-        full_range=full_range,
+        full_2sc_int_range=full_2sc_int_range,
     )
 
     srcB_tensor = _generate_source_tensor(
@@ -530,7 +530,7 @@ def generate_stimuli(
         sfpu=sfpu,
         negative_values=negative_values,
         sequential=sequential_B,
-        full_range=full_range,
+        full_2sc_int_range=full_2sc_int_range,
     )
 
     srcA_tensor, srcB_tensor = _clamp_mx_tensors(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_generator.py
@@ -63,6 +63,7 @@ def generate_random_face(
     sfpu=True,
     face_r_dim=MAX_FACE_R_DIM,
     negative_values=False,
+    full_range=False,
 ):
     size = face_r_dim * FACE_C_DIM  # face_r_dim rows × FACE_C_DIM columns
 
@@ -84,6 +85,10 @@ def generate_random_face(
                 # UInt32 is stored as torch.int64; use the actual uint32 range.
                 if stimuli_format == DataFormat.UInt32:
                     type_min, type_max = 0, 2**32 - 1
+                elif full_range:
+                    iinfo = torch.iinfo(dtype)
+                    type_min = iinfo.min
+                    type_max = iinfo.max
                 else:
                     iinfo = torch.iinfo(dtype)
                     is_signed = iinfo.min < 0
@@ -341,6 +346,7 @@ def _generate_source_tensor(
     sfpu: bool,
     negative_values: bool,
     sequential: bool,
+    full_range: bool = False,
 ) -> torch.Tensor:
     """
     Generate a source tensor with random or sequential values.
@@ -379,6 +385,7 @@ def _generate_source_tensor(
             sfpu=sfpu,
             face_r_dim=face_r_dim,
             negative_values=negative_values,
+            full_range=full_range,
         )
         src.extend(face.tolist())
 
@@ -462,6 +469,7 @@ def generate_stimuli(
     output_format=None,
     sequential_A=False,
     sequential_B=False,
+    full_range=False,
 ):
     """
     Generate stimuli data for testing - ORIGINAL backward-compatible version.
@@ -485,6 +493,7 @@ def generate_stimuli(
         output_format: Optional output format for MX range constraints
         sequential_A: If True, generate sequential values for src_A
         sequential_B: If True, generate sequential values for src_B
+        full_range: If True, use the full two's complement range for integer formats
 
     Returns:
         tuple: (srcA_tensor, tile_cnt_A, srcB_tensor, tile_cnt_B)
@@ -507,6 +516,7 @@ def generate_stimuli(
         sfpu=sfpu,
         negative_values=negative_values,
         sequential=sequential_A,
+        full_range=full_range,
     )
 
     srcB_tensor = _generate_source_tensor(
@@ -520,6 +530,7 @@ def generate_stimuli(
         sfpu=sfpu,
         negative_values=negative_values,
         sequential=sequential_B,
+        full_range=full_range,
     )
 
     srcA_tensor, srcB_tensor = _clamp_mx_tensors(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -440,6 +440,29 @@ class DEST_INDEX(RuntimeParameter):
 
 
 @dataclass
+class SFPU_TILE_INDICES(RuntimeParameter):
+    src0_tile_idx: int = 0
+    src1_tile_idx: int = 1
+    dst_tile_idx: int = 0
+
+    def convert_to_cpp(self) -> str:
+        lines = [
+            f"constexpr int SRC0_TILE_IDX = {self.src0_tile_idx};",
+            f"constexpr int SRC1_TILE_IDX = {self.src1_tile_idx};",
+            f"constexpr int DST_TILE_IDX = {self.dst_tile_idx};",
+        ]
+        return "\n".join(lines)
+
+    def convert_to_struct_fields(self) -> tuple[str, str]:
+        lines = [
+            "int SRC0_TILE_IDX;",
+            "int SRC1_TILE_IDX;",
+            "int DST_TILE_IDX;",
+        ]
+        return "\n".join(lines), "iii"
+
+
+@dataclass
 class L1_ACC(RuntimeParameter):
     l1_acc: L1Accumulation = L1Accumulation.No
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/unpack.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/unpack.py
@@ -40,7 +40,9 @@ def unpack_fp32(packed_list):
     return np.frombuffer(bytes(packed_list), dtype=np.float32).tolist()
 
 
-def unpack_int32(packed_list):
+def unpack_int32(packed_list, twos_complement=False):
+    if twos_complement:
+        return np.frombuffer(bytes(packed_list), dtype=np.int32).tolist()
     # INT32 uses sign-magnitude format in hardware (not two's complement)
     # Format: bit 31 = sign, bits 30:0 = magnitude
     uint32_array = np.frombuffer(bytes(packed_list), dtype=np.uint32)
@@ -53,7 +55,9 @@ def unpack_uint32(packed_list):
     return np.frombuffer(bytes(packed_list), dtype=np.uint32).tolist()
 
 
-def unpack_int16(packed_list):
+def unpack_int16(packed_list, twos_complement=False):
+    if twos_complement:
+        return np.frombuffer(bytes(packed_list), dtype=np.int16).tolist()
     # INT16 uses sign-magnitude format in hardware (not two's complement)
     # Format: bit 15 = sign, bits 14:0 = magnitude
     uint16_array = np.frombuffer(bytes(packed_list), dtype=np.uint16)
@@ -74,7 +78,9 @@ def unpack_fp8_e4m3(packed_list):
     )
 
 
-def unpack_int8(packed_list):
+def unpack_int8(packed_list, twos_complement=False):
+    if twos_complement:
+        return np.frombuffer(bytes(packed_list), dtype=np.int8).tolist()
     # INT8 uses sign-magnitude format in hardware (not two's complement)
     # Format: bit 7 = sign, bits 6:0 = magnitude
     uint8_array = np.frombuffer(bytes(packed_list), dtype=np.uint8)
@@ -379,6 +385,7 @@ def unpack_res_tiles(
     tile_stride_bytes: int = None,
     use_srcs: bool = False,
     dest_acc: bool = False,
+    twos_complement: bool = False,
 ):
     output_dtype = format_dict[output_format]
 
@@ -433,6 +440,12 @@ def unpack_res_tiles(
                 use_srcs=use_srcs,
                 dest_acc=dest_acc,
             )
+        elif twos_complement and unpack_func in (
+            unpack_int32,
+            unpack_int16,
+            unpack_int8,
+        ):
+            unpacked_tile = unpack_func(tile_data, twos_complement=True)
         else:
             unpacked_tile = unpack_func(tile_data)
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import BinarySFPUGolden, get_golden_generator
+from helpers.llk_params import (
+    DestAccumulation,
+    ImpliedMathFormat,
+    MathOperation,
+    UnpackerEngine,
+    format_dict,
+)
+from helpers.param_config import InputOutputFormat
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    MATH_OP,
+    NUM_FACES,
+    SFPU_TILE_INDICES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+)
+from helpers.utils import passed_test
+
+
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "data_format, dest_acc",
+    [
+        (DataFormat.Int32, DestAccumulation.Yes),
+        (DataFormat.Float16_b, DestAccumulation.Yes),
+        (DataFormat.Float16_b, DestAccumulation.No),
+    ],
+)
+@pytest.mark.parametrize(
+    "src0_idx, src1_idx, dst_idx",
+    [
+        (0, 1, 0),
+        (1, 0, 0),
+        (0, 1, 1),
+        (0, 2, 1),
+        (2, 3, 0),
+    ],
+)
+def test_sfpu_binary_add_quasar(data_format, dest_acc, src0_idx, src1_idx, dst_idx):
+    """
+    Test binary SFPU ADD on Quasar architecture.
+
+    Loads tiles directly into DEST via unpack-to-dest,
+    performs elementwise add via SFPU using programmable
+    tile indices, and verifies the result against a golden reference.
+    """
+    num_tiles_needed = max(src0_idx, src1_idx, dst_idx) + 1
+    formats = InputOutputFormat(input_format=data_format, output_format=data_format)
+
+    input_dimensions = [num_tiles_needed * 32, 32]
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=data_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=data_format,
+        input_dimensions_B=input_dimensions,
+        sfpu=False,
+        full_range=True,
+    )
+
+    num_faces = 4
+    mathop = MathOperation.SfpuElwadd
+
+    elements_per_tile = 1024  # 4 faces * 16 rows * 16 cols
+    generate_golden = get_golden_generator(BinarySFPUGolden)
+    golden_full = generate_golden(
+        mathop,
+        src_A,
+        src0_idx,
+        src1_idx,
+        dst_idx,
+        32,  # num_iterations: 32 rows = 1 full tile
+        input_dimensions,
+        data_format,
+    ).flatten()
+    dst_start = dst_idx * elements_per_tile
+    golden_tensor = golden_full[dst_start : dst_start + elements_per_tile]
+
+    tile_count_res = 1  # we only pack the single output tile
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_binary_quasar_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=mathop),
+            IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
+            UNPACKER_ENGINE_SEL(UnpackerEngine.UnpDest),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            SFPU_TILE_INDICES(src0_idx, src1_idx, dst_idx),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            data_format,
+            src_B,
+            data_format,
+            data_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_A,
+            tile_count_res=tile_count_res,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=True,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format = format_dict[data_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor, res_tensor, data_format
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_binary_quasar.py
@@ -67,7 +67,7 @@ def test_sfpu_binary_add_quasar(data_format, dest_acc, src0_idx, src1_idx, dst_i
         stimuli_format_B=data_format,
         input_dimensions_B=input_dimensions,
         sfpu=False,
-        full_range=True,
+        full_2sc_int_range=True,
     )
 
     num_faces = 4
@@ -115,6 +115,7 @@ def test_sfpu_binary_add_quasar(data_format, dest_acc, src0_idx, src1_idx, dst_i
             tile_count_B=tile_cnt_A,
             tile_count_res=tile_count_res,
             num_faces=num_faces,
+            twos_complement=data_format.is_integer(),
         ),
         unpack_to_dest=True,
         dest_acc=dest_acc,

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id          = 0;
+    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+
+    buffer_descriptor_u bd_val = {0};
+
+    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim       = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0);
+
+    _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_binary_sfpu.h"
+#include "params.h"
+#include "sfpu/ckernel_sfpu_add.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    DataFormat src_format = static_cast<DataFormat>(formats.math);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+    const std::uint32_t num_sfpu_iterations = params.TEST_FACE_R_DIM / ckernel::math::SFP_ROWS;
+
+    _llk_math_eltwise_binary_sfpu_init_();
+
+    constexpr int tile_stride = 64; // 4 faces * 16 rows per tile
+    const int in0_offset      = params.SRC0_TILE_IDX * tile_stride;
+    const int in1_offset      = params.SRC1_TILE_IDX * tile_stride;
+    const int out_offset      = params.DST_TILE_IDX * tile_stride;
+
+    _llk_math_eltwise_binary_sfpu_start_(0);
+
+    const bool is_int = (src_format == DataFormat::Int32 || src_format == DataFormat::Int16);
+
+    for (std::uint32_t face = 0; face < NUM_FACES; face++)
+    {
+        if (is_int)
+        {
+            _calculate_add_<true>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+        }
+        else
+        {
+            _calculate_add_<false>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
+        }
+        _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_();
+    }
+
+    _llk_math_eltwise_binary_sfpu_done_();
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
+
+    wait_sfpu_idle();
+    wait_fpu_idle();
+    wait_mop_idle();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    std::uint32_t const buf_desc_id = 8;
+
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+    _llk_pack_init_(buf_desc_id, 1);
+
+    _llk_pack_(params.DST_TILE_IDX, 0);
+
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+#endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
@@ -80,35 +80,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_eltwise_binary_sfpu_init_();
 
-    constexpr int tile_stride = 64; // 4 faces * 16 rows per tile
+    constexpr int tile_stride = NUM_FACES * FACE_R_DIM; // 4 faces * 16 rows per tile
     const int in0_offset      = params.SRC0_TILE_IDX * tile_stride;
     const int in1_offset      = params.SRC1_TILE_IDX * tile_stride;
     const int out_offset      = params.DST_TILE_IDX * tile_stride;
 
     _llk_math_eltwise_binary_sfpu_start_(0);
 
-    const bool is_int = (src_format == DataFormat::Int32 || src_format == DataFormat::Int16);
-
     for (std::uint32_t face = 0; face < NUM_FACES; face++)
     {
-        if (is_int)
-        {
-            _calculate_add_<true>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
-        }
-        else
-        {
-            _calculate_add_<false>(num_sfpu_iterations, in0_offset, in1_offset, out_offset);
-        }
+        _calculate_add_(src_format, num_sfpu_iterations, in0_offset, in1_offset, out_offset);
         _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_();
     }
 
     _llk_math_eltwise_binary_sfpu_done_();
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
-
-    wait_sfpu_idle();
-    wait_fpu_idle();
-    wait_mop_idle();
 }
 
 #endif
@@ -130,7 +117,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
     buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
     bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
     bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_quasar_test.cpp
@@ -53,8 +53,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_MATH
 
-const bool is_int_fpu_en = false;
-
 #include "cfg_defines.h"
 #include "cmath_common.h"
 #include "llk_math_common.h"
@@ -74,7 +72,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
     DataFormat src_format = static_cast<DataFormat>(formats.math);
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false>(src_format, src_format);
 
     const std::uint32_t num_sfpu_iterations = params.TEST_FACE_R_DIM / ckernel::math::SFP_ROWS;
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
@@ -77,4 +77,11 @@ constexpr std::uint32_t DEST_NUM_TILES_FP16      = (DEST_REGISTER_FULL_SIZE * DE
 constexpr std::uint32_t DEST_NUM_TILES_FP16_HALF = DEST_NUM_TILES_FP16 / 2;
 static_assert((DEST_NUM_TILES_FP16 & (DEST_NUM_TILES_FP16 - 1)) == 0);
 
+enum class BinaryOp : std::uint8_t
+{
+    ADD = 0,
+    SUB = 1,
+    MUL = 2,
+};
+
 } // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
@@ -77,11 +77,4 @@ constexpr std::uint32_t DEST_NUM_TILES_FP16      = (DEST_REGISTER_FULL_SIZE * DE
 constexpr std::uint32_t DEST_NUM_TILES_FP16_HALF = DEST_NUM_TILES_FP16 / 2;
 static_assert((DEST_NUM_TILES_FP16 & (DEST_NUM_TILES_FP16 - 1)) == 0);
 
-enum class BinaryOp : std::uint8_t
-{
-    ADD = 0,
-    SUB = 1,
-    MUL = 2,
-};
-
 } // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
@@ -368,6 +368,17 @@ struct p_sfpu
         constexpr static std::uint32_t CLR_CC_EN = 0x0;
     };
 
+    struct sfp_sfpcast_mod
+    {
+        constexpr static std::uint32_t SM32_TO_2SC  = 0x3; // sign+magnitude int32 -> 2's complement
+        constexpr static std::uint32_t TWO_SC_TO_SM = 0x2; // 2's complement -> sign+magnitude int32
+    };
+
+    struct sfp_binary_mod
+    {
+        constexpr static std::uint32_t SFPIADD_DISABLE_CC = 0b0100;
+    };
+
     struct sfp_stochrnd_mod
     {
         constexpr static std::uint32_t FP32_TO_FP16A  = 0x0;

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_sfpu.h
@@ -4,10 +4,14 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
+#include <utility>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "llk_defs.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_recip.h"
@@ -16,3 +20,92 @@
 #include "sfpu/ckernel_sfpu_tanh.h"
 #include "sfpu/ckernel_sfpu_typecast_fp16b_uint16.h"
 #include "sfpu/ckernel_sfpu_typecast_int32_fp32.h"
+
+using namespace ckernel::math;
+
+/**
+ * @brief Programs SFPU addrmods
+ */
+inline void _sfpu_configure_addrmod_()
+{
+    // NOTE: this kernel is typically used in conjunction with
+    // A2D, which is using ADDR_MOD_0 and ADDR_MOD_1, so use one
+    // that doesn't conflict!
+
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 0},
+    }
+        .set(ADDR_MOD_7, csr_read<CSR::TRISC_ID>());
+}
+
+/**
+ * @brief Sets up starting index of SFPU, Stalls till all FPU operations are done
+ * @param tile_index: Use to index to a tile in Destination register
+ */
+inline void _llk_math_sfpu_start_(const std::uint32_t tile_index)
+{
+    _set_dst_write_addr_<ckernel::trisc::DstTileShape::Tile32x32>(tile_index);
+    TTI_STALLWAIT(p_stall::STALL_SFPU, 0, 0, p_stall::MATH);
+}
+
+/**
+ * @brief Resets dest counter to 0
+ */
+inline void _llk_math_sfpu_done_()
+{
+    _reset_counters_<p_setrwc::SET_D>();
+}
+
+/**
+ * @brief Clear SrcS valids
+ * @tparam SRCS_RD_DONE: Whether the source reg S read is done
+ * @tparam SRCS_WR_DONE: Whether the source reg S write is done
+ */
+template <bool SRCS_RD_DONE, bool SRCS_WR_DONE>
+inline void _llk_math_sfpu_srcs_clear_vlds_()
+{
+    TTI_SFPNOP(SRCS_WR_DONE, SRCS_RD_DONE, 0);
+}
+
+/**
+ * @brief Increments dest counter by a face (16x16 default)
+ */
+inline void _llk_math_sfpu_inc_dst_face_addr_()
+{
+    _inc_dst_addr_<16>();
+}
+
+/**
+ * @brief Initialization for SFPU operations
+ */
+inline void _llk_math_sfpu_init_()
+{
+    _init_sfpu_config_reg_();
+    _sfpu_configure_addrmod_();
+    _reset_counters_<p_setrwc::SET_ABD_F>();
+}
+
+/**
+ * @brief Runs SFPU operation for a tile (default 32x32)
+ * @param: sfpu_func: function pointer to the sfpu functions to run, can look at list of functions here: common/inc/sfpu/cmath_sfpu*
+ * @param: dst_tile_index: Starting tile index in the destination register, values = 0 - 15
+ * @param: args: variable number of args can be passed into this function, that will be passed
+ * to the SFPU function pointer
+ */
+template <class F, class... ARGS>
+inline void _llk_math_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, ARGS&&... args)
+{
+    _llk_math_sfpu_start_(dst_tile_index);
+
+    for (std::uint32_t face = 0; face < ckernel::trisc::NUM_FACES; face++)
+    {
+        sfpu_func(std::forward<ARGS>(args)...);
+
+        // Move to the next face
+        _llk_math_sfpu_inc_dst_face_addr_();
+    }
+
+    _llk_math_sfpu_done_();
+}

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_sfpu.h
@@ -21,7 +21,10 @@
 #include "sfpu/ckernel_sfpu_typecast_fp16b_uint16.h"
 #include "sfpu/ckernel_sfpu_typecast_int32_fp32.h"
 
+namespace ckernel
+{
 using namespace ckernel::math;
+using namespace ckernel::trisc;
 
 /**
  * @brief Programs SFPU addrmods
@@ -46,7 +49,7 @@ inline void _sfpu_configure_addrmod_()
  */
 inline void _llk_math_sfpu_start_(const std::uint32_t tile_index)
 {
-    _set_dst_write_addr_<ckernel::trisc::DstTileShape::Tile32x32>(tile_index);
+    _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_index);
     TTI_STALLWAIT(p_stall::STALL_SFPU, 0, 0, p_stall::MATH);
 }
 
@@ -99,7 +102,7 @@ inline void _llk_math_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, 
 {
     _llk_math_sfpu_start_(dst_tile_index);
 
-    for (std::uint32_t face = 0; face < ckernel::trisc::NUM_FACES; face++)
+    for (std::uint32_t face = 0; face < NUM_FACES; face++)
     {
         sfpu_func(std::forward<ARGS>(args)...);
 
@@ -109,3 +112,5 @@ inline void _llk_math_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, 
 
     _llk_math_sfpu_done_();
 }
+
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -10,20 +12,34 @@ namespace ckernel
 {
 namespace sfpu
 {
+template <bool INT_EN = true>
 inline void _calculate_add_(const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
 {
     for (int d = 0; d < iterations; d++)
     {
         // Load inputs into LREG0 and LREG1, if want to load from dest, offset should start from 0x0
         // if want to load from SrcS, inputs should start from 0x400
-        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in0_offset_idx + (d << 1));
-        TT_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, in1_offset_idx + (d << 1));
+        constexpr auto INSTR_MOD = INT_EN ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT;
+        TT_SFPLOAD(p_sfpu::LREG0, INSTR_MOD, ADDR_MOD_7, 0, in0_offset_idx + (d << 1));
+        TT_SFPLOAD(p_sfpu::LREG1, INSTR_MOD, ADDR_MOD_7, 0, in1_offset_idx + (d << 1));
 
-        // Do LREG0 + LREG1, store result in LREG2, takes 2 cycles
-        TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, 0x0);
-        TTI_NOP;
-        // Store result from LREG2 into dest, takes 2 cycles
-        TT_SFPSTORE(p_sfpu::LREG2, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
+        if constexpr (INT_EN)
+        {
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0x3); // convert sign magnitude to 2s complement
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0x3); // convert sign magnitude to 2s complement
+
+            // Do LREG1 = LREG0 + LREG1, takes 1 cycle
+            TTI_SFPIADD(0x0, p_sfpu::LREG0, p_sfpu::LREG1, 0b0100);
+
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0x2); // convert back to sign magnitude
+        }
+        else
+        {
+            TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, 0x0);
+        }
+
+        constexpr auto LREG_DEST = INT_EN ? p_sfpu::LREG1 : p_sfpu::LREG2;
+        TT_SFPSTORE(LREG_DEST, INSTR_MOD, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -5,8 +5,10 @@
 
 #include <cstdint>
 
+#include "ckernel_instr_params.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
+#include "llk_assert.h"
 
 namespace ckernel
 {
@@ -14,8 +16,12 @@ namespace sfpu
 {
 inline void _calculate_add_(const DataFormat fmt, const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
 {
-    const bool is_int    = (fmt == DataFormat::Int32 || fmt == DataFormat::Int16);
-    const auto instr_mod = is_int ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT;
+    LLK_ASSERT(fmt != DataFormat::Int32 || fmt != DataFormat::Float16_b, "Only Int32 and Float16_b are currently supported for SFPU add on Quasar");
+
+    const bool is_int = (fmt == DataFormat::Int32);
+    const auto instr_mod =
+        is_int ? p_sfpu::sfpmem::INT32
+               : p_sfpu::sfpmem::DEFAULT; // There is a quasar bug with implied fmts + upk to dest, so we need use use explicit types for int SFPULOAD/STORE
 
     for (int d = 0; d < iterations; d++)
     {
@@ -24,12 +30,17 @@ inline void _calculate_add_(const DataFormat fmt, const int iterations, const in
 
         if (is_int)
         {
-            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0x3); // S+M -> 2SC
-            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0x3); // S+M -> 2SC
+            // On Quasar, SFPU kernels should assume that integer inputs are in 2's complement format
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag -> 2SC
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag-> 2SC
 
-            TTI_SFPIADD(0x0, p_sfpu::LREG0, p_sfpu::LREG1, 0b0100);
+            TTI_SFPIADD(
+                0x0,
+                p_sfpu::LREG0,
+                p_sfpu::LREG1,
+                p_sfpu::sfp_binary_mod::SFPIADD_DISABLE_CC); // SFPIADD needs to explicitly disable CC output since CC exu is enabled by default
 
-            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0x2); // 2SC -> S+M
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::TWO_SC_TO_SM); // 2SC -> Sing+Mag
 
             TT_SFPSTORE(p_sfpu::LREG1, instr_mod, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
         }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -12,34 +12,33 @@ namespace ckernel
 {
 namespace sfpu
 {
-template <bool INT_EN = true>
-inline void _calculate_add_(const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
+inline void _calculate_add_(const DataFormat fmt, const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
 {
+    const bool is_int    = (fmt == DataFormat::Int32 || fmt == DataFormat::Int16);
+    const auto instr_mod = is_int ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT;
+
     for (int d = 0; d < iterations; d++)
     {
-        // Load inputs into LREG0 and LREG1, if want to load from dest, offset should start from 0x0
-        // if want to load from SrcS, inputs should start from 0x400
-        constexpr auto INSTR_MOD = INT_EN ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT;
-        TT_SFPLOAD(p_sfpu::LREG0, INSTR_MOD, ADDR_MOD_7, 0, in0_offset_idx + (d << 1));
-        TT_SFPLOAD(p_sfpu::LREG1, INSTR_MOD, ADDR_MOD_7, 0, in1_offset_idx + (d << 1));
+        TT_SFPLOAD(p_sfpu::LREG0, instr_mod, ADDR_MOD_7, 0, in0_offset_idx + (d << 1));
+        TT_SFPLOAD(p_sfpu::LREG1, instr_mod, ADDR_MOD_7, 0, in1_offset_idx + (d << 1));
 
-        if constexpr (INT_EN)
+        if (is_int)
         {
-            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0x3); // convert sign magnitude to 2s complement
-            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0x3); // convert sign magnitude to 2s complement
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0x3); // S+M -> 2SC
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0x3); // S+M -> 2SC
 
-            // Do LREG1 = LREG0 + LREG1, takes 1 cycle
             TTI_SFPIADD(0x0, p_sfpu::LREG0, p_sfpu::LREG1, 0b0100);
 
-            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0x2); // convert back to sign magnitude
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0x2); // 2SC -> S+M
+
+            TT_SFPSTORE(p_sfpu::LREG1, instr_mod, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
         }
         else
         {
             TTI_SFPADD(p_sfpu::LCONST_1, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, 0x0);
-        }
 
-        constexpr auto LREG_DEST = INT_EN ? p_sfpu::LREG1 : p_sfpu::LREG2;
-        TT_SFPSTORE(LREG_DEST, INSTR_MOD, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
+            TT_SFPSTORE(p_sfpu::LREG2, instr_mod, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
+        }
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -16,12 +16,11 @@ namespace sfpu
 {
 inline void _calculate_add_(const DataFormat fmt, const int iterations, const int in0_offset_idx, const int in1_offset_idx, const int out_offset_idx)
 {
-    LLK_ASSERT(fmt != DataFormat::Int32 || fmt != DataFormat::Float16_b, "Only Int32 and Float16_b are currently supported for SFPU add on Quasar");
+    LLK_ASSERT(fmt == DataFormat::Int32 || fmt == DataFormat::Float16_b, "Only Int32 and Float16_b are currently supported for SFPU add on Quasar");
 
     const bool is_int = (fmt == DataFormat::Int32);
-    const auto instr_mod =
-        is_int ? p_sfpu::sfpmem::INT32
-               : p_sfpu::sfpmem::DEFAULT; // There is a quasar bug with implied fmts + upk to dest, so we need use use explicit types for int SFPULOAD/STORE
+    const auto instr_mod = is_int ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT; // There is a quasar bug with implied fmts + upk to dest, so we need use
+                                                                                     // use explicit types for int SFPULOAD/STORE TEN-4674
 
     for (int d = 0; d < iterations; d++)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_add.h
@@ -31,8 +31,8 @@ inline void _calculate_add_(const DataFormat fmt, const int iterations, const in
         if (is_int)
         {
             // On Quasar, SFPU kernels should assume that integer inputs are in 2's complement format
-            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag -> 2SC
-            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag-> 2SC
+            // TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag -> 2SC
+            // TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC); // Sign+Mag-> 2SC
 
             TTI_SFPIADD(
                 0x0,
@@ -40,7 +40,7 @@ inline void _calculate_add_(const DataFormat fmt, const int iterations, const in
                 p_sfpu::LREG1,
                 p_sfpu::sfp_binary_mod::SFPIADD_DISABLE_CC); // SFPIADD needs to explicitly disable CC output since CC exu is enabled by default
 
-            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::TWO_SC_TO_SM); // 2SC -> Sing+Mag
+            // TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::TWO_SC_TO_SM); // 2SC -> Sing+Mag
 
             TT_SFPSTORE(p_sfpu::LREG1, instr_mod, ADDR_MOD_7, 0, out_offset_idx + (d << 1));
         }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -94,6 +94,13 @@ enum class SfpuType : std::uint32_t
     where
 };
 
+enum class BinaryOp : std::uint8_t
+{
+    ADD,
+    SUB,
+    MUL,
+};
+
 enum class DstSync : std::uint8_t
 {
     SyncHalf,

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_sfpu.h
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <cstdint>
+
+#include "cmath_common.h"
+#include "llk_defs.h"
+using namespace ckernel::math;
+
+/**
+ * @brief Programs SFPU addrmods for binary SFPU operations
+ */
+inline void _eltwise_binary_sfpu_configure_addrmod_()
+{
+    // NOTE: this kernel is typically used in conjunction with
+    // A2D, which is using ADDR_MOD_0 and ADDR_MOD_1, so use one
+    // that doesn't conflict!
+
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 0},
+    }
+        .set(ADDR_MOD_7, csr_read<CSR::TRISC_ID>());
+}
+
+/**
+ * @brief Sets up starting index of SFPU for binary op, stalls till all FPU operations are done
+ * @param tile_index: Use to index to a tile in Destination register
+ */
+inline void _llk_math_eltwise_binary_sfpu_start_(const std::uint32_t tile_index)
+{
+    _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_index);
+    TTI_STALLWAIT(p_stall::STALL_SFPU, 0, 0, p_stall::MATH);
+}
+
+/**
+ * @brief Resets dest counter to 0
+ */
+inline void _llk_math_eltwise_binary_sfpu_done_()
+{
+    _reset_counters_<p_setrwc::SET_D>();
+}
+
+/**
+ * @brief Increments dest counter by a face (16x16 default)
+ */
+inline void _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_()
+{
+    _inc_dst_addr_<16>();
+}
+
+/**
+ * @brief Initialization for binary SFPU operations
+ */
+inline void _llk_math_eltwise_binary_sfpu_init_()
+{
+    _init_sfpu_config_reg_();
+    _eltwise_binary_sfpu_configure_addrmod_();
+    _reset_counters_<p_setrwc::SET_ABD_F>();
+}
+
+/**
+ * @brief Runs binary SFPU operation for a tile (default 32x32)
+ * @tparam APPROXIMATE: Selects between approximate (faster) or accurate (slower) mode
+ * @param sfpu_func: function pointer to the binary sfpu function to run
+ * @param dst_tile_index: Starting tile index in the destination register
+ * @param args: variable number of args passed through to sfpu_func
+ */
+template <bool APPROXIMATE, class F, class... ARGS>
+inline void _llk_math_eltwise_binary_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, ARGS&&... args)
+{
+    _llk_math_eltwise_binary_sfpu_start_(dst_tile_index);
+
+    for (std::uint32_t face = 0; face < NUM_FACES; face++)
+    {
+        sfpu_func(static_cast<ARGS&&>(args)...);
+
+        _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_();
+    }
+
+    _llk_math_eltwise_binary_sfpu_done_();
+}

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_sfpu.h
@@ -4,39 +4,39 @@
 
 #pragma once
 #include <cstdint>
+#include <utility>
 
-#include "cmath_common.h"
+#include "ckernel_sfpu.h"
 #include "llk_defs.h"
-#include "llk_math_eltwise_unary_sfpu_common.h"
 using namespace ckernel::math;
 
 inline void _eltwise_binary_sfpu_configure_addrmod_()
 {
-    _eltwise_unary_sfpu_configure_addrmod_();
+    _sfpu_configure_addrmod_();
 }
 
 inline void _llk_math_eltwise_binary_sfpu_start_(const std::uint32_t tile_index)
 {
-    _llk_math_eltwise_unary_sfpu_start_(tile_index);
+    _llk_math_sfpu_start_(tile_index);
 }
 
 inline void _llk_math_eltwise_binary_sfpu_done_()
 {
-    _llk_math_eltwise_unary_sfpu_done_();
+    _llk_math_sfpu_done_();
 }
 
 inline void _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_()
 {
-    _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+    _llk_math_sfpu_inc_dst_face_addr_();
 }
 
 inline void _llk_math_eltwise_binary_sfpu_init_()
 {
-    _llk_math_eltwise_unary_sfpu_init_();
+    _llk_math_sfpu_init_();
 }
 
 template <bool APPROXIMATE, class F, class... ARGS>
 inline void _llk_math_eltwise_binary_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, ARGS&&... args)
 {
-    _llk_math_eltwise_unary_sfpu_params_(std::forward<F>(sfpu_func), dst_tile_index, std::forward<ARGS>(args)...);
+    _llk_math_sfpu_params_(std::forward<F>(sfpu_func), dst_tile_index, std::forward<ARGS>(args)...);
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_sfpu.h
@@ -7,79 +7,36 @@
 
 #include "cmath_common.h"
 #include "llk_defs.h"
+#include "llk_math_eltwise_unary_sfpu_common.h"
 using namespace ckernel::math;
 
-/**
- * @brief Programs SFPU addrmods for binary SFPU operations
- */
 inline void _eltwise_binary_sfpu_configure_addrmod_()
 {
-    // NOTE: this kernel is typically used in conjunction with
-    // A2D, which is using ADDR_MOD_0 and ADDR_MOD_1, so use one
-    // that doesn't conflict!
-
-    addr_mod_t {
-        .srca = {.incr = 0},
-        .srcb = {.incr = 0},
-        .dest = {.incr = 0},
-    }
-        .set(ADDR_MOD_7, csr_read<CSR::TRISC_ID>());
+    _eltwise_unary_sfpu_configure_addrmod_();
 }
 
-/**
- * @brief Sets up starting index of SFPU for binary op, stalls till all FPU operations are done
- * @param tile_index: Use to index to a tile in Destination register
- */
 inline void _llk_math_eltwise_binary_sfpu_start_(const std::uint32_t tile_index)
 {
-    _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_index);
-    TTI_STALLWAIT(p_stall::STALL_SFPU, 0, 0, p_stall::MATH);
+    _llk_math_eltwise_unary_sfpu_start_(tile_index);
 }
 
-/**
- * @brief Resets dest counter to 0
- */
 inline void _llk_math_eltwise_binary_sfpu_done_()
 {
-    _reset_counters_<p_setrwc::SET_D>();
+    _llk_math_eltwise_unary_sfpu_done_();
 }
 
-/**
- * @brief Increments dest counter by a face (16x16 default)
- */
 inline void _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_()
 {
-    _inc_dst_addr_<16>();
+    _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
 }
 
-/**
- * @brief Initialization for binary SFPU operations
- */
 inline void _llk_math_eltwise_binary_sfpu_init_()
 {
-    _init_sfpu_config_reg_();
-    _eltwise_binary_sfpu_configure_addrmod_();
-    _reset_counters_<p_setrwc::SET_ABD_F>();
+    _llk_math_eltwise_unary_sfpu_init_();
 }
 
-/**
- * @brief Runs binary SFPU operation for a tile (default 32x32)
- * @tparam APPROXIMATE: Selects between approximate (faster) or accurate (slower) mode
- * @param sfpu_func: function pointer to the binary sfpu function to run
- * @param dst_tile_index: Starting tile index in the destination register
- * @param args: variable number of args passed through to sfpu_func
- */
 template <bool APPROXIMATE, class F, class... ARGS>
 inline void _llk_math_eltwise_binary_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, ARGS&&... args)
 {
-    _llk_math_eltwise_binary_sfpu_start_(dst_tile_index);
-
-    for (std::uint32_t face = 0; face < NUM_FACES; face++)
-    {
-        sfpu_func(static_cast<ARGS&&>(args)...);
-
-        _llk_math_eltwise_binary_sfpu_inc_dst_face_addr_();
-    }
-
-    _llk_math_eltwise_binary_sfpu_done_();
+    _llk_math_eltwise_unary_sfpu_params_(std::forward<F>(sfpu_func), dst_tile_index, std::forward<ARGS>(args)...);
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary_sfpu.h
@@ -8,6 +8,7 @@
 
 #include "ckernel_sfpu.h"
 #include "llk_defs.h"
+using namespace ckernel;
 using namespace ckernel::math;
 
 inline void _eltwise_binary_sfpu_configure_addrmod_()

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
@@ -8,6 +8,7 @@
 
 #include "ckernel_sfpu.h"
 #include "llk_defs.h"
+using namespace ckernel;
 using namespace ckernel::math;
 
 inline void _eltwise_unary_sfpu_configure_addrmod_()

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
@@ -6,96 +6,45 @@
 #include <cstdint>
 #include <utility>
 
-#include "cmath_common.h"
+#include "ckernel_sfpu.h"
 #include "llk_defs.h"
 using namespace ckernel::math;
 
-/**
- * @brief Programs SFPU addrmods
- */
 inline void _eltwise_unary_sfpu_configure_addrmod_()
 {
-    // TODO (RT): Ask if addrmods are still shared between fpu and sfpu?
-    // NOTE: this kernel is typically used in conjunction with
-    // A2D, which is using ADDR_MOD_0 and ADDR_MOD_1, so use one
-    // that doesn't conflict!
-
-    addr_mod_t {
-        .srca = {.incr = 0},
-        .srcb = {.incr = 0},
-        .dest = {.incr = 0},
-    }
-        .set(ADDR_MOD_7, csr_read<CSR::TRISC_ID>());
+    _sfpu_configure_addrmod_();
 }
 
-/**
- * @brief Sets up starting index of SFPU, Stalls till all FPU operations are done
- * @param tile_index: Use to index to a tile in Destination register
- */
 inline void _llk_math_eltwise_unary_sfpu_start_(const std::uint32_t tile_index)
 {
-    _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_index);
-    TTI_STALLWAIT(p_stall::STALL_SFPU, 0, 0, p_stall::MATH);
+    _llk_math_sfpu_start_(tile_index);
 }
 
-/**
- * @brief Resets dest counter to 0
- */
 inline void _llk_math_eltwise_unary_sfpu_done_()
 {
-    _reset_counters_<p_setrwc::SET_D>();
+    _llk_math_sfpu_done_();
 }
 
-/**
- * @brief Clear SrcS valids
- * @tparam SRCS_RD_DONE: Whether the source reg S read is done
- * @tparam SRCS_WR_DONE: Whether the source reg S write is done
- */
 template <bool SRCS_RD_DONE, bool SRCS_WR_DONE>
 inline void _llk_math_eltwise_unary_sfpu_srcs_clear_vlds_()
 {
-    TTI_SFPNOP(SRCS_WR_DONE, SRCS_RD_DONE, 0);
+    _llk_math_sfpu_srcs_clear_vlds_<SRCS_RD_DONE, SRCS_WR_DONE>();
 }
 
-/**
- * @brief Increments dest counter by a face (16x16 default)
- */
 inline void _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_()
 {
-    _inc_dst_addr_<16>();
+    _llk_math_sfpu_inc_dst_face_addr_();
 }
 
-/**
- * @brief Initialization for SFPU operations
- */
 inline void _llk_math_eltwise_unary_sfpu_init_()
 {
-    _init_sfpu_config_reg_();
-    _eltwise_unary_sfpu_configure_addrmod_();
-    _reset_counters_<p_setrwc::SET_ABD_F>();
+    _llk_math_sfpu_init_();
 }
 
-/**
- * @brief Runs SFPU operation for a tile (default 32x32)
- * @param: sfpu_func: function pointer to the sfpu functions to run, can look at list of functions here: common/inc/sfpu/cmath_sfpu*
- * @param: dst_tile_index: Starting tile index in the destination register, values = 0 - 15
- * @param: args: variable number of args can be passed into this function, that will be passed
- * to the SFPU function pointer
- */
 template <class F, class... ARGS>
 inline void _llk_math_eltwise_unary_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, ARGS&&... args)
 {
-    _llk_math_eltwise_unary_sfpu_start_(dst_tile_index);
-
-    for (std::uint32_t face = 0; face < NUM_FACES; face++)
-    {
-        sfpu_func(std::forward<ARGS>(args)...);
-
-        // Move to the next face
-        _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
-    }
-
-    _llk_math_eltwise_unary_sfpu_done_();
+    _llk_math_sfpu_params_(std::forward<F>(sfpu_func), dst_tile_index, std::forward<ARGS>(args)...);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include <cstdint>
+#include <utility>
 
 #include "cmath_common.h"
 #include "llk_defs.h"
@@ -88,7 +89,7 @@ inline void _llk_math_eltwise_unary_sfpu_params_(F&& sfpu_func, std::uint32_t ds
 
     for (std::uint32_t face = 0; face < NUM_FACES; face++)
     {
-        sfpu_func(static_cast<ARGS&&>(args)...);
+        sfpu_func(std::forward<ARGS>(args)...);
 
         // Move to the next face
         _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();


### PR DESCRIPTION
## Summary
- Implements elementwise binary add via SFPU for Quasar with programmable src0/src1/dst tile indices
- Adds LLK headers (`llk_math_eltwise_binary_sfpu.h`, `ckernel_sfpu_add.h`, `ckernel_defs.h`), test kernel (`sfpu_binary_quasar_test.cpp`), and Python test with parameterized index combinations
- Includes stimuli generator updates for integer type conversion and full-range workaround
- Adds tests for all data formats (Float16_b, Int32) and tile index combinations

Migrated from tt-llk branch `pgardner/QSbinarySFPU`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pgardner/QSbinarySFPU-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pgardner/QSbinarySFPU-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pgardner/QSbinarySFPU-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pgardner/QSbinarySFPU-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pgardner/QSbinarySFPU-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pgardner/QSbinarySFPU-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pgardner/QSbinarySFPU-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pgardner/QSbinarySFPU-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pgardner/QSbinarySFPU-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pgardner/QSbinarySFPU-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pgardner/QSbinarySFPU-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pgardner/QSbinarySFPU-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pgardner/QSbinarySFPU-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pgardner/QSbinarySFPU-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pgardner/QSbinarySFPU-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pgardner/QSbinarySFPU-metal)