### PR TITLE
Matmul Helpers

### DIFF
--- a/tests/tt_metal/tt_metal/integration/matmul/test_add_bias_bcast_rows.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_add_bias_bcast_rows.cpp
@@ -1,0 +1,455 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated integration tests for add_bias_bcast_rows helper
+// (ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.hpp).
+//
+// The helper reads matmul partials from partials_cb, adds a row-broadcast
+// bias from bias_cb, and writes to out_cb. Caller owns bias CB wait/pop
+// lifecycle. Tests cover the two production patterns:
+//   (a) BIAS_ONE_TIME_FRONT: reader pushes bias once, helper called N times,
+//       caller waits once on first iter and never pops (SDPA + non-chunked
+//       matmul path where num_blocks_w_dim == 1).
+//   (b) BIAS_PER_ITER_PUSH: reader pushes per-iter, caller waits+pops per-iter
+//       (matmul path where num_blocks_w_dim > 1).
+//   And both patterns with a nontrivial PostBiasFn (relu) to exercise the
+//   functor slot.
+//
+// Inputs are synthetic (random partials + random bias, no upstream matmul).
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include "mesh_dispatch_fixture.hpp"
+
+namespace tt::tt_metal {
+
+using namespace tt::constants;
+
+namespace test_add_bias_bcast_rows {
+
+static float pcc_bfloat16(const std::vector<bfloat16>& a, const std::vector<bfloat16>& b) {
+    float x_mean = 0.0f, y_mean = 0.0f;
+    for (size_t i = 0; i < a.size(); i++) {
+        x_mean += static_cast<float>(a[i]);
+        y_mean += static_cast<float>(b[i]);
+    }
+    x_mean /= a.size();
+    y_mean /= b.size();
+    float cov = 0.0f, x_var = 0.0f, y_var = 0.0f;
+    for (size_t i = 0; i < a.size(); i++) {
+        float xd = static_cast<float>(a[i]) - x_mean;
+        float yd = static_cast<float>(b[i]) - y_mean;
+        cov += xd * yd;
+        x_var += xd * xd;
+        y_var += yd * yd;
+    }
+    if (x_var == 0.0f || y_var == 0.0f) {
+        return (x_var == y_var) ? 1.0f : 0.0f;
+    }
+    return cov / std::sqrt(x_var * y_var);
+}
+
+// Re-tile a row-major-tile-order tilized buffer into subblock-major order
+// (matches what matmul_block<row_major_output=false> produces in partials_cb).
+static std::vector<bfloat16> row_major_to_subblock_order(
+    const std::vector<bfloat16>& tilized, uint32_t Mt, uint32_t Nt, uint32_t out_subblock_h, uint32_t out_subblock_w) {
+    const uint32_t tile_elems = TILE_HEIGHT * TILE_WIDTH;
+    const uint32_t num_sb_w = Nt / out_subblock_w;
+    const uint32_t num_row_groups = Mt / out_subblock_h;
+    std::vector<bfloat16> result(tilized.size());
+    uint32_t dst = 0;
+    for (uint32_t g = 0; g < num_row_groups; g++) {
+        for (uint32_t sb = 0; sb < num_sb_w; sb++) {
+            for (uint32_t h = 0; h < out_subblock_h; h++) {
+                for (uint32_t w = 0; w < out_subblock_w; w++) {
+                    uint32_t row_tile = g * out_subblock_h + h;
+                    uint32_t col_tile = sb * out_subblock_w + w;
+                    uint32_t src_tile_idx = row_tile * Nt + col_tile;
+                    std::copy(
+                        tilized.begin() + src_tile_idx * tile_elems,
+                        tilized.begin() + (src_tile_idx + 1) * tile_elems,
+                        result.begin() + dst);
+                    dst += tile_elems;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+// Reverse of the above: helper emits output in subblock order (reserve+push
+// per subblock); we need to reassemble the tile stream back into row-major
+// for comparison. Total data size matches.
+static std::vector<bfloat16> subblock_order_to_row_major(
+    const std::vector<bfloat16>& subblock_tilized,
+    uint32_t Mt,
+    uint32_t Nt,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w) {
+    const uint32_t tile_elems = TILE_HEIGHT * TILE_WIDTH;
+    const uint32_t num_sb_w = Nt / out_subblock_w;
+    const uint32_t num_row_groups = Mt / out_subblock_h;
+    std::vector<bfloat16> result(subblock_tilized.size());
+    uint32_t src = 0;
+    for (uint32_t g = 0; g < num_row_groups; g++) {
+        for (uint32_t sb = 0; sb < num_sb_w; sb++) {
+            for (uint32_t h = 0; h < out_subblock_h; h++) {
+                for (uint32_t w = 0; w < out_subblock_w; w++) {
+                    uint32_t row_tile = g * out_subblock_h + h;
+                    uint32_t col_tile = sb * out_subblock_w + w;
+                    uint32_t dst_tile_idx = row_tile * Nt + col_tile;
+                    std::copy(
+                        subblock_tilized.begin() + src,
+                        subblock_tilized.begin() + src + tile_elems,
+                        result.begin() + dst_tile_idx * tile_elems);
+                    src += tile_elems;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+enum class BiasPattern { OneTimeFront, PerIterPush };
+
+struct BiasConfig {
+    uint32_t M;
+    uint32_t N;
+    uint32_t out_subblock_h;
+    uint32_t out_subblock_w;
+    uint32_t num_invocations;
+    BiasPattern pattern;
+    bool post_bias_relu = false;
+};
+
+static bool run_add_bias_bcast_rows_test(
+    MeshDispatchFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const BiasConfig& cfg,
+    float pcc_threshold = 0.9995f) {
+    uint32_t Mt = cfg.M / TILE_HEIGHT;
+    uint32_t Nt = cfg.N / TILE_WIDTH;
+    uint32_t in0_num_subblocks = Mt / cfg.out_subblock_h;
+    uint32_t in1_num_subblocks = Nt / cfg.out_subblock_w;
+    uint32_t bias_ntiles = Nt;
+    uint32_t partials_tiles_per_iter = Mt * Nt;
+    uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;
+    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
+    CoreCoord core({0, 0});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program{};
+
+    // DRAM: partials (num_invocations copies), bias (1 or num_invocations copies), output.
+    uint32_t partials_bytes_total = single_tile_size * partials_tiles_per_iter * cfg.num_invocations;
+    uint32_t bias_copies = (cfg.pattern == BiasPattern::OneTimeFront) ? 1u : cfg.num_invocations;
+    uint32_t bias_bytes_total = single_tile_size * bias_ntiles * bias_copies;
+    uint32_t out_bytes_total = partials_bytes_total;
+
+    distributed::DeviceLocalBufferConfig lc_p{
+        .page_size = partials_bytes_total, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig lc_b{
+        .page_size = bias_bytes_total, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig lc_o{
+        .page_size = out_bytes_total, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+
+    auto partials_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = partials_bytes_total}, lc_p, mesh_device.get());
+    auto bias_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = bias_bytes_total}, lc_b, mesh_device.get());
+    auto out_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = out_bytes_total}, lc_o, mesh_device.get());
+
+    // CBs. Size partials and out for one iter's worth; bias CB holds enough
+    // tiles for one push cycle.
+    CircularBufferConfig cb_partials_cfg =
+        CircularBufferConfig(partials_tiles_per_iter * single_tile_size, {{CBIndex::c_24, cb_data_format}})
+            .set_page_size(CBIndex::c_24, single_tile_size);
+    CreateCircularBuffer(program, core, cb_partials_cfg);
+
+    CircularBufferConfig cb_bias_cfg =
+        CircularBufferConfig(bias_ntiles * single_tile_size, {{CBIndex::c_2, cb_data_format}})
+            .set_page_size(CBIndex::c_2, single_tile_size);
+    CreateCircularBuffer(program, core, cb_bias_cfg);
+
+    CircularBufferConfig cb_out_cfg =
+        CircularBufferConfig(partials_tiles_per_iter * single_tile_size, {{CBIndex::c_16, cb_data_format}})
+            .set_page_size(CBIndex::c_16, single_tile_size);
+    CreateCircularBuffer(program, core, cb_out_cfg);
+
+    // Reader: pushes partials per-iter, bias once-or-per-iter per the pattern.
+    auto reader_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bias_test.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    auto writer_id = CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    std::vector<uint32_t> compute_args = {
+        cfg.num_invocations, in0_num_subblocks, in1_num_subblocks, cfg.out_subblock_h, cfg.out_subblock_w, bias_ntiles};
+
+    std::map<std::string, std::string> defines;
+    if (cfg.pattern == BiasPattern::OneTimeFront) {
+        defines["BIAS_ONE_TIME_FRONT"] = "1";
+    } else {
+        defines["BIAS_PER_ITER_PUSH"] = "1";
+    }
+    if (cfg.post_bias_relu) {
+        defines["HELPER_POST_BIAS_RELU"] = "1";
+    }
+
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/test_add_bias_bcast_rows_compute.cpp",
+        core,
+        ComputeConfig{.math_fidelity = MathFidelity::HiFi4, .compile_args = compute_args, .defines = defines});
+
+    uint32_t partials_bytes_per_iter = partials_tiles_per_iter * single_tile_size;
+    uint32_t bias_bytes_per_push = bias_ntiles * single_tile_size;
+
+    SetRuntimeArgs(
+        program,
+        reader_id,
+        core,
+        {partials_dram->address(),
+         0,
+         bias_dram->address(),
+         0,
+         cfg.num_invocations,
+         partials_tiles_per_iter,
+         bias_ntiles,
+         partials_bytes_per_iter,
+         bias_bytes_per_push,
+         (cfg.pattern == BiasPattern::OneTimeFront) ? 1u : 0u});
+
+    SetRuntimeArgs(program, writer_id, core, {out_dram->address(), 0, partials_tiles_per_iter * cfg.num_invocations});
+
+    // ── Inputs ──
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(cfg.post_bias_relu ? -1.0f : 0.0f, 1.0f);
+
+    // Partials: per iter, an MxN random matrix, pre-tilized in subblock order.
+    std::vector<bfloat16> partials_all;
+    std::vector<std::vector<bfloat16>> partials_per_iter_rowmajor;
+    partials_per_iter_rowmajor.reserve(cfg.num_invocations);
+    for (uint32_t i = 0; i < cfg.num_invocations; i++) {
+        std::vector<bfloat16> p(cfg.M * cfg.N);
+        for (auto& v : p) {
+            v = bfloat16(dist(rng));
+        }
+        partials_per_iter_rowmajor.push_back(p);
+        auto t = tilize_nfaces(p, cfg.M, cfg.N);
+        auto sb = row_major_to_subblock_order(t, Mt, Nt, cfg.out_subblock_h, cfg.out_subblock_w);
+        partials_all.insert(partials_all.end(), sb.begin(), sb.end());
+    }
+
+    // Bias: per-push, a 1-row bias repeated across tile height, tilized.
+    std::vector<bfloat16> bias_all;
+    std::vector<std::vector<bfloat16>> bias_per_push_1d;
+    bias_per_push_1d.reserve(bias_copies);
+    for (uint32_t p = 0; p < bias_copies; p++) {
+        std::vector<bfloat16> b(cfg.N);
+        for (auto& v : b) {
+            v = bfloat16(dist(rng));
+        }
+        bias_per_push_1d.push_back(b);
+        // Build 2D tile: [TILE_HEIGHT, N] with bias replicated down the rows.
+        std::vector<bfloat16> b2d(TILE_HEIGHT * cfg.N);
+        for (uint32_t r = 0; r < TILE_HEIGHT; r++) {
+            for (uint32_t c = 0; c < cfg.N; c++) {
+                b2d[r * cfg.N + c] = b[c];
+            }
+        }
+        auto bt = tilize_nfaces(b2d, TILE_HEIGHT, cfg.N);
+        bias_all.insert(bias_all.end(), bt.begin(), bt.end());
+    }
+
+    auto partials_packed = pack_bfloat16_vec_into_uint32_vec(partials_all);
+    auto bias_packed = pack_bfloat16_vec_into_uint32_vec(bias_all);
+    fixture->WriteBuffer(mesh_device, partials_dram, partials_packed);
+    fixture->WriteBuffer(mesh_device, bias_dram, bias_packed);
+
+    workload.add_program(device_range, std::move(program));
+    fixture->RunProgram(mesh_device, workload);
+
+    std::vector<uint32_t> result_packed;
+    fixture->ReadBuffer(mesh_device, out_dram, result_packed);
+    auto result_tilized_sb = unpack_uint32_vec_into_bfloat16_vec(result_packed);
+
+    // Compute golden and compare per iteration.
+    bool all_ok = true;
+    for (uint32_t iter = 0; iter < cfg.num_invocations; iter++) {
+        const auto& b = bias_per_push_1d[(cfg.pattern == BiasPattern::OneTimeFront) ? 0 : iter];
+        const auto& p = partials_per_iter_rowmajor[iter];
+        std::vector<bfloat16> golden(cfg.M * cfg.N);
+        for (uint32_t i = 0; i < cfg.M; i++) {
+            for (uint32_t j = 0; j < cfg.N; j++) {
+                float v = static_cast<float>(p[i * cfg.N + j]) + static_cast<float>(b[j]);
+                if (cfg.post_bias_relu) {
+                    v = std::max(0.0f, v);
+                }
+                golden[i * cfg.N + j] = bfloat16(v);
+            }
+        }
+
+        // Slice the result: iter's worth of tiles, reassemble row-major, untilize.
+        uint32_t tile_elems = TILE_HEIGHT * TILE_WIDTH;
+        std::vector<bfloat16> iter_sb(
+            result_tilized_sb.begin() + iter * partials_tiles_per_iter * tile_elems,
+            result_tilized_sb.begin() + (iter + 1) * partials_tiles_per_iter * tile_elems);
+        auto iter_rm = subblock_order_to_row_major(iter_sb, Mt, Nt, cfg.out_subblock_h, cfg.out_subblock_w);
+        auto iter_untiled = untilize_nfaces(iter_rm, cfg.M, cfg.N);
+
+        float pcc = pcc_bfloat16(golden, iter_untiled);
+        log_info(
+            LogTest,
+            "iter={} M={} N={} sb_h={} sb_w={} pattern={} post_relu={} — PCC = {:.6f}",
+            iter,
+            cfg.M,
+            cfg.N,
+            cfg.out_subblock_h,
+            cfg.out_subblock_w,
+            cfg.pattern == BiasPattern::OneTimeFront ? "one_time" : "per_iter",
+            cfg.post_bias_relu,
+            pcc);
+        if (pcc < pcc_threshold) {
+            all_ok = false;
+        }
+    }
+    return all_ok;
+}
+
+}  // namespace test_add_bias_bcast_rows
+
+using test_add_bias_bcast_rows::BiasConfig;
+using test_add_bias_bcast_rows::BiasPattern;
+using test_add_bias_bcast_rows::run_add_bias_bcast_rows_test;
+
+// (a) One-time-front, no PostBiasFn
+TEST_F(MeshDispatchFixture, TensixAddBiasBcastRowsOneTimeFrontSingleIter) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_add_bias_bcast_rows_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .num_invocations = 1,
+             .pattern = BiasPattern::OneTimeFront}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixAddBiasBcastRowsOneTimeFrontMultiIter) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_add_bias_bcast_rows_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .num_invocations = 3,
+             .pattern = BiasPattern::OneTimeFront}));
+    }
+}
+
+// (b) Per-iter push + pop
+TEST_F(MeshDispatchFixture, TensixAddBiasBcastRowsPerIterMultiIter) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_add_bias_bcast_rows_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .num_invocations = 3,
+             .pattern = BiasPattern::PerIterPush}));
+    }
+}
+
+// Multi-subblock coverage
+TEST_F(MeshDispatchFixture, TensixAddBiasBcastRowsMultiSubblockN) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_add_bias_bcast_rows_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 128,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .num_invocations = 1,
+             .pattern = BiasPattern::OneTimeFront}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixAddBiasBcastRowsMultiSubblockBoth) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_add_bias_bcast_rows_test(
+            this,
+            device,
+            {.M = 128,
+             .N = 128,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .num_invocations = 1,
+             .pattern = BiasPattern::OneTimeFront}));
+    }
+}
+
+// (c) PostBiasFn = relu, one-time-front
+TEST_F(MeshDispatchFixture, TensixAddBiasBcastRowsPostBiasRelu) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_add_bias_bcast_rows_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .num_invocations = 1,
+             .pattern = BiasPattern::OneTimeFront,
+             .post_bias_relu = true}));
+    }
+}
+
+// (c) PostBiasFn = relu + per-iter push
+TEST_F(MeshDispatchFixture, TensixAddBiasBcastRowsPostBiasReluPerIter) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_add_bias_bcast_rows_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .num_invocations = 2,
+             .pattern = BiasPattern::PerIterPush,
+             .post_bias_relu = true}));
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_block_helper.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_block_helper.cpp
@@ -1,0 +1,656 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated integration tests for the matmul_block helper
+// (ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp).
+//
+// Each test pins one dimension of the template parameter pack
+// (transpose, packer_l1_acc, pack_last_to_interm, pack_relu,
+// row_major_output, PostComputeFn) against a CPU golden. Helper signatures
+// are verified regardless of the caller kernel that uses them in production.
+//
+// Pattern adapted from the dropped tests at base commit 23d9cbd4.
+// Key adaptations for the current helper API:
+//   - matmul_block CB arguments are runtime, not template parameters
+//   - row_major_output is a new template bool (absolute-offset packing)
+//   - PostComputeFn is a template type instead of a macro
+//
+// Uses reader_matmul_blocked.cpp + writer_unary.cpp. The reader walks DRAM
+// blocks in K-block order; the writer streams c_16 tiles to DRAM in the
+// order the helper packed them. For row_major_output=true the stream is
+// row-major over the Mt×Nt grid; for row_major_output=false it is subblock
+// major. The host readback reorders to row-major tile order before untilize.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include "mesh_dispatch_fixture.hpp"
+
+namespace tt::tt_metal {
+
+using namespace tt::constants;
+
+namespace test_matmul_block_helper {
+
+static float pcc_bfloat16(const std::vector<bfloat16>& a, const std::vector<bfloat16>& b) {
+    float x_mean = 0.0f, y_mean = 0.0f;
+    for (size_t i = 0; i < a.size(); i++) {
+        x_mean += static_cast<float>(a[i]);
+        y_mean += static_cast<float>(b[i]);
+    }
+    x_mean /= a.size();
+    y_mean /= b.size();
+
+    float cov = 0.0f, x_var = 0.0f, y_var = 0.0f;
+    for (size_t i = 0; i < a.size(); i++) {
+        float xd = static_cast<float>(a[i]) - x_mean;
+        float yd = static_cast<float>(b[i]) - y_mean;
+        cov += xd * yd;
+        x_var += xd * xd;
+        y_var += yd * yd;
+    }
+    if (x_var == 0.0f || y_var == 0.0f) {
+        return (x_var == y_var) ? 1.0f : 0.0f;
+    }
+    return cov / std::sqrt(x_var * y_var);
+}
+
+// Host golden for the matmul. `transpose_b_tiles` mirrors the helper's
+// template-level WH-transpose of B: each 32x32 tile of B is transposed
+// before the multiply. The resulting effect for a matrix partitioned into
+// 32x32 tiles is equivalent to transposing within each tile, which is what
+// the helper's `transpose` flag does via the LLK `matmul_block(transpose=1)`.
+static void golden_matmul(
+    const std::vector<bfloat16>& a,
+    const std::vector<bfloat16>& b,
+    std::vector<bfloat16>& output,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool transpose_b_tiles = false,
+    bool apply_relu = false) {
+    auto get_b = [&](uint32_t k, uint32_t n) -> float {
+        if (!transpose_b_tiles) {
+            return static_cast<float>(b[k * N + n]);
+        }
+        // Within the tile that contains (k, n), swap row/col.
+        uint32_t tile_r = k / TILE_HEIGHT;
+        uint32_t tile_c = n / TILE_WIDTH;
+        uint32_t inner_r = k % TILE_HEIGHT;
+        uint32_t inner_c = n % TILE_WIDTH;
+        // Transposed index within the tile: swap inner_r and inner_c.
+        uint32_t src_k = tile_r * TILE_HEIGHT + inner_c;
+        uint32_t src_n = tile_c * TILE_WIDTH + inner_r;
+        return static_cast<float>(b[src_k * N + src_n]);
+    };
+
+    for (uint32_t i = 0; i < M; i++) {
+        for (uint32_t j = 0; j < N; j++) {
+            float acc = 0.0f;
+            for (uint32_t k = 0; k < K; k++) {
+                acc += static_cast<float>(a[(i * K) + k]) * get_b(k, j);
+            }
+            if (apply_relu) {
+                acc = std::max(0.0f, acc);
+            }
+            output[(i * N) + j] = bfloat16(acc);
+        }
+    }
+}
+
+// Rearrange tilized A from row-major tile order to block-column (K-block) order
+// to match reader_matmul_blocked's layout.
+static std::vector<bfloat16> reorder_tiles_to_block_column(
+    const std::vector<bfloat16>& tilized, uint32_t Mt, uint32_t Kt, uint32_t block_w) {
+    const uint32_t tiles_per_tile = TILE_HEIGHT * TILE_WIDTH;
+    uint32_t num_blocks = Kt / block_w;
+    std::vector<bfloat16> result(tilized.size());
+
+    uint32_t dst_offset = 0;
+    for (uint32_t blk = 0; blk < num_blocks; blk++) {
+        for (uint32_t row = 0; row < Mt; row++) {
+            for (uint32_t col = 0; col < block_w; col++) {
+                uint32_t src_tile_idx = (row * Kt) + (blk * block_w) + col;
+                uint32_t src_offset = src_tile_idx * tiles_per_tile;
+                std::copy(
+                    tilized.begin() + src_offset,
+                    tilized.begin() + src_offset + tiles_per_tile,
+                    result.begin() + dst_offset);
+                dst_offset += tiles_per_tile;
+            }
+        }
+    }
+    return result;
+}
+
+struct BlockMatmulConfig {
+    uint32_t M;               // rows (elements)
+    uint32_t N;               // cols (elements)
+    uint32_t K;               // inner dim (elements)
+    uint32_t out_subblock_h;  // output sub-block height in tiles
+    uint32_t out_subblock_w;  // output sub-block width in tiles
+    uint32_t in0_block_w;     // K-dimension block size in tiles
+    uint32_t batch = 1;
+
+    // Helper feature flags
+    bool transpose = false;          // B tiles WH-transpose
+    bool packer_l1_acc = false;      // HW L1 accumulation across K-blocks
+    bool pack_relu = false;          // helper applies relu on the last pack
+    bool row_major_output = false;   // absolute-offset packing
+    bool post_compute_relu = false;  // PostComputeFn = ReluPostCompute
+    // NOTE: pack_last_to_interm is out-of-scope here because writer_unary only
+    // drains c_16. It is exercised by the production fused-bias kernel plus
+    // the add_bias_bcast_rows isolated test.
+};
+
+static bool run_matmul_block_helper_test(
+    MeshDispatchFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const BlockMatmulConfig& cfg,
+    float pcc_threshold = 0.97f) {
+    uint32_t Mt = cfg.M / TILE_HEIGHT;
+    uint32_t Kt = cfg.K / TILE_WIDTH;
+    uint32_t Nt = cfg.N / TILE_WIDTH;
+    uint32_t in0_block_w = cfg.in0_block_w;
+    uint32_t out_subblock_h = cfg.out_subblock_h;
+    uint32_t out_subblock_w = cfg.out_subblock_w;
+
+    uint32_t num_blocks = Kt / in0_block_w;
+    uint32_t in0_num_subblocks = Mt / out_subblock_h;
+    uint32_t in1_num_subblocks = Nt / out_subblock_w;
+    uint32_t in0_block_num_tiles = Mt * in0_block_w;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+    uint32_t in1_block_num_tiles = Nt * in0_block_w;
+    uint32_t in1_per_core_w = Nt;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+    uint32_t num_output_tiles = Mt * Nt * cfg.batch;
+
+    uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;
+    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
+    CoreCoord core({0, 0});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program{};
+
+    uint32_t dram_size_a = single_tile_size * Mt * Kt * cfg.batch;
+    uint32_t dram_size_b = single_tile_size * Kt * Nt * cfg.batch;
+    uint32_t dram_size_c = single_tile_size * Mt * Nt * cfg.batch;
+
+    distributed::DeviceLocalBufferConfig local_config_a{
+        .page_size = dram_size_a, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig local_config_b{
+        .page_size = dram_size_b, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig local_config_c{
+        .page_size = dram_size_c, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+
+    auto src0_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_a}, local_config_a, mesh_device.get());
+    auto src1_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_b}, local_config_b, mesh_device.get());
+    auto dst_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_c}, local_config_c, mesh_device.get());
+
+    uint32_t in0_cb_tiles = in0_block_num_tiles * 2;
+    CircularBufferConfig cb_in0_config =
+        CircularBufferConfig(in0_cb_tiles * single_tile_size, {{CBIndex::c_0, cb_data_format}})
+            .set_page_size(CBIndex::c_0, single_tile_size);
+    CreateCircularBuffer(program, core, cb_in0_config);
+
+    uint32_t in1_cb_tiles = in1_block_num_tiles * 2;
+    CircularBufferConfig cb_in1_config =
+        CircularBufferConfig(in1_cb_tiles * single_tile_size, {{CBIndex::c_1, cb_data_format}})
+            .set_page_size(CBIndex::c_1, single_tile_size);
+    CreateCircularBuffer(program, core, cb_in1_config);
+
+    // out (c_16) and interm (c_24) share the same L1 address space — matches
+    // legacy multicast factory layout. The helper's shared-memory-protection
+    // reserve covers the sequential (non-row-major) path on non-last K-blocks.
+    uint32_t num_out_cb_tiles = Mt * Nt;
+    std::map<uint8_t, tt::DataFormat> partials_and_out_spec = {
+        {CBIndex::c_24, cb_data_format}, {CBIndex::c_16, cb_data_format}};
+    CircularBufferConfig cb_out_config =
+        CircularBufferConfig(num_out_cb_tiles * single_tile_size, partials_and_out_spec)
+            .set_page_size(CBIndex::c_24, single_tile_size)
+            .set_page_size(CBIndex::c_16, single_tile_size);
+    CreateCircularBuffer(program, core, cb_out_config);
+
+    auto reader_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    // Writer strategy:
+    //   - All tests use writer_unary: streams tiles from c_16 to DRAM in CB
+    //     order. For row_major_output tests that means row-major element
+    //     layout; for subblock-order tests we reorder host-side (see below).
+    //   - pack_last_to_interm is out of scope for the current writer: the
+    //     helper packs to c_24 in that mode, and writer_unary only consumes
+    //     c_16. The mode IS exercised indirectly via the production fused-bias
+    //     kernel's real-matmul path; here we stick to pack_last_to_interm=false.
+    auto writer_id = CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    std::vector<uint32_t> compute_args = {
+        in0_block_w,
+        in0_num_subblocks,
+        in0_block_num_tiles,
+        in0_subblock_num_tiles,
+        in1_num_subblocks,
+        in1_block_num_tiles,
+        in1_per_core_w,
+        num_blocks,
+        out_subblock_h,
+        out_subblock_w,
+        out_subblock_num_tiles,
+        cfg.batch};
+
+    std::map<std::string, std::string> defines;
+    if (cfg.transpose) {
+        defines["HELPER_TRANSPOSE"] = "1";
+    }
+    if (cfg.packer_l1_acc) {
+        defines["HELPER_PACKER_L1_ACC"] = "1";
+    }
+    if (cfg.pack_relu) {
+        defines["HELPER_PACK_RELU"] = "1";
+    }
+    if (cfg.row_major_output) {
+        defines["HELPER_ROW_MAJOR_OUTPUT"] = "1";
+    }
+    if (cfg.post_compute_relu) {
+        defines["HELPER_POST_COMPUTE_RELU"] = "1";
+    }
+
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/test_matmul_block_helper_compute.cpp",
+        core,
+        ComputeConfig{.math_fidelity = MathFidelity::HiFi4, .compile_args = compute_args, .defines = defines});
+
+    uint32_t in0_block_size_bytes = in0_block_num_tiles * single_tile_size;
+    uint32_t in1_block_size_bytes = in1_block_num_tiles * single_tile_size;
+    SetRuntimeArgs(
+        program,
+        reader_id,
+        core,
+        {src0_dram->address(),
+         0,
+         src1_dram->address(),
+         0,
+         num_blocks * cfg.batch,
+         in0_block_num_tiles,
+         in1_block_num_tiles,
+         in0_block_size_bytes,
+         in1_block_size_bytes});
+
+    // writer_unary streams c_16 tiles straight to DRAM in CB order.
+    SetRuntimeArgs(program, writer_id, core, {dst_dram->address(), 0, num_output_tiles});
+
+    // Random inputs. For ReLU tests use a symmetric distribution so the
+    // output has both signs (ReLU fires on meaningful data). For non-ReLU
+    // tests stick to non-negative inputs so the PCC check is stable.
+    std::mt19937 rng(42);
+    const bool need_relu = cfg.pack_relu || cfg.post_compute_relu;
+    std::uniform_real_distribution<float> dist(need_relu ? -1.0f : 0.0f, 1.0f);
+
+    std::vector<bfloat16> src0_vec(cfg.M * cfg.K * cfg.batch);
+    std::vector<bfloat16> src1_vec(cfg.K * cfg.N * cfg.batch);
+    for (auto& v : src0_vec) {
+        v = bfloat16(dist(rng));
+    }
+    for (auto& v : src1_vec) {
+        v = bfloat16(dist(rng));
+    }
+
+    // Golden per batch slice
+    const bool apply_relu = cfg.pack_relu || cfg.post_compute_relu;
+    std::vector<bfloat16> golden_vec(cfg.M * cfg.N * cfg.batch, bfloat16(0.0f));
+    for (uint32_t b = 0; b < cfg.batch; b++) {
+        std::vector<bfloat16> slice_a(src0_vec.begin() + b * cfg.M * cfg.K, src0_vec.begin() + (b + 1) * cfg.M * cfg.K);
+        std::vector<bfloat16> slice_b(src1_vec.begin() + b * cfg.K * cfg.N, src1_vec.begin() + (b + 1) * cfg.K * cfg.N);
+        std::vector<bfloat16> slice_golden(cfg.M * cfg.N, bfloat16(0.0f));
+        golden_matmul(slice_a, slice_b, slice_golden, cfg.M, cfg.N, cfg.K, cfg.transpose, apply_relu);
+        std::copy(slice_golden.begin(), slice_golden.end(), golden_vec.begin() + b * cfg.M * cfg.N);
+    }
+
+    // Tilize per batch, reorder A to block-column
+    std::vector<bfloat16> src0_all_tilized;
+    std::vector<bfloat16> src1_all_tilized;
+    src0_all_tilized.reserve(src0_vec.size());
+    src1_all_tilized.reserve(src1_vec.size());
+    for (uint32_t b = 0; b < cfg.batch; b++) {
+        std::vector<bfloat16> slice_a(src0_vec.begin() + b * cfg.M * cfg.K, src0_vec.begin() + (b + 1) * cfg.M * cfg.K);
+        std::vector<bfloat16> slice_b(src1_vec.begin() + b * cfg.K * cfg.N, src1_vec.begin() + (b + 1) * cfg.K * cfg.N);
+        auto t_a = tilize_nfaces(slice_a, cfg.M, cfg.K);
+        auto t_b = tilize_nfaces(slice_b, cfg.K, cfg.N);
+        t_a = reorder_tiles_to_block_column(t_a, Mt, Kt, in0_block_w);
+        src0_all_tilized.insert(src0_all_tilized.end(), t_a.begin(), t_a.end());
+        src1_all_tilized.insert(src1_all_tilized.end(), t_b.begin(), t_b.end());
+    }
+
+    auto src0_packed = pack_bfloat16_vec_into_uint32_vec(src0_all_tilized);
+    auto src1_packed = pack_bfloat16_vec_into_uint32_vec(src1_all_tilized);
+    fixture->WriteBuffer(mesh_device, src0_dram, src0_packed);
+    fixture->WriteBuffer(mesh_device, src1_dram, src1_packed);
+
+    workload.add_program(device_range, std::move(program));
+    fixture->RunProgram(mesh_device, workload);
+
+    std::vector<uint32_t> result_packed;
+    fixture->ReadBuffer(mesh_device, dst_dram, result_packed);
+    auto result_tilized = unpack_uint32_vec_into_bfloat16_vec(result_packed);
+
+    // Writer_unary streams tiles in CB order. Depending on the helper's pack
+    // strategy, the CB holds tiles in:
+    //   - row-major tile order over the Mt×Nt grid (row_major_output=true)
+    //   - subblock-major order within row-groups (row_major_output=false)
+    // Reassemble to row-major tile order for untilize_nfaces.
+    const uint32_t tile_elems = TILE_HEIGHT * TILE_WIDTH;
+    const uint32_t slice_tile_elems = Mt * Nt * tile_elems;
+    std::vector<bfloat16> untilized(cfg.M * cfg.N * cfg.batch, bfloat16(0.0f));
+
+    for (uint32_t b = 0; b < cfg.batch; b++) {
+        std::vector<bfloat16> slice(
+            result_tilized.begin() + b * slice_tile_elems, result_tilized.begin() + (b + 1) * slice_tile_elems);
+        std::vector<bfloat16> slice_row_major;
+
+        if (cfg.row_major_output) {
+            slice_row_major = std::move(slice);
+        } else {
+            // Reassemble subblock-major tiles to row-major tile order.
+            slice_row_major.resize(slice_tile_elems);
+            uint32_t src = 0;
+            const uint32_t num_sb_w = in1_num_subblocks;
+            const uint32_t num_row_groups = in0_num_subblocks;
+            for (uint32_t g = 0; g < num_row_groups; g++) {
+                for (uint32_t sb = 0; sb < num_sb_w; sb++) {
+                    for (uint32_t h = 0; h < out_subblock_h; h++) {
+                        for (uint32_t w = 0; w < out_subblock_w; w++) {
+                            uint32_t row_tile = g * out_subblock_h + h;
+                            uint32_t col_tile = sb * out_subblock_w + w;
+                            uint32_t dst_tile_idx = row_tile * Nt + col_tile;
+                            std::copy(
+                                slice.begin() + src,
+                                slice.begin() + src + tile_elems,
+                                slice_row_major.begin() + dst_tile_idx * tile_elems);
+                            src += tile_elems;
+                        }
+                    }
+                }
+            }
+        }
+
+        auto u = untilize_nfaces(slice_row_major, cfg.M, cfg.N);
+        std::copy(u.begin(), u.end(), untilized.begin() + b * cfg.M * cfg.N);
+    }
+
+    float pcc = pcc_bfloat16(golden_vec, untilized);
+    log_info(
+        LogTest,
+        "M={} N={} K={} blk_w={} sub_h={} sub_w={} nb={} batch={} "
+        "flags=[T={} L1={} R={} RM={} PCR={}] — PCC = {:.6f} (thresh {:.4f})",
+        cfg.M,
+        cfg.N,
+        cfg.K,
+        cfg.in0_block_w,
+        cfg.out_subblock_h,
+        cfg.out_subblock_w,
+        num_blocks,
+        cfg.batch,
+        cfg.transpose,
+        cfg.packer_l1_acc,
+        cfg.pack_relu,
+        cfg.row_major_output,
+        cfg.post_compute_relu,
+        pcc,
+        pcc_threshold);
+
+    return pcc > pcc_threshold;
+}
+
+}  // namespace test_matmul_block_helper
+
+using test_matmul_block_helper::BlockMatmulConfig;
+using test_matmul_block_helper::run_matmul_block_helper_test;
+
+// ─── Baseline: all flags off ────────────────────────────────────────────────
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperBaseline) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this, device, {.M = 64, .N = 64, .K = 64, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+// ─── num_k_blocks variations (spill/reload path) ────────────────────────────
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperTwoKBlocks) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this, device, {.M = 64, .N = 64, .K = 128, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperFourKBlocks) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this, device, {.M = 64, .N = 64, .K = 256, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+// ─── Multi-subblock M / N / both (sharded-bmm bug regression guard) ─────────
+// Pre-branch, sharded_matmul[bmm] corrupted data when in1 num_subblocks > 1
+// because the legacy writer read row-major while the helper packed subblock
+// order. Locked-in here by exercising in1_num_subblocks=2.
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperMultiSubblockN) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this, device, {.M = 64, .N = 128, .K = 64, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperMultiSubblockM) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this, device, {.M = 128, .N = 64, .K = 64, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperMultiSubblockBoth) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this, device, {.M = 128, .N = 128, .K = 64, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+// ─── Batch > 1 ──────────────────────────────────────────────────────────────
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperBatch2) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64, .N = 64, .K = 64, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2, .batch = 2}));
+    }
+}
+
+// ─── Feature flag coverage ──────────────────────────────────────────────────
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperPackerL1AccMultiBlock) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .K = 128,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .packer_l1_acc = true}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperPackRelu) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .K = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .pack_relu = true}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperPackReluMultiBlock) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .K = 128,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .pack_relu = true}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperRowMajorOutput) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .K = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .row_major_output = true}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperRowMajorOutputMultiSubblockN) {
+    // Exercises row-major packing with N-subblocking: per-row-group reserve/push,
+    // absolute-offset column positions stride across subblocks. The bmm corruption
+    // regression test.
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 128,
+             .K = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .row_major_output = true}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperRowMajorOutputMultiBlock) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .K = 128,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .row_major_output = true}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperPostComputeRelu) {
+    // PostComputeFn: relu applied per sub-block on last K-block before packing.
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .K = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .post_compute_relu = true}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperPostComputeReluMultiBlock) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .K = 128,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .post_compute_relu = true}));
+    }
+}
+
+// ─── Transpose (WH transpose of srcB tiles) ────────────────────────────────
+// Toggles the `transpose` template bool on matmul_block<>. The LLK transposes
+// each srcB tile WH on the fly. Golden mirrors by swapping row/col within
+// every tile of B.
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperTransposeB) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 64,
+             .K = 64,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .transpose = true}));
+    }
+}
+
+// ─── Combined-flag stress ───────────────────────────────────────────────────
+TEST_F(MeshDispatchFixture, TensixMatmulBlockHelperL1AccRowMajorMultiSubblockN) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_block_helper_test(
+            this,
+            device,
+            {.M = 64,
+             .N = 128,
+             .K = 128,
+             .out_subblock_h = 2,
+             .out_subblock_w = 2,
+             .in0_block_w = 2,
+             .packer_l1_acc = true,
+             .row_major_output = true}));
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_reduce_inplace.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_reduce_inplace.cpp
@@ -116,7 +116,17 @@ static bool run_matmul_reduce_inplace_test(
     auto out_dram = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = dram_size_out}, lc_out, mesh_device.get());
 
-    // CBs: c_0 (in_out), c_1 (col-ident, 1 tile), c_16 (out-copy)
+    // CBs:
+    //   c_0  (in_out)   — compute-owned in/out CB for the reduce (double-buffered)
+    //   c_1  (col-ident) — single column-identity tile
+    //   c_2  (staging)  — reader-produced input; compute copies to c_0 to
+    //                     establish compute ownership before matmul_reduce_inplace
+    //   c_16 (out-copy) — reduced output for the writer to drain
+    //
+    // c_2 is necessary because matmul_reduce_inplace requires in_out_cb to be
+    // compute-produced. If the reader fills c_0 directly, T2's tiles_received
+    // shadow for c_0 starts at 0 while L1's counter is already 1; T2's push-back
+    // then writes 1 to L1 (instead of 2), causing cb_wait_front to deadlock.
     uint32_t c0_tiles = total_tiles * 2;  // double-buffered
     CircularBufferConfig cb0_cfg = CircularBufferConfig(c0_tiles * single_tile_size, {{CBIndex::c_0, cb_data_format}})
                                        .set_page_size(CBIndex::c_0, single_tile_size);
@@ -126,13 +136,19 @@ static bool run_matmul_reduce_inplace_test(
                                        .set_page_size(CBIndex::c_1, single_tile_size);
     CreateCircularBuffer(program, core, cb1_cfg);
 
+    // c_2: reader staging CB (reader pushes here, compute consumes and copies to c_0)
+    uint32_t c2_tiles = total_tiles * 2;
+    CircularBufferConfig cb2_cfg = CircularBufferConfig(c2_tiles * single_tile_size, {{CBIndex::c_2, cb_data_format}})
+                                       .set_page_size(CBIndex::c_2, single_tile_size);
+    CreateCircularBuffer(program, core, cb2_cfg);
+
     uint32_t c16_tiles = total_tiles * 2;
     CircularBufferConfig cb16_cfg =
         CircularBufferConfig(c16_tiles * single_tile_size, {{CBIndex::c_16, cb_data_format}})
             .set_page_size(CBIndex::c_16, single_tile_size);
     CreateCircularBuffer(program, core, cb16_cfg);
 
-    // Reader: feeds c_0 (total_tiles) from DRAM then pushes col-ident into c_1.
+    // Reader: feeds c_2 (staging, total_tiles) from DRAM then pushes col-ident into c_1.
     // We use a lightweight inline reader kernel — generate a custom one.
     auto reader_id = CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_reduce_inplace.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_reduce_inplace.cpp
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated integration tests for matmul_reduce_inplace
+// (ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp).
+//
+// The helper reduces `in_out_cb` in place by matmul-ing against a
+// column-identity tile in `in1_cb`. Net CB tile count is unchanged: for
+// every subblock_h tiles consumed, subblock_h tiles are pushed back.
+//
+// Test strategy:
+//   - Seed in_out_cb with an M_tiles × 1-tile column of random bf16 data
+//     (so each "tile row" holds 32 rows × 32 cols of test data).
+//   - Seed in1_cb with a column-identity tile (value=1.0 at column 0 of
+//     every tile row, zeros elsewhere) — matches SDPA's usage produced by
+//     generate_bcast_col_scalar on the reader side.
+//   - After the reduce, column 0 of each output tile holds the row-sum of
+//     the corresponding input tile row. Other columns are zero.
+//   - Also asserts the in-place invariant: total tiles in c_0 unchanged.
+//
+// Varies STATS_GRANULARITY (= subblock_h) and M to walk the num_subblocks
+// dimension. block_kt and subblock_w stay at 1 (SDPA usage).
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include "mesh_dispatch_fixture.hpp"
+
+namespace tt::tt_metal {
+
+using namespace tt::constants;
+
+namespace test_matmul_reduce_inplace {
+
+static float pcc_bfloat16(const std::vector<bfloat16>& a, const std::vector<bfloat16>& b) {
+    float x_mean = 0.0f, y_mean = 0.0f;
+    for (size_t i = 0; i < a.size(); i++) {
+        x_mean += static_cast<float>(a[i]);
+        y_mean += static_cast<float>(b[i]);
+    }
+    x_mean /= a.size();
+    y_mean /= b.size();
+    float cov = 0.0f, x_var = 0.0f, y_var = 0.0f;
+    for (size_t i = 0; i < a.size(); i++) {
+        float xd = static_cast<float>(a[i]) - x_mean;
+        float yd = static_cast<float>(b[i]) - y_mean;
+        cov += xd * yd;
+        x_var += xd * xd;
+        y_var += yd * yd;
+    }
+    if (x_var == 0.0f || y_var == 0.0f) {
+        return (x_var == y_var) ? 1.0f : 0.0f;
+    }
+    return cov / std::sqrt(x_var * y_var);
+}
+
+struct ReduceConfig {
+    // M (in elements) = num_subblocks * subblock_h * TILE_HEIGHT
+    uint32_t num_subblocks;
+    uint32_t subblock_h;
+    // Kept at 1 per SDPA usage.
+    uint32_t subblock_w = 1;
+    uint32_t block_kt = 1;
+};
+
+static bool run_matmul_reduce_inplace_test(
+    MeshDispatchFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const ReduceConfig& cfg,
+    float pcc_threshold = 0.9999f) {
+    const uint32_t M_tiles = cfg.num_subblocks * cfg.subblock_h;
+    const uint32_t N_tiles = cfg.subblock_w;
+    const uint32_t total_tiles = M_tiles * N_tiles;
+    const uint32_t M = M_tiles * TILE_HEIGHT;
+    const uint32_t N = N_tiles * TILE_WIDTH;
+    const uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;
+
+    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
+    CoreCoord core({0, 0});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program{};
+
+    // DRAM buffers: input, col-ident (one tile), output copy.
+    uint32_t dram_size_in = single_tile_size * total_tiles;
+    uint32_t dram_size_cid = single_tile_size;
+    uint32_t dram_size_out = single_tile_size * total_tiles;
+
+    distributed::DeviceLocalBufferConfig lc_in{
+        .page_size = dram_size_in, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig lc_cid{
+        .page_size = dram_size_cid, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig lc_out{
+        .page_size = dram_size_out, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+
+    auto in_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_in}, lc_in, mesh_device.get());
+    auto cid_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_cid}, lc_cid, mesh_device.get());
+    auto out_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_out}, lc_out, mesh_device.get());
+
+    // CBs: c_0 (in_out), c_1 (col-ident, 1 tile), c_16 (out-copy)
+    uint32_t c0_tiles = total_tiles * 2;  // double-buffered
+    CircularBufferConfig cb0_cfg = CircularBufferConfig(c0_tiles * single_tile_size, {{CBIndex::c_0, cb_data_format}})
+                                       .set_page_size(CBIndex::c_0, single_tile_size);
+    CreateCircularBuffer(program, core, cb0_cfg);
+
+    CircularBufferConfig cb1_cfg = CircularBufferConfig(single_tile_size, {{CBIndex::c_1, cb_data_format}})
+                                       .set_page_size(CBIndex::c_1, single_tile_size);
+    CreateCircularBuffer(program, core, cb1_cfg);
+
+    uint32_t c16_tiles = total_tiles * 2;
+    CircularBufferConfig cb16_cfg =
+        CircularBufferConfig(c16_tiles * single_tile_size, {{CBIndex::c_16, cb_data_format}})
+            .set_page_size(CBIndex::c_16, single_tile_size);
+    CreateCircularBuffer(program, core, cb16_cfg);
+
+    // Reader: feeds c_0 (total_tiles) from DRAM then pushes col-ident into c_1.
+    // We use a lightweight inline reader kernel — generate a custom one.
+    auto reader_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_reduce_inplace.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    // Writer: streams c_16 to DRAM.
+    auto writer_id = CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    std::vector<uint32_t> compute_args = {cfg.num_subblocks, cfg.subblock_h, cfg.subblock_w, cfg.block_kt, total_tiles};
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/test_matmul_reduce_inplace_compute.cpp",
+        core,
+        ComputeConfig{.math_fidelity = MathFidelity::HiFi4, .compile_args = compute_args});
+
+    SetRuntimeArgs(
+        program,
+        reader_id,
+        core,
+        {in_dram->address(), 0, cid_dram->address(), 0, total_tiles, total_tiles * single_tile_size, single_tile_size});
+
+    SetRuntimeArgs(program, writer_id, core, {out_dram->address(), 0, total_tiles});
+
+    // ── Input data ──
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+
+    // Fill input as M × N (elements).
+    std::vector<bfloat16> src_vec(M * N);
+    for (auto& v : src_vec) {
+        v = bfloat16(dist(rng));
+    }
+
+    // Col-ident tile: scalar 1.0 in column 0 of the tile, zeros elsewhere.
+    // Mirrors generate_bcast_col_scalar on the device side.
+    std::vector<bfloat16> cid_tile(TILE_HEIGHT * TILE_WIDTH, bfloat16(0.0f));
+    for (uint32_t r = 0; r < TILE_HEIGHT; r++) {
+        cid_tile[r * TILE_WIDTH + 0] = bfloat16(1.0f);
+    }
+    // Host-side "tilize" of a 32×32 tile requires face packing. The input
+    // isn't a tiled "2D matrix" — it's a single tile. Use tilize_nfaces on
+    // a 32×32 element matrix.
+    auto cid_tilized = tilize_nfaces(cid_tile, TILE_HEIGHT, TILE_WIDTH);
+
+    // ── Golden ──
+    // For each tile of the input, the reduce computes col_0 = row_sum,
+    // cols 1..N-1 = 0. Golden produces an M×N element matrix.
+    //
+    // NB: the "row sum" is the sum across the N=1 tile's 32 columns.
+    // If we had multiple N tiles they would all sum together.
+    std::vector<bfloat16> golden(M * N, bfloat16(0.0f));
+    for (uint32_t i = 0; i < M; i++) {
+        float row_sum = 0.0f;
+        for (uint32_t j = 0; j < N; j++) {
+            row_sum += static_cast<float>(src_vec[i * N + j]);
+        }
+        golden[i * N + 0] = bfloat16(row_sum);
+        // cols >=1 stay zero.
+    }
+
+    auto src_tilized = tilize_nfaces(src_vec, M, N);
+
+    auto src_packed = pack_bfloat16_vec_into_uint32_vec(src_tilized);
+    auto cid_packed = pack_bfloat16_vec_into_uint32_vec(cid_tilized);
+    fixture->WriteBuffer(mesh_device, in_dram, src_packed);
+    fixture->WriteBuffer(mesh_device, cid_dram, cid_packed);
+
+    workload.add_program(device_range, std::move(program));
+    fixture->RunProgram(mesh_device, workload);
+
+    // ── Read back ──
+    // Expected: total_tiles were pushed into c_16 (post-reduce), writer drained.
+    // That is the in-place invariant check: same number of tiles after reduce.
+    std::vector<uint32_t> result_packed;
+    fixture->ReadBuffer(mesh_device, out_dram, result_packed);
+    auto result_tilized = unpack_uint32_vec_into_bfloat16_vec(result_packed);
+
+    if (result_tilized.size() != M * N) {
+        log_warning(
+            LogTest, "Result size {} != expected {} — in-place invariant violated?", result_tilized.size(), M * N);
+        return false;
+    }
+
+    auto result_vec = untilize_nfaces(result_tilized, M, N);
+
+    float pcc = pcc_bfloat16(golden, result_vec);
+    log_info(
+        LogTest,
+        "num_subblocks={} subblock_h={} subblock_w={} block_kt={} M_tiles={} N_tiles={} — PCC = {:.6f} (thresh {:.4f})",
+        cfg.num_subblocks,
+        cfg.subblock_h,
+        cfg.subblock_w,
+        cfg.block_kt,
+        M_tiles,
+        N_tiles,
+        pcc,
+        pcc_threshold);
+    return pcc > pcc_threshold;
+}
+
+}  // namespace test_matmul_reduce_inplace
+
+using test_matmul_reduce_inplace::ReduceConfig;
+using test_matmul_reduce_inplace::run_matmul_reduce_inplace_test;
+
+// STATS_GRANULARITY=1 (default SDPA decode path)
+TEST_F(MeshDispatchFixture, TensixMatmulReduceInplaceGranularity1M1) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_reduce_inplace_test(this, device, {.num_subblocks = 1, .subblock_h = 1}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulReduceInplaceGranularity1M4) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_reduce_inplace_test(this, device, {.num_subblocks = 4, .subblock_h = 1}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixMatmulReduceInplaceGranularity1M8) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_reduce_inplace_test(this, device, {.num_subblocks = 8, .subblock_h = 1}));
+    }
+}
+
+// STATS_GRANULARITY=2 (chunked decode path)
+TEST_F(MeshDispatchFixture, TensixMatmulReduceInplaceGranularity2) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_reduce_inplace_test(this, device, {.num_subblocks = 4, .subblock_h = 2}));
+    }
+}
+
+// STATS_GRANULARITY=4 (larger chunk)
+TEST_F(MeshDispatchFixture, TensixMatmulReduceInplaceGranularity4) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_matmul_reduce_inplace_test(this, device, {.num_subblocks = 2, .subblock_h = 4}));
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/integration/matmul/test_reblock_and_untilize.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_reblock_and_untilize.cpp
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated integration tests for reblock_and_untilize helper
+// (ttnn/cpp/ttnn/kernel_lib/reblock_untilize_helpers.hpp).
+//
+// Drives the helper directly with a synthetic subblock-major tiled buffer —
+// no matmul participates. Verifies the helper reorders + untilizes into
+// row-major element output, pushing `out_block_w` tiles worth per row.
+//
+// Test strategy:
+//   - Construct an M×N matrix filled with deterministic bf16 values (i*N + j).
+//   - Tilize normally (nfaces), then re-order the tile sequence so it lands in
+//     subblock-major order within each row-group (matches the matmul_block
+//     output layout when row_major_output=false).
+//   - Push the whole thing into c_24.
+//   - Helper writes row-major untilized into c_16; writer streams to DRAM.
+//   - Compare against the original element-order matrix directly.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include "mesh_dispatch_fixture.hpp"
+
+namespace tt::tt_metal {
+
+using namespace tt::constants;
+
+namespace test_reblock_and_untilize {
+
+// Take a tilized buffer in row-major tile order over an Mt×Nt grid and
+// reorder it into subblock-major tile order within each row-group.
+// Layout within one row-group (out_subblock_h tile-rows):
+//   for each of num_subblocks_w subblocks:
+//     for each row h in out_subblock_h:
+//       for each col w in out_subblock_w:
+//         tile
+static std::vector<bfloat16> row_major_to_subblock_order(
+    const std::vector<bfloat16>& tilized, uint32_t Mt, uint32_t Nt, uint32_t out_subblock_h, uint32_t out_subblock_w) {
+    const uint32_t tile_elems = TILE_HEIGHT * TILE_WIDTH;
+    const uint32_t num_sb_w = Nt / out_subblock_w;
+    const uint32_t num_row_groups = Mt / out_subblock_h;
+    std::vector<bfloat16> result(tilized.size());
+    uint32_t dst = 0;
+    for (uint32_t g = 0; g < num_row_groups; g++) {
+        for (uint32_t sb = 0; sb < num_sb_w; sb++) {
+            for (uint32_t h = 0; h < out_subblock_h; h++) {
+                for (uint32_t w = 0; w < out_subblock_w; w++) {
+                    uint32_t row_tile = g * out_subblock_h + h;
+                    uint32_t col_tile = sb * out_subblock_w + w;
+                    uint32_t src_tile_idx = row_tile * Nt + col_tile;
+                    std::copy(
+                        tilized.begin() + src_tile_idx * tile_elems,
+                        tilized.begin() + (src_tile_idx + 1) * tile_elems,
+                        result.begin() + dst);
+                    dst += tile_elems;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+struct ReblockConfig {
+    uint32_t M;               // rows in elements
+    uint32_t N;               // cols in elements
+    uint32_t out_subblock_h;  // tiles
+    uint32_t out_subblock_w;  // tiles
+};
+
+static bool run_reblock_and_untilize_test(
+    MeshDispatchFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const ReblockConfig& cfg) {
+    uint32_t Mt = cfg.M / TILE_HEIGHT;
+    uint32_t Nt = cfg.N / TILE_WIDTH;
+    uint32_t num_subblocks_w = Nt / cfg.out_subblock_w;
+    uint32_t num_row_groups = Mt / cfg.out_subblock_h;
+    uint32_t total_tiles = Mt * Nt;
+    uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;
+    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
+    CoreCoord core({0, 0});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program{};
+
+    uint32_t dram_size_in = single_tile_size * total_tiles;
+    // Untilized output: writer drains one untilized "row of tiles" per pack,
+    // which is out_block_w tiles worth (= Nt * single_tile_size for full N).
+    uint32_t dram_size_out = single_tile_size * total_tiles;
+
+    distributed::DeviceLocalBufferConfig lc_in{
+        .page_size = dram_size_in, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig lc_out{
+        .page_size = dram_size_out, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+
+    auto in_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_in}, lc_in, mesh_device.get());
+    auto out_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_out}, lc_out, mesh_device.get());
+
+    // c_24 holds the subblock-major tiled input.
+    CircularBufferConfig cb_interm_cfg =
+        CircularBufferConfig(total_tiles * single_tile_size, {{CBIndex::c_24, cb_data_format}})
+            .set_page_size(CBIndex::c_24, single_tile_size);
+    CreateCircularBuffer(program, core, cb_interm_cfg);
+
+    // c_16 holds untilized output.
+    CircularBufferConfig cb_out_cfg =
+        CircularBufferConfig(total_tiles * single_tile_size, {{CBIndex::c_16, cb_data_format}})
+            .set_page_size(CBIndex::c_16, single_tile_size);
+    CreateCircularBuffer(program, core, cb_out_cfg);
+
+    // Reader: push the whole buffer into c_24 in one shot.
+    auto reader_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_push_c24.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    // Writer: stream c_16 to DRAM.
+    auto writer_id = CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    std::vector<uint32_t> compute_args = {
+        num_row_groups,
+        num_subblocks_w,
+        cfg.out_subblock_h,
+        cfg.out_subblock_w,
+        /*out_block_w*/ num_subblocks_w * cfg.out_subblock_w};
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/test_reblock_and_untilize_compute.cpp",
+        core,
+        ComputeConfig{.math_fidelity = MathFidelity::HiFi4, .compile_args = compute_args});
+
+    SetRuntimeArgs(program, reader_id, core, {in_dram->address(), 0, total_tiles, total_tiles * single_tile_size});
+    SetRuntimeArgs(program, writer_id, core, {out_dram->address(), 0, total_tiles});
+
+    // Deterministic input: value at (i, j) = i*N + j (bf16-rounded).
+    std::vector<bfloat16> src_elem(cfg.M * cfg.N);
+    for (uint32_t i = 0; i < cfg.M; i++) {
+        for (uint32_t j = 0; j < cfg.N; j++) {
+            src_elem[i * cfg.N + j] = bfloat16(static_cast<float>(i * cfg.N + j));
+        }
+    }
+
+    auto src_tilized_row_major = tilize_nfaces(src_elem, cfg.M, cfg.N);
+    auto src_tilized_subblock =
+        row_major_to_subblock_order(src_tilized_row_major, Mt, Nt, cfg.out_subblock_h, cfg.out_subblock_w);
+    auto src_packed = pack_bfloat16_vec_into_uint32_vec(src_tilized_subblock);
+    fixture->WriteBuffer(mesh_device, in_dram, src_packed);
+
+    workload.add_program(device_range, std::move(program));
+    fixture->RunProgram(mesh_device, workload);
+
+    std::vector<uint32_t> result_packed;
+    fixture->ReadBuffer(mesh_device, out_dram, result_packed);
+    auto result_tilized = unpack_uint32_vec_into_bfloat16_vec(result_packed);
+
+    // Helper emits row-major untilized output to c_16. writer_unary streams
+    // the raw bytes to DRAM (tile-at-a-time mechanically, but the layout is
+    // whatever the helper packed into the CB). In production this output
+    // feeds writer_unary_interleaved_start_id which expects `num_tiles`
+    // tiles — but the underlying bytes are semantically the MxN matrix in
+    // row-major element layout, not tiled.
+    //
+    // To compare robustly against random or deterministic inputs, compute
+    // PCC between the raw bf16 stream and src_elem (flattened row-major).
+    // If the helper's byte layout differs from "pure row-major concatenated
+    // across pushes", the PCC will drop and flag the mismatch.
+    float max_err = 0.0f;
+    if (result_tilized.size() < src_elem.size()) {
+        log_warning(LogTest, "Result size {} < expected {}", result_tilized.size(), src_elem.size());
+        return false;
+    }
+
+    // Compute PCC on the common prefix.
+    std::vector<bfloat16> got_slice(result_tilized.begin(), result_tilized.begin() + src_elem.size());
+    float sum_e = 0.0f, sum_g = 0.0f;
+    for (size_t k = 0; k < src_elem.size(); k++) {
+        sum_e += static_cast<float>(src_elem[k]);
+        sum_g += static_cast<float>(got_slice[k]);
+    }
+    float mean_e = sum_e / src_elem.size();
+    float mean_g = sum_g / src_elem.size();
+    float cov = 0.0f, var_e = 0.0f, var_g = 0.0f;
+    for (size_t k = 0; k < src_elem.size(); k++) {
+        float ed = static_cast<float>(src_elem[k]) - mean_e;
+        float gd = static_cast<float>(got_slice[k]) - mean_g;
+        cov += ed * gd;
+        var_e += ed * ed;
+        var_g += gd * gd;
+        max_err = std::max(max_err, std::abs(ed - gd));
+    }
+    float pcc = (var_e == 0.0f || var_g == 0.0f) ? (var_e == var_g ? 1.0f : 0.0f) : (cov / std::sqrt(var_e * var_g));
+
+    log_info(
+        LogTest,
+        "M={} N={} sb_h={} sb_w={} rg={} nb_w={} PCC={:.6f} max_err={:.4f}",
+        cfg.M,
+        cfg.N,
+        cfg.out_subblock_h,
+        cfg.out_subblock_w,
+        num_row_groups,
+        num_subblocks_w,
+        pcc,
+        max_err);
+    // Untilize is byte-level lossless. Threshold at 0.9999 for PCC.
+    return pcc > 0.9999f;
+}
+
+}  // namespace test_reblock_and_untilize
+
+using test_reblock_and_untilize::ReblockConfig;
+using test_reblock_and_untilize::run_reblock_and_untilize_test;
+
+// Single subblock per row, single row-group
+TEST_F(MeshDispatchFixture, TensixReblockAndUntilizeSingleSubblock) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(
+            run_reblock_and_untilize_test(this, device, {.M = 32, .N = 32, .out_subblock_h = 1, .out_subblock_w = 1}));
+    }
+}
+
+// Multiple subblocks along N
+TEST_F(MeshDispatchFixture, TensixReblockAndUntilizeMultiSubblockN) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(
+            run_reblock_and_untilize_test(this, device, {.M = 64, .N = 128, .out_subblock_h = 2, .out_subblock_w = 2}));
+    }
+}
+
+// Multiple row-groups along M
+TEST_F(MeshDispatchFixture, TensixReblockAndUntilizeMultiRowGroup) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(
+            run_reblock_and_untilize_test(this, device, {.M = 128, .N = 64, .out_subblock_h = 2, .out_subblock_w = 2}));
+    }
+}
+
+// Both dimensions subblocked
+TEST_F(MeshDispatchFixture, TensixReblockAndUntilizeMultiBoth) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_reblock_and_untilize_test(
+            this, device, {.M = 128, .N = 128, .out_subblock_h = 2, .out_subblock_w = 2}));
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/integration/matmul/test_transpose_pre_k_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_transpose_pre_k_block.cpp
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated integration tests for TransposePreKBlock
+// (ttnn/cpp/ttnn/kernel_lib/transpose_block_helpers.hpp), used as the
+// PreKBlockFn slot of matmul_block.
+//
+// The functor WH-transposes in0 tiles from `in0_transpose_cb` into `in0_cb`
+// once per K-block. The host-side golden mirrors by swapping row/col within
+// each 32×32 tile of A before the plain-C++ matmul.
+//
+// Verify: matmul_block(A, B, TransposePreKBlock) == matmul_block(wh_xpose(A), B)
+//   where wh_xpose transposes within each 32×32 tile of A.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include "mesh_dispatch_fixture.hpp"
+
+namespace tt::tt_metal {
+
+using namespace tt::constants;
+
+namespace test_transpose_pre_k_block {
+
+static float pcc_bfloat16(const std::vector<bfloat16>& a, const std::vector<bfloat16>& b) {
+    float x_mean = 0.0f, y_mean = 0.0f;
+    for (size_t i = 0; i < a.size(); i++) {
+        x_mean += static_cast<float>(a[i]);
+        y_mean += static_cast<float>(b[i]);
+    }
+    x_mean /= a.size();
+    y_mean /= b.size();
+    float cov = 0.0f, x_var = 0.0f, y_var = 0.0f;
+    for (size_t i = 0; i < a.size(); i++) {
+        float xd = static_cast<float>(a[i]) - x_mean;
+        float yd = static_cast<float>(b[i]) - y_mean;
+        cov += xd * yd;
+        x_var += xd * xd;
+        y_var += yd * yd;
+    }
+    if (x_var == 0.0f || y_var == 0.0f) {
+        return (x_var == y_var) ? 1.0f : 0.0f;
+    }
+    return cov / std::sqrt(x_var * y_var);
+}
+
+// Golden matmul with within-tile WH-transpose of A.
+// A_eff[row, col] lives at (i*32 + r, j*32 + c) where (i,j) is the tile index
+// and (r,c) is the within-tile position. WH-transpose swaps (r,c).
+// So A_eff[i*32 + r, j*32 + c] = A_orig[i*32 + c, j*32 + r].
+static void golden_matmul_wh_transpose_a(
+    const std::vector<bfloat16>& a_orig,
+    const std::vector<bfloat16>& b,
+    std::vector<bfloat16>& output,
+    uint32_t M,
+    uint32_t K,
+    uint32_t N) {
+    auto a_eff = [&](uint32_t row, uint32_t col) -> float {
+        uint32_t tile_i = row / TILE_HEIGHT;
+        uint32_t tile_j = col / TILE_WIDTH;
+        uint32_t r = row % TILE_HEIGHT;
+        uint32_t c = col % TILE_WIDTH;
+        // Swap within-tile (r, c)
+        uint32_t src_row = tile_i * TILE_HEIGHT + c;
+        uint32_t src_col = tile_j * TILE_WIDTH + r;
+        return static_cast<float>(a_orig[src_row * K + src_col]);
+    };
+
+    for (uint32_t i = 0; i < M; i++) {
+        for (uint32_t j = 0; j < N; j++) {
+            float acc = 0.0f;
+            for (uint32_t k = 0; k < K; k++) {
+                acc += a_eff(i, k) * static_cast<float>(b[k * N + j]);
+            }
+            output[i * N + j] = bfloat16(acc);
+        }
+    }
+}
+
+// Rearrange tilized A from row-major tile order to block-column order.
+static std::vector<bfloat16> reorder_tiles_to_block_column(
+    const std::vector<bfloat16>& tilized, uint32_t Mt, uint32_t Kt, uint32_t block_w) {
+    const uint32_t tiles_per_tile = TILE_HEIGHT * TILE_WIDTH;
+    uint32_t num_blocks = Kt / block_w;
+    std::vector<bfloat16> result(tilized.size());
+
+    uint32_t dst_offset = 0;
+    for (uint32_t blk = 0; blk < num_blocks; blk++) {
+        for (uint32_t row = 0; row < Mt; row++) {
+            for (uint32_t col = 0; col < block_w; col++) {
+                uint32_t src_tile_idx = (row * Kt) + (blk * block_w) + col;
+                uint32_t src_offset = src_tile_idx * tiles_per_tile;
+                std::copy(
+                    tilized.begin() + src_offset,
+                    tilized.begin() + src_offset + tiles_per_tile,
+                    result.begin() + dst_offset);
+                dst_offset += tiles_per_tile;
+            }
+        }
+    }
+    return result;
+}
+
+struct XposeConfig {
+    uint32_t M;
+    uint32_t N;
+    uint32_t K;
+    uint32_t out_subblock_h;
+    uint32_t out_subblock_w;
+    uint32_t in0_block_w;
+};
+
+static bool run_transpose_pre_k_block_test(
+    MeshDispatchFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const XposeConfig& cfg,
+    float pcc_threshold = 0.97f) {
+    uint32_t Mt = cfg.M / TILE_HEIGHT;
+    uint32_t Kt = cfg.K / TILE_WIDTH;
+    uint32_t Nt = cfg.N / TILE_WIDTH;
+    uint32_t in0_block_w = cfg.in0_block_w;
+
+    uint32_t num_blocks = Kt / in0_block_w;
+    uint32_t in0_num_subblocks = Mt / cfg.out_subblock_h;
+    uint32_t in1_num_subblocks = Nt / cfg.out_subblock_w;
+    uint32_t in0_block_num_tiles = Mt * in0_block_w;
+    uint32_t in0_subblock_num_tiles = cfg.out_subblock_h * in0_block_w;
+    uint32_t in1_block_num_tiles = Nt * in0_block_w;
+    uint32_t in1_per_core_w = Nt;
+    uint32_t out_subblock_num_tiles = cfg.out_subblock_h * cfg.out_subblock_w;
+    uint32_t num_output_tiles = Mt * Nt;
+    uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;
+    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
+    CoreCoord core({0, 0});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program{};
+
+    uint32_t dram_size_a = single_tile_size * Mt * Kt;
+    uint32_t dram_size_b = single_tile_size * Kt * Nt;
+    uint32_t dram_size_c = single_tile_size * Mt * Nt;
+
+    distributed::DeviceLocalBufferConfig lc_a{
+        .page_size = dram_size_a, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig lc_b{
+        .page_size = dram_size_b, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    distributed::DeviceLocalBufferConfig lc_c{
+        .page_size = dram_size_c, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+
+    auto src0_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_a}, lc_a, mesh_device.get());
+    auto src1_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_b}, lc_b, mesh_device.get());
+    auto dst_dram = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_size_c}, lc_c, mesh_device.get());
+
+    // CBs:
+    //   c_3 (in0_transpose) is the reader target — original A.
+    //   c_0 (in0) is what matmul_block consumes — populated by TransposePreKBlock.
+    //   c_1 (in1) is B.
+    //   c_16/c_24 share L1 per the standard multicast layout.
+    uint32_t in0_cb_tiles = in0_block_num_tiles * 2;
+    CircularBufferConfig cb_in0_cfg =
+        CircularBufferConfig(in0_cb_tiles * single_tile_size, {{CBIndex::c_0, cb_data_format}})
+            .set_page_size(CBIndex::c_0, single_tile_size);
+    CreateCircularBuffer(program, core, cb_in0_cfg);
+
+    CircularBufferConfig cb_in0_xp_cfg =
+        CircularBufferConfig(in0_cb_tiles * single_tile_size, {{CBIndex::c_3, cb_data_format}})
+            .set_page_size(CBIndex::c_3, single_tile_size);
+    CreateCircularBuffer(program, core, cb_in0_xp_cfg);
+
+    uint32_t in1_cb_tiles = in1_block_num_tiles * 2;
+    CircularBufferConfig cb_in1_cfg =
+        CircularBufferConfig(in1_cb_tiles * single_tile_size, {{CBIndex::c_1, cb_data_format}})
+            .set_page_size(CBIndex::c_1, single_tile_size);
+    CreateCircularBuffer(program, core, cb_in1_cfg);
+
+    std::map<uint8_t, tt::DataFormat> partials_and_out_spec = {
+        {CBIndex::c_24, cb_data_format}, {CBIndex::c_16, cb_data_format}};
+    CircularBufferConfig cb_out_cfg = CircularBufferConfig(num_output_tiles * single_tile_size, partials_and_out_spec)
+                                          .set_page_size(CBIndex::c_24, single_tile_size)
+                                          .set_page_size(CBIndex::c_16, single_tile_size);
+    CreateCircularBuffer(program, core, cb_out_cfg);
+
+    // Custom reader that pushes A into c_3 (not c_0).
+    auto reader_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked_to_c3.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    auto writer_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unswizzle.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    std::vector<uint32_t> compute_args = {
+        in0_block_w,
+        in0_num_subblocks,
+        in0_block_num_tiles,
+        in0_subblock_num_tiles,
+        in1_num_subblocks,
+        in1_block_num_tiles,
+        in1_per_core_w,
+        num_blocks,
+        cfg.out_subblock_h,
+        cfg.out_subblock_w,
+        out_subblock_num_tiles,
+        1u};
+
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/test_transpose_pre_k_block_compute.cpp",
+        core,
+        ComputeConfig{.math_fidelity = MathFidelity::HiFi4, .compile_args = compute_args});
+
+    uint32_t in0_block_size_bytes = in0_block_num_tiles * single_tile_size;
+    uint32_t in1_block_size_bytes = in1_block_num_tiles * single_tile_size;
+    SetRuntimeArgs(
+        program,
+        reader_id,
+        core,
+        {src0_dram->address(),
+         0,
+         src1_dram->address(),
+         0,
+         num_blocks,
+         in0_block_num_tiles,
+         in1_block_num_tiles,
+         in0_block_size_bytes,
+         in1_block_size_bytes});
+
+    uint32_t stride_r = cfg.out_subblock_w * single_tile_size * (Nt / cfg.out_subblock_w);
+    uint32_t stride_subblock_r = cfg.out_subblock_h * cfg.out_subblock_w * single_tile_size * (Nt / cfg.out_subblock_w);
+    uint32_t stride_subblock_c = cfg.out_subblock_w * single_tile_size;
+    SetRuntimeArgs(
+        program,
+        writer_id,
+        core,
+        {dst_dram->address(),
+         0,
+         cfg.out_subblock_h,
+         cfg.out_subblock_w,
+         in0_num_subblocks,
+         in1_num_subblocks,
+         stride_r,
+         stride_subblock_r,
+         stride_subblock_c});
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+
+    std::vector<bfloat16> src0_vec(cfg.M * cfg.K);
+    std::vector<bfloat16> src1_vec(cfg.K * cfg.N);
+    for (auto& v : src0_vec) {
+        v = bfloat16(dist(rng));
+    }
+    for (auto& v : src1_vec) {
+        v = bfloat16(dist(rng));
+    }
+
+    std::vector<bfloat16> golden(cfg.M * cfg.N, bfloat16(0.0f));
+    golden_matmul_wh_transpose_a(src0_vec, src1_vec, golden, cfg.M, cfg.K, cfg.N);
+
+    auto src0_tilized = tilize_nfaces(src0_vec, cfg.M, cfg.K);
+    auto src1_tilized = tilize_nfaces(src1_vec, cfg.K, cfg.N);
+    src0_tilized = reorder_tiles_to_block_column(src0_tilized, Mt, Kt, in0_block_w);
+
+    auto src0_packed = pack_bfloat16_vec_into_uint32_vec(src0_tilized);
+    auto src1_packed = pack_bfloat16_vec_into_uint32_vec(src1_tilized);
+    fixture->WriteBuffer(mesh_device, src0_dram, src0_packed);
+    fixture->WriteBuffer(mesh_device, src1_dram, src1_packed);
+
+    workload.add_program(device_range, std::move(program));
+    fixture->RunProgram(mesh_device, workload);
+
+    std::vector<uint32_t> result_packed;
+    fixture->ReadBuffer(mesh_device, dst_dram, result_packed);
+    auto result_vec = unpack_uint32_vec_into_bfloat16_vec(result_packed);
+    result_vec = untilize_nfaces(result_vec, cfg.M, cfg.N);
+
+    float pcc = pcc_bfloat16(golden, result_vec);
+    log_info(
+        LogTest,
+        "M={} N={} K={} blk_w={} sub_h={} sub_w={} nb={} — PCC = {:.6f} (thresh {:.4f})",
+        cfg.M,
+        cfg.N,
+        cfg.K,
+        cfg.in0_block_w,
+        cfg.out_subblock_h,
+        cfg.out_subblock_w,
+        num_blocks,
+        pcc,
+        pcc_threshold);
+    return pcc > pcc_threshold;
+}
+
+}  // namespace test_transpose_pre_k_block
+
+using test_transpose_pre_k_block::run_transpose_pre_k_block_test;
+using test_transpose_pre_k_block::XposeConfig;
+
+TEST_F(MeshDispatchFixture, TensixTransposePreKBlockSmall) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_transpose_pre_k_block_test(
+            this, device, {.M = 64, .N = 64, .K = 64, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixTransposePreKBlockMultiBlock) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_transpose_pre_k_block_test(
+            this, device, {.M = 64, .N = 64, .K = 128, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+TEST_F(MeshDispatchFixture, TensixTransposePreKBlockMultiSubblockM) {
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(run_transpose_pre_k_block_test(
+            this, device, {.M = 128, .N = 64, .K = 64, .out_subblock_h = 2, .out_subblock_w = 2, .in0_block_w = 2}));
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/integration/sources.cmake
+++ b/tests/tt_metal/tt_metal/integration/sources.cmake
@@ -11,5 +11,10 @@ set(UNIT_TESTS_INTEGRATION_SRC
     matmul/test_matmul_multi_core_X_dram.cpp
     matmul/test_matmul_single_core.cpp
     matmul/test_matmul_X_tile.cpp
+    matmul/test_matmul_block_helper.cpp
+    matmul/test_matmul_reduce_inplace.cpp
+    matmul/test_transpose_pre_k_block.cpp
+    matmul/test_reblock_and_untilize.cpp
+    matmul/test_add_bias_bcast_rows.cpp
     vecadd/test_vecadd_multi_core.cpp
 )

--- a/tests/tt_metal/tt_metal/test_kernels/compute/test_add_bias_bcast_rows_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/test_add_bias_bcast_rows_compute.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated test compute kernel for add_bias_bcast_rows helper
+// (ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.hpp).
+//
+// CB layout:
+//   c_24 (partials) — synthetic matmul output (host pre-fills)
+//   c_2  (bias)     — row-broadcast bias vector (one tile per N-subblock column)
+//   c_16 (out)      — biased output
+//
+// Compile-time args:
+//   [0] num_invocations    — how many outer iterations (bh * batch loops)
+//   [1] in0_num_subblocks
+//   [2] in1_num_subblocks
+//   [3] out_subblock_h
+//   [4] out_subblock_w
+//   [5] bias_ntiles        — total bias tiles (= in1_num_subblocks * out_subblock_w)
+//
+// Defines:
+//   BIAS_ONE_TIME_FRONT  — reader pushes bias once; caller waits once, never pops
+//   BIAS_PER_ITER_PUSH   — reader pushes bias per iteration; caller waits+pops per iter
+//   HELPER_POST_BIAS_RELU — PostBiasFn applies relu via SFPU
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.hpp"
+#include "api/compute/matmul.h"
+#include "api/compute/bcast.h"
+
+#ifdef HELPER_POST_BIAS_RELU
+#include "api/compute/eltwise_unary/relu.h"
+
+struct ReluPostBias {
+    ALWI void operator()(uint32_t num_tiles) const {
+        relu_tile_init();
+        for (uint32_t i = 0; i < num_tiles; i++) {
+            relu_tile(i);
+        }
+    }
+};
+#endif
+
+void kernel_main() {
+    constexpr uint32_t num_invocations = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_num_subblocks = get_compile_time_arg_val(2);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(3);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(4);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(5);
+
+    constexpr uint32_t partials_cb = tt::CBIndex::c_24;
+    constexpr uint32_t bias_cb = tt::CBIndex::c_2;
+    constexpr uint32_t out_cb = tt::CBIndex::c_16;
+
+    // init_bcast expects all three CBs — mm_init style is insufficient because
+    // the helper uses add_tiles_bcast_rows via add_bcast_rows_init_short().
+    // init_bcast sets the global data formats correctly for the row-bcast add.
+    init_bcast<EltwiseBinaryType::ELWADD, BroadcastType::ROW>(partials_cb, bias_cb, out_cb);
+
+    for (uint32_t iter = 0; iter < num_invocations; ++iter) {
+#if defined(BIAS_ONE_TIME_FRONT)
+        // Production path A (num_blocks_w_dim==1): wait on first iter only, never pop.
+        if (iter == 0) {
+            cb_wait_front(bias_cb, bias_ntiles);
+        }
+#elif defined(BIAS_PER_ITER_PUSH)
+        // Production path B (num_blocks_w_dim>1): wait + pop every iter.
+        cb_wait_front(bias_cb, bias_ntiles);
+#endif
+
+#ifdef HELPER_POST_BIAS_RELU
+        compute_kernel_lib::add_bias_bcast_rows<partials_cb, bias_cb, out_cb, ReluPostBias>(
+            in0_num_subblocks, in1_num_subblocks, out_subblock_h, out_subblock_w, ReluPostBias{});
+#else
+        compute_kernel_lib::add_bias_bcast_rows<partials_cb, bias_cb, out_cb>(
+            in0_num_subblocks, in1_num_subblocks, out_subblock_h, out_subblock_w);
+#endif
+
+#ifdef BIAS_PER_ITER_PUSH
+        cb_pop_front(bias_cb, bias_ntiles);
+#endif
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/test_matmul_block_helper_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/test_matmul_block_helper_compute.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Parameterized test compute kernel for matmul_block helper
+// (ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp).
+//
+// Exercises the template parameter pack: transpose, packer_l1_acc,
+// pack_last_to_interm, pack_relu, row_major_output, and PostComputeFn.
+// PreKBlockFn coverage lives in the dedicated transpose-PreKBlock test.
+//
+// Defines controlling the helper template parameter pack:
+//   HELPER_TRANSPOSE          — transpose=true
+//   HELPER_PACKER_L1_ACC      — packer_l1_acc=true
+//   HELPER_PACK_LAST_INTERM   — pack_last_to_interm=true  (writer reads c_24)
+//   HELPER_PACK_RELU          — pack_relu=true
+//   HELPER_ROW_MAJOR_OUTPUT   — row_major_output=true
+//   HELPER_POST_COMPUTE_RELU  — PostComputeFn applies relu via SFPU
+//
+// CB layout:
+//   c_0   (in0)       — Matrix A input
+//   c_1   (in1)       — Matrix B input
+//   c_16  (out)       — Final output  (used when pack_last_to_interm=false)
+//   c_24  (interm)    — Intermediate / reload / L1-ACC FIFO. When
+//                       pack_last_to_interm=true the writer reads c_24 here
+//                       too (host swaps writer target accordingly).
+//
+// Compile-time args (match existing reader_matmul_blocked + writer_unswizzle
+// conventions so the same host dataflow kernels can be reused):
+//   [0]  in0_block_w
+//   [1]  in0_num_subblocks
+//   [2]  in0_block_num_tiles
+//   [3]  in0_subblock_num_tiles
+//   [4]  in1_num_subblocks
+//   [5]  in1_block_num_tiles
+//   [6]  in1_per_core_w
+//   [7]  num_blocks (K-dim)
+//   [8]  out_subblock_h
+//   [9]  out_subblock_w
+//   [10] out_subblock_num_tiles
+//   [11] batch
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp"
+
+#ifdef HELPER_POST_COMPUTE_RELU
+#include "api/compute/eltwise_unary/relu.h"
+#endif
+
+namespace {
+
+#ifdef HELPER_POST_COMPUTE_RELU
+// Nontrivial PostComputeFn: applies relu per-tile via SFPU on the last K-block
+// output before packing. Host-side golden applies ReLU for parity.
+struct ReluPostCompute {
+    ALWI void operator()(uint32_t num_tiles) const {
+        relu_tile_init();
+        for (uint32_t i = 0; i < num_tiles; i++) {
+            relu_tile(i);
+        }
+    }
+};
+#endif
+
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_num_subblocks = get_compile_time_arg_val(4);
+    constexpr uint32_t num_k_blocks = get_compile_time_arg_val(7);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(8);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(9);
+    constexpr uint32_t batch = get_compile_time_arg_val(11);
+
+    constexpr uint32_t in0_cb = tt::CBIndex::c_0;
+    constexpr uint32_t in1_cb = tt::CBIndex::c_1;
+    constexpr uint32_t out_cb = tt::CBIndex::c_16;
+    constexpr uint32_t interm_cb = tt::CBIndex::c_24;
+
+#ifdef HELPER_TRANSPOSE
+    constexpr bool transpose = true;
+#else
+    constexpr bool transpose = false;
+#endif
+
+#ifdef HELPER_PACKER_L1_ACC
+    constexpr bool packer_l1_acc = true;
+#else
+    constexpr bool packer_l1_acc = false;
+#endif
+
+#ifdef HELPER_PACK_LAST_INTERM
+    constexpr bool pack_last_to_interm = true;
+#else
+    constexpr bool pack_last_to_interm = false;
+#endif
+
+#ifdef HELPER_PACK_RELU
+    constexpr bool pack_relu = true;
+#else
+    constexpr bool pack_relu = false;
+#endif
+
+#ifdef HELPER_ROW_MAJOR_OUTPUT
+    constexpr bool row_major_output = true;
+#else
+    constexpr bool row_major_output = false;
+#endif
+
+    mm_block_init(in0_cb, in1_cb, interm_cb, transpose, out_subblock_w, out_subblock_h, in0_block_w);
+
+#ifdef HELPER_POST_COMPUTE_RELU
+    compute_kernel_lib::
+        matmul_block<transpose, packer_l1_acc, pack_last_to_interm, pack_relu, row_major_output, ReluPostCompute>(
+            in0_cb,
+            in1_cb,
+            out_cb,
+            interm_cb,
+            in0_block_w,
+            in0_num_subblocks,
+            in1_num_subblocks,
+            num_k_blocks,
+            out_subblock_h,
+            out_subblock_w,
+            batch,
+            ReluPostCompute{});
+#else
+    compute_kernel_lib::matmul_block<transpose, packer_l1_acc, pack_last_to_interm, pack_relu, row_major_output>(
+        in0_cb,
+        in1_cb,
+        out_cb,
+        interm_cb,
+        in0_block_w,
+        in0_num_subblocks,
+        in1_num_subblocks,
+        num_k_blocks,
+        out_subblock_h,
+        out_subblock_w,
+        batch);
+#endif
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/test_matmul_reduce_inplace_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/test_matmul_reduce_inplace_compute.cpp
@@ -10,10 +10,19 @@
 // column vector tile.
 //
 // CB layout:
-//   c_0  (in_out)     — input/output CB (produced by reader, overwritten in place)
-//   c_1  (col_ident)  — single column-identity tile (all ones)
-//   c_16 (out_copy)   — copy of c_0 after reduce, so the writer can drain it
-//                       via the standard writer_unary path
+//   c_0  (in_out)      — compute-produced in/out CB for the reduce
+//   c_1  (col_ident)   — single column-identity tile (all ones)
+//   c_2  (staging)     — reader-produced input; compute copies to c_0
+//   c_16 (out_copy)    — copy of c_0 after reduce, so the writer can drain it
+//                        via the standard writer_unary path
+//
+// Design note: matmul_reduce_inplace requires in_out_cb to be compute-owned
+// (T2's tiles_received shadow must track the pushes). A reader-produced CB
+// would leave T2's shadow at 0 while L1's counter is already nonzero, so
+// T2's push-back would overwrite L1 with too-low a value and cause the
+// subsequent cb_wait_front to deadlock. The fix is to have the reader write
+// to c_2 (staging) and then have the compute kernel copy c_2 → c_0 before
+// calling matmul_reduce_inplace, so that T2 owns the c_0 production history.
 //
 // Compile-time args:
 //   [0] num_subblocks
@@ -35,22 +44,38 @@ void kernel_main() {
     constexpr uint32_t block_kt = get_compile_time_arg_val(3);
     constexpr uint32_t total_in_tiles = get_compile_time_arg_val(4);
 
-    constexpr uint32_t in_out_cb = tt::CBIndex::c_0;
+    constexpr uint32_t staging_cb = tt::CBIndex::c_2;  // reader-produced staging
+    constexpr uint32_t in_out_cb = tt::CBIndex::c_0;   // compute-owned in/out
     constexpr uint32_t col_ident_cb = tt::CBIndex::c_1;
     constexpr uint32_t out_copy_cb = tt::CBIndex::c_16;
 
-    // The helper calls mm_block_init_short internally, but we still need the
-    // global mm_init once at TU start to set up compute infra. Configure pack
-    // for in_out_cb since the helper packs back to it (no internal reconfig).
+    // Phase 1: copy staging → in_out_cb to establish compute ownership of c_0.
+    // After this, T2's tiles_received shadow for c_0 correctly reflects the
+    // total_in_tiles pushes, so matmul_reduce_inplace's cb_push_back will
+    // write the right value to L1.
     mm_init(in_out_cb, col_ident_cb, in_out_cb);
+    copy_tile_to_dst_init_short(staging_cb);
+    PACK((pack_reconfig_data_format(in_out_cb)));
 
-    // Reduce in place: c_0 becomes the reduced result while its tile count
-    // stays the same (same num_subblocks * subblock_h * subblock_w tiles).
+    cb_wait_front(staging_cb, total_in_tiles);
+    cb_reserve_back(in_out_cb, total_in_tiles);
+    for (uint32_t i = 0; i < total_in_tiles; i++) {
+        tile_regs_acquire();
+        copy_tile(staging_cb, i, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, in_out_cb);
+        tile_regs_release();
+    }
+    cb_pop_front(staging_cb, total_in_tiles);
+    cb_push_back(in_out_cb, total_in_tiles);
+
+    // Phase 2: in-place reduce — c_0 is now compute-owned, so T2's counter
+    // is in sync with L1. The helper will correctly push-back to c_0 and
+    // T0's subsequent cb_wait_front will see the updated L1 counter.
     compute_kernel_lib::matmul_reduce_inplace(in_out_cb, col_ident_cb, num_subblocks, subblock_h, subblock_w, block_kt);
 
-    // Copy the reduced tiles from in_out_cb into out_copy_cb so the writer
-    // (consumes c_16) can drain them. This also serves as the "in-place"
-    // invariant check: we expect total_in_tiles tiles still fronted.
+    // Phase 3: copy reduced result from c_0 to c_16 for the writer to drain.
     // Helper ended with srcA configured for in_out_cb (via its internal
     // mm_block_init_short). Re-init for copy_tile, reconfigure pack format.
     copy_tile_to_dst_init_short(in_out_cb);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/test_matmul_reduce_inplace_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/test_matmul_reduce_inplace_compute.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated test compute kernel for matmul_reduce_inplace helper
+// (ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp).
+//
+// The helper reduces `in_out_cb` in place using a column-identity tile in
+// `in1_cb`. Used by SDPA to sum rows via a matmul against an all-ones
+// column vector tile.
+//
+// CB layout:
+//   c_0  (in_out)     — input/output CB (produced by reader, overwritten in place)
+//   c_1  (col_ident)  — single column-identity tile (all ones)
+//   c_16 (out_copy)   — copy of c_0 after reduce, so the writer can drain it
+//                       via the standard writer_unary path
+//
+// Compile-time args:
+//   [0] num_subblocks
+//   [1] subblock_h
+//   [2] subblock_w
+//   [3] block_kt
+//   [4] total_in_tiles (= num_subblocks * subblock_h * subblock_w)
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/cb_api.h"
+
+void kernel_main() {
+    constexpr uint32_t num_subblocks = get_compile_time_arg_val(0);
+    constexpr uint32_t subblock_h = get_compile_time_arg_val(1);
+    constexpr uint32_t subblock_w = get_compile_time_arg_val(2);
+    constexpr uint32_t block_kt = get_compile_time_arg_val(3);
+    constexpr uint32_t total_in_tiles = get_compile_time_arg_val(4);
+
+    constexpr uint32_t in_out_cb = tt::CBIndex::c_0;
+    constexpr uint32_t col_ident_cb = tt::CBIndex::c_1;
+    constexpr uint32_t out_copy_cb = tt::CBIndex::c_16;
+
+    // The helper calls mm_block_init_short internally, but we still need the
+    // global mm_init once at TU start to set up compute infra. Configure pack
+    // for in_out_cb since the helper packs back to it (no internal reconfig).
+    mm_init(in_out_cb, col_ident_cb, in_out_cb);
+
+    // Reduce in place: c_0 becomes the reduced result while its tile count
+    // stays the same (same num_subblocks * subblock_h * subblock_w tiles).
+    compute_kernel_lib::matmul_reduce_inplace(in_out_cb, col_ident_cb, num_subblocks, subblock_h, subblock_w, block_kt);
+
+    // Copy the reduced tiles from in_out_cb into out_copy_cb so the writer
+    // (consumes c_16) can drain them. This also serves as the "in-place"
+    // invariant check: we expect total_in_tiles tiles still fronted.
+    // Helper ended with srcA configured for in_out_cb (via its internal
+    // mm_block_init_short). Re-init for copy_tile, reconfigure pack format.
+    copy_tile_to_dst_init_short(in_out_cb);
+    PACK((pack_reconfig_data_format(out_copy_cb)));
+
+    // Wait for the reduced-in-place tiles. Counts must match the original
+    // input population. If matmul_reduce_inplace left the CB in an unexpected
+    // state this wait will hang — that's the in-place regression check.
+    cb_wait_front(in_out_cb, total_in_tiles);
+
+    for (uint32_t i = 0; i < total_in_tiles; i++) {
+        tile_regs_acquire();
+        copy_tile(in_out_cb, i, 0);
+        tile_regs_commit();
+
+        cb_reserve_back(out_copy_cb, 1);
+        tile_regs_wait();
+        pack_tile(0, out_copy_cb);
+        tile_regs_release();
+        cb_push_back(out_copy_cb, 1);
+    }
+
+    cb_pop_front(in_out_cb, total_in_tiles);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/test_reblock_and_untilize_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/test_reblock_and_untilize_compute.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated test compute kernel for reblock_and_untilize helper
+// (ttnn/cpp/ttnn/kernel_lib/reblock_untilize_helpers.hpp).
+//
+// Drives the helper directly with a synthetic subblock-major input — no
+// matmul involved. Exercises a single row-group per invocation, repeated
+// `num_row_groups` times (matches the production caller that loops
+// in0_num_subblocks times).
+//
+// CB layout:
+//   c_24 (interm)  — subblock-major input (reader pushes the whole test buffer)
+//   c_16 (out)     — untilized row-major output
+//
+// Compile-time args:
+//   [0] num_row_groups      (= in0_num_subblocks)
+//   [1] num_subblocks_w     (= in1_num_subblocks)
+//   [2] out_subblock_h
+//   [3] out_subblock_w
+//   [4] out_block_w         (= out_subblock_w * num_subblocks_w)
+
+#include <cstdint>
+
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/cb_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reblock_untilize_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t num_row_groups = get_compile_time_arg_val(0);
+    constexpr uint32_t num_subblocks_w = get_compile_time_arg_val(1);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(2);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(3);
+    constexpr uint32_t out_block_w = get_compile_time_arg_val(4);
+    constexpr uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    constexpr uint32_t interm_cb = tt::CBIndex::c_24;
+    constexpr uint32_t out_cb = tt::CBIndex::c_16;
+
+    // Bootstrap compute infrastructure for the untilize-only pipeline.
+    compute_kernel_hw_startup(interm_cb, out_cb);
+
+    // Helper prereqs: pack_untilize_dest_init + copy_tile_to_dst_init_short
+    // must be called once before the first invocation, and pack_untilize_uninit
+    // after the last. Mirrors the production caller.
+    pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb);
+    copy_tile_to_dst_init_short(interm_cb);
+
+    for (uint32_t g = 0; g < num_row_groups; g++) {
+        compute_kernel_lib::reblock_and_untilize<out_subblock_w, out_block_w>(
+            num_subblocks_w, out_subblock_num_tiles, out_subblock_h, interm_cb, out_cb);
+    }
+
+    pack_untilize_uninit(interm_cb);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/test_transpose_pre_k_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/test_transpose_pre_k_block_compute.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Isolated test compute kernel for TransposePreKBlock
+// (ttnn/cpp/ttnn/kernel_lib/transpose_block_helpers.hpp), used as the
+// PreKBlockFn slot of matmul_block.
+//
+// CB layout matches production fused-bias kernel:
+//   c_0  = cb_in0_transposed  — destination for the transposed tiles
+//   c_3  = cb_in0             — ORIGINAL A tiles read by the host dataflow kernel
+//                               (reader_matmul_blocked). This CB is passed as
+//                               in0_transpose_cb_id into the functor, which
+//                               reads, transposes WH, packs into c_0.
+//   c_1  = cb_in1             — B input
+//   c_16 = cb_out             — output
+//   c_24 = cb_intermed0       — partials
+//
+// Reader pushes the "original" A into c_3 (not c_0). TransposePreKBlock drains
+// c_3 → c_0. matmul_block then consumes c_0 as its in0_cb.
+//
+// Compile-time args:
+//   [0]  in0_block_w
+//   [1]  in0_num_subblocks
+//   [2]  in0_block_num_tiles
+//   [3]  in0_subblock_num_tiles
+//   [4]  in1_num_subblocks
+//   [5]  in1_block_num_tiles
+//   [6]  in1_per_core_w
+//   [7]  num_blocks
+//   [8]  out_subblock_h
+//   [9]  out_subblock_w
+//   [10] out_subblock_num_tiles
+//   [11] batch
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/transpose_block_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t in1_num_subblocks = get_compile_time_arg_val(4);
+    constexpr uint32_t num_k_blocks = get_compile_time_arg_val(7);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(8);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(9);
+    constexpr uint32_t batch = get_compile_time_arg_val(11);
+
+    constexpr uint32_t in0_cb = tt::CBIndex::c_0;            // matmul_block's in0 (transposed)
+    constexpr uint32_t in0_transpose_cb = tt::CBIndex::c_3;  // original A (reader target)
+    constexpr uint32_t in1_cb = tt::CBIndex::c_1;
+    constexpr uint32_t out_cb = tt::CBIndex::c_16;
+    constexpr uint32_t interm_cb = tt::CBIndex::c_24;
+
+    // TransposePreKBlock functor: transposes in0_transpose_cb → in0_cb
+    // at the start of every K-block iteration before matmul_block waits on in0.
+    using XposeFn = compute_kernel_lib::TransposePreKBlock<
+        in0_block_num_tiles,
+        /*in0_transpose_cb_id=*/in0_transpose_cb,
+        /*in0_cb_id=*/in0_cb,
+        /*in1_cb_id=*/in1_cb,
+        /*in1_transpose_tile=*/false,
+        out_subblock_w,
+        out_subblock_h,
+        in0_block_w,
+        /*mm_partials_cb_id=*/interm_cb>;
+
+    mm_block_init(in0_cb, in1_cb, interm_cb, false, out_subblock_w, out_subblock_h, in0_block_w);
+
+    compute_kernel_lib::matmul_block<
+        /*transpose=*/false,
+        /*packer_l1_acc=*/false,
+        /*pack_last_to_interm=*/false,
+        /*pack_relu=*/false,
+        /*row_major_output=*/false,
+        compute_kernel_lib::NoPostCompute,
+        XposeFn>(
+        in0_cb,
+        in1_cb,
+        out_cb,
+        interm_cb,
+        in0_block_w,
+        in0_num_subblocks,
+        in1_num_subblocks,
+        num_k_blocks,
+        out_subblock_h,
+        out_subblock_w,
+        batch,
+        compute_kernel_lib::NoPostCompute{},
+        XposeFn{});
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bias_test.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bias_test.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reader for the add_bias_bcast_rows isolated test.
+// Pushes partials into c_24 per iter, bias into c_2 either once or per-iter
+// depending on `bias_one_time_front`.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t partials_addr = get_arg_val<uint32_t>(0);
+    uint32_t partials_bank = get_arg_val<uint32_t>(1);
+    uint32_t bias_addr = get_arg_val<uint32_t>(2);
+    uint32_t bias_bank = get_arg_val<uint32_t>(3);
+    uint32_t num_invocations = get_arg_val<uint32_t>(4);
+    uint32_t partials_tiles_per_iter = get_arg_val<uint32_t>(5);
+    uint32_t bias_ntiles = get_arg_val<uint32_t>(6);
+    uint32_t partials_bytes_per_iter = get_arg_val<uint32_t>(7);
+    uint32_t bias_bytes_per_push = get_arg_val<uint32_t>(8);
+    uint32_t bias_one_time_front = get_arg_val<uint32_t>(9);
+
+    constexpr uint32_t partials_cb = tt::CBIndex::c_24;
+    constexpr uint32_t bias_cb = tt::CBIndex::c_2;
+
+    for (uint32_t iter = 0; iter < num_invocations; iter++) {
+        // Bias push
+        if (bias_one_time_front == 0 || iter == 0) {
+            uint64_t bias_noc = get_noc_addr_from_bank_id<true>(bias_bank, bias_addr);
+            cb_reserve_back(bias_cb, bias_ntiles);
+            uint32_t l1_b = get_write_ptr(bias_cb);
+            noc_async_read(bias_noc, l1_b, bias_bytes_per_push);
+            noc_async_read_barrier();
+            cb_push_back(bias_cb, bias_ntiles);
+
+            // Advance bias DRAM pointer only in per-iter mode.
+            if (bias_one_time_front == 0) {
+                bias_addr += bias_bytes_per_push;
+            }
+        }
+
+        // Partials push
+        uint64_t partials_noc = get_noc_addr_from_bank_id<true>(partials_bank, partials_addr);
+        cb_reserve_back(partials_cb, partials_tiles_per_iter);
+        uint32_t l1_p = get_write_ptr(partials_cb);
+        noc_async_read(partials_noc, l1_p, partials_bytes_per_iter);
+        noc_async_read_barrier();
+        cb_push_back(partials_cb, partials_tiles_per_iter);
+        partials_addr += partials_bytes_per_iter;
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked_to_c3.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked_to_c3.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Variant of reader_matmul_blocked that pushes in0 into c_3 (instead of c_0)
+// and in1 into c_1. Used by the TransposePreKBlock isolated test — the
+// transpose functor drains c_3 into c_0, so the reader must bypass c_0.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src0_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t src1_addr = get_arg_val<uint32_t>(2);
+    uint32_t src1_bank_id = get_arg_val<uint32_t>(3);
+    uint32_t num_blocks = get_arg_val<uint32_t>(4);
+    uint32_t in0_block_tile_cnt = get_arg_val<uint32_t>(5);
+    uint32_t in1_block_tile_cnt = get_arg_val<uint32_t>(6);
+    uint32_t in0_block_size_bytes = get_arg_val<uint32_t>(7);
+    uint32_t in1_block_size_bytes = get_arg_val<uint32_t>(8);
+
+    constexpr uint32_t cb_id_in0_xp = tt::CBIndex::c_3;
+    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
+
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        uint64_t src0_noc = get_noc_addr_from_bank_id<true>(src0_bank_id, src0_addr);
+        uint64_t src1_noc = get_noc_addr_from_bank_id<true>(src1_bank_id, src1_addr);
+
+        cb_reserve_back(cb_id_in0_xp, in0_block_tile_cnt);
+        cb_reserve_back(cb_id_in1, in1_block_tile_cnt);
+
+        uint32_t l1_w0 = get_write_ptr(cb_id_in0_xp);
+        uint32_t l1_w1 = get_write_ptr(cb_id_in1);
+
+        noc_async_read(src0_noc, l1_w0, in0_block_size_bytes);
+        noc_async_read(src1_noc, l1_w1, in1_block_size_bytes);
+        noc_async_read_barrier();
+
+        cb_push_back(cb_id_in0_xp, in0_block_tile_cnt);
+        cb_push_back(cb_id_in1, in1_block_tile_cnt);
+
+        src0_addr += in0_block_size_bytes;
+        src1_addr += in1_block_size_bytes;
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_reduce_inplace.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_reduce_inplace.cpp
@@ -3,7 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Reader for the matmul_reduce_inplace isolated test.
-// Loads `total_tiles` from DRAM into c_0, then one col-identity tile into c_1.
+// Loads `total_tiles` from DRAM into c_2 (staging for compute), then one
+// col-identity tile into c_1.
+//
+// c_2 (not c_0) is the reader-produced CB so that the compute kernel can
+// copy c_2 → c_0 under compute ownership.  matmul_reduce_inplace requires
+// its in_out_cb to be compute-produced; using a reader-produced CB directly
+// would leave T2's tiles_received shadow out of sync with the L1 counter and
+// cause cb_wait_front to deadlock after the push-back.
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
@@ -17,14 +24,14 @@ void kernel_main() {
     uint32_t src0_bytes = get_arg_val<uint32_t>(5);
     uint32_t src1_bytes = get_arg_val<uint32_t>(6);
 
-    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_staging = tt::CBIndex::c_2;  // reader → compute staging
     constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
 
     uint64_t src0_noc = get_noc_addr_from_bank_id<true>(src0_bank_id, src0_addr);
     uint64_t src1_noc = get_noc_addr_from_bank_id<true>(src1_bank_id, src1_addr);
 
-    cb_reserve_back(cb_id_in0, total_tiles);
-    uint32_t l1_w0 = get_write_ptr(cb_id_in0);
+    cb_reserve_back(cb_id_staging, total_tiles);
+    uint32_t l1_w0 = get_write_ptr(cb_id_staging);
     noc_async_read(src0_noc, l1_w0, src0_bytes);
 
     cb_reserve_back(cb_id_in1, 1);
@@ -33,6 +40,6 @@ void kernel_main() {
 
     noc_async_read_barrier();
 
-    cb_push_back(cb_id_in0, total_tiles);
+    cb_push_back(cb_id_staging, total_tiles);
     cb_push_back(cb_id_in1, 1);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_reduce_inplace.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_reduce_inplace.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reader for the matmul_reduce_inplace isolated test.
+// Loads `total_tiles` from DRAM into c_0, then one col-identity tile into c_1.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src0_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t src1_addr = get_arg_val<uint32_t>(2);
+    uint32_t src1_bank_id = get_arg_val<uint32_t>(3);
+    uint32_t total_tiles = get_arg_val<uint32_t>(4);
+    uint32_t src0_bytes = get_arg_val<uint32_t>(5);
+    uint32_t src1_bytes = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
+
+    uint64_t src0_noc = get_noc_addr_from_bank_id<true>(src0_bank_id, src0_addr);
+    uint64_t src1_noc = get_noc_addr_from_bank_id<true>(src1_bank_id, src1_addr);
+
+    cb_reserve_back(cb_id_in0, total_tiles);
+    uint32_t l1_w0 = get_write_ptr(cb_id_in0);
+    noc_async_read(src0_noc, l1_w0, src0_bytes);
+
+    cb_reserve_back(cb_id_in1, 1);
+    uint32_t l1_w1 = get_write_ptr(cb_id_in1);
+    noc_async_read(src1_noc, l1_w1, src1_bytes);
+
+    noc_async_read_barrier();
+
+    cb_push_back(cb_id_in0, total_tiles);
+    cb_push_back(cb_id_in1, 1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_push_c24.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_push_c24.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Simple reader that pushes `total_tiles` from DRAM into c_24.
+// Used by reblock_and_untilize and add_bias_bcast_rows isolated tests.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t bank_id = get_arg_val<uint32_t>(1);
+    uint32_t total_tiles = get_arg_val<uint32_t>(2);
+    uint32_t total_bytes = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id = tt::CBIndex::c_24;
+
+    uint64_t src_noc = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
+
+    cb_reserve_back(cb_id, total_tiles);
+    uint32_t l1_w = get_write_ptr(cb_id);
+    noc_async_read(src_noc, l1_w, total_bytes);
+    noc_async_read_barrier();
+    cb_push_back(cb_id, total_tiles);
+}

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/compute/bmm_large_block_zm.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/compute/bmm_large_block_zm.cpp
@@ -1,104 +1,44 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/matmul.h"
+#include "ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp"
 
 void kernel_main() {
-    uint32_t in0_block_w = get_compile_time_arg_val(0);              // inner block size in tiles
-    uint32_t in0_num_subblocks = get_compile_time_arg_val(1);        // outer row block size (in inner row blocks)
-    uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);      // out_subblock_h*in0_block_w*in0_num_subblocks;
-    uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);   // out_subblock_h*in0_block_w
-    uint32_t in1_num_subblocks = get_compile_time_arg_val(4);        // outer column block size (in inner column blocks)
-    uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);      // out_subblock_w*in0_block_w* in1_num_subblocks;
-    uint32_t in1_per_core_w = get_compile_time_arg_val(6);           // out_subblock_w*in1_num_subblocks
-    uint32_t num_blocks = get_compile_time_arg_val(7);               // outer inner dim (in inner dim blocks)
-    uint32_t out_subblock_h = get_compile_time_arg_val(8);           // inner row block size in tiles
-    uint32_t out_subblock_w = get_compile_time_arg_val(9);           // inner column block size in tiles
-    uint32_t out_subblock_num_tiles = get_compile_time_arg_val(10);  // out_subblock_h * out_subblock_w;
-    uint32_t batch = get_compile_time_arg_val(11);                   // batch dim
+    uint32_t in0_block_w = get_compile_time_arg_val(0);
+    uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
+    uint32_t in1_num_subblocks = get_compile_time_arg_val(4);
+    uint32_t num_k_blocks = get_compile_time_arg_val(7);
+    uint32_t out_subblock_h = get_compile_time_arg_val(8);
+    uint32_t out_subblock_w = get_compile_time_arg_val(9);
+    uint32_t batch = get_compile_time_arg_val(11);
 
-    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in1 = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t cb_interm = tt::CBIndex::c_24;
+
+    mm_block_init(cb_in0, cb_in1, cb_interm, false, out_subblock_w, out_subblock_h, in0_block_w);
 
     for (uint32_t b = 0; b < batch; b++) {
-        bool spill = num_blocks > 1;
-        bool enable_reload = false;
-        uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
-
-        for (uint32_t block = 0; block < num_blocks; block++) {
-            bool last_out = block == (num_blocks - 1);
-
-            cb_wait_front(tt::CBIndex::c_0, in0_block_num_tiles);
-            cb_wait_front(tt::CBIndex::c_1, in1_block_num_tiles);
-            int in0_index_subblock_offset = 0;
-            for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
-                int in1_index_subblock_offset = 0;
-                for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
-                    acquire_dst();
-
-                    if (enable_reload) {
-                        copy_tile_to_dst_init_short(tt::CBIndex::c_24);
-                        cb_wait_front(tt::CBIndex::c_24, out_subblock_num_tiles);
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            copy_tile(tt::CBIndex::c_24, i, i);
-                        }
-                        cb_pop_front(tt::CBIndex::c_24, out_subblock_num_tiles);
-                        mm_init_short(tt::CBIndex::c_0, tt::CBIndex::c_1);
-                    }
-
-                    // Compute output sub-block from in0_subblock x in1_subblock
-                    int dst_index = 0;
-                    int in0_index_h_offset = 0;
-                    for (uint32_t h = 0; h < out_subblock_h; h++) {
-                        for (uint32_t w = 0; w < out_subblock_w; w++) {
-                            int in1_index_inner_dim_offset = 0;
-                            for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
-                                int in0_index = in0_index_subblock_offset + in0_index_h_offset + inner_dim;
-                                int in1_index = in1_index_subblock_offset + in1_index_inner_dim_offset + w;
-                                matmul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_1, in0_index, in1_index, dst_index);
-                                in1_index_inner_dim_offset += in1_per_core_w;
-                            }
-                            dst_index++;
-                        }
-                        in0_index_h_offset += in0_block_w;
-                    }
-
-                    if (last_out) {
-                        // Pack out to output buffer
-                        cb_reserve_back(tt::CBIndex::c_16, out_subblock_num_tiles);
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            pack_tile(i, tt::CBIndex::c_16);
-                        }
-                        cb_push_back(tt::CBIndex::c_16, out_subblock_num_tiles);
-                    } else {
-                        // Wait for tiles in output buffer to be written out since interm and output share memory
-                        if (block == 0) {
-                            cb_reserve_back(tt::CBIndex::c_16, out_num_tiles_to_wait);
-                            out_num_tiles_to_wait += out_subblock_num_tiles;
-                        }
-                        // Move partial result to interm buffer
-                        cb_reserve_back(tt::CBIndex::c_24, out_subblock_num_tiles);
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            pack_tile(i, tt::CBIndex::c_24);
-                        }
-                        cb_push_back(tt::CBIndex::c_24, out_subblock_num_tiles);
-                    }
-
-                    release_dst();
-                    in1_index_subblock_offset += out_subblock_w;
-                }
-                in0_index_subblock_offset += in0_subblock_num_tiles;
-            }
-
-            if (spill) {
-                enable_reload = true;
-            }
-
-            cb_pop_front(tt::CBIndex::c_0, in0_block_num_tiles);
-            cb_pop_front(tt::CBIndex::c_1, in1_block_num_tiles);
-        }
+        compute_kernel_lib::matmul_block<
+            /*transpose=*/false,
+            /*packer_l1_acc=*/false,
+            /*pack_last_to_interm=*/false,
+            /*pack_relu=*/false,
+            /*row_major_output=*/false>(
+            cb_in0,
+            cb_in1,
+            cb_out,
+            cb_interm,
+            in0_block_w,
+            in0_num_subblocks,
+            in1_num_subblocks,
+            num_k_blocks,
+            out_subblock_h,
+            out_subblock_w,
+            1);
     }
 }

--- a/ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.hpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/bcast.h"
+#include "api/compute/cb_api.h"
+#include "api/compute/pack.h"
+#include "api/debug/assert.h"
+#include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
+
+namespace compute_kernel_lib {
+
+namespace bias_add_config {
+
+// Default no-op post-bias functor.
+// Called per output sub-block after bias addition, before packing.
+// Receives out_subblock_num_tiles. Tiles are in DST[0..num_tiles-1].
+// Use for fused SFPU activation after bias (e.g., gelu, silu).
+struct NoPostBias {
+    ALWI void operator()(uint32_t /* out_subblock_num_tiles */) const {}
+};
+
+}  // namespace bias_add_config
+
+/**
+ * add_bias_bcast_rows: row-broadcast bias addition on matmul output.
+ *
+ * Reads matmul output sub-blocks from partials_cb, adds bias with row broadcast,
+ * optionally applies a post-bias operation (e.g., SFPU activation), and packs
+ * the result to out_cb.
+ *
+ * Composes with matmul_block by reading from the same interm_cb that matmul_block
+ * packed to (when pack_last_to_interm=true).
+ *
+ * CB flow: partials_cb (wait+pop per subblock) + bias_cb (caller owns wait/pop)
+ *          --> out_cb (reserve+push per subblock)
+ *
+ * Uses 4-phase DST management (tile_regs_acquire/commit/wait/release).
+ *
+ * PREREQUISITE: Caller handles PACK_RELU configuration, pack format reconfig,
+ * L1_ACC disable, AND bias CB wait/pop lifecycle. Bias CB wait lifecycle depends
+ * on caller's loop structure (reader often only pushes bias once across multiple
+ * bh/batch iterations), so the helper does not touch bias_cb outside of reading
+ * tiles for the broadcast add.
+ *
+ * ── Template Parameters ────────────────────────────────────────────────────
+ *
+ *   partials_cb    CB containing matmul output (= interm_cb from matmul_block).
+ *   bias_cb        CB containing bias tiles. One tile per output column, row-broadcast.
+ *   out_cb         Output CB for biased result.
+ *   PostBiasFn     Functor called per output sub-block after bias addition, before
+ *                  packing. (default: NoPostBias)
+ *
+ * ── Runtime Parameters ─────────────────────────────────────────────────────
+ *
+ *   in0_num_subblocks  Number of sub-blocks along M dimension.
+ *   in1_num_subblocks  Number of sub-blocks along N dimension.
+ *   out_subblock_h     Output sub-block height in tiles.
+ *   out_subblock_w     Output sub-block width in tiles.
+ *   post_bias          PostBiasFn instance (default: {}).
+ */
+template <uint32_t partials_cb, uint32_t bias_cb, uint32_t out_cb, typename PostBiasFn = bias_add_config::NoPostBias>
+ALWI void add_bias_bcast_rows(
+    uint32_t in0_num_subblocks,
+    uint32_t in1_num_subblocks,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    PostBiasFn post_bias = {});
+
+}  // namespace compute_kernel_lib
+
+#include "bias_add_helpers.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.inl
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file bias_add_helpers.inl
+ * @brief Implementation of add_bias_bcast_rows helper function.
+ *
+ * Row-broadcast bias addition matching the production kernel's bias phase
+ * (bmm_large_block_zm_fused_bias_activation.cpp).
+ * This file should only be included by bias_add_helpers.hpp.
+ */
+
+namespace compute_kernel_lib {
+
+template <
+    uint32_t partials_cb,
+    uint32_t bias_cb,
+    uint32_t out_cb,
+    typename PostBiasFn>
+ALWI void add_bias_bcast_rows(
+    uint32_t in0_num_subblocks,
+    uint32_t in1_num_subblocks,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    PostBiasFn post_bias) {
+
+    // Compile-time validation
+    static_assert(partials_cb < 32, "add_bias_bcast_rows: partials_cb must be less than 32");
+    static_assert(bias_cb < 32, "add_bias_bcast_rows: bias_cb must be less than 32");
+    static_assert(out_cb < 32, "add_bias_bcast_rows: out_cb must be less than 32");
+
+    const uint32_t out_num_tiles = out_subblock_h * out_subblock_w;
+
+    // Runtime validation
+    ASSERT(in0_num_subblocks > 0);
+    ASSERT(in1_num_subblocks > 0);
+    ASSERT(out_subblock_h > 0);
+    ASSERT(out_subblock_w > 0);
+    ASSERT(out_num_tiles <= compute_kernel_lib::DEST_AUTO_LIMIT);
+
+    // Format reconfig + init bias broadcast. The caller is responsible for bias_cb
+    // wait/pop lifecycle (reader may push bias only once across multiple iterations).
+    reconfig_data_format_srca(partials_cb);
+    reconfig_data_format_srcb(bias_cb);
+    pack_reconfig_data_format(out_cb);
+    add_bcast_rows_init_short(partials_cb, bias_cb);
+
+    for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+        int in1_index_subblock_offset = 0;
+        for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+            cb_wait_front(partials_cb, out_num_tiles);
+            tile_regs_acquire();
+
+            // Row-broadcast bias addition
+            for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
+                uint32_t bcast_tile_idx = in1_index_subblock_offset;
+                for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
+                    add_tiles_bcast_rows(partials_cb, bias_cb, i, bcast_tile_idx, i);
+                    bcast_tile_idx++;
+                }
+            }
+
+            // PostBiasFn fires BEFORE commit (matches production kernel's SFPU placement)
+            post_bias(out_num_tiles);
+
+            tile_regs_commit();
+            cb_pop_front(partials_cb, out_num_tiles);
+
+            // Pack out to output buffer
+            cb_reserve_back(out_cb, out_num_tiles);
+            tile_regs_wait();
+            for (uint32_t i = 0; i < out_num_tiles; i++) {
+                pack_tile(i, out_cb);
+            }
+            tile_regs_release();
+            cb_push_back(out_cb, out_num_tiles);
+
+            in1_index_subblock_offset += out_subblock_w;
+        }
+    }
+
+    // NOTE: does NOT pop bias_cb. Caller manages bias tile lifetime.
+}
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp
@@ -112,6 +112,36 @@ ALWI void matmul_block(
     PreKBlockFn pre_k_block = {},
     bool retain_in0 = false);
 
+/**
+ * matmul_reduce_inplace: in-place reduce via matmul using a single-tile column identity.
+ *
+ * Consumes subblock_h×subblock_w tiles from the front of `in_out_cb`, computes
+ *   DST = matmul(in_out_cb[0..subblock_h], in1_cb[0]) × block_kt accumulation
+ * and packs back onto `in_out_cb` — repeated num_subblocks times to reduce the CB in
+ * place. This pattern breaks the standard in0_cb != out_cb invariant that `matmul_block`
+ * enforces, so it lives in a dedicated helper; SDPA uses this to fold partial-sum
+ * results along M via a column-identity tile in in1_cb.
+ *
+ * The helper absorbs mm_block_init_short + reconfig_data_format + wait_front on both
+ * CBs — the caller only needs to have produced the requisite tiles.
+ *
+ * ── Runtime Parameters ─────────────────────────────────────────────────────
+ *
+ *   in_out_cb       CB serving as both input and output (in-place).
+ *   in1_cb          CB with the single column-identity tile (kept fronted, not popped).
+ *   num_subblocks   Number of subblock iterations (= rows / subblock_h).
+ *   subblock_h      Subblock height in tiles (matmul rt_dim).
+ *   subblock_w      Subblock width in tiles (matmul ct_dim; typically 1).
+ *   block_kt        K dimension in tiles for each matmul call (typically 1 = subblock_w).
+ */
+ALWI void matmul_reduce_inplace(
+    uint32_t in_out_cb,
+    uint32_t in1_cb,
+    uint32_t num_subblocks,
+    uint32_t subblock_h,
+    uint32_t subblock_w = 1,
+    uint32_t block_kt = 1);
+
 }  // namespace compute_kernel_lib
 
 #include "matmul_block_helpers.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp
@@ -87,6 +87,12 @@ struct NoPreKBlock {
  *   pre_k_block        PreKBlockFn instance (default: {}).
  *   retain_in0         When true, skip popping in0 on the last K-block so the caller
  *                      retains the data (SDPA reuses Q across K chunks). (default: false)
+ *   in1_per_core_w     Actual number of N-tiles in the in1 CB per K-block (= what NCRISC
+ *                      pushes per block). Defaults to 0, meaning derive from
+ *                      out_subblock_w * in1_num_subblocks. Pass the real value when the
+ *                      factory pads per_core_N_compute above the actual in1 shard width
+ *                      (e.g. matmul_multicore_reuse_mcast_dram_sharded), otherwise the
+ *                      helper will wait/pop wrong tile counts and deadlock.
  */
 template <
     bool transpose = false,
@@ -110,7 +116,8 @@ ALWI void matmul_block(
     uint32_t batch = 1,
     PostComputeFn post_compute = {},
     PreKBlockFn pre_k_block = {},
-    bool retain_in0 = false);
+    bool retain_in0 = false,
+    uint32_t in1_per_core_w = 0);
 
 /**
  * matmul_reduce_inplace: in-place reduce via matmul using a single-tile column identity.

--- a/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/cb_api.h"
+#include "api/compute/pack.h"
+#include "api/debug/assert.h"
+#include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
+
+namespace compute_kernel_lib {
+
+// Default no-op post-compute functor.
+// Called per output sub-block on the last K-block, before packing.
+// Receives out_subblock_num_tiles. Tiles are in DST[0..num_tiles-1].
+struct NoPostCompute {
+    ALWI void operator()(uint32_t /* out_subblock_num_tiles */) const {}
+};
+
+// Default no-op pre-K-block functor.
+// Called at the start of each K-block iteration, before input CB waits.
+// Receives (block_index, num_k_blocks, is_last_block).
+// Use for per-K-block preprocessing (e.g., in0_transpose, global CB pointer manipulation).
+struct NoPreKBlock {
+    ALWI void operator()(uint32_t, uint32_t, bool) const {}
+};
+
+/**
+ * matmul_block: sub-blocked tiled matrix multiplication C = A × B with K-blocking.
+ *
+ * One helper serving both standard matmul (non-multicast bmm) and SDPA. Supports two
+ * output-pack strategies selected at compile time via row_major_output:
+ *
+ *   row_major_output=false (default): sequential pack_tile_block per subblock.
+ *     Output lands in subblock order. Required by multicast writers that expect
+ *     subblock-order tile stream.
+ *   row_major_output=true: absolute-offset pack_tile<true> at row-major positions,
+ *     reserve/push per M-row-group. Decouples subblock choice from output layout so
+ *     the factory can pick larger subblocks (the main SDPA perf path). Also the
+ *     mode SDPA callers require for absolute-offset partial writes across K chunks.
+ *
+ * K-accumulation also selectable at compile time:
+ *   packer_l1_acc=false: Software spill/reload via interm_cb
+ *   packer_l1_acc=true:  Hardware L1 accumulation via packer (no spill/reload)
+ *
+ * PREREQUISITE: Caller must call mm_block_init() before invoking this helper.
+ *
+ * SKIP_COMPUTE: When this macro is defined by the calling TU (microbenchmark path),
+ * the inner ckernel::matmul_block() call is omitted. All other pipeline work (waits,
+ * reloads, packs, L1_ACC toggles) still runs so the harness measures non-compute
+ * overhead. Handled inside this helper — caller does nothing special.
+ *
+ * Uses 4-phase DST management (tile_regs_acquire/commit/wait/release) for correct
+ * MATH-PACK pipelining.
+ *
+ * ── Template Parameters ────────────────────────────────────────────────────
+ *
+ *   transpose         If true, transpose B tiles before multiplication (default: false).
+ *   packer_l1_acc     Enable packer L1 accumulation instead of software spill/reload.
+ *   pack_last_to_interm  If true, last K-block packs to interm_cb instead of out_cb.
+ *                     Use when a post-processing phase (bias add, untilize) reads
+ *                     from interm_cb.
+ *   pack_relu         Enable PACK_RELU on the last K-block when !pack_last_to_interm.
+ *   row_major_output  Enable absolute-offset packing on the last K-block (see above).
+ *   PostComputeFn     Functor called per output sub-block on the last K-block,
+ *                     after matmul but before packing. Receives out_subblock_num_tiles.
+ *   PreKBlockFn       Functor called at the start of each K-block iteration, before
+ *                     input CB waits. Receives (block, num_k_blocks, is_last).
+ *                     Use for per-K-block preprocessing such as in0_transpose.
+ *
+ * ── Runtime Parameters ─────────────────────────────────────────────────────
+ *
+ *   in0_cb, in1_cb     Input CBs for matrices A and B.
+ *   out_cb             Output CB for the final result.
+ *   interm_cb          Intermediate CB for K-blocking spill/reload or L1-ACC FIFO.
+ *                      When num_k_blocks == 1 it is never read; pass any non-output CB.
+ *   block_w            Inner block dimension in tiles (K-dimension block size).
+ *   in0_num_subblocks  Number of sub-blocks along the M dimension.
+ *   in1_num_subblocks  Number of sub-blocks along the N dimension.
+ *   num_k_blocks       Number of blocks along the K dimension.
+ *   out_subblock_h     Output sub-block height in tiles.
+ *   out_subblock_w     Output sub-block width in tiles.
+ *   batch              Number of independent batch slices (default: 1).
+ *   post_compute       PostComputeFn instance (default: {}).
+ *   pre_k_block        PreKBlockFn instance (default: {}).
+ *   retain_in0         When true, skip popping in0 on the last K-block so the caller
+ *                      retains the data (SDPA reuses Q across K chunks). (default: false)
+ */
+template <
+    bool transpose = false,
+    bool packer_l1_acc = false,
+    bool pack_last_to_interm = false,
+    bool pack_relu = false,
+    bool row_major_output = false,
+    typename PostComputeFn = NoPostCompute,
+    typename PreKBlockFn = NoPreKBlock>
+ALWI void matmul_block(
+    uint32_t in0_cb,
+    uint32_t in1_cb,
+    uint32_t out_cb,
+    uint32_t interm_cb,
+    uint32_t block_w,
+    uint32_t in0_num_subblocks,
+    uint32_t in1_num_subblocks,
+    uint32_t num_k_blocks,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t batch = 1,
+    PostComputeFn post_compute = {},
+    PreKBlockFn pre_k_block = {},
+    bool retain_in0 = false);
+
+}  // namespace compute_kernel_lib
+
+#include "matmul_block_helpers.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.inl
@@ -83,33 +83,29 @@ ALWI void matmul_block(
 
             pre_k_block(block, num_k_blocks, last_out);
 
-            // in0 wait strategy: full-block for legacy path, progressive for row-major.
-            // Progressive wait accommodates SDPA's streamed Q and costs nothing when the
-            // full block is already resident in the CB.
-            if constexpr (!row_major_output) {
-                cb_wait_front(in0_cb, in0_block_num_tiles);
-            }
+            // Full-block wait for both modes. Every caller (matmul + SDPA) has the
+            // full in0 block resident before invoking the helper, so progressive
+            // per-subblock waits are pure polling overhead on TRISCs.
+            cb_wait_front(in0_cb, in0_block_num_tiles);
             cb_wait_front(in1_cb, in1_block_num_tiles);
 
             const uint32_t pack_target = pack_last_to_interm ? interm_cb : out_cb;
 
-            // Shared-memory protection (legacy/sequential path only): reserve the full
-            // out_block on the first non-last K-block so interm spills don't overwrite
-            // output data when out_cb and interm_cb share L1 (multicast factory layout).
-            // Single reserve, not per-subblock accumulation — matches main's CB-API
-            // invariant that all wait_front/reserve_back increments are identical.
+            // Legacy/sequential path: reserve the full out_block on the first
+            // non-last K-block so interm spills don't overwrite output data
+            // when out_cb and interm_cb share the same L1 region (multicast
+            // factory layout). Single reserve here keeps all wait_front /
+            // reserve_back increments identical across the K-loop, as the
+            // CB-API contract requires.
             if constexpr (!row_major_output) {
                 if (block == 0 && !last_out) {
                     cb_reserve_back(out_cb, out_block_num_tiles);
                 }
             }
 
-            uint32_t in0_wait_tiles = in0_subblock_num_tiles;
             int in0_index_subblock_offset = 0;
             for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                 if constexpr (row_major_output) {
-                    cb_wait_front(in0_cb, in0_wait_tiles);
-                    in0_wait_tiles += in0_subblock_num_tiles;
                     // Row-major path reserves per M-row-group (one row of all N-subblocks).
                     // Smaller than full-block reserve, so shared out/interm CBs don't deadlock.
                     if (last_out) {
@@ -181,14 +177,24 @@ ALWI void matmul_block(
                         }
 
                         if constexpr (row_major_output) {
-                            // Absolute-offset pack into row-major positions within the row-group.
-                            uint32_t dst_idx = 0;
-                            uint32_t col_base = in1_subblock * out_subblock_w;
-                            for (uint32_t r = 0; r < out_subblock_h; r++) {
-                                uint32_t row_pos = r * in1_per_core_w;
-                                for (uint32_t c = 0; c < out_subblock_w; c++) {
-                                    pack_tile<true>(dst_idx, pack_target, row_pos + col_base + c);
-                                    dst_idx++;
+                            // Single-row subblock: DST tiles are already contiguous in
+                            // row-major order and consecutive in1_subblock iterations land
+                            // at adjacent CB positions, so pack_tile_block produces the
+                            // correct layout with fewer per-tile LLK calls than the
+                            // absolute-offset path below. Multi-row subblocks need the
+                            // absolute-offset pack because DST tiles are packed column-first
+                            // within a subblock while row-major output wants row-first.
+                            if (out_subblock_h == 1) {
+                                pack_tile_block(0, pack_target, out_subblock_w);
+                            } else {
+                                uint32_t dst_idx = 0;
+                                uint32_t col_base = in1_subblock * out_subblock_w;
+                                for (uint32_t r = 0; r < out_subblock_h; r++) {
+                                    uint32_t row_pos = r * in1_per_core_w;
+                                    for (uint32_t c = 0; c < out_subblock_w; c++) {
+                                        pack_tile<true>(dst_idx, pack_target, row_pos + col_base + c);
+                                        dst_idx++;
+                                    }
                                 }
                             }
                         } else {

--- a/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.inl
@@ -260,4 +260,41 @@ ALWI void matmul_block(
     }
 }
 
+ALWI void matmul_reduce_inplace(
+    uint32_t in_out_cb,
+    uint32_t in1_cb,
+    uint32_t num_subblocks,
+    uint32_t subblock_h,
+    uint32_t subblock_w,
+    uint32_t block_kt) {
+
+    const uint32_t subblock_tiles = subblock_h * subblock_w;
+    const uint32_t total_in_tiles = num_subblocks * subblock_tiles;
+
+    // Init + reconfig + input waits. in1_cb holds a single column-identity tile
+    // (fronted for the life of the helper); in_out_cb must have the full input
+    // population fronted before the reduce begins.
+    mm_block_init_short(in_out_cb, in1_cb, /*transpose=*/false, subblock_w, subblock_h, block_kt);
+    reconfig_data_format(in1_cb, in_out_cb);
+    cb_wait_front(in1_cb, 1);
+    cb_wait_front(in_out_cb, total_in_tiles);
+
+    for (uint32_t sub = 0; sub < num_subblocks; ++sub) {
+        tile_regs_acquire();
+        ckernel::matmul_block(
+            in_out_cb, in1_cb, 0, 0, 0,
+            /*transpose=*/false, subblock_w, subblock_h, block_kt);
+        tile_regs_commit();
+        // Pop must happen after commit and before the back-pack so the read pointer
+        // advances past the tiles we just consumed, making room for the write.
+        cb_pop_front(in_out_cb, subblock_tiles);
+        tile_regs_wait();
+        for (uint32_t i = 0; i < subblock_tiles; i++) {
+            pack_tile(i, in_out_cb);
+        }
+        tile_regs_release();
+        cb_push_back(in_out_cb, subblock_tiles);
+    }
+}
+
 }  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.inl
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/cpp/ttnn/kernel_lib/cb_helpers.hpp"
+
+/**
+ * @file matmul_block_helpers.inl
+ * @brief Implementation of matmul_block helper function.
+ *
+ * Single pipeline handles both pack strategies:
+ *   row_major_output=false → sequential pack_tile_block, per-subblock reserve/push
+ *   row_major_output=true  → absolute-offset pack_tile<true>, per-row-group reserve/push
+ *
+ * Both modes share K-loop, reload, L1_ACC management, and pre/post callbacks.
+ * SKIP_COMPUTE (microbench define) elides the inner matmul LLK call only.
+ */
+
+namespace compute_kernel_lib {
+
+template <
+    bool transpose,
+    bool packer_l1_acc,
+    bool pack_last_to_interm,
+    bool pack_relu,
+    bool row_major_output,
+    typename PostComputeFn,
+    typename PreKBlockFn>
+ALWI void matmul_block(
+    uint32_t in0_cb,
+    uint32_t in1_cb,
+    uint32_t out_cb,
+    uint32_t interm_cb,
+    uint32_t block_w,
+    uint32_t in0_num_subblocks,
+    uint32_t in1_num_subblocks,
+    uint32_t num_k_blocks,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t batch,
+    PostComputeFn post_compute,
+    PreKBlockFn pre_k_block,
+    bool retain_in0) {
+
+    const uint32_t out_num_tiles = out_subblock_h * out_subblock_w;
+    const uint32_t in0_subblock_num_tiles = out_subblock_h * block_w;
+    const uint32_t in0_block_num_tiles = in0_subblock_num_tiles * in0_num_subblocks;
+    const uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+    const uint32_t in1_block_num_tiles = out_subblock_w * block_w * in1_num_subblocks;
+    const uint32_t out_block_num_tiles = out_num_tiles * in0_num_subblocks * in1_num_subblocks;
+    const uint32_t row_group_tiles = out_subblock_h * in1_per_core_w;
+
+    ASSERT(block_w > 0);
+    ASSERT(in0_num_subblocks > 0);
+    ASSERT(in1_num_subblocks > 0);
+    ASSERT(num_k_blocks > 0);
+    ASSERT(out_subblock_h > 0);
+    ASSERT(out_subblock_w > 0);
+    ASSERT(batch > 0);
+    ASSERT(in0_cb != out_cb);
+    ASSERT(in1_cb != out_cb);
+
+    ASSERT(out_num_tiles <= compute_kernel_lib::DEST_AUTO_LIMIT);
+
+    for (uint32_t b = 0; b < batch; b++) {
+        bool enable_reload = false;
+
+        for (uint32_t block = 0; block < num_k_blocks; block++) {
+            const bool last_out = block == (num_k_blocks - 1);
+
+            if constexpr (pack_relu && !pack_last_to_interm) {
+                if (last_out) {
+                    PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+                }
+            }
+
+            pre_k_block(block, num_k_blocks, last_out);
+
+            // in0 wait strategy: full-block for legacy path, progressive for row-major.
+            // Progressive wait accommodates SDPA's streamed Q and costs nothing when the
+            // full block is already resident in the CB.
+            if constexpr (!row_major_output) {
+                cb_wait_front(in0_cb, in0_block_num_tiles);
+            }
+            cb_wait_front(in1_cb, in1_block_num_tiles);
+
+            const uint32_t pack_target = pack_last_to_interm ? interm_cb : out_cb;
+
+            // Shared-memory protection (legacy/sequential path only): reserve the full
+            // out_block on the first non-last K-block so interm spills don't overwrite
+            // output data when out_cb and interm_cb share L1 (multicast factory layout).
+            // Single reserve, not per-subblock accumulation — matches main's CB-API
+            // invariant that all wait_front/reserve_back increments are identical.
+            if constexpr (!row_major_output) {
+                if (block == 0 && !last_out) {
+                    cb_reserve_back(out_cb, out_block_num_tiles);
+                }
+            }
+
+            uint32_t in0_wait_tiles = in0_subblock_num_tiles;
+            int in0_index_subblock_offset = 0;
+            for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                if constexpr (row_major_output) {
+                    cb_wait_front(in0_cb, in0_wait_tiles);
+                    in0_wait_tiles += in0_subblock_num_tiles;
+                    // Row-major path reserves per M-row-group (one row of all N-subblocks).
+                    // Smaller than full-block reserve, so shared out/interm CBs don't deadlock.
+                    if (last_out) {
+                        cb_reserve_back(pack_target, row_group_tiles);
+                    }
+                }
+
+                int in1_index_subblock_offset = 0;
+                for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                    tile_regs_acquire();
+
+                    if (enable_reload) {
+                        copy_tile_to_dst_init_short_with_dt(in1_cb, interm_cb);
+                        cb_wait_front(interm_cb, out_num_tiles);
+                        copy_block_matmul_partials(interm_cb, 0, 0, out_num_tiles);
+                        cb_pop_front(interm_cb, out_num_tiles);
+                        mm_block_init_short_with_dt(
+                            in0_cb, in1_cb, interm_cb, transpose, out_subblock_w, out_subblock_h, block_w);
+                    }
+
+                    // Compute output sub-block via hardware block matmul.
+                    // SKIP_COMPUTE (microbench) keeps the surrounding pipeline intact but
+                    // omits the actual matmul LLK call.
+                    uint32_t dst_index = 0;
+                    uint32_t in0_index = in0_index_subblock_offset;
+                    uint32_t in1_index = in1_index_subblock_offset;
+                    for (uint32_t inner_dim = 0; inner_dim < block_w; inner_dim++) {
+#ifndef SKIP_COMPUTE
+                        // ckernel:: disambiguates the LLK matmul_block from this helper.
+                        ckernel::matmul_block(
+                            in0_cb,
+                            in1_cb,
+                            in0_index,
+                            in1_index,
+                            dst_index,
+                            transpose,
+                            out_subblock_w,
+                            out_subblock_h,
+                            block_w);
+#else
+                        (void)in0_index;
+                        (void)in1_index;
+                        (void)dst_index;
+#endif
+                        in0_index++;
+                        in1_index += in1_per_core_w;
+                    }
+
+                    if (last_out) {
+                        post_compute(out_num_tiles);
+
+                        tile_regs_commit();
+                        if constexpr (!row_major_output) {
+                            cb_reserve_back(pack_target, out_num_tiles);
+                        }
+                        tile_regs_wait();
+
+                        if constexpr (packer_l1_acc || get_fp32_dest_acc_enabled()) {
+                            PACK((pack_reconfig_data_format(pack_target)));
+                        }
+
+                        if constexpr (packer_l1_acc) {
+                            if constexpr (pack_last_to_interm) {
+                                // FUSE_BIAS path: L1 accumulates across all blocks.
+                                PACK((llk_pack_reconfig_l1_acc(block == 0 ? 0 : 1)));
+                            } else {
+                                PACK((llk_pack_reconfig_l1_acc(0)));
+                            }
+                        }
+
+                        if constexpr (row_major_output) {
+                            // Absolute-offset pack into row-major positions within the row-group.
+                            uint32_t dst_idx = 0;
+                            uint32_t col_base = in1_subblock * out_subblock_w;
+                            for (uint32_t r = 0; r < out_subblock_h; r++) {
+                                uint32_t row_pos = r * in1_per_core_w;
+                                for (uint32_t c = 0; c < out_subblock_w; c++) {
+                                    pack_tile<true>(dst_idx, pack_target, row_pos + col_base + c);
+                                    dst_idx++;
+                                }
+                            }
+                        } else {
+                            pack_tile_block(0, pack_target, out_num_tiles);
+                        }
+
+                        tile_regs_release();
+                        if constexpr (!row_major_output) {
+                            cb_push_back(pack_target, out_num_tiles);
+                        }
+
+                    } else {
+                        // Non-last K-block: spill partial to interm_cb.
+                        tile_regs_commit();
+                        cb_reserve_back(interm_cb, out_num_tiles);
+                        tile_regs_wait();
+
+                        if constexpr (packer_l1_acc) {
+                            PACK((llk_pack_reconfig_l1_acc(block == 0 ? 0 : 1)));
+                        }
+
+                        pack_tile_block(0, interm_cb, out_num_tiles);
+                        tile_regs_release();
+                        cb_push_back(interm_cb, out_num_tiles);
+                    }
+
+                    in1_index_subblock_offset += out_subblock_w;
+                }
+
+                if constexpr (row_major_output) {
+                    if (last_out) {
+                        cb_push_back(pack_target, row_group_tiles);
+                    }
+                }
+
+                in0_index_subblock_offset += in0_subblock_num_tiles;
+            }
+
+            if constexpr (packer_l1_acc) {
+                // Wait/pop partials in subblock-sized steps so the step size matches
+                // downstream consumers' wait_front(out_num_tiles) calls (e.g. bias add,
+                // reload). The CB API requires identical increments across all waits.
+                if constexpr (pack_last_to_interm) {
+                    if (block < num_k_blocks - 1) {
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_num_tiles) {
+                            cb_wait_front(interm_cb, out_num_tiles);
+                            cb_pop_front(interm_cb, out_num_tiles);
+                        }
+                    }
+                    enable_reload = false;
+                } else {
+                    if (num_k_blocks >= 2 && block < num_k_blocks - 2) {
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_num_tiles) {
+                            cb_wait_front(interm_cb, out_num_tiles);
+                            cb_pop_front(interm_cb, out_num_tiles);
+                        }
+                    }
+                    if (block == num_k_blocks - 2) {
+                        enable_reload = true;
+                    }
+                }
+            } else {
+                if (num_k_blocks > 1) {
+                    enable_reload = true;
+                }
+            }
+
+            // retain_in0: SDPA reuses Q across K chunks, so caller keeps in0 front
+            // on the last iteration. Intermediate blocks always pop.
+            if (!retain_in0 || !last_out) {
+                cb_pop_front(in0_cb, in0_block_num_tiles);
+            }
+            cb_pop_front(in1_cb, in1_block_num_tiles);
+        }
+    }
+}
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.inl
@@ -41,13 +41,19 @@ ALWI void matmul_block(
     uint32_t batch,
     PostComputeFn post_compute,
     PreKBlockFn pre_k_block,
-    bool retain_in0) {
+    bool retain_in0,
+    uint32_t in1_per_core_w) {
 
     const uint32_t out_num_tiles = out_subblock_h * out_subblock_w;
     const uint32_t in0_subblock_num_tiles = out_subblock_h * block_w;
     const uint32_t in0_block_num_tiles = in0_subblock_num_tiles * in0_num_subblocks;
-    const uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
-    const uint32_t in1_block_num_tiles = out_subblock_w * block_w * in1_num_subblocks;
+    // in1_per_core_w: actual N-width of the in1 CB per K-block.
+    // Derived from subblocks by default; callers with padded per_core_N_compute must
+    // pass the real shard width (per_core_N_in1_sender) to avoid CB wait/pop mismatches.
+    if (in1_per_core_w == 0) {
+        in1_per_core_w = out_subblock_w * in1_num_subblocks;
+    }
+    const uint32_t in1_block_num_tiles = in1_per_core_w * block_w;
     const uint32_t out_block_num_tiles = out_num_tiles * in0_num_subblocks * in1_num_subblocks;
     const uint32_t row_group_tiles = out_subblock_h * in1_per_core_w;
 
@@ -289,6 +295,7 @@ ALWI void matmul_reduce_inplace(
         // advances past the tiles we just consumed, making room for the write.
         cb_pop_front(in_out_cb, subblock_tiles);
         tile_regs_wait();
+        cb_reserve_back(in_out_cb, subblock_tiles);
         for (uint32_t i = 0; i < subblock_tiles; i++) {
             pack_tile(i, in_out_cb);
         }

--- a/ttnn/cpp/ttnn/kernel_lib/reblock_untilize_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reblock_untilize_helpers.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/cb_api.h"
+#include "internal/mod_div_lib.h"
+#include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
+
+namespace compute_kernel_lib {
+
+/**
+ * reblock_and_untilize: gather matmul subblock-order output into row-major and
+ * untilize it in a single pass.
+ *
+ * Consumes one "row-group" worth of tiles from `interm_cb` — a band of
+ * `out_subblock_h` tile rows covering all N-subblocks in the block — and writes
+ * row-major untilized output into `out_cb`. Uses pack_untilize_dest per
+ * subblock to walk across columns while preserving row ordering.
+ *
+ * PREREQUISITE: Caller must call pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb)
+ * and copy_tile_to_dst_init_short(interm_cb) once before the first call, and
+ * pack_untilize_uninit(interm_cb) after the last call.
+ *
+ * ── Template Parameters ────────────────────────────────────────────────────
+ *
+ *   out_subblock_w   Subblock width in tiles.
+ *   out_block_w      Full output block width in tiles (= out_subblock_w * num_subblocks_w).
+ *
+ * ── Runtime Parameters ─────────────────────────────────────────────────────
+ *
+ *   num_subblocks_w          Number of subblocks along the N dimension.
+ *   out_subblock_num_tiles   Tiles per subblock (= out_subblock_h * out_subblock_w).
+ *   out_subblock_h           Subblock height in tiles.
+ *   interm_cb_id             Input CB (tiled, subblock-major order).
+ *   out_cb_id                Output CB (untilized row-major).
+ */
+template <uint32_t out_subblock_w, uint32_t out_block_w>
+inline void reblock_and_untilize(
+    uint32_t num_subblocks_w,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_h,
+    uint32_t interm_cb_id,
+    uint32_t out_cb_id);
+
+}  // namespace compute_kernel_lib
+
+#include "reblock_untilize_helpers.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/reblock_untilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reblock_untilize_helpers.inl
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace compute_kernel_lib {
+
+template <uint32_t out_subblock_w, uint32_t out_block_w>
+inline void reblock_and_untilize(
+    uint32_t num_subblocks_w,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_h,
+    uint32_t interm_cb_id,
+    uint32_t out_cb_id) {
+    const uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_subblocks_w);
+    cb_wait_front(interm_cb_id, num_tiles_in_row_of_subblocks);
+
+    uint32_t within_block_index = 0;
+    for (uint32_t h = 0; h < out_subblock_h; h++) {
+        uint32_t block_offset = 0;
+        cb_reserve_back(out_cb_id, out_block_w);
+        for (uint32_t n = 0; n < num_subblocks_w; n++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < out_subblock_w; w++) {
+                copy_tile(interm_cb_id, block_offset + within_block_index + w, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            tile_regs_release();
+            block_offset += out_subblock_num_tiles;
+        }
+        cb_push_back(out_cb_id, out_block_w);
+        within_block_index += out_subblock_w;
+    }
+    cb_pop_front(interm_cb_id, num_tiles_in_row_of_subblocks);
+}
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/transpose_block_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/transpose_block_helpers.hpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/transpose_wh.h"
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/cb_api.h"
+#include "api/compute/pack.h"
+#include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
+
+namespace compute_kernel_lib {
+
+/**
+ * transpose_tile_block: WH-transpose a block of tiles from one CB to another.
+ *
+ * Reads from `in_transpose_cb`, applies transpose_wh_tile to each tile, packs
+ * into `in_cb`. Processes in chunks of `block_size` tiles (default 4, matches
+ * DST-register capacity across dst_sync modes and data formats) with a tail
+ * loop for the remainder.
+ *
+ * ── Template Parameters ────────────────────────────────────────────────────
+ *
+ *   in_block_num_tiles  Total tiles in the block.
+ *   block_size          Tiles per DST batch (default 4).
+ *
+ * ── Runtime Parameters ─────────────────────────────────────────────────────
+ *
+ *   in_transpose_cb  CB to read original tiles from.
+ *   in_cb            CB to write transposed tiles to.
+ */
+template <uint32_t in_block_num_tiles, uint32_t block_size = 4>
+FORCE_INLINE void transpose_tile_block(uint32_t in_transpose_cb, uint32_t in_cb);
+
+/**
+ * TransposePreKBlock: PreKBlockFn functor that transposes in0 before each K-block
+ * iteration of a matmul_block call.
+ *
+ * Reconfigures data formats, runs transpose_tile_block to populate the transposed
+ * input CB, then re-inits matmul and restores pack format. Designed to be passed
+ * as the PreKBlockFn template argument to compute_kernel_lib::matmul_block when
+ * the matmul needs its in0 WH-transposed on the fly.
+ *
+ * All parameters are compile-time template args so the functor has no state.
+ */
+template <
+    uint32_t in0_block_num_tiles,
+    uint32_t in0_transpose_cb_id,
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    bool in1_transpose_tile,
+    uint32_t out_subblock_w,
+    uint32_t out_subblock_h,
+    uint32_t in0_block_w,
+    uint32_t mm_partials_cb_id>
+struct TransposePreKBlock {
+    ALWI void operator()(uint32_t, uint32_t, bool) const;
+};
+
+}  // namespace compute_kernel_lib
+
+#include "transpose_block_helpers.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/transpose_block_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/transpose_block_helpers.inl
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace compute_kernel_lib {
+
+template <uint32_t in_block_num_tiles, uint32_t block_size>
+FORCE_INLINE void transpose_tile_block(uint32_t in_transpose_cb, uint32_t in_cb) {
+    constexpr uint32_t num_blocks = in_block_num_tiles / block_size;
+    constexpr uint32_t last_block_size = in_block_num_tiles % block_size;
+
+    for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
+        cb_wait_front(in_transpose_cb, block_size);
+        tile_regs_acquire();
+        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
+            transpose_wh_tile(in_transpose_cb, tile_idx, tile_idx);
+        }
+        tile_regs_commit();
+        cb_pop_front(in_transpose_cb, block_size);
+
+        cb_reserve_back(in_cb, block_size);
+        tile_regs_wait();
+        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
+            pack_tile(tile_idx, in_cb);
+        }
+        tile_regs_release();
+        cb_push_back(in_cb, block_size);
+    }
+
+    if constexpr (last_block_size > 0) {
+        cb_wait_front(in_transpose_cb, last_block_size);
+        tile_regs_acquire();
+        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
+            transpose_wh_tile(in_transpose_cb, tile_idx, tile_idx);
+        }
+        tile_regs_commit();
+        cb_pop_front(in_transpose_cb, last_block_size);
+
+        cb_reserve_back(in_cb, last_block_size);
+        tile_regs_wait();
+        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
+            pack_tile(tile_idx, in_cb);
+        }
+        tile_regs_release();
+        cb_push_back(in_cb, last_block_size);
+    }
+}
+
+template <
+    uint32_t in0_block_num_tiles,
+    uint32_t in0_transpose_cb_id,
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    bool in1_transpose_tile,
+    uint32_t out_subblock_w,
+    uint32_t out_subblock_h,
+    uint32_t in0_block_w,
+    uint32_t mm_partials_cb_id>
+ALWI void TransposePreKBlock<
+    in0_block_num_tiles,
+    in0_transpose_cb_id,
+    in0_cb_id,
+    in1_cb_id,
+    in1_transpose_tile,
+    out_subblock_w,
+    out_subblock_h,
+    in0_block_w,
+    mm_partials_cb_id>::operator()(uint32_t, uint32_t, bool) const {
+    reconfig_data_format_srca(in1_cb_id, in0_transpose_cb_id);
+    transpose_wh_init_short(in0_transpose_cb_id);
+    PACK((pack_reconfig_data_format(in0_cb_id)));
+#ifdef PACKER_L1_ACC
+    PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+    transpose_tile_block<in0_block_num_tiles>(in0_transpose_cb_id, in0_cb_id);
+    mm_block_init_short_with_dt(
+        in0_cb_id,
+        in1_cb_id,
+        in0_transpose_cb_id,
+        in1_transpose_tile,
+        out_subblock_w,
+        out_subblock_h,
+        in0_block_w);
+    PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+}
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -803,7 +803,6 @@ MatmulProgramConfig get_matmul_program_config(
             "Input A memory layout must not be WIDTH_SHARDED, got: {}",
             input_tensor_a.memory_config().memory_layout());
 
-        bool per_core_N_equals_subblock_w_constraint = false;
         if (output_mem_config.is_sharded()) {
             TT_FATAL(
                 input_tensor_a.memory_config().buffer_type() == output_mem_config.buffer_type(),
@@ -815,7 +814,6 @@ MatmulProgramConfig get_matmul_program_config(
                 "Input A and output memory layouts must match, got input: {} vs output: {}",
                 input_tensor_a.memory_config().memory_layout(),
                 output_mem_config.memory_layout());
-            per_core_N_equals_subblock_w_constraint = true;
         }
 
         const auto N = utilities::get_N_dim(b_shape_padded, in1_tile);
@@ -825,8 +823,8 @@ MatmulProgramConfig get_matmul_program_config(
         uint32_t per_core_N = N;
         uint32_t in0_block_w = in0_shard_shape[1] / in0_tile.get_width();
 
-        auto subblock_hw = bmm_op_utils::get_matmul_subblock_params(
-            per_core_M, per_core_N, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
+        auto subblock_hw =
+            bmm_op_utils::get_matmul_subblock_params(per_core_M, per_core_N, false, false, fp32_dest_acc_en);
         auto out_subblock_h = std::get<0>(subblock_hw);
         auto out_subblock_w = std::get<1>(subblock_hw);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -421,6 +421,10 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     if (output_is_sharded) {
         reader_writer_defines.emplace_back("OUT_SHARDED", "1");
     }
+    // Writer reads tiles in row-major order per row-group, matching the absolute-offset
+    // pack strategy this factory enables on the compute side. Other factories that share
+    // this writer source don't emit the define and rely on the subblock-order path.
+    reader_writer_defines.emplace_back("ROW_MAJOR_OUTPUT", "1");
 
     // Blackhole intermediate CB read workaround
     bool in0_needs_intermediate_cb_read = false;
@@ -473,6 +477,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
     // Compute defines
     KernelDescriptor::Defines compute_defines;
+    compute_defines.emplace_back("ROW_MAJOR_OUTPUT", "1");
     if (packer_l1_acc_en) {
         compute_defines.emplace_back("PACKER_L1_ACC", "1");
     }
@@ -669,38 +674,18 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         in1_tile,
         in1_is_sharded ? in1_buffer : nullptr));
 
-    // CB 4 and CB 5: Output and intermediate accumulator
-    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
-        // Separate output and intermediate CBs
-        program_descriptor.cbs.push_back(make_cb_descriptor(
-
-            out_CB_size,
-            tt::CBIndex::c_4,
-            output_data_format,
-            output_single_tile_size,
-            output_tile,
-            output_is_sharded ? out_buffer : nullptr));
-        program_descriptor.cbs.push_back(make_cb_descriptor(
-            interm0_CB_size, tt::CBIndex::c_5, interm0_data_format, interm0_single_tile_size, output_tile));
-    } else {
-        // Shared output+intermediate CB
-        CBDescriptor output_cb_desc;
-        output_cb_desc.total_size = out_CB_size;
-        output_cb_desc.core_ranges = all_cores;
-        tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
-        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_4,
-            .data_format = output_data_format,
-            .page_size = output_single_tile_size,
-            .tile = output_tile_desc});
-        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_5,
-            .data_format = interm0_data_format,
-            .page_size = interm0_single_tile_size,
-            .tile = output_tile_desc});
-        output_cb_desc.buffer = output_is_sharded ? out_buffer : nullptr;
-        program_descriptor.cbs.push_back(std::move(output_cb_desc));
-    }
+    // CB 4: Output, CB 5: Intermediate accumulator (always separate)
+    // Separate CBs allow the compute kernel to use per-row-group reservation
+    // for absolute-offset packing while partials are still in the intermediate CB.
+    program_descriptor.cbs.push_back(make_cb_descriptor(
+        out_CB_size,
+        tt::CBIndex::c_4,
+        output_data_format,
+        output_single_tile_size,
+        output_tile,
+        output_is_sharded ? out_buffer : nullptr));
+    program_descriptor.cbs.push_back(make_cb_descriptor(
+        interm0_CB_size, tt::CBIndex::c_5, interm0_data_format, interm0_single_tile_size, output_tile));
 
     // Optional CBs for Blackhole intermediate reads
     if (in1_needs_intermediate_cb_read) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -674,18 +674,51 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         in1_tile,
         in1_is_sharded ? in1_buffer : nullptr));
 
-    // CB 4: Output, CB 5: Intermediate accumulator (always separate)
-    // Separate CBs allow the compute kernel to use per-row-group reservation
-    // for absolute-offset packing while partials are still in the intermediate CB.
-    program_descriptor.cbs.push_back(make_cb_descriptor(
-        out_CB_size,
-        tt::CBIndex::c_4,
-        output_data_format,
-        output_single_tile_size,
-        output_tile,
-        output_is_sharded ? out_buffer : nullptr));
-    program_descriptor.cbs.push_back(make_cb_descriptor(
-        interm0_CB_size, tt::CBIndex::c_5, interm0_data_format, interm0_single_tile_size, output_tile));
+    // CB 4 (output) and CB 5 (K-block partials). Default layout overlays both
+    // indices on the same L1 bytes: the row_major_output helper pops partials
+    // from c_5 before packing the final output to c_4, so only one view holds
+    // live data at a time. This halves the output+partials L1 footprint vs
+    // separate CBs and is load-bearing on wormhole_b0 (L1 = 1,499,136 B) —
+    // without it, configs with large per_core_M × per_core_N (e.g. the
+    // canonical MatmulMultiCoreReuseProgramConfig per_core_M=32, per_core_N=16)
+    // overflow L1 by ~1 MB.
+    //
+    // Two cases can't share:
+    //   1. format mismatch — different byte-per-tile sizes, so the two CB views
+    //      can't overlay the same L1 bytes.
+    //   2. untilize with multiple N-subblocks — the untilize phase reads from
+    //      c_5 concurrently with the packer producing the next subblock into
+    //      c_5, so shared CBs would corrupt partials.
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // Separate output and intermediate CBs
+        program_descriptor.cbs.push_back(make_cb_descriptor(
+            out_CB_size,
+            tt::CBIndex::c_4,
+            output_data_format,
+            output_single_tile_size,
+            output_tile,
+            output_is_sharded ? out_buffer : nullptr));
+        program_descriptor.cbs.push_back(make_cb_descriptor(
+            interm0_CB_size, tt::CBIndex::c_5, interm0_data_format, interm0_single_tile_size, output_tile));
+    } else {
+        // Shared L1 region: c_4 and c_5 are two format views on the same buffer.
+        CBDescriptor output_cb_desc;
+        output_cb_desc.total_size = out_CB_size;
+        output_cb_desc.core_ranges = all_cores;
+        tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_4,
+            .data_format = output_data_format,
+            .page_size = output_single_tile_size,
+            .tile = output_tile_desc});
+        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_5,
+            .data_format = interm0_data_format,
+            .page_size = interm0_single_tile_size,
+            .tile = output_tile_desc});
+        output_cb_desc.buffer = output_is_sharded ? out_buffer : nullptr;
+        program_descriptor.cbs.push_back(std::move(output_cb_desc));
+    }
 
     // Optional CBs for Blackhole intermediate reads
     if (in1_needs_intermediate_cb_read) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.cpp
@@ -141,6 +141,7 @@ static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
         tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,
             .compile_args = compute_kernel_args,
+            .defines = {{"ROW_MAJOR_OUTPUT", "1"}},
             .named_compile_args = {
                 {"cb_in0", tt::CBIndex::c_0},
                 {"cb_in1", tt::CBIndex::c_1},

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
@@ -1,115 +1,53 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 
-#include "api/compute/matmul.h"
-#include "api/compute/tile_move_copy.h"
-#include "experimental/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp"
 
 void kernel_main() {
-    uint32_t in0_block_w = get_compile_time_arg_val(0);              // inner block size in tiles
-    uint32_t in0_num_subblocks = get_compile_time_arg_val(1);        // outer row block size (in inner row blocks)
-    uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);      // out_subblock_h*in0_block_w*in0_num_subblocks;
-    uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);   // out_subblock_h*in0_block_w
-    uint32_t in1_num_subblocks = get_compile_time_arg_val(4);        // outer column block size (in inner column blocks)
-    uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);      // out_subblock_w*in0_block_w* in1_num_subblocks;
-    uint32_t in1_per_core_w = get_compile_time_arg_val(6);           // out_subblock_w*in1_num_subblocks
-    uint32_t num_blocks = get_compile_time_arg_val(7);               // outer inner dim (in inner dim blocks)
-    uint32_t out_subblock_h = get_compile_time_arg_val(8);           // inner row block size in tiles
-    uint32_t out_subblock_w = get_compile_time_arg_val(9);           // inner column block size in tiles
-    uint32_t out_subblock_num_tiles = get_compile_time_arg_val(10);  // out_subblock_h * out_subblock_w;
-    uint32_t batch = get_compile_time_arg_val(11);                   // batch dim
+    uint32_t in0_block_w = get_compile_time_arg_val(0);
+    uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
+    uint32_t in1_num_subblocks = get_compile_time_arg_val(4);
+    uint32_t num_k_blocks = get_compile_time_arg_val(7);
+    uint32_t out_subblock_h = get_compile_time_arg_val(8);
+    uint32_t out_subblock_w = get_compile_time_arg_val(9);
+    uint32_t batch = get_compile_time_arg_val(11);
 
     constexpr uint32_t cb_in0 = get_named_compile_time_arg_val("cb_in0");
     constexpr uint32_t cb_in1 = get_named_compile_time_arg_val("cb_in1");
     constexpr uint32_t cb_out = get_named_compile_time_arg_val("cb_out");
     constexpr uint32_t cb_intermed0 = get_named_compile_time_arg_val("cb_intermed0");
 
-    experimental::CircularBuffer in0_cb(cb_in0);
-    experimental::CircularBuffer in1_cb(cb_in1);
-    experimental::CircularBuffer out_cb(cb_out);
-    experimental::CircularBuffer intermed0_cb(cb_intermed0);
+    // Factories that emit ROW_MAJOR_OUTPUT want absolute-offset packing so writers
+    // read tiles in row-major order. Multicast factories (no define) use sequential pack.
+    constexpr bool row_major =
+#ifdef ROW_MAJOR_OUTPUT
+        true;
+#else
+        false;
+#endif
 
-    mm_init(cb_in0, cb_in1, cb_intermed0);
+    mm_block_init(cb_in0, cb_in1, cb_intermed0, false, out_subblock_w, out_subblock_h, in0_block_w);
 
     for (uint32_t b = 0; b < batch; b++) {
-        bool spill = num_blocks > 1;
-        bool enable_reload = false;
-        uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
-
-        for (uint32_t block = 0; block < num_blocks; block++) {
-            bool last_out = block == (num_blocks - 1);
-
-            in0_cb.wait_front(in0_block_num_tiles);
-            in1_cb.wait_front(in1_block_num_tiles);
-            int in0_index_subblock_offset = 0;
-            for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
-                int in1_index_subblock_offset = 0;
-                for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
-                    acquire_dst();
-
-                    if (enable_reload) {
-                        copy_tile_to_dst_init_short_with_dt(cb_in1, cb_intermed0);
-                        intermed0_cb.wait_front(out_subblock_num_tiles);
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            copy_tile(cb_intermed0, i, i);
-                        }
-                        intermed0_cb.pop_front(out_subblock_num_tiles);
-                        mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed0);
-                    }
-
-                    // Compute output sub-block from in0_subblock x in1_subblock
-                    int dst_index = 0;
-                    int in0_index_h_offset = 0;
-                    for (uint32_t h = 0; h < out_subblock_h; h++) {
-                        for (uint32_t w = 0; w < out_subblock_w; w++) {
-                            int in1_index_inner_dim_offset = 0;
-                            for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
-                                int in0_index = in0_index_subblock_offset + in0_index_h_offset + inner_dim;
-                                int in1_index = in1_index_subblock_offset + in1_index_inner_dim_offset + w;
-                                matmul_tiles(cb_in0, cb_in1, in0_index, in1_index, dst_index);
-                                in1_index_inner_dim_offset += in1_per_core_w;
-                            }
-                            dst_index++;
-                        }
-                        in0_index_h_offset += in0_block_w;
-                    }
-
-                    if (last_out) {
-                        // Pack out to output buffer
-                        out_cb.reserve_back(out_subblock_num_tiles);
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            pack_tile(i, cb_out);
-                        }
-                        out_cb.push_back(out_subblock_num_tiles);
-                    } else {
-                        // Wait for tiles in output buffer to be written out since interm and output share memory
-                        if (block == 0) {
-                            out_cb.reserve_back(out_num_tiles_to_wait);
-                            out_num_tiles_to_wait += out_subblock_num_tiles;
-                        }
-                        // Move partial result to interm buffer
-                        intermed0_cb.reserve_back(out_subblock_num_tiles);
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            pack_tile(i, cb_intermed0);
-                        }
-                        intermed0_cb.push_back(out_subblock_num_tiles);
-                    }
-
-                    release_dst();
-                    in1_index_subblock_offset += out_subblock_w;
-                }
-                in0_index_subblock_offset += in0_subblock_num_tiles;
-            }
-
-            if (spill) {
-                enable_reload = true;
-            }
-
-            in0_cb.pop_front(in0_block_num_tiles);
-            in1_cb.pop_front(in1_block_num_tiles);
-        }
+        compute_kernel_lib::matmul_block<
+            /*transpose=*/false,
+            /*packer_l1_acc=*/false,
+            /*pack_last_to_interm=*/false,
+            /*pack_relu=*/false,
+            /*row_major_output=*/row_major>(
+            cb_in0,
+            cb_in1,
+            cb_out,
+            cb_intermed0,
+            in0_block_w,
+            in0_num_subblocks,
+            in1_num_subblocks,
+            num_k_blocks,
+            out_subblock_h,
+            out_subblock_w,
+            1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -1,110 +1,99 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
+/**
+ * @file bmm_large_block_zm_fused_bias_activation.cpp
+ * @brief Blocked matmul with optional fused bias, SFPU activation, transpose, and untilize.
+ *
+ * Full-featured bmm path used when any of: bias, activation, in0_transpose, untilize,
+ * DRAM sharding, or multi-block h/w dims are enabled. For the simple case see
+ * bmm_large_block_zm.cpp.
+ *
+ * Pipeline phases (each optional, selected by compile-time defines):
+ *   1. K-loop matmul (matmul_block helper): K-blocking, spill/reload, L1 accumulation.
+ *      - in0_transpose: TransposePreKBlock functor transposes input before each K-block.
+ *      - SFPU activation (no bias): PostComputeFn applies per sub-block on last K-block.
+ *      - PACK_RELU (no bias): helper enables relu on last K-block output.
+ *      - ROW_MAJOR_OUTPUT (factory-emitted define): helper does absolute-offset pack.
+ *      - SKIP_COMPUTE (microbench define): helper elides inner matmul LLK call.
+ *   2. Bias addition (add_bias_bcast_rows helper): reads partials, adds row-broadcast
+ *      bias, optionally applies SFPU activation, packs to output. Caller owns bias
+ *      CB wait/pop lifecycle since the reader may push bias only once across
+ *      multiple bh/batch iterations.
+ *   3. Untilize (reblock_and_untilize): converts tiled output to row-major.
+ *
+ * NOTE: The perf microbenchmark copy at
+ * tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/
+ *   bmm_large_block_zm_fused_bias_activation_copy.cpp
+ * is a standalone copy using direct LLK calls (cannot import ttnn kernel_lib).
+ */
 
-#include "api/compute/matmul.h"
+#include <cstdint>
+#include <type_traits>
+
 #include "api/compute/pack_untilize.h"
-#include "api/compute/tile_move_copy.h"
 #include "api/compute/transpose_wh.h"
-#include "experimental/circular_buffer.h"
 #include "internal/mod_div_lib.h"
 
+#include "ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp"
+
 #ifdef FUSE_BIAS
-#include "api/compute/bcast.h"
+#include "ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.hpp"
 #endif
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 
-// Please update
-// tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
-// when making any changes to this file.
-// Have to keep a copy because cannot import ttnn into tests/tt_metal.
+// ─── Local helper functions ─────────────────────────────────────────────────
 
 /**
- * @brief Transposes a block of tiles from one circular buffer to another.
+ * @brief Transpose a block of tiles from one CB to another (WH swap per tile).
  *
- * This function reads a block of tiles from the input circular buffer (cb), performs a width-height
- * (WH) transpose on each tile, and writes the transposed tiles to the output circular buffer.
- * The operation is performed in blocks of `block_size` tiles for efficiency, with a separate loop
- * at the end to handle any leftover tiles when the total tile count is not divisible by
- * `block_size`. The default block size is 4, since there are guaranteed to be 4 tiles in the dst
- *               regs irrespective of dst sync mode or data format.
- *
- * @tparam in0_block_num_tiles The number of tiles in the block to be transposed.
- * @tparam block_size The number of tiles in each block to be transposed.
- * @param in0_transpose_cb_id Circular buffer ID to read the original tiles from.
- * @param in0_cb_id Circular buffer ID to which the transposed tiles are written.
+ * Used by the TransposePreKBlock functor below.
  */
 template <uint32_t in0_block_num_tiles, uint32_t block_size = 4>
 FORCE_INLINE void transpose_tile_block(uint32_t in0_transpose_cb_id, uint32_t in0_cb_id) {
-    experimental::CircularBuffer in0_transpose_cb(in0_transpose_cb_id);
-    experimental::CircularBuffer in0_cb(in0_cb_id);
     constexpr uint32_t num_blocks = in0_block_num_tiles / block_size;
     constexpr uint32_t last_block_size = in0_block_num_tiles % block_size;
-    // Lets do 2 passes: One loop until last and one last for the left overs
+
     for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
-        in0_transpose_cb.wait_front(block_size);
+        cb_wait_front(in0_transpose_cb_id, block_size);
         tile_regs_acquire();
         for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
             transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
         }
         tile_regs_commit();
-        in0_transpose_cb.pop_front(block_size);
-
-        in0_cb.reserve_back(block_size);
+        cb_pop_front(in0_transpose_cb_id, block_size);
+        cb_reserve_back(in0_cb_id, block_size);
         tile_regs_wait();
         for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
             pack_tile(tile_idx, in0_cb_id);
         }
         tile_regs_release();
-        in0_cb.push_back(block_size);
+        cb_push_back(in0_cb_id, block_size);
     }
 
     if constexpr (last_block_size > 0) {
-        in0_transpose_cb.wait_front(last_block_size);
+        cb_wait_front(in0_transpose_cb_id, last_block_size);
         tile_regs_acquire();
         for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
             transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
         }
         tile_regs_commit();
-        in0_transpose_cb.pop_front(last_block_size);
-
-        in0_cb.reserve_back(last_block_size);
+        cb_pop_front(in0_transpose_cb_id, last_block_size);
+        cb_reserve_back(in0_cb_id, last_block_size);
         tile_regs_wait();
         for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
             pack_tile(tile_idx, in0_cb_id);
         }
         tile_regs_release();
-        in0_cb.push_back(last_block_size);
+        cb_push_back(in0_cb_id, last_block_size);
     }
 }
 
-FORCE_INLINE void reload_from_cb_to_dst(
-    uint32_t in0_cb_id,
-    uint32_t in1_cb_id,
-    uint32_t mm_partials_cb_id,
-    bool in1_transpose_tile,
-    uint32_t out_subblock_num_tiles,
-    uint32_t out_subblock_w,
-    uint32_t out_subblock_h,
-    uint32_t in0_block_w) {
-    experimental::CircularBuffer mm_partials_cb(mm_partials_cb_id);
-    // Reconfigure input
-    copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
-    mm_partials_cb.wait_front(out_subblock_num_tiles);
-
-    uint32_t start_dst_index = 0;
-    uint32_t start_tile_index = 0;
-    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
-
-    mm_partials_cb.pop_front(out_subblock_num_tiles);
-    // Reconfigure srcA back
-    mm_block_init_short_with_dt(
-        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
-}
-
+/**
+ * @brief Reblock and untilize matmul output from sub-block layout to row-major.
+ */
 template <uint32_t out_subblock_w, uint32_t out_block_w>
 inline void reblock_and_untilize(
     uint32_t num_out_subblocks_in_col,
@@ -112,21 +101,17 @@ inline void reblock_and_untilize(
     uint32_t out_subblock_h,
     uint32_t interm_cb_id,
     uint32_t out_cb_id) {
-    experimental::CircularBuffer interm_cb(interm_cb_id);
-    experimental::CircularBuffer out_cb(out_cb_id);
     uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
-    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
+    cb_wait_front(interm_cb_id, num_tiles_in_row_of_subblocks);
 
     uint32_t within_block_index = 0;
     for (uint32_t h = 0; h < out_subblock_h; h++) {
         uint32_t block_offset = 0;
-
-        out_cb.reserve_back(out_block_w);
+        cb_reserve_back(out_cb_id, out_block_w);
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < out_subblock_w; w++) {
-                uint32_t tile_index = block_offset + within_block_index + w;
-                copy_tile(interm_cb_id, tile_index, w);
+                copy_tile(interm_cb_id, block_offset + within_block_index + w, w);
             }
             tile_regs_commit();
             tile_regs_wait();
@@ -134,92 +119,183 @@ inline void reblock_and_untilize(
             tile_regs_release();
             block_offset += out_subblock_num_tiles;
         }
-        out_cb.push_back(out_block_w);
-
+        cb_push_back(out_cb_id, out_block_w);
         within_block_index += out_subblock_w;
     }
-    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
+    cb_pop_front(interm_cb_id, num_tiles_in_row_of_subblocks);
 }
 
+// ─── Functors for matmul_block / add_bias_bcast_rows callbacks ──────────────
+
+#ifdef SFPU_OP_INIT_ACTIVATION
+// Applied per output sub-block after matmul (no-bias) or after bias addition.
+struct SFPUPostCompute {
+    ALWI void operator()(uint32_t num_tiles) const {
+        for (uint32_t i = 0; i < num_tiles; i++) {
+            SFPU_OP_FUNC_ACTIVATION
+        }
+    }
+};
+#endif
+
+/**
+ * PreKBlockFn: transposes input block before each K-block iteration.
+ * Reconfigures data formats for the transpose, runs the transpose, then reinits matmul.
+ * The matmul_block helper's L1_ACC management restores accumulation state afterward.
+ */
+template <
+    uint32_t in0_block_num_tiles_v,
+    uint32_t in0_transpose_cb_id_v,
+    uint32_t in0_cb_id_v,
+    uint32_t in1_cb_id_v,
+    uint32_t in1_transpose_tile_v,
+    uint32_t out_subblock_w_v,
+    uint32_t out_subblock_h_v,
+    uint32_t in0_block_w_v,
+    uint32_t mm_partials_cb_id_v>
+struct TransposePreKBlock {
+    ALWI void operator()(uint32_t, uint32_t, bool) const {
+        reconfig_data_format_srca(in1_cb_id_v, in0_transpose_cb_id_v);
+        transpose_wh_init_short(in0_transpose_cb_id_v);
+        PACK((pack_reconfig_data_format(in0_cb_id_v)));
+#ifdef PACKER_L1_ACC
+        PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+        transpose_tile_block<in0_block_num_tiles_v>(in0_transpose_cb_id_v, in0_cb_id_v);
+        mm_block_init_short_with_dt(
+            in0_cb_id_v,
+            in1_cb_id_v,
+            in0_transpose_cb_id_v,
+            in1_transpose_tile_v,
+            out_subblock_w_v,
+            out_subblock_h_v,
+            in0_block_w_v);
+        PACK((pack_reconfig_data_format(mm_partials_cb_id_v)));
+    }
+};
+
+// ─── kernel_main ────────────────────────────────────────────────────────────
+
 void kernel_main() {
-// RUNTIME ARGS
+    using namespace compute_kernel_lib;
+
 #ifdef MATMUL_DRAM_SHARDED
-    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
-    // if not worker core, skip
-    if (not is_worker_core) {
+    if (get_arg_val<uint32_t>(0) != 1) {
         return;
     }
 #endif
 
-    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);        // inner block size in tiles
-    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);  // outer row block size (in inner row blocks)
-    constexpr uint32_t in0_block_num_tiles =
-        get_compile_time_arg_val(2);  // out_subblock_h*in0_block_w*in0_num_subblocks;
-    constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);  // out_subblock_h*in0_block_w
-    constexpr uint32_t in1_num_subblocks =
-        get_compile_time_arg_val(4);  // outer column block size (in inner column blocks)
-    constexpr uint32_t in1_block_num_tiles =
-        get_compile_time_arg_val(5);                               // out_subblock_w*in0_block_w* in1_num_subblocks;
-    constexpr uint32_t in1_block_w = get_compile_time_arg_val(6);  // out_subblock_w*in1_num_subblocks
-    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(7);     // outer inner dim (in inner dim blocks)
-    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(8);         // outer inner dim (in inner dim blocks)
-    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(9);         // outer inner dim (in inner dim blocks)
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(10);          // inner row block size in tiles
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(11);          // inner column block size in tiles
-    constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(12);  // out_subblock_h * out_subblock_w;
-    constexpr uint32_t batch = get_compile_time_arg_val(13);                   // batch dim
-    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(14);     // number of tiles in out_block
-    constexpr bool untilize_out = get_compile_time_arg_val(15);                // untilize output
-    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
+    // ── Compile-time arguments ──────────────────────────────────────────
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);
+    constexpr uint32_t in1_num_subblocks = get_compile_time_arg_val(4);
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(6);
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(7);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(8);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(9);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(10);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(11);
+    constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(12);
+    constexpr uint32_t batch = get_compile_time_arg_val(13);
+    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(14);
+    constexpr bool untilize_out = get_compile_time_arg_val(15);
     constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(16);
     constexpr bool in0_transpose_tile = (bool)get_compile_time_arg_val(17);
 
     constexpr uint32_t out_block_w = out_subblock_w * in1_num_subblocks;
 
+    // ── Circular buffer IDs ─────────────────────────────────────────────
     constexpr uint32_t in0_cb_id = in0_transpose_tile ? get_named_compile_time_arg_val("cb_in0_transposed")
                                                       : get_named_compile_time_arg_val("cb_in0");
     constexpr uint32_t in1_cb_id = get_named_compile_time_arg_val("cb_in1");
     constexpr uint32_t out_cb_id = get_named_compile_time_arg_val("cb_out");
     constexpr uint32_t mm_partials_cb_id = get_named_compile_time_arg_val("cb_intermed0");
     constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? mm_partials_cb_id : out_cb_id;
-    // When in0 needs to be transposed, the original data is read from cb_in0 (in0_transpose_cb_id),
-    // transposed, and the result is written to cb_in0_transposed (in0_cb_id), which is then used
-    // as input for the matmul call.
     constexpr uint32_t in0_transpose_cb_id = get_named_compile_time_arg_val("cb_in0");
-
-    experimental::CircularBuffer in0_cb(in0_cb_id);
-    experimental::CircularBuffer in1_cb(in1_cb_id);
-    experimental::CircularBuffer out_cb(out_cb_id);
-    experimental::CircularBuffer mm_partials_cb(mm_partials_cb_id);
-    experimental::CircularBuffer untilize_mode_out_cb(untilize_mode_out_cb_id);
 
 #ifdef FUSE_BIAS
     constexpr uint32_t bias_cb_id = get_named_compile_time_arg_val("cb_bias");
     constexpr uint32_t bias_ntiles = get_named_compile_time_arg_val("bias_ntiles");
     constexpr uint32_t mm_out_cb_id = mm_partials_cb_id;
-    experimental::CircularBuffer bias_cb(bias_cb_id);
 #else
     constexpr uint32_t mm_out_cb_id = untilize_mode_out_cb_id;
 #endif
-    experimental::CircularBuffer mm_out_cb(mm_out_cb_id);
 
-#ifdef SFPU_OP_INIT_ACTIVATION
-    SFPU_OP_INIT_ACTIVATION
-#endif
-
+    // ── Feature flags ───────────────────────────────────────────────────
 #ifdef IN1_TRANSPOSE_TILE
     constexpr uint32_t in1_transpose_tile = true;
 #else
     constexpr uint32_t in1_transpose_tile = false;
 #endif
 
-    constexpr bool spill = num_blocks_inner_dim > 1;
+    constexpr bool l1_acc =
+#ifdef PACKER_L1_ACC
+        true;
+#else
+        false;
+#endif
+
+    // PACK_RELU without bias: helper handles it via pack_relu template param.
+    // PACK_RELU with bias: caller manages RELU config between matmul and bias phases.
+    constexpr bool do_relu =
+#if defined(PACK_RELU) && !defined(FUSE_BIAS)
+        true;
+#else
+        false;
+#endif
+
+    // ROW_MAJOR_OUTPUT: factory opts in to absolute-offset packing; writers read row-major.
+    constexpr bool row_major_output =
+#ifdef ROW_MAJOR_OUTPUT
+        true;
+#else
+        false;
+#endif
+
+    // matmul_block packs its last K-block to interm when a downstream phase (bias, untilize)
+    // consumes from interm.
+    constexpr bool pack_last_to_interm =
+#ifdef FUSE_BIAS
+        true;
+#else
+        untilize_out;
+#endif
+
+    // ── Callback type aliases ───────────────────────────────────────────
+    using XposeFn = TransposePreKBlock<
+        in0_block_num_tiles,
+        in0_transpose_cb_id,
+        in0_cb_id,
+        in1_cb_id,
+        in1_transpose_tile,
+        out_subblock_w,
+        out_subblock_h,
+        in0_block_w,
+        mm_partials_cb_id>;
+    using NoPreFn = NoPreKBlock;
+    using NoPostFn = NoPostCompute;
+    using PreFn = std::conditional_t<in0_transpose_tile, XposeFn, NoPreFn>;
+
+#ifdef SFPU_OP_INIT_ACTIVATION
+    using PostFn = std::conditional_t<pack_last_to_interm, NoPostFn, SFPUPostCompute>;
+#else
+    using PostFn = NoPostFn;
+#endif
+
+    // ── Init ────────────────────────────────────────────────────────────
+#ifdef SFPU_OP_INIT_ACTIVATION
+    SFPU_OP_INIT_ACTIVATION
+#endif
 
     mm_block_init(
         in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+
+    // ── Main loop: batch × output blocks ────────────────────────────────
     for (uint32_t b = 0; b < batch; b++) {
         if constexpr (get_batch_from_reader) {
-            // Check whether this batch is valid
             bool is_batch_valid = false;
             UNPACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
             MATH(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
@@ -231,203 +307,53 @@ void kernel_main() {
 
         for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
             for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
-                bool enable_reload = false;
-
+                // Reset packer state for this output block
 #ifdef PACK_RELU
-                // for each batch we start with relu disabled so that intermediate results are not relu'd
                 if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
                     PACK((llk_pack_relu_config(ReluType::NO_RELU)));
                 }
 #endif
-
                 if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
                     PACK((pack_reconfig_data_format(mm_partials_cb_id)));
                 }
 
-                for (uint32_t block = 0; block < num_blocks_inner_dim; block++) {
-                    bool last_out = block == (num_blocks_inner_dim - 1);
-// Configure packer once for pack out without Bias
-#if not defined FUSE_BIAS and defined PACK_RELU
-                    if (last_out) {
-                        // if last block we pack the final result with relu enabled
-                        PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
-                    }
-#endif
-
-                    if constexpr (in0_transpose_tile) {
-                        reconfig_data_format_srca(in1_cb_id, in0_transpose_cb_id);
-                        transpose_wh_init_short(in0_transpose_cb_id);
-                        PACK((pack_reconfig_data_format(in0_cb_id)));
-#ifdef PACKER_L1_ACC
-                        PACK((llk_pack_reconfig_l1_acc(0)));
-#endif
-                        transpose_tile_block<in0_block_num_tiles>(in0_transpose_cb_id, in0_cb_id);
-                        mm_block_init_short_with_dt(
-                            in0_cb_id,
-                            in1_cb_id,
-                            in0_transpose_cb_id,
-                            in1_transpose_tile,
-                            out_subblock_w,
-                            out_subblock_h,
-                            in0_block_w);
-                        PACK((pack_reconfig_data_format(mm_partials_cb_id)));
-                    }
-
-                    in0_cb.wait_front(in0_block_num_tiles);
-                    in1_cb.wait_front(in1_block_num_tiles);
-
-                    if (block == 0 && !last_out) {
-                        out_cb.reserve_back(out_block_num_tiles);
-                    }
-
-                    int in0_index_subblock_offset = 0;
-                    for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
-                        int in1_index_subblock_offset = 0;
-                        for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
-                            tile_regs_acquire();
-                            if (enable_reload) {
-                                reload_from_cb_to_dst(
-                                    in0_cb_id,
-                                    in1_cb_id,
-                                    mm_partials_cb_id,
-                                    in1_transpose_tile,
-                                    out_subblock_num_tiles,
-                                    out_subblock_w,
-                                    out_subblock_h,
-                                    in0_block_w);
-                            }
-
-#ifndef SKIP_COMPUTE
-                            // Compute output sub-block
-                            uint32_t dst_index =
-                                0;  // start at 0, each call to matmul_block internally increments dst_index
-                            uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
-                            uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
-                            // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
-                            for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; ++inner_dim_idx) {
-                                // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
-                                // accumulation is done by iterating matmul_block across inner dim
-                                // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride
-                                // in0
-                                matmul_block(
-                                    in0_cb_id,
-                                    in1_cb_id,
-                                    in0_index,
-                                    in1_index,
-                                    dst_index,
-                                    in1_transpose_tile,
-                                    out_subblock_w,
-                                    out_subblock_h,
-                                    in0_block_w);
-                                in0_index++;               // stride right by 1
-                                in1_index += in1_block_w;  // to stride down by 1 need to stride by in_per_core_w
-                                                           // (should be called in1_block_w)
-                            }
-
-#endif  // SKIP_COMPUTE
-
-                            if (last_out) {
-// If we fuse bias, we will pack out and run bias + optional sfpu in a separate loop
-#if not defined FUSE_BIAS and defined SFPU_OP_INIT_ACTIVATION
-                                for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                                    SFPU_OP_FUNC_ACTIVATION
-                                }
-#endif
-                                tile_regs_commit();
-                                // Pack out to output buffer
-                                mm_out_cb.reserve_back(out_subblock_num_tiles);
-                                tile_regs_wait();
-
-#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                                PACK((pack_reconfig_data_format(mm_out_cb_id)));
-#endif
-
-#ifdef PACKER_L1_ACC
+                // ── Phase 1: K-loop matmul ──────────────────────────────
+                // Helper absorbs ROW_MAJOR_OUTPUT pack-strategy switch and SKIP_COMPUTE elision.
+                // Pass the "real" downstream out_cb (what the writer eventually consumes) so
+                // the helper's shared-memory-protection reserve targets the right CB. With
+                // FUSE_BIAS that's out_cb_id even though the matmul itself packs to partials;
+                // without bias it's whatever the untilize/writer phase reads.
+                constexpr uint32_t phase1_out_cb =
 #ifdef FUSE_BIAS
-                                if (block == 0) {  // no accumulation for first iteration
-                                    PACK((llk_pack_reconfig_l1_acc(0)));
-                                } else {
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
-                                }
+                    out_cb_id;
 #else
-                                PACK((llk_pack_reconfig_l1_acc(0)));
+                    mm_out_cb_id;
 #endif
-#endif
+                matmul_block<
+                    in1_transpose_tile,
+                    l1_acc,
+                    pack_last_to_interm,
+                    do_relu,
+                    row_major_output,
+                    PostFn,
+                    PreFn>(
+                    in0_cb_id,
+                    in1_cb_id,
+                    phase1_out_cb,
+                    mm_partials_cb_id,
+                    in0_block_w,
+                    in0_num_subblocks,
+                    in1_num_subblocks,
+                    num_blocks_inner_dim,
+                    out_subblock_h,
+                    out_subblock_w,
+                    1,
+                    PostFn{},
+                    PreFn{});
 
-                                uint32_t start_dst_index = 0;
-                                pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
-
-                                tile_regs_release();
-                                mm_out_cb.push_back(out_subblock_num_tiles);
-
-                            } else {
-                                tile_regs_commit();
-                                mm_partials_cb.reserve_back(out_subblock_num_tiles);
-                                tile_regs_wait();
-
-#ifdef PACKER_L1_ACC
-                                if (block == 0) {  // no accumulation for first iteration
-                                    PACK((llk_pack_reconfig_l1_acc(0)));
-                                } else if (block == 1) {
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
-                                } else if (in0_transpose_tile) {
-                                    // For each block, l1_acc would have been enabled during the
-                                    // transpose stage. So let us put it back here.
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
-                                }
-#endif
-
-                                uint32_t start_dst_index = 0;
-                                pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
-
-                                tile_regs_release();
-                                mm_partials_cb.push_back(out_subblock_num_tiles);
-                            }
-
-                            in1_index_subblock_offset += out_subblock_w;
-                        }
-                        in0_index_subblock_offset += in0_subblock_num_tiles;
-                    }
-
-#ifdef PACKER_L1_ACC
-#ifdef FUSE_BIAS
-                    if (block < num_blocks_inner_dim - 1) {
-                        // Wait/pop in subblock-sized steps so the step size
-                        // matches the bias section's wait_front(out_subblock_num_tiles),
-                        // satisfying the CB API requirement that all wait_front
-                        // increments on a given CB are identical.
-                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
-                            mm_partials_cb.wait_front(out_subblock_num_tiles);
-                            mm_partials_cb.pop_front(out_subblock_num_tiles);
-                        }
-                    }
-                    // never reload when with bias, bias uses interm buffer
-                    enable_reload = false;
-#else
-                    // Last iteration does spill and reload to output buffer
-                    if (block < num_blocks_inner_dim - 2) {
-                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
-                            mm_partials_cb.wait_front(out_subblock_num_tiles);
-                            mm_partials_cb.pop_front(out_subblock_num_tiles);
-                        }
-                    }
-                    if (block == num_blocks_inner_dim - 2) {
-                        enable_reload = true;
-                    }  // reload when last iteration
-#endif
-#else
-                    if constexpr (spill) {
-                        enable_reload = true;
-                    }
-#endif
-
-                    in0_cb.pop_front(in0_block_num_tiles);
-                    in1_cb.pop_front(in1_block_num_tiles);
-                }
-
+                // ── Phase 2: Bias addition ──────────────────────────────
 #ifdef FUSE_BIAS
 #ifdef PACK_RELU
-                // if last block we pack the final result with relu enabled
                 PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
 #endif
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
@@ -437,61 +363,31 @@ void kernel_main() {
                 PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
 
-                reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
-                add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
-                // Reader only pushes bias once when num_blocks_w_dim == 1;
-                // the tiles stay in the CB for reuse across bh/batch iterations.
+                // Bias CB lifecycle: the reader pushes bias once when num_blocks_w_dim == 1
+                // (tiles stay fronted across all bh/batch iterations) and pushes per-iter
+                // when num_blocks_w_dim > 1. Wait on first fronting; pop only when consumed.
                 if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
-                    bias_cb.wait_front(bias_ntiles);
+                    cb_wait_front(bias_cb_id, bias_ntiles);
                 }
-                for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
-                    int in1_index_subblock_offset = 0;
-                    for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
-                        // Redundant wait since we know data was just pushed
-                        mm_partials_cb.wait_front(out_subblock_num_tiles);
-                        tile_regs_acquire();
-                        for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
-                            uint32_t bcast_tile_idx = in1_index_subblock_offset;
-                            for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
-                                add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, bcast_tile_idx, i);
-                                bcast_tile_idx++;
-                            }
-                        }
-// if there's no SFPU fusion, we commit the regs so packer can start packing
-#ifndef SFPU_OP_INIT_ACTIVATION
-                        tile_regs_commit();
-#endif
 
-                        mm_partials_cb.pop_front(out_subblock_num_tiles);
-
-// sfpu activation
 #ifdef SFPU_OP_INIT_ACTIVATION
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            SFPU_OP_FUNC_ACTIVATION
-                        }
-                        tile_regs_commit();
+                add_bias_bcast_rows<mm_partials_cb_id, bias_cb_id, untilize_mode_out_cb_id, SFPUPostCompute>(
+                    in0_num_subblocks, in1_num_subblocks, out_subblock_h, out_subblock_w, SFPUPostCompute{});
+#else
+                add_bias_bcast_rows<mm_partials_cb_id, bias_cb_id, untilize_mode_out_cb_id>(
+                    in0_num_subblocks, in1_num_subblocks, out_subblock_h, out_subblock_w);
 #endif
 
-                        // Pack out to output buffer
-                        untilize_mode_out_cb.reserve_back(out_subblock_num_tiles);
-                        tile_regs_wait();
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            pack_tile(i, untilize_mode_out_cb_id);
-                        }
-                        tile_regs_release();
-                        untilize_mode_out_cb.push_back(out_subblock_num_tiles);
-
-                        in1_index_subblock_offset += out_subblock_w;
-                    }
-                }
                 if constexpr (num_blocks_w_dim > 1) {
-                    bias_cb.pop_front(bias_ntiles);
+                    cb_pop_front(bias_cb_id, bias_ntiles);
                 }
 #endif  // FUSE_BIAS
+
+                // ── Phase 3: Untilize ───────────────────────────────────
                 if constexpr (untilize_out) {
 #ifdef PACK_RELU
                     PACK((llk_pack_relu_config(ReluType::NO_RELU)));
-#endif  // PACK_RELU
+#endif
 #ifndef FUSE_BIAS
                     reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
@@ -500,24 +396,23 @@ void kernel_main() {
 #ifdef PACKER_L1_ACC
                     PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
-#endif  // FUSE_BIAS
+#endif  // !FUSE_BIAS
                     pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
                     copy_tile_to_dst_init_short(mm_partials_cb_id);
-                    for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                    for (uint32_t i = 0; i < in0_num_subblocks; ++i) {
                         reblock_and_untilize<out_subblock_w, out_block_w>(
                             in1_num_subblocks, out_subblock_num_tiles, out_subblock_h, mm_partials_cb_id, out_cb_id);
                     }
                     pack_untilize_uninit(mm_partials_cb_id);
                 }
+
+                // ── Reconfigure for next output block ───────────────────
                 if constexpr (batch > 1 || num_blocks_w_dim > 1 || num_blocks_h_dim > 1) {
 #ifdef FUSE_BIAS
-                    // reconfigure unpacker df for src A and src B
                     reconfig_data_format(mm_partials_cb_id, in1_cb_id, bias_cb_id, in0_cb_id);
 #else
-                    // reconfigure unpacker df for src A
                     reconfig_data_format_srca(mm_partials_cb_id, in1_cb_id);
 #endif
-                    // reconfigure init for matmul
                     mm_block_init_short(
                         in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -21,7 +21,8 @@
  *      bias, optionally applies SFPU activation, packs to output. Caller owns bias
  *      CB wait/pop lifecycle since the reader may push bias only once across
  *      multiple bh/batch iterations.
- *   3. Untilize (reblock_and_untilize): converts tiled output to row-major.
+ *   3. Untilize (reblock_and_untilize helper): gathers subblock-order output into
+ *      row-major and untilizes.
  *
  * NOTE: The perf microbenchmark copy at
  * tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/
@@ -32,100 +33,15 @@
 #include <cstdint>
 #include <type_traits>
 
-#include "api/compute/pack_untilize.h"
-#include "api/compute/transpose_wh.h"
-#include "internal/mod_div_lib.h"
-
 #include "ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/reblock_untilize_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/transpose_block_helpers.hpp"
 
 #ifdef FUSE_BIAS
 #include "ttnn/cpp/ttnn/kernel_lib/bias_add_helpers.hpp"
 #endif
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
-
-// ─── Local helper functions ─────────────────────────────────────────────────
-
-/**
- * @brief Transpose a block of tiles from one CB to another (WH swap per tile).
- *
- * Used by the TransposePreKBlock functor below.
- */
-template <uint32_t in0_block_num_tiles, uint32_t block_size = 4>
-FORCE_INLINE void transpose_tile_block(uint32_t in0_transpose_cb_id, uint32_t in0_cb_id) {
-    constexpr uint32_t num_blocks = in0_block_num_tiles / block_size;
-    constexpr uint32_t last_block_size = in0_block_num_tiles % block_size;
-
-    for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
-        cb_wait_front(in0_transpose_cb_id, block_size);
-        tile_regs_acquire();
-        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
-            transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
-        }
-        tile_regs_commit();
-        cb_pop_front(in0_transpose_cb_id, block_size);
-        cb_reserve_back(in0_cb_id, block_size);
-        tile_regs_wait();
-        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
-            pack_tile(tile_idx, in0_cb_id);
-        }
-        tile_regs_release();
-        cb_push_back(in0_cb_id, block_size);
-    }
-
-    if constexpr (last_block_size > 0) {
-        cb_wait_front(in0_transpose_cb_id, last_block_size);
-        tile_regs_acquire();
-        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
-            transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
-        }
-        tile_regs_commit();
-        cb_pop_front(in0_transpose_cb_id, last_block_size);
-        cb_reserve_back(in0_cb_id, last_block_size);
-        tile_regs_wait();
-        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
-            pack_tile(tile_idx, in0_cb_id);
-        }
-        tile_regs_release();
-        cb_push_back(in0_cb_id, last_block_size);
-    }
-}
-
-/**
- * @brief Reblock and untilize matmul output from sub-block layout to row-major.
- */
-template <uint32_t out_subblock_w, uint32_t out_block_w>
-inline void reblock_and_untilize(
-    uint32_t num_out_subblocks_in_col,
-    uint32_t out_subblock_num_tiles,
-    uint32_t out_subblock_h,
-    uint32_t interm_cb_id,
-    uint32_t out_cb_id) {
-    uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
-    cb_wait_front(interm_cb_id, num_tiles_in_row_of_subblocks);
-
-    uint32_t within_block_index = 0;
-    for (uint32_t h = 0; h < out_subblock_h; h++) {
-        uint32_t block_offset = 0;
-        cb_reserve_back(out_cb_id, out_block_w);
-        for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
-            tile_regs_acquire();
-            for (uint32_t w = 0; w < out_subblock_w; w++) {
-                copy_tile(interm_cb_id, block_offset + within_block_index + w, w);
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
-            tile_regs_release();
-            block_offset += out_subblock_num_tiles;
-        }
-        cb_push_back(out_cb_id, out_block_w);
-        within_block_index += out_subblock_w;
-    }
-    cb_pop_front(interm_cb_id, num_tiles_in_row_of_subblocks);
-}
-
-// ─── Functors for matmul_block / add_bias_bcast_rows callbacks ──────────────
 
 #ifdef SFPU_OP_INIT_ACTIVATION
 // Applied per output sub-block after matmul (no-bias) or after bias addition.
@@ -137,44 +53,6 @@ struct SFPUPostCompute {
     }
 };
 #endif
-
-/**
- * PreKBlockFn: transposes input block before each K-block iteration.
- * Reconfigures data formats for the transpose, runs the transpose, then reinits matmul.
- * The matmul_block helper's L1_ACC management restores accumulation state afterward.
- */
-template <
-    uint32_t in0_block_num_tiles_v,
-    uint32_t in0_transpose_cb_id_v,
-    uint32_t in0_cb_id_v,
-    uint32_t in1_cb_id_v,
-    uint32_t in1_transpose_tile_v,
-    uint32_t out_subblock_w_v,
-    uint32_t out_subblock_h_v,
-    uint32_t in0_block_w_v,
-    uint32_t mm_partials_cb_id_v>
-struct TransposePreKBlock {
-    ALWI void operator()(uint32_t, uint32_t, bool) const {
-        reconfig_data_format_srca(in1_cb_id_v, in0_transpose_cb_id_v);
-        transpose_wh_init_short(in0_transpose_cb_id_v);
-        PACK((pack_reconfig_data_format(in0_cb_id_v)));
-#ifdef PACKER_L1_ACC
-        PACK((llk_pack_reconfig_l1_acc(0)));
-#endif
-        transpose_tile_block<in0_block_num_tiles_v>(in0_transpose_cb_id_v, in0_cb_id_v);
-        mm_block_init_short_with_dt(
-            in0_cb_id_v,
-            in1_cb_id_v,
-            in0_transpose_cb_id_v,
-            in1_transpose_tile_v,
-            out_subblock_w_v,
-            out_subblock_h_v,
-            in0_block_w_v);
-        PACK((pack_reconfig_data_format(mm_partials_cb_id_v)));
-    }
-};
-
-// ─── kernel_main ────────────────────────────────────────────────────────────
 
 void kernel_main() {
     using namespace compute_kernel_lib;
@@ -275,14 +153,12 @@ void kernel_main() {
         out_subblock_h,
         in0_block_w,
         mm_partials_cb_id>;
-    using NoPreFn = NoPreKBlock;
-    using NoPostFn = NoPostCompute;
-    using PreFn = std::conditional_t<in0_transpose_tile, XposeFn, NoPreFn>;
+    using PreFn = std::conditional_t<in0_transpose_tile, XposeFn, NoPreKBlock>;
 
 #ifdef SFPU_OP_INIT_ACTIVATION
-    using PostFn = std::conditional_t<pack_last_to_interm, NoPostFn, SFPUPostCompute>;
+    using PostFn = std::conditional_t<pack_last_to_interm, NoPostCompute, SFPUPostCompute>;
 #else
-    using PostFn = NoPostFn;
+    using PostFn = NoPostCompute;
 #endif
 
     // ── Init ────────────────────────────────────────────────────────────

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -69,7 +69,7 @@ void kernel_main() {
     constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);
     constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);
     constexpr uint32_t in1_num_subblocks = get_compile_time_arg_val(4);
-    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);
+    [[maybe_unused]] constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);
     constexpr uint32_t in1_block_w = get_compile_time_arg_val(6);
     constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(7);
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(8);
@@ -194,25 +194,13 @@ void kernel_main() {
                 }
 
                 // ── Phase 1: K-loop matmul ──────────────────────────────
-                // Helper absorbs ROW_MAJOR_OUTPUT pack-strategy switch and SKIP_COMPUTE elision.
-                // Pass the "real" downstream out_cb (what the writer eventually consumes) so
-                // the helper's shared-memory-protection reserve targets the right CB. With
-                // FUSE_BIAS that's out_cb_id even though the matmul itself packs to partials;
-                // without bias it's whatever the untilize/writer phase reads.
                 constexpr uint32_t phase1_out_cb =
 #ifdef FUSE_BIAS
                     out_cb_id;
 #else
                     mm_out_cb_id;
 #endif
-                matmul_block<
-                    in1_transpose_tile,
-                    l1_acc,
-                    pack_last_to_interm,
-                    do_relu,
-                    row_major_output,
-                    PostFn,
-                    PreFn>(
+                matmul_block<in1_transpose_tile, l1_acc, pack_last_to_interm, do_relu, row_major_output, PostFn, PreFn>(
                     in0_cb_id,
                     in1_cb_id,
                     phase1_out_cb,
@@ -225,7 +213,9 @@ void kernel_main() {
                     out_subblock_w,
                     1,
                     PostFn{},
-                    PreFn{});
+                    PreFn{},
+                    /*retain_in0=*/false,
+                    /*in1_per_core_w=*/in1_block_w);
 
                 // ── Phase 2: Bias addition ──────────────────────────────
 #ifdef FUSE_BIAS

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -142,7 +142,51 @@ void kernel_main() {
 #endif  // IN1_SHARDED
 
 #ifndef OUT_SHARDED
-        // WRITER
+        // WRITER — layout of tiles arriving from compute depends on factory intent:
+        //   ROW_MAJOR_OUTPUT defined  → compute packs per M-row-group in row-major
+        //                               order; read full row-group and write across
+        //                               the full output width per row.
+        //   ROW_MAJOR_OUTPUT undefined → compute packs sequentially per subblock;
+        //                                read subblock-by-subblock and write at
+        //                                subblock offsets (main/legacy behavior).
+        //
+        // The define is emitted by factories whose compute path uses absolute-offset
+        // packing (matmul_multicore_reuse_optimized). Multicast / DRAM-sharded
+        // factories sharing this writer file don't emit it and rely on the legacy
+        // subblock-order path.
+#ifdef ROW_MAJOR_OUTPUT
+        {
+            constexpr uint32_t out_row_width = out_subblock_w * out_num_subblocks_w;
+            constexpr uint32_t row_group_tiles = out_subblock_h * out_row_width;
+
+            uint32_t out_tensor_row_group_start = out_tensor_start_tile_id;
+            for (uint32_t sbh = 0; sbh < out_num_subblocks_h; ++sbh) {
+                cb_out.wait_front(row_group_tiles);
+                uint32_t out_read_offset = 0;
+
+                uint32_t out_tensor_row_start = out_tensor_row_group_start;
+                for (uint32_t h = 0; h < out_subblock_h; ++h) {
+                    uint32_t out_tensor_tile_id = out_tensor_row_start;
+                    for (uint32_t w = 0; w < out_row_width; ++w) {
+                        noc.async_write(
+                            experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                            s,
+                            output_single_tile_size_bytes,
+                            {.offset_bytes = out_read_offset},
+                            {.page_id = out_tensor_tile_id});
+
+                        out_read_offset += output_single_tile_size_bytes;
+                        out_tensor_tile_id += out_tensor_stride_w;
+                    }
+                    out_tensor_row_start += out_tensor_stride_h;
+                }
+
+                noc.async_write_barrier();
+                cb_out.pop_front(row_group_tiles);
+                out_tensor_row_group_start += out_tensor_next_subblock_stride_h;
+            }
+        }
+#else
         uint32_t out_tensor_sbh_start_tile_id = out_tensor_start_tile_id;
         for (uint32_t sbh = 0; sbh < out_num_subblocks_h; ++sbh) {
             uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
@@ -163,7 +207,6 @@ void kernel_main() {
                             {.page_id = out_tensor_tile_id});
 
                         out_read_offset += output_single_tile_size_bytes;
-
                         out_tensor_tile_id += out_tensor_stride_w;
                     }
                     out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
@@ -175,6 +218,7 @@ void kernel_main() {
             }
             out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
         }
+#endif  // ROW_MAJOR_OUTPUT
         out_tensor_start_tile_id += MtNt;
 #endif  // OUT_SHARDED
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -38,38 +38,36 @@ void kernel_main() {
     experimental::Noc noc;
     experimental::CircularBuffer cb_out(cb_id_out0);
 
-    bool one_time_profile = true;
+    // Tiles arrive from compute in row-major order per row-group
+    // (one M-subblock's rows × full output width).
+    const uint32_t out_row_width = out_subblock_w * out_num_subblocks_w;
+    const uint32_t row_group_tiles = out_subblock_h * out_row_width;
+
     for (uint32_t b = 0; b < batch; b++) {
-        uint32_t out_tensor_sbh_start_tile_id = out_tensor_start_tile_id;
+        uint32_t out_tensor_row_group_start = out_tensor_start_tile_id;
         for (uint32_t sbh = 0; sbh < out_num_subblocks_h; sbh++) {
-            uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
-            for (uint32_t sbw = 0; sbw < out_num_subblocks_w; sbw++) {
-                uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
+            cb_out.wait_front(row_group_tiles);
+            uint32_t out_read_offset = 0;
 
-                cb_out.wait_front(out_subblock_tile_count);
-                uint32_t out_read_offset = 0;
-
-                for (uint32_t h = 0; h < out_subblock_h; h++) {
-                    uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
-                    for (uint32_t w = 0; w < out_subblock_w; w++) {
-                        noc.async_write(
-                            experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out),
-                            s,
-                            single_tile_size_bytes,
-                            {.offset_bytes = out_read_offset},
-                            {.page_id = out_tensor_tile_id});
-                        out_read_offset += single_tile_size_bytes;
-
-                        out_tensor_tile_id += out_tensor_stride_w;
-                    }
-                    out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
+            uint32_t out_tensor_row_start = out_tensor_row_group_start;
+            for (uint32_t h = 0; h < out_subblock_h; h++) {
+                uint32_t out_tensor_tile_id = out_tensor_row_start;
+                for (uint32_t w = 0; w < out_row_width; w++) {
+                    noc.async_write(
+                        experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                        s,
+                        single_tile_size_bytes,
+                        {.offset_bytes = out_read_offset},
+                        {.page_id = out_tensor_tile_id});
+                    out_read_offset += single_tile_size_bytes;
+                    out_tensor_tile_id += out_tensor_stride_w;
                 }
-
-                noc.async_write_barrier();
-                cb_out.pop_front(out_subblock_tile_count);
-                out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
+                out_tensor_row_start += out_tensor_stride_h;
             }
-            out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
+
+            noc.async_write_barrier();
+            cb_out.pop_front(row_group_tiles);
+            out_tensor_row_group_start += out_tensor_next_subblock_stride_h;
         }
         out_tensor_start_tile_id += MtNt;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1071,12 +1071,6 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         attributes.output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
                         "Output memory layout must not be WIDTH_SHARDED, got: {}",
                         attributes.output_mem_config.memory_layout());
-                    TT_FATAL(
-                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
-                        "Either out_subblock_w ({}) must equal per_core_N ({}) or out_subblock_h ({}) must be 1",
-                        program_config.out_subblock_w,
-                        per_core_N,
-                        program_config.out_subblock_h);
                 }
             } else {
                 TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1254,12 +1254,6 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
     // precondition: in1_cb has 1 produced (column identity)
     // precondition: out_cb has M produced (input rows)
     // postcondition: out_cb has M produced (reduced rows, in-place)
-    //
-    // In-place reduce: out_cb plays both the in0 and the out roles. This violates
-    // matmul_block's in0_cb != out_cb invariant, so we inline the loop directly here
-    // instead of routing through the shared helper.
-
-    constexpr uint32_t N = 1;
 #ifdef STATS_GRANULARITY
     constexpr uint32_t subblock_h = STATS_GRANULARITY;
     constexpr uint32_t in0_num_subblocks = M / STATS_GRANULARITY;
@@ -1267,25 +1261,7 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
     constexpr uint32_t subblock_h = 1;
     constexpr uint32_t in0_num_subblocks = M;
 #endif
-    const uint32_t subblock_tiles = subblock_h * N;
-
-    mm_block_init_short(out_cb, in1_cb, /*transpose=*/false, /*ct=*/N, /*rt=*/subblock_h, /*kt=*/N);
-    reconfig_data_format(in1_cb, out_cb);
-    cb_wait_front(in1_cb, 1);
-    cb_wait_front(out_cb, M);
-
-    for (uint32_t sub = 0; sub < in0_num_subblocks; ++sub) {
-        tile_regs_acquire();
-        ckernel::matmul_block(out_cb, in1_cb, 0, 0, 0, /*transpose=*/false, N, subblock_h, N);
-        tile_regs_commit();
-        cb_pop_front(out_cb, subblock_tiles);
-        tile_regs_wait();
-        for (uint32_t i = 0; i < subblock_tiles; i++) {
-            pack_tile(i, out_cb);
-        }
-        tile_regs_release();
-        cb_push_back(out_cb, subblock_tiles);
-    }
+    compute_kernel_lib::matmul_reduce_inplace(out_cb, in1_cb, in0_num_subblocks, subblock_h);
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -22,6 +22,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/matmul.h"
 #include "api/compute/reduce.h"
+#include "ttnn/cpp/ttnn/kernel_lib/matmul_block_helpers.hpp"
 #include "api/compute/reduce_custom.h"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp"
 #include "cpp/ttnn/kernel_lib/dest_helpers.hpp"
@@ -1169,8 +1170,35 @@ __attribute__((optimize("Os"))) void sub_block(uint32_t in0_cb, uint32_t in1_cb,
 }
 
 /**
- * out_cb = in0_cb @ in1_cb
+ * Optional-mask post-compute functor. The add_mask branch is runtime — sdpa_decode
+ * passes `add_mask_fusion` as a runtime bool, so we fold the check into operator()
+ * and always instantiate the helper with this functor.
  */
+struct OptionalMaskPostCompute {
+    uint32_t mask_cb_id;
+    uint32_t zero_cb_id;
+    bool add_mask;
+    ALWI void operator()(uint32_t out_subblock_num_tiles) const {
+        if (!add_mask) {
+            return;
+        }
+        cb_wait_front(mask_cb_id, out_subblock_num_tiles);
+        cb_wait_front(zero_cb_id, 1);
+        add_tiles_init(zero_cb_id, mask_cb_id, true);
+        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+            add_tiles(zero_cb_id, mask_cb_id, 0, i, i);
+        }
+    }
+};
+
+/**
+ * out_cb = in0_cb @ in1_cb  (single-pass, absolute-offset packing, Q/QK retained).
+ *
+ * Thin SDPA-shaped wrapper around compute_kernel_lib::matmul_block. transpose is a
+ * template bool (compile-time at all call sites); add_mask is runtime (sdpa_decode
+ * passes it dynamically) — handled via OptionalMaskPostCompute.
+ */
+template <bool transpose>
 ALWI void matmul_blocks(
     const uint32_t& in0_cb,
     const uint32_t& in1_cb,
@@ -1184,88 +1212,54 @@ ALWI void matmul_blocks(
     const uint32_t& in0_block_w,
     const uint32_t& subblock_h,
     const uint32_t& subblock_w,
-    const bool& transpose,
     const bool& add_mask = false,
     const uint32_t& mask_cb = 0,
     const uint32_t& zero_cb = 0) {
     // precondition: in0_cb has M*K produced
     // precondition: in1_cb has K*N produced
-    // postcondition: in0_cb is full, in1_cb is empty
+    // postcondition: in0_cb is full (retained), in1_cb is empty
     // postcondition: out_cb has M*N produced
 
-    mm_block_init_short(
-        in0_cb, in1_cb, transpose /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
-
-    const uint32_t output_num_tiles = M * N;
-    const uint32_t out_subblock_num_tiles = subblock_h * subblock_w;
-    const uint32_t in0_subblock_all_cols_num_tiles = subblock_h * N;
-
-    uint32_t in0_index_offset = 0;
-
-    const uint32_t in0_subblock_num_tiles = subblock_h * in0_block_w;
-    uint32_t in0_wait_tiles = in0_subblock_num_tiles;
-
+    // num_blocks == 1 in SDPA, so the helper's K-accumulation path is inert; in0_cb is
+    // forwarded as the interm_cb placeholder — it is unused when num_k_blocks == 1.
+    mm_block_init_short(in0_cb, in1_cb, transpose, subblock_w, subblock_h, in0_block_w);
     reconfig_data_format(in1_cb, in0_cb);
-    cb_wait_front(in1_cb, K * N);
-    cb_reserve_back(out_cb, output_num_tiles);
 
-    for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; ++in0_subblock) {
-        cb_wait_front(in0_cb, in0_wait_tiles);
-        uint32_t in1_index_offset = 0;
-        for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; ++in1_subblock) {
-            tile_regs_acquire();
-
-            uint32_t dst_index = 0;
-            uint32_t in0_index = in0_index_offset;
-            uint32_t in1_index = in1_index_offset;
-
-            for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
-                matmul_block(
-                    in0_cb, in1_cb, in0_index, in1_index, dst_index, transpose, subblock_w, subblock_h, in0_block_w);
-                in0_index++;
-                in1_index += N;
-            }
-            if (add_mask) {
-                cb_wait_front(mask_cb, out_subblock_num_tiles);
-                cb_wait_front(zero_cb, 1);
-                add_tiles_init(zero_cb, mask_cb, true);
-                for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                    add_tiles(zero_cb, mask_cb, 0, i, i);
-                }
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            uint32_t dst_idx = 0;
-            uint32_t out_col_offset = in1_subblock * subblock_w;
-            for (uint32_t r = 0; r < subblock_h; r++) {
-                uint32_t out_row_offset = r * N;
-                for (uint32_t c = 0; c < subblock_w; c++) {
-                    pack_tile<true>(dst_idx, out_cb, out_row_offset + out_col_offset + c);
-                    dst_idx++;
-                }
-            }
-            tile_regs_release();
-            in1_index_offset += subblock_w;
-        }
-        in0_index_offset += subblock_h * in0_block_w;
-        in0_wait_tiles += in0_subblock_num_tiles;
-        // Somewhat granularize the push of in0 subblocks
-        cb_push_back(out_cb, in0_subblock_all_cols_num_tiles);
-    }
-    cb_pop_front(in1_cb, K * N);
+    compute_kernel_lib::matmul_block<
+        transpose,
+        /*packer_l1_acc=*/false,
+        /*pack_last_to_interm=*/false,
+        /*pack_relu=*/false,
+        /*row_major_output=*/true,
+        OptionalMaskPostCompute,
+        compute_kernel_lib::NoPreKBlock>(
+        in0_cb,
+        in1_cb,
+        out_cb,
+        in0_cb,
+        in0_block_w,
+        in0_num_subblocks,
+        in1_num_subblocks,
+        num_blocks,
+        subblock_h,
+        subblock_w,
+        1,
+        OptionalMaskPostCompute{mask_cb, zero_cb, add_mask},
+        compute_kernel_lib::NoPreKBlock{},
+        /*retain_in0=*/true);
 }
 
 template <uint32_t M>
 void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
-    // precondition: in0_cb has M*K produced
-    // precondition: in1_cb has K*N produced
-    // postcondition: in0_cb is full, in1_cb is empty
-    // postcondition: out_cb has M*N produced
+    // precondition: in1_cb has 1 produced (column identity)
+    // precondition: out_cb has M produced (input rows)
+    // postcondition: out_cb has M produced (reduced rows, in-place)
+    //
+    // In-place reduce: out_cb plays both the in0 and the out roles. This violates
+    // matmul_block's in0_cb != out_cb invariant, so we inline the loop directly here
+    // instead of routing through the shared helper.
 
-    constexpr uint32_t N = 1;  // Result of reduce is 1 column
-    constexpr uint32_t in0_block_w = N;
-    constexpr uint32_t subblock_w = N;
-    // Reuse the Sq_chunk_t granularity chosen for sub_exp_block
+    constexpr uint32_t N = 1;
 #ifdef STATS_GRANULARITY
     constexpr uint32_t subblock_h = STATS_GRANULARITY;
     constexpr uint32_t in0_num_subblocks = M / STATS_GRANULARITY;
@@ -1273,39 +1267,24 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
     constexpr uint32_t subblock_h = 1;
     constexpr uint32_t in0_num_subblocks = M;
 #endif
+    const uint32_t subblock_tiles = subblock_h * N;
 
-    /**
-     * Use matmul on Mx1 input to reduce rows within tile to produce Mx1 output.
-     */
-
-    mm_block_init_short(
-        out_cb, in1_cb, 0 /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
-
-    constexpr uint32_t output_num_tiles = M * N;
-    constexpr uint32_t out_subblock_num_tiles = subblock_h * subblock_w;
-
+    mm_block_init_short(out_cb, in1_cb, /*transpose=*/false, /*ct=*/N, /*rt=*/subblock_h, /*kt=*/N);
     reconfig_data_format(in1_cb, out_cb);
-    cb_wait_front(in1_cb, N);
+    cb_wait_front(in1_cb, 1);
     cb_wait_front(out_cb, M);
 
-    for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; ++in0_subblock) {
+    for (uint32_t sub = 0; sub < in0_num_subblocks; ++sub) {
         tile_regs_acquire();
-
-        uint32_t dst_index = 0;
-        uint32_t in0_index = 0;
-        uint32_t in1_index = 0;
-
-        matmul_block(out_cb, in1_cb, in0_index, in1_index, dst_index, 0, subblock_w, subblock_h, in0_block_w);
-
+        ckernel::matmul_block(out_cb, in1_cb, 0, 0, 0, /*transpose=*/false, N, subblock_h, N);
         tile_regs_commit();
-        cb_pop_front(out_cb, subblock_h);
-
+        cb_pop_front(out_cb, subblock_tiles);
         tile_regs_wait();
-        for (uint32_t i = 0; i < subblock_h; i++) {
+        for (uint32_t i = 0; i < subblock_tiles; i++) {
             pack_tile(i, out_cb);
         }
         tile_regs_release();
-        cb_push_back(out_cb, subblock_h);
+        cb_push_back(out_cb, subblock_tiles);
     }
 }
 
@@ -1814,7 +1793,7 @@ void sdpa_inner_loop(
              */
             reconfig_data_format(cb_k_in, cb_q_in);
             pack_reconfig_data_format(cb_qk_im);
-            matmul_blocks(
+            matmul_blocks</*transpose=*/true>(
                 cb_q_in,
                 cb_k_in,
                 cb_qk_im,
@@ -1826,8 +1805,7 @@ void sdpa_inner_loop(
                 qk_in1_num_subblocks,
                 qk_in0_block_w,
                 qk_subblock_h,
-                qk_subblock_w,
-                true /*transpose*/);
+                qk_subblock_w);
 
             /**
              * Note
@@ -1924,7 +1902,7 @@ void sdpa_inner_loop(
             pack_reconfig_data_format(alias_mm2_cur_out);
 
             /* OUT_IM = QK @ V_CHUNK */
-            matmul_blocks(
+            matmul_blocks</*transpose=*/false>(
                 cb_qk_im,
                 cb_v_in,
                 alias_mm2_cur_out,
@@ -1936,8 +1914,7 @@ void sdpa_inner_loop(
                 out_in1_num_subblocks,
                 out_in0_block_w,
                 out_subblock_h,
-                out_subblock_w,
-                false /*transpose*/);
+                out_subblock_w);
 
             cb_pop_front(cb_qk_im, qk_chunk_tiles);
             reconfig_data_format(alias_prev_max, alias_cur_max);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -344,7 +344,7 @@ void kernel_main() {
                     mask_cb_to_use = cb_sliding_window_mask_in;  // Use sliding window mask buffer
                 }
 
-                matmul_blocks(
+                matmul_blocks</*transpose=*/true>(
                     cb_q_in,
                     cb_k_in,
                     cb_qk_im,
@@ -357,7 +357,6 @@ void kernel_main() {
                     qk_in0_block_w,
                     qk_subblock_h_dynamic,
                     qk_subblock_w_dynamic,
-                    true,
                     add_mask_fusion,
                     mask_cb_to_use,
                     cb_zero_in);
@@ -435,7 +434,7 @@ void kernel_main() {
                 /* OUT_IM = QK @ V_CHUNK */
                 reconfig_data_format(cb_v_in, cb_qk_im);  // DEBUG
                 pack_reconfig_data_format(cb_out_im);
-                matmul_blocks(
+                matmul_blocks</*transpose=*/false>(
                     cb_qk_im,
                     cb_v_in,
                     cb_out_mm,
@@ -448,8 +447,7 @@ void kernel_main() {
                     out_in0_block_w_dynamic,
                     out_subblock_h,
                     out_subblock_w,
-                    false /*transpose*/,
-                    false,
+                    false /*add_mask*/,
                     cb_mask_in,
                     cb_zero_in);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39726

### Problem Description
We need Claude friendly API for automated development of kernels that use matmul LLK functions. We also need to unify the disparate matmul kernels to use a centralized helper function so perf optimizations can be applied broadly to all applicable cases.

### What's Changed
  - Adds matmul_block, bias_add, transpose_block, reblock_untilize to ttnn/cpp/ttnn/kernel_lib/.                                                                                                                                                                       
  - Non-multicast matmul factories and SDPA compute kernels rewritten to compose these helpers.
  - 36 isolation gtests covering each helper.                                                                                                                                                                                                                          
  - Two obsolete subblock constraints removed on the non-multicast sharded-output path.

### Perf Improvement Example Results (BH P100):
#### Case 1 — `reuse_fuse_bias` (512×512×512 + bias, single core)

| Parameter | main value | branch value |
|---|---|---|
| grid | 1×1 | 1×1 |
| per_core_M | 16 | 16 |
| per_core_N | 16 | 16 |
| out_subblock_h | 1 | 1 |
| out_subblock_w | 1 | 8 |
| in0_block_w (K-tiles per block) | 1 | 4 |
| K-iterations | 16 | 4 |
| tiles packed per DST acquire | 1 | 8 |
| pack_tile_block fast path | no | yes |
| **Device kernel duration** | **510,394 ns** | **129,495 ns (-74.6%)** |

#### Case 2 — `reuse_optimized_fuse_bias` (1024×512×64 + bias, single core)

| Parameter | main | branch |
|---|---|---|
| grid | 1×1 | 1×1 |
| per_core_M, per_core_N | 32, 2 | 32, 2 |
| out_subblock_h, w | 1, 1 | 4, 2 |
| in0_block_w | 1 | 4 |
| K-iterations | 16 | 4 |
| tiles per DST acquire | 1 | 8 |
| Pack path | sequential per tile | absolute-offset (multi-row) |
| **Device kernel duration** | **134,833 ns** | **37,061 ns (-72.5%)** |

#### Case 3 — `reuse_optimized_nonbias` (1024×1024×1024, 4×1 grid)

| Parameter | main | branch |
|---|---|---|
| grid | 4×1 | 4×1 |
| per_core_M, per_core_N | 8, 32 | 8, 32 |
| out_subblock_h, w | 1, 1 | 1, 8 |
| in0_block_w | 1 | 4 |
| K-iterations | 32 | 8 |
| tiles per DST acquire | 1 | 8 |
| pack_tile_block fast path | no | yes |
| **Device kernel duration** | **1,024,074 ns** | **268,529 ns (-73.8%)** |

### Checklist
TODO