### PR TITLE
[DCAMP-216] Support heterogeneous cabling descriptor merges

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -423,11 +423,13 @@ Node build_node(
     if (it != node_templates.end()) {
         Node node = it->second;  // Copy template
         node.host_id = host_id;
+        node.node_descriptor_name = node_descriptor_name;
         return node;
     }
 
     // Build new node template (with host_id=0)
     Node template_node;
+    template_node.node_descriptor_name = node_descriptor_name;
 
     auto node_descriptor = find_node_descriptor(node_descriptor_name, cluster_descriptor);
 
@@ -528,6 +530,7 @@ Node build_node(
     // Create instance with actual host_id
     Node node = template_node;
     node.host_id = host_id;
+    node.node_descriptor_name = node_descriptor_name;
     return node;
 }
 
@@ -1120,11 +1123,17 @@ static std::optional<std::string> find_template_key_for_node(
 
 // Helper to recreate a node from its template, resetting port availability
 // After merging descriptors, nodes may have stale port usage info. This function
-// preserves host_id and merged inter_board_connections
+// preserves host_id, the source descriptor binding, and merged inter_board_connections
 static Node create_base_node_from_template(
     const Node& source_node, const std::unordered_map<std::string, Node>& node_templates) {
-    // Find the template by matching motherboard and board structure
-    auto template_key = find_template_key_for_node(source_node, node_templates);
+    // Prefer the descriptor name this child was bound to in its source file; fall back to
+    // the shape-based lookup only when the binding is missing (e.g. older callers).
+    std::optional<std::string> template_key;
+    if (!source_node.node_descriptor_name.empty() && node_templates.contains(source_node.node_descriptor_name)) {
+        template_key = source_node.node_descriptor_name;
+    } else {
+        template_key = find_template_key_for_node(source_node, node_templates);
+    }
 
     if (!template_key) {
         throw std::runtime_error(fmt::format(
@@ -1139,6 +1148,10 @@ static Node create_base_node_from_template(
     // (template only has ports marked as used for inter-board connections from node descriptor)
     Node base_node = template_node;
     base_node.host_id = source_node.host_id;
+    // Preserve the per-child binding so output emits the original template name even if the
+    // templates table aliases two names to the same Node (e.g. after a torus merge).
+    base_node.node_descriptor_name =
+        source_node.node_descriptor_name.empty() ? *template_key : source_node.node_descriptor_name;
     // Copy inter_board_connections from source (they may have been merged from multiple files)
     base_node.inter_board_connections = source_node.inter_board_connections;
     // Re-mark ports as used for the merged inter-board connections
@@ -1190,9 +1203,17 @@ static void merge_resolved_graph_instances(
                 // For torus-compatible nodes, we merge the connections
                 // For non-torus nodes, we only merge internal_connections, not inter_board_connections
 
-                // Check if this is a torus-compatible merge scenario
-                auto target_template_key = find_template_key_for_node(target.nodes[name], node_templates);
-                auto source_template_key = find_template_key_for_node(source_node, node_templates);
+                // Check if this is a torus-compatible merge scenario. Prefer the descriptor names
+                // each side was bound to in its source file; fall back to shape-based lookup when
+                // a binding is missing.
+                auto resolve_key = [&](const Node& n) -> std::optional<std::string> {
+                    if (!n.node_descriptor_name.empty() && node_templates.contains(n.node_descriptor_name)) {
+                        return n.node_descriptor_name;
+                    }
+                    return find_template_key_for_node(n, node_templates);
+                };
+                auto target_template_key = resolve_key(target.nodes[name]);
+                auto source_template_key = resolve_key(source_node);
 
                 // Same instance name, different node type across files (e.g. host declared as
                 // WH_GALAXY in one and BH_GALAXY in another) - real conflict; fail with a clear
@@ -1569,7 +1590,13 @@ static void resolved_graph_to_protobuf(
         child->set_name(name);
         auto* node_ref = child->mutable_node_ref();
 
-        auto template_key = find_template_key_for_node(node, node_templates);
+        // Prefer the descriptor name the child was bound to in its source file.
+        std::optional<std::string> template_key;
+        if (!node.node_descriptor_name.empty() && node_templates.contains(node.node_descriptor_name)) {
+            template_key = node.node_descriptor_name;
+        } else {
+            template_key = find_template_key_for_node(node, node_templates);
+        }
         if (!template_key) {
             throw std::runtime_error(fmt::format(
                 "Could not find node descriptor for node '{}' with motherboard '{}' and {} boards",

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -13,6 +13,7 @@
 #include <enchantum/enchantum.hpp>
 #include <filesystem>
 #include <fstream>
+#include <unordered_set>
 #include <fmt/base.h>
 #include <google/protobuf/text_format.h>
 #include <tt-logger/tt-logger.hpp>
@@ -307,48 +308,55 @@ bool try_merge_torus_compatible_template(
     return true;
 }
 
+// All boards in a valid node share an architecture, so the first board is sufficient.
+std::optional<tt::ARCH> get_template_architecture(const Node& node_template) {
+    if (node_template.boards.empty()) {
+        return std::nullopt;
+    }
+    return node_template.boards.begin()->second.get_arch();
+}
+
 void validate_and_merge_node_templates(
     std::unordered_map<std::string, Node>& this_node_desc_name_to_node,
     const std::unordered_map<std::string, Node>& other_node_desc_name_to_node,
     const std::string& existing_source_file,
     const std::string& new_source_file) {
-    // Forward pass: validate/merge templates that exist in both
+    // Union templates across files. Same-name templates must agree on structure;
+    // disjoint templates are carried over (so e.g. REV_AB-only + REV_C-only merges work),
+    // but mixing architectures (e.g. WH + BH) is still rejected.
+    // Genuine same-instance-name conflicts are caught later in merge_resolved_graph_instances.
     for (const auto& [node_desc_name, other_template] : other_node_desc_name_to_node) {
         if (this_node_desc_name_to_node.contains(node_desc_name)) {
-            // Template exists in both - validate it matches
             const auto& this_template = this_node_desc_name_to_node.at(node_desc_name);
             validate_node_structure(this_template, other_template, node_desc_name, new_source_file);
             validate_inter_board_connections(
                 this_template, other_template, node_desc_name, existing_source_file, new_source_file);
+        } else if (try_merge_torus_compatible_template(
+                       this_node_desc_name_to_node,
+                       node_desc_name,
+                       other_template,
+                       existing_source_file,
+                       new_source_file)) {
+            // Folded into an existing torus variant (e.g. X_TORUS + Y_TORUS -> XY_TORUS).
         } else {
-            // Template missing in 'this' - try torus-compatible merge or throw error
-            bool merged = try_merge_torus_compatible_template(
-                this_node_desc_name_to_node, node_desc_name, other_template, existing_source_file, new_source_file);
-
-            if (!merged) {
-                throw std::runtime_error(fmt::format(
-                    "Node template '{}' exists in {} but not in {} - structural mismatch",
-                    node_desc_name,
-                    get_source_description(new_source_file),
-                    get_source_description(existing_source_file)));
+            auto other_arch = get_template_architecture(other_template);
+            if (other_arch.has_value()) {
+                for (const auto& [existing_name, existing_template] : this_node_desc_name_to_node) {
+                    auto existing_arch = get_template_architecture(existing_template);
+                    if (existing_arch.has_value() && *existing_arch != *other_arch) {
+                        throw std::runtime_error(fmt::format(
+                            "Node template '{}' from {} has architecture {} which conflicts with "
+                            "existing template '{}' from {} (architecture {}) - structural mismatch",
+                            node_desc_name,
+                            get_source_description(new_source_file),
+                            enchantum::to_string(*other_arch),
+                            existing_name,
+                            get_source_description(existing_source_file),
+                            enchantum::to_string(*existing_arch)));
+                    }
+                }
             }
-        }
-    }
-
-    // Backward pass: check for templates in 'this' that don't exist in 'other'
-    for (const auto& [node_desc_name, this_template] : this_node_desc_name_to_node) {
-        if (!other_node_desc_name_to_node.contains(node_desc_name)) {
-            // Check if this is a torus type that can be merged with another torus variant
-            bool found_compatible =
-                find_torus_compatible_template(other_node_desc_name_to_node, node_desc_name).has_value();
-
-            if (!found_compatible) {
-                throw std::runtime_error(fmt::format(
-                    "Node template '{}' exists in {} but not in {} - structural mismatch",
-                    node_desc_name,
-                    get_source_description(existing_source_file),
-                    get_source_description(new_source_file)));
-            }
+            this_node_desc_name_to_node[node_desc_name] = other_template;
         }
     }
 }
@@ -675,6 +683,85 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
     return build_graph_instance_impl(graph_instance, cluster_descriptor, nullptr, instance_name, node_templates);
 }
 
+// Collects (host_id -> hostname) for every leaf node by walking the graph recursively.
+// Child `name` matches the host's `host` field in the deployment descriptor by convention.
+void collect_host_id_to_hostname(
+    const tt::scaleout_tools::cabling_generator::proto::GraphInstance& graph_instance,
+    const tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
+    std::map<HostId, std::string>& out) {
+    auto template_it = cluster_descriptor.graph_templates().find(graph_instance.template_name());
+    if (template_it == cluster_descriptor.graph_templates().end()) {
+        return;  // Missing template will be flagged by build_graph_instance_impl later.
+    }
+    const auto& template_def = template_it->second;
+    for (const auto& child_def : template_def.children()) {
+        const std::string& child_name = child_def.name();
+        auto mapping_it = graph_instance.child_mappings().find(child_name);
+        if (mapping_it == graph_instance.child_mappings().end()) {
+            continue;
+        }
+        const auto& mapping = mapping_it->second;
+        if (child_def.has_node_ref()) {
+            if (mapping.mapping_case() ==
+                tt::scaleout_tools::cabling_generator::proto::ChildMapping::kHostId) {
+                out[HostId(mapping.host_id())] = child_name;
+            }
+        } else if (child_def.has_graph_ref()) {
+            if (mapping.mapping_case() ==
+                tt::scaleout_tools::cabling_generator::proto::ChildMapping::kSubInstance) {
+                collect_host_id_to_hostname(mapping.sub_instance(), cluster_descriptor, out);
+            }
+        }
+    }
+}
+
+// Returns a deployment slice containing only the hosts referenced by `cluster_descriptor`,
+// ordered by host_id so positional (host_id -> hosts[i]) indexing in the per-file ctor lines up.
+tt::scaleout_tools::deployment::proto::DeploymentDescriptor filter_deployment_for_cabling(
+    const tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
+    const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& full_deployment,
+    const std::string& cabling_source) {
+    std::map<HostId, std::string> host_id_to_hostname;
+    collect_host_id_to_hostname(cluster_descriptor.root_instance(), cluster_descriptor, host_id_to_hostname);
+
+    tt::scaleout_tools::deployment::proto::DeploymentDescriptor filtered;
+    filtered.set_rack_capacity(full_deployment.rack_capacity());
+    if (host_id_to_hostname.empty()) {
+        return filtered;
+    }
+
+    // Per-file host_ids must be contiguous 0..N-1; positional indexing breaks otherwise.
+    HostId expected_id{0};
+    for (const auto& [hid, _] : host_id_to_hostname) {
+        if (*hid != *expected_id) {
+            throw std::runtime_error(fmt::format(
+                "Cabling file '{}' has non-contiguous host_ids (expected {} but found {}); "
+                "merge requires each file to use a 0..N-1 host_id space",
+                cabling_source,
+                *expected_id,
+                *hid));
+        }
+        expected_id = HostId(*expected_id + 1);
+    }
+
+    std::unordered_map<std::string, const tt::scaleout_tools::deployment::proto::Host*> hostname_to_host;
+    hostname_to_host.reserve(full_deployment.hosts().size());
+    for (const auto& host : full_deployment.hosts()) {
+        hostname_to_host[host.host()] = &host;
+    }
+
+    for (const auto& [hid, hostname] : host_id_to_hostname) {
+        auto it = hostname_to_host.find(hostname);
+        if (it == hostname_to_host.end()) {
+            throw std::runtime_error(
+                "Cabling file '" + cabling_source + "' references host '" + hostname +
+                "' which is not present in the deployment descriptor");
+        }
+        *filtered.add_hosts() = *(it->second);
+    }
+    return filtered;
+}
+
 void populate_deployment_hosts(
     const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor,
     const std::unordered_map<std::string, Node>& node_templates,
@@ -804,6 +891,58 @@ CablingGenerator build_from_directory(const std::string& dir_path, const Deploym
     return merged;
 }
 
+// Same as above, but slices the pre-parsed deployment per cabling file so each per-file
+// ctor sees only the hosts it can validate against its own templates and host_id space.
+CablingGenerator build_from_directory(
+    const std::string& dir_path,
+    const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor) {
+    auto descriptor_files = CablingGenerator::find_descriptor_files(dir_path);
+
+    log_info(
+        tt::LogDistributed, "Found {} cabling descriptor files in directory: {}", descriptor_files.size(), dir_path);
+    for (const auto& file : descriptor_files) {
+        log_info(tt::LogDistributed, "  - {}", file);
+    }
+
+    auto slice = [&](const std::string& cabling_file) {
+        auto cluster = load_cluster_descriptor(cabling_file);
+        return filter_deployment_for_cabling(cluster, deployment_descriptor, cabling_file);
+    };
+
+    auto first_slice = slice(descriptor_files[0]);
+    CablingGenerator merged(descriptor_files[0], first_slice);
+    std::string merged_source_description = descriptor_files[0];
+
+    for (size_t i = 1; i < descriptor_files.size(); ++i) {
+        auto next_slice = slice(descriptor_files[i]);
+        merged.merge(descriptor_files[i], next_slice, merged_source_description);
+        merged_source_description += ", " + descriptor_files[i];
+    }
+
+    // Catch hosts orphaned by per-file slicing (typo / wrong file picked).
+    std::unordered_set<std::string> claimed;
+    claimed.reserve(merged.deployment_hosts_.size());
+    for (const auto& host : merged.deployment_hosts_) {
+        claimed.insert(host.hostname);
+    }
+    std::vector<std::string> orphans;
+    for (const auto& host : deployment_descriptor.hosts()) {
+        if (!claimed.contains(host.host())) {
+            orphans.push_back(host.host());
+        }
+    }
+    if (!orphans.empty()) {
+        std::string msg = "Deployment descriptor contains hosts not referenced by any cabling file in '" + dir_path +
+                          "': " + orphans[0];
+        for (size_t i = 1; i < orphans.size(); ++i) {
+            msg += ", " + orphans[i];
+        }
+        throw std::runtime_error(msg);
+    }
+
+    return merged;
+}
+
 // Helper: Deep copy a ResolvedGraphInstance (including all nested subgraphs)
 static std::unique_ptr<ResolvedGraphInstance> clone_resolved_graph(const ResolvedGraphInstance& source) {
     auto cloned = std::make_unique<ResolvedGraphInstance>();
@@ -833,6 +972,22 @@ void ResolvedGraphInstance::add_connection(PortType port_type, const PortConnect
     connection_pairs.insert(normalized);
 }
 
+// Single-file init shared by the (path, path) and (path, DeploymentDescriptor) ctors.
+void CablingGenerator::initialize_from_single_file(
+    const std::string& cluster_descriptor_path,
+    const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor) {
+    auto cluster_descriptor = load_cluster_descriptor(cluster_descriptor_path);
+    initialize_cluster(cluster_descriptor, deployment_descriptor);
+    populate_deployment_hosts(deployment_descriptor, node_templates_, deployment_hosts_);
+    // Order deployment_hosts_ by DFS-assigned host_id; rebuild falls back to the current
+    // order internally when node names don't match hostnames (e.g. test fixtures).
+    std::unordered_map<std::string, Host> all_hosts;
+    for (const auto& host : deployment_hosts_) {
+        all_hosts[host.hostname] = host;
+    }
+    rebuild_deployment_hosts_in_dfs_order(all_hosts);
+}
+
 // Constructor with full deployment descriptor
 // cluster_descriptor_path can be a single file or a directory
 CablingGenerator::CablingGenerator(
@@ -841,26 +996,35 @@ CablingGenerator::CablingGenerator(
         throw std::runtime_error("Path does not exist: " + cluster_descriptor_path);
     }
     if (std::filesystem::is_directory(cluster_descriptor_path)) {
-        auto merged = build_from_directory(cluster_descriptor_path, deployment_descriptor_path);
+        // Dispatch to the parsed-deployment overload, which slices the deployment per cabling file.
+        auto deployment_descriptor = load_deployment_descriptor(deployment_descriptor_path);
+        auto merged = build_from_directory(cluster_descriptor_path, deployment_descriptor);
         node_templates_ = std::move(merged.node_templates_);
         root_instance_ = std::move(merged.root_instance_);
         host_id_to_node_ = std::move(merged.host_id_to_node_);
         chip_connections_ = std::move(merged.chip_connections_);
         deployment_hosts_ = std::move(merged.deployment_hosts_);
     } else {
-        auto cluster_descriptor = load_cluster_descriptor(cluster_descriptor_path);
-        auto deployment_descriptor = load_deployment_descriptor(deployment_descriptor_path);
-        initialize_cluster(cluster_descriptor, deployment_descriptor);
-        populate_deployment_hosts(deployment_descriptor, node_templates_, deployment_hosts_);
-        // Ensure deployment_hosts_ is ordered by DFS-assigned host_id, not deployment file order.
-        // (rebuild_deployment_hosts_in_dfs_order keeps the current order when node names don't
-        // match hostnames, e.g. test fixtures.)
-        std::unordered_map<std::string, Host> all_hosts;
-        for (const auto& host : deployment_hosts_) {
-            all_hosts[host.hostname] = host;
-        }
-        rebuild_deployment_hosts_in_dfs_order(all_hosts);
+        initialize_from_single_file(
+            cluster_descriptor_path, load_deployment_descriptor(deployment_descriptor_path));
     }
+}
+
+// Same as (path, path) single-file branch but takes a parsed deployment.
+// Used by build_from_directory after slicing.
+CablingGenerator::CablingGenerator(
+    const std::string& cluster_descriptor_path,
+    const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor) {
+    if (!std::filesystem::exists(cluster_descriptor_path)) {
+        throw std::runtime_error("Path does not exist: " + cluster_descriptor_path);
+    }
+    if (std::filesystem::is_directory(cluster_descriptor_path)) {
+        throw std::runtime_error(
+            "CablingGenerator(path, DeploymentDescriptor) does not support directory paths; "
+            "use build_from_directory directly: " +
+            cluster_descriptor_path);
+    }
+    initialize_from_single_file(cluster_descriptor_path, deployment_descriptor);
 }
 
 // Constructor with just hostnames (no physical location info)
@@ -989,6 +1153,22 @@ static void merge_resolved_graph_instances(
                 auto target_template_key = find_template_key_for_node(target.nodes[name], node_templates);
                 auto source_template_key = find_template_key_for_node(source_node, node_templates);
 
+                // Same instance name, different node type across files (e.g. host declared as
+                // WH_GALAXY in one and BH_GALAXY in another) - real conflict; fail with a clear
+                // message instead of a downstream inter_board_connections mismatch.
+                if (target_template_key && source_template_key &&
+                    *target_template_key != *source_template_key &&
+                    !are_torus_compatible_for_merge(*target_template_key, *source_template_key)) {
+                    throw std::runtime_error(fmt::format(
+                        "Node '{}' has conflicting node types across cabling descriptors: "
+                        "'{}' from {} vs '{}' from {} - structural mismatch",
+                        name,
+                        *target_template_key,
+                        get_source_description(existing_source_file),
+                        *source_template_key,
+                        get_source_description(new_source_file)));
+                }
+
                 bool is_torus_merge =
                     (target_template_key && source_template_key &&
                      are_torus_compatible_for_merge(*target_template_key, *source_template_key));
@@ -1112,12 +1292,9 @@ static void merge_resolved_graph_instances(
     }
 }
 
-template <typename DeploymentArg>
-void CablingGenerator::merge(
-    const std::string& new_file_path, const DeploymentArg& deployment_arg, const std::string& existing_sources) {
-    // Create CablingGenerator for the new file
-    CablingGenerator other(new_file_path, deployment_arg);
-
+// Post-construction merge logic shared by both merge() entry points.
+void CablingGenerator::merge_other(
+    CablingGenerator& other, const std::string& new_file_path, const std::string& existing_sources) {
     if (!root_instance_ || !other.root_instance_) {
         throw std::runtime_error("Cannot merge: both CablingGenerators must have root_instance_");
     }
@@ -1215,6 +1392,21 @@ void CablingGenerator::merge(
     rebuild_deployment_hosts_in_dfs_order(all_hosts);
 
     generate_logical_chip_connections();
+}
+
+template <typename DeploymentArg>
+void CablingGenerator::merge(
+    const std::string& new_file_path, const DeploymentArg& deployment_arg, const std::string& existing_sources) {
+    CablingGenerator other(new_file_path, deployment_arg);
+    merge_other(other, new_file_path, existing_sources);
+}
+
+void CablingGenerator::merge(
+    const std::string& new_file_path,
+    const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor,
+    const std::string& existing_sources) {
+    CablingGenerator other(new_file_path, deployment_descriptor);
+    merge_other(other, new_file_path, existing_sources);
 }
 
 // Getters for all data

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -891,8 +891,15 @@ CablingGenerator build_from_directory(const std::string& dir_path, const Deploym
     return merged;
 }
 
-// Same as above, but slices the pre-parsed deployment per cabling file so each per-file
-// ctor sees only the hosts it can validate against its own templates and host_id space.
+// Same as above, but optionally slices the pre-parsed deployment per cabling file so each
+// per-file ctor sees only the hosts it can validate against its own templates and host_id space.
+//
+// Slicing is gated on every leaf child name in every cabling file matching a deployment hostname
+// (the convention used by heterogeneous-merge inputs). When that doesn't hold - e.g. cabling files
+// use placeholder names like "node1" while the deployment lists real hostnames - we fall back to
+// the pre-PR behaviour of passing the full deployment to each per-file ctor. That path doesn't
+// support disjoint per-file templates against a single deployment, but it preserves the existing
+// positional convention used by single-file ctors in production.
 CablingGenerator build_from_directory(
     const std::string& dir_path,
     const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor) {
@@ -904,40 +911,74 @@ CablingGenerator build_from_directory(
         log_info(tt::LogDistributed, "  - {}", file);
     }
 
-    auto slice = [&](const std::string& cabling_file) {
-        auto cluster = load_cluster_descriptor(cabling_file);
-        return filter_deployment_for_cabling(cluster, deployment_descriptor, cabling_file);
+    // Parse cabling files once so we can both probe for the naming convention and (when slicing)
+    // reuse the parsed cluster descriptors below.
+    std::vector<cabling_generator::proto::ClusterDescriptor> clusters;
+    clusters.reserve(descriptor_files.size());
+    for (const auto& file : descriptor_files) {
+        clusters.push_back(load_cluster_descriptor(file));
+    }
+
+    std::unordered_set<std::string> deployment_hostnames;
+    deployment_hostnames.reserve(deployment_descriptor.hosts().size());
+    for (const auto& host : deployment_descriptor.hosts()) {
+        deployment_hostnames.insert(host.host());
+    }
+
+    bool can_slice = true;
+    for (const auto& cluster : clusters) {
+        std::map<HostId, std::string> name_map;
+        collect_host_id_to_hostname(cluster.root_instance(), cluster, name_map);
+        for (const auto& [hid, hostname] : name_map) {
+            if (!deployment_hostnames.contains(hostname)) {
+                can_slice = false;
+                break;
+            }
+        }
+        if (!can_slice) {
+            break;
+        }
+    }
+
+    auto per_file_deployment = [&](size_t i) -> tt::scaleout_tools::deployment::proto::DeploymentDescriptor {
+        if (!can_slice) {
+            return deployment_descriptor;
+        }
+        return filter_deployment_for_cabling(clusters[i], deployment_descriptor, descriptor_files[i]);
     };
 
-    auto first_slice = slice(descriptor_files[0]);
-    CablingGenerator merged(descriptor_files[0], first_slice);
+    CablingGenerator merged(descriptor_files[0], per_file_deployment(0));
     std::string merged_source_description = descriptor_files[0];
 
     for (size_t i = 1; i < descriptor_files.size(); ++i) {
-        auto next_slice = slice(descriptor_files[i]);
-        merged.merge(descriptor_files[i], next_slice, merged_source_description);
+        merged.merge(descriptor_files[i], per_file_deployment(i), merged_source_description);
         merged_source_description += ", " + descriptor_files[i];
     }
 
-    // Catch hosts orphaned by per-file slicing (typo / wrong file picked).
-    std::unordered_set<std::string> claimed;
-    claimed.reserve(merged.deployment_hosts_.size());
-    for (const auto& host : merged.deployment_hosts_) {
-        claimed.insert(host.hostname);
-    }
-    std::vector<std::string> orphans;
-    for (const auto& host : deployment_descriptor.hosts()) {
-        if (!claimed.contains(host.host())) {
-            orphans.push_back(host.host());
+    // Orphan detection is only meaningful when we sliced: each cabling file declares a subset of
+    // hosts and a deployment-only host represents a typo or wrong-file mistake. In the
+    // full-deployment fallback every per-file ctor already sees the entire deployment, so this
+    // class of error can't arise here.
+    if (can_slice) {
+        std::unordered_set<std::string> claimed;
+        claimed.reserve(merged.deployment_hosts_.size());
+        for (const auto& host : merged.deployment_hosts_) {
+            claimed.insert(host.hostname);
         }
-    }
-    if (!orphans.empty()) {
-        std::string msg = "Deployment descriptor contains hosts not referenced by any cabling file in '" + dir_path +
-                          "': " + orphans[0];
-        for (size_t i = 1; i < orphans.size(); ++i) {
-            msg += ", " + orphans[i];
+        std::vector<std::string> orphans;
+        for (const auto& host : deployment_descriptor.hosts()) {
+            if (!claimed.contains(host.host())) {
+                orphans.push_back(host.host());
+            }
         }
-        throw std::runtime_error(msg);
+        if (!orphans.empty()) {
+            std::string msg = "Deployment descriptor contains hosts not referenced by any cabling file in '" +
+                              dir_path + "': " + orphans[0];
+            for (size_t i = 1; i < orphans.size(); ++i) {
+                msg += ", " + orphans[i];
+            }
+            throw std::runtime_error(msg);
+        }
     }
 
     return merged;

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -162,6 +162,12 @@ public:
     template <typename DeploymentArg>
     friend CablingGenerator build_from_directory(const std::string& dir_path, const DeploymentArg& deployment_arg);
 
+    // Overload taking a parsed deployment; slices it per cabling file before each per-file ctor
+    // so positional (host_id-indexed) access stays consistent across files.
+    friend CablingGenerator build_from_directory(
+        const std::string& dir_path,
+        const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor);
+
     // Getters for all data
     const std::vector<Host>& get_deployment_hosts() const;
     const std::vector<LogicalChannelConnection>& get_chip_connections() const;
@@ -190,6 +196,11 @@ private:
         std::optional<std::reference_wrapper<const deployment::proto::DeploymentDescriptor>> deployment_descriptor =
             std::nullopt);
 
+    // Single-file init shared by the (path, path) and (path, DeploymentDescriptor) ctors.
+    void initialize_from_single_file(
+        const std::string& cluster_descriptor_path,
+        const deployment::proto::DeploymentDescriptor& deployment_descriptor);
+
     // Merge another descriptor file into this CablingGenerator
     // Creates CablingGenerator internally and merges it
     // existing_sources: accumulated list of previously merged files (for error messages)
@@ -198,6 +209,21 @@ private:
     template <typename DeploymentArg>
     void merge(
         const std::string& new_file_path, const DeploymentArg& deployment_arg, const std::string& existing_sources);
+
+    // Ctor / merge overloads taking a parsed deployment; used by build_from_directory after
+    // slicing the full deployment per cabling file.
+    CablingGenerator(
+        const std::string& cluster_descriptor_path,
+        const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor);
+
+    void merge(
+        const std::string& new_file_path,
+        const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor,
+        const std::string& existing_sources);
+
+    // Post-construction merge logic shared by both merge() entry points.
+    void merge_other(
+        CablingGenerator& other, const std::string& new_file_path, const std::string& existing_sources);
 
     // Utility function for finding descriptor files in a directory
     static std::vector<std::string> find_descriptor_files(const std::string& directory_path);

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -92,6 +92,7 @@ struct Node {
     std::string motherboard;
     std::map<TrayId, Board> boards;
     HostId host_id{0};
+    std::string node_descriptor_name;
 
     // Board-to-board connections within this node: PortType -> [(tray_id, port_id) <-> (tray_id, port_id)]
     using BoardEndpoint = std::pair<TrayId, PortId>;

--- a/tools/tests/scaleout/test_host_id_assignment.cpp
+++ b/tools/tests/scaleout/test_host_id_assignment.cpp
@@ -243,8 +243,10 @@ root_instance { template_name: "root"
 
 // ---- Heterogeneous merge tests ----
 //
-// These exercise build_from_directory(dir, DeploymentDescriptor): each cabling file
-// declares its own (disjoint) templates and the deployment is sliced per file.
+// These exercise build_from_directory(dir, DeploymentDescriptor). When every leaf child
+// name in every cabling file maps to a deployment hostname, the deployment is sliced
+// per file (enables disjoint per-file templates). Otherwise we fall back to feeding the
+// full deployment to each per-file ctor (preserves the pre-PR positional convention).
 
 static void write_single_node_cabling(
     const std::string& path, const std::string& node, const std::string& desc, uint32_t hid = 0) {
@@ -314,15 +316,26 @@ root_instance { template_name: "root"
     std::filesystem::remove_all(dir);
 }
 
-// Cabling refers to a hostname (child_name) that is not in the deployment descriptor.
-TEST(HeterogeneousMergeTest, HostnameMissingFromDeployment_Throws) {
-    auto dir = tmp_dir("hetero_missing");
+// Directory mode with placeholder child names + real deployment hostnames (the existing
+// in-repo convention used by 5_wh_galaxy_y_torus_superpod, 16_n300_lb_cluster, etc.). Slicing
+// must auto-disable here so directory mode stays compatible with the single-file ctor.
+TEST(HeterogeneousMergeTest, PlaceholderNamesWithRealHostnames_FallsBackToFullDeployment) {
+    auto dir = tmp_dir("hetero_placeholder");
     std::string cdir = dir + "c/";
     std::filesystem::create_directories(cdir);
-    write_single_node_cabling(cdir + "a.textproto", "node1", "WH_GALAXY");
-    write_deploy(dir + "dep.textproto", {"other"}, "WH_GALAXY");
+    std::filesystem::copy(k5NodeCabling, cdir + "a.textproto");
+    write(dir + "dep.textproto",
+        "hosts{host:\"wh-glx-a03u02\" node_type:\"WH_GALAXY_Y_TORUS\"}\n"
+        "hosts{host:\"wh-glx-a03u08\" node_type:\"WH_GALAXY_Y_TORUS\"}\n"
+        "hosts{host:\"wh-glx-a03u14\" node_type:\"WH_GALAXY_Y_TORUS\"}\n"
+        "hosts{host:\"wh-glx-a04u02\" node_type:\"WH_GALAXY_Y_TORUS\"}\n"
+        "hosts{host:\"wh-glx-a04u08\" node_type:\"WH_GALAXY_Y_TORUS\"}\n");
 
-    EXPECT_THROW(CablingGenerator(cdir, dir + "dep.textproto"), std::runtime_error);
+    CablingGenerator gen(cdir, dir + "dep.textproto");
+    const auto hosts = gen.generate_factory_system_descriptor().hosts();
+    ASSERT_EQ(hosts.size(), 5u);
+    EXPECT_EQ(hosts[0].hostname(), "wh-glx-a03u02");
+    EXPECT_EQ(hosts[4].hostname(), "wh-glx-a04u08");
 
     std::filesystem::remove_all(dir);
 }

--- a/tools/tests/scaleout/test_host_id_assignment.cpp
+++ b/tools/tests/scaleout/test_host_id_assignment.cpp
@@ -241,4 +241,90 @@ root_instance { template_name: "root"
     std::filesystem::remove_all(dir);
 }
 
+// ---- Heterogeneous merge tests ----
+//
+// These exercise build_from_directory(dir, DeploymentDescriptor): each cabling file
+// declares its own (disjoint) templates and the deployment is sliced per file.
+
+static void write_single_node_cabling(
+    const std::string& path, const std::string& node, const std::string& desc, uint32_t hid = 0) {
+    write(path,
+        "graph_templates { key: \"root\" value {\n"
+        "  children { name: \"" + node + "\" node_ref { node_descriptor: \"" + desc + "\" } }\n"
+        "}}\nroot_instance { template_name: \"root\"\n"
+        "  child_mappings { key: \"" + node + "\" value { host_id: " + std::to_string(hid) + " } }\n}\n");
+}
+
+// File A declares WH_GALAXY, file B declares WH_GALAXY_Y_TORUS - disjoint same-arch templates.
+// Pre-PR this failed as "structural mismatch"; post-PR the templates union and merge succeeds.
+TEST(HeterogeneousMergeTest, DisjointSameArchTemplates_Merge) {
+    auto dir = tmp_dir("hetero_disjoint");
+    std::string cdir = dir + "c/";
+    std::filesystem::create_directories(cdir);
+    write_single_node_cabling(cdir + "a.textproto", "node1", "WH_GALAXY");
+    write_single_node_cabling(cdir + "b.textproto", "node2", "WH_GALAXY_Y_TORUS");
+    write(dir + "dep.textproto",
+        "hosts{host:\"node1\" node_type:\"WH_GALAXY\"}\n"
+        "hosts{host:\"node2\" node_type:\"WH_GALAXY_Y_TORUS\"}\n");
+
+    CablingGenerator gen(cdir, dir + "dep.textproto");
+    const auto hosts = gen.generate_factory_system_descriptor().hosts();
+
+    ASSERT_EQ(hosts.size(), 2u);
+    EXPECT_EQ(hosts[0].hostname(), "node1");
+    EXPECT_EQ(hosts[1].hostname(), "node2");
+
+    std::filesystem::remove_all(dir);
+}
+
+// Deployment lists a host that no cabling file references - new orphan check should fire.
+TEST(HeterogeneousMergeTest, OrphanDeploymentHost_Throws) {
+    auto dir = tmp_dir("hetero_orphan");
+    std::string cdir = dir + "c/";
+    std::filesystem::create_directories(cdir);
+    write_single_node_cabling(cdir + "a.textproto", "node1", "WH_GALAXY");
+    write(dir + "dep.textproto",
+        "hosts{host:\"node1\" node_type:\"WH_GALAXY\"}\n"
+        "hosts{host:\"ghost\" node_type:\"WH_GALAXY\"}\n");
+
+    EXPECT_THROW(CablingGenerator(cdir, dir + "dep.textproto"), std::runtime_error);
+
+    std::filesystem::remove_all(dir);
+}
+
+// Cabling file uses host_ids {0, 2} - per-file slicing requires a contiguous 0..N-1 space.
+TEST(HeterogeneousMergeTest, NonContiguousHostIds_Throws) {
+    auto dir = tmp_dir("hetero_gap");
+    std::string cdir = dir + "c/";
+    std::filesystem::create_directories(cdir);
+    write(cdir + "a.textproto", R"(
+graph_templates { key: "root" value {
+  children { name: "node1" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "node2" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "node1" value { host_id: 0 } }
+  child_mappings { key: "node2" value { host_id: 2 } }
+}
+)");
+    write_deploy(dir + "dep.textproto", {"node1", "node2"}, "WH_GALAXY");
+
+    EXPECT_THROW(CablingGenerator(cdir, dir + "dep.textproto"), std::runtime_error);
+
+    std::filesystem::remove_all(dir);
+}
+
+// Cabling refers to a hostname (child_name) that is not in the deployment descriptor.
+TEST(HeterogeneousMergeTest, HostnameMissingFromDeployment_Throws) {
+    auto dir = tmp_dir("hetero_missing");
+    std::string cdir = dir + "c/";
+    std::filesystem::create_directories(cdir);
+    write_single_node_cabling(cdir + "a.textproto", "node1", "WH_GALAXY");
+    write_deploy(dir + "dep.textproto", {"other"}, "WH_GALAXY");
+
+    EXPECT_THROW(CablingGenerator(cdir, dir + "dep.textproto"), std::runtime_error);
+
+    std::filesystem::remove_all(dir);
+}
+
 }  // namespace tt::scaleout_tools

--- a/tools/tests/scaleout/test_host_id_assignment.cpp
+++ b/tools/tests/scaleout/test_host_id_assignment.cpp
@@ -12,6 +12,7 @@
 
 #include <cabling_generator/cabling_generator.hpp>
 #include "protobuf/cluster_config.pb.h"
+#include "protobuf/deployment.pb.h"
 #include "protobuf/factory_system_descriptor.pb.h"
 
 namespace tt::scaleout_tools {
@@ -312,6 +313,52 @@ root_instance { template_name: "root"
     write_deploy(dir + "dep.textproto", {"node1", "node2"}, "WH_GALAXY");
 
     EXPECT_THROW(CablingGenerator(cdir, dir + "dep.textproto"), std::runtime_error);
+
+    std::filesystem::remove_all(dir);
+}
+
+// REV_AB and REV_C share motherboard + boards and differ only in internal wiring, so the
+// shape-based output lookup collapsed every child to the same key. Each child must keep its
+// source template, and cabling node_descriptor must equal deployment node_type per host.
+TEST(HeterogeneousMergeTest, MixedRevAB_RevC_PreservesPerChildBinding) {
+    auto dir = tmp_dir("hetero_mixed_revs");
+    std::string cdir = dir + "c/";
+    std::filesystem::create_directories(cdir);
+    write_single_node_cabling(cdir + "a.textproto", "host_ab", "BH_GALAXY_REV_AB", 0);
+    write_single_node_cabling(cdir + "b.textproto", "host_c", "BH_GALAXY_REV_C", 0);
+    write(
+        dir + "dep.textproto",
+        "hosts{host:\"host_ab\" node_type:\"BH_GALAXY_REV_AB\"}\n"
+        "hosts{host:\"host_c\" node_type:\"BH_GALAXY_REV_C\"}\n");
+
+    CablingGenerator gen(cdir, dir + "dep.textproto");
+    gen.emit_cabling_descriptor(dir + "out.textproto");
+    gen.emit_deployment_descriptor(dir + "dep_out.textproto");
+
+    cabling_generator::proto::ClusterDescriptor desc;
+    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(read_file(dir + "out.textproto"), &desc));
+    tt::scaleout_tools::deployment::proto::DeploymentDescriptor dep_out;
+    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(read_file(dir + "dep_out.textproto"), &dep_out));
+
+    std::map<std::string, std::string> child_to_desc;
+    for (const auto& [_, tmpl] : desc.graph_templates()) {
+        for (const auto& child : tmpl.children()) {
+            if (child.has_node_ref()) {
+                child_to_desc[child.name()] = child.node_ref().node_descriptor();
+            }
+        }
+    }
+    std::map<std::string, std::string> host_to_node_type;
+    for (const auto& h : dep_out.hosts()) {
+        host_to_node_type[h.host()] = h.node_type();
+    }
+
+    ASSERT_EQ(child_to_desc.size(), 2u);
+    EXPECT_EQ(child_to_desc["host_ab"], "BH_GALAXY_REV_AB");
+    EXPECT_EQ(child_to_desc["host_c"], "BH_GALAXY_REV_C");
+    for (const auto& [name, desc_name] : child_to_desc) {
+        EXPECT_EQ(host_to_node_type[name], desc_name) << name;
+    }
 
     std::filesystem::remove_all(dir);
 }


### PR DESCRIPTION
### Summary
Merging two cabling descriptors via `run_cabling_generator` failed whenever the two files didn't describe identical clusters. Two root causes, both fixed here:

- **Per-file constructor got the combined deployment** -> threw `Node type '...' not found in cluster descriptor templates` or `Node type mismatch for host X (host_id 0): ...`. Now `build_from_directory` slices the deployment per file to match each file's local 0..N-1 `host_id` space, and checks no input host is left unclaimed.
- **`validate_and_merge_node_templates` enforced template-set equality** -> blocked heterogeneous merges (e.g. REV_AB-only + REV_C-only). Now it takes the union; same-name templates must still agree, and cross-architecture mixes (WH + BH) are still rejected.
- same-hostname-different-node-type conflicts now throw an explicit error in `merge_resolved_graph_instances` instead of failing downstream on inter-board connections.

### Notes for reviewers
- Public API unchanged. `(path, string)` ctor loads the deployment once and dispatches to a new private `(path, DeploymentDescriptor)` overload; hostnames (`vector<string>`) path untouched. Two shared helpers (`initialize_from_single_file`, `merge_other`) extracted to dedupe.
- All cabling gen tests pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/cabling_gen_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/cabling_gen_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/cabling_gen_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/cabling_gen_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/cabling_gen_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/cabling_gen_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/cabling_gen_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/cabling_gen_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/cabling_gen_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/cabling_gen_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/cabling_gen_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/cabling_gen_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/cabling_gen_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/cabling_gen_ext)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/cabling_gen_ext)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/cabling_gen_ext)