### PR TITLE
perf: reduce ProgramDescriptor dispatch overhead (SmallVector, string_view, caching, Buffer::create_device_view)

### DIFF
--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -339,6 +339,97 @@ Both must succeed with zero errors.
 
 ---
 
+## Performance best practices
+
+The ProgramDescriptor path calls `create_descriptor` on **every dispatch** (cache hit or miss).
+Everything built inside it — CBDescriptors, KernelDescriptors, CoreRangeSet copies,
+runtime arg vectors — is allocation overhead. Follow these patterns to keep it fast.
+
+### Use constexpr kernel paths
+
+Never build kernel paths with string concatenation. Always use `static constexpr const char*`:
+
+```cpp
+// BAD — heap allocation on every dispatch
+const std::string kernels_dir = "ttnn/cpp/ttnn/operations/my_op/device/kernels/";
+reader_desc.kernel_source = kernels_dir + "reader.cpp";
+
+// GOOD — zero cost
+static constexpr const char* READER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/my_op/device/kernels/reader.cpp";
+reader_desc.kernel_source = READER_KERNEL_PATH;
+```
+
+`kernel_source` is `std::string_view` — it must point to a string that outlives the descriptor.
+`static constexpr const char*` satisfies this.
+
+### Use KernelDescriptor type aliases for args
+
+Use `KernelDescriptor::CompileTimeArgs` and `KernelDescriptor::CoreRuntimeArgs` instead of
+`std::vector<uint32_t>`. These are `SmallVector` types that avoid heap allocation for small ops:
+
+```cpp
+// BAD
+std::vector<uint32_t> compile_time_args{cb_id};
+
+// GOOD
+KernelDescriptor::CompileTimeArgs compile_time_args{cb_id};
+```
+
+### Cache work split results with thread_local
+
+`split_work_to_cores`, `grid_to_cores`, and `device->compute_with_storage_grid_size()` are
+expensive and return identical results for the same (device, units_to_divide) pair.
+Cache them with a `thread_local` struct:
+
+```cpp
+namespace {
+struct WorkSplitCache {
+    IDevice* device = nullptr;
+    uint32_t units = 0;
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t units_per_core_group_1 = 0, units_per_core_group_2 = 0;
+    std::vector<CoreCoord> cores;
+
+    bool matches(IDevice* dev, uint32_t u) const { return device == dev && units == u; }
+
+    void update(IDevice* dev, uint32_t u) {
+        device = dev; units = u;
+        auto grid = dev->compute_with_storage_grid_size();
+        auto [nc, ac, cg1, cg2, upcg1, upcg2] = split_work_to_cores(grid, u);
+        // ... store results
+        cores = grid_to_cores(nc, grid.x, grid.y);
+    }
+};
+static thread_local WorkSplitCache work_split_cache;
+}
+```
+
+Also cache `get_compute_kernel_config_args` in the same struct — arch and config are constant.
+
+### Cache the program hash
+
+The descriptor structure is identical across dispatches for the same (device, shape, dtype).
+Cache the hash to skip the full traversal:
+
+```cpp
+// In WorkSplitCache:
+std::size_t program_hash = 0;  // reset to 0 on cache invalidation
+
+// At the end of create_descriptor:
+if (work_split_cache.program_hash == 0) {
+    work_split_cache.program_hash = std::hash<ProgramDescriptor>{}(desc);
+}
+desc.custom_program_hash = work_split_cache.program_hash;
+```
+
+### See randn as the reference implementation
+
+`ttnn/cpp/ttnn/operations/randn/device/randn_program_factory.cpp` applies all of the above.
+Use it as the template for new descriptor ops.
+
+---
+
 ## Common pitfalls
 
 1. **Namespace resolution after moving factories.** If factories move to a different

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -144,7 +144,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpArgmaxSingleCore) {
 }
 
 TEST_F(TTNNFixtureWithDevice, TestGenericOpUnaryReluSharded) {
-    const std::vector<std::pair<std::string, std::string>> defines_relu = {
+    const KernelDescriptor::Defines defines_relu = {
         {"SFPU_OP_CHAIN_0", "SFPU_OP_CHAIN_0_INIT_0 SFPU_OP_CHAIN_0_FUNC_0"},
         {"SFPU_OP_CHAIN_0_FUNC_0", "relu_tile(0);"},
         {"SFPU_OP_CHAIN_0_INIT_0", "relu_tile_init();"},
@@ -262,7 +262,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpUnaryReluSharded) {
 }
 
 TEST_F(TTNNFixtureWithDevice, TestGenericOpBinaryEltwiseAdd) {
-    const std::vector<std::pair<std::string, std::string>> defines_eltwise_add = {
+    const KernelDescriptor::Defines defines_eltwise_add = {
         {"ELTWISE_OP", "add_tiles"},
         {"ELTWISE_OP_TYPE", "EltwiseBinaryType::ELWADD"},
     };
@@ -691,7 +691,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpMatmul) {
 }
 
 TEST_F(TTNNFixtureWithDevice, TestGenericOpEltwiseSFPU) {
-    const std::vector<std::pair<std::string, std::string>> sfpu_defines = {
+    const KernelDescriptor::Defines sfpu_defines = {
         {"SFPU_OP_EXP_INCLUDE", "1"}, {"SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);"}};
 
     uint32_t num_tiles = 4;
@@ -803,7 +803,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpEltwiseSFPU) {
 TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
     log_info(tt::LogTest, "Running {}", __func__);
 
-    const std::vector<std::pair<std::string, std::string>> sfpu_defines = {
+    const KernelDescriptor::Defines sfpu_defines = {
         {"SFPU_OP_EXP_INCLUDE", "1"}, {"SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);"}};
 
     ttnn::Shape shape{1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
@@ -841,7 +841,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
 
     ProgramDescriptor program_descriptor = {
         .kernels =
-            {{
+            {KernelDescriptor{
                  .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
                                   "reader_unary_interleaved_start_id.cpp",
                  .core_ranges = device_cores,
@@ -849,7 +849,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
                  .runtime_args = {{{0, 0}, {device_input_tensor_1.buffer()->address(), num_tiles, 0u}}},
                  .config = tt::tt_metal::ReaderConfigDescriptor{},
              },
-             {
+             KernelDescriptor{
                  .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
                                   "writer_unary_interleaved_start_id.cpp",
                  .core_ranges = device_cores,
@@ -857,7 +857,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
                  .runtime_args = {{{0, 0}, {device_output_tensor_1.buffer()->address(), num_tiles, 0u}}},
                  .config = tt::tt_metal::WriterConfigDescriptor{},
              },
-             {
+             KernelDescriptor{
                  .kernel_source = "tt_metal/kernels/compute/eltwise_sfpu.cpp",
                  .core_ranges = device_cores,
                  .compile_time_args = {num_tiles, 1},
@@ -1134,7 +1134,8 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
     auto worker_fwd_virtual = mesh_device_->worker_core_from_logical_core(worker_fwd_core);
     auto worker_bwd_virtual = mesh_device_->worker_core_from_logical_core(worker_bwd_core);
 
-    auto mux_ct_args = mux_config.get_fabric_mux_compile_time_args();
+    auto mux_ct_args_vec = mux_config.get_fabric_mux_compile_time_args();
+    KernelDescriptor::CompileTimeArgs mux_ct_args(mux_ct_args_vec.begin(), mux_ct_args_vec.end());
 
     // =========================================================================
     // Build MeshProgramDescriptor for each device in the 1x4 line
@@ -1163,7 +1164,7 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         };
 
         // Common CT args for reader/writer
-        std::vector<uint32_t> common_ct_args = {
+        KernelDescriptor::CompileTimeArgs common_ct_args = {
             ring_size,
             ring_index,
             static_cast<uint32_t>(sender_cb_index),
@@ -1185,12 +1186,12 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         };
 
         // Reader CT args
-        std::vector<uint32_t> reader_ct_args = common_ct_args;
+        KernelDescriptor::CompileTimeArgs reader_ct_args = common_ct_args;
         tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_ct_args);
         tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(reader_ct_args);
 
         // Writer CT args
-        std::vector<uint32_t> writer_ct_args = common_ct_args;
+        KernelDescriptor::CompileTimeArgs writer_ct_args = common_ct_args;
         // fabric_mux_connection_ct_args
         writer_ct_args.push_back(mux_config.get_num_buffers(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL));
         writer_ct_args.push_back(
@@ -1319,31 +1320,36 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         }
 
         // Kernel Descriptors
-        program_desc.kernels.push_back({
+        program_desc.kernels.push_back(KernelDescriptor{
             .kernel_source =
                 "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp",
             .core_ranges = worker_cores,
             .compile_time_args = reader_ct_args,
-            .runtime_args = {{worker_fwd_core, fwd_reader_rt}, {worker_bwd_core, bwd_reader_rt}},
+            .runtime_args =
+                {{worker_fwd_core, KernelDescriptor::CoreRuntimeArgs(fwd_reader_rt.begin(), fwd_reader_rt.end())},
+                 {worker_bwd_core, KernelDescriptor::CoreRuntimeArgs(bwd_reader_rt.begin(), bwd_reader_rt.end())}},
             .config = tt::tt_metal::ReaderConfigDescriptor{},
         });
 
-        program_desc.kernels.push_back({
+        program_desc.kernels.push_back(KernelDescriptor{
             .kernel_source =
                 "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp",
             .core_ranges = worker_cores,
             .compile_time_args = writer_ct_args,
             .defines = {{"USE_WORKER_MUX", "1"}},
-            .runtime_args = {{worker_fwd_core, fwd_writer_rt}, {worker_bwd_core, bwd_writer_rt}},
+            .runtime_args =
+                {{worker_fwd_core, KernelDescriptor::CoreRuntimeArgs(fwd_writer_rt.begin(), fwd_writer_rt.end())},
+                 {worker_bwd_core, KernelDescriptor::CoreRuntimeArgs(bwd_writer_rt.begin(), bwd_writer_rt.end())}},
             .config = tt::tt_metal::WriterConfigDescriptor{},
         });
 
         if (has_forward) {
-            program_desc.kernels.push_back({
+            program_desc.kernels.push_back(KernelDescriptor{
                 .kernel_source = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
                 .core_ranges = mux_fwd_core_set,
                 .compile_time_args = mux_ct_args,
-                .runtime_args = {{mux_fwd_core, fwd_mux_rt}},
+                .runtime_args =
+                    {{mux_fwd_core, KernelDescriptor::CoreRuntimeArgs(fwd_mux_rt.begin(), fwd_mux_rt.end())}},
                 .config =
                     tt::tt_metal::DataMovementConfigDescriptor{
                         .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
@@ -1351,11 +1357,12 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
             });
         }
         if (has_backward) {
-            program_desc.kernels.push_back({
+            program_desc.kernels.push_back(KernelDescriptor{
                 .kernel_source = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
                 .core_ranges = mux_bwd_core_set,
                 .compile_time_args = mux_ct_args,
-                .runtime_args = {{mux_bwd_core, bwd_mux_rt}},
+                .runtime_args =
+                    {{mux_bwd_core, KernelDescriptor::CoreRuntimeArgs(bwd_mux_rt.begin(), bwd_mux_rt.end())}},
                 .config =
                     tt::tt_metal::DataMovementConfigDescriptor{
                         .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
@@ -1412,7 +1419,7 @@ TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
 
     auto worker_mem_map = this->generate_worker_mem_map(sender_device, topology);
 
-    std::vector<uint32_t> compile_time_args = {
+    KernelDescriptor::CompileTimeArgs compile_time_args = {
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
         worker_mem_map.notification_mailbox_address,
@@ -1463,7 +1470,9 @@ TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
         api_type);
 
     // NOW set the complete runtime args on the kernel (after append has added connection args)
-    sender_program_descriptor.kernels[kernel_id].runtime_args = {{sender_logical_core, sender_runtime_args}};
+    sender_program_descriptor.kernels[kernel_id].runtime_args = {
+        {sender_logical_core,
+         KernelDescriptor::CoreRuntimeArgs(sender_runtime_args.begin(), sender_runtime_args.end())}};
 
     ProgramDescriptor receiver_program_descriptor;
 
@@ -1477,7 +1486,9 @@ TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
         .kernel_source = "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_receiver.cpp",
         .core_ranges = {receiver_logical_core},
         .compile_time_args = compile_time_args,
-        .runtime_args = {{receiver_logical_core, receiver_runtime_args}},
+        .runtime_args =
+            {{receiver_logical_core,
+              KernelDescriptor::CoreRuntimeArgs(receiver_runtime_args.begin(), receiver_runtime_args.end())}},
         .common_runtime_args = {},
         .config = tt::tt_metal::DataMovementConfigDescriptor{},
     };

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -216,6 +216,10 @@ public:
         std::optional<bool> bottom_up = std::nullopt,
         std::optional<SubDeviceId> sub_device_id = std::nullopt);
 
+    // Creates a lightweight non-owning view of an existing buffer on a different device.
+    // No validation, no allocation. Used by MeshBuffer to create per-device handles cheaply.
+    static std::shared_ptr<Buffer> create_device_view(IDevice* device, const Buffer& source);
+
     // Creates a view of the region of the buffer.
     // The view is a new buffer (unless the region is the entire buffer) that shares the same underlying device memory.
     // The view keeps the underlying buffer alive as long as the view is alive.
@@ -293,6 +297,11 @@ public:
         std::optional<SubDeviceId> sub_device_id,
         bool owns_data,
         Private);
+
+    // Lightweight constructor: creates a non-owning view of an existing buffer on a different device.
+    // Copies address, size, page_size, shard_spec, etc. from the source buffer.
+    // No validation, no allocation — just a device-remapped handle.
+    Buffer(IDevice* device, const Buffer& source, Private);
 
 private:
     enum class AllocationStatus : uint8_t {

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -17,6 +17,7 @@
 
 #include <bitset>
 #include <optional>
+#include <string_view>
 #include <vector>
 
 /**
@@ -99,17 +100,17 @@ struct ComputeConfigDescriptor {
 struct KernelDescriptor {
     // TODO: investigate using SmallVector here, using std::vector for now to abide size constraint
     // in tt_stl/tt_stl/reflection.hpp:185:23
-    using CompileTimeArgs = std::vector<uint32_t>;
+    using CompileTimeArgs = ttsl::SmallVector<uint32_t, 16>;
     using NamedCompileTimeArgs = std::vector<std::pair<std::string, uint32_t>>;
-    using Defines = std::vector<std::pair<std::string, std::string>>;
-    using CoreRuntimeArgs = std::vector<uint32_t>;
+    using Defines = ttsl::SmallVector<std::pair<std::string, std::string>, 4>;
+    using CoreRuntimeArgs = ttsl::SmallVector<uint32_t, 8>;
     using RuntimeArgs = std::vector<std::pair<CoreCoord, CoreRuntimeArgs>>;
     using CommonRuntimeArgs = CoreRuntimeArgs;
     using ConfigDescriptor = std::
         variant<ReaderConfigDescriptor, WriterConfigDescriptor, DataMovementConfigDescriptor, ComputeConfigDescriptor>;
     enum class SourceType { FILE_PATH, SOURCE_CODE };
 
-    std::string kernel_source;
+    std::string_view kernel_source;
     SourceType source_type = SourceType::FILE_PATH;
 
     CoreRangeSet core_ranges;

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -36,8 +36,10 @@ public:
     static TensorAccessorArgs create_dram_interleaved();
     static TensorAccessorArgs create_l1_interleaved();
 
-    void append_to(std::vector<uint32_t>& compile_time_args) const;
-    void append_to(std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const;
+    template <typename ArgsVec>
+    void append_to(ArgsVec& compile_time_args) const;
+    template <typename ArgsVec1, typename ArgsVec2>
+    void append_to(ArgsVec1& compile_time_args, ArgsVec2& common_runtime_args) const;
 
     std::vector<uint32_t> get_compile_time_args() const;
     std::vector<uint32_t> get_common_runtime_args() const;

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -169,9 +169,19 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
 }
 
 void MeshBuffer::initialize_device_buffers() {
-    auto init_device_buffer_at_address = [this](const MeshCoordinate& coord) {
+    // If we have a backing buffer, create lightweight device views instead of full Buffer::create.
+    // For per-core allocation or externally-owned buffers, fall back to the full path.
+    auto* backing = get_backing_buffer();
+    bool use_fast_path =
+        backing != nullptr && !per_core_allocation::is_per_core_allocation(device_local_config_.sharding_args);
+
+    auto init_device_buffer_at_address = [this, backing, use_fast_path](const MeshCoordinate& coord) {
+        auto* physical_device = device()->impl().get_device(coord);
+        if (use_fast_path) {
+            return Buffer::create_device_view(physical_device, *backing);
+        }
         std::shared_ptr<Buffer> buffer = Buffer::create(
-            device()->impl().get_device(coord),
+            physical_device,
             address_,
             device_local_size_,
             device_local_config_.page_size,

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -379,6 +379,27 @@ std::shared_ptr<Buffer> Buffer::create(
     return buffer;
 }
 
+Buffer::Buffer(IDevice* device, const Buffer& source, Private) :
+    device_(device),
+    size_(source.size_),
+    buffer_type_(source.buffer_type_),
+    buffer_layout_(source.buffer_layout_),
+    bottom_up_(source.bottom_up_),
+    sub_device_id_(std::nullopt),
+    owns_data_(false),
+    page_size_(source.page_size_),
+    shard_spec_(source.shard_spec_),
+    buffer_distribution_spec_(source.buffer_distribution_spec_) {
+    address_ = source.address_;
+    allocation_status_ = AllocationStatus::ALLOCATED;
+    allocator_ = device->allocator_impl().get();
+    unique_id_ = next_unique_id.fetch_add(1);
+}
+
+std::shared_ptr<Buffer> Buffer::create_device_view(IDevice* device, const Buffer& source) {
+    return std::make_shared<Buffer>(device, source, Private());
+}
+
 std::shared_ptr<Buffer> Buffer::view(const BufferRegion& region) {
     TT_FATAL(region.offset % page_size() == 0, "Region offset must be a multiple of page size");
     TT_FATAL(region.size % page_size() == 0, "Region size must be a multiple of page size");

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -7,13 +7,15 @@
 #include <limits>
 
 #include <tt-metalium/device.hpp>
+#include <tt_stl/small_vector.hpp>
 
 namespace tt::tt_metal {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
+template <typename ArgsVec>
 void append_sharded_args(
-    const Buffer& buffer, tensor_accessor::ArgsConfig args_config, std::vector<uint32_t>& args, bool is_runtime) {
+    const Buffer& buffer, tensor_accessor::ArgsConfig args_config, ArgsVec& args, bool is_runtime) {
     TT_FATAL(buffer.buffer_distribution_spec(), "Buffer must have a buffer distribution spec");
 
     const auto& buffer_distribution_spec = buffer.buffer_distribution_spec().value();
@@ -151,8 +153,8 @@ void TensorAccessorArgs::update_args_config() {
     }
 }
 
-void TensorAccessorArgs::append_to(
-    std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const {
+template <typename ArgsVec1, typename ArgsVec2>
+void TensorAccessorArgs::append_to(ArgsVec1& compile_time_args, ArgsVec2& common_runtime_args) const {
     if (args_config_.test(tensor_accessor::ArgConfig::Sharded)) {
         CMAKE_UNIQUE_NAMESPACE::append_sharded_args(*buffer_, args_config_, compile_time_args, /* is_runtime */ false);
         CMAKE_UNIQUE_NAMESPACE::append_sharded_args(*buffer_, args_config_, common_runtime_args, /* is_runtime */ true);
@@ -168,7 +170,8 @@ void TensorAccessorArgs::append_to(
     }
 }
 
-void TensorAccessorArgs::append_to(std::vector<uint32_t>& compile_time_args) const {
+template <typename ArgsVec>
+void TensorAccessorArgs::append_to(ArgsVec& compile_time_args) const {
     TT_FATAL(
         (args_config_ & tensor_accessor::ArgConfig::Runtime).raw() == 0,
         "Common runtime arguments are required for ArgsConfig {}",
@@ -211,5 +214,16 @@ std::vector<uint32_t> TensorAccessorArgs::get_common_runtime_args() const {
     }
     return common_runtime_args;
 }
+
+// Explicit template instantiations for append_to
+// std::vector<uint32_t> (legacy callers)
+template void TensorAccessorArgs::append_to<std::vector<uint32_t>>(std::vector<uint32_t>&) const;
+template void TensorAccessorArgs::append_to<std::vector<uint32_t>, std::vector<uint32_t>>(
+    std::vector<uint32_t>&, std::vector<uint32_t>&) const;
+
+// SmallVector instantiations for KernelDescriptor::CompileTimeArgs and CommonRuntimeArgs
+template void TensorAccessorArgs::append_to<ttsl::SmallVector<uint32_t, 16>>(ttsl::SmallVector<uint32_t, 16>&) const;
+template void TensorAccessorArgs::append_to<ttsl::SmallVector<uint32_t, 16>, ttsl::SmallVector<uint32_t, 8>>(
+    ttsl::SmallVector<uint32_t, 16>&, ttsl::SmallVector<uint32_t, 8>&) const;
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -301,9 +301,10 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
             kernel_descriptor.config);
 
         auto kernel_handle =
-            is_file
-                ? CreateKernel(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config)
-                : CreateKernelFromString(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config);
+            is_file ? CreateKernel(
+                          *this, std::string(kernel_descriptor.kernel_source), kernel_descriptor.core_ranges, config)
+                    : CreateKernelFromString(
+                          *this, std::string(kernel_descriptor.kernel_source), kernel_descriptor.core_ranges, config);
 
         for (const auto& [core_coord, core_runtime_args] : kernel_descriptor.runtime_args) {
             SetRuntimeArgs(*this, kernel_handle, core_coord, core_runtime_args);

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -50,14 +50,14 @@ public:
         CoreCoord target(x_, y);
         for (auto& [coord, vec] : args_) {
             if (coord == target) {
-                vec = values;  // Update existing
+                vec.assign(values.begin(), values.end());  // Update existing
                 return;
             }
         }
-        args_.push_back({target, values});  // Append if not found
+        args_.push_back({target, {values.begin(), values.end()}});  // Append if not found
     }
 
-    std::vector<uint32_t>& get_item(size_t y) {
+    tt::tt_metal::KernelDescriptor::CoreRuntimeArgs& get_item(size_t y) {
         CoreCoord target(x_, y);
         for (auto& [coord, values] : args_) {
             if (coord == target) {
@@ -69,12 +69,12 @@ public:
     }
 
     void extend_item(size_t y, const std::vector<uint32_t>& values) {
-        std::vector<uint32_t>& target_vec = get_item(y);
+        auto& target_vec = get_item(y);
         target_vec.insert(target_vec.end(), values.begin(), values.end());
     }
 
     void append_item(size_t y, uint32_t value) {
-        std::vector<uint32_t>& target_vec = get_item(y);
+        auto& target_vec = get_item(y);
         target_vec.push_back(value);
     }
 
@@ -90,14 +90,16 @@ public:
 
     RuntimeArgsColProxy get_col(size_t x) { return RuntimeArgsColProxy(args_, x); }
 
-    void append(const CoreCoord& coord, const std::vector<uint32_t>& values) { args_.push_back({coord, values}); }
+    void append(const CoreCoord& coord, const std::vector<uint32_t>& values) {
+        args_.push_back({coord, {values.begin(), values.end()}});
+    }
 
     tt::tt_metal::KernelDescriptor::RuntimeArgs& get() { return args_; }
     const tt::tt_metal::KernelDescriptor::RuntimeArgs& get() const { return args_; }
 
     size_t size() const { return args_.size(); }
 
-    std::pair<CoreCoord, std::vector<uint32_t>>& at(size_t idx) { return args_.at(idx); }
+    auto& at(size_t idx) { return args_[idx]; }
 
     void clear() { args_.clear(); }
 

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -89,21 +89,26 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
 
     // ---- Kernels ----
 
-    const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/";
+    static constexpr const char* READER_KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/reader_bernoulli.cpp";
+    static constexpr const char* WRITER_KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/writer_bernoulli.cpp";
+    static constexpr const char* COMPUTE_KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/compute_bernoulli.cpp";
 
     // Reader kernel
-    std::vector<uint32_t> reader_compile_time_args{in_cb_id};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{in_cb_id};
     TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
-    reader_desc.kernel_source = kernels_dir_path + "reader_bernoulli.cpp";
+    reader_desc.kernel_source = READER_KERNEL_PATH;
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = reader_compile_time_args;
     reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer kernel
-    std::vector<uint32_t> writer_compile_time_args{in_cb_id, intermed_cb_id, intermed1_cb_id};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{in_cb_id, intermed_cb_id, intermed1_cb_id};
     TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
     KernelDescriptor::Defines writer_defines;
@@ -119,7 +124,7 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     }
 
     KernelDescriptor writer_desc;
-    writer_desc.kernel_source = kernels_dir_path + "writer_bernoulli.cpp";
+    writer_desc.kernel_source = WRITER_KERNEL_PATH;
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = writer_compile_time_args;
@@ -127,13 +132,13 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
 
     // Compute kernel
-    const std::vector<uint32_t> compute_compile_time_args{intermed_cb_id};
+    const KernelDescriptor::CompileTimeArgs compute_compile_time_args{intermed_cb_id};
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
     KernelDescriptor compute_desc;
-    compute_desc.kernel_source = kernels_dir_path + "compute_bernoulli.cpp";
+    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = all_cores;
     compute_desc.compile_time_args = compute_compile_time_args;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -270,7 +270,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
 
     // --- Reader Kernel Descriptor ---
     // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> reader_compile_time_args = {num_dims};
+    tt::tt_metal::KernelDescriptor::CompileTimeArgs reader_compile_time_args = {num_dims};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
@@ -285,7 +285,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     accumulated_total_per_dim[0] = num_total_Xt;
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
-    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
+    tt::tt_metal::KernelDescriptor::CommonRuntimeArgs reader_common_args(1 + (num_dims * 2));
     reader_common_args[0] = src0_buffer->address();
     uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
     uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
@@ -315,12 +315,12 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             // no-op core
-            std::vector<uint32_t> reader_args(2 + num_dims, 0);
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs reader_args(2 + num_dims, 0);
             reader_runtime_args.emplace_back(core, std::move(reader_args));
             continue;
         }
 
-        std::vector<uint32_t> reader_args(2 + num_dims);
+        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs reader_args(2 + num_dims);
         // Compute per-dim indices for this core's starting position
         reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
         uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
@@ -352,7 +352,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
 
     // --- Writer Kernel Descriptor ---
     // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> writer_compile_time_args = {};
+    tt::tt_metal::KernelDescriptor::CompileTimeArgs writer_compile_time_args = {};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
@@ -366,12 +366,14 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             // no-op core
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            writer_runtime_args.emplace_back(core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{0, 0, 0});
             continue;
         }
 
         writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+            core,
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
+                dst_buffer->address(), num_tiles_per_core, num_tiles_written});
         num_tiles_written += num_tiles_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
@@ -61,7 +61,7 @@ ProgramDescriptor ExampleDeviceOperation::MultiCore::create_descriptor(
     });
 
     // Reader kernel
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
@@ -73,7 +73,7 @@ ProgramDescriptor ExampleDeviceOperation::MultiCore::create_descriptor(
     reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer kernel
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     KernelDescriptor writer_desc;
@@ -85,7 +85,7 @@ ProgramDescriptor ExampleDeviceOperation::MultiCore::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
 
     // Compute kernel -- group 1
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
+    KernelDescriptor::CompileTimeArgs compute_kernel_args_group_1 = {
         num_tiles_per_core_group_1,  // per_core_block_cnt
         1                            // per_core_block_size
     };
@@ -102,7 +102,7 @@ ProgramDescriptor ExampleDeviceOperation::MultiCore::create_descriptor(
 
     // Second compute kernel for the remainder core group (different tile count)
     if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_kernel_args_group_2 = {
+        KernelDescriptor::CompileTimeArgs compute_kernel_args_group_2 = {
             num_tiles_per_core_group_2,  // per_core_block_cnt
             1                            // per_core_block_size
         };

--- a/ttnn/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
@@ -63,7 +63,7 @@ ProgramDescriptor ExampleDeviceOperation::SingleCore::create_descriptor(
     });
 
     // Reader kernel
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
@@ -75,7 +75,7 @@ ProgramDescriptor ExampleDeviceOperation::SingleCore::create_descriptor(
     reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer kernel
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     KernelDescriptor writer_desc;
@@ -87,7 +87,7 @@ ProgramDescriptor ExampleDeviceOperation::SingleCore::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
 
     // Compute kernel
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
+    KernelDescriptor::CompileTimeArgs compute_kernel_args_group_1 = {
         num_tiles_per_core_group_1,  // per_core_block_cnt
         1                            // per_core_block_size
     };

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -369,7 +369,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
 
     // Compile time args for reader
-    std::vector<uint32_t> reader_compile_time_args = {
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {
         (std::uint32_t)in0_tensor_stride_w,
         (std::uint32_t)in0_tensor_stride_h,
         (std::uint32_t)in0_tensor_next_block_stride,
@@ -385,7 +385,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
 
     // Compile time args for reader/writer
-    std::vector<uint32_t> reader_writer_compile_time_args = {
+    KernelDescriptor::CompileTimeArgs reader_writer_compile_time_args = {
         (std::uint32_t)in1_tensor_stride_w,
         (std::uint32_t)in1_tensor_stride_h,
         (std::uint32_t)in1_tensor_next_block_stride,
@@ -449,7 +449,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     };
 
     // Compute kernel compile time args (group 1)
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
+    KernelDescriptor::CompileTimeArgs compute_kernel_args_group_1 = {
         in0_block_w,
         in0_num_subblocks,
         in0_block_num_tiles,
@@ -521,7 +521,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
         reader_runtime_args.emplace_back(
             core,
-            std::vector<uint32_t>{
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
                 (uint32_t)in0_buffer->address(),
                 in0_start_tile_id,
                 num_output_blocks_per_core,
@@ -529,7 +529,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
         reader_writer_runtime_args.emplace_back(
             core,
-            std::vector<uint32_t>{
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
                 (uint32_t)in1_buffer->address(),
                 in1_start_tile_id,
                 num_output_blocks_per_core,
@@ -539,9 +539,9 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
         // Compute kernels have no per-core runtime args
         if (i < g1_numcores) {
-            compute_runtime_args_g1.emplace_back(core, std::vector<uint32_t>{});
+            compute_runtime_args_g1.emplace_back(core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{});
         } else {
-            compute_runtime_args_g2.emplace_back(core, std::vector<uint32_t>{});
+            compute_runtime_args_g2.emplace_back(core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{});
         }
 
         num_blocks_written += num_output_blocks_per_core;
@@ -594,7 +594,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
     // Core group 2 compute kernel (if needed)
     if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_kernel_args_group_2 = {
+        KernelDescriptor::CompileTimeArgs compute_kernel_args_group_2 = {
             in0_block_w,
             in0_num_subblocks,
             in0_block_num_tiles,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -390,7 +390,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     const auto fuse_pre_add = b.has_value();
 
     // Build compile time args for reader kernel
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_size};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {(std::uint32_t)block_size};
     if (!large_tensor_needed) {
         reader_compile_time_args.push_back((std::uint32_t)use_welford);
     }
@@ -413,7 +413,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     }
 
     // Build compile time args for writer kernel
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)block_size};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {(std::uint32_t)block_size};
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
     if (input_is_row_major) {
         // RM writer needs elem_size to compute per-row NOC write sizes
@@ -499,7 +499,8 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
 
     // Build compute args
     bool float32_reduction = fp32_dest_acc_en && !legacy_reduction;
-    std::vector<uint32_t> compute_args = {Wt, block_size, gamma.has_value(), beta.has_value(), fp32_dest_acc_en};
+    KernelDescriptor::CompileTimeArgs compute_args = {
+        Wt, block_size, gamma.has_value(), beta.has_value(), fp32_dest_acc_en};
     if (use_welford_and_not_rms_norm) {
         compute_args.push_back(W);
         compute_args.push_back(ttnn::types::TILE_SIZE);
@@ -568,7 +569,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
             (use_welford_and_not_rms_norm && large_tensor_needed) || (use_row_major_kernel && !input_is_row_major);
         const uint32_t reader_start = using_legacy_tile_reader ? tile_offset : curr_row;
 
-        std::vector<uint32_t> reader_args = {
+        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs reader_args = {
             a_addr,
             num_tile_rows_per_core,
             Wt,
@@ -591,12 +592,14 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         // For the RM output writer arg[3] is start_tile_row (starting tile-row index for this core),
         // not the flat tile offset, because the RM writer computes row addresses directly.
         const uint32_t writer_start = input_is_row_major ? curr_row : tile_offset;
-        std::vector<uint32_t> writer_args = {dst_addr, Wt, num_tile_rows_per_core, writer_start};
+        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs writer_args = {
+            dst_addr, Wt, num_tile_rows_per_core, writer_start};
         if (input_is_row_major) {
             writer_args.push_back(H_logical);  // arg[4]
         }
         writer_runtime_args.emplace_back(core, std::move(writer_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
+        compute_runtime_args.emplace_back(
+            core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{num_tile_rows_per_core});
 
         curr_row += num_tile_rows_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -453,30 +453,49 @@ KernelPaths KernelPaths::get(
     bool is_pre_all_gather, bool is_post_all_gather, bool use_row_major_kernel, bool use_welford) {
     KernelPaths paths;
 
-    constexpr const char* base_path = "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/";
-
     if (is_pre_all_gather) {
         paths.reader_sender =
-            std::string(base_path) + "dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp";
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp";
         paths.reader_receiver =
-            std::string(base_path) + "dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp";
-        paths.writer = std::string(base_path) + "dataflow/writer_unary_sharded_ln_pre_all_gather.cpp";
-        paths.compute = std::string(base_path) + "compute/layernorm_sharded_pre_allgather.cpp";
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp";
+        paths.writer =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "writer_unary_sharded_ln_pre_all_gather.cpp";
+        paths.compute =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/"
+            "layernorm_sharded_pre_allgather.cpp";
     } else if (is_post_all_gather) {
         paths.reader_sender =
-            std::string(base_path) + "dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp";
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_sender_unary_sharded_ln_post_allgather.cpp";
         paths.reader_receiver =
-            std::string(base_path) + "dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp";
-        paths.writer = use_row_major_kernel ? std::string(base_path) + "dataflow/writer_unary_sharded_ln_rm_gb.cpp"
-                                            : std::string(base_path) + "dataflow/writer_unary_sharded_ln.cpp";
-        paths.compute = std::string(base_path) + "compute/layernorm_sharded_post_allgather.cpp";
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp";
+        paths.writer = use_row_major_kernel ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/"
+                                              "dataflow/writer_unary_sharded_ln_rm_gb.cpp"
+                                            : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/"
+                                              "dataflow/writer_unary_sharded_ln.cpp";
+        paths.compute =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/"
+            "layernorm_sharded_post_allgather.cpp";
     } else {
-        paths.reader_sender = std::string(base_path) + "dataflow/reader_mcast_sender_unary_sharded_ln.cpp";
-        paths.reader_receiver = std::string(base_path) + "dataflow/reader_mcast_receiver_unary_sharded_ln.cpp";
-        paths.writer = use_row_major_kernel ? std::string(base_path) + "dataflow/writer_unary_sharded_ln_rm_gb.cpp"
-                                            : std::string(base_path) + "dataflow/writer_unary_sharded_ln.cpp";
-        paths.compute = use_welford ? std::string(base_path) + "compute/layernorm_sharded_welford.cpp"
-                                    : std::string(base_path) + "compute/layernorm_sharded.cpp";
+        paths.reader_sender =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_sender_unary_sharded_ln.cpp";
+        paths.reader_receiver =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_receiver_unary_sharded_ln.cpp";
+        paths.writer = use_row_major_kernel ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/"
+                                              "dataflow/writer_unary_sharded_ln_rm_gb.cpp"
+                                            : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/"
+                                              "dataflow/writer_unary_sharded_ln.cpp";
+        paths.compute =
+            use_welford
+                ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/"
+                  "layernorm_sharded_welford.cpp"
+                : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp";
     }
 
     return paths;
@@ -1235,7 +1254,7 @@ bool CoreIndices::is_all_to_all(const RuntimeArgsContext& ctx) const {
     return width_index < ctx.workers.num_cores_all_to_all;
 }
 
-std::vector<uint32_t> build_compute_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_compute_args(
     const CoreIndices& idx, const RuntimeArgsContext& ctx, bool& is_all_to_all_out) {
     std::vector<uint32_t> args{idx.num_reduce_tiles_per_block_h};
     is_all_to_all_out = idx.is_all_to_all(ctx);
@@ -1260,10 +1279,10 @@ std::vector<uint32_t> build_compute_args(
             args.push_back((uint32_t)ctx.num_distributed_devices);
         }
     }
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_reader_sender_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_reader_sender_args(
     const CoreCoord& core, const CoreIndices& idx, const RuntimeArgsContext& ctx, IDevice* device) {
     // Compute mcast range
     CoreCoord mcast_start, mcast_end;
@@ -1317,10 +1336,10 @@ std::vector<uint32_t> build_reader_sender_args(
             args.insert(args.end(), ctx.mcast_noc_y.begin(), ctx.mcast_noc_y.end());
         }
     }
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_reader_receiver_all_to_all_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_reader_receiver_all_to_all_args(
     const CoreCoord& core, const CoreIndices& idx, const RuntimeArgsContext& ctx) {
     std::vector<uint32_t> args;
 
@@ -1355,10 +1374,11 @@ std::vector<uint32_t> build_reader_receiver_all_to_all_args(
             args.insert(args.end(), ctx.mcast_noc_y.begin(), ctx.mcast_noc_y.end());
         }
     }
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_reader_receiver_not_all_to_all_args(const CoreIndices& idx, const RuntimeArgsContext& ctx) {
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_reader_receiver_not_all_to_all_args(
+    const CoreIndices& idx, const RuntimeArgsContext& ctx) {
     std::vector<uint32_t> args;
     args.push_back(false);  // is_last_all_to_all_worker
     args.push_back(idx.all_to_all_worker_tile_offset_bytes);
@@ -1378,14 +1398,14 @@ std::vector<uint32_t> build_reader_receiver_not_all_to_all_args(const CoreIndice
             args.push_back(ctx.mcast_noc_y[0]);
         }
     }
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_write_back_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_write_back_args(
     const RuntimeArgsContext& ctx, uint32_t& current_storage_core, uint32_t& current_storage_core_offset) {
     std::vector<uint32_t> args;
     if (!ctx.is_post_all_gather) {
-        return args;
+        return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
     }
 
     args.push_back(current_storage_core_offset * ctx.out_single_tile_size);
@@ -1415,13 +1435,13 @@ std::vector<uint32_t> build_write_back_args(
         }
     }
     args.insert(args.begin(), num_segments);
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_writer_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_writer_args(
     const CoreIndices& idx,
     const RuntimeArgsContext& ctx,
-    const std::vector<uint32_t>& write_back_args,
+    const tt::tt_metal::KernelDescriptor::CoreRuntimeArgs& write_back_args,
     bool is_all_to_all) {
     std::vector<uint32_t> args;
 
@@ -1441,7 +1461,7 @@ std::vector<uint32_t> build_writer_args(
     args.push_back(idx.gamma_tile_start_id);
     args.push_back(idx.beta_tile_start_id);
     args.insert(args.end(), write_back_args.begin(), write_back_args.end());
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
 RuntimeArgsResult RuntimeArgsResult::build(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -114,10 +114,10 @@ struct KernelLayout {
 
 // Struct to hold kernel file paths based on operation mode
 struct KernelPaths {
-    std::string reader_sender;
-    std::string reader_receiver;
-    std::string writer;
-    std::string compute;
+    std::string_view reader_sender;
+    std::string_view reader_receiver;
+    std::string_view writer;
+    std::string_view compute;
 
     static KernelPaths get(
         bool is_pre_all_gather, bool is_post_all_gather, bool use_row_major_kernel, bool use_welford);
@@ -243,13 +243,13 @@ struct CompileTimeArgsContext {
 
 // Result of building compile-time args
 struct CompileTimeArgs {
-    std::vector<uint32_t> reader_sender;
-    std::vector<uint32_t> reader_receiver_all_to_all;
-    std::vector<uint32_t> reader_receiver;
-    std::vector<uint32_t> writer_sender;
-    std::vector<uint32_t> writer_receiver;
-    std::vector<uint32_t> compute_all_to_all;
-    std::vector<uint32_t> compute_not_all_to_all;
+    KernelDescriptor::CompileTimeArgs reader_sender;
+    KernelDescriptor::CompileTimeArgs reader_receiver_all_to_all;
+    KernelDescriptor::CompileTimeArgs reader_receiver;
+    KernelDescriptor::CompileTimeArgs writer_sender;
+    KernelDescriptor::CompileTimeArgs writer_receiver;
+    KernelDescriptor::CompileTimeArgs compute_all_to_all;
+    KernelDescriptor::CompileTimeArgs compute_not_all_to_all;
 
     static CompileTimeArgs build(const CompileTimeArgsContext& ctx);
 };
@@ -261,19 +261,19 @@ struct CompileTimeArgs {
 // Struct to hold kernel configuration for building kernel descriptors
 struct KernelConfig {
     // Paths
-    std::string reader_sender_path;
-    std::string reader_receiver_path;
-    std::string writer_path;
-    std::string compute_path;
+    std::string_view reader_sender_path;
+    std::string_view reader_receiver_path;
+    std::string_view writer_path;
+    std::string_view compute_path;
 
     // Compile time args
-    std::vector<uint32_t> reader_sender_ct_args;
-    std::vector<uint32_t> reader_receiver_all_to_all_ct_args;
-    std::vector<uint32_t> reader_receiver_ct_args;
-    std::vector<uint32_t> writer_sender_ct_args;
-    std::vector<uint32_t> writer_receiver_ct_args;
-    std::vector<uint32_t> compute_all_to_all_ct_args;
-    std::vector<uint32_t> compute_not_all_to_all_ct_args;
+    KernelDescriptor::CompileTimeArgs reader_sender_ct_args;
+    KernelDescriptor::CompileTimeArgs reader_receiver_all_to_all_ct_args;
+    KernelDescriptor::CompileTimeArgs reader_receiver_ct_args;
+    KernelDescriptor::CompileTimeArgs writer_sender_ct_args;
+    KernelDescriptor::CompileTimeArgs writer_receiver_ct_args;
+    KernelDescriptor::CompileTimeArgs compute_all_to_all_ct_args;
+    KernelDescriptor::CompileTimeArgs compute_not_all_to_all_ct_args;
 
     // Defines
     KernelDescriptor::Defines reader_sender_defines;

--- a/ttnn/cpp/ttnn/operations/randn/device/randn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/randn/device/randn_device_operation.hpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::randn {
 
@@ -25,33 +26,16 @@ struct RandnDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    struct ProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle compute_kernel_id{};
-            tt::tt_metal::KernelHandle writer_kernel_id{};
-            std::vector<CoreCoord> cores;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-    };
-
-    using program_factory_t = std::variant<ProgramFactory>;
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output);
 
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/randn/device/randn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/randn/device/randn_program_factory.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #include <cstring>
 
 #include <tt-metalium/constants.hpp>
@@ -18,122 +19,157 @@ std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max(
 
 auto get_random_seed(std::mt19937& rng) -> uint32_t { return distribution(rng); }
 
-RandnDeviceOperation::ProgramFactory::cached_program_t RandnDeviceOperation::ProgramFactory::create(
+static constexpr const char* WRITER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/randn/device/kernels/writer_standard_normal.cpp";
+static constexpr const char* COMPUTE_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/randn/device/kernels/compute_standard_normal.cpp";
+
+namespace {
+// Cached work split + grid + compute config — avoid recomputing on every dispatch.
+struct WorkSplitCache {
+    IDevice* device = nullptr;
+    CoreCoord grid{0, 0};
+    uint32_t units = 0;
+    uint32_t num_cores = 0;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1 = 0;
+    uint32_t units_per_core_group_2 = 0;
+    std::vector<CoreCoord> cores;
+
+    // Cached compute kernel config — depends only on arch + config, constant across dispatches
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+    bool math_approx_mode = false;
+    bool dst_full_sync_en = false;
+
+    // Cached program hash — structure is identical for same device/shape/dtype
+    std::size_t program_hash = 0;
+
+    bool matches(IDevice* dev, uint32_t u) const { return device == dev && units == u; }
+
+    void update(IDevice* dev, uint32_t u) {
+        device = dev;
+        units = u;
+        grid = dev->compute_with_storage_grid_size();
+        auto [nc, ac, cg1, cg2, upcg1, upcg2] = split_work_to_cores(grid, u);
+        num_cores = nc;
+        all_cores = std::move(ac);
+        core_group_1 = std::move(cg1);
+        core_group_2 = std::move(cg2);
+        units_per_core_group_1 = upcg1;
+        units_per_core_group_2 = upcg2;
+        cores = grid_to_cores(num_cores, grid.x, grid.y);
+        program_hash = 0;  // invalidate hash on structural change
+    }
+};
+static thread_local WorkSplitCache work_split_cache;
+}  // namespace
+
+ProgramDescriptor RandnDeviceOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
     [[maybe_unused]] const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     IDevice* device = output.device();
-    auto grid = device->compute_with_storage_grid_size();
 
     uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
-    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
-        split_work_to_cores(grid, units_to_divide);
+    if (!work_split_cache.matches(device, units_to_divide)) {
+        work_split_cache.update(device, units_to_divide);
 
-    uint32_t num_cores_x = grid.x;
-    uint32_t num_cores_y = grid.y;
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y);
-
-    Program program = Program();
+        // Cache compute kernel config — arch and config are constant for the lifetime of the device
+        auto [mf, mam, fp32, pl1, dfs] =
+            get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+        work_split_cache.math_fidelity = mf;
+        work_split_cache.math_approx_mode = mam;
+        work_split_cache.dst_full_sync_en = dfs;
+    }
+    const auto& all_cores = work_split_cache.all_cores;
+    const auto& core_group_1 = work_split_cache.core_group_1;
+    const auto& units_per_core_group_1 = work_split_cache.units_per_core_group_1;
+    const auto& units_per_core_group_2 = work_split_cache.units_per_core_group_2;
+    const auto& cores = work_split_cache.cores;
+    const auto num_cores_total = cores.size();
 
     DataType output_dtype = output.dtype();
     auto out_data_format = datatype_to_dataformat_converter(output_dtype);
     const uint32_t dtype_tile_size = tile_size(out_data_format);
 
     constexpr uint32_t in_out_num_tiles = 2;
-
     constexpr uint32_t dst_cb_id = CBIndex::c_0;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(in_out_num_tiles * dtype_tile_size, {{dst_cb_id, out_data_format}})
-            .set_page_size(dst_cb_id, dtype_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
-    const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/randn/device/kernels/";
-    std::vector<uint32_t> writer_compile_time_args{dst_cb_id};
-    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-    const std::string writer_file_path = kernels_dir_path + "writer_standard_normal.cpp";
-    const std::vector<uint32_t> compute_compile_time_args{dst_cb_id};
-    const std::string compute_file_path = kernels_dir_path + "compute_standard_normal.cpp";
+    ProgramDescriptor desc;
 
-    KernelHandle writer_kernel_id = tt_metal::CreateKernel(
-        program, writer_file_path, all_cores, WriterDataMovementConfig(writer_compile_time_args));
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in_out_num_tiles * dtype_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = dst_cb_id,
+            .data_format = out_data_format,
+            .page_size = dtype_tile_size,
+        }}},
+    });
 
-    std::map<std::string, std::string> compute_defines;
-    switch (output_dtype) {
-        case DataType::BFLOAT16: compute_defines["OUTPUT_DTYPE_BFLOAT16"] = "1"; break;
-        default: break;
+    // Writer kernel
+    KernelDescriptor::CompileTimeArgs writer_ct_args;
+    writer_ct_args.reserve(8);
+    writer_ct_args.push_back(dst_cb_id);
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = WRITER_KERNEL_PATH;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.runtime_args.reserve(num_cores_total);
+
+    // Compute kernel
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = {dst_cb_id};
+    if (output_dtype == DataType::BFLOAT16) {
+        compute_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1");
     }
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = work_split_cache.math_fidelity,
+        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
+                                   // generated number out of range [from, to)
+        .dst_full_sync_en = work_split_cache.dst_full_sync_en,
+        .math_approx_mode = work_split_cache.math_approx_mode,
+    };
+    compute_desc.runtime_args.reserve(num_cores_total);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
-    KernelHandle compute_kernel_id = CreateKernel(
-        program,
-        compute_file_path,
-        all_cores,
-        ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                       // generated number out of range [from, to)
-            .dst_full_sync_en = dst_full_sync_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = compute_defines,
-        });
+    const uint32_t output_addr = output.buffer()->address();
 
+    // Runtime args
     std::mt19937 rng = operation_attributes.seed.has_value() ? std::mt19937(*operation_attributes.seed)
                                                              : std::mt19937(std::time(nullptr));
 
     uint32_t tile_offset = 0;
-    for (auto core : cores) {
-        uint32_t units_per_core;
-        if (core_group_1.contains(core)) {
-            units_per_core = units_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            units_per_core = units_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
+    for (const auto& core : cores) {
+        uint32_t units_per_core = core_group_1.contains(core) ? units_per_core_group_1 : units_per_core_group_2;
 
-        uint32_t seed = get_random_seed(rng);
+        compute_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{get_random_seed(rng), units_per_core});
 
-        std::vector<uint32_t> compute_runtime_args = {seed, units_per_core};
-        SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
-
-        std::vector<uint32_t> writer_runtime_args = {output.buffer()->address(), tile_offset, units_per_core};
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        writer_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset, units_per_core});
 
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.compute_kernel_id = compute_kernel_id, .writer_kernel_id = writer_kernel_id, .cores = cores}};
-}
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void RandnDeviceOperation::ProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& operation_attributes,
-    [[maybe_unused]] const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& compute_kernel_id = cached_program.shared_variables.compute_kernel_id;
-    auto& cores = cached_program.shared_variables.cores;
-
-    const uint32_t output_addr = output.buffer()->address();
-
-    std::mt19937 rng = operation_attributes.seed.has_value() ? std::mt19937(*operation_attributes.seed)
-                                                             : std::mt19937(std::time(nullptr));
-
-    for (auto core : cores) {
-        {
-            auto& runtime_args = GetRuntimeArgs(program, compute_kernel_id, core);
-            runtime_args[0] = get_random_seed(rng);
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output_addr;
-        }
+    // Cache hash — descriptor structure never changes for same device/shape/dtype
+    if (work_split_cache.program_hash == 0) {
+        work_split_cache.program_hash = std::hash<ProgramDescriptor>{}(desc);
     }
+    desc.custom_program_hash = work_split_cache.program_hash;
+
+    return desc;
 }
 
 }  // namespace ttnn::operations::randn


### PR DESCRIPTION
## Summary

- **`Buffer::create_device_view`**: lightweight non-owning per-device buffer handle, used in `MeshBuffer::initialize_device_buffers` to skip full `Buffer::create` (validation + allocation) on cache hits — benefits every op
- **`KernelDescriptor`**: `CompileTimeArgs`, `CoreRuntimeArgs`, `Defines` → `SmallVector` to eliminate heap allocations for small ops; `kernel_source` → `string_view` to remove string copy per dispatch
- **`TensorAccessorArgs::append_to`**: templatized to accept `SmallVector` in addition to `std::vector`
- **randn**: migrated from legacy `ProgramFactory` + `override_runtime_arguments` to `ProgramDescriptor`; added `WorkSplitCache` to cache grid size, work split, compute config, and program hash (all constant for same device/shape/dtype)
- **bernoulli, layernorm**: kernel paths changed from string concatenation to `constexpr` literals (no heap per dispatch)
- **`.cursor/descriptor-migration-recipe.md`**: added performance best practices section so future ops are migrated correctly

## Benchmark results

Measured on Wormhole B0, N=10000, process pinned to single CPU core to reduce scheduler variance:

| Op | Before | After | Delta |
|---|---|---|---|
| `neg [32x32 bf16]` | 15.31 us | 14.90 us | **-2.7%** |
| `add [1024x1024 bf16]` | 21.26 us | 20.69 us | **-2.7%** |
| `randn [32x32 bf16]` | 13.33 us | 12.69 us | **-4.8%** |
| `randn [1024x1024 bf16]` | 16.32 us | 15.62 us | **-4.3%** |

Improvements are consistent across both legacy (`add`, `neg`) and descriptor-based (`randn`) ops.

## Test plan

- [ ] Existing randn Python tests pass
- [ ] Existing bernoulli tests pass
- [ ] Existing layernorm tests pass
- [ ] `test_generic_op` gtest passes
- [ ] No regressions in sweep tests for affected ops