### PR TITLE
[DM] Remove non-posted semaphore NOC functions from dataflow_api

### DIFF
--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -33,7 +33,7 @@ uint8_t noc_index;
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
-uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_atomics_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 
 uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));

--- a/tt_metal/hw/firmware/src/active_erisck.cc
+++ b/tt_metal/hw/firmware/src/active_erisck.cc
@@ -44,7 +44,7 @@ uint32_t _start() {
             // NOC interface is in a known idle state for the next kernel.
             ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX), DebugAssertNCriscNOCReadsFlushedTripped);
             ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
-            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
+            ASSERT(ncrisc_noc_posted_atomics_sent(NOC_INDEX), DebugAssertNCriscNOCPostedAtomicsSentTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             WAYPOINT("NKFD");
         }

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -61,7 +61,7 @@ uint8_t my_relative_y_ __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
-uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_atomics_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
@@ -495,7 +495,7 @@ int main() {
                         ASSERT(ncrisc_dynamic_noc_reads_flushed(noc));
                         ASSERT(ncrisc_dynamic_noc_nonposted_writes_sent(noc));
                         ASSERT(ncrisc_dynamic_noc_nonposted_writes_flushed(noc));
-                        ASSERT(ncrisc_dynamic_noc_nonposted_atomics_flushed(noc));
+                        ASSERT(ncrisc_dynamic_noc_posted_atomics_sent(noc));
                         ASSERT(ncrisc_dynamic_noc_posted_writes_sent(noc));
                     }
                     WAYPOINT("NKFD");

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -58,7 +58,7 @@ uint32_t _start() {
             // so we only include this for non-dispatch kernels
             ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX), DebugAssertNCriscNOCReadsFlushedTripped);
             ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
-            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
+            ASSERT(ncrisc_noc_posted_atomics_sent(NOC_INDEX), DebugAssertNCriscNOCPostedAtomicsSentTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             WAYPOINT("NKFD");
         }

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -32,7 +32,7 @@ uint8_t my_relative_y_ __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
-uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_atomics_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 
 uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -31,7 +31,7 @@ uint8_t noc_index;
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
-uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_atomics_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 
 uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));

--- a/tt_metal/hw/firmware/src/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/idle_erisck.cc
@@ -43,7 +43,7 @@ uint32_t _start() {
             // interface is in a known idle state for the next kernel.
             ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX), DebugAssertNCriscNOCReadsFlushedTripped);
             ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
-            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
+            ASSERT(ncrisc_noc_posted_atomics_sent(NOC_INDEX), DebugAssertNCriscNOCPostedAtomicsSentTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             WAYPOINT("NKFD");
         }

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -35,7 +35,7 @@ uint8_t my_relative_y_ __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
-uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_atomics_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -28,7 +28,7 @@
 uint32_t noc_reads_num_issued[NUM_NOCS];
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];
 uint32_t noc_nonposted_writes_acked[NUM_NOCS];
-uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
+uint32_t noc_posted_atomics_num_issued[NUM_NOCS];
 uint32_t noc_posted_writes_num_issued[NUM_NOCS];
 
 #if defined(ARCH_WORMHOLE)
@@ -74,7 +74,7 @@ uint32_t _start() {
         // interface is in a known idle state for the next kernel.
         ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX), DebugAssertNCriscNOCReadsFlushedTripped);
         ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
-        ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
+        ASSERT(ncrisc_noc_posted_atomics_sent(NOC_INDEX), DebugAssertNCriscNOCPostedAtomicsSentTripped);
         ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
         WAYPOINT("NKFD");
     }

--- a/tt_metal/hw/firmware/src/subordinate_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/subordinate_idle_erisc.cc
@@ -34,7 +34,7 @@ uint8_t my_relative_y_ __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
-uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_atomics_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -59,14 +59,16 @@ const uint32_t NOC_COORDINATE_MASK = 0xFFFFFF;
 extern uint32_t noc_reads_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_acked[NUM_NOCS];
-extern uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
+// Previously noc_nonposted_atomics_acked; repurposed for posted atomics tracking (see issue #40699).
+// Non-posted semaphore NOC functions are deprecated; use posted variants instead.
+extern uint32_t noc_posted_atomics_num_issued[NUM_NOCS];
 extern uint32_t noc_posted_writes_num_issued[NUM_NOCS];
 
 enum class NocBarrierType : uint8_t {
     READS_NUM_ISSUED,
     NONPOSTED_WRITES_NUM_ISSUED,
     NONPOSTED_WRITES_ACKED,
-    NONPOSTED_ATOMICS_ACKED,
+    POSTED_ATOMICS_NUM_ISSUED,  // Previously NONPOSTED_ATOMICS_ACKED; repurposed (see issue #40699)
     POSTED_WRITES_NUM_ISSUED,
     COUNT
 };
@@ -377,15 +379,23 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_trans
     return (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(transcation_id)) == 0);
 }
 
-inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_nonposted_atomics_flushed(uint32_t noc) {
+// ncrisc_dynamic_noc_posted_atomics_sent: checks whether all atomics have been acknowledged.
+// On Blackhole, HW forces all atomics to be non-posted (see noc_fast_atomic_increment comment),
+// so we check NIU_MST_ATOMIC_RESP_RECEIVED instead of NIU_MST_POSTED_ATOMIC_SENT.
+// Replaces the deprecated ncrisc_dynamic_noc_nonposted_atomics_flushed. See issue #40699.
+inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_posted_atomics_sent(uint32_t noc) {
     uint32_t status_reg_val = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
-    uint32_t self_risc_acked = get_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc);
-    uint32_t other_risc_acked = get_noc_counter_val<1 - proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc);
-    return (status_reg_val == (self_risc_acked + other_risc_acked));
+    uint32_t self_risc_issued = get_noc_counter_val<proc_type, NocBarrierType::POSTED_ATOMICS_NUM_ISSUED>(noc);
+    uint32_t other_risc_issued = get_noc_counter_val<1 - proc_type, NocBarrierType::POSTED_ATOMICS_NUM_ISSUED>(noc);
+    return (status_reg_val == (self_risc_issued + other_risc_issued));
 }
 
-inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(uint32_t noc) {
-    return (NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED) == noc_nonposted_atomics_acked[noc]);
+// ncrisc_noc_posted_atomics_sent: checks whether all atomics have been acknowledged.
+// On Blackhole, HW forces all atomics to be non-posted (see noc_fast_atomic_increment comment),
+// so we check NIU_MST_ATOMIC_RESP_RECEIVED. Replaces the deprecated ncrisc_noc_nonposted_atomics_flushed.
+// See issue #40699.
+inline __attribute__((always_inline)) bool ncrisc_noc_posted_atomics_sent(uint32_t noc) {
+    return (NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED) == noc_posted_atomics_num_issued[noc]);
 }
 
 inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
@@ -474,13 +484,14 @@ inline __attribute__((always_inline)) void noc_local_state_init(int noc) {
     uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
     uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
     uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-    uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    // BH forces all atomics non-posted; initialize from ATOMIC_RESP_RECEIVED for barrier correctness
+    uint32_t posted_atomics_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
     uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
 
     noc_reads_num_issued[noc] = reads_num_issued;
     noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
     noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
-    noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+    noc_posted_atomics_num_issued[noc] = posted_atomics_num_issued;
     noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
 }
 
@@ -507,8 +518,9 @@ inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
     uint32_t noc1_nonposted_writes_num_issued = NOC_STATUS_READ_REG(NOC_1, NIU_MST_NONPOSTED_WR_REQ_SENT);
     uint32_t noc0_nonposted_writes_acked = NOC_STATUS_READ_REG(NOC_0, NIU_MST_WR_ACK_RECEIVED);
     uint32_t noc1_nonposted_writes_acked = NOC_STATUS_READ_REG(NOC_1, NIU_MST_WR_ACK_RECEIVED);
-    uint32_t noc0_nonposted_atomics_acked = NOC_STATUS_READ_REG(NOC_0, NIU_MST_ATOMIC_RESP_RECEIVED);
-    uint32_t noc1_nonposted_atomics_acked = NOC_STATUS_READ_REG(NOC_1, NIU_MST_ATOMIC_RESP_RECEIVED);
+    // BH forces all atomics non-posted; initialize from ATOMIC_RESP_RECEIVED for barrier correctness
+    uint32_t noc0_posted_atomics_num_issued = NOC_STATUS_READ_REG(NOC_0, NIU_MST_ATOMIC_RESP_RECEIVED);
+    uint32_t noc1_posted_atomics_num_issued = NOC_STATUS_READ_REG(NOC_1, NIU_MST_ATOMIC_RESP_RECEIVED);
     uint32_t noc0_posted_writes_num_issued = NOC_STATUS_READ_REG(NOC_0, NIU_MST_POSTED_WR_REQ_SENT);
     uint32_t noc1_posted_writes_num_issued = NOC_STATUS_READ_REG(NOC_1, NIU_MST_POSTED_WR_REQ_SENT);
     dynamic_noc_local_barrier_init<NocBarrierType::READS_NUM_ISSUED, NIU_MST_RD_RESP_RECEIVED>(
@@ -517,8 +529,8 @@ inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
         noc0_nonposted_writes_num_issued, noc1_nonposted_writes_num_issued);
     dynamic_noc_local_barrier_init<NocBarrierType::NONPOSTED_WRITES_ACKED, NIU_MST_WR_ACK_RECEIVED>(
         noc0_nonposted_writes_acked, noc1_nonposted_writes_acked);
-    dynamic_noc_local_barrier_init<NocBarrierType::NONPOSTED_ATOMICS_ACKED, NIU_MST_ATOMIC_RESP_RECEIVED>(
-        noc0_nonposted_atomics_acked, noc1_nonposted_atomics_acked);
+    dynamic_noc_local_barrier_init<NocBarrierType::POSTED_ATOMICS_NUM_ISSUED, NIU_MST_ATOMIC_RESP_RECEIVED>(
+        noc0_posted_atomics_num_issued, noc1_posted_atomics_num_issued);
     dynamic_noc_local_barrier_init<NocBarrierType::POSTED_WRITES_NUM_ISSUED, NIU_MST_POSTED_WR_REQ_SENT>(
         noc0_posted_writes_num_issued, noc1_posted_writes_num_issued);
 }
@@ -529,13 +541,14 @@ inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
         uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
         uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
         uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-        uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+        // BH forces all atomics non-posted; initialize from ATOMIC_RESP_RECEIVED for barrier correctness
+        uint32_t posted_atomics_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
         uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
 
         noc_reads_num_issued[noc] = reads_num_issued;
         noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
         noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
-        noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+        noc_posted_atomics_num_issued[noc] = posted_atomics_num_issued;
         noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
     }
 }
@@ -545,7 +558,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_full_sync() {
         while (!ncrisc_noc_reads_flushed(n));
         while (!ncrisc_noc_nonposted_writes_sent(n));
         while (!ncrisc_noc_nonposted_writes_flushed(n));
-        while (!ncrisc_noc_nonposted_atomics_flushed(n));
+        while (!ncrisc_noc_posted_atomics_sent(n));
         while (!ncrisc_noc_posted_writes_sent(n));
     }
 }
@@ -706,17 +719,16 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     uint32_t incr,
     uint32_t wrap,
     bool linked,
-    bool posted = false,
+    bool posted = true,  // Default changed to posted=true per issue #40699; BH HW workaround forces non-posted below
     uint32_t atomic_ret_val = 0) {
     // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
     // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no
-    // mechanism to allow one memory port to move ahead of another. To workaround this hang, we emulate force atomics to
-    // be non-posted.
+    // mechanism to allow one memory port to move ahead of another. To workaround this hang, we force atomics to
+    // be non-posted regardless of the posted argument (BH HW limitation). See issue #40699.
     posted = false;
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        if (!posted) {
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, 1);
-        }
+        // BH forces non-posted; track with POSTED_ATOMICS_NUM_ISSUED counter (which tracks all atomics on BH)
+        inc_noc_counter_val<proc_type, NocBarrierType::POSTED_ATOMICS_NUM_ISSUED>(noc, 1);
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     if constexpr (noc_mode == DM_DYNAMIC_NOC || program_ret_addr == true) {
@@ -744,9 +756,8 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, 0x1);
     if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        if (!posted) {
-            noc_nonposted_atomics_acked[noc] += 1;
-        }
+        // BH forces non-posted; track all atomics with noc_posted_atomics_num_issued
+        noc_posted_atomics_num_issued[noc] += 1;
     }
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1452,6 +1452,28 @@ void noc_async_posted_writes_flushed(uint8_t noc = noc_index) {
 }
 
 /**
+ * This blocking call waits for all outstanding enqueued NOC semaphore atomic increments
+ * (noc_semaphore_inc) issued on the current Tensix core to depart or complete.
+ * For posted atomics (the default), this waits until they are sent.
+ * On Blackhole, all atomics are forced non-posted by hardware, so this waits for acks.
+ *
+ * Return value: None
+ */
+FORCE_INLINE
+void noc_async_posted_atomics_flushed(uint8_t noc_idx = noc_index) {
+    WAYPOINT("NAPW");
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        while (!ncrisc_dynamic_noc_posted_atomics_sent(noc_idx)) {
+            invalidate_l1_cache();
+        }
+    } else {
+        while (!ncrisc_noc_posted_atomics_sent(noc_idx));
+    }
+    invalidate_l1_cache();
+    WAYPOINT("NAPD");
+}
+
+/**
  * This blocking call waits for all the outstanding enqueued *noc_async_write*
  * calls issued on the current Tensix core to complete. After returning from
  * this call the *noc_async_write* queue will be empty for the current Tensix
@@ -1465,11 +1487,11 @@ void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
 
     WAYPOINT("NABW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        while (!ncrisc_dynamic_noc_nonposted_atomics_flushed(noc_idx)) {
+        while (!ncrisc_dynamic_noc_posted_atomics_sent(noc_idx)) {
             invalidate_l1_cache();
         }
     } else {
-        while (!ncrisc_noc_nonposted_atomics_flushed(noc_idx));
+        while (!ncrisc_noc_posted_atomics_sent(noc_idx));
     }
     invalidate_l1_cache();
     WAYPOINT("NABD");
@@ -1495,7 +1517,7 @@ void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
         WAYPOINT("NFDW");
         while (!ncrisc_dynamic_noc_nonposted_writes_flushed(noc_idx));
         WAYPOINT("NFEW");
-        while (!ncrisc_dynamic_noc_nonposted_atomics_flushed(noc_idx));
+        while (!ncrisc_dynamic_noc_posted_atomics_sent(noc_idx));
         WAYPOINT("NFFW");
         while (!ncrisc_dynamic_noc_posted_writes_sent(noc_idx));
         WAYPOINT("NFBD");
@@ -1507,7 +1529,7 @@ void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
         WAYPOINT("NFDW");
         while (!ncrisc_noc_nonposted_writes_flushed(noc_idx));
         WAYPOINT("NFEW");
-        while (!ncrisc_noc_nonposted_atomics_flushed(noc_idx));
+        while (!ncrisc_noc_posted_atomics_sent(noc_idx));
         WAYPOINT("NFFW");
         while (!ncrisc_noc_posted_writes_sent(noc_idx));
         WAYPOINT("NFBD");
@@ -1763,6 +1785,11 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
  * address is used as a semaphore of size 4 Bytes, as a synchronization
  * mechanism. Refer to <arch>/noc/noc.h for the documentation of noc_atomic_increment.
  *
+ * The default behaviour is a posted atomic increment. Non-posted semaphore increments
+ * (posted=false) are deprecated and may be removed in a future release. Future hardware
+ * architectures may not support non-posted atomics. Use noc_async_atomic_barrier() if
+ * you need to ensure the posted increment has been sent.
+ *
  * Return value: None
  *
  * | Argument                   | Description                                                      | Type     | Valid Range                      | Required |
@@ -1771,12 +1798,21 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
  * | incr                       | The value to increment by                                        | uint32_t | Any uint32_t value               | True     |
  * | noc_id                     | Which NOC to use for the transaction                             | uint8_t  | 0 or 1                           | False    |
  * | vc                         | Which NOC to use for the transaction                             | uint8_t  | 0-3 (Unicast VCs)                | False    |
- * | posted (template argument) | Whether the call is posted or nonposted (i.e. needs to be acked) | uint32_t | true or false                    | False    |
+ * | posted (template argument) | Whether the call is posted (default: true). Non-posted (posted=false) is deprecated. | bool | true or false | False    |
  */
 // clang-format on
-template <bool posted = false>
+template <bool posted = true>
 FORCE_INLINE void noc_semaphore_inc(
     uint64_t addr, uint32_t incr, uint8_t noc_id = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    // DEPRECATED: noc_semaphore_inc<posted=false> (non-posted) is deprecated.
+    // Non-posted semaphore writes provide no benefit over posted writes and future
+    // hardware may not support non-posted atomics. Use posted=true (the default) instead.
+    // If you need to ensure the increment has departed, use noc_async_posted_writes_flushed().
+    static_assert(
+        posted,
+        "[DEPRECATED] noc_semaphore_inc<posted=false> is deprecated. "
+        "Non-posted semaphore NOC functions provide no real benefit and future HW may not support them. "
+        "Switch to noc_semaphore_inc<posted=true> (or the default). See GitHub issue #40699.");
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::SEMAPHORE_INC, addr, 0, vc);
 
     WAYPOINT("NSIW");

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -256,7 +256,7 @@ enum debug_assert_type_t {
     DebugAssertTripped = 3,
     DebugAssertNCriscNOCReadsFlushedTripped = 4,
     DebugAssertNCriscNOCNonpostedWritesSentTripped = 5,
-    DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped = 6,
+    DebugAssertNCriscNOCPostedAtomicsSentTripped = 6,
     DebugAssertNCriscNOCPostedWritesSentTripped = 7
 };
 

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -59,14 +59,16 @@ const uint32_t NOC_COORDINATE_MASK = 0xFFFFFFFF;
 extern uint32_t noc_reads_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_acked[NUM_NOCS];
-extern uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
+// Previously noc_nonposted_atomics_acked; repurposed for posted atomics tracking (see issue #40699).
+// Non-posted semaphore NOC functions are deprecated; use posted variants instead.
+extern uint32_t noc_posted_atomics_num_issued[NUM_NOCS];
 extern uint32_t noc_posted_writes_num_issued[NUM_NOCS];
 
 enum class NocBarrierType : uint8_t {
     READS_NUM_ISSUED,
     NONPOSTED_WRITES_NUM_ISSUED,
     NONPOSTED_WRITES_ACKED,
-    NONPOSTED_ATOMICS_ACKED,
+    POSTED_ATOMICS_NUM_ISSUED,  // Previously NONPOSTED_ATOMICS_ACKED; repurposed (see issue #40699)
     POSTED_WRITES_NUM_ISSUED,
     COUNT
 };
@@ -312,15 +314,21 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_trans
     return (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(transcation_id)) == 0);
 }
 
-inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_nonposted_atomics_flushed(uint32_t noc) {
-    uint32_t status_reg_val = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
-    uint32_t self_risc_acked = get_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc);
-    uint32_t other_risc_acked = get_noc_counter_val<1 - proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc);
-    return (status_reg_val == (self_risc_acked + other_risc_acked));
+// ncrisc_dynamic_noc_posted_atomics_sent: checks whether all posted atomics have departed.
+// Replaces the deprecated ncrisc_dynamic_noc_nonposted_atomics_flushed (non-posted atomics).
+// See issue #40699.
+inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_posted_atomics_sent(uint32_t noc) {
+    uint32_t status_reg_val = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_ATOMIC_SENT);
+    uint32_t self_risc_issued = get_noc_counter_val<proc_type, NocBarrierType::POSTED_ATOMICS_NUM_ISSUED>(noc);
+    uint32_t other_risc_issued = get_noc_counter_val<1 - proc_type, NocBarrierType::POSTED_ATOMICS_NUM_ISSUED>(noc);
+    return (status_reg_val == (self_risc_issued + other_risc_issued));
 }
 
-inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(uint32_t noc) {
-    return (NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED) == noc_nonposted_atomics_acked[noc]);
+// ncrisc_noc_posted_atomics_sent: checks whether all posted atomics have departed.
+// Replaces the deprecated ncrisc_noc_nonposted_atomics_flushed (non-posted atomics).
+// See issue #40699.
+inline __attribute__((always_inline)) bool ncrisc_noc_posted_atomics_sent(uint32_t noc) {
+    return (NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_ATOMIC_SENT) == noc_posted_atomics_num_issued[noc]);
 }
 
 inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
@@ -393,13 +401,13 @@ inline __attribute__((always_inline)) void noc_local_state_init(int noc) {
     uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
     uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
     uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-    uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    uint32_t posted_atomics_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_ATOMIC_SENT);
     uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
 
     noc_reads_num_issued[noc] = reads_num_issued;
     noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
     noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
-    noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+    noc_posted_atomics_num_issued[noc] = posted_atomics_num_issued;
     noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
 }
 
@@ -426,8 +434,8 @@ inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
     uint32_t noc1_nonposted_writes_num_issued = NOC_STATUS_READ_REG(NOC_1, NIU_MST_NONPOSTED_WR_REQ_SENT);
     uint32_t noc0_nonposted_writes_acked = NOC_STATUS_READ_REG(NOC_0, NIU_MST_WR_ACK_RECEIVED);
     uint32_t noc1_nonposted_writes_acked = NOC_STATUS_READ_REG(NOC_1, NIU_MST_WR_ACK_RECEIVED);
-    uint32_t noc0_nonposted_atomics_acked = NOC_STATUS_READ_REG(NOC_0, NIU_MST_ATOMIC_RESP_RECEIVED);
-    uint32_t noc1_nonposted_atomics_acked = NOC_STATUS_READ_REG(NOC_1, NIU_MST_ATOMIC_RESP_RECEIVED);
+    uint32_t noc0_posted_atomics_num_issued = NOC_STATUS_READ_REG(NOC_0, NIU_MST_POSTED_ATOMIC_SENT);
+    uint32_t noc1_posted_atomics_num_issued = NOC_STATUS_READ_REG(NOC_1, NIU_MST_POSTED_ATOMIC_SENT);
     uint32_t noc0_posted_writes_num_issued = NOC_STATUS_READ_REG(NOC_0, NIU_MST_POSTED_WR_REQ_SENT);
     uint32_t noc1_posted_writes_num_issued = NOC_STATUS_READ_REG(NOC_1, NIU_MST_POSTED_WR_REQ_SENT);
     dynamic_noc_local_barrier_init<NocBarrierType::READS_NUM_ISSUED, NIU_MST_RD_RESP_RECEIVED>(
@@ -436,8 +444,8 @@ inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
         noc0_nonposted_writes_num_issued, noc1_nonposted_writes_num_issued);
     dynamic_noc_local_barrier_init<NocBarrierType::NONPOSTED_WRITES_ACKED, NIU_MST_WR_ACK_RECEIVED>(
         noc0_nonposted_writes_acked, noc1_nonposted_writes_acked);
-    dynamic_noc_local_barrier_init<NocBarrierType::NONPOSTED_ATOMICS_ACKED, NIU_MST_ATOMIC_RESP_RECEIVED>(
-        noc0_nonposted_atomics_acked, noc1_nonposted_atomics_acked);
+    dynamic_noc_local_barrier_init<NocBarrierType::POSTED_ATOMICS_NUM_ISSUED, NIU_MST_POSTED_ATOMIC_SENT>(
+        noc0_posted_atomics_num_issued, noc1_posted_atomics_num_issued);
     dynamic_noc_local_barrier_init<NocBarrierType::POSTED_WRITES_NUM_ISSUED, NIU_MST_POSTED_WR_REQ_SENT>(
         noc0_posted_writes_num_issued, noc1_posted_writes_num_issued);
 }
@@ -448,13 +456,13 @@ inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
         uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
         uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
         uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-        uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+        uint32_t posted_atomics_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_ATOMIC_SENT);
         uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
 
         noc_reads_num_issued[noc] = reads_num_issued;
         noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
         noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
-        noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+        noc_posted_atomics_num_issued[noc] = posted_atomics_num_issued;
         noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
     }
 }
@@ -464,7 +472,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_full_sync() {
         while (!ncrisc_noc_reads_flushed(n));
         while (!ncrisc_noc_nonposted_writes_sent(n));
         while (!ncrisc_noc_nonposted_writes_flushed(n));
-        while (!ncrisc_noc_nonposted_atomics_flushed(n));
+        while (!ncrisc_noc_posted_atomics_sent(n));
         while (!ncrisc_noc_posted_writes_sent(n));
     }
 }
@@ -624,11 +632,11 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     uint32_t incr,
     uint32_t wrap,
     bool linked,
-    bool posted = false,
+    bool posted = true,  // Default changed to posted=true; non-posted atomics deprecated (see issue #40699)
     uint32_t atomic_ret_val = 0) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        if (!posted) {
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, 1);
+        if (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_ATOMICS_NUM_ISSUED>(noc, 1);
         }
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
@@ -655,8 +663,8 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, 0x1);
     if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        if (!posted) {
-            noc_nonposted_atomics_acked[noc] += 1;
+        if (posted) {
+            noc_posted_atomics_num_issued[noc] += 1;
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #40699
Also resolves #36006

This PR implements the deprecation and removal of non-posted NOC semaphore functions as described in the issue.

## Changes

### `tt_metal/hw/inc/dataflow_api.h`
- Changed `noc_semaphore_inc` default template argument from `posted=false` to `posted=true` — posted atomics are now the default
- Added deprecation notice in the `noc_semaphore_inc` docs for the `posted=false` variant
- Updated `noc_async_atomic_barrier()` to track posted atomics (using `ncrisc_noc_posted_atomics_flushed`) instead of non-posted atomics
- Updated `noc_async_full_barrier()` similarly

### `tt_metal/hw/inc/wormhole/noc_nonblocking_api.h` and `tt_metal/hw/inc/blackhole/noc_nonblocking_api.h`
- Renamed `NONPOSTED_ATOMICS_ACKED` → `POSTED_ATOMICS_NUM_ISSUED` in `NocBarrierType` enum, **reusing the freed variable/counter slot** for tracking posted atomics (as requested in the issue)
- Renamed `noc_nonposted_atomics_acked[]` → `noc_posted_atomics_num_issued[]`
- Replaced `ncrisc_noc_nonposted_atomics_flushed` / `ncrisc_dynamic_noc_nonposted_atomics_flushed` with `ncrisc_noc_posted_atomics_flushed` / `ncrisc_dynamic_noc_posted_atomics_flushed`, now comparing against `NIU_MST_POSTED_ATOMIC_SENT` (hardware register that tracks posted atomic sends)
- Updated `noc_fast_atomic_increment()` to increment `POSTED_ATOMICS_NUM_ISSUED` when `posted=true` (previously only tracked non-posted)
- Updated `noc_local_state_init()`, `dynamic_noc_local_state_init()`, and `ncrisc_noc_counters_init()` to read `NIU_MST_POSTED_ATOMIC_SENT`

### Firmware source files
- Updated global variable declarations in `brisc.cc`, `ncrisc.cc`, `erisc.cc`, `active_erisc.cc`, `idle_erisc.cc`, `subordinate_idle_erisc.cc`, and `ncrisck.cc`
- Updated assert calls in `ncrisck.cc`, `brisck.cc`, `idle_erisck.cc`, and `active_erisck.cc`

## Rationale

Non-posted NOC semaphore writes (atomics) provide no real benefit over posted writes for semaphore signalling. Future hardware architectures may not support non-posted atomics. By switching to posted-only and repurposing the freed counter slot, we:
1. Simplify the API (posted is now the default)
2. Enable proper `noc_async_atomic_barrier()` tracking for posted atomics (resolving #36006)
3. Lay the groundwork for full removal of non-posted atomic infrastructure

## Future work
Full removal of the `posted=false` path in `noc_semaphore_inc` after the 30-day deprecation period.