### PR TITLE
Named runtime args & uniform kernel arg retrieval for Metal 2.0 APIs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -99,8 +99,8 @@ inline ProgramRunParams::KernelRunParams MakeKernelRunParams(
     const std::vector<uint32_t>& common_args) {
     return ProgramRunParams::KernelRunParams{
         .kernel_spec_name = kernel_name,
-        .runtime_args = {{node, per_node_args}},
-        .common_runtime_args = common_args,
+        .runtime_varargs = {{node, per_node_args}},
+        .common_runtime_varargs = common_args,
     };
 }
 
@@ -130,8 +130,8 @@ TEST_F(ProgramRunParamsTestQuasar, UnknownKernelNameFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "nonexistent_kernel",
-        .runtime_args = {},
-        .common_runtime_args = {},
+        .runtime_varargs = {},
+        .common_runtime_varargs = {},
     });
 
     EXPECT_ANY_THROW(SetProgramRunParameters(program, params));
@@ -146,8 +146,8 @@ TEST_F(ProgramRunParamsTestQuasar, InvalidNodeForKernelFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_args = {{wrong_node, {1, 2}}},  // Wrong node!
-        .common_runtime_args = {},
+        .runtime_varargs = {{wrong_node, {1, 2}}},  // Wrong node!
+        .common_runtime_varargs = {},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -214,8 +214,8 @@ TEST_F(ProgramRunParamsTestQuasar, MissingNodeRTAsFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_args = {},  // Missing node RTAs!
-        .common_runtime_args = {},
+        .runtime_varargs = {},  // Missing node RTAs!
+        .common_runtime_varargs = {},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -279,8 +279,8 @@ TEST_F(ProgramRunParamsTestQuasar, DuplicateNodeCoordInRuntimeArgsFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_args = {{node, {1, 2}}, {node, {3, 4}}},  // Duplicate node!
-        .common_runtime_args = {},
+        .runtime_varargs = {{node, {1, 2}}, {node, {3, 4}}},  // Duplicate node!
+        .common_runtime_varargs = {},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -470,13 +470,13 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "producer",
-        .runtime_args = {{node0, {10, 20}}, {node1, {30, 40}}},
-        .common_runtime_args = {100},
+        .runtime_varargs = {{node0, {10, 20}}, {node1, {30, 40}}},
+        .common_runtime_varargs = {100},
     });
     params.kernel_run_params.push_back({
         .kernel_spec_name = "consumer",
-        .runtime_args = {{node0, {}}, {node1, {}}},
-        .common_runtime_args = {},
+        .runtime_varargs = {{node0, {}}, {node1, {}}},
+        .common_runtime_varargs = {},
     });
 
     EXPECT_NO_THROW(SetProgramRunParameters(program, params));
@@ -517,13 +517,13 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "producer",
-        .runtime_args = {{node0, {10, 20}}},  // Missing node1!
-        .common_runtime_args = {},
+        .runtime_varargs = {{node0, {10, 20}}},  // Missing node1!
+        .common_runtime_varargs = {},
     });
     params.kernel_run_params.push_back({
         .kernel_spec_name = "consumer",
-        .runtime_args = {{node0, {}}, {node1, {}}},
-        .common_runtime_args = {},
+        .runtime_varargs = {{node0, {}}, {node1, {}}},
+        .common_runtime_varargs = {},
     });
 
     EXPECT_ANY_THROW(SetProgramRunParameters(program, params));
@@ -668,7 +668,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_args = {{node_a, {10, 20}}, {node_b, {100, 200, 300, 400, 500}}},
+        .runtime_varargs = {{node_a, {10, 20}}, {node_b, {100, 200, 300, 400, 500}}},
     });
     EXPECT_NO_THROW(SetProgramRunParameters(program, params));
 }
@@ -706,7 +706,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
-        .kernel_spec_name = "dm_kernel", .runtime_args = {{node_a, {10, 20}}},  // node_b missing!
+        .kernel_spec_name = "dm_kernel", .runtime_varargs = {{node_a, {10, 20}}},  // node_b missing!
     });
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
@@ -725,7 +725,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyUnknownNodeFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_args = {{wrong_node, {42}}},
+        .runtime_varargs = {{wrong_node, {42}}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
     EXPECT_THAT(
@@ -765,7 +765,7 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
         .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}}}},
-        .runtime_args = {{node, {7, 8, 9}}},
+        .runtime_varargs = {{node, {7, 8, 9}}},
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -537,6 +537,245 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
 // still fires when it should.
 
 // Test fixture for ProgramRunParams on Wormhole - uses WORMHOLE_B0 mock device
+// ============================================================================
+// SECTION 4: Named RTA / CRTA Tests (Quasar)
+// ============================================================================
+
+// Make a ProgramSpec where the DM kernel has a named-RTA / named-CRTA schema.
+inline ProgramSpec MakeSpecWithNamedArgs(
+    const NodeCoord& node, const std::vector<std::string>& named_rtas, const std::vector<std::string>& named_crtas) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.named_runtime_args = named_rtas;
+    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = named_crtas;
+    (void)node;  // node inherited from MakeMinimalValidProgramSpec (0,0)
+    return spec;
+}
+
+TEST_F(ProgramRunParamsTestQuasar, NamedRTAsAndCRTAsSucceed) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr", "output_ptr"}, {"tile_count"});
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}, {"output_ptr", 0x2000}}}},
+        .named_common_runtime_args = {{"tile_count", 64}},
+    });
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+
+    EXPECT_NO_THROW(SetProgramRunParameters(program, params));
+}
+
+TEST_F(ProgramRunParamsTestQuasar, MissingNamedRTAForNodeFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr"}, {});
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        // No named_runtime_args for node (0,0) at all — but schema declares one.
+    });
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("has named RTAs declared but no named_runtime_args provided for node")));
+}
+
+TEST_F(ProgramRunParamsTestQuasar, MissingDeclaredNamedRTANameFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr", "output_ptr"}, {});
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        // Only one name provided — output_ptr missing.
+        .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}}}},
+    });
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("expects 2 named RTAs, but 1 were provided")));
+}
+
+TEST_F(ProgramRunParamsTestQuasar, UndeclaredNamedRTAFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr"}, {});
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}, {"not_in_schema", 0}}}},
+    });
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("expects 1 named RTAs, but 2 were provided")));
+}
+
+TEST_F(ProgramRunParamsTestQuasar, NamedCRTACountMismatchFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"tile_count", "scale"});
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        // Only one CRTA provided; schema declares two.
+        .named_common_runtime_args = {{"tile_count", 4}},
+    });
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("expects 2 named CRTAs, but 1 were provided")));
+}
+
+// ============================================================================
+// Vararg-only regression tests
+// ============================================================================
+//
+// These document the "legacy kernel migrated to Metal 2.0" pattern: all args as positional
+// varargs, no named RTAs/CRTAs/CTAs. This is expected to be the dominant migration shape —
+// users who port existing kernels will default to leaving everything as positional args
+// because that's how the old kernel source reads them. These tests are deliberately the
+// strongest regression canaries in this file; breaking them will break migration.
+
+TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
+    // A kernel on two nodes with DIFFERENT vararg counts per node. The RTA dispatch buffer
+    // must be sized per-node, which is a common failure mode for layout bugs.
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
+    NodeRangeSet nodes{std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}}};
+
+    ProgramSpec spec;
+    spec.program_id = "vararg_differing_counts";
+    auto kernel = MakeMinimalDMKernel("dm_kernel", nodes);
+    kernel.runtime_arguments_schema.num_runtime_args_per_node = {{node_a, 2}, {node_b, 5}};
+    spec.kernels = {kernel};
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        .runtime_args = {{node_a, {10, 20}}, {node_b, {100, 200, 300, 400, 500}}},
+    });
+    EXPECT_NO_THROW(SetProgramRunParameters(program, params));
+}
+
+TEST_F(ProgramRunParamsTestQuasar, VarargOnlyAcrossMultipleKernelsSucceeds) {
+    // Two kernels, each with only vararg RTAs / CRTAs — the shape of a whole-program
+    // migration where nothing has been upgraded to named args yet.
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.num_runtime_args_per_node = {{node, 3}};
+    spec.kernels[0].runtime_arguments_schema.num_common_runtime_args = 1;
+    spec.kernels[1].runtime_arguments_schema.num_runtime_args_per_node = {{node, 2}};
+    spec.kernels[1].runtime_arguments_schema.num_common_runtime_args = 2;
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back(MakeKernelRunParams("dm_kernel", node, {1, 2, 3}, {99}));
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {7, 8}, {42, 43}));
+    EXPECT_NO_THROW(SetProgramRunParameters(program, params));
+}
+
+TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
+    // If the schema declares varargs for a node, SetProgramRunParameters must insist on
+    // values for that node. Regression canary for per-node coverage in the vararg path.
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
+    NodeRangeSet nodes{std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}}};
+
+    ProgramSpec spec;
+    spec.program_id = "vararg_missing_node";
+    auto kernel = MakeMinimalDMKernel("dm_kernel", nodes);
+    kernel.runtime_arguments_schema.num_runtime_args_per_node = {{node_a, 2}, {node_b, 2}};
+    spec.kernels = {kernel};
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel", .runtime_args = {{node_a, {10, 20}}},  // node_b missing!
+    });
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("missing vararg runtime_args for node")));
+}
+
+TEST_F(ProgramRunParamsTestQuasar, VarargOnlyUnknownNodeFails) {
+    // Host passes runtime_args for a node the kernel doesn't run on. Regression canary for
+    // the domain check added alongside named-RTA validation.
+    NodeCoord node{0, 0};
+    NodeCoord wrong_node{3, 3};
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.num_runtime_args_per_node = {{node, 1}};
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        .runtime_args = {{wrong_node, {42}}},
+    });
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+    EXPECT_THAT(
+        [&] { SetProgramRunParameters(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("the kernel does not run on that node")));
+}
+
+// ============================================================================
+// Edge case: empty schema
+// ============================================================================
+
+// A kernel can legitimately declare no RTAs / CRTAs / CTAs of any kind (named or vararg).
+// Verify the whole MakeProgramFromSpec + SetProgramRunParameters pipeline handles this case
+// cleanly — no missing-schema TT_FATALs, no empty-buffer write attempts, no validation errors.
+TEST_F(ProgramRunParamsTestQuasar, AllEmptySchemaSucceeds) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    // spec.kernels already default to empty named_runtime_args / named_common_runtime_args /
+    // compile_time_arg_bindings / num_runtime_args_per_node / num_common_runtime_args.
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({.kernel_spec_name = "dm_kernel"});
+    params.kernel_run_params.push_back({.kernel_spec_name = "compute_kernel"});
+
+    EXPECT_NO_THROW(SetProgramRunParameters(program, params));
+}
+
+TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
+    // A kernel with both named RTAs (schema) and varargs (num_runtime_args_per_node).
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"input_ptr"};
+    spec.kernels[0].runtime_arguments_schema.num_runtime_args_per_node = {{node, 3}};
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}}}},
+        .runtime_args = {{node, {7, 8, 9}}},
+    });
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+
+    EXPECT_NO_THROW(SetProgramRunParameters(program, params));
+}
+
+// ============================================================================
+// SECTION 5: Gen1 (WH/BH) Tests
+// ============================================================================
+
 class ProgramRunParamsTestGen1 : public ::testing::Test {
 protected:
     void SetUp() override { experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1); }
@@ -587,7 +826,7 @@ TEST_F(ProgramRunParamsTestGen1, WrongRuntimeArgsCountFails) {
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("expects 3 runtime args, but 2 were provided")));
+            ::testing::HasSubstr("expects 3 vararg runtime_args, but 2 were provided")));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -210,7 +210,7 @@ TEST_F(ProgramRunParamsTestQuasar, MissingNodeRTAsFails) {
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/0);
     Program program = MakeProgramFromSpec(spec);
 
-    // Don't provide the per-node RTAs (empty runtime_args)
+    // Don't provide the per-node RTAs (empty runtime_varargs)
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
@@ -275,7 +275,7 @@ TEST_F(ProgramRunParamsTestQuasar, DuplicateNodeCoordInRuntimeArgsFails) {
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/0);
     Program program = MakeProgramFromSpec(spec);
 
-    // Provide runtime_args with duplicate node_coord entries
+    // Provide runtime_varargs with duplicate node_coord entries
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
@@ -710,11 +710,11 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
     });
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("missing vararg runtime_args for node")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("missing vararg runtime args for node")));
 }
 
 TEST_F(ProgramRunParamsTestQuasar, VarargOnlyUnknownNodeFails) {
-    // Host passes runtime_args for a node the kernel doesn't run on. Regression canary for
+    // Host passes runtime_varargs for a node the kernel doesn't run on. Regression canary for
     // the domain check added alongside named-RTA validation.
     NodeCoord node{0, 0};
     NodeCoord wrong_node{3, 3};
@@ -826,7 +826,7 @@ TEST_F(ProgramRunParamsTestGen1, WrongRuntimeArgsCountFails) {
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("expects 3 vararg runtime_args, but 2 were provided")));
+            ::testing::HasSubstr("expects 3 vararg runtime args, but 2 were provided")));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -561,16 +561,52 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
 // SECTION 3: WorkerSpec Validation Tests
 // ============================================================================
 
-TEST_F(ProgramSpecTestQuasar, MissingWorkerSpecsFails) {
-    // Gen2 requires WorkerSpecs
-    NodeCoord node{0, 0};
+TEST_F(ProgramSpecTestQuasar, MissingWorkerSpecsInfersWorkers) {
+    // If the user omits WorkerSpecs, they get inferred from kernel/DFB/semaphore
+    // target_nodes. An otherwise-valid spec should create successfully.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.workers = std::nullopt;
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, InferredWorkersPartitionByCoverage) {
+    // Two kernels on disjoint node ranges should produce two inferred WorkerSpecs.
+    // If inference gets this wrong (e.g., merges nodes with differing coverage),
+    // downstream validation will fail.
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.program_id = "multi_region";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
-    spec.kernels = {kernel};
-    // spec.workers is NOT set (nullopt)
+    spec.kernels = {MakeMinimalDMKernel("kernel_a", node_a), MakeMinimalDMKernel("kernel_b", node_b)};
+    // spec.workers left unset -> inference should yield one worker per node.
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, InferredWorkerWithDFBOnlyNodeFails) {
+    // If a DFB targets a node that no kernel covers, the inferred worker for
+    // that node has no kernels, which fails validation.
+    NodeCoord kernel_node{0, 0};
+    NodeCoord dfb_extra_node{1, 0};
+    NodeRangeSet dfb_nodes{
+        std::vector<NodeRange>{NodeRange{kernel_node, kernel_node}, NodeRange{dfb_extra_node, dfb_extra_node}}};
+
+    ProgramSpec spec;
+    spec.program_id = "dfb_only_node";
+
+    auto producer = MakeMinimalDMKernel("producer", kernel_node);
+    auto consumer = MakeMinimalDMKernel("consumer", kernel_node);
+    auto dfb = MakeMinimalDFB("dfb", dfb_nodes);
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    // spec.workers left unset.
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -572,8 +572,10 @@ TEST_F(ProgramSpecTestQuasar, MissingWorkerSpecsInfersWorkers) {
 
 TEST_F(ProgramSpecTestQuasar, InferredWorkersPartitionByCoverage) {
     // Two kernels on disjoint node ranges should produce two inferred WorkerSpecs.
-    // If inference gets this wrong (e.g., merges nodes with differing coverage),
-    // downstream validation will fail.
+    // This is a black-box check: if inference wrongly produced a single worker
+    // covering both nodes, ValidateProgramSpec's "kernel target_nodes must contain
+    // worker target_nodes" rule would reject it (each kernel only covers one of
+    // the two nodes). So NO_THROW implies inference partitioned correctly.
     NodeCoord node_a{0, 0};
     NodeCoord node_b{1, 0};
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -487,6 +487,97 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsFail) {
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
+// ---- Named RTA / CRTA / CTA schema validation ----
+
+TEST_F(ProgramSpecTestQuasar, NamedRuntimeArgsSucceeds) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"input_ptr", "output_ptr"};
+    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"tile_count"};
+    spec.kernels[0].compile_time_arg_bindings = {{"block_size", 64}};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, CustomArgsNamespaceSucceeds) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].args_namespace = "reader_args";
+    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"input_ptr"};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, InvalidArgsNamespaceFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].args_namespace = "9bad";  // starts with a digit
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("args_namespace '9bad' which is not a valid C++ identifier")));
+}
+
+TEST_F(ProgramSpecTestQuasar, EmptyArgsNamespaceFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].args_namespace = "";
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("args_namespace '' which is not a valid C++ identifier")));
+}
+
+TEST_F(ProgramSpecTestQuasar, InvalidNamedRtaIdentifierFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"int"};  // C++ keyword
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("named RTA name 'int' is not a valid C++ identifier")));
+}
+
+TEST_F(ProgramSpecTestQuasar, InvalidNamedCrtaIdentifierFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"has-dash"};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("named CRTA name 'has-dash' is not a valid C++ identifier")));
+}
+
+TEST_F(ProgramSpecTestQuasar, NamedRtaCrtaCollisionFails) {
+    // A single name cannot be both a named RTA and a named CRTA (they share the user namespace).
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"count"};
+    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"count"};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("naming collision: 'count' is declared as both a named RTA and a named CRTA")));
+}
+
+TEST_F(ProgramSpecTestQuasar, NamedRtaCtaCollisionFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"block_size"};
+    spec.kernels[0].compile_time_arg_bindings = {{"block_size", 64}};  // same name as CTA
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("naming collision: 'block_size' is declared as both a named RTA and a named CTA")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DifferentKernelsMayReuseArgNames) {
+    // Collision rule is per-kernel. Two different kernels may have identically-named args.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"shared_name"};
+    spec.kernels[1].runtime_arguments_schema.named_runtime_args = {"shared_name"};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
 TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
     NodeCoord node{0, 0};
 
@@ -1381,6 +1472,40 @@ TEST(AggregateSpecTypes, WorkerSpecDesignatedInitializers) {
     EXPECT_EQ(worker.unique_id, "my_worker");
     EXPECT_EQ(worker.kernels.size(), 2u);
     EXPECT_EQ(worker.dataflow_buffers.size(), 2u);
+}
+
+TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
+    // Named RTAs + CRTAs + vararg counts, all via designated initializers.
+    KernelSpec::RuntimeArgSchema schema{
+        .named_runtime_args = {"input_ptr", "output_ptr"},
+        .named_common_runtime_args = {"tile_count"},
+        .num_runtime_args_per_node = {{NodeCoord{0, 0}, 4}},
+        .num_common_runtime_args = 2,
+    };
+
+    EXPECT_EQ(schema.named_runtime_args.size(), 2u);
+    EXPECT_EQ(schema.named_common_runtime_args.size(), 1u);
+    EXPECT_EQ(schema.num_runtime_args_per_node.size(), 1u);
+    EXPECT_EQ(schema.num_common_runtime_args, 2u);
+}
+
+TEST(AggregateSpecTypes, KernelSpecArgsNamespaceDesignatedInitializers) {
+    KernelSpec k{
+        .unique_id = "k",
+        .source = KernelSpec::SourceCode{"void kernel_main() {}"},
+        .target_nodes = NodeCoord{0, 0},
+        .args_namespace = "reader_args",
+        .runtime_arguments_schema =
+            KernelSpec::RuntimeArgSchema{
+                .named_runtime_args = {"input_ptr"},
+            },
+        .config_spec =
+            DataMovementConfiguration{
+                .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+            },
+    };
+    EXPECT_EQ(k.args_namespace, "reader_args");
+    EXPECT_EQ(k.runtime_arguments_schema.named_runtime_args.size(), 1u);
 }
 
 TEST(AggregateSpecTypes, SemaphoreSpecDesignatedInitializers) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -175,5 +175,101 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     EXPECT_EQ(output_data, input_data);
 }
 
+// ============================================================================
+// Named RTA / CRTA / CTA Loopback Test
+// ============================================================================
+//
+// End-to-end on real WH/BH hardware:
+//   1. kernel_args_generated.h is emitted (args::src_addr, args::dst_addr, args::num_entries,
+//      args::bank_id, args::entry_size resolve at kernel compile time)
+//   2. Named RTAs + CRTAs + CTAs all route correctly through the dispatch buffer
+//   3. get_vararg(0) correctly indexes past the named RTA section
+//   4. Data flows end-to-end: DRAM → producer (named args) → DFB → consumer (named args) → DRAM
+//
+// Same shape as DFBAccessorNameLoopback but all runtime args are sourced via the new
+// named-arg accessors, plus one vararg on the producer to verify the offset mechanism.
+
+TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+
+    constexpr uint32_t entry_size = 1024;
+    constexpr uint32_t num_entries_in_dfb = 4;
+    constexpr uint32_t num_transfers = 8;
+    constexpr uint32_t total_bytes = entry_size * num_transfers;
+    constexpr uint32_t producer_vararg_sentinel = 0xC0FFEEu;
+
+    const NodeCoord node{0, 0};
+
+    InterleavedBufferConfig dram_config{
+        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
+    auto input_buffer = CreateBuffer(dram_config);
+    auto output_buffer = CreateBuffer(dram_config);
+
+    ProgramSpec spec;
+    spec.program_id = "named_args_loopback";
+
+    // Producer: BRISC reads DRAM → DFB, using named RTA (src_addr) + named CRTA (num_entries)
+    // + named CTAs (bank_id, entry_size) + one vararg RTA (a sentinel for offset verification).
+    auto producer = MakeMinimalGen1DMKernel("producer", node, DataMovementProcessor::RISCV_0);
+    producer.source =
+        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp"};
+    producer.runtime_arguments_schema.named_runtime_args = {"src_addr"};
+    producer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
+    producer.runtime_arguments_schema.num_runtime_args_per_node = {{node, 1}};  // 1 vararg
+    producer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
+
+    // Consumer: NCRISC reads DFB → DRAM, using named RTA (dst_addr) + named CRTA (num_entries)
+    // + named CTAs (bank_id, entry_size). No varargs.
+    auto consumer = MakeMinimalGen1DMKernel("consumer", node, DataMovementProcessor::RISCV_1);
+    consumer.source =
+        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp"};
+    consumer.runtime_arguments_schema.named_runtime_args = {"dst_addr"};
+    consumer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
+    consumer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
+
+    auto dfb = MakeMinimalDFB("loopback_dfb", node, entry_size, num_entries_in_dfb);
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    BindDFBToKernel(producer, "loopback_dfb", "loopback_dfb", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "loopback_dfb", "loopback_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.workers =
+        std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"producer", "consumer"}, {"loopback_dfb"})};
+
+    Program program = MakeProgramFromSpec(spec);
+
+    ProgramRunParams params;
+    params.kernel_run_params = {
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "producer",
+            .named_runtime_args = {{.node = node, .args = {{"src_addr", input_buffer->address()}}}},
+            .named_common_runtime_args = {{"num_entries", num_transfers}},
+            .runtime_args = {{node, {producer_vararg_sentinel}}},
+        },
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "consumer",
+            .named_runtime_args = {{.node = node, .args = {{"dst_addr", output_buffer->address()}}}},
+            .named_common_runtime_args = {{"num_entries", num_transfers}},
+        },
+    };
+    SetProgramRunParameters(program, params);
+
+    std::vector<uint32_t> input_data(total_bytes / sizeof(uint32_t));
+    for (size_t i = 0; i < input_data.size(); i++) {
+        input_data[i] = static_cast<uint32_t>(i);
+    }
+    detail::WriteToBuffer(input_buffer, input_data);
+
+    detail::LaunchProgram(device, program);
+
+    std::vector<uint32_t> output_data;
+    detail::ReadFromBuffer(output_buffer, output_data);
+
+    ASSERT_EQ(output_data.size(), input_data.size());
+    EXPECT_EQ(output_data, input_data);
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -130,7 +130,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     params.kernel_run_params = {
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "producer",
-            .runtime_args =
+            .runtime_varargs =
                 {{node,
                   {
                       input_buffer->address(),
@@ -140,7 +140,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
         },
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "consumer",
-            .runtime_args =
+            .runtime_varargs =
                 {{node,
                   {
                       output_buffer->address(),
@@ -246,7 +246,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
             .kernel_spec_name = "producer",
             .named_runtime_args = {{.node = node, .args = {{"src_addr", input_buffer->address()}}}},
             .named_common_runtime_args = {{"num_entries", num_transfers}},
-            .runtime_args = {{node, {producer_vararg_sentinel}}},
+            .runtime_varargs = {{node, {producer_vararg_sentinel}}},
         },
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "consumer",

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel: Metal 2.0 named-args loopback consumer.
+// Reads data from a DFB and writes it to a single-page DRAM buffer.
+//
+// Uses Metal 2.0 named-arg accessors exclusively (via get_arg):
+//   args::dst_addr      — named RTA (per-node), DRAM destination address
+//   args::num_entries   — named CRTA (broadcast), number of entries to transfer
+//   args::bank_id       — named CTA, DRAM bank ID
+//   args::entry_size    — named CTA, bytes per DFB entry
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg(args::dst_addr);
+    uint32_t num_entries = get_arg(args::num_entries);
+    constexpr uint32_t bank_id = get_arg(args::bank_id);
+    constexpr uint32_t entry_size = get_arg(args::entry_size);
+
+    experimental::DataflowBuffer buf(dfb::loopback_dfb);
+
+    for (uint32_t i = 0; i < num_entries; i++) {
+        buf.wait_front(1);
+        uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
+        noc_async_write(buf.get_read_ptr(), dst_noc_addr, entry_size);
+        noc_async_write_barrier();
+        buf.pop_front(1);
+        dst_addr += entry_size;
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel: Metal 2.0 named-args loopback producer.
+// Reads data from a single-page DRAM buffer and pushes it entry-by-entry into a DFB.
+//
+// Uses Metal 2.0 named-arg accessors exclusively (via get_arg):
+//   args::src_addr      — named RTA (per-node), DRAM source address
+//   args::num_entries   — named CRTA (broadcast), number of entries to transfer
+//   args::bank_id       — named CTA, DRAM bank ID (typically 0 for single-page buffers)
+//   args::entry_size    — named CTA, bytes per DFB entry
+//   get_vararg(0)       — vararg RTA (0-indexed), a sentinel value the test verifies
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg(args::src_addr);
+    uint32_t num_entries = get_arg(args::num_entries);
+    constexpr uint32_t bank_id = get_arg(args::bank_id);
+    constexpr uint32_t entry_size = get_arg(args::entry_size);
+
+    // Prove that get_vararg(0) addresses the first vararg regardless of how many named
+    // RTAs precede it in the dispatch buffer. The host passes an agreed sentinel value;
+    // if the offset is wrong, we'd read back garbage (or worse, the first named RTA).
+    uint32_t sentinel = get_vararg(0);
+    // Use it to ensure the compiler doesn't DCE the load.
+    volatile uint32_t touch = sentinel;
+    (void)touch;
+
+    experimental::DataflowBuffer buf(dfb::loopback_dfb);
+
+    for (uint32_t i = 0; i < num_entries; i++) {
+        buf.reserve_back(1);
+        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
+        noc_async_read(src_noc_addr, buf.get_write_ptr(), entry_size);
+        noc_async_read_barrier();
+        buf.push_back(1);
+        src_addr += entry_size;
+    }
+}

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -138,28 +138,48 @@ struct KernelSpec {
 
     // TODO -- GlobalSemaphore bindings
     // TODO -- GlobalDataflowBuffer bindings
-    // TODO -- Socket bindings
 
-    // Compile time argument bindings (values cannot be changed between Program executions)
-    using CompileTimeArgBindings = std::unordered_map<std::string, uint32_t>;
+    //////////////////////////////////////////////////////////////////////////////
+    // Kernel arguments
+    //////////////////////////////////////////////////////////////////////////////
+
+    // Namespace for the kernel argument accessors in the kernel source code, e.g.
+    //   auto my_arg = get_argument(my_args_namespace::my_arg_name);
+    // Use a custom namespace to avoid identifier collisions when fusing kernels;
+    // otherwise, use the default "args" namespace.
+    std::string args_namespace = "args";
+
+    //----------------------------------------------------------------------------
+    // Compile time argument bindings
+    // (Bound argument values cannot be changed between Program executions)
+    using CompileTimeArgBindings = std::vector<std::pair<std::string, uint32_t>>;
     CompileTimeArgBindings compile_time_arg_bindings;
     // TODO -- extend to support arbitrary POD types, including user-defined structs.
 
-    //////////////////////////////////////////////////////////////////////////////
-    // Runtime argument schema / declaration
-    //////////////////////////////////////////////////////////////////////////////
+    //----------------------------------------------------------------------------
+    // Runtime argument schema (declaration)
 
-    // Schema for runtime and common runtime arguments
+    // Schema for runtime arguments (RTA) and common runtime arguments (CRTA)
     // (The VALUES of these arguments are set as ProgramRunParams.)
+    //
+    // Two mechanisms are supported per kernel:
+    //   - Named RTAs/CRTAs: referenced by name in kernel code via `<args_namespace>::<name>`.
+    //     (Currently, only uint32_t type is supported.)
+    //   - Vararg RTAs/CRTAs: positional, variable-count, always uint32_t.
+    //     Indexed from 0 in kernel code via `get_vararg(idx)` / `get_common_vararg(idx)`.
+    //     Vararg indices are stable across schema changes (e.g., moving a named arg from RTA→CRTA).
     struct RuntimeArgSchema {
-        // Schema for named and typed RTAs + CRTAs
-        // (These must be fully specified in the kernel code.)
-        //   TODO
+        // Named RTAs: names in declaration order. Must be unique valid C++ identifiers.
+        std::vector<std::string> named_runtime_args;
 
-        // Schema for unnamed/variable RTAs + CRTAs
-        // (Must be of uint32_t; can be treated as varargs in the kernel code)
+        // Named CRTAs: names in declaration order. Must be unique valid C++ identifiers.
+        std::vector<std::string> named_common_runtime_args;
+
+        // Vararg RTAs: per-node count (unnamed, uint32_t, indexed from 0).
         using NumRTAsPerNode = std::vector<std::pair<NodeCoord, size_t>>;  // {node, num_rtas}
         NumRTAsPerNode num_runtime_args_per_node;                          // default: empty
+
+        // Vararg CRTAs: count (unnamed, uint32_t, indexed from 0).
         size_t num_common_runtime_args = 0;
     };
     RuntimeArgSchema runtime_arguments_schema{};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -23,8 +23,8 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation = fals
 // (This will become a member function for the Program class)
 // This performs a copy from the ProgramRunParams to the Program's internal data structures.
 //
-// COMPLETENESS: You must specify runtime_args for every (kernel, node) pair that
-// requires runtime arguments. Missing entries will cause an error.
+// COMPLETENESS: You must specify runtime args (named and vararg alike) for every
+// (kernel, node) pair that requires runtime arguments. Missing entries will cause an error.
 //
 // For high-performance inner loops, prefer the in-place power user API below.
 // If stateful behavior of parameters is required, use the power user API.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -48,14 +48,14 @@ struct ProgramRunParams {
 
         // Unnamed runtime argument "varargs"
         // (these are specified per-node; length can vary per-node)
-        using NodeRuntimeArgs = std::vector<uint32_t>;
-        using RuntimeArgs = std::vector<std::pair<NodeCoord, NodeRuntimeArgs>>;
-        RuntimeArgs runtime_args;
+        using NodeVarargs = std::vector<uint32_t>;
+        using Varargs = std::vector<std::pair<NodeCoord, NodeVarargs>>;
+        Varargs runtime_varargs;
 
         // Unnamed common runtime argument "varargs"
         // (common to all nodes on which the kernel runs)
-        using CommonRuntimeArgs = std::vector<uint32_t>;
-        CommonRuntimeArgs common_runtime_args;
+        using CommonVarargs = std::vector<uint32_t>;
+        CommonVarargs common_runtime_varargs;
     };
     // KernelRunParams must be specified for ALL kernels in the ProgramSpec.
     std::vector<KernelRunParams> kernel_run_params;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -105,11 +105,11 @@ struct ProgramRunParams {
 //
 struct ProgramRunParamsView {
     struct KernelRunParamsView {
-        // Direct views into per-node runtime args
-        std::vector<std::pair<NodeCoord, std::span<uint32_t>>> runtime_args;
+        // Direct views into per-node vararg runtime args
+        std::vector<std::pair<NodeCoord, std::span<uint32_t>>> runtime_varargs;
 
-        // Direct view into common runtime args
-        std::span<uint32_t> common_runtime_args;
+        // Direct view into common vararg runtime args
+        std::span<uint32_t> common_runtime_varargs;
     };
     // TODO: Better to just expose the multi-dim dispatch vectors directly?
     //       Would eliminate the lookup indirection.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -29,11 +29,22 @@ struct ProgramRunParams {
         // Kernel identifier
         KernelSpecName kernel_spec_name;
 
-        // Defined runtime arguments (named & typed)
-        //   TODO
+        // Named Runtime Argument bindings
+        // Every argument in this kernel's RuntimeArgSchema::named_runtime_args must be set,
+        // for every node the kernel runs on.
+        // Missing arguments or superfluous arguments will trigger validation errors.
+        //
+        // NOTE: If a kernel runtime argument always has the same value for all nodes, passing
+        // a common runtime argument would provide better dispatch efficiency.
+        struct NodeNamedRTAs {
+            NodeCoord node;
+            std::unordered_map<std::string, uint32_t> args;
+        };
+        std::vector<NodeNamedRTAs> named_runtime_args;
 
-        // Defined common runtime arguments (named & typed)
-        //   TODO
+        // Named Common Runtime Arguments bindings.
+        // Every name in this kernel's RuntimeArgSchema::named_common_runtime_args must be set.
+        std::unordered_map<std::string, uint32_t> named_common_runtime_args;
 
         // Unnamed runtime argument "varargs"
         // (these are specified per-node; length can vary per-node)

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -33,7 +33,8 @@ using WorkerSpecName = std::string;
 // ProgramSpec & WorkerSpec
 //------------------------------------------------
 
-// WorkerSpec describes the configuration of a worker node
+// WorkerSpec describes the specific configuration of a worker node,
+// (kernels, DFBs, and semaphores) and the set of nodes it applies to.
 struct WorkerSpec {
     // Worker type identifier
     WorkerSpecName unique_id;
@@ -59,11 +60,10 @@ struct ProgramSpec {
     std::vector<SemaphoreSpec> semaphores;
 
     // (Optional) Worker specifications.
-    // If std::nullopt, workers are inferred automatically from kernel/DFB/semaphore
-    // target_nodes fields (nodes with identical coverage become one inferred WorkerSpec,
-    // named "inferred_worker@<node_range_set>").
-    // User-supplied workers let you assign readable names, and act as a redundant sanity
-    // check on which nodes each entity covers.
+    // Providing WorkerSpecs explicitly improves the readability of the
+    // ProgramSpec and results in clearer error messaging.
+    // If left as std::nullopt, the runtime automatically infers WorkerSpecs
+    // based on the target_nodes fields of the kernel, DFB and semaphore specs.
     std::optional<std::vector<WorkerSpec>> workers = std::nullopt;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -58,9 +58,12 @@ struct ProgramSpec {
     std::vector<DataflowBufferSpec> dataflow_buffers;
     std::vector<SemaphoreSpec> semaphores;
 
-    // Worker specifications (optional on Gen1, required on Gen2+)
-    // This info is redundant, but improves clarity and messaging.
-    // (Done to simplify porting from ProgramDescriptor.)
+    // (Optional) Worker specifications.
+    // If std::nullopt, workers are inferred automatically from kernel/DFB/semaphore
+    // target_nodes fields (nodes with identical coverage become one inferred WorkerSpec,
+    // named "inferred_worker@<node_range_set>").
+    // User-supplied workers let you assign readable names, and act as a redundant sanity
+    // check on which nodes each entity covers.
     std::optional<std::vector<WorkerSpec>> workers = std::nullopt;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -33,8 +33,7 @@ using WorkerSpecName = std::string;
 // ProgramSpec & WorkerSpec
 //------------------------------------------------
 
-// WorkerSpec describes the specific configuration of a worker node,
-// (kernels, DFBs, and semaphores) and the set of nodes it applies to.
+// WorkerSpec describes the configuration of a worker node
 struct WorkerSpec {
     // Worker type identifier
     WorkerSpecName unique_id;
@@ -59,11 +58,9 @@ struct ProgramSpec {
     std::vector<DataflowBufferSpec> dataflow_buffers;
     std::vector<SemaphoreSpec> semaphores;
 
-    // (Optional) Worker specifications.
-    // Providing WorkerSpecs explicitly improves the readability of the
-    // ProgramSpec and results in clearer error messaging.
-    // If left as std::nullopt, the runtime automatically infers WorkerSpecs
-    // based on the target_nodes fields of the kernel, DFB and semaphore specs.
+    // Worker specifications (optional on Gen1, required on Gen2+)
+    // This info is redundant, but improves clarity and messaging.
+    // (Done to simplify porting from ProgramDescriptor.)
     std::optional<std::vector<WorkerSpec>> workers = std::nullopt;
 };
 

--- a/tt_metal/hw/inc/experimental/kernel_args.h
+++ b/tt_metal/hw/inc/experimental/kernel_args.h
@@ -25,8 +25,6 @@
 // NOTE: Currently, only uint32_t args are supported. However, named kernel arguments via
 // get_arg() will later be extended to support arbitrary POD types.
 
-#include "api/dataflow/dataflow_api.h"
-
 namespace experimental {
 
 // byte_offset is measured from the start of the *named* section of the dispatch buffer.

--- a/tt_metal/hw/inc/experimental/kernel_args.h
+++ b/tt_metal/hw/inc/experimental/kernel_args.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Metal 2.0 kernel argument accessors.
+//
+// This header defines the device-side machinery for named kernel arguments:
+//   - RtaArg<T> / CrtaArg<T> / CtaVal<T> accessor structs
+//   - get_arg() overloads, one per accessor kind
+//
+// The accessor constants themselves (e.g., `args::input_dim`) are emitted per-kernel into
+// kernel_args_generated.h. That generated header is included before the user kernel source,
+// so kernel code can write:
+//
+//   auto dim = get_arg(args::input_dim);   // RTA
+//   auto cnt = get_arg(args::tile_count);  // CRTA
+//   auto bsz = get_arg(args::block_size);  // CTA (compile-time constant)
+//
+// The kernel source is identical regardless of whether an arg is dispatched via RTA, CRTA,
+// or CTA — moving an arg between kinds only requires a host-side schema change.
+// (Then get_arg() call is resolved via ADL on the accessor type's `experimental` namespace.)
+//
+// NOTE: Currently, only uint32_t args are supported. However, named kernel arguments via
+// get_arg() will later be extended to support arbitrary POD types.
+
+#include "api/dataflow/dataflow_api.h"
+
+namespace experimental {
+
+// byte_offset is measured from the start of the *named* section of the dispatch buffer.
+// Varargs live after the named section; see get_vararg() in kernel_args_generated.h.
+template <typename T>
+struct RtaArg {
+    uint32_t byte_offset;
+};
+
+template <typename T>
+struct CrtaArg {
+    uint32_t byte_offset;
+};
+
+template <typename T>
+struct CtaVal {
+    T value;
+};
+
+template <typename T>
+FORCE_INLINE T get_arg(RtaArg<T> arg) {
+    static_assert(sizeof(T) == 4, "Only uint32_t args are currently supported.");
+    return *((tt_l1_ptr T*)(get_arg_addr(arg.byte_offset / sizeof(uint32_t))));
+}
+
+template <typename T>
+FORCE_INLINE T get_arg(CrtaArg<T> arg) {
+    static_assert(sizeof(T) == 4, "Only uint32_t args are currently supported.");
+    return *((tt_l1_ptr T*)(get_common_arg_addr(arg.byte_offset / sizeof(uint32_t))));
+}
+
+template <typename T>
+FORCE_INLINE constexpr T get_arg(CtaVal<T> arg) {
+    return arg.value;
+}
+
+}  // namespace experimental

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -133,6 +133,7 @@ set(HW_JIT_API_HEADERS
     inc/experimental/noc.h
     inc/experimental/circular_buffer.h
     inc/experimental/dataflow_buffer.h
+    inc/experimental/kernel_args.h
     inc/experimental/noc_semaphore.h
     inc/experimental/endpoints.h
     inc/experimental/core_local_mem.h

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -105,7 +105,10 @@ Kernel::Kernel(
     const std::vector<uint32_t>& compile_args,
     const std::map<std::string, std::string>& defines,
     const std::unordered_map<std::string, uint32_t>& named_compile_args,
-    const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles) :
+    const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles,
+    const std::vector<std::string>& named_runtime_args,
+    const std::vector<std::string>& named_common_runtime_args,
+    const std::string& args_namespace) :
     programmable_core_type_(programmable_core_type),
     processor_class_(processor_class),
     kernel_src_(kernel_src),
@@ -113,6 +116,9 @@ Kernel::Kernel(
     compile_time_args_(compile_args),
     named_compile_time_args_(named_compile_args),
     dataflow_buffer_local_accessor_handles_(dataflow_buffer_local_accessor_handles),
+    named_runtime_args_(named_runtime_args),
+    named_common_runtime_args_(named_common_runtime_args),
+    args_namespace_(args_namespace),
 
     core_with_max_runtime_args_({0, 0}),
     defines_(defines),
@@ -439,6 +445,18 @@ uint64_t Kernel::compute_hash() const {
     for (const auto& it : sorted_iters(this->dataflow_buffer_local_accessor_handles_)) {
         hasher.update(it->first);
         hasher.update(static_cast<uint64_t>(it->second));
+    }
+    // Named RTA/CRTA schema: order matters (determines byte offsets), so hash the sequence.
+    // args_namespace is emitted as a C++ namespace in the generated header.
+    // Counts are hashed too — they keep ["a"], [] distinct from [], ["a"].
+    hasher.update(this->args_namespace_);
+    hasher.update(static_cast<uint64_t>(this->named_runtime_args_.size()));
+    for (const auto& name : this->named_runtime_args_) {
+        hasher.update(name);
+    }
+    hasher.update(static_cast<uint64_t>(this->named_common_runtime_args_.size()));
+    for (const auto& name : this->named_common_runtime_args_) {
+        hasher.update(name);
     }
     hasher.update(this->kernel_src_.source_);
     hasher.update(this->compile_time_args_.begin(), this->compile_time_args_.end());

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -146,6 +146,11 @@ public:
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const override;
     void process_dataflow_buffer_local_accessor_handles(
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const override;
+    const std::vector<std::string>& get_named_runtime_args() const override { return named_runtime_args_; }
+    const std::vector<std::string>& get_named_common_runtime_args() const override {
+        return named_common_runtime_args_;
+    }
+    const std::string& get_args_namespace() const override { return args_namespace_; }
     void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     void validate_runtime_args_size(
@@ -197,7 +202,10 @@ protected:
         const std::vector<uint32_t>& compile_args,
         const std::map<std::string, std::string>& defines,
         const std::unordered_map<std::string, uint32_t>& named_compile_args,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {});
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const std::vector<std::string>& named_runtime_args = {},
+        const std::vector<std::string>& named_common_runtime_args = {},
+        const std::string& args_namespace = "args");
 
     HalProgrammableCoreType programmable_core_type_;
     HalProcessorClassType processor_class_;
@@ -209,6 +217,12 @@ protected:
     std::vector<uint32_t> compile_time_args_;
     std::unordered_map<std::string, uint32_t> named_compile_time_args_;
     const DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
+    // Metal 2.0 named-args schema. Order of these vectors determines byte-offset layout
+    // in the dispatch buffer; args_namespace_ controls the C++ namespace emitted into
+    // kernel_args_generated.h.
+    const std::vector<std::string> named_runtime_args_;
+    const std::vector<std::string> named_common_runtime_args_;
+    const std::string args_namespace_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
     std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_{0};
@@ -240,7 +254,10 @@ public:
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const DataMovementConfig& config,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {}) :
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const std::vector<std::string>& named_runtime_args = {},
+        const std::vector<std::string>& named_common_runtime_args = {},
+        const std::string& args_namespace = "args") :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::DM,
@@ -249,7 +266,10 @@ public:
             config.compile_args,
             config.defines,
             config.named_compile_args,
-            dataflow_buffer_local_accessor_handles),
+            dataflow_buffer_local_accessor_handles,
+            named_runtime_args,
+            named_common_runtime_args,
+            args_namespace),
         config_(config) {
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
@@ -363,7 +383,10 @@ public:
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const ComputeConfig& config,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {}) :
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const std::vector<std::string>& named_runtime_args = {},
+        const std::vector<std::string>& named_common_runtime_args = {},
+        const std::string& args_namespace = "args") :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::COMPUTE,
@@ -372,7 +395,10 @@ public:
             config.compile_args,
             config.defines,
             config.named_compile_args,
-            dataflow_buffer_local_accessor_handles),
+            dataflow_buffer_local_accessor_handles,
+            named_runtime_args,
+            named_common_runtime_args,
+            args_namespace),
         config_(config) {
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
@@ -435,7 +461,10 @@ public:
         const CoreRangeSet& cr_set,
         const QuasarDataMovementConfig& config,
         const std::set<DataMovementProcessor>& dm_processors,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {}) :
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const std::vector<std::string>& named_runtime_args = {},
+        const std::vector<std::string>& named_common_runtime_args = {},
+        const std::string& args_namespace = "args") :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::DM,
@@ -444,7 +473,10 @@ public:
             config.compile_args,
             config.defines,
             config.named_compile_args,
-            dataflow_buffer_local_accessor_handles),
+            dataflow_buffer_local_accessor_handles,
+            named_runtime_args,
+            named_common_runtime_args,
+            args_namespace),
         config_(config),
         dm_processors_(dm_processors.begin(), dm_processors.end()) {
         TT_FATAL(
@@ -493,7 +525,10 @@ public:
         const CoreRangeSet& cr_set,
         const QuasarComputeConfig& config,
         const std::set<QuasarComputeProcessor>& compute_processors,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {}) :
+        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const std::vector<std::string>& named_runtime_args = {},
+        const std::vector<std::string>& named_common_runtime_args = {},
+        const std::string& args_namespace = "args") :
         Kernel(
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::COMPUTE,
@@ -502,7 +537,10 @@ public:
             config.compile_args,
             config.defines,
             config.named_compile_args,
-            dataflow_buffer_local_accessor_handles),
+            dataflow_buffer_local_accessor_handles,
+            named_runtime_args,
+            named_common_runtime_args,
+            args_namespace),
         config_(config),
         compute_processors_(compute_processors.begin(), compute_processors.end()) {
         TT_FATAL(

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -57,7 +57,7 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
 
         // Validate vararg RTA counts per node
         std::unordered_set<NodeCoord> nodes_with_vararg_params;
-        for (const auto& [node_coord, args] : kernel_params.runtime_args) {
+        for (const auto& [node_coord, args] : kernel_params.runtime_varargs) {
             auto [it_node, node_inserted] = nodes_with_vararg_params.insert(node_coord);
             TT_FATAL(
                 node_inserted,
@@ -94,11 +94,11 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
 
         // Validate vararg CRTA count
         TT_FATAL(
-            kernel_params.common_runtime_args.size() == schema->num_common_runtime_args,
+            kernel_params.common_runtime_varargs.size() == schema->num_common_runtime_args,
             "Kernel '{}' expects {} vararg common_runtime_args, but {} were provided",
             kernel_name,
             schema->num_common_runtime_args,
-            kernel_params.common_runtime_args.size());
+            kernel_params.common_runtime_varargs.size());
 
         // Validate named RTAs: every declared name set per-node, no extras, no duplicate node entries.
         const auto& named_rta_names = schema->named_runtime_args;
@@ -220,7 +220,7 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
         // Build a node -> vararg-values-span lookup.
         std::unordered_map<NodeCoord, const std::vector<uint32_t>*> varargs_by_node;
-        for (const auto& [node, args] : kernel_params.runtime_args) {
+        for (const auto& [node, args] : kernel_params.runtime_varargs) {
             varargs_by_node[node] = &args;
         }
 
@@ -264,7 +264,7 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
         // Combine named CRTAs and vararg CRTAs into one common buffer.
         std::vector<uint32_t> combined_crtas;
-        combined_crtas.reserve(schema->named_common_runtime_args.size() + kernel_params.common_runtime_args.size());
+        combined_crtas.reserve(schema->named_common_runtime_args.size() + kernel_params.common_runtime_varargs.size());
         for (const auto& name : schema->named_common_runtime_args) {
             auto v_it = kernel_params.named_common_runtime_args.find(name);
             TT_FATAL(
@@ -275,7 +275,9 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
             combined_crtas.push_back(v_it->second);
         }
         combined_crtas.insert(
-            combined_crtas.end(), kernel_params.common_runtime_args.begin(), kernel_params.common_runtime_args.end());
+            combined_crtas.end(),
+            kernel_params.common_runtime_varargs.begin(),
+            kernel_params.common_runtime_varargs.end());
 
         // Set common runtime args
         // TODO: Why on earth does SetCommonRuntimeArgs() only work the first time??

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -61,13 +61,13 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
             auto [it_node, node_inserted] = nodes_with_vararg_params.insert(node_coord);
             TT_FATAL(
                 node_inserted,
-                "Duplicate node_coord {} in runtime_args for kernel '{}'.",
+                "Duplicate node_coord {} in runtime_varargs for kernel '{}'.",
                 node_coord.str(),
                 kernel_name);
 
             TT_FATAL(
                 kernel_nodes.contains(node_coord),
-                "Kernel '{}' is setting runtime_args for node {}, but the kernel does not run on that node.",
+                "Kernel '{}' is setting runtime_varargs for node {}, but the kernel does not run on that node.",
                 kernel_name,
                 node_coord.str());
 
@@ -76,7 +76,7 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
                 (it_schema != schema->num_runtime_args_per_node.end()) ? it_schema->second : 0;
             TT_FATAL(
                 args.size() == expected_varargs,
-                "Kernel '{}' node {} expects {} vararg runtime_args, but {} were provided",
+                "Kernel '{}' node {} expects {} vararg runtime args, but {} were provided",
                 kernel_name,
                 node_coord.str(),
                 expected_varargs,
@@ -86,7 +86,7 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
         for (const auto& [node_coord, expected_count] : schema->num_runtime_args_per_node) {
             TT_FATAL(
                 nodes_with_vararg_params.contains(node_coord),
-                "Kernel '{}' is missing vararg runtime_args for node {} (expected {} args)",
+                "Kernel '{}' is missing vararg runtime args for node {} (expected {} args)",
                 kernel_name,
                 node_coord.str(),
                 expected_count);
@@ -95,7 +95,7 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
         // Validate vararg CRTA count
         TT_FATAL(
             kernel_params.common_runtime_varargs.size() == schema->num_common_runtime_args,
-            "Kernel '{}' expects {} vararg common_runtime_args, but {} were provided",
+            "Kernel '{}' expects {} vararg common runtime args, but {} were provided",
             kernel_name,
             schema->num_common_runtime_args,
             kernel_params.common_runtime_varargs.size());

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -21,7 +21,13 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // Type alias for readability
 using KernelRTASchema = detail::ProgramImpl::KernelRTASchema;
 
-// Internal validation function - validates ProgramRunParams against the Program's schema
+// Internal validation function - validates ProgramRunParams against the Program's schema.
+//
+// Named RTAs/CRTAs and vararg RTAs/CRTAs are validated separately:
+//   - Named args must have EVERY declared name set (and no extras). Named RTA values are
+//     required for every node the kernel runs on.
+//   - Vararg counts per-node must match the schema. A node with no vararg entry in the schema
+//     expects zero varargs (but may still have named RTAs, if the schema declares them).
 void ValidateProgramRunParams(const Program& program, const ProgramRunParams& params) {
     const detail::ProgramImpl& program_impl = program.impl();
 
@@ -45,54 +51,113 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
             "Kernel '{}' has no RTA schema registered. Was the Program created from a ProgramSpec?",
             kernel_name);
 
-        // Validate per-node runtime args counts
-        std::unordered_set<NodeCoord> nodes_with_args;
+        // Nodes the kernel runs on — the required domain for named-RTA coverage.
+        const std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
+        const std::set<CoreCoord>& kernel_nodes = kernel->logical_cores();
+
+        // Validate vararg RTA counts per node
+        std::unordered_set<NodeCoord> nodes_with_vararg_params;
         for (const auto& [node_coord, args] : kernel_params.runtime_args) {
-            auto [it_node, node_inserted] = nodes_with_args.insert(node_coord);
+            auto [it_node, node_inserted] = nodes_with_vararg_params.insert(node_coord);
             TT_FATAL(
                 node_inserted,
                 "Duplicate node_coord {} in runtime_args for kernel '{}'.",
                 node_coord.str(),
                 kernel_name);
 
-            auto it = schema->num_runtime_args_per_node.find(node_coord);
             TT_FATAL(
-                it != schema->num_runtime_args_per_node.end(),
-                "Kernel {} is setting RTAs for node {}, but this is not a valid node for this kernel.",
+                kernel_nodes.contains(node_coord),
+                "Kernel '{}' is setting runtime_args for node {}, but the kernel does not run on that node.",
                 kernel_name,
                 node_coord.str());
+
+            auto it_schema = schema->num_runtime_args_per_node.find(node_coord);
+            const size_t expected_varargs =
+                (it_schema != schema->num_runtime_args_per_node.end()) ? it_schema->second : 0;
             TT_FATAL(
-                args.size() == it->second,
-                "Kernel '{}' node {} expects {} runtime args, but {} were provided",
+                args.size() == expected_varargs,
+                "Kernel '{}' node {} expects {} vararg runtime_args, but {} were provided",
                 kernel_name,
                 node_coord.str(),
-                it->second,
+                expected_varargs,
                 args.size());
         }
+        // Every node with a schema vararg entry must have values provided.
+        for (const auto& [node_coord, expected_count] : schema->num_runtime_args_per_node) {
+            TT_FATAL(
+                nodes_with_vararg_params.contains(node_coord),
+                "Kernel '{}' is missing vararg runtime_args for node {} (expected {} args)",
+                kernel_name,
+                node_coord.str(),
+                expected_count);
+        }
 
-        // Validate common runtime args count
+        // Validate vararg CRTA count
         TT_FATAL(
             kernel_params.common_runtime_args.size() == schema->num_common_runtime_args,
-            "Kernel '{}' expects {} common runtime args, but {} were provided",
+            "Kernel '{}' expects {} vararg common_runtime_args, but {} were provided",
             kernel_name,
             schema->num_common_runtime_args,
             kernel_params.common_runtime_args.size());
 
-        // Validate that all nodes in the schema have runtime args provided
-        for (const auto& [node_coord, expected_count] : schema->num_runtime_args_per_node) {
-            bool found = false;
-            for (const auto& [provided_node, args] : kernel_params.runtime_args) {
-                if (provided_node == node_coord) {
-                    found = true;
-                    break;
-                }
-            }
+        // Validate named RTAs: every declared name set per-node, no extras, no duplicate node entries.
+        const auto& named_rta_names = schema->named_runtime_args;
+        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
+
+        std::unordered_set<NodeCoord> nodes_with_named_params;
+        for (const auto& node_params : kernel_params.named_runtime_args) {
+            auto [it_node, inserted_node] = nodes_with_named_params.insert(node_params.node);
             TT_FATAL(
-                found,
-                "Kernel '{}' is missing runtime args for node {} (expected {} args)",
+                inserted_node,
+                "Duplicate node_coord {} in named_runtime_args for kernel '{}'.",
+                node_params.node.str(),
+                kernel_name);
+            TT_FATAL(
+                kernel_nodes.contains(node_params.node),
+                "Kernel '{}' is setting named_runtime_args for node {}, but the kernel does not run on that node.",
                 kernel_name,
-                node_coord.str(),
-                expected_count);
+                node_params.node.str());
+            TT_FATAL(
+                node_params.args.size() == named_rta_names.size(),
+                "Kernel '{}' node {} expects {} named RTAs, but {} were provided",
+                kernel_name,
+                node_params.node.str(),
+                named_rta_names.size(),
+                node_params.args.size());
+            for (const auto& [name, _value] : node_params.args) {
+                (void)_value;
+                TT_FATAL(
+                    named_rta_name_set.contains(name),
+                    "Kernel '{}' node {} sets named RTA '{}' which is not declared in the schema.",
+                    kernel_name,
+                    node_params.node.str(),
+                    name);
+            }
+        }
+        if (!named_rta_names.empty()) {
+            for (const auto& node : kernel_nodes) {
+                TT_FATAL(
+                    nodes_with_named_params.contains(node),
+                    "Kernel '{}' has named RTAs declared but no named_runtime_args provided for node {}.",
+                    kernel_name,
+                    node.str());
+            }
+        }
+
+        // Validate named CRTAs: every declared name set, no extras.
+        const auto& named_crta_names = schema->named_common_runtime_args;
+        TT_FATAL(
+            kernel_params.named_common_runtime_args.size() == named_crta_names.size(),
+            "Kernel '{}' expects {} named CRTAs, but {} were provided",
+            kernel_name,
+            named_crta_names.size(),
+            kernel_params.named_common_runtime_args.size());
+        for (const auto& name : named_crta_names) {
+            TT_FATAL(
+                kernel_params.named_common_runtime_args.contains(name),
+                "Kernel '{}' is missing named CRTA '{}'.",
+                kernel_name,
+                name);
         }
     }
 
@@ -134,36 +199,101 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
     detail::ProgramImpl& program_impl = program.impl();
 
-    // Process kernel runtime arguments
+    // Process kernel runtime arguments.
+    // Named RTAs/CRTAs and vararg RTAs/CRTAs share a single dispatch buffer each (RTA + CRTA).
+    // Layout:
+    //   RTA per-node:  [named_rta_0 ... named_rta_N-1, vararg_0 ... vararg_M-1]
+    //   CRTA:          [named_crta_0 ... named_crta_K-1, vararg_0 ... vararg_L-1]
+    // Named args are placed first in schema declaration order (matches the byte-offset
+    // layout emitted into kernel_args_generated.h). The device-side get_vararg / get_common_vararg
+    // helpers add the named-arg offset transparently, so kernel code indexes varargs from 0.
     for (const auto& kernel_params : params.kernel_run_params) {
         std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_params.kernel_spec_name);
+        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(kernel_params.kernel_spec_name);
+        TT_FATAL(schema != nullptr, "Kernel '{}' has no RTA schema registered.", kernel_params.kernel_spec_name);
 
-        // Set per-node runtime args
-        // set_runtime_args handles both first-time allocation and subsequent updates
-        for (const auto& [node_coord, args] : kernel_params.runtime_args) {
-            kernel->set_runtime_args(node_coord, args);
+        // Build a node -> named-RTA-values-map lookup for serialization.
+        std::unordered_map<NodeCoord, const std::unordered_map<std::string, uint32_t>*> named_rtas_by_node;
+        for (const auto& node_params : kernel_params.named_runtime_args) {
+            named_rtas_by_node[node_params.node] = &node_params.args;
         }
+
+        // Build a node -> vararg-values-span lookup.
+        std::unordered_map<NodeCoord, const std::vector<uint32_t>*> varargs_by_node;
+        for (const auto& [node, args] : kernel_params.runtime_args) {
+            varargs_by_node[node] = &args;
+        }
+
+        // Iterate over every node the kernel runs on. We need to set RTAs on any node that
+        // has either named RTAs or vararg RTAs. (Validation has already confirmed coverage.)
+        const std::set<CoreCoord>& kernel_nodes = kernel->logical_cores();
+        const bool kernel_has_named_rtas = !schema->named_runtime_args.empty();
+        for (const auto& node : kernel_nodes) {
+            auto named_it = named_rtas_by_node.find(node);
+            auto vararg_it = varargs_by_node.find(node);
+            const bool has_named = named_it != named_rtas_by_node.end();
+            const bool has_varargs = vararg_it != varargs_by_node.end();
+            if (!kernel_has_named_rtas && !has_varargs) {
+                continue;  // Nothing to set on this node.
+            }
+
+            std::vector<uint32_t> combined;
+            combined.reserve(schema->named_runtime_args.size() + (has_varargs ? vararg_it->second->size() : 0));
+            if (kernel_has_named_rtas) {
+                TT_FATAL(
+                    has_named,
+                    "Internal error: validation passed but named RTAs missing for kernel '{}' node {}.",
+                    kernel_params.kernel_spec_name,
+                    node.str());
+                for (const auto& name : schema->named_runtime_args) {
+                    auto v_it = named_it->second->find(name);
+                    TT_FATAL(
+                        v_it != named_it->second->end(),
+                        "Internal error: named RTA '{}' missing for kernel '{}' node {}.",
+                        name,
+                        kernel_params.kernel_spec_name,
+                        node.str());
+                    combined.push_back(v_it->second);
+                }
+            }
+            if (has_varargs) {
+                combined.insert(combined.end(), vararg_it->second->begin(), vararg_it->second->end());
+            }
+            kernel->set_runtime_args(node, combined);
+        }
+
+        // Combine named CRTAs and vararg CRTAs into one common buffer.
+        std::vector<uint32_t> combined_crtas;
+        combined_crtas.reserve(schema->named_common_runtime_args.size() + kernel_params.common_runtime_args.size());
+        for (const auto& name : schema->named_common_runtime_args) {
+            auto v_it = kernel_params.named_common_runtime_args.find(name);
+            TT_FATAL(
+                v_it != kernel_params.named_common_runtime_args.end(),
+                "Internal error: named CRTA '{}' missing for kernel '{}'.",
+                name,
+                kernel_params.kernel_spec_name);
+            combined_crtas.push_back(v_it->second);
+        }
+        combined_crtas.insert(
+            combined_crtas.end(), kernel_params.common_runtime_args.begin(), kernel_params.common_runtime_args.end());
 
         // Set common runtime args
         // TODO: Why on earth does SetCommonRuntimeArgs() only work the first time??
-        if (!kernel_params.common_runtime_args.empty()) {
+        if (!combined_crtas.empty()) {
             if (kernel->common_runtime_args().empty()) {
                 // First time: use the normal setter which allocates storage
-                kernel->set_common_runtime_args(kernel_params.common_runtime_args);
+                kernel->set_common_runtime_args(combined_crtas);
             } else {
                 // Subsequent calls: update in-place
                 // (set_common_runtime_args fatals if called twice, so use direct access)
                 RuntimeArgsData& crta = kernel->common_runtime_args_data();
                 TT_FATAL(
-                    crta.size() == kernel_params.common_runtime_args.size(),
+                    crta.size() == combined_crtas.size(),
                     "Kernel '{}' common runtime args count cannot change from {} to {}",
                     kernel_params.kernel_spec_name,
                     crta.size(),
-                    kernel_params.common_runtime_args.size());
-                std::memcpy(
-                    crta.data(),
-                    kernel_params.common_runtime_args.data(),
-                    kernel_params.common_runtime_args.size() * sizeof(uint32_t));
+                    combined_crtas.size());
+                std::memcpy(crta.data(), combined_crtas.data(), combined_crtas.size() * sizeof(uint32_t));
             }
         }
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -743,7 +743,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // it says "hey, your input was malformed, fix it". This is a developer-facing, active
     // documentation of the code's assumptions.
     // We REALLY shouldn't be using TT_FATAL for both flavors.
-    TT_FATAL(spec.workers.has_value(), "Interal Error: spec.workers must be populated.");
+    TT_FATAL(spec.workers.has_value(), "Internal Error: spec.workers must be populated.");
     const auto& workers = spec.workers.value();
     TT_FATAL(!workers.empty(), "At least one WorkerSpec is required");
 
@@ -1552,7 +1552,7 @@ Program MakeProgramFromSpec(const ProgramSpec& user_spec, bool skip_validation) 
             runtime_schema.num_runtime_args_per_node[node_coord] = num_args;
         }
         runtime_schema.num_common_runtime_args = user_schema.num_common_runtime_args;
-        program_impl->register_kernel_rta_schema(kernel_spec.unique_id, std::move(runtime_schema));
+        program_impl->register_kernel_rta_schema(kernel_spec.unique_id, runtime_schema);
     }
 
     return Program(std::move(program_impl));

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -515,6 +515,44 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.unique_id);
     }
 
+    // Validate named RTA/CRTA schema and named CTAs
+    for (const auto& kernel : spec.kernels) {
+        TT_FATAL(
+            IsValidCppIdentifier(kernel.args_namespace),
+            "KernelSpec '{}' has args_namespace '{}' which is not a valid C++ identifier.",
+            kernel.unique_id,
+            kernel.args_namespace);
+
+        // All three kinds share the user namespace — their names must be mutually unique.
+        std::unordered_map<std::string, const char*> seen;  // name -> kind
+        auto check_name = [&](const std::string& name, const char* kind) {
+            TT_FATAL(
+                IsValidCppIdentifier(name),
+                "KernelSpec '{}' {} name '{}' is not a valid C++ identifier.",
+                kernel.unique_id,
+                kind,
+                name);
+            auto [it, inserted] = seen.try_emplace(name, kind);
+            TT_FATAL(
+                inserted,
+                "KernelSpec '{}' has a naming collision: '{}' is declared as both a {} and a {}.",
+                kernel.unique_id,
+                name,
+                it->second,
+                kind);
+        };
+        for (const auto& name : kernel.runtime_arguments_schema.named_runtime_args) {
+            check_name(name, "named RTA");
+        }
+        for (const auto& name : kernel.runtime_arguments_schema.named_common_runtime_args) {
+            check_name(name, "named CRTA");
+        }
+        for (const auto& [name, value] : kernel.compile_time_arg_bindings) {
+            (void)value;
+            check_name(name, "named CTA");
+        }
+    }
+
     // Validate kernel thread counts
     for (const auto& kernel : spec.kernels) {
         TT_FATAL(kernel.num_threads > 0, "KernelSpec '{}' has no threads!", kernel.unique_id);
@@ -1243,26 +1281,31 @@ KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
 // MakeGen1DataMovementConfig: Create a DataMovementConfig (WH/BH) from a KernelSpec
 // ----------------------------------------------------------------------------
 
+// (Temporary) Shims
+// ProgramSpec APIs use vector<pair> for conceptually map-like data structures.
+// This is deliberate, done so ProgramSpec stays hashable for TTNN's program caching.
+// For now, just convert to the map types that the core runtime expects.
+// TODO: Fix this inefficiency eventually.
+std::unordered_map<std::string, uint32_t> to_named_compile_args_map(
+    const KernelSpec::CompileTimeArgBindings& bindings) {
+    return std::unordered_map<std::string, uint32_t>(bindings.begin(), bindings.end());
+}
+std::map<std::string, std::string> to_defines_map(const KernelSpec::CompilerOptions::Defines& defines) {
+    return std::map<std::string, std::string>(defines.begin(), defines.end());
+}
+
 DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
     TT_FATAL(kernel_spec.is_dm_kernel(), "Expected a DM kernel");
     const auto& dm_config = std::get<DataMovementConfiguration>(kernel_spec.config_spec);
     const auto& gen1 = dm_config.gen1_data_movement_config.value();
-
-    // Convert defines from vector<pair> to map (yuck)
-    // API uses vector<pair> for ease of Program caching.
-    // TODO: Make the lower level runtime support vector<pair> to avoid pointless conversion.
-    std::map<std::string, std::string> defines_map;
-    for (const auto& [key, value] : kernel_spec.compiler_options.defines) {
-        defines_map[key] = value;
-    }
 
     return DataMovementConfig{
         .processor = gen1.processor,
         .noc = gen1.noc,
         .noc_mode = gen1.noc_mode,
         .compile_args = {},  // only named_compile_args is used
-        .defines = defines_map,
-        .named_compile_args = kernel_spec.compile_time_arg_bindings,
+        .defines = to_defines_map(kernel_spec.compiler_options.defines),
+        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
         .opt_level = kernel_spec.compiler_options.opt_level,
     };
 }
@@ -1281,14 +1324,6 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
         unpack_modes[dfb_id] = mode;
     }
 
-    // Convert defines from vector<pair> to map (yuck)
-    // API uses vector<pair> for ease of Program caching.
-    // TODO: Make the lower level runtime support vector<pair> to avoid pointless conversion.
-    std::map<std::string, std::string> defines_map;
-    for (const auto& [key, value] : kernel_spec.compiler_options.defines) {
-        defines_map[key] = value;
-    }
-
     return ComputeConfig{
         .math_fidelity = compute_config.math_fidelity,
         .fp32_dest_acc_en = compute_config.fp32_dest_acc_en,
@@ -1297,8 +1332,8 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
         .bfp8_pack_precise = compute_config.bfp8_pack_precise,
         .math_approx_mode = compute_config.math_approx_mode,
         .compile_args = {},  // only named_compile_args is used
-        .defines = defines_map,
-        .named_compile_args = kernel_spec.compile_time_arg_bindings,
+        .defines = to_defines_map(kernel_spec.compiler_options.defines),
+        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
         .opt_level = kernel_spec.compiler_options.opt_level,
     };
 }
@@ -1310,17 +1345,11 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
 experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(const KernelSpec& kernel_spec) {
     TT_FATAL(kernel_spec.is_dm_kernel(), "Expected a DM kernel");
 
-    // Convert defines from vector<pair> to map (yuck)
-    std::map<std::string, std::string> defines_map;
-    for (const auto& [key, value] : kernel_spec.compiler_options.defines) {
-        defines_map[key] = value;
-    }
-
     return experimental::quasar::QuasarDataMovementConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
         .compile_args = {},  // only named_compile_args is used
-        .defines = defines_map,
-        .named_compile_args = kernel_spec.compile_time_arg_bindings,
+        .defines = to_defines_map(kernel_spec.compiler_options.defines),
+        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
         .is_legacy_kernel = false,
         .opt_level = kernel_spec.compiler_options.opt_level,
     };
@@ -1349,12 +1378,6 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         unpack_modes[dfb_id] = mode;
     }
 
-    // Convert defines from vector<pair> to map (yuck)
-    std::map<std::string, std::string> defines_map;
-    for (const auto& [key, value] : kernel_spec.compiler_options.defines) {
-        defines_map[key] = value;
-    }
-
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
         .math_fidelity = compute_config.math_fidelity,
@@ -1364,8 +1387,8 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         .bfp8_pack_precise = compute_config.bfp8_pack_precise,
         .math_approx_mode = compute_config.math_approx_mode,
         .compile_args = {},  // Compile args are passed via named_compile_args
-        .defines = defines_map,
-        .named_compile_args = kernel_spec.compile_time_arg_bindings,
+        .defines = to_defines_map(kernel_spec.compiler_options.defines),
+        .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
         .opt_level = kernel_spec.compiler_options.opt_level,
     };
 }
@@ -1480,6 +1503,12 @@ Program MakeProgramFromSpec(const ProgramSpec& user_spec, bool skip_validation) 
         const tt::tt_metal::DataflowBufferLocalAccessorHandleMap dfb_handles =
             MakeDataflowBufferLocalAccessorHandles(kernel_spec, dfb_name_to_id);
 
+        // Named-args schema fields passed to the Kernel ctor. The names are used at JIT time
+        // to emit kernel_args_generated.h and factor into the kernel cache key.
+        const auto& named_rtas = kernel_spec.runtime_arguments_schema.named_runtime_args;
+        const auto& named_crtas = kernel_spec.runtime_arguments_schema.named_common_runtime_args;
+        const auto& args_ns = kernel_spec.args_namespace;
+
         // Create the kernel object
         std::shared_ptr<Kernel> kernel;
 
@@ -1489,20 +1518,22 @@ Program MakeProgramFromSpec(const ProgramSpec& user_spec, bool skip_validation) 
                 auto config = MakeQuasarDataMovementConfig(kernel_spec);
                 auto processors = GetDMProcessorSet(DMProcessorMask{(uint8_t)(risc_mask & 0xFF)});
                 kernel = std::make_shared<experimental::quasar::QuasarDataMovementKernel>(
-                    kernel_src, node_ranges, config, processors, dfb_handles);
+                    kernel_src, node_ranges, config, processors, dfb_handles, named_rtas, named_crtas, args_ns);
             } else {
                 auto config = MakeQuasarComputeConfig(kernel_spec, dfb_name_to_id);
                 auto processors = GetComputeProcessorSet(ComputeEngineMask{(uint8_t)(risc_mask >> 8)});
                 kernel = std::make_shared<experimental::quasar::QuasarComputeKernel>(
-                    kernel_src, node_ranges, config, processors, dfb_handles);
+                    kernel_src, node_ranges, config, processors, dfb_handles, named_rtas, named_crtas, args_ns);
             }
         } else {  // gen1
             if (kernel_spec.is_dm_kernel()) {
                 auto config = MakeGen1DataMovementConfig(kernel_spec);
-                kernel = std::make_shared<DataMovementKernel>(kernel_src, node_ranges, config, dfb_handles);
+                kernel = std::make_shared<DataMovementKernel>(
+                    kernel_src, node_ranges, config, dfb_handles, named_rtas, named_crtas, args_ns);
             } else {
                 auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_id);
-                kernel = std::make_shared<ComputeKernel>(kernel_src, node_ranges, config, dfb_handles);
+                kernel = std::make_shared<ComputeKernel>(
+                    kernel_src, node_ranges, config, dfb_handles, named_rtas, named_crtas, args_ns);
             }
         }
 
@@ -1510,14 +1541,18 @@ Program MakeProgramFromSpec(const ProgramSpec& user_spec, bool skip_validation) 
         KernelHandle handle = program_impl->add_kernel(kernel, HalProgrammableCoreType::TENSIX);
         program_impl->register_kernel_spec_name(kernel_spec.unique_id, handle);
 
-        // Register the RTA+CRTA schema
-        const auto& schema = kernel_spec.runtime_arguments_schema;
-        std::unordered_map<CoreCoord, size_t> num_rtas_per_node;
-        for (const auto& [node_coord, num_args] : schema.num_runtime_args_per_node) {
-            num_rtas_per_node[node_coord] = num_args;
+        // Register the RTA+CRTA schema (named lists + vararg counts) with the ProgramImpl.
+        // Used by ValidateProgramRunParams and SetProgramRunParameters to validate and serialize
+        // the user-provided values at dispatch time.
+        const auto& user_schema = kernel_spec.runtime_arguments_schema;
+        detail::ProgramImpl::KernelRTASchema runtime_schema;
+        runtime_schema.named_runtime_args = user_schema.named_runtime_args;
+        runtime_schema.named_common_runtime_args = user_schema.named_common_runtime_args;
+        for (const auto& [node_coord, num_args] : user_schema.num_runtime_args_per_node) {
+            runtime_schema.num_runtime_args_per_node[node_coord] = num_args;
         }
-        program_impl->register_kernel_rta_schema(
-            kernel_spec.unique_id, num_rtas_per_node, schema.num_common_runtime_args);
+        runtime_schema.num_common_runtime_args = user_schema.num_common_runtime_args;
+        program_impl->register_kernel_rta_schema(kernel_spec.unique_id, std::move(runtime_schema));
     }
 
     return Program(std::move(program_impl));

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <unordered_set>
 
+#include <fmt/format.h>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program.hpp>
@@ -339,6 +340,68 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 }
 
 // ----------------------------------------------------------------------------
+// Default Inference (optional inputs -> explicit)
+// ----------------------------------------------------------------------------
+//
+// Some optional parameters in the ProgramSpec are automatically inferred by the
+// runtime if the user doesn't specify them explicitly:
+//   - WorkerSpecs
+//   - Gen1 DM kernel configuration (TODO)
+//
+//
+// Infer WorkerSpecs from kernels, DFBs, and semaphores.
+std::vector<WorkerSpec> InferWorkers(const ProgramSpec& spec) {
+    using CoverageSig = std::tuple<std::set<KernelSpecName>, std::set<DFBSpecName>, std::set<SemaphoreSpecName>>;
+
+    std::map<NodeCoord, CoverageSig> node_to_sig;
+
+    // Compute coverage signatures for each node mentioned in any target_nodes field.
+    auto for_each_node = [&](const std::variant<NodeCoord, NodeRange, NodeRangeSet>& target_nodes, auto&& fn) {
+        const NodeRangeSet range_set = to_node_range_set(target_nodes);
+        for (const NodeRange& range : range_set.ranges()) {
+            for (const NodeCoord& node : range) {
+                fn(node);
+            }
+        }
+    };
+
+    // Accumulate coverage signatures from kernels, DFBs, and semaphores.
+    for (const KernelSpec& kernel : spec.kernels) {
+        for_each_node(
+            kernel.target_nodes, [&](const NodeCoord& n) { std::get<0>(node_to_sig[n]).insert(kernel.unique_id); });
+    }
+    for (const DataflowBufferSpec& dfb : spec.dataflow_buffers) {
+        for_each_node(dfb.target_nodes, [&](const NodeCoord& n) { std::get<1>(node_to_sig[n]).insert(dfb.unique_id); });
+    }
+    for (const SemaphoreSpec& sem : spec.semaphores) {
+        for_each_node(sem.target_nodes, [&](const NodeCoord& n) { std::get<2>(node_to_sig[n]).insert(sem.unique_id); });
+    }
+
+    // Group nodes by coverage signature.
+    std::map<CoverageSig, std::vector<NodeCoord>> sig_to_nodes;
+    for (const auto& [node, sig] : node_to_sig) {
+        sig_to_nodes[sig].push_back(node);
+    }
+
+    // Build one WorkerSpec per signature.
+    // Inferred unique_ids have the form "inferred_worker@<node_range_set>"
+    // (so auto-generated status is explicit in error messages).
+    std::vector<WorkerSpec> workers;
+    workers.reserve(sig_to_nodes.size());
+    for (const auto& [sig, nodes] : sig_to_nodes) {
+        NodeRangeSet nrs = NodeRangeSet(ttsl::Span<const NodeCoord>(nodes)).merge_ranges();
+        workers.push_back(WorkerSpec{
+            .unique_id = fmt::format("inferred_worker@{}", nrs),
+            .kernels = std::vector<KernelSpecName>(std::get<0>(sig).begin(), std::get<0>(sig).end()),
+            .dataflow_buffers = std::vector<DFBSpecName>(std::get<1>(sig).begin(), std::get<1>(sig).end()),
+            .semaphores = std::vector<SemaphoreSpecName>(std::get<2>(sig).begin(), std::get<2>(sig).end()),
+            .target_nodes = nrs,
+        });
+    }
+    return workers;
+}
+
+// ----------------------------------------------------------------------------
 // ValidateNodeBounds: Node coordinate bounds checking
 // ----------------------------------------------------------------------------
 //
@@ -634,12 +697,9 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate WorkerSpecs
     //////////////////////////////
 
-    // WorkerSpecs are now required for all architectures.
-    // NOTE: WorkerSpec data is strictly redundant, but improves clarity and messaging.
-    //       If it's hated, we can make it optional, and derive the WorkerSpec if absent.
-    //       (Only on WH/BH though, I definitely want to require it on Quasar.)
-    TT_FATAL(spec.workers.has_value(), "Workers are required");
-    const auto& workers = spec.workers.value();
+    // By contract, MakeProgramFromSpec runs InferWorkers before validation, so
+    // spec.workers is always populated here — either by the user or by inference.
+    const auto& workers = *spec.workers;
     TT_FATAL(!workers.empty(), "At least one WorkerSpec is required");
 
     // WorkerSpecs may not overlap in their target nodes
@@ -1350,13 +1410,23 @@ std::set<experimental::quasar::QuasarComputeProcessor> GetComputeProcessorSet(Co
 // Public Entry Point
 // ============================================================================
 
-Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
-    log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.program_id);
+Program MakeProgramFromSpec(const ProgramSpec& user_spec, bool skip_validation) {
+    log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", user_spec.program_id);
 
-    // Step 1a: Collect derived data (builds lookup tables, checks structural invariants)
+    // Step 1a: Copy the spec and infer defaults for any optional fields the user
+    // left unspecified. After this, `spec` is guaranteed to have workers populated.
+    // NOTE: We copy before CollectSpecData because the collected data caches
+    // pointers into spec.kernels; downstream maps (kernel_to_risc_mask) are keyed
+    // by those same pointers, so `collected` and the solver must see the same spec.
+    ProgramSpec spec = user_spec;
+    if (!spec.workers.has_value()) {
+        spec.workers = InferWorkers(spec);
+    }
+
+    // Step 1b: Collect derived data (builds lookup tables, checks structural invariants)
     CollectedSpecData collected = CollectSpecData(spec);
 
-    // Step 1b: Validate semantic rules (can be skipped for trusted inputs)
+    // Step 1c: Validate semantic rules (can be skipped for trusted inputs)
     if (!skip_validation) {
         ValidateProgramSpec(spec, collected);
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -340,22 +340,20 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 }
 
 // ----------------------------------------------------------------------------
-// Default Inference (optional inputs -> explicit)
+// InferWorkers: Populate spec.workers if not supplied by the user
 // ----------------------------------------------------------------------------
 //
-// Some optional parameters in the ProgramSpec are automatically inferred by the
-// runtime if the user doesn't specify them explicitly:
-//   - WorkerSpecs
-//   - Gen1 DM kernel configuration (TODO)
-//
-//
-// Infer WorkerSpecs from kernels, DFBs, and semaphores.
+// If WorkerSpecs are not supplied by the user, infer them from the
+// ProgramSpec's kernel/DFB/semaphore target_nodes fields.
 std::vector<WorkerSpec> InferWorkers(const ProgramSpec& spec) {
-    using CoverageSig = std::tuple<std::set<KernelSpecName>, std::set<DFBSpecName>, std::set<SemaphoreSpecName>>;
+    // NodeContents: the kernels, DFBs, and semaphores on a given node are its "signature"
+    // Nodes with the same NodeContents can be grouped together into the same WorkerSpec
+    using NodeContents = std::tuple<std::set<KernelSpecName>, std::set<DFBSpecName>, std::set<SemaphoreSpecName>>;
 
-    std::map<NodeCoord, CoverageSig> node_to_sig;
+    std::map<NodeCoord, NodeContents> node_contents_map;
 
-    // Compute coverage signatures for each node mentioned in any target_nodes field.
+    // Visit every node in a std::variant<NodeCoord, NodeRange, NodeRangeSet>
+    // TODO: Why the heck do we always deal with this silly variant? Why not just NodeRangeSet everywhere?
     auto for_each_node = [&](const std::variant<NodeCoord, NodeRange, NodeRangeSet>& target_nodes, auto&& fn) {
         const NodeRangeSet range_set = to_node_range_set(target_nodes);
         for (const NodeRange& range : range_set.ranges()) {
@@ -365,27 +363,30 @@ std::vector<WorkerSpec> InferWorkers(const ProgramSpec& spec) {
         }
     };
 
-    // Accumulate coverage signatures from kernels, DFBs, and semaphores.
+    // Populate the NodeContents for every node (mentioned somewhere in the ProgramSpec)
     for (const KernelSpec& kernel : spec.kernels) {
-        for_each_node(
-            kernel.target_nodes, [&](const NodeCoord& n) { std::get<0>(node_to_sig[n]).insert(kernel.unique_id); });
+        for_each_node(kernel.target_nodes, [&](const NodeCoord& n) {
+            std::get<0>(node_contents_map[n]).insert(kernel.unique_id);
+        });
     }
     for (const DataflowBufferSpec& dfb : spec.dataflow_buffers) {
-        for_each_node(dfb.target_nodes, [&](const NodeCoord& n) { std::get<1>(node_to_sig[n]).insert(dfb.unique_id); });
+        for_each_node(
+            dfb.target_nodes, [&](const NodeCoord& n) { std::get<1>(node_contents_map[n]).insert(dfb.unique_id); });
     }
     for (const SemaphoreSpec& sem : spec.semaphores) {
-        for_each_node(sem.target_nodes, [&](const NodeCoord& n) { std::get<2>(node_to_sig[n]).insert(sem.unique_id); });
+        for_each_node(
+            sem.target_nodes, [&](const NodeCoord& n) { std::get<2>(node_contents_map[n]).insert(sem.unique_id); });
     }
 
-    // Group nodes by coverage signature.
-    std::map<CoverageSig, std::vector<NodeCoord>> sig_to_nodes;
-    for (const auto& [node, sig] : node_to_sig) {
+    // Group nodes by NodeContents signature
+    std::map<NodeContents, std::vector<NodeCoord>> sig_to_nodes;
+    for (const auto& [node, sig] : node_contents_map) {
         sig_to_nodes[sig].push_back(node);
     }
 
-    // Build one WorkerSpec per signature.
+    // Build one WorkerSpec per NodeContents signature.
     // Inferred unique_ids have the form "inferred_worker@<node_range_set>"
-    // (so auto-generated status is explicit in error messages).
+    // (this makes the auto-inference obvious in error messaging).
     std::vector<WorkerSpec> workers;
     workers.reserve(sig_to_nodes.size());
     for (const auto& [sig, nodes] : sig_to_nodes) {
@@ -697,9 +698,15 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate WorkerSpecs
     //////////////////////////////
 
-    // By contract, MakeProgramFromSpec runs InferWorkers before validation, so
-    // spec.workers is always populated here — either by the user or by inference.
-    const auto& workers = *spec.workers;
+    // spec.workers is ALWAYS populated at this point.
+    // Either the user provided it, or runtime inferred it in a previous step.
+    //
+    // TODO: This isn't a user-facing error! A user-facing error is actionable to the user,
+    // it says "hey, your input was malformed, fix it". This is a developer-facing, active
+    // documentation of the code's assumptions.
+    // We REALLY shouldn't be using TT_FATAL for both flavors.
+    TT_FATAL(spec.workers.has_value(), "Interal Error: spec.workers must be populated.");
+    const auto& workers = spec.workers.value();
     TT_FATAL(!workers.empty(), "At least one WorkerSpec is required");
 
     // WorkerSpecs may not overlap in their target nodes
@@ -1413,15 +1420,23 @@ std::set<experimental::quasar::QuasarComputeProcessor> GetComputeProcessorSet(Co
 Program MakeProgramFromSpec(const ProgramSpec& user_spec, bool skip_validation) {
     log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", user_spec.program_id);
 
-    // Step 1a: Copy the spec and infer defaults for any optional fields the user
-    // left unspecified. After this, `spec` is guaranteed to have workers populated.
-    // NOTE: We copy before CollectSpecData because the collected data caches
-    // pointers into spec.kernels; downstream maps (kernel_to_risc_mask) are keyed
-    // by those same pointers, so `collected` and the solver must see the same spec.
-    ProgramSpec spec = user_spec;
-    if (!spec.workers.has_value()) {
-        spec.workers = InferWorkers(spec);
+    // Step 1a: Infer missing fields (required, but "opt in" for the user)
+    //    - WorkerSpecs
+    //   - Gen1 DM kernel configs (TODO - upcoming PR)
+
+    // For now, just make a full copy of the ProgramSpec if inference is required.
+    // This is simple, but wasteful -- specs can be large, and inference will
+    // only fill in a few spare fields.
+    // TODO: Optimize this. We can maintain a separate "inference results" struct,
+    // and plumb that through the rest of the code alongside the user's spec.
+
+    std::optional<ProgramSpec> inferred_spec;
+    // If we need to infer some fields, for now just suck it up and copy everything.
+    if (!user_spec.workers.has_value()) {
+        inferred_spec = user_spec;
+        inferred_spec->workers = InferWorkers(*inferred_spec);
     }
+    const ProgramSpec& spec = inferred_spec.has_value() ? *inferred_spec : user_spec;
 
     // Step 1b: Collect derived data (builds lookup tables, checks structural invariants)
     CollectedSpecData collected = CollectSpecData(spec);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -479,15 +479,11 @@ uint32_t ProgramImpl::get_semaphore_handle(const SemaphoreSpecName& name) const 
     return it->second;
 }
 
-void ProgramImpl::register_kernel_rta_schema(
-    const KernelSpecName& name,
-    const std::unordered_map<CoreCoord, size_t>& num_runtime_args_per_node,
-    size_t num_common_runtime_args) {
+void ProgramImpl::register_kernel_rta_schema(const KernelSpecName& name, KernelRTASchema schema) {
     if (!metal2_registry_) {
         metal2_registry_ = Metal2NameRegistry{};
     }
-    auto [it, inserted] = metal2_registry_->kernel_rta_schemas.try_emplace(
-        name, KernelRTASchema{num_runtime_args_per_node, num_common_runtime_args});
+    auto [it, inserted] = metal2_registry_->kernel_rta_schemas.try_emplace(name, std::move(schema));
     TT_FATAL(inserted, "Duplicate kernel RTA schema for: {}", name);
 }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -479,11 +479,11 @@ uint32_t ProgramImpl::get_semaphore_handle(const SemaphoreSpecName& name) const 
     return it->second;
 }
 
-void ProgramImpl::register_kernel_rta_schema(const KernelSpecName& name, KernelRTASchema schema) {
+void ProgramImpl::register_kernel_rta_schema(const KernelSpecName& name, const KernelRTASchema& schema) {
     if (!metal2_registry_) {
         metal2_registry_ = Metal2NameRegistry{};
     }
-    auto [it, inserted] = metal2_registry_->kernel_rta_schemas.try_emplace(name, std::move(schema));
+    auto [it, inserted] = metal2_registry_->kernel_rta_schemas.try_emplace(name, schema);
     TT_FATAL(inserted, "Duplicate kernel RTA schema for: {}", name);
 }
 

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -353,7 +353,7 @@ public:
     };
 
     // Metal 2.0: Runtime argument schema registration and lookup
-    void register_kernel_rta_schema(const KernelSpecName& name, KernelRTASchema schema);
+    void register_kernel_rta_schema(const KernelSpecName& name, const KernelRTASchema& schema);
     const KernelRTASchema* get_kernel_rta_schema(const KernelSpecName& name) const;
 
     // Metal 2.0: Get all registered kernel names (for completeness validation)

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -339,17 +339,21 @@ public:
         return get_kernel(get_kernel_handle(name));
     }
 
-    // Metal 2.0: Runtime argument schema for validation
+    // Metal 2.0: Runtime argument schema for validation.
+    // Includes both the named args (declaration-order name lists) and the vararg counts.
     struct KernelRTASchema {
+        // Named arg names, in declaration order. Used to serialize ProgramRunParams values
+        // into the dispatch buffer and to validate that every declared name is supplied.
+        std::vector<std::string> named_runtime_args;
+        std::vector<std::string> named_common_runtime_args;
+
+        // Vararg counts. RTA vararg count is per-node; CRTA vararg is a single broadcast count.
         std::unordered_map<CoreCoord, size_t> num_runtime_args_per_node;
         size_t num_common_runtime_args = 0;
     };
 
     // Metal 2.0: Runtime argument schema registration and lookup
-    void register_kernel_rta_schema(
-        const KernelSpecName& name,
-        const std::unordered_map<CoreCoord, size_t>& num_runtime_args_per_node,
-        size_t num_common_runtime_args);
+    void register_kernel_rta_schema(const KernelSpecName& name, KernelRTASchema schema);
     const KernelRTASchema* get_kernel_rta_schema(const KernelSpecName& name) const;
 
     // Metal 2.0: Get all registered kernel names (for completeness validation)

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -68,6 +68,7 @@ string build_trisc_prolog(const char* trisc_define) {
     ostringstream prolog;
     prolog << "#define " << trisc_define << "\n";
     prolog << "#include \"kernel_bindings_generated.h\"\n";
+    prolog << "#include \"kernel_args_generated.h\"\n";
     prolog << "#include \"defines_generated.h\"\n";
     return prolog.str();
 }
@@ -132,6 +133,86 @@ void write_kernel_bindings_generated_header(const std::filesystem::path& out_dir
     write_file(path, content.str());
 }
 
+// Emits per-kernel accessors for named RTAs, CRTAs, and CTAs inside the user-configurable
+// args namespace. Also emits get_vararg() / get_common_vararg() helpers with the named-args
+// offset baked in — so that vararg indices in kernel code are stable across schema changes.
+//
+// The generated header itself is never hashed; the kernel cache key is derived in
+// Kernel::compute_hash() from the input data (kernel source, schema, CTA bindings, etc).
+// So we don't need to massage the generation order for hash stability — we just emit what
+// we're given.
+void write_kernel_args_generated_header(const string& out_dir, const JitBuildSettings& settings) {
+    const string path = out_dir + "kernel_args_generated.h";
+
+    // Named RTAs/CRTAs come straight from the settings as ordered vectors.
+    const vector<string>& rta_names = settings.get_named_runtime_args();
+    const vector<string>& crta_names = settings.get_named_common_runtime_args();
+
+    // Named CTAs come through the legacy unordered_map path (Kernel internal storage).
+    // The order in which we emit them doesn't matter: CTA values are baked into the header
+    // as independent constexpr constants; they don't affect RTA/CRTA byte offsets.
+    vector<pair<string, uint32_t>> cta_entries;
+    settings.process_named_compile_time_args(
+        [&cta_entries](const std::unordered_map<std::string, uint32_t>& named_args) {
+            for (const auto& [name, value] : named_args) {
+                cta_entries.emplace_back(name, value);
+            }
+        });
+
+    const string& ns = settings.get_args_namespace();
+
+    ostringstream content;
+    content << "// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.\n"
+               "//\n"
+               "// SPDX-License-Identifier: Apache-2.0\n\n"
+               "// AUTO-GENERATED — do not edit.\n\n"
+               "#pragma once\n\n";
+
+    const bool has_any = !rta_names.empty() || !crta_names.empty() || !cta_entries.empty();
+    if (!has_any) {
+        content << "// No named kernel args for this kernel.\n";
+        write_file(path, content.str());
+        return;
+    }
+
+    content << "#include \"experimental/kernel_args.h\"\n\n";
+    content << "namespace " << ns << " {\n";
+
+    // Named RTAs
+    // Here, rta_offset tracks the byte_offset of the RTA in the dispatch buffer.
+    // (Only uint32_t arg types are currently supported, but we later want to extend this.)
+    uint32_t rta_offset = 0;
+    for (const auto& name : rta_names) {
+        content << "constexpr experimental::RtaArg<uint32_t> " << name << "{" << rta_offset << "};\n";
+        rta_offset += sizeof(uint32_t);
+    }
+    // Named CRTAs
+    uint32_t crta_offset = 0;
+    for (const auto& name : crta_names) {
+        content << "constexpr experimental::CrtaArg<uint32_t> " << name << "{" << crta_offset << "};\n";
+        crta_offset += sizeof(uint32_t);
+    }
+    // Named CTAs
+    // No offsets to deal with here; CTA values are emitted directly into the generated header.
+    for (const auto& [name, value] : cta_entries) {
+        content << "constexpr experimental::CtaVal<uint32_t> " << name << "{" << value << "u};\n";
+    }
+
+    content << "}  // namespace " << ns << "\n\n";
+
+    // Vararg helpers.
+    // The starting offset (named_arg_count) is baked in so kernel code uses 0-based
+    // indexing: get_vararg(0) is the first vararg, regardless of named-arg count.
+    const uint32_t named_rta_words = static_cast<uint32_t>(rta_names.size());
+    const uint32_t named_crta_words = static_cast<uint32_t>(crta_names.size());
+    content << "FORCE_INLINE uint32_t get_vararg(uint32_t idx) { return get_arg_val<uint32_t>(" << named_rta_words
+            << " + idx); }\n"
+            << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { return get_common_arg_val<uint32_t>("
+            << named_crta_words << " + idx); }\n";
+
+    write_file(path, content.str());
+}
+
 }  // namespace
 
 void jit_build_genfiles_kernel_include(
@@ -140,11 +221,15 @@ void jit_build_genfiles_kernel_include(
     log_trace(tt::LogBuildKernels, "Generating defines for BRISC/NCRISC/ERISC user kernel");
 
     fs::path out_dir = fs::path(env.get_out_kernel_root_path()) / settings.get_full_kernel_name();
+
     write_kernel_bindings_generated_header(out_dir, settings);
+    write_kernel_args_generated_header(out_dir, settings);
+
     fs::path kernel_header = out_dir / "kernel_includes.hpp";
 
     const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src);
-    const string kernel_header_content = string("#include \"kernel_bindings_generated.h\"\n") + kernel_src_to_include;
+    const string kernel_header_content = string("#include \"kernel_bindings_generated.h\"\n") +
+                                         string("#include \"kernel_args_generated.h\"\n") + kernel_src_to_include;
     write_file(kernel_header, kernel_header_content);
 }
 
@@ -154,7 +239,10 @@ void jit_build_genfiles_triscs_src(
     log_trace(tt::LogBuildKernels, "Generating defines for TRISCs");
 
     const fs::path out_dir = fs::path(env.get_out_kernel_root_path()) / settings.get_full_kernel_name();
+    
     write_kernel_bindings_generated_header(out_dir, settings);
+    write_kernel_args_generated_header(out_dir, settings);
+
     const fs::path unpack_cpp = out_dir / "chlkc_unpack.cpp";
     const fs::path math_cpp = out_dir / "chlkc_math.cpp";
     const fs::path pack_cpp = out_dir / "chlkc_pack.cpp";

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -141,8 +141,8 @@ void write_kernel_bindings_generated_header(const std::filesystem::path& out_dir
 // Kernel::compute_hash() from the input data (kernel source, schema, CTA bindings, etc).
 // So we don't need to massage the generation order for hash stability — we just emit what
 // we're given.
-void write_kernel_args_generated_header(const string& out_dir, const JitBuildSettings& settings) {
-    const string path = out_dir + "kernel_args_generated.h";
+void write_kernel_args_generated_header(const std::filesystem::path& out_dir, const JitBuildSettings& settings) {
+    const fs::path path = out_dir / "kernel_args_generated.h";
 
     // Named RTAs/CRTAs come straight from the settings as ordered vectors.
     const vector<string>& rta_names = settings.get_named_runtime_args();

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -240,7 +240,7 @@ void jit_build_genfiles_triscs_src(
     log_trace(tt::LogBuildKernels, "Generating defines for TRISCs");
 
     const fs::path out_dir = fs::path(env.get_out_kernel_root_path()) / settings.get_full_kernel_name();
-    
+
     write_kernel_bindings_generated_header(out_dir, settings);
     write_kernel_args_generated_header(out_dir, settings);
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -166,43 +166,44 @@ void write_kernel_args_generated_header(const string& out_dir, const JitBuildSet
                "//\n"
                "// SPDX-License-Identifier: Apache-2.0\n\n"
                "// AUTO-GENERATED — do not edit.\n\n"
-               "#pragma once\n\n";
+               "#pragma once\n\n"
+               "#include \"experimental/kernel_args.h\"\n\n";
 
-    const bool has_any = !rta_names.empty() || !crta_names.empty() || !cta_entries.empty();
-    if (!has_any) {
-        content << "// No named kernel args for this kernel.\n";
-        write_file(path, content.str());
-        return;
+    // Named args namespace: emit only when the kernel has at least one named arg or CTA.
+    // A kernel with only varargs (and no named anything) still needs the vararg helpers below,
+    // so we keep emitting those unconditionally.
+    const bool has_named_args = !rta_names.empty() || !crta_names.empty() || !cta_entries.empty();
+    if (has_named_args) {
+        content << "namespace " << ns << " {\n";
+
+        // Named RTAs
+        // Here, rta_offset tracks the byte_offset of the RTA in the dispatch buffer.
+        // (Only uint32_t arg types are currently supported, but we later want to extend this.)
+        uint32_t rta_offset = 0;
+        for (const auto& name : rta_names) {
+            content << "constexpr experimental::RtaArg<uint32_t> " << name << "{" << rta_offset << "};\n";
+            rta_offset += sizeof(uint32_t);
+        }
+        // Named CRTAs
+        uint32_t crta_offset = 0;
+        for (const auto& name : crta_names) {
+            content << "constexpr experimental::CrtaArg<uint32_t> " << name << "{" << crta_offset << "};\n";
+            crta_offset += sizeof(uint32_t);
+        }
+        // Named CTAs
+        // No offsets to deal with here; CTA values are emitted directly into the generated header.
+        for (const auto& [name, value] : cta_entries) {
+            content << "constexpr experimental::CtaVal<uint32_t> " << name << "{" << value << "u};\n";
+        }
+
+        content << "}  // namespace " << ns << "\n\n";
     }
 
-    content << "#include \"experimental/kernel_args.h\"\n\n";
-    content << "namespace " << ns << " {\n";
-
-    // Named RTAs
-    // Here, rta_offset tracks the byte_offset of the RTA in the dispatch buffer.
-    // (Only uint32_t arg types are currently supported, but we later want to extend this.)
-    uint32_t rta_offset = 0;
-    for (const auto& name : rta_names) {
-        content << "constexpr experimental::RtaArg<uint32_t> " << name << "{" << rta_offset << "};\n";
-        rta_offset += sizeof(uint32_t);
-    }
-    // Named CRTAs
-    uint32_t crta_offset = 0;
-    for (const auto& name : crta_names) {
-        content << "constexpr experimental::CrtaArg<uint32_t> " << name << "{" << crta_offset << "};\n";
-        crta_offset += sizeof(uint32_t);
-    }
-    // Named CTAs
-    // No offsets to deal with here; CTA values are emitted directly into the generated header.
-    for (const auto& [name, value] : cta_entries) {
-        content << "constexpr experimental::CtaVal<uint32_t> " << name << "{" << value << "u};\n";
-    }
-
-    content << "}  // namespace " << ns << "\n\n";
-
-    // Vararg helpers.
+    // Vararg helpers — always emitted.
     // The starting offset (named_arg_count) is baked in so kernel code uses 0-based
-    // indexing: get_vararg(0) is the first vararg, regardless of named-arg count.
+    // indexing: get_vararg(0) is the first vararg, regardless of named-arg count. When
+    // there are no named args, the offset is zero and these helpers are just thin wrappers
+    // around get_arg_val / get_common_arg_val.
     const uint32_t named_rta_words = static_cast<uint32_t>(rta_names.size());
     const uint32_t named_crta_words = static_cast<uint32_t>(crta_names.size());
     content << "FORCE_INLINE uint32_t get_vararg(uint32_t idx) { return get_arg_val<uint32_t>(" << named_rta_words

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <vector>
 
 namespace tt::tt_metal {
 
@@ -35,6 +36,26 @@ public:
     // (Initially just DFB local accessor names, but will be extended and refactored as needed.)
     virtual void process_dataflow_buffer_local_accessor_handles(
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const {}
+
+    // Named RTA/CRTA schema (Metal 2.0 APIs).
+    // The order of names determines the byte offset of each arg within the named-args
+    // section of the dispatch buffer.
+    // Returned by const-ref rather than via a process_* callback because the concrete storage
+    // is already an ordered vector — the callback indirection would just force a copy.
+    virtual const std::vector<std::string>& get_named_runtime_args() const {
+        static const std::vector<std::string> k_empty;
+        return k_empty;
+    }
+    virtual const std::vector<std::string>& get_named_common_runtime_args() const {
+        static const std::vector<std::string> k_empty;
+        return k_empty;
+    }
+    // User-configurable C++ namespace emitted around named RTA/CRTA/CTA accessors in
+    // kernel_args_generated.h. Defaults to "args" when not overridden.
+    virtual const std::string& get_args_namespace() const {
+        static const std::string k_default = "args";
+        return k_default;
+    }
 
     // Called to process additional include paths (e.g., kernel source directory for relative includes)
     virtual void process_include_paths(const std::function<void(const std::string& path)>&) const {}


### PR DESCRIPTION
### PR Type
Feature

### Summary
Improved kernel argument syntax for Metal 2.0!
 - Named runtime /common runtime arguments (RTAs + CRTAs)
 - RTA and CRTA varargs (flexible in number; positionally accessed)
 - Uniform kernel argument access (whether it's a CTA, RTA, or CRTA is only expressed in host code)
 - JIT compile-time error checking of argument names
 - (Optional) user-defined kernel argument namespace 

Also lays groundwork for kernel arguments of arbitrary POD type (future work).

### Motivation
The legacy kernel argument APIs are notoriously difficult to use:
 - RTAs, CRTAs and "classic" CTAs must be accessed positionally (`get_arg_val(7)`)
          - brittle, error prone, unreadable
 - Named CTAs (`get_named_compile_time_arg_val("x_dim")`) have shortcomings
         -  a typo in the string literal happily compiles... then the kernel produces garbage results
         - kernel fusion can result in name collisions
 - Changing an argument's dispatch type (CTA, RTA, or CTRA) requires editing **both** host  and device code. This friction discourages trivial (but impactful) dispatch overhead optimization / design space exploration.

### How it works
In device code, argument retrieval now looks like this:
```C++
void kernel_main() {
    // Arguments are just arguments
    // Kernel source doesn't care whether each value arrives as RTA, CRTA, or CTA.
    uint32_t data_size    = get_arg(args::data_size);     // RTA
    uint32_t num_tiles    = get_arg(args::num_tiles);     // CRTA
    uint32_t bs                 = get_arg(args::block_size);    // CTA

    // No string literals, so typos are compile errors at the offending token
    auto bad = get_arg(args::blokc_size);  // error

    // Use varargs for flexible variable number of arguments (i.e. retrieval in a loop),
    // or for legacy compatibility mode
    uint32_t flex = get_vararg(0);   // (stored after named args in dispatch buffer)
}
```

In host code, arguments are declared and bound like this:
```C++
(add this)
```


### Changes

 - **Host API**: Named runtime argument schema in `KernelSpec`; named runtime arg value binding in `ProgramRunParams`
 - **Device API**: New API header (`hw/inc/experimental/kernel_args.h`) with accessor structs and `get_arg()` 
 - **Header generation**: New auto-generated header (`kernel_args_generated.h`) encodes accessors.
 - **Validation**: Runtime validation for argument specification. 
 - **Plumbing**: Small changes in `ProgramImpl` and `Kernel` to convey the new data to the JIT build.
 - **Tests**: Multiple unit tests (using mock device) and a HW loopback test exercising kernel-side arg retrieval.

### TODOs

 - **"Power user" API for setting RTAs + CRTAs in performance-sensitive contexts**: `ProgramRunParams` is user friendly but not particularly efficient. Implement the stub API for direct argument setting via direct view into the dispatch data structures. (https://github.com/tenstorrent/tt-metal/issues/40985)
 - **Kernel args with POD types**: This change adds arg names, but types are still confined to `uint32_t`. Typed args are in-plan and will be added later.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/named_runtime_args2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/named_runtime_args2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/named_runtime_args2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/named_runtime_args2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/named_runtime_args2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/named_runtime_args2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/named_runtime_args2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/named_runtime_args2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/named_runtime_args2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/named_runtime_args2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/named_runtime_args2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/named_runtime_args2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/named_runtime_args2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/named_runtime_args2)