### PR TITLE
fix(moe): pass scores instead of undefined weights to reduce_module

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -474,7 +474,7 @@ class TtMoe(LightweightModule):
         # 2. Reduce-scatter across TP axis: (1, 1, 256, 2048) -> (1, 1, 256, 512) per device
         routed_output = self.reduce_module(
             combined_output,
-            weights=weights,
+            weights=scores,
             indices=indices,
             expert_dispatch_table=self.tt_expert_dispatch_table,
         )


### PR DESCRIPTION
weights was never assigned in TtMoe.forward; the gate returns scores which are the per-token routing weights for top-k experts.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/fix-moe-weights-undefined)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/fix-moe-weights-undefined)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/fix-moe-weights-undefined)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/fix-moe-weights-undefined)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/fix-moe-weights-undefined)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/fix-moe-weights-undefined)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/fix-moe-weights-undefined)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/fix-moe-weights-undefined)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/fix-moe-weights-undefined)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/fix-moe-weights-undefined)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/fix-moe-weights-undefined)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/fix-moe-weights-undefined)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/fix-moe-weights-undefined)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/fix-moe-weights-undefined)