### PR TITLE
Fix comp_pcc false pass for constant tensors

### DIFF
--- a/models/common/metrics.py
+++ b/models/common/metrics.py
@@ -17,6 +17,7 @@ Key Features:
 
 import numpy as np
 import torch
+from loguru import logger
 
 import ttnn
 
@@ -349,9 +350,10 @@ def compute_pcc_host(impl, ref):
         if torch.all(torch.isnan(golden)) or torch.all(torch.isnan(calculated)):
             return 0.0
 
-        # One tensor is all zero, the other is not
+        # One tensor is all zero, the other is not — also a zero-variance case.
         if torch.any(golden.bool()) != torch.any(calculated.bool()):
-            return 0.0
+            logger.warning("One tensor is all zero. PCC undefined; falling back to allclose.")
+            return float(torch.allclose(golden, calculated, rtol=1e-05, atol=1e-04))
 
         # Mask all infs and nans
         golden = golden.clone()
@@ -376,26 +378,25 @@ def compute_pcc_host(impl, ref):
             golden = golden.type(torch.float32)
             calculated = calculated.type(torch.float32)
 
-        # Single element case
+        # Single element or constant tensor: PCC is undefined.
         if golden.numel() == 1:
-            return float(torch.equal(golden, calculated))
+            return float(torch.allclose(golden, calculated, rtol=1e-05, atol=1e-04))
 
-        # If both tensors are constant
-        if torch.max(golden) == torch.min(golden) and torch.max(calculated) == torch.min(calculated):
-            return torch.isclose(torch.max(golden), torch.max(calculated)).item()
+        if torch.max(golden) == torch.min(golden) or torch.max(calculated) == torch.min(calculated):
+            logger.warning("One or both tensors are constant (zero std dev). PCC undefined; falling back to allclose.")
+            return float(torch.allclose(golden, calculated, rtol=1e-05, atol=1e-04))
 
         # Compute PCC using numpy's corrcoef
         cal_pcc = np.ma.corrcoef(
             np.ma.masked_invalid(torch.squeeze(golden).detach().numpy()).flatten(),
             np.ma.masked_invalid(torch.squeeze(calculated).detach().numpy()).flatten(),
         )
-        # Remove correlation coefficient with self (typically always 1.0)
-        mask = np.ones(cal_pcc.shape, dtype=bool)
-        np.fill_diagonal(mask, 0)
-        cal_pcc = np.min(cal_pcc[mask])
+        # Read off-diagonal directly to avoid diagonal contamination.
+        cal_pcc = cal_pcc[0, 1]
 
-        if isinstance(cal_pcc, np.ma.core.MaskedConstant):
-            return 1.0
+        if isinstance(cal_pcc, np.ma.core.MaskedConstant) or np.isnan(float(cal_pcc)):
+            logger.warning("PCC returned NaN/masked. Falling back to allclose.")
+            return float(torch.allclose(golden, calculated, rtol=1e-05, atol=1e-04))
 
         return float(cal_pcc)
     except Exception:

--- a/models/common/tests/test_validation_tools.py
+++ b/models/common/tests/test_validation_tools.py
@@ -502,7 +502,8 @@ def test_return_reference_output_torch(ttnn_mesh_device: ttnn.MeshDevice):
     # Registry records one validation
     assert len(registry.results) == before + 1
     assert not registry.results[-1].metrics[Metric.MAX_ABS_ERROR].passed
-    assert registry.results[-1].metrics[Metric.PCC].passed
+    # Mock ref is constant (ones); impl is matmul
+    assert not registry.results[-1].metrics[Metric.PCC].passed
 
     # Convert both outputs to host and verify numerical equivalence
     out_host = to_torch_auto_compose(out_tt)
@@ -558,7 +559,7 @@ def test_validation_non_decorator_host(ttnn_mesh_device: ttnn.MeshDevice):
     assert registry.results[-1].passed
 
 
-def test_validation_raises_on_reference_exception(ttnn_mesh_device: ttnn.MeshDevice):
+def test_validation_raises_on_reference_exception(ttnn_mesh_device: ttnn.MeshDevice, expect_error):
     """When raise_exceptions=True, reference exceptions should propagate and not record results."""
     registry = get_validation_registry()
     before = len(registry.results)
@@ -576,7 +577,7 @@ def test_validation_raises_on_reference_exception(ttnn_mesh_device: ttnn.MeshDev
     def _matmul(a, b):
         return ttnn.matmul(a, b)
 
-    with pytest.raises(TypeError) as e:
+    with expect_error(TypeError, "missing 1 required positional argument: 'c'") as e:
         _ = _matmul(a_tt, b_tt)
     assert "missing 1 required positional argument: 'c'" in str(e.value)
     assert len(registry.results) == before + 1
@@ -586,7 +587,7 @@ def test_validation_raises_on_reference_exception(ttnn_mesh_device: ttnn.MeshDev
     def _matmul_too(a, b):
         return ttnn.matmul(a, b)
 
-    with pytest.raises(TypeError) as e:
+    with expect_error(TypeError, "missing 1 required positional argument: 'y'") as e:
         _ = _matmul_too(a_tt, b_tt)
     assert "missing 1 required positional argument: 'y'" in str(e.value)
     assert len(registry.results) == before + 2
@@ -596,7 +597,7 @@ def test_validation_raises_on_reference_exception(ttnn_mesh_device: ttnn.MeshDev
     def _matmul_three(a, b):
         return ttnn.matmul(a, b)
 
-    with pytest.raises(TypeError) as e:
+    with expect_error(TypeError, "takes 1 positional argument but 2 were given") as e:
         _ = _matmul_three(a_tt, b_tt)
     assert "takes 1 positional argument but 2 were given" in str(e.value)
     assert len(registry.results) == before + 3

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -485,7 +485,7 @@ def comp_allclose(golden, calculated, rtol=1e-05, atol=1e-08):
     )
 
 
-def comp_pcc(golden, calculated, pcc=0.99):
+def comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04):
     golden = torch.Tensor(golden)
     calculated = torch.Tensor(calculated)
 
@@ -545,9 +545,12 @@ def comp_pcc(golden, calculated, pcc=0.99):
     denom = torch.sqrt(g_centered.pow(2).sum(dtype=torch.float64) * c_centered.pow(2).sum(dtype=torch.float64))
     cal_pcc = (cov / denom).item()
 
-    # Zero variance -> denom == 0 -> cal_pcc is nan: treat as a perfect match.
+    # Zero variance -> denom == 0 -> cal_pcc is nan: PCC is undefined for constant tensors.
+    # Fall back to allclose rather than returning a misleading 1.0.
     if math.isnan(cal_pcc):
-        return True, 1.0
+        logger.warning("PCC is NaN (zero variance / constant tensor). Falling back to allclose check.")
+        result = torch.allclose(golden, calculated, rtol=rtol, atol=atol)
+        return result, float(result)
 
     return cal_pcc >= pcc, cal_pcc
 
@@ -739,7 +742,7 @@ def comp_allclose_and_pcc(golden, calculated, rtol=1e-05, atol=1e-08, pcc=0.99):
     passing &= passing_allclose
     output += output_allclose
     if torch.numel(golden) != 1:
-        passing_pcc, output_pcc = comp_pcc(golden, calculated, pcc)
+        passing_pcc, output_pcc = comp_pcc(golden, calculated, pcc, rtol=rtol, atol=atol)
         passing &= passing_pcc
         output += f", pcc={output_pcc}"
 

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -542,7 +542,16 @@ def comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04):
     g_centered = golden - (golden.sum(dtype=torch.float64) / n).to(golden.dtype)
     c_centered = calculated - (calculated.sum(dtype=torch.float64) / n).to(calculated.dtype)
     cov = (g_centered * c_centered).sum(dtype=torch.float64)
-    denom = torch.sqrt(g_centered.pow(2).sum(dtype=torch.float64) * c_centered.pow(2).sum(dtype=torch.float64))
+    g_sq_sum = g_centered.pow(2).sum(dtype=torch.float64)
+    c_sq_sum = c_centered.pow(2).sum(dtype=torch.float64)
+    denom = torch.sqrt(g_sq_sum * c_sq_sum)
+    # pow/sum stay in float32 before the reduction; large-magnitude tensors (e.g. ldexp)
+    # can overflow to inf here even though float64 accumulation would be finite.
+    if not math.isfinite(denom.item()) or not math.isfinite(cov.item()):
+        g_centered64 = g_centered.to(torch.float64)
+        c_centered64 = c_centered.to(torch.float64)
+        cov = (g_centered64 * c_centered64).sum()
+        denom = torch.sqrt(g_centered64.pow(2).sum() * c_centered64.pow(2).sum())
     cal_pcc = (cov / denom).item()
 
     # Zero variance -> denom == 0 -> cal_pcc is nan: PCC is undefined for constant tensors.

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -500,10 +500,13 @@ def comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04):
         logger.error("One tensor is all nan, the other is not.")
         return False, 0.0
 
-    # Test if either is completely zero
+    # Test if either is completely zero — but a zero tensor is also a constant tensor,
+    # so fall back to allclose instead of a hard 0.0: zero-vs-small-constant may be
+    # within the caller's tolerances.
     if torch.any(golden.bool()) != torch.any(calculated.bool()):
-        logger.error("One tensor is all zero")
-        return False, 0.0
+        logger.warning("One tensor is all zero. PCC undefined; falling back to allclose.")
+        result = torch.allclose(golden, calculated, rtol=rtol, atol=atol)
+        return result, float(result)
 
     golden = torch.squeeze(golden).flatten()
     calculated = torch.squeeze(calculated).flatten()

--- a/models/demos/gpt_oss/tests/unit/test_rope.py
+++ b/models/demos/gpt_oss/tests/unit/test_rope.py
@@ -21,6 +21,27 @@ from models.tt_transformers.tt.rope import rotary_embedding_factory
 
 from ..test_factory import parametrize_mesh_with_fabric
 
+# bf16 tolerance for rope cos/sin at position 0 where all elements share the same
+# value (cos(0)·scale = const).  PCC is undefined on constant tensors; allclose
+# with this atol covers normal bf16 quantisation error (observed ~0.003, <1 ULP).
+_ROPE_BF16_ATOL = 0.01
+_ROPE_BF16_RTOL = 1e-5
+
+
+def _compare_rope_vector(golden, calculated, pcc_threshold=0.99):
+    """Compare two rope embedding vectors, handling constant-tensor PCC edge case.
+
+    When both tensors are constant (e.g. cos at position 0), PCC is undefined.
+    Fall back to allclose with bf16-appropriate tolerance instead of relying on
+    comp_pcc's internal fallback whose default atol is too tight for bf16.
+    """
+    is_golden_const = golden.numel() > 0 and (golden.max() == golden.min()).item()
+    is_calc_const = calculated.numel() > 0 and (calculated.max() == calculated.min()).item()
+    if is_golden_const and is_calc_const:
+        close = torch.allclose(golden, calculated, rtol=_ROPE_BF16_RTOL, atol=_ROPE_BF16_ATOL)
+        return close, 1.0 if close else 0.0
+    return comp_pcc(golden, calculated, pcc_threshold)
+
 
 def get_rope_cos_sin_from_tt_setup(rope_setup, mesh_device, seq_len):
     """
@@ -504,9 +525,9 @@ def test_rope_embedding_lookup_multi_user(mesh_device, device_params, batch_size
         cos_hf_pos = cos_hf_unique[pos, :]  # [head_dim/2]
         sin_hf_pos = sin_hf_unique[pos, :]  # [head_dim/2]
 
-        # Compare
-        cos_passing, cos_pcc = comp_pcc(cos_hf_pos.float(), cos_tt_user.float(), 0.99)
-        sin_passing, sin_pcc = comp_pcc(sin_hf_pos.float(), sin_tt_user.float(), 0.99)
+        # Compare (constant-tensor safe: cos at position 0 is constant across head_dim)
+        cos_passing, cos_pcc = _compare_rope_vector(cos_hf_pos.float(), cos_tt_user.float(), 0.99)
+        sin_passing, sin_pcc = _compare_rope_vector(sin_hf_pos.float(), sin_tt_user.float(), 0.99)
 
         if user_idx < 4 or user_idx == users_to_compare - 1:  # Log first few and last user
             logger.info(f"User {user_idx} at position {pos}: cos PCC={cos_pcc:.6f}, sin PCC={sin_pcc:.6f}")
@@ -620,9 +641,9 @@ def test_rope_embedding_lookup_users_row_sharded(mesh_device, device_params, max
         cos_hf_pos = cos_hf_unique[pos, :]
         sin_hf_pos = sin_hf_unique[pos, :]
 
-        # Compare
-        cos_passing, cos_pcc = comp_pcc(cos_hf_pos.float(), cos_tt_user.float(), 0.99)
-        sin_passing, sin_pcc = comp_pcc(sin_hf_pos.float(), sin_tt_user.float(), 0.99)
+        # Compare (constant-tensor safe: cos at position 0 is constant across head_dim)
+        cos_passing, cos_pcc = _compare_rope_vector(cos_hf_pos.float(), cos_tt_user.float(), 0.99)
+        sin_passing, sin_pcc = _compare_rope_vector(sin_hf_pos.float(), sin_tt_user.float(), 0.99)
 
         if user_idx < 4 or user_idx == users_to_compare - 1:
             logger.info(f"User {user_idx} at position {pos}: cos PCC={cos_pcc:.6f}, sin PCC={sin_pcc:.6f}")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py
@@ -14,15 +14,25 @@ from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
 
 def run_pow_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
     torch.manual_seed(data_seed)
+    random.seed(data_seed)
 
-    x = torch.Tensor(size=input_shape[0]).uniform_(-100, 100)
+    # bfloat8_b input with negative base + fractional exponent yields NaN in torch.pow
+    # but inf/zero on device; restrict to non-negative inputs for that path.
+    in_low, in_high = (-100, 100)
+    if dtype[0] == ttnn.bfloat8_b:
+        in_low, in_high = (0, 100)
+
+    x = torch.Tensor(size=input_shape[0]).uniform_(in_low, in_high)
     y = random.uniform(0, 10)
 
     try:
-        # get ref result
-        ref_value = torch.pow(x, y)
+        # Quantize on host via from_torch (matches device dtype conversion; no device roundtrip).
+        x_quantized = ttnn.to_torch(ttnn.from_torch(x, dtype=dtype[0], layout=dlayout[0], device=None)).to(
+            torch.float32
+        )
+        ref_value = torch.pow(x_quantized, y)
 
-        x = ttnn_ops.setup_ttnn_tensor(x, device, dlayout[0], in_mem_config, dtype[0])
+        x = ttnn_ops.setup_ttnn_tensor(x_quantized, device, dlayout[0], in_mem_config, dtype[0])
 
         tt_result = ttnn.pow(x, y)
         tt_result = ttnn_ops.ttnn_tensor_to_torch(tt_result, output_mem_config)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -114,9 +114,18 @@ def test_unary_inverse_trig_functions_ttnn(input_shapes, torch_dtype, ttnn_dtype
     if high > 0.9 or low < -0.9:
         ulp_threshold = 65
     output_tensor = ttnn.to_torch(output_tensor)
-    if ttnn_dtype == ttnn.bfloat16 and low != -100:
+    if low == -100 and ttnn_dtype == ttnn.bfloat8_b:
+        # Wide out-of-domain range: PCC is undefined on mostly-non-finite outputs.
+        # bfloat8_b may return +/-Inf where torch golden returns NaN; in-domain
+        # accuracy is covered by the [-0.9, 0.9] and [-1, 1] parametrizations.
+        g_nonfinite = ~torch.isfinite(golden_tensor)
+        d_nonfinite = ~torch.isfinite(output_tensor)
+        assert torch.equal(g_nonfinite, d_nonfinite), "Non-finite positions differ between golden and device"
+    elif ttnn_dtype == ttnn.bfloat16 and low != -100:
         assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=ulp_threshold)
-    assert_with_pcc(output_tensor, golden_tensor, pcc=pcc)
+        assert_with_pcc(output_tensor, golden_tensor, pcc=pcc)
+    else:
+        assert_with_pcc(output_tensor, golden_tensor, pcc=pcc)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/test_comp_pcc_fix.py
+++ b/tests/ttnn/unit_tests/test_comp_pcc_fix.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/test_comp_pcc_fix.py
+++ b/tests/ttnn/unit_tests/test_comp_pcc_fix.py
@@ -76,3 +76,12 @@ class TestCompPccConstantTensor:
         passing, pcc_val = comp_pcc(golden, calculated, pcc=0.99)
         assert isinstance(pcc_val, float), f"Expected float, got {type(pcc_val)}: {pcc_val}"
         assert not math.isnan(pcc_val), "pcc_val should not be NaN"
+
+    def test_large_magnitude_float32_tensors_use_float64_correlation(self):
+        """ldexp-scale outputs overflow float32 sum-of-squares; PCC must not fall back to allclose."""
+        torch.manual_seed(0)
+        golden = torch.randn(64, 128, dtype=torch.float32) * 1e19
+        calculated = golden + torch.randn(64, 128, dtype=torch.float32) * 1e15
+        passing, pcc_val = comp_pcc(golden, calculated, pcc=0.99)
+        assert passing, f"Expected high-PCC large-magnitude tensors to pass, got pcc={pcc_val}"
+        assert pcc_val > 0.99, f"Expected pcc > 0.99, got {pcc_val}"

--- a/tests/ttnn/unit_tests/test_comp_pcc_fix.py
+++ b/tests/ttnn/unit_tests/test_comp_pcc_fix.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression tests for the comp_pcc constant-tensor false-pass fix.
+
+Before the fix, np.ma.corrcoef on a constant tensor returned a masked matrix
+and np.min returned the diagonal 1.0 instead of the undefined off-diagonal
+value, causing a silent false-pass for one-constant-vs-random comparisons.
+"""
+
+import math
+import pytest
+import torch
+
+from models.common.utility_functions import comp_pcc
+
+
+class TestCompPccConstantTensor:
+    """comp_pcc must not return 1.0 when one tensor is constant and the other varies."""
+
+    def test_one_constant_vs_random_fails(self):
+        """Golden is constant, calculated is random: should fail (not silently pass at 1.0)."""
+        golden = torch.ones(32, 32)
+        calculated = torch.randn(32, 32)
+        passing, pcc_val = comp_pcc(golden, calculated, pcc=0.99)
+        assert not passing, f"Expected failure but got passing=True, pcc={pcc_val}"
+        # pcc_val is the allclose result (0.0), not the false 1.0
+        assert pcc_val != 1.0, f"pcc_val should not be 1.0 for non-matching constant vs random"
+
+    def test_random_vs_one_constant_fails(self):
+        """Calculated is constant, golden is random: should fail."""
+        golden = torch.randn(32, 32)
+        calculated = torch.ones(32, 32) * 5.0
+        passing, pcc_val = comp_pcc(golden, calculated, pcc=0.99)
+        assert not passing, f"Expected failure but got passing=True, pcc={pcc_val}"
+
+    def test_both_constant_same_value_passes(self):
+        """Both tensors identical constants: should pass (allclose is True)."""
+        golden = torch.full((16, 16), 3.14)
+        calculated = torch.full((16, 16), 3.14)
+        passing, pcc_val = comp_pcc(golden, calculated, pcc=0.99)
+        assert passing, f"Expected pass for identical constants but got passing=False, pcc={pcc_val}"
+
+    def test_both_constant_different_values_fails(self):
+        """Both tensors constant but different values: should fail (allclose is False)."""
+        golden = torch.full((16, 16), 1.0)
+        calculated = torch.full((16, 16), 2.0)
+        passing, pcc_val = comp_pcc(golden, calculated, pcc=0.99)
+        assert not passing, f"Expected failure for mismatched constants but got passing=True, pcc={pcc_val}"
+
+    def test_normal_nonconstant_tensors_pass(self):
+        """Sanity: normal correlated tensors should still pass."""
+        golden = torch.linspace(0, 1, 1024)
+        calculated = golden + torch.randn(1024) * 0.001
+        passing, pcc_val = comp_pcc(golden, calculated, pcc=0.99)
+        assert passing, f"Expected high-PCC tensors to pass but got passing=False, pcc={pcc_val}"
+        assert pcc_val > 0.99, f"Expected pcc > 0.99, got {pcc_val}"
+
+    def test_rtol_atol_forwarded_for_close_constants(self):
+        """Caller-supplied rtol/atol must reach the allclose fallback for constant tensors."""
+        golden = torch.full((32,), 1.0)
+        calculated = torch.full((32,), 1.0 + 5e-4)  # within atol=1e-3 but outside default atol=1e-4
+        # With tight defaults it should fail
+        passing_tight, _ = comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04)
+        assert not passing_tight, "Expected failure with tight atol"
+        # With relaxed atol it should pass
+        passing_relaxed, _ = comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-03)
+        assert passing_relaxed, "Expected pass with relaxed atol"
+
+    def test_nan_pcc_returns_float_not_masked(self):
+        """pcc_val must be a plain Python float in all cases (no MaskedConstant)."""
+        golden = torch.ones(64)
+        calculated = torch.ones(64) * 2.0
+        passing, pcc_val = comp_pcc(golden, calculated, pcc=0.99)
+        assert isinstance(pcc_val, float), f"Expected float, got {type(pcc_val)}: {pcc_val}"
+        assert not math.isnan(pcc_val), "pcc_val should not be NaN"

--- a/ttnn/tt_lib/_internal/comparison_funcs.py
+++ b/ttnn/tt_lib/_internal/comparison_funcs.py
@@ -71,21 +71,24 @@ def get_atol_rtol_pcc(golden, calculated):
             if golden.numel() == 1:
                 return float(torch.equal(golden, calculated))
 
-            # If both tensors are constant
-            if torch.max(golden) == torch.min(golden) and torch.max(calculated) == torch.min(calculated):
-                return torch.isclose(torch.max(golden), torch.max(calculated)).item()
+            # If either tensor is constant (zero std dev), PCC is undefined. Fall back to
+            # allclose rather than returning a misleading 1.0 from the corrcoef diagonal.
+            if torch.max(golden) == torch.min(golden) or torch.max(calculated) == torch.min(calculated):
+                logger.warning(
+                    "One or both tensors are constant (zero std dev). PCC undefined; falling back to allclose."
+                )
+                return float(torch.allclose(golden, calculated, rtol=1e-05, atol=1e-04))
 
             cal_pcc = np.ma.corrcoef(
                 np.ma.masked_invalid(torch.squeeze(golden).detach().numpy()).flatten(),
                 np.ma.masked_invalid(torch.squeeze(calculated).detach().numpy()).flatten(),
             )
-            # Remove correlation coefficient with self (typically always 1.0)
-            mask = np.ones(cal_pcc.shape, dtype=bool)
-            np.fill_diagonal(mask, 0)
-            cal_pcc = np.min(cal_pcc[mask])
+            # Read off-diagonal directly to avoid diagonal contamination.
+            cal_pcc = cal_pcc[0, 1]
 
-            if isinstance(cal_pcc, np.ma.core.MaskedConstant):
-                return 1.0
+            if isinstance(cal_pcc, np.ma.core.MaskedConstant) or np.isnan(float(cal_pcc)):
+                logger.warning("PCC returned NaN/masked. Falling back to allclose.")
+                return float(torch.allclose(golden, calculated, rtol=1e-05, atol=1e-04))
 
             return cal_pcc
 

--- a/ttnn/tt_lib/_internal/comparison_funcs.py
+++ b/ttnn/tt_lib/_internal/comparison_funcs.py
@@ -7,7 +7,7 @@ import numpy as np
 from loguru import logger
 
 
-def get_atol_rtol_pcc(golden, calculated):
+def get_atol_rtol_pcc(golden, calculated, rtol=1e-05, atol=1e-04):
     if golden.is_complex() and calculated.is_complex():
         golden = torch.view_as_real(golden.clone())
         calculated = torch.view_as_real(calculated.clone())
@@ -32,65 +32,56 @@ def get_atol_rtol_pcc(golden, calculated):
             logger.error("One tensor is all nan, the other is not.")
             return 0.0
 
-        # One tensor is all zero, the other is not
-        if torch.any(golden.bool()) != torch.any(calculated.bool()):
-            logger.warning("One tensor is all zero")
-            return 0.0
-
         # if torch.any(torch.isinf(golden)) or torch.any(torch.isinf(calculated)):
         #    raise RuntimeError(f"Tensor overflow to infinity: \n{golden}\n{calculated}")
 
         # if torch.any(torch.isneginf(golden)) or torch.any(torch.isneginf(calculated)):
         #    raise RuntimeError(f"Tensor overflow to negative infinity: \n{golden}\n{calculated}")
 
-        else:
-            # For now, mask all infs and nans so that we check the rest... TODO
-            golden = golden.clone()
-            golden[
-                torch.logical_or(
-                    torch.isnan(golden),
-                    torch.logical_or(torch.isinf(golden), torch.isneginf(golden)),
-                )
-            ] = 0
-            calculated = calculated.clone()
-            calculated[
-                torch.logical_or(
-                    torch.isnan(calculated),
-                    torch.logical_or(torch.isinf(calculated), torch.isneginf(calculated)),
-                )
-            ] = 0
-
-            if torch.equal(golden, calculated):
-                return 1.0
-
-            if golden.dtype == torch.bfloat16:
-                golden = golden.type(torch.float32)
-                calculated = calculated.type(torch.float32)
-
-            # Single element case
-            if golden.numel() == 1:
-                return float(torch.equal(golden, calculated))
-
-            # If either tensor is constant (zero std dev), PCC is undefined. Fall back to
-            # allclose rather than returning a misleading 1.0 from the corrcoef diagonal.
-            if torch.max(golden) == torch.min(golden) or torch.max(calculated) == torch.min(calculated):
-                logger.warning(
-                    "One or both tensors are constant (zero std dev). PCC undefined; falling back to allclose."
-                )
-                return float(torch.allclose(golden, calculated, rtol=1e-05, atol=1e-04))
-
-            cal_pcc = np.ma.corrcoef(
-                np.ma.masked_invalid(torch.squeeze(golden).detach().numpy()).flatten(),
-                np.ma.masked_invalid(torch.squeeze(calculated).detach().numpy()).flatten(),
+        # For now, mask all infs and nans so that we check the rest... TODO
+        golden = golden.clone()
+        golden[
+            torch.logical_or(
+                torch.isnan(golden),
+                torch.logical_or(torch.isinf(golden), torch.isneginf(golden)),
             )
-            # Read off-diagonal directly to avoid diagonal contamination.
-            cal_pcc = cal_pcc[0, 1]
+        ] = 0
+        calculated = calculated.clone()
+        calculated[
+            torch.logical_or(
+                torch.isnan(calculated),
+                torch.logical_or(torch.isinf(calculated), torch.isneginf(calculated)),
+            )
+        ] = 0
 
-            if isinstance(cal_pcc, np.ma.core.MaskedConstant) or np.isnan(float(cal_pcc)):
-                logger.warning("PCC returned NaN/masked. Falling back to allclose.")
-                return float(torch.allclose(golden, calculated, rtol=1e-05, atol=1e-04))
+        if torch.equal(golden, calculated):
+            return 1.0
 
-            return cal_pcc
+        if golden.dtype == torch.bfloat16:
+            golden = golden.type(torch.float32)
+            calculated = calculated.type(torch.float32)
+
+        # Single element or constant tensor: PCC is undefined. Fall back to allclose
+        # using the caller's tolerances so relaxed-tolerance callers aren't penalised.
+        if golden.numel() == 1:
+            return float(torch.allclose(golden, calculated, rtol=rtol, atol=atol))
+
+        if torch.max(golden) == torch.min(golden) or torch.max(calculated) == torch.min(calculated):
+            logger.warning("One or both tensors are constant (zero std dev). PCC undefined; falling back to allclose.")
+            return float(torch.allclose(golden, calculated, rtol=rtol, atol=atol))
+
+        cal_pcc = np.ma.corrcoef(
+            np.ma.masked_invalid(torch.squeeze(golden).detach().numpy()).flatten(),
+            np.ma.masked_invalid(torch.squeeze(calculated).detach().numpy()).flatten(),
+        )
+        # Read off-diagonal directly to avoid diagonal contamination.
+        cal_pcc = cal_pcc[0, 1]
+
+        if isinstance(cal_pcc, np.ma.core.MaskedConstant) or np.isnan(float(cal_pcc)):
+            logger.warning("PCC returned NaN/masked. Falling back to allclose.")
+            return float(torch.allclose(golden, calculated, rtol=rtol, atol=atol))
+
+        return cal_pcc
 
     cal_pcc = get_pcc(golden, calculated)
 
@@ -202,7 +193,7 @@ def comp_allclose_and_pcc(golden, calculated, rtol=1e-05, atol=1e-08, pcc=0.99):
     if golden.dtype != calculated.dtype:
         calculated = calculated.type(golden.dtype)
 
-    _, _, cal_pcc, output_str = get_atol_rtol_pcc(golden, calculated)
+    _, _, cal_pcc, output_str = get_atol_rtol_pcc(golden, calculated, rtol=rtol, atol=atol)
     passing = True
     allclose_passing = torch.allclose(golden, calculated, rtol, atol, True)
     passing &= allclose_passing

--- a/ttnn/ttnn/operations/comparison.py
+++ b/ttnn/ttnn/operations/comparison.py
@@ -33,10 +33,11 @@ def pearson_correlation_coefficient(expected, actual):
         logger.error("One tensor is all nan, the other is not.")
         return 0.0
 
-    # Test if either is completely zero
+    # Test if either is completely zero — also a constant (zero-variance) case.
+    # Fall back to allclose so that zero-vs-small-constant within tolerance passes.
     if torch.any(expected.bool()) != torch.any(actual.bool()):
-        logger.error("One tensor is all zero")
-        return 0.0
+        logger.warning("One tensor is all zero. PCC undefined; falling back to allclose.")
+        return float(torch.allclose(expected, actual, rtol=1e-05, atol=1e-04))
 
     # For now, mask all infs and nans so that we check the rest... TODO
     expected = expected.clone()

--- a/ttnn/ttnn/operations/comparison.py
+++ b/ttnn/ttnn/operations/comparison.py
@@ -60,17 +60,23 @@ def pearson_correlation_coefficient(expected, actual):
     if expected.dtype == torch.bfloat16:
         expected = expected.type(torch.float32)
         actual = actual.type(torch.float32)
-    output = np.min(
-        np.ma.corrcoef(
-            np.ma.masked_invalid(torch.squeeze(expected).detach().numpy()).flatten(),
-            np.ma.masked_invalid(torch.squeeze(actual).detach().numpy()).flatten(),
-        )
-    )
 
-    if isinstance(output, np.ma.core.MaskedConstant):
-        return 1.0
+    # If either tensor is constant (zero std dev), PCC is undefined. Fall back to allclose
+    # rather than returning a misleading 1.0 from the corrcoef diagonal.
+    if torch.max(expected) == torch.min(expected) or torch.max(actual) == torch.min(actual):
+        logger.warning("One or both tensors are constant (zero std dev). PCC undefined; falling back to allclose.")
+        return float(torch.allclose(expected, actual, rtol=1e-05, atol=1e-04))
 
-    return output
+    output = np.ma.corrcoef(
+        np.ma.masked_invalid(torch.squeeze(expected).detach().numpy()).flatten(),
+        np.ma.masked_invalid(torch.squeeze(actual).detach().numpy()).flatten(),
+    )[0, 1]
+
+    if isinstance(output, np.ma.core.MaskedConstant) or np.isnan(float(output)):
+        logger.warning("PCC returned NaN/masked. Falling back to allclose.")
+        return float(torch.allclose(expected, actual, rtol=1e-05, atol=1e-04))
+
+    return float(output)
 
 
 __all__ = []


### PR DESCRIPTION
### Issue
#45299

### Summary

Pearson correlation (PCC) is undefined when either tensor has zero variance (constant, single-element, or all-zero). Several shared comparison helpers treated that case incorrectly:

- **False pass:** `np.ma.corrcoef` on one-constant vs random tensors produced a masked matrix; reading via `np.min` returned the diagonal `1.0` instead of the undefined off-diagonal value → silent pass even when tensors did not match.
- **False pass (NaN):** zero-variance `comp_pcc` returned `(True, 1.0)` when `cal_pcc` was NaN.
- **False negative:** all-zero early returns (`return 0.0`) ran before the constant-tensor fallback, so zero-vs-small-constant cases within caller tolerance still failed the PCC leg.

This PR fixes all four shared PCC paths and adds regression coverage. Stricter semantics also exposed latent test/golden issues in a few eltwise tests (fixed here or split to follow-up PRs).

### Core changes (4 files)

| File | Change |
|------|--------|
| `models/common/utility_functions.py` | `comp_pcc`: NaN/zero-variance → `allclose` fallback (not `1.0`); all-zero → `allclose` with caller `rtol`/`atol`; float64 overflow guard for large-magnitude tensors; `comp_allclose_and_pcc` forwards tolerances |
| `ttnn/tt_lib/_internal/comparison_funcs.py` | `get_atol_rtol_pcc` / inner `get_pcc`: same constant/single-element/MaskedConstant handling; `[0,1]` off-diagonal read; caller `rtol`/`atol` threaded through; removed all-zero hard fail |
| `ttnn/ttnn/operations/comparison.py` | `pearson_correlation_coefficient`: same fixes (replaces `np.min` + MaskedConstant → `1.0`) |
| `models/common/metrics.py` | `compute_pcc_host`: same one-constant / all-zero / MaskedConstant fixes (was still false-passing) |

**Fallback behavior:** when PCC is undefined, helpers log a warning and return `torch.allclose(..., rtol, atol)` instead of a misleading `1.0` or hard `0.0`.

### Regression tests

`tests/ttnn/unit_tests/test_comp_pcc_fix.py` — host-side coverage for:

- one-constant vs random (must **fail**, not pass at `1.0`)
- both-constant same / different values
- caller `rtol`/`atol` forwarded to allclose fallback
- large-magnitude float32 tensors (ldexp-scale; no spurious allclose fallback)
- `pcc_val` always a plain `float` (no `MaskedConstant`)

### Test ripple fixes

Stricter `comp_pcc` exposed latent assertion issues. These are **test-only**; they do not change `comp_pcc` further.

`tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py`

**Need:** `bfloat8_b` with negative base + fractional exponent produces NaN in `torch.pow` but inf/zero on device, so PCC/comparison against host golden was unreliable after stricter checks.

**Change:**
- Restrict bf8 inputs to non-negative range `[0, 100]`
- Quantize host input via `from_torch` before golden `torch.pow`, so golden matches device dtype conversion

`tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py`

**Need:** Wide out-of-domain range (`low=-100`) for asin/acos with `bfloat8_b` produces mostly non-finite outputs. PCC is undefined / misleading there; bf8 may also place Inf where torch golden has NaN.

**Change:** For `bfloat8_b` + `low=-100`, assert non-finite **position masks** match (`torch.equal` on `~isfinite`). In-domain accuracy stays covered by the `[-0.9, 0.9]` / `[-1, 1]` parametrizations with ULP + PCC.

`models/common/tests/test_validation_tools.py`

**Need:** `test_return_reference_output_torch[1x1]` mocks `reference_fn = torch.ones` against real `ttnn.matmul`. Old PCC false-passed at `1.0` for constant ref vs variable impl. After the fix, PCC correctly fails (`0.0`).

**Change:** Expect `Metric.PCC` to **fail** (not pass). Primary check is unchanged: `return_reference_output=True` still verified via `torch.allclose(out_host, ref_host)`. Also switched `pytest.raises` → `expect_error` in the related exception test (pre-commit).

`models/demos/gpt_oss/tests/unit/test_rope.py`

**Need:** At position 0 with yarn-scaled RoPE, `cos(0·θ)·scale` is constant across `head_dim`. Both TT (bf16 ≈ `1.3438`) and HF (fp32 ≈ `1.3466`) are flat → PCC undefined. Default allclose fallback (`atol=1e-4`) rejects normal bf16 quant noise (~0.003, <1 ULP).

**Change:** Added `_compare_rope_vector`: if both vectors are constant, use `allclose(atol=0.01)`; otherwise keep `comp_pcc(..., 0.99)`. Applied in:
- `test_rope_embedding_lookup_multi_user`
- `test_rope_embedding_lookup_users_row_sharded`


### Pipeline status

- [x] Sanity
- [x] (Runtime) Sanity Test
- [x] BHPC
- [x] Nightly for all categories
- [x] All model test
- [x] Single card
- [x] T3K
- [x] Galaxy

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_fix_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/pcc_fix_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_fix_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/pcc_fix_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_fix_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/pcc_fix_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/pcc_fix_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/pcc_fix_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/pcc_fix_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/pcc_fix_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/pcc_fix_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/pcc_fix_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/pcc_fix_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/pcc_fix_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/pcc_fix_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/pcc_fix_issue)