### PR TITLE
[LLK]: Expose separate transpose settings in llk_unpack_AB

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h
@@ -30,7 +30,8 @@ ALWI void deepseek_moe_gate_init(uint32_t icb0, uint32_t icb1) {
         transpose_wh_init_short(icb0);
     } else {
         // Init copy add (FPU)
-        UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1, 1)));
+        UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(
+            icb0, icb1, /*transpose_of_faces=*/1, /*within_face_16x16_transpose=*/1)));
         MATH((llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands<
               ELWADD,
               DeepseekMoeGateEltwiseBinaryMode::COPY,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h
@@ -30,8 +30,7 @@ ALWI void deepseek_moe_gate_init(uint32_t icb0, uint32_t icb1) {
         transpose_wh_init_short(icb0);
     } else {
         // Init copy add (FPU)
-        UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(
-            icb0, icb1, /*transpose_of_faces=*/1, /*within_face_16x16_transpose=*/1)));
+        UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1, Transpose::Both)));
         MATH((llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands<
               ELWADD,
               DeepseekMoeGateEltwiseBinaryMode::COPY,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -18,7 +18,10 @@ inline void llk_unpack_AB_mop_config(const bool transpose_of_faces = false, cons
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
-    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose = 0) {
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t transpose_of_faces = 0,
+    const std::uint32_t within_face_16x16_transpose = 0) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
@@ -32,7 +35,7 @@ inline void llk_unpack_AB_init(
         get_operand_num_faces(operandA_id),
         get_operand_num_faces(get_operand_id(operandB))));
 
-    _llk_unpack_AB_init_<BType>(tensor_shape, transpose);
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -20,8 +20,8 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
-    const std::uint32_t transpose_of_faces = 0,
-    const std::uint32_t within_face_16x16_transpose = 0) {
+    const std::uint32_t transpose_of_faces,
+    const std::uint32_t within_face_16x16_transpose) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
@@ -36,6 +36,17 @@ inline void llk_unpack_AB_init(
         get_operand_num_faces(get_operand_id(operandB))));
 
     _llk_unpack_AB_init_<BType>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t operandB) {
+    llk_unpack_AB_init<BType>(operandA, operandB, 0, 0);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init(
+    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
+    llk_unpack_AB_init<BType>(operandA, operandB, transpose, transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -18,10 +18,7 @@ inline void llk_unpack_AB_mop_config(const bool transpose_of_faces = false, cons
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
-    const std::uint32_t operandA,
-    const std::uint32_t operandB,
-    const std::uint32_t transpose_of_faces,
-    const std::uint32_t within_face_16x16_transpose) {
+    const std::uint32_t operandA, const std::uint32_t operandB, const ckernel::Transpose transpose) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
@@ -35,18 +32,18 @@ inline void llk_unpack_AB_init(
         get_operand_num_faces(operandA_id),
         get_operand_num_faces(get_operand_id(operandB))));
 
-    _llk_unpack_AB_init_<BType>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t operandB) {
-    llk_unpack_AB_init<BType>(operandA, operandB, 0, 0);
+    llk_unpack_AB_init<BType>(operandA, operandB, ckernel::Transpose::None);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
-    llk_unpack_AB_init<BType>(operandA, operandB, transpose, transpose);
+    llk_unpack_AB_init<BType>(operandA, operandB, transpose > 0 ? ckernel::Transpose::Both : ckernel::Transpose::None);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -41,12 +41,6 @@ inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
-inline void llk_unpack_AB_init(
-    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
-    llk_unpack_AB_init<BType>(operandA, operandB, transpose > 0 ? ckernel::Transpose::Both : ckernel::Transpose::None);
-}
-
-template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB(
     const std::uint32_t operandA,
     const std::uint32_t operandB,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -19,11 +19,15 @@
  * @tparam BType: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
  * @param operandA: The input operand dataflow buffer for source A
  * @param operandB: The input operand dataflow buffer for source B
- * @param transpose: Unused param; only for API compatibiliy.
+ * @param transpose_of_faces: Unused param; only for API compatibility.
+ * @param within_face_16x16_transpose: Unused param; only for API compatibility.
  */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
-    const std::uint32_t operandA, const std::uint32_t operandB, [[maybe_unused]] const std::uint32_t transpose = 0) {
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    [[maybe_unused]] const std::uint32_t transpose_of_faces = 0,
+    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose = 0) {
     static_assert(BType == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
     // TODO (tt-metal #42916): Once runtime asserts are added for Quasar, assert that transpose is unused

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -26,17 +26,29 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
-    [[maybe_unused]] const std::uint32_t transpose_of_faces = 0,
-    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose = 0) {
+    [[maybe_unused]] const std::uint32_t transpose_of_faces,
+    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose) {
     static_assert(BType == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
-    // TODO (tt-metal #42916): Once runtime asserts are added for Quasar, assert that transpose is unused
+    // TODO (tt-metal #42916): Once runtime asserts are added for Quasar, assert that transpose_of_faces
+    // and within_face_16x16_transpose are unused
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
     // num_tiles set to 1 for back-compatibility with existing APIs, can be increased in the future for better
     // performance.
     _llk_unpack_binary_operands_init_(operandA_id, operandB_id, 1);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t operandB) {
+    llk_unpack_AB_init<BType>(operandA, operandB, 0, 0);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init(
+    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
+    llk_unpack_AB_init<BType>(operandA, operandB, transpose, transpose);
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -19,19 +19,14 @@
  * @tparam BType: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
  * @param operandA: The input operand dataflow buffer for source A
  * @param operandB: The input operand dataflow buffer for source B
- * @param transpose_of_faces: Unused param; only for API compatibility.
- * @param within_face_16x16_transpose: Unused param; only for API compatibility.
+ * @param transpose: Unused param; only for API compatibility.
  */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
-    const std::uint32_t operandA,
-    const std::uint32_t operandB,
-    [[maybe_unused]] const std::uint32_t transpose_of_faces,
-    [[maybe_unused]] const std::uint32_t within_face_16x16_transpose) {
+    const std::uint32_t operandA, const std::uint32_t operandB, [[maybe_unused]] const ckernel::Transpose transpose) {
     static_assert(BType == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
-    // TODO (tt-metal #42916): Once runtime asserts are added for Quasar, assert that transpose_of_faces
-    // and within_face_16x16_transpose are unused
+    // TODO (tt-metal #42916): Once runtime asserts are added for Quasar, assert that transpose is unused
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
@@ -42,13 +37,13 @@ inline void llk_unpack_AB_init(
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t operandB) {
-    llk_unpack_AB_init<BType>(operandA, operandB, 0, 0);
+    llk_unpack_AB_init<BType>(operandA, operandB, ckernel::Transpose::None);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
-    llk_unpack_AB_init<BType>(operandA, operandB, transpose, transpose);
+    llk_unpack_AB_init<BType>(operandA, operandB, transpose > 0 ? ckernel::Transpose::Both : ckernel::Transpose::None);
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -40,12 +40,6 @@ inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t
     llk_unpack_AB_init<BType>(operandA, operandB, ckernel::Transpose::None);
 }
 
-template <BroadcastType BType = BroadcastType::NONE>
-inline void llk_unpack_AB_init(
-    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
-    llk_unpack_AB_init<BType>(operandA, operandB, transpose > 0 ? ckernel::Transpose::Both : ckernel::Transpose::None);
-}
-
 /**
  * @brief Unpacks binary operands for SrcA & SrcB
  * @tparam BType: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -18,7 +18,10 @@ inline void llk_unpack_AB_mop_config(const bool transpose_of_faces = false, cons
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
-    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose = 0) {
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t transpose_of_faces = 0,
+    const std::uint32_t within_face_16x16_transpose = 0) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
@@ -32,7 +35,7 @@ inline void llk_unpack_AB_init(
         get_operand_num_faces(operandA_id),
         get_operand_num_faces(get_operand_id(operandB))));
 
-    _llk_unpack_AB_init_<BType>(tensor_shape, transpose);
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -20,8 +20,8 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
-    const std::uint32_t transpose_of_faces = 0,
-    const std::uint32_t within_face_16x16_transpose = 0) {
+    const std::uint32_t transpose_of_faces,
+    const std::uint32_t within_face_16x16_transpose) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
@@ -36,6 +36,17 @@ inline void llk_unpack_AB_init(
         get_operand_num_faces(get_operand_id(operandB))));
 
     _llk_unpack_AB_init_<BType>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t operandB) {
+    llk_unpack_AB_init<BType>(operandA, operandB, 0, 0);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init(
+    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
+    llk_unpack_AB_init<BType>(operandA, operandB, transpose, transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -18,10 +18,7 @@ inline void llk_unpack_AB_mop_config(const bool transpose_of_faces = false, cons
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
-    const std::uint32_t operandA,
-    const std::uint32_t operandB,
-    const std::uint32_t transpose_of_faces,
-    const std::uint32_t within_face_16x16_transpose) {
+    const std::uint32_t operandA, const std::uint32_t operandB, const ckernel::Transpose transpose) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
@@ -35,18 +32,18 @@ inline void llk_unpack_AB_init(
         get_operand_num_faces(operandA_id),
         get_operand_num_faces(get_operand_id(operandB))));
 
-    _llk_unpack_AB_init_<BType>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t operandB) {
-    llk_unpack_AB_init<BType>(operandA, operandB, 0, 0);
+    llk_unpack_AB_init<BType>(operandA, operandB, ckernel::Transpose::None);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
-    llk_unpack_AB_init<BType>(operandA, operandB, transpose, transpose);
+    llk_unpack_AB_init<BType>(operandA, operandB, transpose > 0 ? ckernel::Transpose::Both : ckernel::Transpose::None);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -41,12 +41,6 @@ inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
-inline void llk_unpack_AB_init(
-    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t transpose) {
-    llk_unpack_AB_init<BType>(operandA, operandB, transpose > 0 ? ckernel::Transpose::Both : ckernel::Transpose::None);
-}
-
-template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB(
     const std::uint32_t operandA,
     const std::uint32_t operandB,

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -82,7 +82,7 @@ ALWI void binary_tiles_init(
     }
 
     if constexpr (full_init) {
-        UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1, 0 /*transpose*/)));
+        UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1, Transpose::None)));
     }
 }
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -249,11 +249,6 @@ class FpuMathSchema(BaseModel):
                     "SrcA transpose is not supported with scalar broadcast"
                 )
 
-            if self.unpack_transpose_within_face != self.unpack_transpose_faces:
-                raise ValueError(
-                    "UnpackerAB does not support different values for transpose_faces and transpose_within_face"
-                )
-
         # LLK contract: eltwise add/sub only support LoFi fidelity.
         if (
             self.operation in [FpuOperationEnum.Elwadd, FpuOperationEnum.Elwsub]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
@@ -135,15 +135,23 @@ class UnpackerAB(Unpacker):
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
 
         tile_shape = compute_unit.src_a.tile_shape
-        transpose_value = "1" if compute_unit.unpack_transpose_faces.value else "0"
-        within_face_value = (
-            "1" if compute_unit.unpack_transpose_within_face.value else "0"
-        )
+        if compute_unit.unpack_transpose_faces.value:
+            transpose_value = (
+                "ckernel::Transpose::Both"
+                if compute_unit.unpack_transpose_within_face.value
+                else "ckernel::Transpose::InterFace"
+            )
+        else:
+            transpose_value = (
+                "ckernel::Transpose::IntraFace"
+                if compute_unit.unpack_transpose_within_face.value
+                else "ckernel::Transpose::None"
+            )
         shape_var = f"tensor_shape_stage_{operation.stage_id}"
         return (
             f"const ckernel::TensorShape {shape_var} = "
             f"{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}};\n"
-            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value}, {within_face_value});\n"
+            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value});\n"
         )
 
     def unpack(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
@@ -136,11 +136,14 @@ class UnpackerAB(Unpacker):
 
         tile_shape = compute_unit.src_a.tile_shape
         transpose_value = "1" if compute_unit.unpack_transpose_faces.value else "0"
+        within_face_value = (
+            "1" if compute_unit.unpack_transpose_within_face.value else "0"
+        )
         shape_var = f"tensor_shape_stage_{operation.stage_id}"
         return (
             f"const ckernel::TensorShape {shape_var} = "
             f"{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}};\n"
-            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value});\n"
+            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value}, {within_face_value});\n"
         )
 
     def unpack(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
@@ -248,11 +248,6 @@ class FpuMathSchema(BaseModel):
                     "SrcA transpose is not supported with scalar broadcast"
                 )
 
-            if self.unpack_transpose_within_face != self.unpack_transpose_faces:
-                raise ValueError(
-                    "UnpackerAB does not support different values for transpose_faces and transpose_within_face"
-                )
-
         # LLK contract: eltwise add/sub only support LoFi fidelity.
         if (
             self.operation in [FpuOperationEnum.Elwadd, FpuOperationEnum.Elwsub]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
@@ -134,16 +134,24 @@ class UnpackerAB(Unpacker):
     ) -> str:
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         tile_shape = compute_unit.src_a.tile_shape
-        transpose_value = "1" if compute_unit.unpack_transpose_faces.value else "0"
-        within_face_value = (
-            "1" if compute_unit.unpack_transpose_within_face.value else "0"
-        )
+        if compute_unit.unpack_transpose_faces.value:
+            transpose_value = (
+                "ckernel::Transpose::Both"
+                if compute_unit.unpack_transpose_within_face.value
+                else "ckernel::Transpose::InterFace"
+            )
+        else:
+            transpose_value = (
+                "ckernel::Transpose::IntraFace"
+                if compute_unit.unpack_transpose_within_face.value
+                else "ckernel::Transpose::None"
+            )
 
         shape_var = f"tensor_shape_stage_{operation.stage_id}"
         return (
             f"const ckernel::TensorShape {shape_var} = "
             f"{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}};\n"
-            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value}, {within_face_value});\n"
+            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value});\n"
         )
 
     def unpack(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
@@ -135,12 +135,15 @@ class UnpackerAB(Unpacker):
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         tile_shape = compute_unit.src_a.tile_shape
         transpose_value = "1" if compute_unit.unpack_transpose_faces.value else "0"
+        within_face_value = (
+            "1" if compute_unit.unpack_transpose_within_face.value else "0"
+        )
 
         shape_var = f"tensor_shape_stage_{operation.stage_id}"
         return (
             f"const ckernel::TensorShape {shape_var} = "
             f"{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, {tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}};\n"
-            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value});\n"
+            f"_llk_unpack_AB_init_<{broadcast_type}>({shape_var}, {transpose_value}, {within_face_value});\n"
         )
 
     def unpack(

--- a/tt_metal/tt-llk/tests/python_tests/fuser_config/README.md
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_config/README.md
@@ -371,7 +371,7 @@ unpack_transpose_faces: true         # Step 1: Transpose face layout
 unpack_transpose_within_face: true   # Step 2: Transpose within each face
 ```
 
-**Unpacker compatibility:** `UnpackerA` supports independent values for these two transpose options. `UnpackerAB` and `MatmulUnpacker` require both transpose options to have the same value. `UnpackerTilizeA` does not support transpose operations.
+**Unpacker compatibility:** `UnpackerA` and `UnpackerAB` support independent values for these two transpose options. `MatmulUnpacker` requires both transpose options to have the same value. `UnpackerTilizeA` does not support transpose operations.
 
 ---
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
@@ -35,7 +35,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint8_t num_faces_r_dim      = static_cast<std::uint8_t>(params.num_faces_r_dim_A);
     const std::uint8_t num_faces_c_dim      = static_cast<std::uint8_t>(params.num_faces_c_dim_A);
     const ckernel::TensorShape tensor_shape = {face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim};
-    const std::uint32_t transpose           = params.UNPACK_TRANSPOSE_FACES;
+    const std::uint32_t transpose_of_faces          = params.UNPACK_TRANSPOSE_FACES;
+    const std::uint32_t within_face_16x16_transpose = params.UNPACK_TRANSPOSE_WITHIN_FACE;
 
     // Configure hardware for unpacking, no broadcast, no transpose
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
@@ -50,7 +51,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.TILE_SIZE_UNPACK_A,
         params.TILE_SIZE_UNPACK_B);
 
-    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, transpose);
+    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
 
 #ifdef EN_DEST_REUSE
     const std::uint32_t num_total_tiles = params.INPUT_NUM_TILES_IN_BLOCK * params.INPUT_NUM_BLOCKS;

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
@@ -35,8 +35,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint8_t num_faces_r_dim      = static_cast<std::uint8_t>(params.num_faces_r_dim_A);
     const std::uint8_t num_faces_c_dim      = static_cast<std::uint8_t>(params.num_faces_c_dim_A);
     const ckernel::TensorShape tensor_shape = {face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim};
-    const std::uint32_t transpose_of_faces          = params.UNPACK_TRANSPOSE_FACES;
-    const std::uint32_t within_face_16x16_transpose = params.UNPACK_TRANSPOSE_WITHIN_FACE;
+    const ckernel::Transpose transpose      = params.UNPACK_TRANSPOSE_FACES
+                                                  ? (params.UNPACK_TRANSPOSE_WITHIN_FACE ? ckernel::Transpose::Both : ckernel::Transpose::InterFace)
+                                                  : (params.UNPACK_TRANSPOSE_WITHIN_FACE ? ckernel::Transpose::IntraFace : ckernel::Transpose::None);
 
     // Configure hardware for unpacking, no broadcast, no transpose
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
@@ -51,7 +52,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.TILE_SIZE_UNPACK_A,
         params.TILE_SIZE_UNPACK_B);
 
-    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, transpose_of_faces, within_face_16x16_transpose);
+    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, transpose);
 
 #ifdef EN_DEST_REUSE
     const std::uint32_t num_total_tiles = params.INPUT_NUM_TILES_IN_BLOCK * params.INPUT_NUM_BLOCKS;

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
@@ -33,11 +33,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
 
     // Initialize unpack with column broadcast on srcB and transpose on srcA
-    _llk_unpack_AB_init_<BROADCAST_TYPE>(
-        FACE_R_DIM,
-        4 /* num_faces */,
-        false,                          // narrow_tile
-        params.UNPACK_TRANSPOSE_FACES); // Enable face rearrangement for srcA
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, params.UNPACK_TRANSPOSE_FACES);
 
     // Unpack tiles: srcA will be transposed, srcB will be column broadcasted
     for (int i = 0; i < params.TILE_CNT; ++i)

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
@@ -34,7 +34,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Initialize unpack with column broadcast on srcB and transpose on srcA
     const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
-    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, params.UNPACK_TRANSPOSE_FACES);
+    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, params.UNPACK_TRANSPOSE_FACES, params.UNPACK_TRANSPOSE_FACES);
 
     // Unpack tiles: srcA will be transposed, srcB will be column broadcasted
     for (int i = 0; i < params.TILE_CNT; ++i)

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
@@ -34,7 +34,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Initialize unpack with column broadcast on srcB and transpose on srcA
     const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
-    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, params.UNPACK_TRANSPOSE_FACES, params.UNPACK_TRANSPOSE_FACES);
+    _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, params.UNPACK_TRANSPOSE_FACES ? ckernel::Transpose::Both : ckernel::Transpose::None);
 
     // Unpack tiles: srcA will be transposed, srcB will be column broadcasted
     for (int i = 0; i < params.TILE_CNT; ++i)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_defs.h
@@ -78,6 +78,14 @@ enum BroadcastType
     SCALAR = 0x3, // A - None || B - Scalar Broadcast
 };
 
+enum class Transpose : std::uint8_t
+{
+    None      = 0,
+    IntraFace = 1,
+    InterFace = 2,
+    Both      = 3,
+};
+
 enum src_op_id_e
 {
     OP_SRC0 = 0,

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -151,18 +151,20 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
  *
  * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
  * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim)
- * @param transpose: Whether to transpose within each face (0 = no transpose, >0 = transpose)
+ * @param transpose_of_faces: Whether to transpose faces (reorder faces 0,2,1,3) (0 = no transpose, >0 = transpose)
+ * @param within_face_16x16_transpose: Whether to transpose within each face using 16x16 haloize mode (0 = no transpose, >0 = transpose)
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t transpose = 0)
+inline void _llk_unpack_AB_init_(
+    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces = 0, const std::uint32_t within_face_16x16_transpose = 0)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose); // transpose within the face
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose); // transpose within the face
 
     config_unpacker_x_end<p_setadc::UNP_AB>(tensor_shape.face_r_dim);
 
-    _llk_unpack_AB_mop_config_<BType>(transpose > 0, tensor_shape); // transpose of faces 0,2,1,3
+    _llk_unpack_AB_mop_config_<BType>(transpose_of_faces > 0, tensor_shape); // transpose of faces 0,2,1,3
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -156,7 +156,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
  */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(
-    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces = 0, const std::uint32_t within_face_16x16_transpose = 0)
+    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces, const std::uint32_t within_face_16x16_transpose)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
@@ -165,6 +165,18 @@ inline void _llk_unpack_AB_init_(
     config_unpacker_x_end<p_setadc::UNP_AB>(tensor_shape.face_r_dim);
 
     _llk_unpack_AB_mop_config_<BType>(transpose_of_faces > 0, tensor_shape); // transpose of faces 0,2,1,3
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
+{
+    _llk_unpack_AB_init_<BType>(tensor_shape, 0, 0);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t transpose)
+{
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose, transpose);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -14,6 +14,7 @@
 #include "ckernel_template.h"
 #include "cunpack_common.h"
 #include "llk_assert.h"
+#include "llk_defs.h"
 #include "llk_unpack_common.h"
 
 using namespace ckernel;
@@ -151,32 +152,32 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
  *
  * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
  * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim)
- * @param transpose_of_faces: Whether to transpose faces (reorder faces 0,2,1,3) (0 = no transpose, >0 = transpose)
- * @param within_face_16x16_transpose: Whether to transpose within each face using 16x16 haloize mode (0 = no transpose, >0 = transpose)
+ * @param transpose: Transpose mode for SrcA face order and/or within-face transpose.
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_AB_init_(
-    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces, const std::uint32_t within_face_16x16_transpose)
+inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const ckernel::Transpose transpose)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const bool within_face_16x16_transpose = transpose == ckernel::Transpose::IntraFace || transpose == ckernel::Transpose::Both;
+    const bool transpose_of_faces          = transpose == ckernel::Transpose::InterFace || transpose == ckernel::Transpose::Both;
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose); // transpose within the face
 
     config_unpacker_x_end<p_setadc::UNP_AB>(tensor_shape.face_r_dim);
 
-    _llk_unpack_AB_mop_config_<BType>(transpose_of_faces > 0, tensor_shape); // transpose of faces 0,2,1,3
+    _llk_unpack_AB_mop_config_<BType>(transpose_of_faces, tensor_shape); // transpose of faces 0,2,1,3
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
-    _llk_unpack_AB_init_<BType>(tensor_shape, 0, 0);
+    _llk_unpack_AB_init_<BType>(tensor_shape, ckernel::Transpose::None);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t transpose)
 {
-    _llk_unpack_AB_init_<BType>(tensor_shape, transpose, transpose);
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose > 0 ? ckernel::Transpose::Both : ckernel::Transpose::None);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -52,6 +52,14 @@ enum class BroadcastType : std::uint8_t
     SCALAR,
 };
 
+enum class Transpose : std::uint8_t
+{
+    None      = 0,
+    IntraFace = 1,
+    InterFace = 2,
+    Both      = 3,
+};
+
 enum class SfpuType : std::uint32_t
 {
     tanh,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
@@ -78,6 +78,14 @@ enum BroadcastType
     SCALAR = 0x3, // A - None || B - Scalar Broadcast
 };
 
+enum class Transpose : std::uint8_t
+{
+    None      = 0,
+    IntraFace = 1,
+    InterFace = 2,
+    Both      = 3,
+};
+
 enum src_op_id_e
 {
     OP_SRC0 = 0,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -139,18 +139,20 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
  *
  * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
  * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim)
- * @param transpose: Whether to transpose within each face (0 = no transpose, >0 = transpose)
+ * @param transpose_of_faces: Whether to transpose faces (reorder faces 0,2,1,3) (0 = no transpose, >0 = transpose)
+ * @param within_face_16x16_transpose: Whether to transpose within each face using 16x16 haloize mode (0 = no transpose, >0 = transpose)
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t transpose = 0)
+inline void _llk_unpack_AB_init_(
+    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces = 0, const std::uint32_t within_face_16x16_transpose = 0)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose); // transpose within the face
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose); // transpose within the face
 
     config_unpacker_x_end<p_setadc::UNP_AB>(tensor_shape.face_r_dim);
 
-    _llk_unpack_AB_mop_config_<BType>(transpose > 0, tensor_shape); // transpose of faces 0,2,1,3
+    _llk_unpack_AB_mop_config_<BType>(transpose_of_faces > 0, tensor_shape); // transpose of faces 0,2,1,3
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -144,7 +144,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
  */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(
-    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces = 0, const std::uint32_t within_face_16x16_transpose = 0)
+    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces, const std::uint32_t within_face_16x16_transpose)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
@@ -153,6 +153,18 @@ inline void _llk_unpack_AB_init_(
     config_unpacker_x_end<p_setadc::UNP_AB>(tensor_shape.face_r_dim);
 
     _llk_unpack_AB_mop_config_<BType>(transpose_of_faces > 0, tensor_shape); // transpose of faces 0,2,1,3
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
+{
+    _llk_unpack_AB_init_<BType>(tensor_shape, 0, 0);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t transpose)
+{
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose, transpose);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -14,6 +14,7 @@
 #include "ckernel_template.h"
 #include "cunpack_common.h"
 #include "llk_assert.h"
+#include "llk_defs.h"
 #include "llk_unpack_common.h"
 #include "lltt.h"
 
@@ -139,32 +140,32 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
  *
  * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
  * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim)
- * @param transpose_of_faces: Whether to transpose faces (reorder faces 0,2,1,3) (0 = no transpose, >0 = transpose)
- * @param within_face_16x16_transpose: Whether to transpose within each face using 16x16 haloize mode (0 = no transpose, >0 = transpose)
+ * @param transpose: Transpose mode for SrcA face order and/or within-face transpose.
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_AB_init_(
-    const ckernel::TensorShape tensor_shape, const std::uint32_t transpose_of_faces, const std::uint32_t within_face_16x16_transpose)
+inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const ckernel::Transpose transpose)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const bool within_face_16x16_transpose = transpose == ckernel::Transpose::IntraFace || transpose == ckernel::Transpose::Both;
+    const bool transpose_of_faces          = transpose == ckernel::Transpose::InterFace || transpose == ckernel::Transpose::Both;
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose); // transpose within the face
 
     config_unpacker_x_end<p_setadc::UNP_AB>(tensor_shape.face_r_dim);
 
-    _llk_unpack_AB_mop_config_<BType>(transpose_of_faces > 0, tensor_shape); // transpose of faces 0,2,1,3
+    _llk_unpack_AB_mop_config_<BType>(transpose_of_faces, tensor_shape); // transpose of faces 0,2,1,3
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
-    _llk_unpack_AB_init_<BType>(tensor_shape, 0, 0);
+    _llk_unpack_AB_init_<BType>(tensor_shape, ckernel::Transpose::None);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t transpose)
 {
-    _llk_unpack_AB_init_<BType>(tensor_shape, transpose, transpose);
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose > 0 ? ckernel::Transpose::Both : ckernel::Transpose::None);
 }
 
 /**


### PR DESCRIPTION

Splits the single `transpose` parameter in `_llk_unpack_AB_init_` and `llk_unpack_AB_init` into two independent knobs, matching the existing pattern in `_llk_unpack_A_init_`:

  - `transpose_of_faces` (was: `transpose > 0`) — gates MOP face-order rearrangement (faces 0,2,1,3)
  - `within_face_16x16_transpose` (was: `transpose`) — gates THCON_SEC0_REG2_Haloize_mode_RMW (16x16 within-face transpose)

Both params default to 0, so all existing callers that pass zero or nothing are fully backward-compatible.

### Summary
Fixes tenstorrent/tt-llk#1089

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/1089_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/1089_llk_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/1089_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/1089_llk_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/1089_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/1089_llk_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/1089_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/1089_llk_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/1089_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/1089_llk_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/1089_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/1089_llk_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/1089_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/1089_llk_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/1089_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/1089_llk_issue)