### PR TITLE
fix: add quasar arch to get_string_lowercase()

### DIFF
--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -16,6 +16,7 @@ inline std::string get_string_lowercase(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: return "wormhole_b0";
         case tt::ARCH::BLACKHOLE: return "blackhole";
+        case tt::ARCH::QUASAR: return "quasar";
         case tt::ARCH::Invalid:
         default: return "invalid";
     }

--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/driver_atomics.hpp>
 #include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/simulation/simulation_chip.hpp>
@@ -11,16 +12,6 @@
 #include "llrt/tt_cluster.hpp"  // Full definition needed for Cluster::is_mock_or_emulated()
 
 #include <string>
-
-inline std::string get_string_lowercase(tt::ARCH arch) {
-    switch (arch) {
-        case tt::ARCH::WORMHOLE_B0: return "wormhole_b0";
-        case tt::ARCH::BLACKHOLE: return "blackhole";
-        case tt::ARCH::QUASAR: return "quasar";
-        case tt::ARCH::Invalid:
-        default: return "invalid";
-    }
-}
 
 namespace tt::test_utils {
 inline std::string get_env_arch_name() {
@@ -55,12 +46,12 @@ inline std::string get_umd_arch_name() {
         TT_FATAL(
             arch == detected_arch,
             "Expected all devices to be {} but device {} is {}",
-            get_string_lowercase(arch),
+            tt::get_string_lowercase(arch),
             device_id,
-            get_string_lowercase(detected_arch));
+            tt::get_string_lowercase(detected_arch));
     }
 
-    return get_string_lowercase(arch);
+    return tt::get_string_lowercase(arch);
 
 }
 

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -14,6 +14,7 @@ std::string tt::get_string(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: return "WORMHOLE_B0"; break;
         case tt::ARCH::BLACKHOLE: return "BLACKHOLE"; break;
+        case tt::ARCH::QUASAR: return "QUASAR"; break;
         case tt::ARCH::Invalid:
         default: return "Invalid"; break;
     }
@@ -23,6 +24,7 @@ std::string tt::get_string_lowercase(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: return "wormhole_b0"; break;
         case tt::ARCH::BLACKHOLE: return "blackhole"; break;
+        case tt::ARCH::QUASAR: return "quasar"; break;
         case tt::ARCH::Invalid:
         default: return "invalid"; break;
     }
@@ -32,6 +34,7 @@ std::string tt::get_alias(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: return "wormhole"; break;
         case tt::ARCH::BLACKHOLE: return "blackhole"; break;
+        case tt::ARCH::QUASAR: return "quasar"; break;
         default: return "invalid"; break;
     }
 }


### PR DESCRIPTION
### Summary
Quasar architecture was missing from get_string_lowercase().

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/add-quasar-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/add-quasar-arch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=filip/add-quasar-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/add-quasar-arch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/add-quasar-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/add-quasar-arch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/add-quasar-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/add-quasar-arch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/add-quasar-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/add-quasar-arch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/add-quasar-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/add-quasar-arch)