### PR TITLE
Fix DeepSeek prefill combine op: add num_dispatch_groups compile-time arg

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -300,6 +300,9 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     {
         auto counter_shape = expert_token_counts.tensor_spec().logical_shape();
         uint32_t num_routed_experts = counter_shape[-1];
+        TT_FATAL(operation_attributes.experts_per_chip > 0, "experts_per_chip must be > 0");
+        TT_FATAL(operation_attributes.dispatch_group_size > 0, "dispatch_group_size must be > 0");
+        TT_FATAL(num_routed_experts > 0, "num_routed_experts must be > 0");
         uint32_t computed_ndg =
             num_routed_experts / (operation_attributes.experts_per_chip * operation_attributes.dispatch_group_size);
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -295,7 +295,31 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         read_batch_size,
     };
 
-    // Append TensorAccessorArgs for all 4 tensors
+    // Compute and append num_dispatch_groups (index 34, after read_batch_size at 33) from tensor dimensions.
+    // This decouples the combine kernel from the assumption that mesh_cols == num_dispatch_groups.
+    {
+        auto counter_shape = expert_token_counts.tensor_spec().logical_shape();
+        uint32_t num_routed_experts = counter_shape[-1];
+        uint32_t computed_ndg =
+            num_routed_experts / (operation_attributes.experts_per_chip * operation_attributes.dispatch_group_size);
+        TT_FATAL(
+            computed_ndg > 0 &&
+                computed_ndg * operation_attributes.experts_per_chip * operation_attributes.dispatch_group_size ==
+                    num_routed_experts,
+            "num_dispatch_groups computation failed: routed_experts={} experts_per_chip={} group_size={}",
+            num_routed_experts,
+            operation_attributes.experts_per_chip,
+            operation_attributes.dispatch_group_size);
+        compile_time_args.push_back(computed_ndg);
+
+        log_debug(
+            tt::LogOp,
+            "Combine: num_routed_experts={} computed num_dispatch_groups={}",
+            num_routed_experts,
+            computed_ndg);
+    }
+
+    // Append TensorAccessorArgs for all 4 tensors (starting at index 35, after num_dispatch_groups at 34)
     tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(dispatched_metadata.buffer()).append_to(compile_time_args);
     tt::tt_metal::TensorAccessorArgs(expert_token_counts.buffer()).append_to(compile_time_args);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -76,9 +76,11 @@ void kernel_main() {
 
     // Batch configuration (index 33)
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(33);
+    // Number of dispatch groups (index 34)
+    constexpr uint32_t num_dispatch_groups = get_compile_time_arg_val(34);
 
     // TensorAccessorArgs for all 4 tensors (starting at index 34)
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<34>();
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<35>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();
     constexpr auto experts_tok_counter_args =
@@ -153,13 +155,15 @@ void kernel_main() {
     }
     noc_async_read_barrier();
 
-    // Expert token counts are laid out as [n_dispatch_groups, experts_per_dispatch_group]
-    // where each dispatch group is a mesh column (all rows in that column).
-    // Row-major linearization: linearized_mesh_coord = mesh_row * mesh_cols + mesh_col
-    constexpr uint32_t mesh_row = linearized_mesh_coord / mesh_cols;  // position within dispatch group
-    constexpr uint32_t mesh_col = linearized_mesh_coord % mesh_cols;  // which dispatch group
-    constexpr uint32_t experts_per_dispatch_group = experts_per_chip * mesh_rows;
-    constexpr uint32_t offset = mesh_col * experts_per_dispatch_group + mesh_row * experts_per_chip;
+    // Expert token counts: flat [num_routed_experts] array per device.
+    // Decompose linearized_mesh_coord into (row, col) using physical mesh dims,
+    // then map col -> dispatch_group_idx via modulo num_dispatch_groups.
+    // This handles DP replicas (ndg < mesh_cols) where multiple columns share the same group.
+    constexpr uint32_t mesh_row = linearized_mesh_coord / mesh_cols;
+    constexpr uint32_t mesh_col = linearized_mesh_coord % mesh_cols;
+    constexpr uint32_t dispatch_group_idx = mesh_col % num_dispatch_groups;
+    constexpr uint32_t experts_per_dispatch_group = experts_per_chip * num_chips;
+    constexpr uint32_t offset = dispatch_group_idx * experts_per_dispatch_group + mesh_row * experts_per_chip;
     volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -79,7 +79,7 @@ void kernel_main() {
     // Number of dispatch groups (index 34)
     constexpr uint32_t num_dispatch_groups = get_compile_time_arg_val(34);
 
-    // TensorAccessorArgs for all 4 tensors (starting at index 34)
+    // TensorAccessorArgs for all 4 tensors (starting at index 35)
     constexpr auto dispatched_buffer_args = TensorAccessorArgs<35>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -75,9 +75,12 @@ void kernel_main() {
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(32);
 
     // Batch configuration (index 33) — read_batch_size not used by writer
+    // Number of dispatch groups (index 34) — not used directly by writer but shifts TensorAccessorArgs
+    constexpr uint32_t num_dispatch_groups = get_compile_time_arg_val(34);  // unused but must match reader
+    (void)num_dispatch_groups;
 
-    // TensorAccessorArgs for all 4 tensors (starting at index 34)
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<34>();
+    // TensorAccessorArgs for all 4 tensors (starting at index 35)
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<35>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();
     constexpr auto experts_tok_counter_args =


### PR DESCRIPTION
The combine kernel hardcoded dispatch_group_idx = mesh_col, which breaks when num_dispatch_groups < mesh_cols (DP replicas where multiple columns share the same dispatch group). Fix:
- Add num_dispatch_groups as compile-time arg (index 33), computed from expert_token_counts tensor shape
- Use dispatch_group_idx = mesh_col % num_dispatch_groups so DP replicas correctly map to their dispatch group
- Shift TensorAccessorArgs from index 33 to 34

This unblocks GPT-OSS 120B batched prefill on 4x8 Galaxy where EP=4 on rows but ndg=8 on columns (all 8 columns are active dispatch groups, no DP). Also correctly handles future DP configs where ndg < mesh_cols.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/fix-deepseek-combine-num-dispatch-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/fix-deepseek-combine-num-dispatch-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/fix-deepseek-combine-num-dispatch-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/fix-deepseek-combine-num-dispatch-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/fix-deepseek-combine-num-dispatch-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/fix-deepseek-combine-num-dispatch-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sraizada/fix-deepseek-combine-num-dispatch-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sraizada/fix-deepseek-combine-num-dispatch-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/fix-deepseek-combine-num-dispatch-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/fix-deepseek-combine-num-dispatch-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/fix-deepseek-combine-num-dispatch-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/fix-deepseek-combine-num-dispatch-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/fix-deepseek-combine-num-dispatch-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/fix-deepseek-combine-num-dispatch-groups)