### PR TITLE
SDXL vae pcc threshold relaxed

### DIFF
--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -25,7 +25,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ((1024, 1024), (1, 3, 1024, 1024), 0.9769 if is_wormhole_b0() else 0.964, "encoder"),
         # 512x512 image resolution
         ((512, 512), (1, 4, 64, 64), 0.936, "decoder"),
-        ((512, 512), (1, 3, 512, 512), 0.9797, "encoder"),
+        ((512, 512), (1, 3, 512, 512), 0.9796, "encoder"),
     ],
     ids=("test_1024x1024_decode", "test_1024x1024_encode", "test_512x512_decode", "test_512x512_encode"),
 )


### PR DESCRIPTION
### Summary
Vae encode pcc failing in Metal CI on (Single-card) Frequent model and ttnn tests and (Single-card) Device perf regressions [example_link](https://github.com/tenstorrent/tt-metal/actions/runs/24728633554/job/72337947633)

After commit is [MatmulMultiCoreProgramFactory to pass accuracy params to kernels](https://github.com/tenstorrent/tt-metal/commit/92b71b1ba6132b80861933fe550e37ac09ae0898) bug with hardcoded MathFidelity HiFi4 for MatmulMultiCoreProgramFactory is solved which resulted in perf regression

### Checklist

- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/24729423177) passed on n150 and p150, n300 in queue⚠️
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/24729462493) passed (upload benchmark data is failing only)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmitrovic/vae_encode_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmitrovic/vae_encode_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jmitrovic/vae_encode_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jmitrovic/vae_encode_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmitrovic/vae_encode_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmitrovic/vae_encode_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmitrovic/vae_encode_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmitrovic/vae_encode_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmitrovic/vae_encode_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmitrovic/vae_encode_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmitrovic/vae_encode_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmitrovic/vae_encode_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmitrovic/vae_encode_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmitrovic/vae_encode_pcc)