### PR TITLE
Increase GPT-OSS test_model timeout to 1200s

### DIFF
--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -1059,6 +1059,7 @@ def run_model_forward_test(
     [1],
     ids=["1_layer"],
 )
+@pytest.mark.timeout(1200)
 def test_model(mesh_device, device_params, batch_size, seq_len, mode, mesh_shape, num_layers, reset_seeds):
     """
     Test full model forward pass comparing TT implementation to HuggingFace reference.


### PR DESCRIPTION
## Summary
`test_model` loads real weights for GPT-OSS 120B which takes ~7.5 minutes on T3K CI runners. The 600s pytest timeout kills it before it can finish (exit code 137).

Adds `@pytest.mark.timeout(900)` to give enough headroom.

Fixes https://github.com/tenstorrent/tt-metal/actions/runs/24693272778/job/72220858379

## Test plan
- [ ] T3K CI passes with the increased timeout

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/fix-gpt-oss-t3k-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/fix-gpt-oss-t3k-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/fix-gpt-oss-t3k-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/fix-gpt-oss-t3k-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/fix-gpt-oss-t3k-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/fix-gpt-oss-t3k-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/fix-gpt-oss-t3k-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/fix-gpt-oss-t3k-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/fix-gpt-oss-t3k-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/fix-gpt-oss-t3k-test-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/fix-gpt-oss-t3k-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/fix-gpt-oss-t3k-test-timeout)