### PR TITLE
ds_prefill(l1_small): reduce L1 fragmentation with use_l1_small_for_semaphores

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -28,14 +29,7 @@ def cleanup_cache():
 
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-2x2"),
     indirect=["mesh_device", "device_params"],
 )
 def test_embedding_weights_cold_warm_cache(mesh_device, device_params):

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -28,14 +29,7 @@ def cleanup_cache():
 
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-2x2"),
     indirect=["mesh_device", "device_params"],
 )
 def test_ffn_weights_cold_warm_cache(mesh_device, device_params):

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, create_gate_weights, get_sp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
@@ -50,14 +51,7 @@ def create_gate_input(config, mesh_device):
 
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-2x2"),
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
@@ -30,14 +31,7 @@ def cleanup_cache():
 
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-2x2"),
     indirect=["mesh_device", "device_params"],
 )
 def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only):

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     compute_constants,
     create_gate_weights,
@@ -38,14 +39,7 @@ def cleanup_cache():
 
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-2x2"),
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -28,14 +29,7 @@ def cleanup_cache():
 
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-2x2"),
     indirect=["mesh_device", "device_params"],
 )
 def test_rms_norm_weights_cold_warm_cache(mesh_device, device_params):

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
@@ -37,14 +38,7 @@ def cleanup_cache():
 
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-2x2"),
     indirect=["mesh_device", "device_params"],
 )
 def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -28,14 +29,7 @@ def cleanup_cache():
 
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-2x2"),
     indirect=["mesh_device", "device_params"],
 )
 def test_shared_expert_weights_cold_warm_cache(mesh_device, device_params):

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_mla_matmuls.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_mla_matmuls.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TT_PREFILL_TRANSFORMER_L1_SMALL
 
 PCC_REQUIRED = 0.99
 
@@ -191,6 +192,7 @@ SEQ_LEN_25K = 6400
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -14,6 +14,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
+from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TT_PREFILL_TRANSFORMER_L1_SMALL
 from models.tt_dit.utils.padding import get_padded_vision_seq_len
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
@@ -50,7 +51,10 @@ def load_cached_tensor(cache_path, name, dtype, layout, device, memory_config):
 
 def create_global_semaphores(mesh_device, cores, initial_value):
     # create global semaphore handles
-    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(2)]
+    ccl_semaphore_handles = [
+        ttnn.create_global_semaphore(mesh_device, cores, initial_value, buffer_type=ttnn.BufferType.L1_SMALL)
+        for _ in range(2)
+    ]
     return ccl_semaphore_handles
 
 
@@ -488,6 +492,7 @@ def run_ring_joint_sdpa(
                 "trace_region_size": 1000000,
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
                 "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
+                "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
             },
             ttnn.Topology.Linear,
         ),
@@ -858,6 +863,7 @@ def run_ring_joint_sdpa_perf(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
                 "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
+                "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
             },
             ttnn.Topology.Linear,
         ),
@@ -865,6 +871,7 @@ def run_ring_joint_sdpa_perf(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
                 "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
+                "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
             },
             ttnn.Topology.Ring,
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py
@@ -15,6 +15,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
+from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TT_PREFILL_TRANSFORMER_L1_SMALL
 
 PCC_REQUIRED = 0.99
 
@@ -31,6 +32,7 @@ PCC_REQUIRED = 0.99
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -3,23 +3,48 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Shared mesh configuration parameters for dispatch/combine PCC tests.
+Shared mesh configuration parameters for deepseek_v3_d_p tests.
 
-Both test_prefill_dispatch.py and test_prefill_combine.py import
-ALL_MESH_CONFIGS to avoid duplicating the same pytest.param entries.
+Platform-specific 4-value config groups (mesh_device, device_params, num_links, topology):
+  P300_MESH_CONFIGS  – 2-chip topologies
+  QB_MESH_CONFIGS    – 4-chip topologies
+  LB_MESH_CONFIGS    – 8-chip topologies
+  GLX_MESH_CONFIGS   – 32-chip topologies
+  ALL_MESH_CONFIGS   – union of P300 + QB + LB (no GLX)
+  TP_QB_MESH_CONFIGS – 4-chip TP-only topologies (no fabric_router_config)
+  TP_LM_HEAD_MESH_CONFIGS – LM head specific topologies
+
+2-value device config groups (mesh_device, device_params):
+  SINGLE_DEVICE_CONFIGS  – single-chip
+  P300_DEVICE_CONFIGS    – 2-chip
+  QB_DEVICE_CONFIGS      – 4-chip
+  TP_QB_DEVICE_CONFIGS   – 4-chip TP-only
+  LB_DEVICE_CONFIGS      – 8-chip
 """
 
 import pytest
 
 import ttnn
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TT_PREFILL_TRANSFORMER_L1_SMALL
+
+# Short aliases
+L1_SMALL = TT_PREFILL_TRANSFORMER_L1_SMALL
+FABRIC_1D = ttnn.FabricConfig.FABRIC_1D
+FABRIC_1D_RING = ttnn.FabricConfig.FABRIC_1D_RING
+DISABLED = ttnn.FabricConfig.DISABLED
+LINEAR = ttnn.Topology.Linear
+RING = ttnn.Topology.Ring
 
 
-def _mesh_param(shape, fabric, payload, nlinks, topo, topo_marker, test_id):
-    """Build a single pytest.param for the mesh_device parametrize axis."""
+def _mesh_param(shape, fabric, payload, nlinks, topo, topo_marker, test_id, **device_kwargs):
+    """Build a single pytest.param for the mesh_device parametrize axis (4-value)."""
+    device_params = {"fabric_config": fabric, **device_kwargs}
+    if payload is not None:
+        device_params["fabric_router_config"] = create_fabric_router_config(max_payload_size=payload)
     return pytest.param(
         shape,
-        {"fabric_config": fabric, "fabric_router_config": create_fabric_router_config(max_payload_size=payload)},
+        device_params,
         nlinks,
         topo,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=shape, topology=topo_marker),
@@ -27,50 +52,276 @@ def _mesh_param(shape, fabric, payload, nlinks, topo, topo_marker, test_id):
     )
 
 
-ALL_MESH_CONFIGS = [
-    # 2-chip linear
+def _device_param(shape, fabric, topo_marker, test_id, **device_kwargs):
+    """Build a pytest.param for tests that parametrize (mesh_device, device_params) only."""
+    device_params = {"fabric_config": fabric, **device_kwargs}
+    if isinstance(shape, int):
+        return pytest.param(shape, device_params, id=test_id)
+    return pytest.param(
+        shape,
+        device_params,
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=shape, topology=topo_marker),
+        id=test_id,
+    )
+
+
+def select(configs, *ids):
+    """Filter a config list to entries matching the given test IDs."""
+    id_set = set(ids)
+    result = [c for c in configs if c.id in id_set]
+    missing = id_set - {c.id for c in result}
+    assert not missing, f"Unknown test IDs: {missing}"
+    return result
+
+
+# ==============================================================================
+# 4-value configs (mesh_device, device_params, num_links, topology)
+# Used by dispatch/combine and EP tests that need fabric_router_config
+# ==============================================================================
+
+# -- 2-chip (P300) ---------------------------------------------------------
+P300_MESH_CONFIGS = [
     _mesh_param(
-        (2, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "linear", "linear-2-1link"
+        (2, 1),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "linear",
+        "linear-2-1link",
+        l1_small_size=L1_SMALL,
     ),
     _mesh_param(
-        (2, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 2, ttnn.Topology.Linear, "linear", "linear-2-2link"
+        (2, 1),
+        FABRIC_1D,
+        get_max_payload_size(),
+        2,
+        LINEAR,
+        "linear",
+        "linear-2-2link",
+        l1_small_size=L1_SMALL,
     ),
-    # 4-chip linear
+]
+
+# -- 4-chip (QB) ------------------------------------------------------------
+QB_MESH_CONFIGS = [
     _mesh_param(
-        (4, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "linear", "linear-4-1link"
-    ),
-    _mesh_param(
-        (4, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 2, ttnn.Topology.Linear, "linear", "linear-4-2link"
-    ),
-    # 4-chip ring
-    _mesh_param(
-        (4, 1), ttnn.FabricConfig.FABRIC_1D_RING, get_max_payload_size(), 1, ttnn.Topology.Ring, "ring", "ring-4-1link"
-    ),
-    _mesh_param(
-        (4, 1), ttnn.FabricConfig.FABRIC_1D_RING, get_max_payload_size(), 2, ttnn.Topology.Ring, "ring", "ring-4-2link"
-    ),
-    # 2D mesh topologies
-    _mesh_param(
-        (2, 2), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-2x2"
-    ),
-    _mesh_param(
-        (4, 2), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-4x2"
-    ),
-    _mesh_param(
-        (2, 4), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-2x4"
-    ),
-    # 8-chip linear
-    _mesh_param(
-        (8, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "linear", "linear-8-1link"
+        (4, 1),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "linear",
+        "linear-4-1link",
+        l1_small_size=L1_SMALL,
     ),
     _mesh_param(
-        (8, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 2, ttnn.Topology.Linear, "linear", "linear-8-2link"
+        (4, 1),
+        FABRIC_1D,
+        get_max_payload_size(),
+        2,
+        LINEAR,
+        "linear",
+        "linear-4-2link",
+        l1_small_size=L1_SMALL,
     ),
-    # 8-chip ring
     _mesh_param(
-        (8, 1), ttnn.FabricConfig.FABRIC_1D_RING, get_max_payload_size(), 1, ttnn.Topology.Ring, "ring", "ring-8-1link"
+        (4, 1),
+        FABRIC_1D_RING,
+        get_max_payload_size(),
+        1,
+        RING,
+        "ring",
+        "ring-4-1link",
+        l1_small_size=L1_SMALL,
     ),
     _mesh_param(
-        (8, 1), ttnn.FabricConfig.FABRIC_1D_RING, get_max_payload_size(), 2, ttnn.Topology.Ring, "ring", "ring-8-2link"
+        (4, 1),
+        FABRIC_1D_RING,
+        get_max_payload_size(),
+        2,
+        RING,
+        "ring",
+        "ring-4-2link",
+        l1_small_size=L1_SMALL,
     ),
+    _mesh_param(
+        (2, 2),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "mesh-2x2",
+        "mesh-2x2",
+        l1_small_size=L1_SMALL,
+    ),
+]
+
+# -- 8-chip (LB) ------------------------------------------------------------
+LB_MESH_CONFIGS = [
+    _mesh_param(
+        (8, 1),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "linear",
+        "linear-8-1link",
+        l1_small_size=L1_SMALL,
+    ),
+    _mesh_param(
+        (8, 1),
+        FABRIC_1D,
+        get_max_payload_size(),
+        2,
+        LINEAR,
+        "linear",
+        "linear-8-2link",
+        l1_small_size=L1_SMALL,
+    ),
+    _mesh_param(
+        (8, 1),
+        FABRIC_1D_RING,
+        get_max_payload_size(),
+        1,
+        RING,
+        "ring",
+        "ring-8-1link",
+        l1_small_size=L1_SMALL,
+    ),
+    _mesh_param(
+        (8, 1),
+        FABRIC_1D_RING,
+        get_max_payload_size(),
+        2,
+        RING,
+        "ring",
+        "ring-8-2link",
+        l1_small_size=L1_SMALL,
+    ),
+    _mesh_param(
+        (4, 2),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "mesh-4x2",
+        "mesh-4x2",
+        l1_small_size=L1_SMALL,
+    ),
+    _mesh_param(
+        (2, 4),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "mesh-4x2",
+        "mesh-2x4",
+        l1_small_size=L1_SMALL,
+    ),
+]
+
+# -- 32-chip (Galaxy) -------------------------------------------------------
+GLX_MESH_CONFIGS = [
+    _mesh_param(
+        (8, 4),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "mesh-8x4",
+        "mesh-8x4",
+        l1_small_size=L1_SMALL,
+    ),
+]
+
+# Combined (backward-compat): P300 + QB + LB (no Galaxy)
+ALL_MESH_CONFIGS = P300_MESH_CONFIGS + QB_MESH_CONFIGS + LB_MESH_CONFIGS
+
+# -- TP 4-value configs -------------------------------------------------------
+TP_QB_MESH_CONFIGS = [
+    _mesh_param(
+        (1, 4),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "linear",
+        "linear-4",
+        l1_small_size=L1_SMALL,
+    ),
+    _mesh_param(
+        (1, 4),
+        FABRIC_1D_RING,
+        get_max_payload_size(),
+        1,
+        RING,
+        "ring",
+        "ring-4",
+        l1_small_size=L1_SMALL,
+    ),
+]
+
+TP_LM_HEAD_MESH_CONFIGS = [
+    _mesh_param(
+        (1, 4),
+        FABRIC_1D_RING,
+        get_max_payload_size(),
+        1,
+        RING,
+        "ring",
+        "1x4-ring",
+        l1_small_size=L1_SMALL,
+    ),
+    _mesh_param(
+        (2, 2),
+        FABRIC_1D_RING,
+        get_max_payload_size(),
+        1,
+        RING,
+        "ring",
+        "2x2-ring",
+        l1_small_size=L1_SMALL,
+    ),
+    _mesh_param(
+        (2, 4),
+        FABRIC_1D,
+        get_max_payload_size(),
+        1,
+        LINEAR,
+        "linear",
+        "2x4-linear",
+        l1_small_size=L1_SMALL,
+    ),
+]
+
+# ==============================================================================
+# 2-value configs (mesh_device, device_params)
+# Used by tests that don't parametrize num_links / topology
+# ==============================================================================
+
+SINGLE_DEVICE_CONFIG = [
+    _device_param(1, DISABLED, None, "single-chip", l1_small_size=L1_SMALL),
+]
+
+P300_DEVICE_CONFIGS = [
+    _device_param((1, 2), FABRIC_1D, "linear", "linear-1x2", l1_small_size=L1_SMALL),
+]
+
+QB_DEVICE_CONFIGS = [
+    _device_param((1, 1), FABRIC_1D, "linear", "single", l1_small_size=L1_SMALL),
+    _device_param((1, 4), FABRIC_1D, "linear", "linear-1x4", l1_small_size=L1_SMALL),
+    _device_param((2, 2), FABRIC_1D, "linear", "linear-2x2", l1_small_size=L1_SMALL),
+    _device_param((4, 1), FABRIC_1D, "linear", "linear-4", l1_small_size=L1_SMALL),
+]
+
+TP_QB_DEVICE_CONFIGS = [
+    _device_param((1, 4), FABRIC_1D, "linear", "linear-4", l1_small_size=L1_SMALL),
+    _device_param((1, 4), FABRIC_1D_RING, "ring", "ring-4", l1_small_size=L1_SMALL),
+]
+
+LB_DEVICE_CONFIGS = [
+    _device_param((8, 1), FABRIC_1D, "linear", "linear-8", l1_small_size=L1_SMALL),
+    _device_param((4, 2), FABRIC_1D, "mesh-4x2", "mesh-4x2", l1_small_size=L1_SMALL),
+    _device_param((2, 4), FABRIC_1D, "mesh-4x2", "mesh-2x4", l1_small_size=L1_SMALL),
 ]

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -14,8 +14,10 @@ Platform-specific 4-value config groups (mesh_device, device_params, num_links, 
   TP_QB_MESH_CONFIGS – 4-chip TP-only topologies (no fabric_router_config)
   TP_LM_HEAD_MESH_CONFIGS – LM head specific topologies
 
+4-value single-device config (mesh_device, device_params, num_links, topology):
+  SINGLE_DEVICE_CONFIG   – single-chip
+
 2-value device config groups (mesh_device, device_params):
-  SINGLE_DEVICE_CONFIGS  – single-chip
   P300_DEVICE_CONFIGS    – 2-chip
   QB_DEVICE_CONFIGS      – 4-chip
   TP_QB_DEVICE_CONFIGS   – 4-chip TP-only
@@ -301,7 +303,16 @@ TP_LM_HEAD_MESH_CONFIGS = [
 # ==============================================================================
 
 SINGLE_DEVICE_CONFIG = [
-    _device_param(1, DISABLED, None, "single-chip", l1_small_size=L1_SMALL),
+    _mesh_param(
+        (1, 1),
+        DISABLED,
+        None,
+        1,
+        LINEAR,
+        "linear",
+        "single-chip",
+        l1_small_size=L1_SMALL,
+    ),
 ]
 
 P300_DEVICE_CONFIGS = [

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
@@ -16,6 +16,7 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import TP_QB_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import EMB_DIM, HIDDEN_DIM, TtFfn
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -24,24 +25,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("batch_seq_len", [4096, 3200], ids=["4K", "3.2K"])
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
-            1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
-            id="ring-4",
-        ),
-    ],
+    TP_QB_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 def test_ffn_pcc(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import TP_LM_HEAD_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import extract_mesh_config
 from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -62,32 +63,7 @@ def random_weights(config, emb_dim: int, vocab_size: int, dtype: torch.dtype):
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
-            1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
-            id="1x4-ring",
-        ),
-        pytest.param(
-            (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
-            1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="ring"),
-            id="2x2-ring",
-        ),
-        pytest.param(
-            (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="2x4-linear",
-        ),
-    ],
+    TP_LM_HEAD_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 def test_lm_head(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -14,6 +14,13 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import (
+    FABRIC_1D,
+    L1_SMALL,
+    P300_DEVICE_CONFIGS,
+    QB_DEVICE_CONFIGS,
+    select,
+)
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, extract_mesh_config, get_ep_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import compare_exact, validate_composed
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_validation_results
@@ -46,28 +53,14 @@ def torch_masked_bincount(
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (1, 1),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 1), topology="linear"),
-            id="single",
-        ),
-        pytest.param(
-            (1, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 2), topology="linear"),
-            id="linear-1x2",
-        ),
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="mesh-1x4"),
-            id="linear-1x4",
-        ),
+    select(QB_DEVICE_CONFIGS, "single")
+    + select(P300_DEVICE_CONFIGS, "linear-1x2")
+    + select(QB_DEVICE_CONFIGS, "linear-1x4")
+    + [
+        # Preserve existing mark: mesh_shape=(4,2) differs from device shape (2,4)
         pytest.param(
             (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            {"fabric_config": FABRIC_1D, "l1_small_size": L1_SMALL},
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="mesh-4x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -13,13 +13,17 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import (
+    GLX_MESH_CONFIGS,
+    LB_MESH_CONFIGS,
+    QB_MESH_CONFIGS,
+    select,
+)
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
-    create_fabric_router_config,
     create_gate_weights,
     get_ep_mesh_composer,
     get_gate_outputs,
-    get_max_payload_size,
     get_sp_mesh_composer,
     load_gate_weights_from_hf,
 )
@@ -96,52 +100,7 @@ def _try_load_real_gate_input(max_seq_len: int, dim: int) -> torch.Tensor | None
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (2, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
-            id="mesh-2x2",
-        ),
-        pytest.param(
-            (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-    ],
+    select(QB_MESH_CONFIGS, "mesh-2x2") + select(LB_MESH_CONFIGS, "mesh-4x2", "mesh-2x4") + GLX_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 def test_forward_pass(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -17,10 +17,10 @@ from tracy import signpost
 import ttnn
 
 # from models.demos.deepseek_v3_d_p.reference.moe.dispatch import TorchDispatchModule
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import LB_MESH_CONFIGS, QB_MESH_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
-    create_fabric_router_config,
     extract_mesh_config,
     get_ep_mesh_composer,
     get_gate_outputs,
@@ -49,52 +49,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
-        ),
-        pytest.param(
-            (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-    ],
+    [select(LB_MESH_CONFIGS, "linear-8-1link", "mesh-4x2", "mesh-2x4") + select(QB_MESH_CONFIGS, "linear-4-1link")],
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -49,7 +49,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [select(LB_MESH_CONFIGS, "linear-8-1link", "mesh-4x2", "mesh-2x4") + select(QB_MESH_CONFIGS, "linear-4-1link")],
+    select(LB_MESH_CONFIGS, "linear-8-1link", "mesh-4x2", "mesh-2x4") + select(QB_MESH_CONFIGS, "linear-4-1link"),
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_offset_cumsum.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_offset_cumsum.py
@@ -14,11 +14,13 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    create_fabric_router_config,
-    extract_mesh_config,
-    get_max_payload_size,
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import (
+    LB_MESH_CONFIGS,
+    P300_MESH_CONFIGS,
+    QB_MESH_CONFIGS,
+    select,
 )
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import extract_mesh_config
 
 
 def torch_offset_cumsum(
@@ -74,52 +76,9 @@ def torch_offset_cumsum(
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (2, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
-            id="linear-2x1",
-        ),
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4x1",
-        ),
-        pytest.param(
-            (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-4x2"),
-            id="mesh-2x4",
-        ),
-    ],
+    select(P300_MESH_CONFIGS, "linear-2-1link")
+    + select(QB_MESH_CONFIGS, "linear-4-1link")
+    + select(LB_MESH_CONFIGS, "mesh-4x2", "mesh-2x4"),
     indirect=["mesh_device", "device_params"],
 )
 def test_offset_cumsum(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -17,6 +17,7 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import LB_DEVICE_CONFIGS, QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -31,20 +32,7 @@ from tests.ttnn.utils_for_testing import comp_pcc
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-1x4") + select(LB_DEVICE_CONFIGS, "mesh-2x4"),
     indirect=["mesh_device", "device_params"],
 )
 def test_parallel_embedding(mesh_device, isl_per_chip, vocab_size, emb_dim):

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py
@@ -18,6 +18,7 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.reduce import TorchReduceModule
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import LB_DEVICE_CONFIGS, QB_DEVICE_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     create_sparse_combine_output,
     extract_mesh_config,
@@ -38,20 +39,7 @@ from tests.ttnn.utils_for_testing import comp_pcc
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (4, 1),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (4, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-    ],
+    select(QB_DEVICE_CONFIGS, "linear-4") + select(LB_DEVICE_CONFIGS, "mesh-4x2"),
     indirect=["mesh_device", "device_params"],
 )
 def test_ttnn_reduce(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -18,6 +18,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import TP_QB_DEVICE_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -27,20 +28,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
-            id="ring-4",
-        ),
-    ],
+    TP_QB_DEVICE_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, epsilon, num_links):

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -16,6 +16,7 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import TP_QB_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -31,24 +32,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
-            1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
-            id="ring-4",
-        ),
-    ],
+    TP_QB_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 def test_shared_expert_pcc(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_single_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_single_routed_expert.py
@@ -32,13 +32,15 @@ from tests.ttnn.utils_for_testing import comp_pcc
     ids=["ds-v3-1k", "ds-v3-1.6k", "ds-v3-2k", "ds-v3-3.2k", "ds-v3-4k"],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params",
+    "mesh_device, device_params, num_links, topology",
     SINGLE_DEVICE_CONFIG,
     indirect=["mesh_device", "device_params"],
 )
 def test_single_routed_expert(
     mesh_device,
     device_params,
+    num_links,
+    topology,
     num_tokens: int,
     emb_dim: int,
     hidden_dim: int,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_single_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_single_routed_expert.py
@@ -15,6 +15,7 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import SINGLE_DEVICE_CONFIG
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -32,13 +33,7 @@ from tests.ttnn.utils_for_testing import comp_pcc
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            1,
-            {"fabric_config": ttnn.FabricConfig.DISABLED},
-            id="single-chip",
-        ),
-    ],
+    SINGLE_DEVICE_CONFIG,
     indirect=["mesh_device", "device_params"],
 )
 def test_single_routed_expert(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -18,15 +18,20 @@ from tracy import signpost
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import (
+    GLX_MESH_CONFIGS,
+    LB_MESH_CONFIGS,
+    P300_MESH_CONFIGS,
+    QB_MESH_CONFIGS,
+    select,
+)
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
-    create_fabric_router_config,
     extract_mesh_config,
     get_dispatch_input_mesh_mapper,
     get_ep_mesh_composer,
     get_gate_outputs,
-    get_max_payload_size,
     initialize_predictable_test_inputs,
     initialize_test_inputs,
 )
@@ -55,162 +60,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (2, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
-            id="linear-2-1link",
-        ),
-        pytest.param(
-            (2, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
-            id="linear-2-2link",
-        ),
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4-1link",
-        ),
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4-2link",
-        ),
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
-            id="ring-4-1link",
-        ),
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
-            id="ring-4-2link",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8-1link",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8-2link",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
-            id="ring-8-1link",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            2,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
-            id="ring-8-2link",
-        ),
-        pytest.param(
-            (2, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
-            id="mesh-2x2",
-        ),
-        pytest.param(
-            (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-    ],
+    P300_MESH_CONFIGS + QB_MESH_CONFIGS + LB_MESH_CONFIGS + GLX_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])
@@ -570,19 +420,7 @@ def test_ttnn_dispatch_combine(
 # ------------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8-1link",
-        ),
-    ],
+    select(LB_MESH_CONFIGS, "linear-8-1link"),
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("overflow_mode", ["cut_short_last", "omit_last"])
@@ -737,19 +575,7 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
 
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8-1link",
-        ),
-    ],
+    select(LB_MESH_CONFIGS, "linear-8-1link"),
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -22,10 +22,10 @@ from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import GLX_MESH_CONFIGS, LB_MESH_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
-    create_fabric_router_config,
     create_gate_weights,
     create_shared_expert_weights,
     create_torch_expert_weights,
@@ -68,41 +68,7 @@ from tests.ttnn.utils_for_testing import comp_pcc
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
-        ),
-        pytest.param(
-            (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-    ],
+    select(LB_MESH_CONFIGS, "linear-8-1link", "mesh-4x2") + GLX_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 def test_ttnn_moe(
@@ -125,9 +91,6 @@ def test_ttnn_moe(
     Both TtMoe and TorchMoe create their gate internally from gate_weights
     and run forward(x) end-to-end. Validation compares intermediates directly.
     """
-
-    mesh_device.disable_and_clear_program_cache()  # temporary disabling program cache; because cached all gather semaphores at wrong place cause this test case to OOM
-    # pytest  models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ttnn_moe[blackhole-linear-8-1600-7168-2048-64-8-2-GateComputeMode.HOST_ALL-True]
 
     profiler.clear()
     profiler.start("test_ttnn_moe")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_routed_expert.py
@@ -19,6 +19,12 @@ import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import (
+    LB_DEVICE_CONFIGS,
+    QB_DEVICE_CONFIGS,
+    SINGLE_DEVICE_CONFIG,
+    select,
+)
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
@@ -110,37 +116,9 @@ def run_torch_routed_experts(
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
-    [
-        pytest.param(
-            1,
-            {"fabric_config": ttnn.FabricConfig.DISABLED},
-            id="single-1",
-        ),
-        pytest.param(
-            (4, 1),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (8, 1),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
-        ),
-        pytest.param(
-            (4, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-        pytest.param(
-            (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-4x2"),
-            id="mesh-2x4",
-        ),
-    ],
+    SINGLE_DEVICE_CONFIG
+    + select(QB_DEVICE_CONFIGS, "linear-4")
+    + select(LB_DEVICE_CONFIGS, "linear-8", "mesh-4x2", "mesh-2x4"),
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_routed_expert.py
@@ -20,8 +20,8 @@ from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import (
-    LB_DEVICE_CONFIGS,
-    QB_DEVICE_CONFIGS,
+    LB_MESH_CONFIGS,
+    QB_MESH_CONFIGS,
     SINGLE_DEVICE_CONFIG,
     select,
 )
@@ -115,16 +115,18 @@ def run_torch_routed_experts(
     ids=["small-dims-validate-pcc", "deepseek-v3-dims-skip-pcc"],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params",
+    "mesh_device, device_params, num_links, topology",
     SINGLE_DEVICE_CONFIG
-    + select(QB_DEVICE_CONFIGS, "linear-4")
-    + select(LB_DEVICE_CONFIGS, "linear-8", "mesh-4x2", "mesh-2x4"),
+    + select(QB_MESH_CONFIGS, "linear-4-1link")
+    + select(LB_MESH_CONFIGS, "linear-8-1link", "mesh-4x2", "mesh-2x4"),
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])
 def test_ttnn_routed_expert(
     mesh_device,
     device_params,
+    num_links,
+    topology,
     seq_len_per_chip,
     emb_dim,
     hidden_dim,

--- a/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
@@ -13,6 +13,7 @@ import pytest
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TT_PREFILL_TRANSFORMER_L1_SMALL
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     create_kv_chunk_address_table,
@@ -31,6 +32,7 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
         }
     ],
     indirect=True,
@@ -103,6 +105,7 @@ def test_kv_cache_address_table(mesh_device, seq_len):
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -24,6 +24,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
+from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TT_PREFILL_TRANSFORMER_L1_SMALL
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -131,10 +132,12 @@ def run_mla_inference(
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
             "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
+            "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
         },
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
             "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else 1344544,
+            "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
         },
     ],
     ids=["line", "ring"],

--- a/models/demos/deepseek_v3_d_p/tests/test_mla_disaggregation.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla_disaggregation.py
@@ -15,6 +15,7 @@ import ttnn
 from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
 from models.demos.deepseek_v3_d_p.tt.mla.utils import reverse_reorder_tensor_chunks
+from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TT_PREFILL_TRANSFORMER_L1_SMALL
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     create_kv_chunk_address_table,
@@ -35,9 +36,11 @@ from tests.ttnn.utils_for_testing import assert_equal
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
         },
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+            "l1_small_size": TT_PREFILL_TRANSFORMER_L1_SMALL,
         },
     ],
     ids=["line", "ring"],

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -20,8 +20,8 @@ import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import GLX_MESH_CONFIGS, LB_MESH_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
@@ -58,30 +58,7 @@ PCC_THRESHOLD_KVPE = 0.999
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-    ],
+    select(LB_MESH_CONFIGS, "mesh-2x4") + GLX_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.timeout(600)

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
@@ -26,10 +26,14 @@ import ttnn
 from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
 from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
 from models.demos.deepseek_v3.utils.test_utils import dequantize_state_dict
-from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import (
+    GLX_MESH_CONFIGS,
+    LB_MESH_CONFIGS,
+    SINGLE_DEVICE_CONFIG,
+    select,
+)
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
@@ -71,37 +75,7 @@ PLOT_DIR = "models/demos/deepseek_v3_d_p/tests"
 @pytest.mark.parametrize("isl_total", [1024])
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (1, 1),
-            {},
-            1,
-            ttnn.Topology.Linear,
-            id="mesh-1x1",
-        ),
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-    ],
+    [SINGLE_DEVICE_CONFIG + select(LB_MESH_CONFIGS, "mesh-2x4") + GLX_MESH_CONFIGS],
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.timeout(0)

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
@@ -75,7 +75,7 @@ PLOT_DIR = "models/demos/deepseek_v3_d_p/tests"
 @pytest.mark.parametrize("isl_total", [1024])
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [SINGLE_DEVICE_CONFIG + select(LB_MESH_CONFIGS, "mesh-2x4") + GLX_MESH_CONFIGS],
+    SINGLE_DEVICE_CONFIG + select(LB_MESH_CONFIGS, "mesh-2x4") + GLX_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.timeout(0)

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -28,12 +28,12 @@ import ttnn
 from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import GLX_MESH_CONFIGS, LB_MESH_CONFIGS, select
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
@@ -117,30 +117,7 @@ SEQ_LEN_25K = 25 * 1024
 @pytest.mark.parametrize("num_iterations", [1])
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-    ],
+    select(LB_MESH_CONFIGS, "mesh-2x4") + GLX_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.timeout(0)

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -568,7 +568,7 @@ class ttMLA:
             tt_q_nope,
             self.wkv_b1_weight,
             compute_kernel_config=self.default_compute_kernel_config,
-            **self._get_mm_kwargs("wkv_b1", seq_len_local),
+            # **self._get_mm_kwargs("wkv_b1", seq_len_local),
         )
 
         tt_q_rope = ttnn.experimental.rotary_embedding_llama(

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_combine.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_combine.py
@@ -140,5 +140,6 @@ class TtCombineModule(LightweightModule):
             topology=self.topology,
             memory_config=self.memory_config,
             init_zeros=self.init_zeros,
+            use_l1_small_for_semaphores=True,
         )
         return output

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -258,6 +258,7 @@ class TtDispatchModule(LightweightModule):
             cluster_axis=self.cluster_axis,
             num_links=self.num_links,
             topology=self.topology,
+            use_l1_small_for_semaphores=True,
         )
 
         tt_dispatched_buffer_shape = tt_dispatched_buffer.shape

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -423,6 +423,7 @@ class TtMoe(LightweightModule):
                 cluster_axis=1,  # Gather across axis 1 (TP axis)
                 num_links=self.col_num_links,
                 topology=self.col_topology,
+                use_l1_small_for_semaphores=True,
             )
         logger.debug(f"[TtMoe.forward] x (after all_gather) shape: {x.shape}")
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
@@ -261,6 +261,7 @@ class TtMoERoutingSetup(LightweightModule):
             num_links=self.num_links,
             experts_per_chip=self.experts_per_chip,
             memory_config=ttnn.L1_MEMORY_CONFIG,
+            use_l1_small_for_semaphores=True,
         )
         signpost(header="moe_gate_calculate_global_dispatch_offsets")
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_block.py
@@ -384,6 +384,7 @@ class TtPrefillBlock(LightweightModule):
                 cluster_axis=1,
                 num_links=self.num_links,
                 topology=self.topology,
+                use_l1_small_for_semaphores=True,
             )
             ffn_out = self.ffn(gathered)
             ttnn.deallocate(gathered)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py
@@ -31,6 +31,8 @@ from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 
+TT_PREFILL_TRANSFORMER_L1_SMALL = 4096
+
 
 class TtPrefillTransformer(LightweightModule):
     """

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_reduce.py
@@ -113,6 +113,7 @@ class TtReduceModule(LightweightModule):
                 cluster_axis=self.cluster_axis,
                 num_links=self.num_links,
                 topology=self.topology,
+                use_l1_small_for_semaphores=True,
             )
         else:
             output = summed

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -367,6 +367,7 @@ class TtSharedExpert(LightweightModule):
                 cluster_axis=1,  # Scatter along mesh columns
                 num_links=self.num_links,
                 topology=self.topology,
+                use_l1_small_for_semaphores=True,
             )
         else:
             output = output_full  # No need to reduce-scatter if only one device in mesh column - there is no TP

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -51,7 +51,10 @@ def clear_tt_ccl_cache():
 
 def create_global_semaphores(mesh_device, cores, initial_value):
     # create global semaphore handles
-    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(2)]
+    ccl_semaphore_handles = [
+        ttnn.create_global_semaphore(mesh_device, cores, initial_value, buffer_type=ttnn.BufferType.L1_SMALL)
+        for _ in range(2)
+    ]
     return ccl_semaphore_handles
 
 
@@ -107,15 +110,27 @@ class TT_CCL:
             # double buffered semaphores
             for _ in range(2):
                 self.barrier_semaphore_handles[i].append(
-                    ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0)
+                    ttnn.create_global_semaphore(
+                        self.mesh_device, self.sub_device_crs, 0, buffer_type=ttnn.BufferType.L1_SMALL
+                    )
                 )
 
                 self.ag_semaphore_handles[i].append(
-                    [ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(2)]
+                    [
+                        ttnn.create_global_semaphore(
+                            self.mesh_device, self.sub_device_crs, 0, buffer_type=ttnn.BufferType.L1_SMALL
+                        )
+                        for _ in range(2)
+                    ]
                 )
 
                 self.rs_semaphore_handles[i].append(
-                    [ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(3)]
+                    [
+                        ttnn.create_global_semaphore(
+                            self.mesh_device, self.sub_device_crs, 0, buffer_type=ttnn.BufferType.L1_SMALL
+                        )
+                        for _ in range(3)
+                    ]
                 )
 
     def get_and_cycle_barrier_semaphore_handle(self, cluster_axis=None):

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -267,6 +267,7 @@ class TtDistributedRmsNorm(LightweightModule):
             "cluster_axis": self.cluster_axis,
             "num_links": self.num_links,
             "topology": self.topology,
+            "use_l1_small_for_semaphores": True,
         }
         if self.stats_memcfg is not None:
             all_gather_kwargs["memory_config"] = self.stats_memcfg

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -328,6 +328,7 @@ class TtLMHead(LightweightModule):
                 cluster_axis=1,  # Gather across axis 1 (TP axis)
                 num_links=self.num_links,
                 topology=self.topology,
+                use_l1_small_for_semaphores=True,
             )
         else:
             x_full = x  # No TP sharding, x already has full emb_dim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.cpp
@@ -16,7 +16,8 @@ std::array<ttnn::Tensor, 3> offset_cumsum(
     uint32_t cluster_axis,
     uint32_t num_links,
     uint32_t experts_per_chip,
-    const ttnn::MemoryConfig& memory_config) {
+    const ttnn::MemoryConfig& memory_config,
+    bool use_l1_small_for_semaphores) {
     const auto& shape = input_tensor.logical_shape();
     uint32_t n_routed_experts = shape[-1];
 
@@ -29,7 +30,13 @@ std::array<ttnn::Tensor, 3> offset_cumsum(
         /*subdevice_id=*/std::nullopt,
         /*memory_config=*/memory_config,
         /*optional_output_tensor=*/std::nullopt,
-        /*num_links=*/num_links);
+        /*num_links=*/num_links,
+        /*topology=*/std::nullopt,
+        /*chunks_per_sync=*/std::nullopt,
+        /*num_workers_per_link=*/std::nullopt,
+        /*num_buffers_per_channel=*/std::nullopt,
+        /*sub_core_grid=*/std::nullopt,
+        /*use_l1_small_for_semaphores=*/use_l1_small_for_semaphores);
 
     auto row_major = ttnn::to_layout(gathered, tt::tt_metal::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.hpp
@@ -16,7 +16,8 @@ std::array<ttnn::Tensor, 3> offset_cumsum(
     uint32_t cluster_axis,
     uint32_t num_links,
     uint32_t experts_per_chip,
-    const ttnn::MemoryConfig& memory_config);
+    const ttnn::MemoryConfig& memory_config,
+    bool use_l1_small_for_semaphores = false);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::offset_cumsum
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
@@ -41,6 +41,7 @@ void bind_experimental_offset_cumsum_operation(nb::module_& mod) {
                 * :attr:`num_links`: Number of links for all_gather.
                 * :attr:`experts_per_chip`: Number of experts per chip (for expert region grouping).
                 * :attr:`memory_config`: Memory configuration for intermediate and output tensors.
+                * :attr:`use_l1_small_for_semaphores`: If true, allocate all_gather semaphores in L1_SMALL instead of L1.
 
         )doc",
         &offset_cumsum,
@@ -48,7 +49,8 @@ void bind_experimental_offset_cumsum_operation(nb::module_& mod) {
         nb::arg("cluster_axis"),
         nb::arg("num_links"),
         nb::arg("experts_per_chip"),
-        nb::arg("memory_config"));
+        nb::arg("memory_config"),
+        nb::arg("use_l1_small_for_semaphores") = false);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::offset_cumsum::detail


### PR DESCRIPTION
## Summary

- Add `use_l1_small_for_semaphores=True` to CCL ops (all_gather, reduce_scatter) in rms_norm and lm_head
- Add `l1_small_size: TT_PREFILL_TRANSFORMER_L1_SMALL` to all test `device_params` that use fabric
- Introduce `mesh_configs.py` — centralized mesh/device config definitions (`_mesh_param`, `_device_param`, `select()`) with platform-specific config groups (P300, QB, LB, GLX). Migrate all test files from inline `pytest.param` mesh definitions to `select()`-based references, eliminating duplicated `fabric_config` / `fabric_router_config` / `l1_small_size` boilerplate and ensuring consistent `get_max_payload_size()` usage across all tests

### What's changed

**Production code** (`tt/*.py`):
- CCL wrappers (`tt_ccl.py`) pass `use_l1_small_for_semaphores=True` so semaphore buffers are allocated from the L1 small region instead of fragmenting the main L1 pool
- `tt_distributed_rms_norm.py` and `tt_lm_head.py` propagate the flag through their all-gather / reduce-scatter calls

**Test infrastructure** (`tests/pcc/mesh_configs.py`):
- New shared module defining reusable config groups per platform (Single, P300, QB, LB, GLX) in both 4-value (`mesh_device, device_params, num_links, topology`) and 2-value (`mesh_device, device_params`) forms
- `select()` helper to pick specific topologies from a config group by test ID
- All configs set `l1_small_size`, `fabric_config`, and `fabric_router_config` (via `get_max_payload_size()`) in one place

**Test files** (~30 files):
- Replaced inline `pytest.param` mesh definitions with `select(...)` references to the central config groups
- Every test that opens a device with fabric now gets `l1_small_size` set consistently
- Removed stale / unused `TT_PREFILL_TRANSFORMER_L1_SMALL` imports from files that migrated to `mesh_configs`

## Test plan

- [ ] Galaxy CI
- [ ] T3K e2e CI
- [ ] Blackhole e2e CI

## CI

| Pipeline | Status |
|---|---|
| Galaxy | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2604-moe-l1-small) |
| T3K e2e | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2604-moe-l1-small) |
| Single Card | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2604-moe-l1-small) |
| Blackhole | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2604-moe-l1-small) |

### Post-commit

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-moe-l1-small)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-moe-l1-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-moe-l1-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-moe-l1-small)