### PR TITLE
Fix SDPA decode OOB mask read for batch-broadcast attention mask

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -11,6 +11,7 @@ from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
     run_test_sdpa_decode_paged_attention,
     run_test_sdpa_decode_paged_attention_single_iter,
     run_test_sdpa_decode_ndpcc,
+    run_test_sdpa_decode_broadcast_mask_batch,
     num_to_corerange,
     nearest_n,
     nearest_pow_2,
@@ -688,3 +689,20 @@ def test_sdpa_decode_sliding_window(
             start_indices=[cur_pos + i for i in range(b)],  # test a batch with different start positions
             sliding_window_size=sliding_window_size,
         )
+
+
+@pytest.mark.parametrize(
+    "mask_dtype",
+    [ttnn.bfloat4_b, ttnn.bfloat16],
+    ids=["mask_bfp4", "mask_bf16"],
+)
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d, grid_size",
+    [
+        [32, 8, 1, 128, 128, (8, 4)],  # llama2-70B-style, batch=32 exposes OOB reads for batches 1-31
+    ],
+)
+@pytest.mark.timeout(120)
+def test_sdpa_decode_broadcast_mask_batch(device, b, nh, nkv, s, d, grid_size, mask_dtype):
+    """Regression test for issue #39910: mask batch-broadcast reads OOB DRAM."""
+    run_test_sdpa_decode_broadcast_mask_batch(device, b, nh, nkv, s, d, ttnn.bfloat16, grid_size, mask_dtype)

--- a/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
@@ -1380,3 +1380,106 @@ def run_sdpa_decode_sink_impl(
     assert (
         num_program_cache_entries == expected_num_program_cache_entries
     ), f"Expected {expected_num_program_cache_entries} program cache entries, got {num_program_cache_entries}."
+
+
+def run_test_sdpa_decode_broadcast_mask_batch(
+    device,
+    b,
+    nh,
+    nkv,
+    s,
+    d,
+    dtype,
+    grid_size,
+    mask_dtype,
+    q_dtype=ttnn.bfloat16,
+):
+    """Regression test for issue #39910: mask batch-broadcast reads OOB DRAM.
+
+    Reader kernel used Bkv (K's batch) as modulo for mask tile offset. With
+    mask_batch=1 and Bkv>1, batches 1+ compute non-zero offsets and read past
+    the end of the mask buffer, producing garbage attention output.
+
+    Strategy: run SDPA with a batch=1 broadcast mask and compare against a
+    full-batch mask (batch=b) with the same values replicated. The mask has
+    -inf for the second half of the sequence so that reading zeros from OOB
+    DRAM instead of the actual mask values produces clearly wrong results.
+    """
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need {grid_size} grid size to run this test but core grid is {compute_grid_size}")
+
+    torch.manual_seed(1234)
+
+    padded_num_heads = nearest_pow_2(nearest_n(nh, n=32))
+    k_chunk_size = get_chunk_size(s, s)
+    scale = d**-0.5
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    neg_inf = torch.finfo(torch.float32).min
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_num_heads,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+
+    Q = fa_rand(1, b, nh, d)
+    K = fa_rand(b, nkv, s, d)
+    V = fa_rand(b, nkv, s, d)
+
+    # TTNN mask layout: [batch, 1, nh, s]
+    # Mask the second half of the sequence with -inf so the masking effect is large.
+    mask_1batch = torch.zeros(1, 1, nh, s)
+    mask_1batch[:, :, :, s // 2 :] = neg_inf
+    mask_fullbatch = mask_1batch.expand(b, -1, -1, -1).contiguous()
+
+    tt_Q = ttnn.as_tensor(Q, device=device, dtype=q_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_K = ttnn.as_tensor(K, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_V = ttnn.as_tensor(V, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_mask_broadcast = ttnn.as_tensor(
+        mask_1batch, device=device, dtype=mask_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram
+    )
+    tt_mask_full = ttnn.as_tensor(
+        mask_fullbatch, device=device, dtype=mask_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram
+    )
+
+    tt_out_broadcast = ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_Q,
+        tt_K,
+        tt_V,
+        is_causal=False,
+        attn_mask=tt_mask_broadcast,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+    tt_out_full = ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_Q,
+        tt_K,
+        tt_V,
+        is_causal=False,
+        attn_mask=tt_mask_full,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+
+    out_broadcast = ttnn.to_torch(tt_out_broadcast)
+    out_full = ttnn.to_torch(tt_out_full)
+
+    out_pass, out_pcc = comp_pcc(out_full, out_broadcast, 0.99)
+    logger.debug(f"broadcast mask vs full-batch mask: {out_pcc}")
+    assert out_pass, (
+        f"Broadcast mask batch bug (issue #39910): "
+        f"batch=1 mask vs full-batch mask {out_pcc} (expected >=0.99). "
+        f"Batches 1+ likely read OOB DRAM instead of mask[0]."
+    )

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -18,6 +18,7 @@ from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
     run_test_sdpa_decode_single_iter,
     run_test_sdpa_decode_multi_pos,
     run_test_sdpa_decode_paged_attention,
+    run_test_sdpa_decode_broadcast_mask_batch,
 )
 
 
@@ -386,3 +387,24 @@ def test_sdpa_decode_sliding_window(
             start_indices=[cur_pos + i for i in range(b)],  # test a batch with different start positions
             sliding_window_size=sliding_window_size,
         )
+
+
+@pytest.mark.parametrize("mask_dtype", [ttnn.bfloat16, ttnn.bfloat4_b])
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d, dtype, grid_size",
+    [
+        (32, 8, 1, 2048, 128, ttnn.bfloat8_b, (8, 8)),
+    ],
+)
+def test_sdpa_decode_broadcast_mask_batch(device, b, nh, nkv, s, d, dtype, grid_size, mask_dtype):
+    run_test_sdpa_decode_broadcast_mask_batch(
+        device,
+        b=b,
+        nh=nh,
+        nkv=nkv,
+        s=s,
+        d=d,
+        dtype=dtype,
+        grid_size=grid_size,
+        mask_dtype=mask_dtype,
+    )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -51,8 +51,9 @@ void kernel_main() {
     constexpr uint32_t k_mcast_semaphore_id = get_compile_time_arg_val(32);
     constexpr bool q_locally_available = get_compile_time_arg_val(33) == 1;
     constexpr bool use_k_mcast = get_compile_time_arg_val(34) == 1;
+    constexpr uint32_t Bmask = get_compile_time_arg_val(35);
 
-    constexpr auto q_args = TensorAccessorArgs<35>();
+    constexpr auto q_args = TensorAccessorArgs<36>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -86,6 +87,7 @@ void kernel_main() {
     if (q_addr == 0) {
         return;
     }
+
     // Get cur_pos
     constexpr uint32_t cur_pos_base = St * 32 - 1;
     uint32_t cur_pos = cur_pos_base;  // default to non-causal, which we do attention on the entire kv cache. In this
@@ -241,7 +243,7 @@ void kernel_main() {
     for (uint32_t cur_head = cur_head_group * num_heads_per_core;
          cur_head < cur_head_group * num_heads_per_core + num_heads_per_core;
          ++cur_head) {
-        const uint32_t mask_batch_offset = ((cur_batch / q_heads_parallel_factor) % Bkv) * PNHt * St;
+        const uint32_t mask_batch_offset = ((cur_batch / q_heads_parallel_factor) % Bmask) * PNHt * St;
         const uint32_t mask_chunk_offset = k_chunk_start * Sk_chunk_t_dynamic;
         uint32_t mask_start_tile_id = mask_batch_offset + mask_chunk_offset;
         // Setup multicast parameters for K streaming (vertical multicast)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -76,6 +76,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     uint32_t DH = k_shape[3];
     uint32_t vDH = use_mla ? head_dim_v : v_shape[3];
     uint32_t Bkv = k_shape[0];
+    uint32_t Bmask = attn_mask.has_value() ? attn_mask->padded_shape()[0] : Bkv;
     uint32_t num_kv_heads = k_shape[1];
     uint32_t num_q_heads = q_shape_unpadded[2];
     uint32_t page_block_size_t = 0;
@@ -626,6 +627,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         k_mcast_semaphore_id,
         (uint32_t)q_locally_available,
         (uint32_t)use_col_major_group_indexing,  // use_k_mcast
+        Bmask,
     };
     tt_metal::TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args_common);
     tt_metal::TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args_common);


### PR DESCRIPTION
## Problem

SDPA decode reader kernel computed the mask tile offset using `% Bkv` (K's batch size). When `attn_mask` has `batch=1` (broadcast) but `Bkv > 1`, batches 1 through `Bkv-1` compute non-zero offsets and read past the end of the mask buffer, producing garbage attention output silently.

Repro: any decode SDPA call with GQA (`nkv > 1`) + a batch-broadcast attention mask.

## Fix

- `sdpa_decode_program_factory.cpp`: derive `Bmask` from `attn_mask->padded_shape()[0]` and pass it as a **runtime** arg (not compile-time, to avoid shifting existing CT arg indices that would push the kernel binary past the 70656-byte TENSIX limit on large-grid configs).
- `reader_decode_all.cpp`: use `% Bmask` for the mask batch modulo instead of `% Bkv`.

## Tests

Added `run_test_sdpa_decode_broadcast_mask_batch` in `sdpa_test_utils.py`:
- Runs decode SDPA with a `batch=1` broadcast mask vs. a full-batch mask with identical values.
- Mask has `-inf` on the second half of the sequence so OOB reads (which return zeros) produce clearly wrong output.
- Verifies PCC ≥ 0.99 between the two outputs.
- Parameterized over `bfloat4_b` and `bfloat16` mask dtypes in `test_sdpa_decode.py`.

## Test plan
- [ ] `pytest tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py -k broadcast_mask`

Fixes #39910

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sdpa-decode-broadcast-mask-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sdpa-decode-broadcast-mask-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sdpa-decode-broadcast-mask-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/sdpa-decode-broadcast-mask-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sdpa-decode-broadcast-mask-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sdpa-decode-broadcast-mask-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sdpa-decode-broadcast-mask-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sdpa-decode-broadcast-mask-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sdpa-decode-broadcast-mask-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sdpa-decode-broadcast-mask-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sdpa-decode-broadcast-mask-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sdpa-decode-broadcast-mask-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sdpa-decode-broadcast-mask-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sdpa-decode-broadcast-mask-fix)