### PR TITLE
Gate ds-rc1 merges on release owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -449,3 +449,6 @@ tt-train/tests/** @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczewskiTT @abustam
 # Tech reports
 tech_reports/LLMs/vLLM_integration.md @skhorasganiTT @viktorpusTT @tenstorrent/codeowner-bypass
 models/experimental/yunet @tvardhineniTT @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass
+
+# ds-rc1 release-candidate gate. Keep this final so PRs targeting ds-rc1 require one of these owners.
+* @kpaigwar @yalrawwashTT


### PR DESCRIPTION
## Summary
- Add a ds-rc1-only final CODEOWNERS rule requiring ownership by @kpaigwar or @yalrawwashTT for PRs targeting ds-rc1.
- Keep main unaffected because GitHub reads CODEOWNERS from the PR base branch.

## Testing
- pre-commit hooks via git commit

## Follow-up
- Enable a branch ruleset/protection for ds-rc1 with required PR review count 1 and required code owner review. The CODEOWNERS rule supplies the owners; the branch rule enforces the merge block.