### PR TITLE
ttnn.reshape: apply pad_value for tiled tensors

### DIFF
--- a/models/demos/vision/segmentation/vgg_unet/wormhole/tests/perf/test_perf_vgg_unet.py
+++ b/models/demos/vision/segmentation/vgg_unet/wormhole/tests/perf/test_perf_vgg_unet.py
@@ -11,7 +11,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 293],
+        [1, 302],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_tm_reshape.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_tm_reshape.py
@@ -102,21 +102,27 @@ def test_reshape_tiled_pad_value(device, input_shape, output_shape, pad_value):
         _assert_padding_filled(tt_output, full, pad_value)
 
 
-def test_reshape_tiled_default_pad_is_zero(device):
-    """Without an explicit pad_value, padded tile regions must default to 0 (issue #22178)."""
-    torch_input = torch.ones((12,), dtype=torch.float32)
+def test_reshape_tiled_no_pad_value_does_not_fill(device):
+    """Without an explicit pad_value, non-BFLOAT8_B reshape must not dispatch a fill.
+
+    Contract: ``ttnn.reshape(tensor, shape)`` is a zero-cost view-reinterpretation that does
+    not touch padding lanes. Writing into padding lanes of prim::reshape_view's output
+    would corrupt logical lanes of aliased buffers (see tt-train AdamW regression). The
+    explicit ``pad_value=0.0`` case is covered by test_reshape_tiled_pad_value; BFLOAT8_B
+    force-fill is covered by test_reshape_tiled_pad_value_bfloat8_b.
+
+    This test verifies two observable properties on the default path:
+      1. Logical values round-trip unchanged (the reshape is functionally correct).
+      2. Padding lanes are NOT unconditionally rewritten to 0 (no default fill side effect).
+    """
+    # 1..12, distinguishable from a default-zero fill.
+    torch_input = torch.arange(1, 13, dtype=torch.float32)
     tt_input = ttnn.from_torch(torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
     tt_output = ttnn.reshape(tt_input, (12, 1, 1))
-    full = _read_padded_region(tt_output)
 
-    # Logical values preserved.
     logical = ttnn.to_torch(tt_output).reshape(-1)
-    assert torch.equal(logical, torch_input.reshape(-1)), "Default fill path corrupted logical values"
-
-    # Per-lane check: every padding lane must be exactly 0.0 (default pad_value).
-    if full.numel() > logical.numel():
-        _assert_padding_filled(tt_output, full, 0.0)
+    assert torch.equal(logical, torch_input.reshape(-1)), "Reshape corrupted logical values"
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_tm_reshape.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_tm_reshape.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+# Shared sharded-memory-config builder lives in the sibling reshape test file; importing
+# it (instead of duplicating ~80 LoC of identical grid/alignment logic) keeps the two
+# reshape suites aligned when those rules change.
+from tests.ttnn.nightly.unit_tests.operations.data_movement.test_universal_input_tm_reshape import (
+    make_sharded_memory_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Check pad_value behavior for tiled reshape.
+# ---------------------------------------------------------------------------
+
+
+def _read_padded_region(tensor):
+    """Host view of the padded buffer via ``reshape(padded_shape, padded_shape)``.
+
+    Inner-2D is tile-aligned, so ``has_inner_2d_tile_padding`` is false and no fill runs
+    even without ``skip_padding_fill``. Pass it explicitly anyway: this reshape is a pure
+    view re-expression for inspection, never a logical pad — the flag self-documents that
+    intent and guards against future relaxation of the alignment check.
+    """
+    padded = ttnn.reshape(tensor, tensor.padded_shape, tensor.padded_shape, skip_padding_fill=True)
+    return ttnn.to_torch(padded)
+
+
+def _padding_mask(padded_shape, logical_shape):
+    """True at implicit tile-padding positions, False at logical positions.
+
+    TILE_LAYOUT pads only the inner 2D, but outer dims also count if logical < padded.
+    Logical region is ``[:d0, :d1, ..., :dn]`` for ``logical_shape == [d0, ..., dn]``.
+    """
+    padded = tuple(int(d) for d in padded_shape)
+    logical = tuple(int(d) for d in logical_shape)
+    assert len(padded) == len(logical), f"rank mismatch: padded={padded}, logical={logical}"
+    mask = torch.ones(padded, dtype=torch.bool)
+    mask[tuple(slice(0, d) for d in logical)] = False
+    return mask
+
+
+def _assert_padding_filled(tt_output, full_padded_torch, pad_value, *, atol=0.0, rtol=0.0):
+    """Per-lane check: every implicit-tile-padding position equals ``pad_value`` (within tol).
+
+    Uses a layout-accurate mask derived from ``(padded_shape, logical_shape)`` so cancelling
+    wrong values across lanes can't fool the assertion (unlike a sum-only check).
+    """
+    mask = _padding_mask(tt_output.padded_shape, tt_output.shape)
+    padding_values = full_padded_torch[mask]
+    expected = torch.full_like(padding_values, pad_value)
+    if atol == 0.0 and rtol == 0.0:
+        ok = torch.equal(padding_values, expected)
+    else:
+        ok = torch.allclose(padding_values, expected, atol=atol, rtol=rtol)
+    if not ok:
+        diff = (padding_values - expected).abs()
+        bad = diff > max(atol, rtol * abs(pad_value))
+        n_bad = int(bad.sum().item())
+        sample = padding_values[bad][:8].tolist()
+        raise AssertionError(
+            f"Padded region not uniformly filled with pad_value={pad_value}: "
+            f"{n_bad}/{padding_values.numel()} lanes differ. "
+            f"max_abs_diff={diff.max().item():.6g}, first_bad_values={sample}"
+        )
+
+
+@pytest.mark.parametrize(
+    "input_shape,output_shape",
+    [
+        ((12,), (12, 1, 1)),
+        ((32, 32), (32, 16, 2)),
+        ((1, 96), (3, 1, 32)),
+    ],
+    ids=["issue_22178", "tile_to_sub_tile", "reshape_1d_to_3d"],
+)
+@pytest.mark.parametrize("pad_value", [0.0, 1.0, -2.5], ids=["pad_0", "pad_1", "pad_neg"])
+def test_reshape_tiled_pad_value(device, input_shape, output_shape, pad_value):
+    """Padded tile regions must be filled with pad_value (issue #22178)."""
+    torch.manual_seed(0)
+    torch_input = torch.arange(1, int(torch.tensor(input_shape).prod().item()) + 1, dtype=torch.float32).reshape(
+        input_shape
+    )
+
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = ttnn.reshape(tt_input, output_shape, pad_value=pad_value)
+
+    full = _read_padded_region(tt_output)
+
+    # Logical volume preserved and values unchanged.
+    logical = ttnn.to_torch(tt_output).reshape(-1)
+    assert torch.equal(logical, torch_input.reshape(-1)), "Logical values changed during reshape"
+
+    # Per-lane check via a layout-accurate padding mask. Float32 is exact: tol=0.
+    if full.numel() > logical.numel():
+        _assert_padding_filled(tt_output, full, pad_value)
+
+
+def test_reshape_tiled_default_pad_is_zero(device):
+    """Without an explicit pad_value, padded tile regions must default to 0 (issue #22178)."""
+    torch_input = torch.ones((12,), dtype=torch.float32)
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tt_output = ttnn.reshape(tt_input, (12, 1, 1))
+    full = _read_padded_region(tt_output)
+
+    # Logical values preserved.
+    logical = ttnn.to_torch(tt_output).reshape(-1)
+    assert torch.equal(logical, torch_input.reshape(-1)), "Default fill path corrupted logical values"
+
+    # Per-lane check: every padding lane must be exactly 0.0 (default pad_value).
+    if full.numel() > logical.numel():
+        _assert_padding_filled(tt_output, full, 0.0)
+
+
+@pytest.mark.parametrize(
+    "input_shape,output_shape",
+    [
+        # Tile-aligned input (128 = 4*32, 128 = 4*32) -> output with inner-2D padding.
+        ([128, 128], [128, 4, 32]),
+        # Tile-padded input (100 is not a multiple of 32: input pads H 100->128) -> output
+        # with inner-2D padding. Exercises the fill on top of an input that itself has
+        # implicit tile padding lanes.
+        ([100, 96], [100, 3, 32]),
+    ],
+    ids=["aligned_in_padded_out", "padded_in_padded_out"],
+)
+@pytest.mark.parametrize(
+    "strategy",
+    [ttnn.ShardStrategy.HEIGHT, ttnn.ShardStrategy.WIDTH, ttnn.ShardStrategy.BLOCK],
+    ids=["height", "width", "block"],
+)
+@pytest.mark.parametrize("pad_value", [0.0, 1.0, -2.5], ids=["pad_0", "pad_1", "pad_neg"])
+def test_reshape_tiled_pad_value_sharded(device, input_shape, output_shape, strategy, pad_value):
+    """Sharded tiled reshape: pad_value must fill the implicit tile-padding lanes."""
+    torch.manual_seed(0)
+    torch_input = torch.arange(1, int(torch.tensor(input_shape).prod().item()) + 1, dtype=torch.bfloat16).reshape(
+        input_shape
+    )
+
+    input_mem_cfg = make_sharded_memory_config(device, input_shape, strategy, ttnn.TILE_LAYOUT)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+        memory_config=input_mem_cfg,
+    )
+
+    tt_output = ttnn.reshape(tt_input, output_shape, pad_value=pad_value)
+
+    # Logical values preserved.
+    logical = ttnn.to_torch(tt_output).reshape(-1).to(torch.float32)
+    assert torch.equal(logical, torch_input.reshape(-1).to(torch.float32)), "Logical values changed during reshape"
+
+    # Per-lane padding check (bf16 round-trip exact for 0.0, 1.0, -2.5 since they fit in 8 bits).
+    full = _read_padded_region(tt_output).to(torch.float32)
+    assert full.numel() > logical.numel(), "Test expects the output to have tile padding"
+    _assert_padding_filled(tt_output, full, pad_value)
+
+
+# ---------------------------------------------------------------------------
+# BFLOAT8_B pad_value path: fill runs on the bfloat16 intermediate before the
+# typecast back to BFLOAT8_B; use PCC rather than exact equality.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_shape,output_shape",
+    [
+        ((32, 32), (32, 16, 2)),
+        ((1, 96), (3, 1, 32)),
+    ],
+    ids=["tile_to_sub_tile", "reshape_1d_to_3d"],
+)
+def test_reshape_tiled_pad_value_bfloat8_b(device, input_shape, output_shape):
+    """BFLOAT8_B interleaved reshape: fill happens on the bf16 intermediate before re-typecast.
+
+    Uses pad_value=0.0 because BF8 is a block-float format (16-element sub-blocks with shared exponent):
+    a small pad_value in a sub-block that also contains large logical values quantizes to ~0, making
+    exact-sum checks unreliable. 0.0 is represented exactly for any block exponent, so the check is clean.
+    """
+    torch.manual_seed(0)
+    torch_input = torch.arange(1, int(torch.tensor(input_shape).prod().item()) + 1, dtype=torch.bfloat16).reshape(
+        input_shape
+    )
+
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = ttnn.reshape(tt_input, output_shape, pad_value=0.0)
+
+    # Logical values preserved within BF8 quantization (PCC).
+    actual = ttnn.to_torch(tt_output).reshape(-1).to(torch.float32)
+    expected_logical = torch_input.reshape(-1).to(torch.float32)
+    assert_with_pcc(expected_logical, actual, 0.99)
+
+    # Per-lane padding check. pad_value=0.0 is exactly representable for any BF8 shared
+    # exponent (0 * 2^exp = 0), so the round-trip is exact and atol=0 is correct.
+    full = _read_padded_region(tt_output).to(torch.float32)
+    if full.numel() > actual.numel():
+        _assert_padding_filled(tt_output, full, 0.0)
+
+
+@pytest.mark.parametrize(
+    "input_shape,output_shape",
+    [([128, 128], [128, 4, 32])],
+    ids=["aligned_in_padded_out"],
+)
+@pytest.mark.parametrize(
+    "strategy",
+    [ttnn.ShardStrategy.HEIGHT, ttnn.ShardStrategy.WIDTH, ttnn.ShardStrategy.BLOCK],
+    ids=["height", "width", "block"],
+)
+def test_reshape_tiled_pad_value_sharded_bfloat8_b(device, input_shape, output_shape, strategy):
+    """Sharded BFLOAT8_B tiled reshape: pad_value must fill the implicit tile-padding lanes.
+
+    Uses pad_value=0.0: BF8's shared exponent makes other values lossy, but 0.0 is exact.
+    """
+    torch.manual_seed(0)
+    torch_input = torch.arange(1, int(torch.tensor(input_shape).prod().item()) + 1, dtype=torch.bfloat16).reshape(
+        input_shape
+    )
+
+    input_mem_cfg = make_sharded_memory_config(device, input_shape, strategy, ttnn.TILE_LAYOUT)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        memory_config=input_mem_cfg,
+    )
+    tt_output = ttnn.reshape(tt_input, output_shape, pad_value=0.0)
+
+    # Logical values preserved within BF8 quantization (PCC).
+    actual = ttnn.to_torch(tt_output).reshape(-1).to(torch.float32)
+    expected_logical = torch_input.reshape(-1).to(torch.float32)
+    assert_with_pcc(expected_logical, actual, 0.99)
+
+    # Per-lane padding check. pad_value=0.0 is exactly representable for any BF8 shared
+    # exponent, so atol=0 holds.
+    full = _read_padded_region(tt_output).to(torch.float32)
+    if full.numel() > actual.numel():
+        _assert_padding_filled(tt_output, full, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Integer dtypes: pad_value_as_float() takes the static_cast<float>(uint32_t) branch
+# (not the FLOAT32 bit_cast); fill_pad_program_factory then packs via
+# static_cast<uint32_t>(fill_value). Small integer pad values (< 2^24) round-trip
+# exactly through this float bottleneck, which the float-dtype tests above do not
+# exercise.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [ttnn.int32, ttnn.uint32], ids=["int32", "uint32"])
+@pytest.mark.parametrize("pad_value", [0, 1, 7], ids=["pad_0", "pad_1", "pad_7"])
+def test_reshape_tiled_pad_value_integer(device, dtype, pad_value):
+    """Integer tiled reshape: confirms the integer fill path doesn't crash AND that small
+    pad_values round-trip exactly through the pad_value_as_float -> fill_pad path."""
+    torch.manual_seed(0)
+    torch_input = torch.arange(1, 13, dtype=torch.int32)  # shape (12,)
+    tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = ttnn.reshape(tt_input, (12, 1, 1), pad_value=pad_value)
+
+    # Logical integer values preserved.
+    logical = ttnn.to_torch(tt_output).reshape(-1).to(torch.int64)
+    assert torch.equal(logical, torch_input.to(torch.int64)), "Logical int values changed during reshape"
+
+    # Per-lane padding check (integer round-trip is exact for small values).
+    full = _read_padded_region(tt_output).to(torch.int64)
+    assert full.numel() > logical.numel(), "Test expects output to have tile padding"
+    _assert_padding_filled(tt_output, full, pad_value)
+
+
+# ---------------------------------------------------------------------------
+# skip_padding_fill opt-out: callers that handle padding downstream can skip
+# the fill_implicit_tile_padding dispatch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [None, ttnn.ShardStrategy.HEIGHT, ttnn.ShardStrategy.WIDTH, ttnn.ShardStrategy.BLOCK],
+    ids=["interleaved", "height", "width", "block"],
+)
+def test_reshape_tiled_skip_padding_fill(device, strategy):
+    """skip_padding_fill=True preserves logical values AND skips the fill_pad dispatch.
+
+    Observable: program-cache delta. Default path caches strictly more programs than the
+    skip path -- the missing one is fill_pad (plus, for sharded outputs, the s2i/i2s
+    detour around it). Cache must be enabled + cleared before each reshape so each count
+    reflects only that call. ``strategy=None`` is interleaved; others are sharded.
+    """
+    PAD_VALUE = 42.0  # exact in bf16 (fits in 7 bits) -> per-lane check is exact.
+
+    torch.manual_seed(0)
+    input_shape = [100, 96]
+    output_shape = [100, 3, 32]
+    torch_input = torch.arange(1, int(torch.tensor(input_shape).prod().item()) + 1, dtype=torch.bfloat16).reshape(
+        input_shape
+    )
+
+    input_mem_cfg = (
+        make_sharded_memory_config(device, input_shape, strategy, ttnn.TILE_LAYOUT) if strategy is not None else None
+    )
+    tt_input = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+        memory_config=input_mem_cfg,
+    )
+
+    device.enable_program_cache()
+
+    device.clear_program_cache()
+    tt_filled = ttnn.reshape(tt_input, output_shape, pad_value=PAD_VALUE)
+    n_default = device.num_program_cache_entries()
+
+    device.clear_program_cache()
+    tt_skip = ttnn.reshape(tt_input, output_shape, pad_value=PAD_VALUE, skip_padding_fill=True)
+    n_skip = device.num_program_cache_entries()
+
+    # Property (1): default path dispatched strictly more programs than skip path.
+    assert n_default > n_skip, (
+        f"skip_padding_fill=True did not skip the fill dispatch: "
+        f"default-path cache entries={n_default}, skip-path cache entries={n_skip} "
+        f"(expected default > skip by the fill_pad program count)"
+    )
+
+    # Property (2): logical correctness on both paths; default path's padding is filled.
+    expected = torch_input.reshape(-1).to(torch.float32)
+    assert torch.equal(
+        ttnn.to_torch(tt_skip).reshape(-1).to(torch.float32), expected
+    ), "skip_padding_fill=True must not corrupt logical values"
+    assert torch.equal(
+        ttnn.to_torch(tt_filled).reshape(-1).to(torch.float32), expected
+    ), "Default fill path corrupted logical values"
+    full_filled = _read_padded_region(tt_filled).to(torch.float32)
+    assert full_filled.numel() > expected.numel(), "Test expects output to have tile padding"
+    _assert_padding_filled(tt_filled, full_filled, PAD_VALUE)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [None, ttnn.ShardStrategy.HEIGHT, ttnn.ShardStrategy.WIDTH, ttnn.ShardStrategy.BLOCK],
+    ids=["interleaved", "height", "width", "block"],
+)
+def test_reshape_tiled_skip_padding_fill_bfloat8_b_is_force_filled(device, strategy):
+    """skip_padding_fill=True is silently ignored for BFLOAT8_B.
+
+    BF8 shares an exponent per 16-elem sub-block, so unfilled padding would corrupt
+    logical lanes. Asserts ``n_skip == n_default`` program-cache entries: equality proves
+    fill_pad ran on both paths. ``strategy=None`` is interleaved; others are sharded.
+    """
+    PAD_VALUE = 0.0
+
+    torch.manual_seed(0)
+    input_shape = [100, 96]
+    output_shape = [100, 3, 32]
+    torch_input = torch.arange(1, int(torch.tensor(input_shape).prod().item()) + 1, dtype=torch.bfloat16).reshape(
+        input_shape
+    )
+
+    input_mem_cfg = (
+        make_sharded_memory_config(device, input_shape, strategy, ttnn.TILE_LAYOUT) if strategy is not None else None
+    )
+    tt_input = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        memory_config=input_mem_cfg,
+    )
+
+    device.enable_program_cache()
+
+    device.clear_program_cache()
+    tt_default = ttnn.reshape(tt_input, output_shape, pad_value=PAD_VALUE)
+    n_default = device.num_program_cache_entries()
+
+    device.clear_program_cache()
+    tt_skip = ttnn.reshape(tt_input, output_shape, pad_value=PAD_VALUE, skip_padding_fill=True)
+    n_skip = device.num_program_cache_entries()
+
+    # Force-fill observable: skip is ignored for BF8, so both paths dispatch the same set of
+    # programs (including fill_pad). If skip were honoured, n_skip would be strictly smaller.
+    assert n_skip == n_default, (
+        f"BF8 skip_padding_fill must be silently ignored: default cache entries={n_default}, "
+        f"skip cache entries={n_skip}. A smaller skip count means fill_pad was dropped -- "
+        f"that would expose logical lanes to shared-exponent corruption in BF8 sub-blocks."
+    )
+
+    # Sanity: logical values survive on both paths (PCC, since BF8 quantises).
+    expected = torch_input.reshape(-1).to(torch.float32)
+    assert_with_pcc(expected, ttnn.to_torch(tt_default).reshape(-1).to(torch.float32), 0.99)
+    assert_with_pcc(expected, ttnn.to_torch(tt_skip).reshape(-1).to(torch.float32), 0.99)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -157,6 +157,12 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
 
+        # BFLOAT8_B tensors are TILE-only (shared exponent in 16-elem sub-blocks
+        # is undefined under ROW_MAJOR). Round-trip via BFLOAT16 for host inspection.
+        # Pre-PR #42770, fill_implicit_tile_padding leaked BFLOAT16 on rank-4 BFP8
+        # inputs, silently upcasting in0_t and producing BFLOAT16 layer_norm output.
+        if ttz.dtype == ttnn.bfloat8_b:
+            ttz = ttnn.typecast(ttz, ttnn.bfloat16)
         tt_got_back = ttz.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 
         pt_in = in0 + in1 if test_id <= 5 else in0
@@ -167,13 +173,24 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
 
         ref_lnorm = ref_fn(pt_in, gamma.flatten(), beta.flatten(), epsf)
 
+        # BFLOAT8_B layer_norm uses a shared exponent per 16-element sub-block, so its
+        # accuracy on small inner dims (e.g. width=42 padded to tile=64, ~1k elements)
+        # is fundamentally lower than BFLOAT16/FLOAT32. Worst observed across the 12
+        # (test_id, shape) cases: ATOL=0.86, relFro=0.186, PCC=0.984. Pre-PR #42770
+        # these never triggered because the fill_implicit_tile_padding dtype leak
+        # silently ran the norm in BFLOAT16.
+        if in_dtype == ttnn.bfloat8_b:
+            pcc_threshold, atol, frobenius_threshold = 0.98, 1.0, 0.22
+        else:
+            pcc_threshold, atol, frobenius_threshold = 0.999, 0.098, 0.016
+
         assert_numeric_metrics(
             ref_lnorm,
             tt_got_back,
-            pcc_threshold=0.999,
+            pcc_threshold=pcc_threshold,
             rtol=3.266,
-            atol=0.098,
-            frobenius_threshold=0.016,
+            atol=atol,
+            frobenius_threshold=frobenius_threshold,
         )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_interleaved.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_interleaved.py
@@ -127,13 +127,17 @@ def test_softmax_mix_precision(device, inplace, in_dtype):
         golden_output_tensor = torch.softmax(input_tensor, dim=-1)
         print_diff_argmax(tt_output_tensor, golden_output_tensor)
 
+        # BF8 thresholds loosened: shared-exponent quantization amplified by softmax's
+        # exp()+normalize. Was previously masked by fill_implicit_tile_padding leaking
+        # BF16 on rank>3 inputs (PR #42770).
+        is_bfp8 = in_dtype == ttnn.bfloat8_b
         assert_numeric_metrics(
             golden_output_tensor,
             tt_output_tensor,
-            pcc_threshold=0.999,
+            pcc_threshold=0.99 if is_bfp8 else 0.999,
             rtol=1.186,
-            atol=0.026,
-            frobenius_threshold=0.032,
+            atol=0.05 if is_bfp8 else 0.026,
+            frobenius_threshold=0.08 if is_bfp8 else 0.032,
         )
 
 

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -563,8 +563,8 @@ def test_reshape_subgrid(device, input_shape, output_shape, layout, memory_confi
     assert_equal(torch_result, output)
 
 
-@pytest.mark.parametrize("recreate_mapping_tensor", (ttnn.TileReshapeMapMode.CACHE, ttnn.TileReshapeMapMode.RECREATE))
-def test_reshape_tile_program_cache(device, recreate_mapping_tensor):
+@pytest.mark.parametrize("reshape_tile_mode", (ttnn.TileReshapeMapMode.CACHE, ttnn.TileReshapeMapMode.RECREATE))
+def test_reshape_tile_program_cache(device, reshape_tile_mode):
     for input_shape, output_shape in ((1, 8, 8), (1, 16, 4)), ((16, 1, 5), (4, 2, 10)):
         for _ in range(3):
             torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
@@ -573,7 +573,7 @@ def test_reshape_tile_program_cache(device, recreate_mapping_tensor):
             input_tensor = ttnn.from_torch(
                 torch_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device
             )
-            ttnn_output = ttnn.reshape(input_tensor, output_shape, recreate_mapping_tensor=recreate_mapping_tensor)
+            ttnn_output = ttnn.reshape(input_tensor, output_shape, reshape_tile_mode=reshape_tile_mode)
 
             output = ttnn.to_torch(ttnn_output)
             assert_equal(torch_result, output)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
@@ -148,6 +148,11 @@ def test_fill_pad_bfloat8_b(
     )
 
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=output_mem_config)
+    # Guard against the rank>3 dtype leak: BFLOAT8_B inputs typecast through BFLOAT16 internally,
+    # but the helper must cast back to BFLOAT8_B on every return path (incl. the rank>3 reshape branch).
+    assert (
+        output_tensor.dtype == dtype
+    ), f"fill_implicit_tile_padding leaked dtype: expected {dtype}, got {output_tensor.dtype}"
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
     # bfloat8_b is a reduced-precision format; keep PCC-based validation for stability.

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_h_interleaved.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_h_interleaved.py
@@ -183,5 +183,5 @@ def test_2D_tensor(device, batch_size, h, w, c, n, dim, input_dtype, input_memor
         pcc_threshold=0.999,
         rtol=1.021,
         atol=12.240,
-        frobenius_threshold=0.009,
+        frobenius_threshold=0.011,
     )

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/core/core.hpp"
 #include <utility>
 #include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 
 namespace ttnn {
 
@@ -17,7 +18,7 @@ Tensor fill_implicit_tile_padding(
     uint32_t padded_height =
         tt::div_up(input_tensor.logical_shape()[-2], tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;
     uint32_t padded_width =
-        tt::div_up(input_tensor.logical_shape()[-1], tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;
+        tt::div_up(input_tensor.logical_shape()[-1], tt::constants::TILE_WIDTH) * tt::constants::TILE_WIDTH;
     if (padded_width == input_tensor.logical_shape()[-1] && padded_height == input_tensor.logical_shape()[-2]) {
         return input_tensor;
     }
@@ -26,6 +27,7 @@ Tensor fill_implicit_tile_padding(
     if (input_tensor.dtype() == DataType::BFLOAT8_B) {
         mutable_input_tensor = ttnn::typecast(mutable_input_tensor, DataType::BFLOAT16);
     }
+    Tensor output_tensor;
     // if input_tensor is rank > 3, then we need to reshape it to rank 3 such that the last 2 dims are the same
     if (mutable_input_tensor.logical_shape().rank() > 3) {
         ttnn::Shape original_shape = mutable_input_tensor.logical_shape();
@@ -36,12 +38,33 @@ Tensor fill_implicit_tile_padding(
         }
 
         ttnn::Shape new_shape = ttnn::Shape{std::array<uint32_t, 3>{third_dim, original_shape[-2], original_shape[-1]}};
-        auto reshaped_tensor = ttnn::reshape(mutable_input_tensor, new_shape);
+        // skip_padding_fill=true breaks a potential recursion: ttnn::reshape now calls fill_implicit_tile_padding
+        // for tiled outputs, and this helper calls ttnn::reshape. The inner reshapes here should never touch
+        // padding lanes (they are pure rank re-views), so opt out of the fill dispatch explicitly.
+        auto reshaped_tensor = ttnn::reshape(
+            mutable_input_tensor,
+            new_shape,
+            /*memory_config=*/std::nullopt,
+            /*pad_value=*/std::nullopt,
+            ttnn::TileReshapeMapMode::CACHE,
+            /*sub_core_grid=*/std::nullopt,
+            /*skip_padding_fill=*/true);
 
         reshaped_tensor = ttnn::prim::fill_pad(reshaped_tensor, fill_value, output_memory_config);
-        return ttnn::reshape(reshaped_tensor, original_shape);
+        output_tensor = ttnn::reshape(
+            reshaped_tensor,
+            original_shape,
+            /*memory_config=*/std::nullopt,
+            /*pad_value=*/std::nullopt,
+            ttnn::TileReshapeMapMode::CACHE,
+            /*sub_core_grid=*/std::nullopt,
+            /*skip_padding_fill=*/true);
+    } else {
+        output_tensor = ttnn::prim::fill_pad(mutable_input_tensor, fill_value, output_memory_config);
     }
-    auto output_tensor = ttnn::prim::fill_pad(mutable_input_tensor, fill_value, output_memory_config);
+    // BFLOAT8_B was typecast to BFLOAT16 above for fill_pad; restore the original dtype on every return path,
+    // including the rank>3 branch (previously the cast-back only fired on the rank<=3 path, leaking BFLOAT16
+    // for rank>3 BFLOAT8_B inputs).
     if (input_tensor.dtype() == DataType::BFLOAT8_B) {
         return ttnn::typecast(output_tensor, DataType::BFLOAT8_B);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <functional>
+#include <type_traits>
 #include <utility>
+#include <variant>
 
+#include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <ttnn/tensor/layout/tensor_layout.hpp>
 #include <ttnn/tensor/tensor_spec.hpp>
@@ -12,6 +16,7 @@
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 #include "ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp"
 #include "ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp"
@@ -38,6 +43,30 @@ static uint32_t find_best_n_1d(uint32_t dim, uint32_t max_n, uint32_t align) {
         }
     }
     return 0;
+}
+
+// Flatten PadValue to float for fill_implicit_tile_padding.
+//   - uint32 + FLOAT32: caller-supplied uint32 is the bit pattern of the desired float, use bit_cast.
+//   - Otherwise: caller-supplied value is a numeric integer or float, use static_cast.
+// Note: integer pad values > 2^24 lose precision through this float bottleneck.
+static float pad_value_as_float(const PadValue& pad_value, DataType dtype) {
+    return std::visit(
+        [dtype](auto v) -> float {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (std::is_same_v<T, uint32_t>) {
+                if (dtype == DataType::FLOAT32) {
+                    return std::bit_cast<float>(v);
+                }
+            }
+            return static_cast<float>(v);
+        },
+        pad_value);
+}
+
+// True if the inner-2D of `shape` is not tile-aligned, i.e. the tiled output has implicit padding lanes.
+static bool has_inner_2d_tile_padding(const ttnn::Shape& shape) {
+    TT_ASSERT(shape.rank() >= 2, "has_inner_2d_tile_padding requires rank >= 2");
+    return (shape[-1] % tt::constants::TILE_WIDTH != 0) || (shape[-2] % tt::constants::TILE_HEIGHT != 0);
 }
 
 // Returns a sharded output MemoryConfig, or INTERLEAVED if no valid grid exists.
@@ -285,10 +314,13 @@ ttnn::Tensor reshape_tiled(
     const ttnn::Tensor& tensor,
     const ttnn::Shape& logical_shape,
     const MemoryConfig& memory_config,
-    const PadValue& /*pad_value*/,
+    const PadValue& pad_value,
     const bool recreate_mapping_tensor,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    bool explicit_memory_config) {
+    bool explicit_memory_config,
+    const bool skip_padding_fill) {
+    // fill_implicit_tile_padding takes float; integer pad is not bit-exact for all dtypes/values.
+    const float fill_value = detail::pad_value_as_float(pad_value, tensor.dtype());
     // squeeze input tensor and requested shape to 3D
     auto transform_to_3d = [](const auto& shape) -> ttnn::Shape {
         if (shape.rank() > 3) {
@@ -334,6 +366,12 @@ ttnn::Tensor reshape_tiled(
                 working_output_memory_config,
                 recreate_mapping_tensor,
                 sub_core_grid);
+            // Fill in BF16 (rank-3, non-recursive). skip_padding_fill is *intentionally*
+            // ignored for BF8: shared exponent over 16-elem sub-blocks would otherwise let
+            // unfilled padding corrupt logical lanes. See skip_padding_fill docstring.
+            if (detail::has_inner_2d_tile_padding(requested_shape_3d)) {
+                output_tensor_3d = ttnn::fill_implicit_tile_padding(output_tensor_3d, fill_value, std::nullopt);
+            }
             output_tensor_3d = ttnn::typecast(output_tensor_3d, tensor.dtype());
             if (memory_config.is_sharded()) {
                 auto output_mem_config = detail::recompute_shard_spec_for_output(
@@ -377,6 +415,23 @@ ttnn::Tensor reshape_tiled(
             recreate_mapping_tensor,
             sub_core_grid);
 
+        // Fill implicit tile padding. Output may be sharded (typical) or INTERLEAVED if
+        // recompute fell back; handle both. Tensors here are rank-3, so the fill stays
+        // on its non-recursive path and cannot loop back into ttnn::reshape.
+        if (!skip_padding_fill && detail::has_inner_2d_tile_padding(requested_shape_3d)) {
+            if (output_tensor_3d.memory_config().is_sharded()) {
+                // TODO(#43090): drop this s2i/i2s detour once prim::fill_pad supports sharded buffers
+                // without overflowing fill_pad_writer's per-core runtime-arg cap (341).
+                const auto sharded_mem_config = output_tensor_3d.memory_config();
+                MemoryConfig interleaved_mem{TensorMemoryLayout::INTERLEAVED, sharded_mem_config.buffer_type()};
+                auto interleaved = ttnn::sharded_to_interleaved(output_tensor_3d, interleaved_mem, std::nullopt);
+                interleaved = ttnn::fill_implicit_tile_padding(interleaved, fill_value, std::nullopt);
+                output_tensor_3d = ttnn::interleaved_to_sharded(interleaved, sharded_mem_config, std::nullopt);
+            } else {
+                output_tensor_3d = ttnn::fill_implicit_tile_padding(output_tensor_3d, fill_value, std::nullopt);
+            }
+        }
+
         return PerformView(output_tensor_3d, logical_shape, compute_padded_shape(logical_shape));
     }
 
@@ -419,6 +474,15 @@ ttnn::Tensor reshape_tiled(
         recreate_mapping_tensor,
         sub_core_grid);
 
+    // Fill in BF16 for BFLOAT8_B inputs, otherwise in native dtype (rank-3, non-recursive).
+    // skip_padding_fill is forced off for BF8: the downstream typecast's 16-elem shared
+    // exponent would otherwise let unfilled padding corrupt logical lanes in the same block.
+    const bool is_bfloat8_b_output = (tensor.dtype() == DataType::BFLOAT8_B);
+    const bool should_fill = (!skip_padding_fill || is_bfloat8_b_output);
+    if (should_fill && detail::has_inner_2d_tile_padding(requested_shape_3d)) {
+        output_tensor_3d = ttnn::fill_implicit_tile_padding(output_tensor_3d, fill_value, std::nullopt);
+    }
+
     if (tensor.dtype() == DataType::BFLOAT8_B) {
         TT_FATAL(!sub_core_grid.has_value(), "Bfloat8 reshape does not support sub core grid specification\n");
         output_tensor_3d = ttnn::typecast(output_tensor_3d, tensor.dtype());
@@ -437,7 +501,8 @@ ttnn::Tensor ttnn::reshape(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value,
     const TileReshapeMapMode reshape_map_mode,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const bool skip_padding_fill) {
     MemoryConfig mem_config = memory_config.value_or(tensor.memory_config());
     const bool explicit_memory_config = memory_config.has_value();
     auto layout = tensor.layout();
@@ -525,7 +590,8 @@ ttnn::Tensor ttnn::reshape(
         pad_value.value_or(default_pad_value),
         reshape_map_mode == TileReshapeMapMode::RECREATE,
         sub_core_grid,
-        explicit_memory_config);
+        explicit_memory_config,
+        skip_padding_fill);
 }
 
 ttnn::Tensor ttnn::reshape(
@@ -534,8 +600,9 @@ ttnn::Tensor ttnn::reshape(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value,
     const TileReshapeMapMode reshape_map_mode,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
-    return reshape(tensor, shape, shape, memory_config, pad_value, reshape_map_mode, sub_core_grid);
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const bool skip_padding_fill) {
+    return reshape(tensor, shape, shape, memory_config, pad_value, reshape_map_mode, sub_core_grid, skip_padding_fill);
 }
 
 ttnn::Tensor ttnn::reshape(
@@ -544,12 +611,14 @@ ttnn::Tensor ttnn::reshape(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value,
     const TileReshapeMapMode reshape_map_mode,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    const bool skip_padding_fill) {
     return reshape(
         tensor,
         operations::data_movement::detail::infer_dims_for_reshape(tensor, shape_vector),
         memory_config,
         pad_value,
         reshape_map_mode,
-        sub_core_grid);
+        sub_core_grid,
+        skip_padding_fill);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -318,7 +318,8 @@ ttnn::Tensor reshape_tiled(
     const bool recreate_mapping_tensor,
     const std::optional<CoreRangeSet>& sub_core_grid,
     bool explicit_memory_config,
-    const bool skip_padding_fill) {
+    const bool skip_padding_fill,
+    const bool pad_value_explicit) {
     // fill_implicit_tile_padding takes float; integer pad is not bit-exact for all dtypes/values.
     const float fill_value = detail::pad_value_as_float(pad_value, tensor.dtype());
     // squeeze input tensor and requested shape to 3D
@@ -415,10 +416,13 @@ ttnn::Tensor reshape_tiled(
             recreate_mapping_tensor,
             sub_core_grid);
 
-        // Fill implicit tile padding. Output may be sharded (typical) or INTERLEAVED if
+        // Fill implicit tile padding only when the caller explicitly asked for it (pad_value_explicit).
+        // Default-on fill would write into "padding" lanes of prim::reshape_view, which can be a zero-cost
+        // alias of the input buffer; in extreme low-rank cases (e.g. inner-2D (1, 1)) this clobbers
+        // logical lanes of aliased tensors. Output may be sharded (typical) or INTERLEAVED if
         // recompute fell back; handle both. Tensors here are rank-3, so the fill stays
         // on its non-recursive path and cannot loop back into ttnn::reshape.
-        if (!skip_padding_fill && detail::has_inner_2d_tile_padding(requested_shape_3d)) {
+        if (pad_value_explicit && !skip_padding_fill && detail::has_inner_2d_tile_padding(requested_shape_3d)) {
             if (output_tensor_3d.memory_config().is_sharded()) {
                 // TODO(#43090): drop this s2i/i2s detour once prim::fill_pad supports sharded buffers
                 // without overflowing fill_pad_writer's per-core runtime-arg cap (341).
@@ -474,11 +478,16 @@ ttnn::Tensor reshape_tiled(
         recreate_mapping_tensor,
         sub_core_grid);
 
-    // Fill in BF16 for BFLOAT8_B inputs, otherwise in native dtype (rank-3, non-recursive).
-    // skip_padding_fill is forced off for BF8: the downstream typecast's 16-elem shared
-    // exponent would otherwise let unfilled padding corrupt logical lanes in the same block.
+    // Fill rules:
+    //   - BFLOAT8_B: ALWAYS fill (skip_padding_fill is ignored). The downstream typecast's 16-elem
+    //     shared exponent would otherwise let unfilled padding corrupt logical lanes in the same block.
+    //   - Otherwise (BF16/FP32/int): fill only when the caller EXPLICITLY passed pad_value. A default-on
+    //     fill writes into "padding" lanes of prim::reshape_view, which can be a zero-cost alias of the
+    //     input buffer; in extreme low-rank cases (e.g. inner-2D (1, 1)) this clobbers logical lanes of
+    //     aliased tensors and silently corrupts unrelated callers (e.g. tt-train AdamW / ColumnParallel).
+    //   - skip_padding_fill (when caller did pass pad_value) still suppresses non-BF8 fills.
     const bool is_bfloat8_b_output = (tensor.dtype() == DataType::BFLOAT8_B);
-    const bool should_fill = (!skip_padding_fill || is_bfloat8_b_output);
+    const bool should_fill = is_bfloat8_b_output || (pad_value_explicit && !skip_padding_fill);
     if (should_fill && detail::has_inner_2d_tile_padding(requested_shape_3d)) {
         output_tensor_3d = ttnn::fill_implicit_tile_padding(output_tensor_3d, fill_value, std::nullopt);
     }
@@ -583,6 +592,9 @@ ttnn::Tensor ttnn::reshape(
             pad_value.value_or(default_pad_value),
             sub_core_grid);
     }
+    // Preserve whether the caller explicitly passed pad_value. value_or(default_pad_value) below
+    // collapses that signal, but reshape_tiled needs it to gate the default-off fill for non-BF8.
+    const bool pad_value_explicit = pad_value.has_value();
     return operations::data_movement::reshape_tiled(
         tensor,
         logical_shape,
@@ -591,7 +603,8 @@ ttnn::Tensor ttnn::reshape(
         reshape_map_mode == TileReshapeMapMode::RECREATE,
         sub_core_grid,
         explicit_memory_config,
-        skip_padding_fill);
+        skip_padding_fill,
+        pad_value_explicit);
 }
 
 ttnn::Tensor ttnn::reshape(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
@@ -31,13 +31,17 @@ ttnn::Tensor PerformView(
 }  // namespace operations::data_movement
 
 // Free function declarations with default parameters
+// `skip_padding_fill`: if true, `pad_value` is ignored and tile padding is left as-is.
+//   Exception: BFLOAT8_B outputs always run the fill (skip is silently ignored) to prevent
+//   shared-exponent corruption in 16-elem sub-blocks that straddle the logical/padded boundary.
 ttnn::Tensor reshape(
     const ttnn::Tensor& input_tensor,
     const ttnn::Shape& logical_shape,
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<PadValue>& pad_value = std::nullopt,
     TileReshapeMapMode reshape_map_mode = TileReshapeMapMode::CACHE,
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    bool skip_padding_fill = false);
 
 ttnn::Tensor reshape(
     const ttnn::Tensor& input_tensor,
@@ -46,7 +50,8 @@ ttnn::Tensor reshape(
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<PadValue>& pad_value = std::nullopt,
     TileReshapeMapMode reshape_map_mode = TileReshapeMapMode::CACHE,
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    bool skip_padding_fill = false);
 
 ttnn::Tensor reshape(
     const ttnn::Tensor& input_tensor,
@@ -54,6 +59,7 @@ ttnn::Tensor reshape(
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<PadValue>& pad_value = std::nullopt,
     TileReshapeMapMode reshape_map_mode = TileReshapeMapMode::CACHE,
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    bool skip_padding_fill = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
@@ -26,8 +26,10 @@ ttnn::Tensor reshape_shape_vector_wrapper(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value,
     const ttnn::TileReshapeMapMode reshape_tile_mode,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return ttnn::reshape(input_tensor, shape, memory_config, pad_value, reshape_tile_mode, sub_core_grids);
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const bool skip_padding_fill) {
+    return ttnn::reshape(
+        input_tensor, shape, memory_config, pad_value, reshape_tile_mode, sub_core_grids, skip_padding_fill);
 }
 
 void bind_reshape_view_operation(nb::module_& mod) {
@@ -43,8 +45,9 @@ void bind_reshape_view_operation(nb::module_& mod) {
             Keyword Args:
                 * :attr:`memory_config`: Memory Config of the output tensor. Default is to match input tensor memory config
                 * :attr:`pad_value` (number): Value to pad the output tensor. Default is 0
-                * :attr:`reshape_map_mode` (TileReshapeMapMode): Advanced option. Set to RECREATE to recompute and realloc mapping tensor. This may alleviate DRAM fragmentation but is slow. Default is CACHE.
-                * :attr:`sub_core_grid` (CoreRangeSet, optional): Specifies sub-core grid ranges for advanced core selection control. Default uses all the cores in the device.
+                * :attr:`reshape_tile_mode` (TileReshapeMapMode): Advanced option. Set to RECREATE to recompute and reallocate the mapping tensor. This may alleviate DRAM fragmentation but is slow. Default is CACHE. This keyword is named :attr:`reshape_tile_mode` on all overloads; the small-vector (tuple/list) shape overload previously used the name ``recreate_mapping_tensor`` for the same option—update callers to ``reshape_tile_mode``.
+                * :attr:`sub_core_grids` (CoreRangeSet, optional): Specifies sub-core grid ranges for advanced core selection control. Default uses all the cores in the device.
+                * :attr:`skip_padding_fill` (bool): If False, ``pad_value`` is applied to tile padding lanes. If True, ``pad_value`` is ignored and tile padding is left as-is. Default is False. Note: this option is silently ignored for ``BFLOAT8_B`` outputs because the BF8 typecast computes a shared exponent across each 16-element sub-block, and unfilled padding would corrupt logical values in straddling sub-blocks; the fill always runs in that case.
 
 
             Returns:
@@ -63,14 +66,16 @@ void bind_reshape_view_operation(nb::module_& mod) {
                 const std::optional<MemoryConfig>&,
                 const std::optional<PadValue>&,
                 TileReshapeMapMode,
-                const std::optional<CoreRangeSet>&>(&ttnn::reshape),
+                const std::optional<CoreRangeSet>&,
+                bool>(&ttnn::reshape),
             nb::arg("input_tensor"),
             nb::arg("shape"),
             nb::kw_only(),
             nb::arg("memory_config") = nb::none(),
             nb::arg("pad_value") = nb::none(),
             nb::arg("reshape_tile_mode") = nb::cast(ttnn::TileReshapeMapMode::CACHE),
-            nb::arg("sub_core_grids") = nb::none()),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("skip_padding_fill") = false),
 
         // Overload 2: logical_shape and padded_shape (ttnn::Shape, ttnn::Shape)
         ttnn::overload_t(
@@ -81,7 +86,8 @@ void bind_reshape_view_operation(nb::module_& mod) {
                 const std::optional<MemoryConfig>&,
                 const std::optional<PadValue>&,
                 TileReshapeMapMode,
-                const std::optional<CoreRangeSet>&>(&ttnn::reshape),
+                const std::optional<CoreRangeSet>&,
+                bool>(&ttnn::reshape),
             nb::arg("input_tensor"),
             nb::arg("logical_shape"),
             nb::arg("padded_shape"),
@@ -89,7 +95,8 @@ void bind_reshape_view_operation(nb::module_& mod) {
             nb::arg("memory_config") = nb::none(),
             nb::arg("pad_value") = nb::none(),
             nb::arg("reshape_tile_mode") = nb::cast(ttnn::TileReshapeMapMode::CACHE),
-            nb::arg("sub_core_grids") = nb::none()),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("skip_padding_fill") = false),
 
         // Overload 3: shape vector (SmallVector<int32_t>)
         ttnn::overload_t(
@@ -99,8 +106,9 @@ void bind_reshape_view_operation(nb::module_& mod) {
             nb::kw_only(),
             nb::arg("memory_config") = nb::none(),
             nb::arg("pad_value") = nb::none(),
-            nb::arg("recreate_mapping_tensor") = nb::cast(ttnn::TileReshapeMapMode::CACHE),
-            nb::arg("sub_core_grids") = nb::none()));
+            nb::arg("reshape_tile_mode") = nb::cast(ttnn::TileReshapeMapMode::CACHE),
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("skip_padding_fill") = false));
 }
 
 }  // namespace detail


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22178

### Problem Description
`ttnn.reshape` on `TILE_LAYOUT` tensors ignored `pad_value` and left implicit tile padding uninitialized — even with the default `pad_value=0` documented in pybind. See the issue for the full repro.

### What this PR does
**`ttnn.reshape` (tiled) — honor `pad_value`**
- Un-discards `pad_value` in `reshape_tiled`; adds a `pad_value_as_float` helper to collapse `std::variant<uint32_t, float>` into a single `float` (`bit_cast` for `uint32_t` on `FLOAT32`, `static_cast` for the rest — consistent with `tilize_with_val_padding`).
- Calls `ttnn::fill_implicit_tile_padding` on the rank-3 output of `prim::reshape_view`:
  - **Sharded inputs (`HEIGHT/WIDTH/BLOCK_SHARDED`)** enter the direct-sharded branch in `reshape_tiled`. Fill takes the s2i → fill → i2s detour when the recomputed output is still sharded (workaround for #43090 — `fill_pad_writer`'s 341 per-core runtime-arg cap), or runs `fill_implicit_tile_padding` directly when `recompute_shard_spec_for_output` falls back to INTERLEAVED.
  - **Interleaved inputs** fall through to the interleaved path: fill runs directly on the rank-3 output (no detour — `recompute_shard_spec_for_output` is grid-aware after #42543, runtime args fit naturally).
  - **`BFLOAT8_B`**: fill runs on the BFLOAT16 intermediate before the typecast back; for sharded BFP8, the path keeps both typecasts on interleaved tensors and only re-shards at the end.

**Opt-out**
- Adds `skip_padding_fill` (bool, default `False`) kwarg to `ttnn.reshape`. When `True`, `pad_value` is ignored and tile padding lanes are left as-is — useful when callers manage padding downstream.
- **BFLOAT8_B carve-out**: `skip_padding_fill=True` is silently ignored for `BFLOAT8_B` outputs (both interleaved and sharded paths). BF8 shares an exponent across 16-element sub-blocks; unfilled padding in a straddling sub-block would corrupt logical lanes, so reshape chooses safety over the opt-out. This is documented in the C++ header, Python docstring, and a regression test.
- `fill_implicit_tile_padding`'s internal rank>3 reshape calls pass `skip_padding_fill=true` to prevent recursion between the two ops.

**Latent bug fixes pulled in along the way**
- `fill_pad.cpp`: BFLOAT8_B dtype leak on the rank>3 path. The function casts BFLOAT8_B → BFLOAT16 for the device kernel, but the cast-back only fired on the rank≤3 return path. Restructured so every return path casts back; added a dtype assertion in `test_fill_pad_bfloat8_b` as a regression guard.

| File | Change | Reason |
|---|---|---|
| `tests/ ... /data_movement/test_fill_pad.py` | Added `assert output_tensor.dtype == dtype` to `test_fill_pad_bfloat8_b`. | Regression guard for the rank>3 dtype-leak fix in `fill_pad.cpp`. |
| `tests/ ... /reduce/test_reduction_h_interleaved.py` | Bumped Frobenius threshold `0.009 → 0.011` for BFLOAT8_B `test_2D_tensor`. | Pre-PR leak made `sum` run on BFLOAT16 (high precision); post-PR `sum` runs on true BFLOAT8_B with ~5–6× higher error — old threshold was silently calibrated against BF16. [Detailed document](https://github.com/user-attachments/files/27961467/failure.analysis.-.Google.Docs.pdf) |
| `tests/ ... /fused/test_layernorm.py` | (a) Added BFP8 → BF16 typecast before `to(ROW_MAJOR_LAYOUT)`; (b) made tolerances (PCC/ATOL/Frobenius) dtype-aware (relaxed for BFP8, strict for BF16/FP32). | Pre-PR leak made `layernorm` output BFLOAT16 → layout convert was legal and tolerances were honest. Post-PR output is true BFLOAT8_B → (a) BFP8 is TILE-only so layout convert needs typecast first, (b) tolerances were silently calibrated to BF16 precision. Detailed doc :[test_layernorm_mix_precision failure](https://github.com/user-attachments/files/27963054/test_layernorm_mix_precision.failure.-.Google.Docs.pdf) |
| `tests/ ... /fused/test_softmax_interleaved.py` | Dtype-aware tolerances in `test_softmax_mix_precision`: `bfloat8_b` → `frobenius=0.08, pcc=0.99, atol=0.05`; `bfloat16` unchanged. | Same BF8 dtype-leak unmask as above tests - `fill_implicit_tile_padding` no longer leaks BF16 on rank>3 inputs, so softmax now runs in true BF8 precision. Softmax has the largest threshold gap of the three because `exp()` exponentially amplifies BF8's shared-exponent quantization. See [test_softmax_mix_precision failure.pdf](https://github.com/user-attachments/files/27986321/test_softmax_mix_precision.failure.pdf) |


- `fill_pad.cpp`: width-padding early-exit comparison fixed `TILE_HEIGHT` → `TILE_WIDTH` (latent: both constants are 32 today; future-proofing).
- `fill_pad_program_factory.cpp`: three additional width-related computations fixed `TILE_HEIGHT` → `TILE_WIDTH` (`padded_width`, `tiles_per_2d_tensor` width divisor, `tiles_per_tile_row`).
- Incidental perf side-effect: VGG-UNet device kernel SAMPLES/S rose from ~293 → ~301.5 (+3.0%, ~100 µs saved per inference) because the gate now correctly skips the spurious fill on its `(1, 1, n*h*w, c)` reshape. `test_perf_vgg_unet.py` `expected_perf` re-baselined 293 → 302; 

**Python surface**
- Renames the shape-vector overload's `recreate_mapping_tensor` kwarg to `reshape_tile_mode` so all three `ttnn.reshape` Python overloads expose the same name (the other two already used `reshape_tile_mode`). Internal C++ name is unchanged.
- Public docstring polish (`realloc` → `reallocate`); `skip_padding_fill` documented including the BFP8 carve-out.

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Main branch | Proposed branch
-- | --
<img width="623" height="636" alt="Screenshot 2026-04-21 at 8 41 24 PM" src="https://github.com/user-attachments/assets/204d67ad-fd32-460b-8074-947cf1caa069" /> | <img width="545" height="654" alt="After" src="https://github.com/user-attachments/assets/af9f5673-e40b-40f1-9425-ba970bf2cc5a" />

**Follow-up fix (post-approval):** 
- the default-on `fill_implicit_tile_padding` was corrupting aliased `prim::reshape_view` buffers (tt-train AdamW + ColumnParallel sanity tests). `reshape_tiled` now only runs the default fill for non-BFLOAT8_B outputs when the caller explicitly passes `pad_value`; BFLOAT8_B still force-fills for shared-exponent correctness. `test_reshape_tiled_default_pad_is_zero` renamed to `test_reshape_tiled_no_pad_value_does_not_fill` to match the new contract : [sanity - tt-train failures fix explanation doc](https://github.com/user-attachments/files/27985815/sanity.-.tt-train.failures.pdf)


### Pipeline Checklist

- [x] Sanity tests - PASSED
- [x] (Runtime) Sanity Tests - PASSED
- [x] BHPC - PASSED
- [x] Nightly L2 - PASSED as in main (Verified for all cartegories)
- [x] All Model Tests - PASSED as in main
- [x] Single card - PASSED as in main
- [x] T3K - PASSED as in main
- [x] Galaxy - PASSED as in main


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_pad_Value_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/reshape_pad_Value_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_pad_Value_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/reshape_pad_Value_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/reshape_pad_Value_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/reshape_pad_Value_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/reshape_pad_Value_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/reshape_pad_Value_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/reshape_pad_Value_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/reshape_pad_Value_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/reshape_pad_Value_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/reshape_pad_Value_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/reshape_pad_Value_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/reshape_pad_Value_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/reshape_pad_Value_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/reshape_pad_Value_fix)