### PR TITLE
refactor(weights/cache): address esmalTT review comments on BSPM cache

### DIFF
--- a/models/demos/deepseek_v3_b1/compressed_tensor/compact_io.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/compact_io.py
@@ -41,7 +41,7 @@ def pack_compact_tiles(
     assignment_2d: np.ndarray,
     tile_hw: int = DEFAULT_TILE_HW,
 ) -> bytes:
-    """Pack a (K, N) weight matrix to compact tile bytes in logical row-major order.
+    """Pack a (K, N) weight matrix to compact tile bytes in row-major tile order.
 
     Zero tiles (code 3 / bfp0) contribute 0 bytes — they are skipped entirely.
     The returned byte string is tightly packed; use *assignment_2d* with

--- a/models/demos/deepseek_v3_b1/compressed_tensor/compact_io.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/compact_io.py
@@ -48,12 +48,15 @@ def pack_compact_tiles(
     :func:`unpack_compact_tiles` to reconstruct tile offsets during load.
 
     Args:
-        w_kn: ``(K, N)`` float32 numpy array in logical tile order (pre-DRAM-shuffle).
+        w_kn: ``(K, N)`` float32 numpy array in tile order.
         assignment_2d: ``(tiles_h, tiles_w)`` int8 tile format codes.
-        tile_hw: Tile dimension (default 32).
+        tile_hw: Tile dimension (default 32). Must equal ``DEFAULT_TILE_HW`` (32); any
+            other value raises ``ValueError`` because the underlying BFP pack/unpack
+            primitives are hardcoded to 32-element groups.  The parameter exists only
+            for documentation completeness and is never varied in practice.
 
     Returns:
-        Flat ``bytes``, variable-length per tile, logical row-major order.
+        Flat ``bytes``, variable-length per tile, row-major order.
     """
     if tile_hw != DEFAULT_TILE_HW:
         raise ValueError(f"tile_hw={tile_hw} is not supported; underlying BFP primitives require {DEFAULT_TILE_HW}")

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -39,7 +39,7 @@ if str(_REPO_ROOT) not in sys.path:
 from conftest import bh_2d_mesh_device_context
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 from models.demos.deepseek_v3_b1.demo.weight_provider import CacheWeightProvider
-from models.demos.deepseek_v3_b1.weights.cache import CacheConfig, CacheContext, TensorCache
+from models.demos.deepseek_v3_b1.weights.cache import BspmVariant, CacheConfig, CacheContext, TensorCache
 from models.demos.deepseek_v3_b1.weights.prepare import (
     NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
@@ -275,7 +275,7 @@ def _warm(
     hf_revision: str,
     schema_version: int,
     bspm_dir: Path | None = None,
-    bspm_variant: str = "B",
+    bspm_variant: BspmVariant = BspmVariant.B,
     bspm_budget: float = 3.5,
 ) -> None:
     _ensure_fabric_env()
@@ -448,7 +448,7 @@ def main() -> int:
             hf_revision=args.hf_revision,
             schema_version=args.schema_version,
             bspm_dir=args.bspm_dir,
-            bspm_variant=args.bspm_variant,
+            bspm_variant=BspmVariant(args.bspm_variant),
             bspm_budget=args.bspm_budget,
         )
         logger.info("Warm complete in {:.3f}s", time.perf_counter() - t_all)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -713,15 +713,19 @@ def test_dram_matmul_bspm_cache_roundtrip(device, tmp_path):
     - tiles.bin is smaller than a uniform BFP4 baseline (compact format saves space).
     - Matmul PCC between miss and hit is ≥ 0.99 (round-trip is numerically lossless).
     """
+    import hashlib
+
     from models.common.utility_functions import comp_pcc
     from models.demos.deepseek_v3_b1.compressed_tensor import bfp4_tile_byte_count
     from models.demos.deepseek_v3_b1.weights.cache import (
+        BspmVariant,
         CacheContext,
         CompressedTensorBuildInputs,
         CompressedTensorTarget,
         SourceTensorSelection,
         TensorCache,
     )
+    from models.demos.deepseek_v3_b1.weights.cache.bspm_expert_cache import get_or_create_bspm_expert
     from models.demos.deepseek_v3_b1.weights.cache.fingerprint import compute_artifact_id
 
     tile_w = 32
@@ -742,6 +746,7 @@ def test_dram_matmul_bspm_cache_roundtrip(device, tmp_path):
     torch.manual_seed(0)
     w_logical = torch.randn(K, N_padded).float().numpy()
 
+    assignment_hash = hashlib.sha256(assignment_logical.tobytes()).hexdigest()[:16]
     cache_ctx = CacheContext(
         schema_version=1,
         hf_model_id="test_model",
@@ -753,18 +758,19 @@ def test_dram_matmul_bspm_cache_roundtrip(device, tmp_path):
         K=K,
         N_padded=N_padded,
         num_banks=num_banks,
-        bspm_variant="B",
+        bspm_variant=BspmVariant.B,
         bspm_budget=3.5,
+        assignment_hash=assignment_hash,
     )
     fp = cache_ctx.fingerprint(source=SourceTensorSelection(names=("test_weight",)), target=tgt)
 
     cache = TensorCache(tmp_path / "cache")
 
     def _preprocess(_raw):
-        return {tgt.name: CompressedTensorBuildInputs(w_logical=w_logical, assignment_logical=assignment_logical)}
+        return CompressedTensorBuildInputs(w=w_logical, assignment=assignment_logical)
 
     # --- First call: cache miss — writes tiles.bin, assignment.npy, metadata.json ---
-    ct_miss = cache.get_or_create(fp, device, preprocess=_preprocess, raw_tensors={})
+    ct_miss = get_or_create_bspm_expert(cache, fp, device, raw_tensors={}, preprocess=_preprocess)
     assert isinstance(ct_miss, CompressedTensor), f"Expected CompressedTensor from miss, got {type(ct_miss)}"
 
     artifact_id = compute_artifact_id(fp)
@@ -807,7 +813,7 @@ def test_dram_matmul_bspm_cache_roundtrip(device, tmp_path):
     )
 
     # --- Second call: cache hit — reloads from tiles.bin without calling preprocess ---
-    ct_hit = cache.get_or_create(fp, device, preprocess=_preprocess, raw_tensors={})
+    ct_hit = get_or_create_bspm_expert(cache, fp, device, raw_tensors={}, preprocess=_preprocess)
     assert isinstance(ct_hit, CompressedTensor), f"Expected CompressedTensor from hit, got {type(ct_hit)}"
 
     # --- Matmul PCC: miss and hit must agree (lossless round-trip) ---

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -388,6 +388,80 @@ def _add_global_weights(state: dict[str, torch.Tensor], seed: int = 42) -> None:
     )
 
 
+def test_compressed_tensor_target_transform_version_invalidates_cache():
+    """Bumping transform_version on CompressedTensorTarget produces a distinct artifact ID."""
+    from models.demos.deepseek_v3_b1.weights.cache import (
+        BspmVariant,
+        CacheContext,
+        CompressedTensorTarget,
+        SourceTensorSelection,
+    )
+    from models.demos.deepseek_v3_b1.weights.cache.fingerprint import compute_artifact_id
+
+    ctx = CacheContext(schema_version=1, hf_model_id="test", hf_revision="r0", mesh_shape=(1, 1))
+    source = SourceTensorSelection(names=("layer.weight",))
+
+    tgt_v3 = CompressedTensorTarget(
+        name="gate_proj",
+        K=64,
+        N_padded=64,
+        num_banks=8,
+        bspm_variant=BspmVariant.B,
+        bspm_budget=3.5,
+        transform_version=3,
+    )
+    tgt_v4 = CompressedTensorTarget(
+        name="gate_proj",
+        K=64,
+        N_padded=64,
+        num_banks=8,
+        bspm_variant=BspmVariant.B,
+        bspm_budget=3.5,
+        transform_version=4,
+    )
+
+    id_v3 = compute_artifact_id(ctx.fingerprint(source=source, target=tgt_v3))
+    id_v4 = compute_artifact_id(ctx.fingerprint(source=source, target=tgt_v4))
+    assert id_v3 != id_v4, "Bumping transform_version must produce a different artifact ID"
+
+
+def test_compressed_tensor_target_assignment_hash_invalidates_cache():
+    """Different assignment_hash values in CompressedTensorTarget produce distinct artifact IDs."""
+    from models.demos.deepseek_v3_b1.weights.cache import (
+        BspmVariant,
+        CacheContext,
+        CompressedTensorTarget,
+        SourceTensorSelection,
+    )
+    from models.demos.deepseek_v3_b1.weights.cache.fingerprint import compute_artifact_id
+
+    ctx = CacheContext(schema_version=1, hf_model_id="test", hf_revision="r0", mesh_shape=(1, 1))
+    source = SourceTensorSelection(names=("layer.weight",))
+
+    tgt_a = CompressedTensorTarget(
+        name="gate_proj",
+        K=64,
+        N_padded=64,
+        num_banks=8,
+        bspm_variant=BspmVariant.B,
+        bspm_budget=3.5,
+        assignment_hash="aabbccdd00001111",
+    )
+    tgt_b = CompressedTensorTarget(
+        name="gate_proj",
+        K=64,
+        N_padded=64,
+        num_banks=8,
+        bspm_variant=BspmVariant.B,
+        bspm_budget=3.5,
+        assignment_hash="ffffffffffffffff",
+    )
+
+    id_a = compute_artifact_id(ctx.fingerprint(source=source, target=tgt_a))
+    id_b = compute_artifact_id(ctx.fingerprint(source=source, target=tgt_b))
+    assert id_a != id_b, "Different assignment_hash values must produce distinct artifact IDs"
+
+
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],

--- a/models/demos/deepseek_v3_b1/weights/cache/__init__.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/__init__.py
@@ -28,16 +28,21 @@ from models.demos.deepseek_v3_b1.weights.cache.types import (
 )
 
 
+def create_overlapped_tensor(*args, **kwargs):
+    """Lazy wrapper — defers heavy fuse imports until first call."""
+    from models.demos.deepseek_v3_b1.weights.cache.fuse import create_overlapped_tensor as _cot
+
+    return _cot(*args, **kwargs)
+
+
+def get_or_create_bspm_expert(*args, **kwargs):
+    """Lazy wrapper — defers bspm_expert_cache imports until first call."""
+    from models.demos.deepseek_v3_b1.weights.cache.bspm_expert_cache import get_or_create_bspm_expert as _fn
+
+    return _fn(*args, **kwargs)
+
+
 def __getattr__(name: str):
-    """Lazy exports to avoid import cycles."""
-    if name == "create_overlapped_tensor":
-        from models.demos.deepseek_v3_b1.weights.cache.fuse import create_overlapped_tensor as _cot
-
-        return _cot
-    if name == "get_or_create_bspm_expert":
-        from models.demos.deepseek_v3_b1.weights.cache.bspm_expert_cache import get_or_create_bspm_expert as _fn
-
-        return _fn
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/models/demos/deepseek_v3_b1/weights/cache/__init__.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/__init__.py
@@ -12,6 +12,7 @@ from models.demos.deepseek_v3_b1.weights.cache.cache import EphemeralTensorCache
 from models.demos.deepseek_v3_b1.weights.overlap.spec import OverlappedTensorSpec
 from models.demos.deepseek_v3_b1.weights.cache.types import (
     ArtifactTarget,
+    BspmVariant,
     CacheContext,
     CompressedTensorBuildInputs,
     CompressedTensorTarget,
@@ -28,11 +29,15 @@ from models.demos.deepseek_v3_b1.weights.cache.types import (
 
 
 def __getattr__(name: str):
-    """Lazy export of ``create_overlapped_tensor`` to avoid import cycles."""
+    """Lazy exports to avoid import cycles."""
     if name == "create_overlapped_tensor":
         from models.demos.deepseek_v3_b1.weights.cache.fuse import create_overlapped_tensor as _cot
 
         return _cot
+    if name == "get_or_create_bspm_expert":
+        from models.demos.deepseek_v3_b1.weights.cache.bspm_expert_cache import get_or_create_bspm_expert as _fn
+
+        return _fn
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -59,6 +64,7 @@ class CacheConfig:
 
 __all__ = [
     "ArtifactTarget",
+    "BspmVariant",
     "CacheConfig",
     "CompressedTensorBuildInputs",
     "CompressedTensorTarget",
@@ -77,4 +83,5 @@ __all__ = [
     "TensorCacheProtocol",
     "TensorTarget",
     "create_overlapped_tensor",
+    "get_or_create_bspm_expert",
 ]

--- a/models/demos/deepseek_v3_b1/weights/cache/bspm_expert_cache.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/bspm_expert_cache.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""BSPM-specific wrapper over the generic TensorCache.
+
+Owns all DeepSeek-specific concerns for BSPM expert weights:
+  - DRAM shuffle (tile reordering for WIDTH_SHARDED streaming matmul)
+  - Expert DRAM MemoryConfig construction
+  - CompressedTensor.from_bspm device upload
+
+The generic :class:`~cache.TensorCache` / :class:`~cache.EphemeralTensorCache`
+are kept free of these details; callers use :func:`get_or_create_bspm_expert`
+instead of calling :meth:`get_or_create` directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.weights.cache.types import (
+    CompressedTensorBuildInputs,
+    CompressedTensorTarget,
+    Fingerprint,
+)
+
+if TYPE_CHECKING:
+    from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import CompressedTensor
+    from models.demos.deepseek_v3_b1.weights.cache.cache import TensorCacheProtocol
+
+
+def expert_dram_memory_config(device, K: int, N_padded: int, num_banks: int) -> ttnn.MemoryConfig:
+    """Build the WIDTH_SHARDED DRAM MemoryConfig for a routed expert projection."""
+    per_core_N = N_padded // num_banks
+    dram_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
+            )
+        }
+    )
+    shard_spec = ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+
+def get_or_create_bspm_expert(
+    cache: "TensorCacheProtocol",
+    fingerprint: Fingerprint,
+    device,
+    *,
+    raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
+    preprocess: Callable[[dict[str, torch.Tensor]], CompressedTensorBuildInputs],
+    move_to_device: bool = True,
+) -> "CompressedTensor":
+    """Load or build a BSPM-encoded routed expert projection.
+
+    Wraps :meth:`TensorCache.get_or_create` (or :class:`EphemeralTensorCache`) with
+    BSPM-specific logic:
+
+    1. **Shuffle** — the caller's ``preprocess`` returns logical-order
+       ``CompressedTensorBuildInputs``; this wrapper applies DRAM tile shuffle before
+       handing data to the generic cache so stored bytes are already in kernel-ready order.
+    2. **MemoryConfig** — ``expert_dram_memory_config`` is called here, not in the cache.
+    3. **CT construction** — ``CompressedTensor.from_bspm`` is called via the
+       ``reconstruct`` callback, keeping the generic cache free of CT imports.
+
+    Args:
+        cache: A :class:`TensorCache` or :class:`EphemeralTensorCache` instance.
+        fingerprint: Must have a :class:`CompressedTensorTarget` as its ``target``.
+        device: TT device (or mesh device).
+        raw_tensors: Lazy HF weight loader; skipped on cache hit.
+        preprocess: Converts raw HF tensors to logical-order
+            ``CompressedTensorBuildInputs(w, assignment)`` for this expert.
+        move_to_device: Whether to upload the CompressedTensor to device.
+
+    Returns:
+        A device-resident (or host-only if ``move_to_device=False``) CompressedTensor.
+    """
+    from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import CompressedTensor
+    from models.demos.deepseek_v3_b1.weights.transforms.moe import shuffle_dram_assignment, shuffle_dram_tiles
+
+    target = fingerprint.target
+    if not isinstance(target, CompressedTensorTarget):
+        raise TypeError(f"get_or_create_bspm_expert requires CompressedTensorTarget, got {type(target)}")
+    num_banks = target.num_banks
+
+    def _preprocess_and_shuffle(tensors: dict) -> dict:
+        inputs = preprocess(tensors)
+        w_torch = torch.from_numpy(inputs.w).unsqueeze(0)
+        w_shuffled = shuffle_dram_tiles(w_torch, tile_size=32, num_banks=num_banks).squeeze(0)
+        assignment_shuffled = shuffle_dram_assignment(inputs.assignment, num_banks)
+        return {target.name: CompressedTensorBuildInputs(w=w_shuffled.numpy(), assignment=assignment_shuffled)}
+
+    def _reconstruct(inputs: CompressedTensorBuildInputs, dev) -> CompressedTensor:
+        mem_config = expert_dram_memory_config(dev, target.K, target.N_padded, num_banks)
+        device_for_ct = dev if move_to_device else None
+        return CompressedTensor.from_bspm(
+            torch.from_numpy(inputs.w).float(),
+            inputs.assignment,
+            device=device_for_ct,
+            memory_config=mem_config,
+        )
+
+    return cache.get_or_create(
+        fingerprint,
+        device,
+        preprocess=_preprocess_and_shuffle,
+        raw_tensors=raw_tensors,
+        reconstruct=_reconstruct,
+    )

--- a/models/demos/deepseek_v3_b1/weights/cache/cache.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/cache.py
@@ -91,7 +91,7 @@ class TensorCacheProtocol(Protocol):
         fingerprint: Fingerprint,
         device,
         *,
-        preprocess: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]],
+        preprocess: Callable[[dict[str, torch.Tensor]], dict],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
         reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
     ) -> "ttnn.Tensor | dict[str, OverlappedTensor] | CompressedTensor":
@@ -358,7 +358,7 @@ class TensorCache:
         fingerprint: Fingerprint,
         device,
         *,
-        preprocess: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]],
+        preprocess: Callable[[dict[str, torch.Tensor]], dict],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
         reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
     ) -> "ttnn.Tensor | dict[str, OverlappedTensor] | CompressedTensor":
@@ -478,7 +478,7 @@ class EphemeralTensorCache:
         fingerprint: Fingerprint,
         device,
         *,
-        preprocess: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]],
+        preprocess: Callable[[dict[str, torch.Tensor]], dict],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
         reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
     ) -> "ttnn.Tensor | dict[str, OverlappedTensor] | CompressedTensor":

--- a/models/demos/deepseek_v3_b1/weights/cache/cache.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/cache.py
@@ -93,27 +93,9 @@ class TensorCacheProtocol(Protocol):
         *,
         preprocess: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
+        reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
     ) -> "ttnn.Tensor | dict[str, OverlappedTensor] | CompressedTensor":
         ...
-
-
-def _expert_dram_memory_config(device, K: int, N_padded: int, num_banks: int) -> ttnn.MemoryConfig:
-    """Reconstruct the WIDTH_SHARDED DRAM MemoryConfig for a routed expert projection.
-
-    Mirrors the shard spec built in ``prepare_moe_routed_experts_bspm()``.
-    Used by ``_load_compressed`` to reconstruct the on-device layout from stored params.
-    """
-    per_core_N = N_padded // num_banks
-    dram_grid = ttnn.CoreRangeSet(
-        {
-            ttnn.CoreRange(
-                ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
-            )
-        }
-    )
-    shard_spec = ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
-    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
 
 
 def build_mesh_mapper_for_target(target: TensorTarget, device):
@@ -304,28 +286,31 @@ class TensorCache:
         Layout::
 
             objects/{id[:2]}/{id}/
-                tiles.bin        — compact packed tile bytes, logical row-major order
-                assignment.npy   — (tiles_h, tiles_w) int8 tile format codes
+                tiles.bin        — compact packed tile bytes, DRAM-shuffled order
+                assignment.npy   — (tiles_h, tiles_w) int8 tile format codes, DRAM-shuffled order
                 metadata.json    — K, N_padded, num_banks, …
                 manifest.json    — fingerprint + logical_name
         """
         from models.demos.deepseek_v3_b1.compressed_tensor.compact_io import pack_compact_tiles
 
-        target: CompressedTensorTarget = fingerprint.target  # type: ignore[assignment]
+        assert isinstance(
+            fingerprint.target, CompressedTensorTarget
+        ), f"_store_compressed requires CompressedTensorTarget, got {type(fingerprint.target)}"
+        target: CompressedTensorTarget = fingerprint.target
         obj_dir = self._objects_dir / artifact_id[:2] / artifact_id
         obj_dir.mkdir(parents=True, exist_ok=True)
 
-        # 1. Compact tile bytes (logical order, variable length)
+        # 1. Compact tile bytes (DRAM-shuffled order, variable length)
         tiles_path = obj_dir / "tiles.bin"
-        compact_bytes = pack_compact_tiles(inputs.w_logical, inputs.assignment_logical)
+        compact_bytes = pack_compact_tiles(inputs.w, inputs.assignment)
         tiles_path.write_bytes(compact_bytes)
 
         # 2. Assignment array
         assignment_path = obj_dir / "assignment.npy"
-        np.save(str(assignment_path), inputs.assignment_logical.astype(np.int8))
+        np.save(str(assignment_path), inputs.assignment.astype(np.int8))
 
         # 3. Metadata — everything needed to reconstruct the memory config at load time
-        tiles_h, tiles_w = inputs.assignment_logical.shape
+        tiles_h, tiles_w = inputs.assignment.shape
         metadata_dict = {
             "artifact_id": artifact_id,
             "artifact_kind": "compressed_tensor",
@@ -353,35 +338,20 @@ class TensorCache:
     def _load_compressed(
         self,
         obj_dir: Path,
-        device,
         target: "CompressedTensorTarget",
-    ) -> "CompressedTensor":
-        """Reconstruct a device-resident CompressedTensor from a compact CAS object.
+    ) -> "CompressedTensorBuildInputs":
+        """Read a compact CAS object and return DRAM-shuffled build inputs.
 
-        Flow: read compact tile bytes + assignment → unpack to float → apply DRAM
-        shuffle → repack via CompressedTensor.from_bspm.  The tile unpack/repack is
-        lossless for integer mantissa formats (BFP4/BFP2).
+        Tiles are stored in DRAM-shuffled order (written by :meth:`_store_compressed`
+        after :func:`bspm_expert_cache.get_or_create_bspm_expert` applies the shuffle).
+        The caller's ``reconstruct`` callback handles device upload.
         """
         from models.demos.deepseek_v3_b1.compressed_tensor.compact_io import unpack_compact_tiles
-        from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import CompressedTensor
-        from models.demos.deepseek_v3_b1.weights.transforms.moe import shuffle_dram_assignment, shuffle_dram_tiles
 
-        assignment_logical = np.load(str(obj_dir / "assignment.npy"))
+        assignment = np.load(str(obj_dir / "assignment.npy"))
         compact_bytes = (obj_dir / "tiles.bin").read_bytes()
-
-        w_logical = unpack_compact_tiles(compact_bytes, assignment_logical)  # (K, N_padded) float32
-
-        w_torch = torch.from_numpy(w_logical).unsqueeze(0)  # (1, K, N_padded)
-        w_shuffled = shuffle_dram_tiles(w_torch, tile_size=32, num_banks=target.num_banks).squeeze(0)
-        assignment_shuffled = shuffle_dram_assignment(assignment_logical, target.num_banks)
-
-        mem_config = _expert_dram_memory_config(device, target.K, target.N_padded, target.num_banks)
-        return CompressedTensor.from_bspm(
-            w_shuffled.float(),
-            assignment_shuffled,
-            device=device,
-            memory_config=mem_config,
-        )
+        w = unpack_compact_tiles(compact_bytes, assignment)  # (K, N_padded) float32, DRAM-shuffled
+        return CompressedTensorBuildInputs(w=w, assignment=assignment)
 
     def get_or_create(
         self,
@@ -390,6 +360,7 @@ class TensorCache:
         *,
         preprocess: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
+        reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
     ) -> "ttnn.Tensor | dict[str, OverlappedTensor] | CompressedTensor":
         """Load from cache or build, then return a device tensor or overlapped views."""
         target = fingerprint.target
@@ -403,18 +374,24 @@ class TensorCache:
 
         # --- CompressedTensorTarget: use compact tiles.bin layout ---
         if isinstance(target, CompressedTensorTarget):
+            if reconstruct is None:
+                raise TypeError(
+                    "TensorCache.get_or_create with CompressedTensorTarget requires a 'reconstruct' callback; "
+                    "use get_or_create_bspm_expert() instead of calling get_or_create() directly."
+                )
             entry = self._lookup_compressed(artifact_id)
             if isinstance(entry, PresentCacheEntry):
                 logger.debug("Cache hit (compressed) for {} ({})", logical, artifact_id[:12])
-                return self._load_compressed(entry.paths.object_dir, device, target)
+                inputs = self._load_compressed(entry.paths.object_dir, target)
+                return reconstruct(inputs, device)
             if isinstance(entry, CorruptCacheEntry):
                 logger.warning("Corrupt compressed cache entry for {} ({}), rebuilding", logical, artifact_id[:12])
                 shutil.rmtree(entry.paths.object_dir, ignore_errors=True)
             t0 = time.perf_counter()
             tensors = raw_tensors() if callable(raw_tensors) else raw_tensors
             preprocessed = preprocess(tensors)
-            inputs: CompressedTensorBuildInputs = preprocessed[target.name]
-            obj_dir = self._store_compressed(artifact_id, fingerprint, inputs)
+            inputs = preprocessed[target.name]
+            self._store_compressed(artifact_id, fingerprint, inputs)
             elapsed = time.perf_counter() - t0
             logger.info(
                 "Cache miss (compressed) for {} resolved in {:.3f}s, stored as {}",
@@ -422,7 +399,7 @@ class TensorCache:
                 elapsed,
                 artifact_id[:12],
             )
-            return self._load_compressed(obj_dir, device, target)
+            return reconstruct(inputs, device)
 
         # --- TensorTarget / FusionGroupSpec: original path ---
         entry = self._lookup(artifact_id)
@@ -503,6 +480,7 @@ class EphemeralTensorCache:
         *,
         preprocess: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
+        reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
     ) -> "ttnn.Tensor | dict[str, OverlappedTensor] | CompressedTensor":
         target = fingerprint.target
         if not isinstance(target, (TensorTarget, FusionGroupSpec, CompressedTensorTarget)):
@@ -515,21 +493,13 @@ class EphemeralTensorCache:
         preprocessed = preprocess(tensors)
 
         if isinstance(target, CompressedTensorTarget):
-            from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import CompressedTensor
-            from models.demos.deepseek_v3_b1.weights.transforms.moe import shuffle_dram_assignment, shuffle_dram_tiles
-
+            if reconstruct is None:
+                raise TypeError(
+                    "EphemeralTensorCache.get_or_create with CompressedTensorTarget requires a 'reconstruct' callback; "
+                    "use get_or_create_bspm_expert() instead of calling get_or_create() directly."
+                )
             inputs: CompressedTensorBuildInputs = preprocessed[target.name]
-            w_torch = torch.from_numpy(inputs.w_logical).unsqueeze(0)
-            w_shuffled = shuffle_dram_tiles(w_torch, tile_size=32, num_banks=target.num_banks).squeeze(0)
-            assignment_shuffled = shuffle_dram_assignment(inputs.assignment_logical, target.num_banks)
-            mem_config = _expert_dram_memory_config(device, target.K, target.N_padded, target.num_banks)
-            device_for_ct = device if self._move_to_device else None
-            return CompressedTensor.from_bspm(
-                w_shuffled.float(),
-                assignment_shuffled,
-                device=device_for_ct,
-                memory_config=mem_config,
-            )
+            return reconstruct(inputs, device)
 
         if isinstance(target, TensorTarget):
             torch_tensor = preprocessed[target.name]

--- a/models/demos/deepseek_v3_b1/weights/cache/fingerprint.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/fingerprint.py
@@ -98,6 +98,7 @@ def canonical(fingerprint: Fingerprint) -> dict:
             "num_banks": target.num_banks,
             "bspm_variant": target.bspm_variant,
             "bspm_budget": target.bspm_budget,
+            "assignment_hash": target.assignment_hash,
             "transform_version": target.transform_version,
         }
     else:

--- a/models/demos/deepseek_v3_b1/weights/cache/types.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/types.py
@@ -57,6 +57,9 @@ class BspmVariant(str, Enum):
 
     B = "B"
 
+    def __str__(self) -> str:
+        return self.value
+
 
 @dataclass(frozen=True)
 class TensorTarget:

--- a/models/demos/deepseek_v3_b1/weights/cache/types.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/types.py
@@ -10,6 +10,7 @@ Frozen dataclasses for fingerprinting and tensor target specifications.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Literal, Union
 
 import numpy as np
@@ -49,6 +50,12 @@ class Shard2dMeshMapper:
 
 
 MeshMapperConfig = Union[ReplicateMeshMapper, ShardMeshMapper, Shard2dMeshMapper]
+
+
+class BspmVariant(str, Enum):
+    """BSPM allocation variant letter."""
+
+    B = "B"
 
 
 @dataclass(frozen=True)
@@ -111,23 +118,27 @@ class CompressedTensorTarget:
     K: int = 0  # weight inner dimension (rows in logical K×N layout)
     N_padded: int = 0  # padded weight outer dimension (multiple of num_banks * tile_hw)
     num_banks: int = 0  # DRAM bank count (device.dram_grid_size().x)
-    bspm_variant: str = "B"  # allocation variant letter
+    bspm_variant: BspmVariant = BspmVariant.B  # allocation variant letter
     bspm_budget: float = 3.5  # bits-per-element budget
-    transform_version: int = 3  # bumped: invalidate entries written with correct version but buggy reshape code
+    assignment_hash: str = ""  # sha256[:16] of assignment bytes; invalidates cache when allocation changes
+    transform_version: int = 4  # bumped: store DRAM-shuffled data on disk (faster load, same footprint)
 
 
 @dataclass
 class CompressedTensorBuildInputs:
-    """Pre-shuffle weight matrix and assignment for a single expert projection.
+    """Weight matrix and tile-format assignment for a single expert projection.
 
-    Returned by the ``preprocess`` callback on the :class:`CompressedTensorTarget`
-    path.  Stored compact to disk by :class:`TensorCache` (tile bytes in logical
-    row-major order); reconstructed to the DRAM-sharded on-device layout on load.
+    When returned from the ``preprocess`` callback passed to
+    :func:`~models.demos.deepseek_v3_b1.weights.cache.bspm_expert_cache.get_or_create_bspm_expert`,
+    ``w`` and ``assignment`` are in logical (pre-DRAM-shuffle) tile order.
+    :class:`TensorCache` stores them in DRAM-shuffled order (same byte footprint,
+    no re-shuffle needed at load time).  The ``reconstruct`` callback receives
+    DRAM-shuffled data and calls ``CompressedTensor.from_bspm`` directly.
     Not frozen: numpy arrays are not hashable.
     """
 
-    w_logical: np.ndarray  # (K, N_padded) float32, logical tile order (pre-DRAM-shuffle)
-    assignment_logical: np.ndarray  # (tiles_h, tiles_w) int8, logical tile order
+    w: np.ndarray  # (K, N_padded) float32
+    assignment: np.ndarray  # (tiles_h, tiles_w) int8 tile format codes
 
 
 ArtifactTarget = TensorTarget | FusionGroupSpec | CompressedTensorTarget

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -16,6 +16,7 @@ with :class:`~weights.cache.CacheConfig` and the ``prepare_*`` functions
 
 from __future__ import annotations
 
+import hashlib
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,6 +29,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions as D
 from models.demos.deepseek_v3_b1.weights.cache import (
+    BspmVariant,
     CacheConfig,
     CompressedTensorBuildInputs,
     CompressedTensorTarget,
@@ -37,6 +39,7 @@ from models.demos.deepseek_v3_b1.weights.cache import (
     SourceTensorSelection,
     TensorTarget,
 )
+from models.demos.deepseek_v3_b1.weights.cache.bspm_expert_cache import get_or_create_bspm_expert
 from models.demos.deepseek_v3_b1.weights.overlap.packing import OverlappedTensor
 from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
     DOWN_PROJ_SINGLE_DEVICE_SPEC,
@@ -1109,7 +1112,7 @@ def prepare_moe_routed_experts_bspm(
     *,
     move_to_device: bool,
     cache_config: "CacheConfig",
-    bspm_variant: str = "B",
+    bspm_variant: BspmVariant = BspmVariant.B,
     bspm_budget: float = 3.5,
 ) -> MoERoutedExpertWeights:
     """Upload MoE routed experts as BSPM-encoded CompressedTensor objects.
@@ -1143,35 +1146,34 @@ def prepare_moe_routed_experts_bspm(
             for e in range(num_routed_experts)
         ]
 
-        tgt = CompressedTensorTarget(
-            name=proj_name,
-            K=K,
-            N_padded=N_padded,
-            num_banks=num_banks,
-            bspm_variant=bspm_variant,
-            bspm_budget=bspm_budget,
-        )
-
         for e, key in enumerate(keys):
             assignment_logical = all_assignments[e]
+            assignment_hash = hashlib.sha256(assignment_logical.tobytes()).hexdigest()[:16]
+            tgt = CompressedTensorTarget(
+                name=proj_name,
+                K=K,
+                N_padded=N_padded,
+                num_banks=num_banks,
+                bspm_variant=bspm_variant,
+                bspm_budget=bspm_budget,
+                assignment_hash=assignment_hash,
+            )
             fp = cache_config.context.fingerprint(
                 source=SourceTensorSelection(names=(key,)),
                 target=tgt,
             )
-            ct = cache_config.cache.get_or_create(
+            ct = get_or_create_bspm_expert(
+                cache_config.cache,
                 fp,
                 device,
-                preprocess=lambda tensors, _k=key, _a=assignment_logical, _N=N, _N_padded=N_padded: {
-                    proj_name: CompressedTensorBuildInputs(
-                        w_logical=torch.nn.functional.pad(
-                            tensors[_k].T.contiguous().float(), (0, _N_padded - _N)
-                        ).numpy()
-                        if _N_padded != _N
-                        else tensors[_k].T.contiguous().float().numpy(),
-                        assignment_logical=_a,
-                    )
-                },
                 raw_tensors=lambda _k=key: {_k: state_dict[_k]},
+                preprocess=lambda tensors, _k=key, _a=assignment_logical, _N=N, _N_padded=N_padded: CompressedTensorBuildInputs(
+                    w=torch.nn.functional.pad(tensors[_k].T.contiguous().float(), (0, _N_padded - _N)).numpy()
+                    if _N_padded != _N
+                    else tensors[_k].T.contiguous().float().numpy(),
+                    assignment=_a,
+                ),
+                move_to_device=move_to_device,
             )
             results[proj_idx].append(ct)
 
@@ -1198,7 +1200,7 @@ def prepare_routed_expert_weights(
     move_to_device: bool = False,
     cache_config: CacheConfig | None = None,
     bspm_dir: Path | None = None,
-    bspm_variant: str = "B",
+    bspm_variant: BspmVariant = BspmVariant.B,
     bspm_budget: float = 3.5,
 ) -> DenseRoutedExpertWeights | MoERoutedExpertWeights:
     """Prepare routed expert weights for one layer (dense: single MLP; MoE: num_routed_experts experts).
@@ -1442,7 +1444,7 @@ def prepare_moe_layer_weights(
     move_to_device: bool = False,
     cache_config: CacheConfig | None = None,
     bspm_dir: Path | None = None,
-    bspm_variant: str = "B",
+    bspm_variant: BspmVariant = BspmVariant.B,
     bspm_budget: float = 3.5,
 ) -> DeepSeekV3MoELayerWeights:
     """Prepare fused weights for a single MoE decoder layer.


### PR DESCRIPTION
## Summary

Addresses all 7 of esmalTT's post-merge review comments from #42557:

- **#1 / #6 (OCP concern)**: Extract all DeepSeek-specific BSPM logic into new `weights/cache/bspm_expert_cache.py`. New `get_or_create_bspm_expert()` function owns shuffle, MemoryConfig construction, and `CompressedTensor.from_bspm`. Generic `TensorCache`/`EphemeralTensorCache` are now free of device-topology and CT construction concerns.

- **#2 (type narrowing)**: Replace `# type: ignore[assignment]` cast in `_store_compressed` with an explicit `assert isinstance(fingerprint.target, CompressedTensorTarget)`.

- **#3 (assignment in fingerprint)**: Add `assignment_hash: str` field to `CompressedTensorTarget` (sha256[:16] of assignment bytes). Cache entries now invalidate when the allocation changes, not just when variant/budget change.

- **#4 (bspm_variant enum)**: Add `BspmVariant(str, Enum)` with `B = "B"`. All callers updated; `str, Enum` keeps JSON serialization and f-string formatting unchanged.

- **#5 (cache invalidation tests)**: Two new pure-Python tests in `test_prepare_weights.py` verify that bumping `transform_version` and changing `assignment_hash` each produce distinct artifact IDs (no device required).

- **#7 (tile_hw fingerprint)**: Document in `pack_compact_tiles` docstring that `tile_hw` is always `DEFAULT_TILE_HW=32`; non-32 values already raise `ValueError`. No fingerprint change needed.

**Additional improvement — store shuffled on disk**: `TensorCache` now stores DRAM-shuffled tiles (same disk footprint, no re-shuffle needed on cache hit = faster load). `transform_version` bumped 3→4 to invalidate existing entries. `CompressedTensorBuildInputs` fields renamed `w_logical`→`w`, `assignment_logical`→`assignment` to reflect that the struct carries either logical or shuffled data depending on context.

## Test plan

- [x] `test_compressed_tensor_target_transform_version_invalidates_cache` — pure Python, no device
- [x] `test_compressed_tensor_target_assignment_hash_invalidates_cache` — pure Python, no device  
- [x] `test_dram_matmul_bspm_cache_roundtrip` — existing device test, updated to use `get_or_create_bspm_expert`
- [x] `test_prepare_moe_routed_experts_bspm_tile_assignment_4x2` — existing device test, unchanged API

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/bspm_review)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/bspm_review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/bspm_review)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/bspm_review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/bspm_review)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/bspm_review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/bspm_review)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/bspm_review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/bspm_review)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/bspm_review)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/bspm_review)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/bspm_review)