### PR TITLE
docs: fix typos in comments and documentation

### DIFF
--- a/models/demos/llama3_70b_galaxy/README.md
+++ b/models/demos/llama3_70b_galaxy/README.md
@@ -101,7 +101,7 @@ It supports the following parameters:
 #### Mixing topologies in prefill ccl ops [Debug-Only]
 Please note that using line topology on a galaxy system might affect model accuracy. This functionality is for debug purposes only!
 
-When running `text_demo.py` on a machine with torus, all ops will by default use ring topology. To use line implementation of ops you can set enviroment variables:
+When running `text_demo.py` on a machine with torus, all ops will by default use ring topology. To use line implementation of ops you can set environment variables:
 
 - LINE_RS = 1: to use line for all ReduceScatter ops
 - LINE_AG = 1: use line for all AllGather ops

--- a/models/demos/multimodal/gemma3/tt/multi_modal_projector.py
+++ b/models/demos/multimodal/gemma3/tt/multi_modal_projector.py
@@ -1,6 +1,6 @@
 """
-This is the implmentation of MultiModalprojector for Gemma-3-4b-it model.
-There is no Independent MultiModalprojector support in TT-Transformers.
+This is the implementation of MultiModal Projector for Gemma-3-4b-it model.
+There is no Independent MultiModal Projector support in TT-Transformers.
 """
 
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.

--- a/models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py
+++ b/models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py
@@ -176,7 +176,7 @@ def run_decode(
 
     sampling_func = get_sampling_func(data_args.top_k, data_args.top_p, data_args.temperature)
 
-    # intialize continuous batching data structures
+    # initialize continuous batching data structures
     prompts_q = Queue()
     output_q = []
     for user_id, (p, t) in enumerate(zip(prompts, prompt_tokens)):

--- a/models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py
+++ b/models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py
@@ -196,7 +196,7 @@ def run_decode(
 
     sampling_func = get_sampling_func(data_args.top_k, data_args.top_p, data_args.temperature)
 
-    # intialize continuous batching data structures
+    # initialize continuous batching data structures
     prompts_q = Queue()
     output_q = []
     for user_id, (p, t) in enumerate(zip(prompts, prompt_tokens)):

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1001,7 +1001,7 @@ class Generator(WarmupForwardMixin):
             self.mode = Mode.DECODE
             mode_switched = True
 
-        # Switch to decode mode for prefetcher to reintialize sub devices
+        # Switch to decode mode for prefetcher to reinitialize sub devices
         for i in range(len(self.model)):
             self.model[i].switch_mode(Mode.DECODE)
 

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
@@ -51,7 +51,7 @@ def check_uniform_distribution(data, value_range=(0, 1), is_discrete=False):
     if min_val == max_val:
         return False
 
-    # torch ops don't suport integer data types, convert to list
+    # torch ops don't support integer data types, convert to list
     data = data.detach().cpu().flatten().tolist()
 
     # Calculate sample statistics


### PR DESCRIPTION
## Summary

This PR fixes a collection of spelling typos found in comments and documentation across the `models/` directory.

## Changes

| File | Typo | Fix |
|------|------|-----|
| `models/demos/multimodal/gemma3/tt/multi_modal_projector.py` | `implmentation` | `implementation` |
| `models/demos/multimodal/gemma3/tt/multi_modal_projector.py` | `MultiModalprojector` | `MultiModal Projector` |
| `models/demos/llama3_70b_galaxy/README.md` | `enviroment` | `environment` |
| `models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py` | `intialize` | `initialize` |
| `models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py` | `intialize` | `initialize` |
| `tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py` | `suport` | `support` |
| `models/tt_transformers/tt/generator.py` | `reintialize` | `reinitialize` |

## Testing

No functional changes — comments and documentation only. No tests required.