### PR TITLE
Add ttnn data movement sanity tests (one per device kernel)

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -68,9 +68,9 @@ metal_infra:
 # No official decision has been made yet for division of budgets per team.
 ttnn:
   sanity:
-    wh_n300_civ2: 540
-    bh_p100: 540
-    bh_p150b_civ2: 540
+    wh_n300_civ2: 600
+    bh_p100: 600
+    bh_p150b_civ2: 600
   unit:
     wh_llmbox: 50
   e2e:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -68,9 +68,9 @@ metal_infra:
 # No official decision has been made yet for division of budgets per team.
 ttnn:
   sanity:
-    wh_n300_civ2: 600
-    bh_p100: 600
-    bh_p150b_civ2: 600
+    wh_n300_civ2: 545
+    bh_p100: 545
+    bh_p150b_civ2: 545
   unit:
     wh_llmbox: 50
   e2e:

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -11,7 +11,7 @@
 
 - name: "ttnn data movement group"
   cmd: >-
-    pytest --timeout 300 -v
+    pytest --timeout 60 -v
     tests/ttnn/unit_tests/operations/data_movement/test_tilize.py::test_tilize_test
     tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py::test_run_tilize_with_val_padding_test
     tests/ttnn/unit_tests/operations/data_movement/test_untilize.py::test_untilize_single_core_interleaved_to_interleaved

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -11,7 +11,7 @@
 
 - name: "ttnn data movement group"
   cmd: >-
-    pytest --timeout 60 -v
+    pytest --timeout 60 -xv
     tests/ttnn/unit_tests/operations/data_movement/test_tilize.py::test_tilize_test
     tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py::test_run_tilize_with_val_padding_test
     tests/ttnn/unit_tests/operations/data_movement/test_untilize.py::test_untilize_single_core_interleaved_to_interleaved

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -10,14 +10,37 @@
 # =============================================================================
 
 - name: "ttnn data movement group"
-  cmd: "pytest --timeout 300 tests/ttnn/unit_tests/operations/data_movement -v"
+  cmd: >-
+    pytest --timeout 300 -v
+    tests/ttnn/unit_tests/operations/data_movement/test_tilize.py::test_tilize_test
+    tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py::test_run_tilize_with_val_padding_test
+    tests/ttnn/unit_tests/operations/data_movement/test_untilize.py::test_untilize_single_core_interleaved_to_interleaved
+    tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py::test_untilize_with_unpadding_height_sharded
+    tests/ttnn/unit_tests/operations/data_movement/test_pad.py::test_pad
+    tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py::test_fill_pad_complex_sharding
+    tests/ttnn/unit_tests/operations/data_movement/test_concat.py::test_tiled_concat
+    tests/ttnn/unit_tests/operations/data_movement/test_permute.py::test_permute_identity
+    tests/ttnn/unit_tests/operations/data_movement/test_slice.py::test_slice_usecase1
+    tests/ttnn/unit_tests/operations/data_movement/test_repeat.py::test_pc_with_different_shapes_in_sequence
+    tests/ttnn/unit_tests/operations/data_movement/test_embedding.py::test_base_case
+    tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py::test_embedding_bw_with_program_cache
+    tests/ttnn/unit_tests/operations/data_movement/test_gather.py::test_gather_multirow
+    tests/ttnn/unit_tests/operations/data_movement/test_tosa_scatter.py::test_tosa_scatter_normal
+    tests/ttnn/unit_tests/operations/data_movement/test_clone.py::test_clone_callback
+    tests/ttnn/unit_tests/operations/data_movement/test_sort.py::test_sort_indices
+    tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py::test_interleaved_to_sharded_nd_with_equivalent_2d
+    tests/ttnn/unit_tests/operations/data_movement/test_sharded_to_interleaved_oob.py::test_s2i_dram_height_sharded
+    tests/ttnn/unit_tests/operations/data_movement/test_convert_to_hwc.py::test_convert_to_hwc_dram_uneven_sharding
+    tests/ttnn/unit_tests/operations/data_movement/test_full.py::test_full_int
+    tests/ttnn/unit_tests/operations/data_movement/test_dropout.py::test_dopout
+    tests/ttnn/unit_tests/operations/data_movement/test_non_zero_indices.py::test_non_zero_indices_ttnn
   skus:
     wh_n300_civ2:
-      timeout: 60
+      timeout: 5
     bh_p100:
-      timeout: 60
+      timeout: 5
     bh_p150b_civ2:
-      timeout: 60
+      timeout: 5
   team: ttnn
   owner_id: U05ACKAJTHS # Naif Tarafdar
   merge_gate: false

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -19,7 +19,7 @@
     bh_p150b_civ2:
       timeout: 60
   team: ttnn
-  owner_id: U084B1CES7M # Borys Bradel
+  owner_id: U05ACKAJTHS # Naif Tarafdar
   merge_gate: false
   ttsim: true
 

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -9,6 +9,20 @@
 # Optional: merge_gate (filter in workflow), ttsim (for TTSim), fast_runtime_mode_off.
 # =============================================================================
 
+- name: "ttnn data movement group"
+  cmd: "pytest --timeout 300 tests/ttnn/unit_tests/operations/data_movement -v"
+  skus:
+    wh_n300_civ2:
+      timeout: 60
+    bh_p100:
+      timeout: 60
+    bh_p150b_civ2:
+      timeout: 60
+  team: ttnn
+  owner_id: U084B1CES7M # Borys Bradel
+  merge_gate: false
+  ttsim: true
+
 - name: "ttnn example tests"
   cmd: "./tests/scripts/run_ttnn_examples.sh"
   skus:

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -148,6 +148,9 @@ def test_run_tilize_large_row_input(device, input_shape):
         ),
     ],
 )
+@pytest.mark.skip(
+    reason="Output shape mismatch for ND sharded inputs — ttnn.tilize_with_val_padding returns wrong shape (#42815)"
+)
 @pytest.mark.parametrize("pad_value", [10.2, 0.0])
 @pytest.mark.parametrize("input_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 @pytest.mark.parametrize("output_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
@@ -258,6 +261,9 @@ def test_tilize_with_val_padding_nd_sharded_to_interleaved(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
         ),
     ],
+)
+@pytest.mark.skip(
+    reason="Output shape mismatch for ND sharded output — ttnn.tilize_with_val_padding returns wrong shape (#42815)"
 )
 @pytest.mark.parametrize("pad_value", [10.2, 0.0])
 @pytest.mark.parametrize("output_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
@@ -408,6 +414,9 @@ _ND_TO_LEGACY_PARAMS = [
 @pytest.mark.parametrize(
     "tensor_shape, input_shard_shape, output_padded_shape, shard_core_grid, output_memory_layout, output_shard_shape_legacy",
     _ND_TO_LEGACY_PARAMS,
+)
+@pytest.mark.skip(
+    reason="Output shape mismatch for ND sharded input to legacy sharded output — ttnn.tilize_with_val_padding returns wrong shape (#42815)"
 )
 @pytest.mark.parametrize("pad_value", [10.2])
 @pytest.mark.parametrize("input_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR])


### PR DESCRIPTION
## Summary

- Adds a `ttnn data movement group` to the sanity CI pipeline (`ttnn-tests.yaml`) with **one fast representative test per unique device kernel** (22 kernels, 96 parametrized cases, ~30 sec)
- Skips 22 parametrized test cases in `test_tilize_with_val_padding.py` that fail due to an ND sharding bug in `ttnn.tilize_with_val_padding` (tracked in #42815)
- Bumps `ttnn.sanity` time budget from 540 → 545 min to accommodate the new group (5 min per SKU)

## Device kernels covered

| Kernel | Test |
|---|---|
| tilize | `test_tilize_test` |
| tilize_with_val_padding | `test_run_tilize_with_val_padding_test` |
| untilize | `test_untilize_single_core_interleaved_to_interleaved` |
| untilize_with_unpadding | `test_untilize_with_unpadding_height_sharded` |
| pad | `test_pad` |
| fill_pad | `test_fill_pad_complex_sharding` |
| concat | `test_tiled_concat` |
| permute | `test_permute_identity` |
| slice | `test_slice_usecase1` |
| repeat | `test_pc_with_different_shapes_in_sequence` |
| embedding | `test_base_case` |
| embedding_backward | `test_embedding_bw_with_program_cache` |
| gather | `test_gather_multirow` |
| scatter | `test_tosa_scatter_normal` |
| clone | `test_clone_callback` |
| sort | `test_sort_indices` |
| interleaved_to_sharded | `test_interleaved_to_sharded_nd_with_equivalent_2d` |
| sharded_to_interleaved | `test_s2i_dram_height_sharded` |
| convert_to_hwc | `test_convert_to_hwc_dram_uneven_sharding` |
| full | `test_full_int` |
| dropout | `test_dopout` |
| non_zero_indices | `test_non_zero_indices_ttnn` |

Host-only ops (stack, repeat_interleave, full_like, reallocate) and kernel wrappers (tilize_with_zero_padding, tosa_gather) are excluded — they don't exercise unique device kernels.

## Test results (local)

```
96 tests: 90 passed, 6 skipped, 0 failed in 30.45s
```

## Test plan

- [x] Full `data_movement` suite (8,961 tests) run locally — only 22 ND sharded tilize failures, now skipped
- [x] Refined 96-test suite passes locally in ~30s
- [x] GitHub issue created for skipped tests: #42815
- [ ] CI passes on this PR

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ntarafdar/disable-failing-tilize-nd-sharded-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ntarafdar/disable-failing-tilize-nd-sharded-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ntarafdar/disable-failing-tilize-nd-sharded-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ntarafdar/disable-failing-tilize-nd-sharded-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ntarafdar/disable-failing-tilize-nd-sharded-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ntarafdar/disable-failing-tilize-nd-sharded-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ntarafdar/disable-failing-tilize-nd-sharded-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ntarafdar/disable-failing-tilize-nd-sharded-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ntarafdar/disable-failing-tilize-nd-sharded-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ntarafdar/disable-failing-tilize-nd-sharded-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ntarafdar/disable-failing-tilize-nd-sharded-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ntarafdar/disable-failing-tilize-nd-sharded-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ntarafdar/disable-failing-tilize-nd-sharded-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ntarafdar/disable-failing-tilize-nd-sharded-tests)