### PR TITLE
Bug Fix: optimal DRAM workers invalid for harvested devices in column major

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -201,7 +201,7 @@ class ModelOptimizations:
         All models use bfp4 in FF1 and FF3 MLPs in this configuration
         """
         base_model_name = get_base_model_name(model_name)
-        if base_model_name in ["Qwen2.5-7B", "Qwen2.5-VL-7B"]:
+        if base_model_name in ["Qwen2.5-7B", "Qwen2.5-VL-7B", "Mistral-7B"]:
             logger.info(
                 f"Model {model_name} is degraded under standard high-performance settings, using BF16 attention and BFP8 MLP"
             )

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -201,7 +201,7 @@ class ModelOptimizations:
         All models use bfp4 in FF1 and FF3 MLPs in this configuration
         """
         base_model_name = get_base_model_name(model_name)
-        if base_model_name in ["Qwen2.5-7B", "Qwen2.5-VL-7B", "Mistral-7B"]:
+        if base_model_name in ["Qwen2.5-7B", "Qwen2.5-VL-7B"]:
             logger.info(
                 f"Model {model_name} is degraded under standard high-performance settings, using BF16 attention and BFP8 MLP"
             )

--- a/tests/tt_metal/tt_metal/noc/sources.cmake
+++ b/tests/tt_metal/tt_metal/noc/sources.cmake
@@ -1,4 +1,7 @@
 # Source files for tt_metal noc tests
 # Module owners should update this file when adding/removing/renaming source files
 
-set(UNIT_TESTS_NOC_SRC test_dynamic_noc.cpp)
+set(UNIT_TESTS_NOC_SRC
+    test_dynamic_noc.cpp
+    test_optimal_dram_workers.cpp
+)

--- a/tests/tt_metal/tt_metal/noc/test_optimal_dram_workers.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_optimal_dram_workers.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include "impl/context/metal_context.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+// Regression coverage for issue #41031, fixed in PR #42819.
+//
+// get_optimal_dram_bank_to_logical_worker_assignment returns one Tensix worker core per
+// DRAM bank. This test asserts the two invariants the API guarantees:
+//   * Cardinality: the returned vector size equals the DRAM grid size (one core per bank).
+//   * Validity: every returned (x, y) is inside compute_with_storage_grid_size(). That
+//     grid is the logical Tensix worker grid (it already excludes harvested rows and
+//     dispatch columns), so an in-grid logical core is by construction a valid worker.
+//
+// Parameterised over the dispatch axes supported on the current arch. Slow- vs
+// fast-dispatch coverage is provided by CI invoking this binary twice (with/without
+// TT_METAL_SLOW_DISPATCH_MODE).
+class OptimalDramWorkers : public ::testing::TestWithParam<DispatchCoreAxis> {};
+
+// Resolved at static-init from the ARCH_NAME env var (set by build/test scripts), so
+// gtest enumeration only lists axes that the platform actually supports — no runtime
+// skips appear in the test output.
+//
+// Blackhole rejects ROW dispatch (see ttnn::Device guard:
+// "ROW dispatch core axis is not supported for blackhole arch"), so we omit ROW on BH.
+static std::vector<DispatchCoreAxis> supported_dispatch_axes() {
+    std::vector<DispatchCoreAxis> axes = {DispatchCoreAxis::COL};
+    const char* arch = std::getenv("ARCH_NAME");
+    if (arch == nullptr || std::string(arch) != "blackhole") {
+        axes.push_back(DispatchCoreAxis::ROW);
+    }
+    return axes;
+}
+
+TEST_P(OptimalDramWorkers, ReturnsOneValidWorkerPerDramBank) {
+    const DispatchCoreAxis axis = GetParam();
+    const DispatchCoreConfig cfg{DispatchCoreType::WORKER, axis};
+
+    const auto& ids_set = MetalContext::instance().get_cluster().user_exposed_chip_ids();
+    if (ids_set.empty()) {
+        GTEST_SKIP() << "No user-exposed chips available";
+    }
+    std::vector<int> ids(ids_set.begin(), ids_set.end());
+
+    auto devs = distributed::MeshDevice::create_unit_meshes(
+        ids, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, /*num_command_queues=*/1, cfg);
+
+    for (auto& [chip_id, dev] : devs) {
+        const CoreCoord grid = dev->compute_with_storage_grid_size();
+        const CoreCoord dram_grid = dev->dram_grid_size();
+        const size_t expected_banks = static_cast<size_t>(dram_grid.x) * dram_grid.y;
+
+        for (NOC noc : {NOC::NOC_0, NOC::NOC_1}) {
+            const auto cores = dev->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+
+            EXPECT_EQ(cores.size(), expected_banks)
+                << "Device " << chip_id << ", NOC " << static_cast<int>(noc) << ": expected " << expected_banks
+                << " optimal worker cores (one per DRAM bank), got " << cores.size();
+
+            for (size_t i = 0; i < cores.size(); ++i) {
+                const CoreCoord& c = cores[i];
+                EXPECT_LT(c.x, grid.x) << "Device " << chip_id << ", NOC " << static_cast<int>(noc) << ", DRAM bank "
+                                       << i << ": optimal worker core (" << c.x << ", " << c.y
+                                       << ") x is outside compute grid (" << grid.x << ", " << grid.y << ")";
+                EXPECT_LT(c.y, grid.y) << "Device " << chip_id << ", NOC " << static_cast<int>(noc) << ", DRAM bank "
+                                       << i << ": optimal worker core (" << c.x << ", " << c.y
+                                       << ") y is outside compute grid (" << grid.x << ", " << grid.y << ")";
+            }
+        }
+    }
+
+    for (auto& [_, dev] : devs) {
+        dev->close();
+        dev.reset();
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DispatchAxes,
+    OptimalDramWorkers,
+    ::testing::ValuesIn(supported_dispatch_axes()),
+    [](const ::testing::TestParamInfo<DispatchCoreAxis>& info) {
+        return info.param == DispatchCoreAxis::ROW ? "Row" : "Col";
+    });
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/noc/test_optimal_dram_workers.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_optimal_dram_workers.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
+#include "llrt/tt_cluster.hpp"
 
 namespace tt::tt_metal {
 namespace {
@@ -43,7 +44,7 @@ class OptimalDramWorkers : public ::testing::TestWithParam<DispatchCoreAxis> {};
 //
 // Blackhole rejects ROW dispatch (see ttnn::Device guard:
 // "ROW dispatch core axis is not supported for blackhole arch"), so we omit ROW on BH.
-static std::vector<DispatchCoreAxis> supported_dispatch_axes() {
+std::vector<DispatchCoreAxis> supported_dispatch_axes() {
     std::vector<DispatchCoreAxis> axes = {DispatchCoreAxis::COL};
     const char* arch = std::getenv("ARCH_NAME");
     if (arch == nullptr || std::string(arch) != "blackhole") {

--- a/tests/tt_metal/tt_metal/noc/test_optimal_dram_workers.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_optimal_dram_workers.cpp
@@ -42,7 +42,7 @@ class OptimalDramWorkers : public ::testing::TestWithParam<DispatchCoreAxis> {};
 // gtest enumeration only lists axes that the platform actually supports — no runtime
 // skips appear in the test output.
 //
-// Blackhole rejects ROW dispatch (see ttnn::Device guard:
+// Blackhole rejects ROW dispatch (the Device guard emits
 // "ROW dispatch core axis is not supported for blackhole arch"), so we omit ROW on BH.
 std::vector<DispatchCoreAxis> supported_dispatch_axes() {
     std::vector<DispatchCoreAxis> axes = {DispatchCoreAxis::COL};

--- a/tests/ttnn/unit_tests/base_functionality/test_get_optimal_worker_cores_for_sharded_tensor.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_get_optimal_worker_cores_for_sharded_tensor.py
@@ -905,3 +905,30 @@ def test_get_optimal_worker_cores_for_sharded_tensor_rejects_interleaved_tensor(
 
     with pytest.raises(RuntimeError, match="Tensor must be sharded to compute optimal worker cores"):
         ttnn.get_optimal_worker_cores_for_sharded_tensor(tt_tensor)
+
+
+# ============================================================================
+#  Optimal DRAM Worker Core Bounds Validation
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
+@pytest.mark.parametrize("noc", [ttnn.NOC.NOC_0, ttnn.NOC.NOC_1])
+def test_optimal_dram_workers_within_compute_grid(device, noc):
+    """
+    Validate that all cores returned by get_optimal_dram_bank_to_logical_worker_assignment
+    fall within the valid compute grid. Regression test for issue #41031 where column major
+    dispatch on harvested devices returned cores on the dispatch column.
+    """
+    compute_grid = device.compute_with_storage_grid_size()
+    optimal_workers = device.get_optimal_dram_bank_to_logical_worker_assignment(noc)
+
+    for i, core in enumerate(optimal_workers):
+        assert core.x < compute_grid.x and core.y < compute_grid.y, (
+            f"DRAM bank {i}: optimal worker core ({core.x}, {core.y}) is outside "
+            f"compute grid ({compute_grid.x}, {compute_grid.y})"
+        )

--- a/tests/ttnn/unit_tests/base_functionality/test_get_optimal_worker_cores_for_sharded_tensor.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_get_optimal_worker_cores_for_sharded_tensor.py
@@ -920,12 +920,25 @@ def test_get_optimal_worker_cores_for_sharded_tensor_rejects_interleaved_tensor(
 @pytest.mark.parametrize("noc", [ttnn.NOC.NOC_0, ttnn.NOC.NOC_1])
 def test_optimal_dram_workers_within_compute_grid(device, noc):
     """
-    Validate that all cores returned by get_optimal_dram_bank_to_logical_worker_assignment
-    fall within the valid compute grid. Regression test for issue #41031 where column major
-    dispatch on harvested devices returned cores on the dispatch column.
+    Validate that get_optimal_dram_bank_to_logical_worker_assignment returns one valid
+    worker core per DRAM bank, with every core inside the device's logical compute grid.
+
+    Since compute_with_storage_grid_size() is the logical Tensix worker grid (it already
+    excludes dispatch columns and harvested rows), an in-bounds logical core is by
+    construction a valid worker core.
+
+    Regression test for issue #41031, where column major dispatch on harvested Wormhole
+    devices returned cores on the dispatch column (e.g. (7, 2) on a 7x9 compute grid).
     """
     compute_grid = device.compute_with_storage_grid_size()
+    dram_grid = device.dram_grid_size()
+    expected_num_banks = dram_grid.x * dram_grid.y
+
     optimal_workers = device.get_optimal_dram_bank_to_logical_worker_assignment(noc)
+
+    assert len(optimal_workers) == expected_num_banks, (
+        f"Expected {expected_num_banks} optimal worker cores (one per DRAM bank), " f"got {len(optimal_workers)}"
+    )
 
     for i, core in enumerate(optimal_workers):
         assert core.x < compute_grid.x and core.y < compute_grid.y, (

--- a/tests/ttnn/unit_tests/base_functionality/test_get_optimal_worker_cores_for_sharded_tensor.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_get_optimal_worker_cores_for_sharded_tensor.py
@@ -890,20 +890,20 @@ def test_dram_nd_sharded_round_robin(device, tensor_shape, shard_shape, grid, or
     assert_cores_match(actual_cores, expected_cores)
 
 
-def test_get_optimal_worker_cores_for_sharded_tensor_rejects_host_tensor():
+def test_get_optimal_worker_cores_for_sharded_tensor_rejects_host_tensor(expect_error):
     torch_tensor = torch.randn([1, 1, 32, 64], dtype=torch.bfloat16)
     tt_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
 
-    with pytest.raises(RuntimeError, match="Tensor must be on device to compute optimal worker cores"):
+    with expect_error(RuntimeError, "Tensor must be on device to compute optimal worker cores"):
         ttnn.get_optimal_worker_cores_for_sharded_tensor(tt_tensor)
 
 
-def test_get_optimal_worker_cores_for_sharded_tensor_rejects_interleaved_tensor(device):
+def test_get_optimal_worker_cores_for_sharded_tensor_rejects_interleaved_tensor(device, expect_error):
     torch_tensor = torch.randn([1, 1, 32, 64], dtype=torch.bfloat16)
     tt_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_tensor = ttnn.to_device(tt_tensor, device)
 
-    with pytest.raises(RuntimeError, match="Tensor must be sharded to compute optimal worker cores"):
+    with expect_error(RuntimeError, "Tensor must be sharded to compute optimal worker cores"):
         ttnn.get_optimal_worker_cores_for_sharded_tensor(tt_tensor)
 
 

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -16,6 +16,7 @@ namespace tt::tt_metal {
 
 std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
     const std::vector<uint32_t>& non_worker_rows,
+    const std::vector<uint32_t>& non_worker_cols,
     const std::vector<CoreCoord>& dram_interface_workers,
     uint32_t num_dram_banks,
     uint32_t max_worker_y_physical,
@@ -96,12 +97,20 @@ std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
             if (std::find(non_worker_rows.begin(), non_worker_rows.end(), y) != non_worker_rows.end() ||
                 std::count(group_y.begin(), group_y.end(), y) >= 2) {
                 auto shift_coord_based_on_harvesting = [&](int start, int end, int step) {
+                    auto clamp_x_to_valid_col = [&]() {
+                        while (std::find(non_worker_cols.begin(), non_worker_cols.end(), coord.x) !=
+                                   non_worker_cols.end() &&
+                               coord.x > 0) {
+                            coord.x--;
+                        }
+                    };
                     bool found_new_row = false;
                     for (int j = start; step > 0 ? j <= end : j >= end; j += step) {
                         if (std::find(non_worker_rows.begin(), non_worker_rows.end(), j) == non_worker_rows.end() &&
                             std::count(group_y.begin(), group_y.end(), j) == 0) {
                             coord.y = j;
                             coord.x += x_step;
+                            clamp_x_to_valid_col();
                             x_step--;
                             found_new_row = true;
                             break;
@@ -112,6 +121,7 @@ std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
                             if (std::find(non_worker_rows.begin(), non_worker_rows.end(), j) == non_worker_rows.end()) {
                                 coord.y = j;
                                 coord.x += x_step;
+                                clamp_x_to_valid_col();
                                 x_step--;
                                 found_new_row = true;
                                 break;
@@ -169,7 +179,7 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
     std::vector<uint32_t> non_worker_cols;
     uint32_t max_worker_y_physical = 0;
     uint32_t min_worker_y_physical = std::numeric_limits<uint32_t>::max();
-    // For WH, rows are harvested. Track them here.
+    // For WH, rows are harvested. Track non-worker rows and non-worker columns (e.g. dispatch columns).
     if (arch == ARCH::WORMHOLE_B0) {
         for (int y_coord = 0; y_coord < full_grid_size_y; ++y_coord) {
             if (std::find(worker_phy_y.begin(), worker_phy_y.end(), y_coord) == worker_phy_y.end()) {
@@ -177,6 +187,11 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
             }
             max_worker_y_physical = std::max<uint32_t>(y_coord, max_worker_y_physical);
             min_worker_y_physical = std::min<uint32_t>(y_coord, min_worker_y_physical);
+        }
+        for (int x_coord = 0; x_coord < full_grid_size_x; ++x_coord) {
+            if (std::find(worker_phy_x.begin(), worker_phy_x.end(), x_coord) == worker_phy_x.end()) {
+                non_worker_cols.push_back(x_coord);
+            }
         }
     }
     std::vector<CoreCoord> dram_interface_workers;
@@ -197,13 +212,23 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
         } else {
             dram_core_y = dram_core.y;
         }
-        dram_interface_workers.push_back(CoreCoord(dram_core.x + 1, dram_core_y));
+        uint32_t worker_x = dram_core.x + 1;
+        while (std::find(non_worker_cols.begin(), non_worker_cols.end(), worker_x) != non_worker_cols.end() &&
+               worker_x < full_grid_size_x - 1) {
+            worker_x++;
+        }
+        dram_interface_workers.push_back(CoreCoord(worker_x, dram_core_y));
     }
 
     if (arch == ARCH::WORMHOLE_B0) {
-        // Reassign worker cores based on harvesting for WH.
+        // Reassign worker cores based on harvesting and non-worker columns (e.g. dispatch) for WH.
         return reassign_dram_interface_cores_for_wormhole(
-            non_worker_rows, dram_interface_workers, num_dram_banks, max_worker_y_physical, min_worker_y_physical);
+            non_worker_rows,
+            non_worker_cols,
+            dram_interface_workers,
+            num_dram_banks,
+            max_worker_y_physical,
+            min_worker_y_physical);
     }
     if (arch == ARCH::BLACKHOLE) {
         // Reassign worker cores based on harvesting for BH.

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -104,6 +104,14 @@ std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
                             coord.x--;
                         }
                     };
+                    // Saturating decrement: x_step is unsigned and the number of
+                    // shifts in pathological harvesting configurations could otherwise
+                    // wrap it to UINT32_MAX, producing out-of-grid coord.x values.
+                    auto decrement_x_step = [&]() {
+                        if (x_step > 0) {
+                            x_step--;
+                        }
+                    };
                     bool found_new_row = false;
                     for (int j = start; step > 0 ? j <= end : j >= end; j += step) {
                         if (std::find(non_worker_rows.begin(), non_worker_rows.end(), j) == non_worker_rows.end() &&
@@ -111,7 +119,7 @@ std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
                             coord.y = j;
                             coord.x += x_step;
                             clamp_x_to_valid_col();
-                            x_step--;
+                            decrement_x_step();
                             found_new_row = true;
                             break;
                         }
@@ -122,7 +130,7 @@ std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
                                 coord.y = j;
                                 coord.x += x_step;
                                 clamp_x_to_valid_col();
-                                x_step--;
+                                decrement_x_step();
                                 found_new_row = true;
                                 break;
                             }
@@ -217,6 +225,18 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
                worker_x < full_grid_size_x - 1) {
             worker_x++;
         }
+        // If walking right hit the boundary on a non-worker column (e.g. the rightmost
+        // column is the reserved dispatch column on harvested WH + COL dispatch), fall
+        // back to walking left to find the nearest valid worker column.
+        while (std::find(non_worker_cols.begin(), non_worker_cols.end(), worker_x) != non_worker_cols.end() &&
+               worker_x > 0) {
+            worker_x--;
+        }
+        TT_FATAL(
+            std::find(non_worker_cols.begin(), non_worker_cols.end(), worker_x) == non_worker_cols.end(),
+            "Could not find a valid worker column adjacent to DRAM core at physical (x={}, y={})",
+            dram_core.x,
+            dram_core.y);
         dram_interface_workers.push_back(CoreCoord(worker_x, dram_core_y));
     }
 

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -20,7 +20,8 @@ std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
     const std::vector<CoreCoord>& dram_interface_workers,
     uint32_t num_dram_banks,
     uint32_t max_worker_y_physical,
-    uint32_t min_worker_y_physical) {
+    uint32_t min_worker_y_physical,
+    uint32_t full_grid_size_x) {
     // Reassign optimally placed DRAM Interface worker cores based on harvesting for WH
     std::vector<CoreCoord> dram_interface_workers_g1;
     std::vector<CoreCoord> dram_interface_workers_g2;
@@ -98,6 +99,15 @@ std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
                 std::count(group_y.begin(), group_y.end(), y) >= 2) {
                 auto shift_coord_based_on_harvesting = [&](int start, int end, int step) {
                     auto clamp_x_to_valid_col = [&]() {
+                        // x_step shifts above can push coord.x past the right edge of
+                        // the physical grid. non_worker_cols only contains in-grid x
+                        // values, so the walk-left below alone would not bring such an
+                        // out-of-grid coord back in. Clamp to the rightmost in-grid
+                        // index first, then walk left past any reserved dispatch /
+                        // DRAM / harvested columns.
+                        if (full_grid_size_x > 0 && coord.x >= full_grid_size_x) {
+                            coord.x = full_grid_size_x - 1;
+                        }
                         while (std::find(non_worker_cols.begin(), non_worker_cols.end(), coord.x) !=
                                    non_worker_cols.end() &&
                                coord.x > 0) {
@@ -248,7 +258,8 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
             dram_interface_workers,
             num_dram_banks,
             max_worker_y_physical,
-            min_worker_y_physical);
+            min_worker_y_physical,
+            full_grid_size_x);
     }
     if (arch == ARCH::BLACKHOLE) {
         // Reassign worker cores based on harvesting for BH.

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -924,36 +924,24 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         worker_phy_x.reserve(num_cores_x);
         for (int i = 0; i < num_cores_x; ++i) {
             auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(i, 0));
-            worker_phy_x.at(i) = core_phy.x;
+            worker_phy_x.push_back(core_phy.x);
         }
         // Get optimal placement of worker cores interfacing with DRAM Controllers in physical coordinate space
         auto physical_worker_cores = get_optimal_dram_to_physical_worker_assignment(
             this->arch(), dram_phy_coords, full_grid_size_x, full_grid_size_y, worker_phy_x, worker_phy_y);
 
-        // Convert physical worker coordinates back to logical compute-grid coordinates by
-        // reversing the worker_phy_x / worker_phy_y mapping we built above. We deliberately
-        // avoid soc_desc.translate_coord_to(..., NOC0, LOGICAL) here: the SOC's LOGICAL space
-        // numbers every Tensix core (including the reserved dispatch column on COL dispatch
-        // and the harvested-row aware fold-down), whereas compute_with_storage_grid_size()
-        // exposes only the user-facing worker grid. Reversing through worker_phy_{x,y}
-        // guarantees the returned coord is in that user-facing grid, and TT_FATALs loudly
-        // if the placement algorithm ever produced a physical core outside it.
-        for (const auto& physical_worker_core : physical_worker_cores) {
-            auto x_it = std::find(worker_phy_x.begin(), worker_phy_x.end(), physical_worker_core.x);
-            auto y_it = std::find(worker_phy_y.begin(), worker_phy_y.end(), physical_worker_core.y);
-            TT_FATAL(
-                x_it != worker_phy_x.end() && y_it != worker_phy_y.end(),
-                "Optimal DRAM-worker placement produced physical core ({}, {}) which is not in "
-                "the compute_with_storage_grid_size logical worker grid ({}, {}). This indicates "
-                "a bug in get_optimal_dram_to_physical_worker_assignment landing on a reserved "
-                "dispatch / harvested / out-of-grid core.",
-                physical_worker_core.x,
-                physical_worker_core.y,
-                num_cores_x,
-                num_cores_y);
-            uint32_t logical_x = static_cast<uint32_t>(std::distance(worker_phy_x.begin(), x_it));
-            uint32_t logical_y = static_cast<uint32_t>(std::distance(worker_phy_y.begin(), y_it));
-            this->optimal_dram_bank_to_logical_worker_assignment_.push_back(CoreCoord(logical_x, logical_y));
+        const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
+        // Convert to physical worker coordinates to logical. This gets returned to the user.
+        for (auto physical_worker_core : physical_worker_cores) {
+            tt::umd::CoreCoord logical_coord_translated =
+                soc_desc.translate_coord_to(physical_worker_core, CoordSystem::NOC0, CoordSystem::LOGICAL);
+            this->optimal_dram_bank_to_logical_worker_assignment_.push_back(
+                CoreCoord(logical_coord_translated.x, logical_coord_translated.y));
+            TT_ASSERT(
+                logical_coord_translated.core_type == CoreType::TENSIX,
+                "Worker dram interface core {} should be a Tensix core, algorithm to place DRAM interfacing workers is "
+                "invalid",
+                logical_coord_translated.str());
         }
     }
     return this->optimal_dram_bank_to_logical_worker_assignment_;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -924,7 +924,7 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         worker_phy_x.reserve(num_cores_x);
         for (int i = 0; i < num_cores_x; ++i) {
             auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(i, 0));
-            worker_phy_x.push_back(core_phy.x);
+            worker_phy_x.at(i) = core_phy.x;
         }
         // Get optimal placement of worker cores interfacing with DRAM Controllers in physical coordinate space
         auto physical_worker_cores = get_optimal_dram_to_physical_worker_assignment(

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -572,6 +572,9 @@ bool Device::close() {
     this->command_queue_programs_.clear();
     this->command_queues_.clear();
     this->sysmem_manager_.reset();
+    this->optimal_dram_bank_to_logical_worker_assignment_.clear();
+    this->optimal_dram_bank_to_logical_worker_assignment_noc_.reset();
+    this->optimal_dram_bank_to_logical_worker_assignment_grid_size_.reset();
 
     // Clean up shared memory stats provider
     this->shm_stats_provider_.reset();
@@ -877,16 +880,16 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
     // and passes them to logic in core_assignment.cpp to derive the most optimal core placement
     // based on architecture specific logic and Physical Grid configuration.
     const auto noc_tag = static_cast<std::uint8_t>(noc);
+    auto compute_with_storage_grid_size = this->compute_with_storage_grid_size();
     if (!this->optimal_dram_bank_to_logical_worker_assignment_.empty() &&
-        this->optimal_dram_bank_to_logical_worker_assignment_noc_ == noc_tag) {
+        this->optimal_dram_bank_to_logical_worker_assignment_noc_ == noc_tag &&
+        this->optimal_dram_bank_to_logical_worker_assignment_grid_size_ == compute_with_storage_grid_size) {
         return this->optimal_dram_bank_to_logical_worker_assignment_;
     }
     this->optimal_dram_bank_to_logical_worker_assignment_.clear();
 
     uint32_t full_grid_size_x = this->grid_size().x;
     uint32_t full_grid_size_y = this->grid_size().y;
-
-    auto compute_with_storage_grid_size = this->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     // Get physical coordinates of DRAM Controller NOC end-points
@@ -966,6 +969,7 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         this->optimal_dram_bank_to_logical_worker_assignment_.push_back(CoreCoord(logical_x, logical_y));
     }
     this->optimal_dram_bank_to_logical_worker_assignment_noc_ = noc_tag;
+    this->optimal_dram_bank_to_logical_worker_assignment_grid_size_ = compute_with_storage_grid_size;
     return this->optimal_dram_bank_to_logical_worker_assignment_;
 }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -930,18 +930,30 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         auto physical_worker_cores = get_optimal_dram_to_physical_worker_assignment(
             this->arch(), dram_phy_coords, full_grid_size_x, full_grid_size_y, worker_phy_x, worker_phy_y);
 
-        const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
-        // Convert to physical worker coordinates to logical. This gets returned to the user.
-        for (auto physical_worker_core : physical_worker_cores) {
-            tt::umd::CoreCoord logical_coord_translated =
-                soc_desc.translate_coord_to(physical_worker_core, CoordSystem::NOC0, CoordSystem::LOGICAL);
-            this->optimal_dram_bank_to_logical_worker_assignment_.push_back(
-                CoreCoord(logical_coord_translated.x, logical_coord_translated.y));
-            TT_ASSERT(
-                logical_coord_translated.core_type == CoreType::TENSIX,
-                "Worker dram interface core {} should be a Tensix core, algorithm to place DRAM interfacing workers is "
-                "invalid",
-                logical_coord_translated.str());
+        // Convert physical worker coordinates back to logical compute-grid coordinates by
+        // reversing the worker_phy_x / worker_phy_y mapping we built above. We deliberately
+        // avoid soc_desc.translate_coord_to(..., NOC0, LOGICAL) here: the SOC's LOGICAL space
+        // numbers every Tensix core (including the reserved dispatch column on COL dispatch
+        // and the harvested-row aware fold-down), whereas compute_with_storage_grid_size()
+        // exposes only the user-facing worker grid. Reversing through worker_phy_{x,y}
+        // guarantees the returned coord is in that user-facing grid, and TT_FATALs loudly
+        // if the placement algorithm ever produced a physical core outside it.
+        for (const auto& physical_worker_core : physical_worker_cores) {
+            auto x_it = std::find(worker_phy_x.begin(), worker_phy_x.end(), physical_worker_core.x);
+            auto y_it = std::find(worker_phy_y.begin(), worker_phy_y.end(), physical_worker_core.y);
+            TT_FATAL(
+                x_it != worker_phy_x.end() && y_it != worker_phy_y.end(),
+                "Optimal DRAM-worker placement produced physical core ({}, {}) which is not in "
+                "the compute_with_storage_grid_size logical worker grid ({}, {}). This indicates "
+                "a bug in get_optimal_dram_to_physical_worker_assignment landing on a reserved "
+                "dispatch / harvested / out-of-grid core.",
+                physical_worker_core.x,
+                physical_worker_core.y,
+                num_cores_x,
+                num_cores_y);
+            uint32_t logical_x = static_cast<uint32_t>(std::distance(worker_phy_x.begin(), x_it));
+            uint32_t logical_y = static_cast<uint32_t>(std::distance(worker_phy_y.begin(), y_it));
+            this->optimal_dram_bank_to_logical_worker_assignment_.push_back(CoreCoord(logical_x, logical_y));
         }
     }
     return this->optimal_dram_bank_to_logical_worker_assignment_;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -876,82 +876,96 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
     // This function queries Physical Coordinates (only exposed directly to the Device class)
     // and passes them to logic in core_assignment.cpp to derive the most optimal core placement
     // based on architecture specific logic and Physical Grid configuration.
-    if (this->optimal_dram_bank_to_logical_worker_assignment_.empty()) {
-        uint32_t full_grid_size_x = this->grid_size().x;
-        uint32_t full_grid_size_y = this->grid_size().y;
-
-        auto compute_with_storage_grid_size = this->compute_with_storage_grid_size();
-        uint32_t num_cores_x = compute_with_storage_grid_size.x;
-        uint32_t num_cores_y = compute_with_storage_grid_size.y;
-        // Get physical coordinates of DRAM Controller NOC end-points
-        uint32_t num_dram_banks = this->num_dram_channels();
-
-        const auto& hal = MetalEnvAccessor(*env_).impl().get_hal();
-        bool noc_translation_enabled = true;
-        if (!MetalEnvAccessor(*env_).impl().get_cluster().is_mock_or_emulated()) {
-            noc_translation_enabled =
-                MetalEnvAccessor(*env_).impl().get_cluster().get_cluster_desc()->get_noc_translation_table_en().at(
-                    this->id());
-        }
-        bool dram_is_virtualized =
-            noc_translation_enabled && (hal.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM));
-        const metal_SocDescriptor& soc_d = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id());
-        std::vector<CoreCoord> dram_phy_coords;
-        for (int i = 0; i < num_dram_banks; ++i) {
-            auto dram_core = this->dram_core_from_dram_channel(i, noc);
-            if (dram_is_virtualized) {
-                tt::umd::CoreCoord umd_dram_coord = soc_d.translate_coord_to(
-                    tt_xy_pair(dram_core.x, dram_core.y), CoordSystem::TRANSLATED, CoordSystem::NOC0);
-                dram_core = CoreCoord(umd_dram_coord.x, umd_dram_coord.y);
-            }
-            dram_phy_coords.push_back(dram_core);
-        }
-        // Get all logical cores in the worker grid
-        std::vector<CoreCoord> all_worker_cores_logical;
-        for (int i = 0; i < num_cores_x; ++i) {
-            for (int j = 0; j < num_cores_y; ++j) {
-                all_worker_cores_logical.push_back(CoreCoord(i, j));
-            }
-        }
-        // Get the physical rows and cols  (y, x) in the worker grid
-        std::vector<uint32_t> worker_phy_y;
-        worker_phy_y.reserve(num_cores_y);
-        for (int i = 0; i < num_cores_y; ++i) {
-            auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(0, i));
-            worker_phy_y.push_back(core_phy.y);
-        }
-        std::vector<uint32_t> worker_phy_x;
-        worker_phy_x.reserve(num_cores_x);
-        for (int i = 0; i < num_cores_x; ++i) {
-            auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(i, 0));
-            worker_phy_x.push_back(core_phy.x);
-        }
-        // Get optimal placement of worker cores interfacing with DRAM Controllers in physical coordinate space
-        auto physical_worker_cores = get_optimal_dram_to_physical_worker_assignment(
-            this->arch(), dram_phy_coords, full_grid_size_x, full_grid_size_y, worker_phy_x, worker_phy_y);
-
-        // Convert physical worker coordinates back to compute-grid logical coordinates by
-        // reversing the worker_phy_{x,y} mapping. soc_desc.translate_coord_to(NOC0, LOGICAL)
-        // numbers every Tensix core including the reserved dispatch column, which can yield
-        // a logical x equal to compute_with_storage_grid_size().x on harvested WH + COL
-        // dispatch. Reversing through worker_phy_{x,y} guarantees the returned coord is in
-        // the user-facing worker grid.
-        for (const auto& physical_worker_core : physical_worker_cores) {
-            auto x_it = std::find(worker_phy_x.begin(), worker_phy_x.end(), physical_worker_core.x);
-            auto y_it = std::find(worker_phy_y.begin(), worker_phy_y.end(), physical_worker_core.y);
-            TT_FATAL(
-                x_it != worker_phy_x.end() && y_it != worker_phy_y.end(),
-                "Optimal DRAM-worker placement produced physical core ({}, {}) outside the "
-                "compute_with_storage_grid_size worker grid ({}, {})",
-                physical_worker_core.x,
-                physical_worker_core.y,
-                num_cores_x,
-                num_cores_y);
-            uint32_t logical_x = static_cast<uint32_t>(std::distance(worker_phy_x.begin(), x_it));
-            uint32_t logical_y = static_cast<uint32_t>(std::distance(worker_phy_y.begin(), y_it));
-            this->optimal_dram_bank_to_logical_worker_assignment_.push_back(CoreCoord(logical_x, logical_y));
-        }
+    const auto noc_tag = static_cast<std::uint8_t>(noc);
+    if (!this->optimal_dram_bank_to_logical_worker_assignment_.empty() &&
+        this->optimal_dram_bank_to_logical_worker_assignment_noc_ == noc_tag) {
+        return this->optimal_dram_bank_to_logical_worker_assignment_;
     }
+    this->optimal_dram_bank_to_logical_worker_assignment_.clear();
+
+    uint32_t full_grid_size_x = this->grid_size().x;
+    uint32_t full_grid_size_y = this->grid_size().y;
+
+    auto compute_with_storage_grid_size = this->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    // Get physical coordinates of DRAM Controller NOC end-points
+    uint32_t num_dram_banks = this->num_dram_channels();
+
+    const auto& hal = MetalEnvAccessor(*env_).impl().get_hal();
+    bool noc_translation_enabled = true;
+    if (!MetalEnvAccessor(*env_).impl().get_cluster().is_mock_or_emulated()) {
+        noc_translation_enabled =
+            MetalEnvAccessor(*env_).impl().get_cluster().get_cluster_desc()->get_noc_translation_table_en().at(
+                this->id());
+    }
+    bool dram_is_virtualized =
+        noc_translation_enabled && (hal.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM));
+    const metal_SocDescriptor& soc_d = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id());
+    std::vector<CoreCoord> dram_phy_coords;
+    for (int i = 0; i < num_dram_banks; ++i) {
+        auto dram_core = this->dram_core_from_dram_channel(i, noc);
+        if (dram_is_virtualized) {
+            tt::umd::CoreCoord umd_dram_coord = soc_d.translate_coord_to(
+                tt_xy_pair(dram_core.x, dram_core.y), CoordSystem::TRANSLATED, CoordSystem::NOC0);
+            dram_core = CoreCoord(umd_dram_coord.x, umd_dram_coord.y);
+        }
+        dram_phy_coords.push_back(dram_core);
+    }
+    // Physical NOC0 x/y for each logical worker column/row in compute_with_storage_grid_size() (used by placement).
+    std::vector<uint32_t> worker_phy_y;
+    worker_phy_y.reserve(num_cores_y);
+    for (int i = 0; i < num_cores_y; ++i) {
+        auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(0, i));
+        worker_phy_y.push_back(core_phy.y);
+    }
+    std::vector<uint32_t> worker_phy_x;
+    worker_phy_x.reserve(num_cores_x);
+    for (int i = 0; i < num_cores_x; ++i) {
+        auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(i, 0));
+        worker_phy_x.push_back(core_phy.x);
+    }
+    // Get optimal placement of worker cores interfacing with DRAM Controllers in physical coordinate space
+    auto physical_worker_cores = get_optimal_dram_to_physical_worker_assignment(
+        this->arch(), dram_phy_coords, full_grid_size_x, full_grid_size_y, worker_phy_x, worker_phy_y);
+
+    // Map each physical placement to the unique logical worker in compute_with_storage_grid_size().
+    // Do not use soc_desc.translate_coord_to(NOC0, LOGICAL): that numbers all Tensix cores including
+    // dispatch columns. Also do not split x/y lookups via worker_phy_x/y alone: (phys_x, phys_y) must
+    // match physical_worker_core_from_logical_core((lx, ly)) as a pair.
+    for (const auto& physical_worker_core : physical_worker_cores) {
+        bool found = false;
+        uint32_t logical_x = 0;
+        uint32_t logical_y = 0;
+        for (uint32_t ly = 0; ly < num_cores_y && !found; ++ly) {
+            for (uint32_t lx = 0; lx < num_cores_x; ++lx) {
+                const auto phy = this->physical_worker_core_from_logical_core(CoreCoord(lx, ly));
+                if (phy.x == physical_worker_core.x && phy.y == physical_worker_core.y) {
+                    logical_x = lx;
+                    logical_y = ly;
+                    found = true;
+                    break;
+                }
+            }
+        }
+        TT_FATAL(
+            found,
+            "Optimal DRAM-worker placement produced physical core ({}, {}) that does not map to any logical "
+            "worker in compute_with_storage_grid_size ({}, {})",
+            physical_worker_core.x,
+            physical_worker_core.y,
+            num_cores_x,
+            num_cores_y);
+        TT_FATAL(
+            logical_x < num_cores_x && logical_y < num_cores_y,
+            "Optimal DRAM worker logical core ({}, {}) is outside compute_with_storage_grid_size ({}, {})",
+            logical_x,
+            logical_y,
+            num_cores_x,
+            num_cores_y);
+        this->optimal_dram_bank_to_logical_worker_assignment_.push_back(CoreCoord(logical_x, logical_y));
+    }
+    this->optimal_dram_bank_to_logical_worker_assignment_noc_ = noc_tag;
     return this->optimal_dram_bank_to_logical_worker_assignment_;
 }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -930,18 +930,26 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         auto physical_worker_cores = get_optimal_dram_to_physical_worker_assignment(
             this->arch(), dram_phy_coords, full_grid_size_x, full_grid_size_y, worker_phy_x, worker_phy_y);
 
-        const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
-        // Convert to physical worker coordinates to logical. This gets returned to the user.
-        for (auto physical_worker_core : physical_worker_cores) {
-            tt::umd::CoreCoord logical_coord_translated =
-                soc_desc.translate_coord_to(physical_worker_core, CoordSystem::NOC0, CoordSystem::LOGICAL);
-            this->optimal_dram_bank_to_logical_worker_assignment_.push_back(
-                CoreCoord(logical_coord_translated.x, logical_coord_translated.y));
-            TT_ASSERT(
-                logical_coord_translated.core_type == CoreType::TENSIX,
-                "Worker dram interface core {} should be a Tensix core, algorithm to place DRAM interfacing workers is "
-                "invalid",
-                logical_coord_translated.str());
+        // Convert physical worker coordinates back to compute-grid logical coordinates by
+        // reversing the worker_phy_{x,y} mapping. soc_desc.translate_coord_to(NOC0, LOGICAL)
+        // numbers every Tensix core including the reserved dispatch column, which can yield
+        // a logical x equal to compute_with_storage_grid_size().x on harvested WH + COL
+        // dispatch. Reversing through worker_phy_{x,y} guarantees the returned coord is in
+        // the user-facing worker grid.
+        for (const auto& physical_worker_core : physical_worker_cores) {
+            auto x_it = std::find(worker_phy_x.begin(), worker_phy_x.end(), physical_worker_core.x);
+            auto y_it = std::find(worker_phy_y.begin(), worker_phy_y.end(), physical_worker_core.y);
+            TT_FATAL(
+                x_it != worker_phy_x.end() && y_it != worker_phy_y.end(),
+                "Optimal DRAM-worker placement produced physical core ({}, {}) outside the "
+                "compute_with_storage_grid_size worker grid ({}, {})",
+                physical_worker_core.x,
+                physical_worker_core.y,
+                num_cores_x,
+                num_cores_y);
+            uint32_t logical_x = static_cast<uint32_t>(std::distance(worker_phy_x.begin(), x_it));
+            uint32_t logical_y = static_cast<uint32_t>(std::distance(worker_phy_y.begin(), y_it));
+            this->optimal_dram_bank_to_logical_worker_assignment_.push_back(CoreCoord(logical_x, logical_y));
         }
     }
     return this->optimal_dram_bank_to_logical_worker_assignment_;

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <unordered_set>
 
 #include <tt-metalium/device.hpp>
@@ -254,6 +255,8 @@ private:
     std::set<CoreCoord> storage_only_cores_;
     std::set<CoreCoord> ethernet_cores_;
     std::vector<CoreCoord> optimal_dram_bank_to_logical_worker_assignment_;
+    // Cached assignment is NOC-specific (DRAM endpoints differ per NOC).
+    std::optional<std::uint8_t> optimal_dram_bank_to_logical_worker_assignment_noc_;
 
     std::vector<int32_t> dram_bank_offset_map_;
     std::vector<int32_t> l1_bank_offset_map_;

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -255,8 +255,10 @@ private:
     std::set<CoreCoord> storage_only_cores_;
     std::set<CoreCoord> ethernet_cores_;
     std::vector<CoreCoord> optimal_dram_bank_to_logical_worker_assignment_;
-    // Cached assignment is NOC-specific (DRAM endpoints differ per NOC).
+    // Cached assignment is NOC-specific (DRAM endpoints differ per NOC) and compute-grid-specific
+    // (dispatch axis / harvesting change logical worker bounds).
     std::optional<std::uint8_t> optimal_dram_bank_to_logical_worker_assignment_noc_;
+    std::optional<CoreCoord> optimal_dram_bank_to_logical_worker_assignment_grid_size_;
 
     std::vector<int32_t> dram_bank_offset_map_;
     std::vector<int32_t> l1_bank_offset_map_;


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/41031

### Problem
`get_optimal_dram_bank_to_logical_worker_assignment` returns invalid worker cores on harvested Wormhole devices (N150/N300) when using column major dispatch. The harvesting reassignment in `reassign_dram_interface_cores_for_wormhole` shifts `coord.x += x_step` without checking whether the resulting physical column is reserved for dispatch, causing cores like `(x=7, y=2)` to be returned on a 7x9 compute grid.

Additionally, `worker_phy_x` in `device.cpp` was incorrectly populated using `push_back` on a pre-sized vector, producing `2*N` entries with leading zeros.

### Changes
- **`tt_metal/impl/device/device.cpp`**: Fix `worker_phy_x` initialization (`push_back` → `.at(i) =`)
- **`tt_metal/common/core_assignment.cpp`**:
  - Compute `non_worker_cols` for WH from `worker_phy_x` (same pattern BH already uses)
  - Validate initial DRAM worker placement against non-worker columns
  - Clamp `coord.x` to valid worker columns after harvesting shifts

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-optimal-dram-workers-col-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-optimal-dram-workers-col-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-optimal-dram-workers-col-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-optimal-dram-workers-col-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-optimal-dram-workers-col-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/fix-optimal-dram-workers-col-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-optimal-dram-workers-col-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-optimal-dram-workers-col-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-optimal-dram-workers-col-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-optimal-dram-workers-col-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-optimal-dram-workers-col-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-optimal-dram-workers-col-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-optimal-dram-workers-col-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-optimal-dram-workers-col-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-optimal-dram-workers-col-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-optimal-dram-workers-col-dispatch)