### PR TITLE
Implement read_decode_output

### DIFF
--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import torch
 from loguru import logger
 
+import ttnn
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
@@ -234,6 +235,22 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         # - sample_on_device=True  -> sampled token ids
         # - sample_on_device=False -> logits [B, 1, V] for host sampling
         return decode_output
+
+    def read_decode_output(self, tt_out, async_read=False):
+        # If decode already returned host tensors, pass through.
+        if isinstance(tt_out, torch.Tensor):
+            return (tt_out, []) if async_read else tt_out
+
+        # Device-sampling decode output: TT tensor -> host torch token ids.
+        if isinstance(tt_out, ttnn.Tensor):
+            host_tokens = self._tokens_from_device(
+                tt_out,
+                self.mesh_device,
+                batch_size_per_row=self.batch_size_per_row,
+            )
+            return (host_tokens, []) if async_read else host_tokens
+
+        raise TypeError(f"Unsupported decode output type from DeepseekV3ForCausalLM: {type(tt_out)}")
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
         assert (


### PR DESCRIPTION
## Issue
https://github.com/tenstorrent/tt-metal/issues/42813

## Summary
- add `read_decode_output` handling in the DeepSeek V3 vLLM generator path to support decode output reads
- keep decode flow consistent with the latest ds-rc1 branch behavior for this generator component
## Test plan
- [x] Run DeepSeek V3 vLLM decode path smoke test
- [x] Run targeted DeepSeek demo/test that exercises decode output reads