### PR TITLE
[tt-triage] Fix erisc elf not being found

### DIFF
--- a/tools/triage/callstack_provider.py
+++ b/tools/triage/callstack_provider.py
@@ -85,7 +85,7 @@ def get_callstack(
                 error_message = None
                 if len(cs) == 0:
                     error_message = "PC was not in range of any provided ELF files."
-                    if location in location._device.active_eth_block_locations:
+                    if dispatcher_core_data.block_type == "active_eth":
                         error_message += " Probably context switch occurred and PC is contained in base ERISC firmware."
                 return KernelCallstackWithMessage(callstack=cs, message=error_message)
             except TimeoutDeviceRegisterError:
@@ -98,7 +98,7 @@ def get_callstack(
                 error_message = None
                 if len(cs) == 0:
                     error_message = "PC was not in range of any provided ELF files."
-                    if location in location._device.active_eth_block_locations:
+                    if dispatcher_core_data.block_type == "active_eth":
                         error_message += " Probably context switch occurred and PC is contained in base ERISC firmware."
                 return KernelCallstackWithMessage(callstack=cs, message=error_message)
             except TimeoutDeviceRegisterError:
@@ -113,7 +113,7 @@ def get_callstack(
                     cs = top_callstack(pc, elfs, offsets, context)
                     if len(cs) == 0:
                         additional_message = "PC was not in range of any provided ELF files."
-                        if location in location._device.active_eth_block_locations:
+                        if dispatcher_core_data.block_type == "active_eth":
                             additional_message += (
                                 " Probably context switch occurred and PC is contained in base ERISC firmware."
                             )
@@ -273,7 +273,7 @@ class CallstackProvider:
                 kernel_callstack_with_message=KernelCallstackWithMessage(callstack=[], message="Core is in reset"),
             )
 
-        if location in location._device.active_eth_block_locations and not self.force_active_eth:
+        if dispatcher_core_data.block_type == "active_eth" and not self.force_active_eth:
             callstack_with_message = get_callstack(
                 location,
                 risc_name,

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -78,6 +78,9 @@ class DispatcherCoreData:
     # Host-assigned id from the previous launch message entry (best-effort).
     # Not serialized by default; used by scripts that need accurate previous-op tracking.
     previous_host_assigned_id: int | None = None
+    # Inspector/control-plane-sourced block type for this core. Used by callers to reason about
+    # active-vs-idle ETH without re-consulting the cluster descriptor.
+    block_type: BlockType | None = None
 
 
 class DispatcherData:
@@ -537,11 +540,16 @@ class DispatcherData:
                 f"failed to read subordinate sync from mailboxes. {MAILBOX_CORRUPTED_MESSAGE}",
             )
 
+        # Path picking must use the same source of truth as block_type above (inspector /
+        # metal control plane), not location.device.active_eth_block_locations (cluster
+        # descriptor / exalens).
+        is_active_eth = block_type == "active_eth"
+
         # Construct the firmware path from the build_env instead of relative paths
         # This ensures we get the correct firmware path for this device and build config
         if block_type == "dram":
             firmware_path = os.path.join(build_env.firmwarePath, "drisc", "drisc.elf")
-        elif location in location.device.active_eth_block_locations:
+        elif is_active_eth:
             if proc_name.lower() == "erisc":
                 firmware_path = os.path.join(build_env.firmwarePath, "erisc", "erisc.elf")
             elif proc_name.lower() == "erisc0":
@@ -565,7 +573,7 @@ class DispatcherData:
         firmware_path = os.path.realpath(firmware_path)
 
         if kernel:
-            if location in location.device.active_eth_block_locations:
+            if is_active_eth:
                 if proc_name.lower() == "erisc":
                     kernel_path = kernel.path + "/erisc/erisc.elf"
                 elif proc_name.lower() == "erisc0":
@@ -591,7 +599,7 @@ class DispatcherData:
             if proc_name == "NCRISC" and location.device.is_wormhole():
                 kernel_offset = 0xFFC00000
             # In wormhole we only use text offset to calculate the kernel offset for active ETH
-            elif location in location.device.active_eth_block_locations and location.device.is_wormhole():
+            elif is_active_eth and location.device.is_wormhole():
                 kernel_offset = kernel_text_offset
             elif block_type == "dram":
                 # DRAM kernel ELFs are linked at their actual load address (kernel_text_offset),
@@ -630,6 +638,7 @@ class DispatcherData:
             enables=enables,
             subordinate_sync=subordinate_sync,
             watcher_enabled=watcher_enabled,
+            block_type=block_type,
         )
 
 

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -29,7 +29,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from functools import cached_property
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import Literal, TypeAlias, get_args
 
 from inspector_data import run as get_inspector_data, InspectorData
 from triage import (
@@ -57,36 +57,18 @@ script_config = ScriptConfig(
     depends=["inspector_data", "metal_device_id_mapping"],
 )
 
-# List of block types that script returns, can be extended if other block types are needed
-BLOCK_TYPES = [
-    "idle_eth",
-    "active_eth",
-    "tensix",
-    "eth",
-    "dram",
-]
+# Block and core types that scripts return.
+BlockType: TypeAlias = Literal["idle_eth", "active_eth", "tensix", "eth", "dram"]
+CoreType: TypeAlias = Literal["brisc", "trisc0", "trisc1", "trisc2", "ncrisc", "erisc", "erisc0", "erisc1", "drisc"]
+
+BLOCK_TYPES: list[BlockType] = list(get_args(BlockType))
+CORE_TYPES: set[CoreType] = set(get_args(CoreType))
 
 # We need to map triage block types to inspector block types since we cannot use _ in capnp struct names
 INSPECTOR_BLOCK_TYPES = {
     "idle_eth": "idleEth",
     "active_eth": "activeEth",
 }
-
-# List of RISC cores currently supported
-CORE_TYPES = {
-    "brisc",
-    "trisc0",
-    "trisc1",
-    "trisc2",
-    "ncrisc",
-    "erisc",
-    "erisc0",
-    "erisc1",
-    "drisc",
-}
-
-BlockType: TypeAlias = Literal[BLOCK_TYPES]
-CoreType: TypeAlias = Literal[CORE_TYPES]
 
 
 # Classes for storing check results for devices, blocks and cores


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
When dumping callstacks, sometimes (60% of triage runs in CI) erisc elfs are not found due to triage relying on exalens to determine active/idle eth's instead of metal (like for everything else). This change aligns it to metal.

Closes https://github.com/tenstorrent/tt-exalens/issues/994

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/eth-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/eth-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/eth-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/eth-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/eth-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/eth-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/eth-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/eth-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/eth-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/eth-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/eth-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/eth-fix)