### PR TITLE
Factor out AR and AG open connection logic to run before gather

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -1708,8 +1708,11 @@ void kernel_main() {
         // ========================================================================
         // GatherReduce3: 112 matmul5 cores (2x56 halves) -> sender core (11, 9)
         // Reduces [1, 32] * 56 from each half -> [1, 1792] per device
+        // Non-sender cores run it here; sender-core RISCs run it inside the
+        // CCL block below, after connections are opened (so the fabric
+        // handshake overlaps the sync-sem wait).
         // ========================================================================
-        {
+        if constexpr (!Core::is_allreduce_sender_core) {
             DeviceZoneScopedN("GATHER3");
             deepseek_b1_ops::GatherReduce::
                 Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, Core::is_allreduce_sender_core, true, true>
@@ -1728,15 +1731,31 @@ void kernel_main() {
             DeviceZoneScopedN("CCL_SENDER_WRITER");
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
             deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> ccl_writer;
+            ccl_writer.open_connections(ccl_sender_args);
+            deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
+            noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("sdpa_fwd_num_cores"));
+            allgather_sender.open_connections(allgather_transport_args, false);
+#endif
+            // gather3 must run on ALL RISCs (TRISC does the reduce that feeds local_data_cb).
+            {
+                DeviceZoneScopedN("GATHER3");
+                deepseek_b1_ops::GatherReduce::Op<
+                    Core::is_matmul5_core,
+                    Core::is_allreduce_sender_core,
+                    Core::is_allreduce_sender_core,
+                    true,
+                    true>
+                    gather3;
+                gather3(gather3_args);
+            }
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
             ccl_writer(ccl_sender_args);
 
             // All-Gather: transport sender (BRISC=fwd, NCRISC=bwd)
             {
                 DeviceZoneScopedN("ALLGATHER_TRANSPORT");
-                deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
-                volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                    get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
-                noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("sdpa_fwd_num_cores"));
                 allgather_sender(allgather_transport_args);
                 // R2 active waits for the other risc to finish, so it's safe to reset the semaphore here.
                 if constexpr (AllGatherTransportCT::r2_active) {

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -2555,7 +2555,7 @@ void kernel_main() {
         // GatherReduce3: 112 cores (2x56 halves) -> sender core (11, 9)
         // Each sender produces 1 tile of 1x32; halves are reduced on receiver
         // ========================================================================
-        {
+        if constexpr (!Core::is_allreduce_sender_core) {
             DeviceZoneScopedN("GATHER3");
             deepseek_b1_ops::GatherReduce::
                 Op<Core::is_matmul5_core, Core::is_allreduce_sender_core, Core::is_allreduce_sender_core, true, true>
@@ -2574,22 +2574,36 @@ void kernel_main() {
             DeviceZoneScopedN("CCL_SENDER_WRITER");
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
             deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> ccl_writer;
+            ccl_writer.open_connections(ccl_sender_args);
+            deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
+            noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("sdpa_fwd_num_cores"));
+            allgather_sender.open_connections(allgather_transport_args, false);
+#endif
+            // gather3 must run on ALL RISCs (TRISC does the reduce that feeds local_data_cb).
+            {
+                DeviceZoneScopedN("GATHER3");
+                deepseek_b1_ops::GatherReduce::Op<
+                    Core::is_matmul5_core,
+                    Core::is_allreduce_sender_core,
+                    Core::is_allreduce_sender_core,
+                    true,
+                    true>
+                    gather3;
+                gather3(gather3_args);
+            }
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
             ccl_writer(ccl_sender_args);
-
             // All-Gather: transport sender (BRISC=fwd, NCRISC=bwd)
             {
                 DeviceZoneScopedN("ALLGATHER_TRANSPORT");
-                deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
-                volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                    get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
-                noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("sdpa_fwd_num_cores"));
                 allgather_sender(allgather_transport_args);
                 // R2 active waits for the other risc to finish, so it's safe to reset the semaphore here.
                 if constexpr (AllGatherTransportCT::r2_active) {
                     noc_semaphore_set(ccl_sync_sem, 0);
                 }
             }
-
             constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore2_addr");
             constexpr uint32_t input_noc_coord_x = get_named_compile_time_arg_val("input_noc_coord_x");
             constexpr uint32_t input_noc_coord_y = get_named_compile_time_arg_val("input_noc_coord_y");

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -593,6 +593,7 @@ void kernel_main() {
         args.dest_noc_y = get_common_arg_val<uint32_t>(2);
         args.per_core_rta_start_idx = 0;
         deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> writer;
+        writer.open_connections(args);
         writer(args);
     }
     if constexpr (Core::is_allreduce_receiver_core) {
@@ -626,6 +627,7 @@ void kernel_main() {
         args.dest_noc_y = get_common_arg_val<uint32_t>(2);
         args.per_core_rta_start_idx = 0;
         deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceBriscWriterCTArgs> writer;
+        writer.open_connections(args);
         writer(args);
     }
 

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/kernels/all_gather_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/kernels/all_gather_kernel.cpp
@@ -76,6 +76,7 @@ void kernel_main() {
     if constexpr (Core::is_transport_core) {
         DeviceZoneScopedN("ALLGATHER_TRANSPORT");
         deepseek_b1_ops::AllGather::TransportSender<TransportCT> sender;
+        sender.open_connections(transport_args);
         sender(transport_args);
     }
 #endif

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/kernels/all_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/kernels/all_reduce_kernel.cpp
@@ -32,6 +32,7 @@ void kernel_main() {
         deepseek_b1_ops::AllReduce::WriterSingleLink<WriterCT> writer;
         {
             DeviceZoneScopedN("CCL_SENDER_WRITER");
+            writer.open_connections(args);
             writer(args);
         }
     }

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
@@ -145,33 +145,38 @@ template <typename CTArgs>
 class TransportSender {
 public:
     void operator()(const TransportArgs& args) { impl(args); }
+    void open_connections(const TransportArgs& args, bool reset_header_pool = true) {
+        open_connections_impl(args, reset_header_pool);
+    }
 
 private:
     static constexpr uint32_t max_header_ring_size = 2;
     static constexpr uint32_t header_ring_size = CTArgs::num_chunks <= 1 ? 1u : max_header_ring_size;
-
-    void impl([[maybe_unused]] const TransportArgs& args) {
+    static constexpr bool use_posted_transport_writes = true;
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+    uint64_t dest_output_noc = 0;
+    uint64_t dest_recv_sem_noc = 0;
+    tt::tt_fabric::WorkerToFabricEdmSender connection;
+    std::array<volatile tt_l1_ptr PACKET_HEADER_TYPE*, header_ring_size> headers = {};
+#endif
+    void open_connections_impl([[maybe_unused]] const TransportArgs& args, [[maybe_unused]] bool reset_header_pool) {
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
         static_assert(CTArgs::num_links == 1, "All-gather TransportSender is single-link only");
-
         size_t arg_idx = size_t(args.per_core_rta_start_idx);
         const uint32_t dst_mesh_id = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t dst_chip_id = get_arg_val<uint32_t>(arg_idx++);
 
-        constexpr bool use_posted_transport_writes = true;
-
-        auto connection =
+        connection =
             tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
-
-        const uint64_t dest_output_noc =
-            safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, args.dest_output_base_addr, 0);
-        const uint64_t dest_recv_sem_noc =
-            safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, args.dest_recv_sem_addr, 0);
-
         const auto connection_direction = get_next_hop_router_direction(dst_mesh_id, dst_chip_id);
-        std::array<volatile PACKET_HEADER_TYPE*, header_ring_size> headers = {};
         connection.open_start();
-        PacketHeaderPool::reset();
+        if (reset_header_pool) {
+            PacketHeaderPool::reset();
+        }
+
+        dest_output_noc = safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, args.dest_output_base_addr, 0);
+        dest_recv_sem_noc = safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, args.dest_recv_sem_addr, 0);
+
         for (uint32_t i = 0; i < header_ring_size; ++i) {
             headers[i] = PacketHeaderPool::allocate_header();
             fabric_set_single_hop_unicast_route_from_direction(
@@ -180,6 +185,11 @@ private:
                 {dest_output_noc, dest_recv_sem_noc, /* placeholder inc_value */ 1, false}, CTArgs::chunk_size_bytes);
         }
         connection.open_finish();
+#endif
+    }
+    void impl([[maybe_unused]] const TransportArgs& args) {
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+
         connection.setup_stateful_send_cmd_bufs<use_posted_transport_writes>();
 
         volatile tt_l1_ptr uint32_t* handoff_sem_ptr =

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_reduce.hpp
@@ -140,6 +140,9 @@ template <typename CTArgs>
 class WriterSingleLink {
 public:
     void operator()(const SenderArgs& args) { impl(args); }
+    void open_connections(const SenderArgs& args, bool reset_header_pool = true) {
+        open_connections_impl(args, reset_header_pool);
+    }
 
 private:
     // This writer only sends chunk indices:
@@ -159,9 +162,25 @@ private:
         }
     }
 
-    void impl([[maybe_unused]] const SenderArgs& args) {
+    static constexpr bool use_posted_transport_writes = true;
+    static constexpr uint32_t max_header_ring_size = 2;
+    static constexpr uint32_t packets_to_send = packets_to_send_for_writer();
+    // A single packet never reuses a header, so the second header only pays setup cost with no flush savings.
+    static constexpr uint32_t header_ring_size = packets_to_send <= 1u ? 1u : max_header_ring_size;
+
+    static constexpr uint32_t regular_payload_bytes = CTArgs::tiles_per_chunk * CTArgs::page_size_bytes;
+    static constexpr uint32_t last_payload_bytes = CTArgs::last_chunk_tiles * CTArgs::page_size_bytes;
+
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
-        constexpr uint32_t packets_to_send = packets_to_send_for_writer();
+    uint64_t dst_noc_base = 0;
+    uint64_t remote_sem_noc = 0;
+    uint64_t local_ready_noc_addr = 0;
+    tt::tt_fabric::WorkerToFabricEdmSender connection;
+    std::array<volatile tt_l1_ptr PACKET_HEADER_TYPE*, header_ring_size> headers = {};
+#endif
+
+    void open_connections_impl([[maybe_unused]] const SenderArgs& args, [[maybe_unused]] bool reset_header_pool) {
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
         if constexpr (CTArgs::link_index >= CTArgs::num_links || packets_to_send == 0) {
             return;
         }
@@ -171,7 +190,6 @@ private:
         const uint32_t dst_chip_id = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t link_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
 
-        uint64_t local_ready_noc_addr = 0;
         if constexpr (CTArgs::signal_local_ready) {
             const uint32_t local_ready_dest_noc_x = get_arg_val<uint32_t>(arg_idx++);
             const uint32_t local_ready_dest_noc_y = get_arg_val<uint32_t>(arg_idx++);
@@ -180,8 +198,31 @@ private:
                 safe_get_noc_addr(local_ready_dest_noc_x, local_ready_dest_noc_y, local_ready_sem_bank, 0);
         }
 
-        auto connection =
-            tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+        connection = tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+        connection.open_start();
+        if (reset_header_pool) {
+            PacketHeaderPool::reset();
+        }
+
+        dst_noc_base = safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, args.intermediate_buffer_address, 0);
+        remote_sem_noc = safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, link_sem_bank_addr, 0);
+        const auto connection_direction = get_next_hop_router_direction(dst_mesh_id, dst_chip_id);
+        for (uint32_t i = 0; i < header_ring_size; ++i) {
+            headers[i] = PacketHeaderPool::allocate_header();
+            fabric_set_single_hop_unicast_route_from_direction(
+                headers[i], connection_direction, dst_chip_id, dst_mesh_id);
+            headers[i]->to_noc_fused_unicast_write_atomic_inc(
+                {dst_noc_base, remote_sem_noc, 1, false}, regular_payload_bytes);
+        }
+        connection.open_finish();
+#endif
+    }
+
+    void impl([[maybe_unused]] const SenderArgs& args) {
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+        if constexpr (CTArgs::link_index >= CTArgs::num_links || packets_to_send == 0) {
+            return;
+        }
 
         // Ensure local data is available in the CB before signaling or sending.
         if constexpr (CTArgs::skip_local_push) {
@@ -201,35 +242,7 @@ private:
             noc_semaphore_inc(local_ready_noc_addr, 1);
         }
 
-        constexpr bool use_posted_transport_writes = true;
-
-        connection.open_start();
-        constexpr uint32_t max_header_ring_size = 2;
-        // A single packet never reuses a header, so the second header only pays setup cost with no flush savings.
-        constexpr uint32_t header_ring_size = packets_to_send <= 1u ? 1u : max_header_ring_size;
-
-        constexpr uint32_t regular_payload_bytes = CTArgs::tiles_per_chunk * CTArgs::page_size_bytes;
-        constexpr uint32_t last_payload_bytes = CTArgs::last_chunk_tiles * CTArgs::page_size_bytes;
-
-        PacketHeaderPool::reset();
-
-        uint64_t dst_noc_base =
-            safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, args.intermediate_buffer_address, 0);
-        uint64_t remote_sem_noc = safe_get_noc_addr(args.dest_noc_x, args.dest_noc_y, link_sem_bank_addr, 0);
-        const auto connection_direction = get_next_hop_router_direction(dst_mesh_id, dst_chip_id);
-
-        std::array<volatile tt_l1_ptr PACKET_HEADER_TYPE*, header_ring_size> headers = {};
-        for (uint32_t i = 0; i < header_ring_size; ++i) {
-            headers[i] = PacketHeaderPool::allocate_header();
-            fabric_set_single_hop_unicast_route_from_direction(
-                headers[i], connection_direction, dst_chip_id, dst_mesh_id);
-            headers[i]->to_noc_fused_unicast_write_atomic_inc(
-                {dst_noc_base, remote_sem_noc, 1, false}, regular_payload_bytes);
-        }
-
         const uint32_t src_base_addr = get_read_ptr(CTArgs::local_data_cb_id);
-
-        connection.open_finish();
 
         connection.setup_stateful_send_cmd_bufs<use_posted_transport_writes>();
 


### PR DESCRIPTION
### Summary
Gather3 blocks the brisc of All Reduce from connecting to fabric ahead of time. All reduce blocks the riscs of all gather from connecting ahead of time, even though they connect to different fabric endpoints.
Refactor the connection logic into separate setup fns for all reduce and all gather. Call these setup fns before we call gather3 on the ccl cores to enable connecting to fabric before stalling.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/connections)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/connections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/connections)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/connections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/connections)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/connections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/connections)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/connections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/connections)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/connections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/connections)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/connections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/connections)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/connections)