### PR TITLE
Revert "Increase unroll insn limit [BUGFIX] (#42162)"

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -135,11 +135,8 @@ void JitBuildEnv::init(
 
     // Flags
     string common_flags =
-        "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval "
-        "-flto=auto -ffast-math -fno-exceptions "
-        // The default (200) is too small to unroll loops that it is
-        // profitable for us to do so.
-        "--param=max-completely-peeled-insns=350 ";
+        "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval"
+        " -flto=auto -ffast-math -fno-exceptions ";
 
     if (rtoptions.get_jit_analytics_enabled()) {
         common_flags += "-fdump-rtl-all -fdump-tree-original ";


### PR DESCRIPTION
## Summary
Reverts #42162 which added `--param=max-completely-peeled-insns=350` to JIT kernel compilation flags.

## Test plan
- [ ] CI sanity tests

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/revert-unroll-insn-limit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/revert-unroll-insn-limit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/revert-unroll-insn-limit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/revert-unroll-insn-limit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/revert-unroll-insn-limit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/revert-unroll-insn-limit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/revert-unroll-insn-limit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/revert-unroll-insn-limit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/revert-unroll-insn-limit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/revert-unroll-insn-limit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/revert-unroll-insn-limit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/revert-unroll-insn-limit)