### PR TITLE
[tt-triage] Move elfs cache to use mmap

### DIFF
--- a/tools/triage/elfs_cache.py
+++ b/tools/triage/elfs_cache.py
@@ -10,17 +10,22 @@ Usage:
 Description:
     Thread-safe data provider for caching ParsedElfFile objects.
     Provides an API for grabbing or caching ParsedElfFile objects by given elf path.
+    ELF files are accessed via mmap rather than held-open file descriptors.
 
 Owner:
     adjordjevic-TT
 """
 
+import mmap
 import os
 import threading
+
+from elftools.elf.elffile import ELFFile
+
 from triage import triage_singleton, ScriptConfig, run_script, TTTriageError
 from ttexalens.context import Context
 from ttexalens.hardware.risc_debug import ParsedElfFile
-from ttexalens.tt_exalens_lib import parse_elf
+from utils import INFO
 
 script_config = ScriptConfig(
     data_provider=True,
@@ -29,95 +34,89 @@ script_config = ScriptConfig(
 
 class ElfsCache:
     """
-    Thread-safe cache for ParsedElfFile objects.
-
-    This class provides a thread-safe API for caching and retrieving ParsedElfFile
-    objects parsed from ELF files. It automatically parses and caches ELF files
-    on first access and returns cached instances on subsequent requests.
+    Thread-safe cache for ParsedElfFile objects, backed by mmap.
+    When `enabled=False` the cache acts as a pass-through: every lookup
+    re-parses the ELF. Intended as a mitigation toggle via --disable-elf-cache
+    if the cache misbehaves.
     """
 
-    def __init__(self, context: Context):
-        """
-        Initialize the ELF cache.
-
-        Args:
-            context: ttexalens Context object for parsing ELF files
-        """
+    def __init__(self, context: Context, enabled: bool = True):
         self.context = context
+        self._enabled = enabled
         self._cache: dict[str, ParsedElfFile] = {}
         self._lock = threading.Lock()
 
+        self._distinct_paths: set[str] = set()
+        self._total_bytes = 0
+
     def __getitem__(self, elf_path: str) -> ParsedElfFile:
-        """
-        Get a ParsedElfFile from cache or parse and cache it if not present.
-
-        This method is thread-safe and will only parse each ELF file once,
-        returning the cached instance on subsequent calls.
-
-        Args:
-            elf_path: Path to the ELF file
-
-        Returns:
-            ParsedElfFile object for the given path
-        """
         if not os.path.exists(elf_path):
             raise TTTriageError(f"ELF file {elf_path} does not exist.")
+
         with self._lock:
-            if elf_path not in self._cache:
-                parsed_elf = parse_elf(elf_path, self.context)
-                if not parsed_elf:
-                    raise TTTriageError(
-                        f"Failed to extract DWARF info from ELF file {elf_path}.\nRun workload with TT_METAL_RISCV_DEBUG_INFO=1 to enable debug info."
-                    )
+            if self._enabled and elf_path in self._cache:
+                return self._cache[elf_path]
+
+            parsed_elf = self._parse(elf_path)
+
+            if elf_path not in self._distinct_paths:
+                self._distinct_paths.add(elf_path)
+                try:
+                    self._total_bytes += os.path.getsize(elf_path)
+                except OSError:
+                    pass
+
+            if self._enabled:
                 self._cache[elf_path] = parsed_elf
-            return self._cache[elf_path]
+            return parsed_elf
 
     def has_elf(self, elf_path: str) -> bool:
-        """
-        Check if an ELF file is already cached.
-
-        Args:
-            elf_path: Path to the ELF file
-
-        Returns:
-            True if the ELF file is cached, False otherwise
-        """
         with self._lock:
             return elf_path in self._cache
 
     def clear_cache(self) -> None:
-        """
-        Clear all cached ELF files.
-
-        This method removes all cached ParsedElfFile objects from the cache.
-        """
         with self._lock:
             self._cache.clear()
 
     def get_cached_paths(self) -> list[str]:
-        """
-        Get list of all cached ELF file paths.
-
-        Returns:
-            List of ELF file paths currently in the cache
-        """
         with self._lock:
             return list(self._cache.keys())
+
+    def log_stats(self) -> None:
+        with self._lock:
+            INFO(
+                f"elfs cache enabled={self._enabled}\n"
+                f"distinct elf files={len(self._distinct_paths)}\n"
+                f"total size={self._total_bytes / 1e6:.1f}MB\n"
+            )
+
+    @staticmethod
+    def _parse(elf_path: str) -> ParsedElfFile:
+        fd = os.open(elf_path, os.O_RDONLY)
+        try:
+            mm = mmap.mmap(fd, 0, prot=mmap.PROT_READ)
+        finally:
+            os.close(fd)
+
+        try:
+            elf = ELFFile(mm)
+            if not elf.has_dwarf_info():
+                mm.close()
+                raise TTTriageError(
+                    f"Failed to extract DWARF info from ELF file {elf_path}.\n"
+                    f"Run workload with TT_METAL_RISCV_DEBUG_INFO=1 to enable debug info."
+                )
+        except Exception:
+            mm.close()
+            raise
+
+        return ParsedElfFile(elf, elf_path)
 
 
 @triage_singleton
 def run(args, context: Context) -> ElfsCache:
-    """
-    Create and return a thread-safe ELF cache instance.
-
-    Args:
-        args: Script arguments (unused)
-        context: ttexalens Context object
-
-    Returns:
-        ElfsCache instance for caching ParsedElfFile objects
-    """
-    return ElfsCache(context)
+    enabled = not bool(args["--disable-elf-cache"])
+    return ElfsCache(context, enabled=enabled)
 
 
 if __name__ == "__main__":

--- a/tools/triage/elfs_cache.py
+++ b/tools/triage/elfs_cache.py
@@ -64,6 +64,8 @@ class ElfsCache:
                 try:
                     self._total_bytes += os.path.getsize(elf_path)
                 except OSError:
+                    # Size accounting is best-effort; a stat failure here
+                    # must not block ELF parsing or caching.
                     pass
 
             if self._enabled:
@@ -101,7 +103,6 @@ class ElfsCache:
         try:
             elf = ELFFile(mm)
             if not elf.has_dwarf_info():
-                mm.close()
                 raise TTTriageError(
                     f"Failed to extract DWARF info from ELF file {elf_path}.\n"
                     f"Run workload with TT_METAL_RISCV_DEBUG_INFO=1 to enable debug info."

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -995,12 +995,9 @@ def main():
         except Exception as e:
             utils.WARN(f"Failed to write triage summary: {e}")
 
-    try:
-        from elfs_cache import run as get_elfs_cache
+    from elfs_cache import run as get_elfs_cache
 
-        get_elfs_cache(args, context).log_stats()
-    except Exception as e:
-        utils.WARN(f"Failed to log elfs_cache stats: {e}")
+    get_elfs_cache(args, context).log_stats()
 
     # Remove nanobind leak check to avoid false positives on exit
     os._exit(0)

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,7 +5,7 @@
 
 """
 Usage:
-    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--triage-summary-path=<path>]
+    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>]
 
 Options:
     --remote-exalens                 Connect to remote exalens server.
@@ -23,6 +23,7 @@ Options:
                                      Level 2 (-vv): Include internal debug fields (RD PTR, Base, Offset, Kernel XIP Path)
     --disable-colors                 Disable colored output. [default: False]
     --disable-progress               Disable progress bars. [default: False]
+    --disable-elf-cache              Re-parse ELF files on every access instead of caching. [default: False]
     --triage-summary-path=<path>     Write a triage summary file to the given path (used by CI for hang reports).
 
 Description:
@@ -993,6 +994,13 @@ def main():
             utils.INFO(f"Triage summary written to {triage_summary_path}")
         except Exception as e:
             utils.WARN(f"Failed to write triage summary: {e}")
+
+    try:
+        from elfs_cache import run as get_elfs_cache
+
+        get_elfs_cache(args, context).log_stats()
+    except Exception as e:
+        utils.WARN(f"Failed to log elfs_cache stats: {e}")
 
     # Remove nanobind leak check to avoid false positives on exit
     os._exit(0)


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Moves elfs cache to use mmap instead of holding file descriptors open as we hit the limit of 1024 open files and triage fails on OS Error 24. mmap should have a limit of 65535.

Additionally adds a flag `--disable-elf-cache` that just disables elf cache for easy mitigation if something breaks.

Also adds an info log at the end of triage to track how many files were opened by elf cache and their size.

Closes https://github.com/tenstorrent/tt-exalens/issues/985

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/elf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/elf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/elf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/elf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/elf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/elf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/elf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/elf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/elf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/elf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/elf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/elf-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/elf-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/elf-cache)