### PR TITLE
Reduce iterations in pytest that runs on Sanity

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -1763,7 +1763,7 @@ class TestDeepSeekV3:
             )
 
     def test_q_kv_rms_norm_profile(self, device):
-        """Profile fused-inline vs fused-persistent vs unfused (100 trials × 100 iters)."""
+        """Profile fused-inline vs fused-persistent vs unfused (n trials × n iters)."""
         import statistics
         import time
 
@@ -1771,7 +1771,7 @@ class TestDeepSeekV3:
         from models.experimental.ops.descriptors.normalization import rms_norm
 
         s = self._setup_mla_norm_configs(device)
-        # Numbers of trials and iterations reduced to 1 for CI efficiency.
+        # Number of trials and iterations reduced to 1 for CI efficiency.
         # For reasonable perf estimates, increase these to e.g. 100.
         N_TRIALS = 1
         N_ITERS = 1

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -1771,8 +1771,10 @@ class TestDeepSeekV3:
         from models.experimental.ops.descriptors.normalization import rms_norm
 
         s = self._setup_mla_norm_configs(device)
-        N_TRIALS = 100
-        N_ITERS = 100
+        # Numbers of trials and iterations reduced to 1 for CI efficiency.
+        # For reasonable perf estimates, increase these to e.g. 100.
+        N_TRIALS = 1
+        N_ITERS = 1
 
         torch_q_in = torch.rand(1, 1, s["bsz"], s["q_lora_rank"], dtype=torch.bfloat16)
         torch_kv_in = torch.rand(1, 1, s["bsz"], s["kv_lora_rank"], dtype=torch.bfloat16)


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

tt-sim Sanity test runs were timing out. Culprit looked liked a single test that was taking over half an hour out of 40 minutes on the last passing run:
https://github.com/tenstorrent/tt-metal/actions/runs/24770410808/job/72481955830#step:12:3897
```
============================== slowest durations ===============================
1833.35s call     tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py::TestDeepSeekV3::test_q_kv_rms_norm_profile
```

That test has
```
        N_TRIALS = 100
        N_ITERS = 100
```

Reduced these to 1 with a comment.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-0_test_iters)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-0_test_iters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-0_test_iters)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-0_test_iters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-0_test_iters)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-0_test_iters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-0_test_iters)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-0_test_iters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-0_test_iters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-0_test_iters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-0_test_iters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-0_test_iters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-0_test_iters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-0_test_iters)