### PR TITLE
[tt-train] Optimized MoE routing for deepseek training

### DIFF
--- a/tt-train/sources/ttml/ttml/models/deepseek/moe.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/moe.py
@@ -174,8 +174,8 @@ class MoE(AbstractModuleBase):
                 [b, 1, s, self.n_limited_groups], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, biased.device()
             )
             group_mask = ttnn.scatter(group_mask, -1, top_group_indices_u32, group_src)
-            group_mask = ttnn.to_layout(group_mask, ttnn.TILE_LAYOUT)
             group_mask = ttnn.repeat_interleave(group_mask, experts_per_group, dim=-1)
+            group_mask = ttnn.to_layout(group_mask, ttnn.TILE_LAYOUT)
             neg_inf = ttnn.multiply(ttnn.subtract(group_mask, 1.0), 1e9)
             biased_masked = ttnn.add(biased, neg_inf)
 

--- a/tt-train/sources/ttml/ttml/models/deepseek/moe.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/moe.py
@@ -162,21 +162,20 @@ class MoE(AbstractModuleBase):
                 ttnn.typecast(group_scores, ttnn.DataType.BFLOAT16), self.n_limited_groups, dim=-1
             )
 
-            # Workaround for ttnn.eq with uint16 bug
+            # Build group mask [B, 1, S, num_experts] via scatter + repeat_interleave.
+            # Scatter needs UINT32 indices in ROW_MAJOR layout.
+            b, _, s, _ = list(biased.shape)
             top_group_indices_u32 = ttnn.typecast(top_group_indices, ttnn.DataType.UINT32)
-
-            # Build group mask [B, 1, S, num_experts]
-            group_mask_parts = []
-            for g in range(self.n_groups):
-                match = ttnn.eq(top_group_indices_u32, float(g))
-                match_f = ttnn.typecast(match, ttnn.DataType.BFLOAT16)
-                match_any = ttnn.sum(match_f, dim=-1, keepdim=True)
-                group_selected = ttnn.gt(match_any, 0.0)
-                group_selected = ttnn.typecast(group_selected, ttnn.DataType.BFLOAT16)
-                group_expert_mask = ttnn.repeat(group_selected, ttnn.Shape([1, 1, 1, experts_per_group]))
-                group_mask_parts.append(group_expert_mask)
-
-            group_mask = ttnn.concat(group_mask_parts, dim=-1)
+            top_group_indices_u32 = ttnn.to_layout(top_group_indices_u32, ttnn.ROW_MAJOR_LAYOUT)
+            group_mask = ttnn.zeros(
+                [b, 1, s, self.n_groups], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, biased.device()
+            )
+            group_src = ttnn.ones(
+                [b, 1, s, self.n_limited_groups], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, biased.device()
+            )
+            group_mask = ttnn.scatter(group_mask, -1, top_group_indices_u32, group_src)
+            group_mask = ttnn.to_layout(group_mask, ttnn.TILE_LAYOUT)
+            group_mask = ttnn.repeat_interleave(group_mask, experts_per_group, dim=-1)
             neg_inf = ttnn.multiply(ttnn.subtract(group_mask, 1.0), 1e9)
             biased_masked = ttnn.add(biased, neg_inf)
 
@@ -196,20 +195,17 @@ class MoE(AbstractModuleBase):
 
         scores, _topk_values, topk_indices = self.compute_routing(x)
 
-        # ── 3. Build per-expert routing masks [B, 1, S, 1] ──
-        # Workaround for ttnn.eq with uint16 bug
+        # ── 3. Build dense per-token expert mask via scatter ──
+        # Scatter ones at topk indices into a zero tensor to produce a
+        # one-hot-per-selected-expert mask [B, 1, S, num_experts] in a single
+        # op instead of num_experts independent eq/sum/gt/typecast chains.
+        device = x.get_value().device()
         topk_indices_u32 = ttnn.typecast(topk_indices, ttnn.DataType.UINT32)
-
-        expert_masks = {}
-        mask_parts = []  # for the full [B, 1, S, num_experts] mask
-        for expert_idx in range(self.num_experts):
-            match = ttnn.eq(topk_indices_u32, float(expert_idx))
-            match_f = ttnn.typecast(match, ttnn.DataType.BFLOAT16)
-            match_any = ttnn.sum(match_f, dim=-1, keepdim=True)  # [B, 1, S, 1]
-            mask_narrow = ttnn.gt(match_any, 0.0)
-            mask_narrow = ttnn.typecast(mask_narrow, ttnn.DataType.BFLOAT16)
-            expert_masks[expert_idx] = mask_narrow
-            mask_parts.append(mask_narrow)
+        topk_indices_u32 = ttnn.to_layout(topk_indices_u32, ttnn.ROW_MAJOR_LAYOUT)
+        expert_mask_all = ttnn.zeros([B, 1, S, self.num_experts], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, device)
+        expert_src = ttnn.ones([B, 1, S, self.n_activated], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, device)
+        expert_mask_all = ttnn.scatter(expert_mask_all, -1, topk_indices_u32, expert_src)
+        expert_mask_all = ttnn.to_layout(expert_mask_all, ttnn.TILE_LAYOUT)
 
         # ── 4. Routing weights ──
         # For sigmoid: use MoERoutingNormalize which has the full Jacobian
@@ -217,21 +213,14 @@ class MoE(AbstractModuleBase):
         # softmax: selected scores are used directly (no renorm), so we fall
         # back to the per-expert multiply with a detached mask.
         if self.score_func == "sigmoid":
-            full_mask = ttnn.concat(mask_parts, dim=-1)  # [B, 1, S, num_experts]
-            routing_weights = moe_routing_normalize(scores, full_mask, self.route_scale, 1e-20)
+            routing_weights = moe_routing_normalize(scores, expert_mask_all, self.route_scale, 1e-20)
         else:
             routing_weights = None  # softmax path uses score_i directly below
 
-        # Accumulate token counts on device (unchanged):
-        # Stack all expert mask sums into [1, 1, 1, num_experts]
-        expert_count_scalars = []
-        for expert_idx in range(self.num_experts):
-            # Sum mask [B,1,S,1] -> scalar, reshape to [1,1,1,1]
-            count = ttnn.sum(expert_masks[expert_idx])  # scalar-ish tensor
-            count = ttnn.reshape(count, [1, 1, 1, 1])
-            expert_count_scalars.append(count)
-        batch_counts = ttnn.concat(expert_count_scalars, dim=-1)  # [1, 1, 1, num_experts]
-        # Add to running accumulator
+        # Accumulate token counts on device via a single reduction:
+        # expert_mask_all [B, 1, S, num_experts] -> [1, 1, 1, num_experts].
+        mask_bs_flat = ttnn.reshape(expert_mask_all, [1, 1, B * S, self.num_experts])
+        batch_counts = ttnn.sum(mask_bs_flat, dim=-2, keepdim=True)  # [1, 1, 1, num_experts]
         new_counts = ttnn.add(self._token_counts.tensor.get_value(), batch_counts)
         self._token_counts.tensor.set_value(new_counts)
 
@@ -251,7 +240,7 @@ class MoE(AbstractModuleBase):
                 )
                 weighted = ttml.ops.binary.mul(expert_out, rw_i)
             else:
-                mask_narrow = expert_masks[expert_idx]
+                mask_narrow = ttnn.slice(expert_mask_all, [0, 0, 0, expert_idx], [B, 1, S, expert_idx + 1])
                 expert_mask = ttnn.repeat(mask_narrow, ttnn.Shape([1, 1, 1, dim]))
                 mask_tt = ttml.autograd.Tensor(expert_mask, False)
                 score_i = autograd_slice(scores, [0, 0, 0, expert_idx], [B, 1, S, expert_idx + 1])

--- a/tt-train/sources/ttml/ttml/models/deepseek/moe.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/moe.py
@@ -188,7 +188,7 @@ class MoE(AbstractModuleBase):
                 [b, 1, s, self.n_limited_groups], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, biased.device()
             )
             group_mask = ttnn.scatter(group_mask, -1, top_group_indices_u32, group_src)
-            group_mask = ttnn.repeat_interleave(group_mask, experts_per_group, dim=-1)
+            group_mask = ttnn.repeat(group_mask, ttnn.Shape([1, 1, 1, experts_per_group]))
             group_mask = ttnn.to_layout(group_mask, ttnn.TILE_LAYOUT)
             neg_inf = ttnn.multiply(ttnn.subtract(group_mask, 1.0), 1e9)
             biased_masked = ttnn.add(biased, neg_inf)

--- a/tt-train/sources/ttml/ttml/models/deepseek/moe.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/moe.py
@@ -24,8 +24,6 @@ using on-device token count accumulation.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import ttnn
 import ttml
@@ -39,16 +37,6 @@ from .autograd_ops import (
     autograd_softmax,
     moe_routing_normalize,
 )
-
-
-# Set ``MOE_DEBUG_EQ=1`` in the environment to compare two evaluations of
-# ``ttnn.eq(topk_indices, float(expert_idx))`` per expert per forward:
-# one read on the host (used to populate ``activated_experts``) versus the
-# downstream device chain that feeds ``_token_counts`` and ``mask_narrow``.
-# Any disagreement is printed on its own line and points at non-deterministic
-# / re-execution behaviour of ``ttnn.eq`` on UINT16 + non-zero float scalars
-# at the production tile shape.
-_MOE_DEBUG_EQ = os.environ.get("MOE_DEBUG_EQ", "0") == "1"
 
 
 class Expert(AbstractModuleBase):

--- a/tt-train/sources/ttml/ttml/models/deepseek/moe.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/moe.py
@@ -24,8 +24,12 @@ using on-device token count accumulation.
 
 from __future__ import annotations
 
+import os
+
+import numpy as np
 import ttnn
 import ttml
+from ttml.common.profiler_utils import profiler_marker
 from ttml.modules import AbstractModuleBase, LinearLayer, Buffer, ModuleList
 
 from .transformer import DeepSeekMLP
@@ -35,6 +39,16 @@ from .autograd_ops import (
     autograd_softmax,
     moe_routing_normalize,
 )
+
+
+# Set ``MOE_DEBUG_EQ=1`` in the environment to compare two evaluations of
+# ``ttnn.eq(topk_indices, float(expert_idx))`` per expert per forward:
+# one read on the host (used to populate ``activated_experts``) versus the
+# downstream device chain that feeds ``_token_counts`` and ``mask_narrow``.
+# Any disagreement is printed on its own line and points at non-deterministic
+# / re-execution behaviour of ``ttnn.eq`` on UINT16 + non-zero float scalars
+# at the production tile shape.
+_MOE_DEBUG_EQ = os.environ.get("MOE_DEBUG_EQ", "0") == "1"
 
 
 class Expert(AbstractModuleBase):
@@ -168,10 +182,10 @@ class MoE(AbstractModuleBase):
             top_group_indices_u32 = ttnn.typecast(top_group_indices, ttnn.DataType.UINT32)
             top_group_indices_u32 = ttnn.to_layout(top_group_indices_u32, ttnn.ROW_MAJOR_LAYOUT)
             group_mask = ttnn.zeros(
-                [b, 1, s, self.n_groups], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, biased.device()
+                [b, 1, s, self.n_groups], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, biased.device()
             )
             group_src = ttnn.ones(
-                [b, 1, s, self.n_limited_groups], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, biased.device()
+                [b, 1, s, self.n_limited_groups], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, biased.device()
             )
             group_mask = ttnn.scatter(group_mask, -1, top_group_indices_u32, group_src)
             group_mask = ttnn.repeat_interleave(group_mask, experts_per_group, dim=-1)
@@ -193,7 +207,12 @@ class MoE(AbstractModuleBase):
     def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
         B, _, S, dim = list(x.get_value().shape)
 
-        scores, _topk_values, topk_indices = self.compute_routing(x)
+        # Branch subsections from x_in so backward markers are attributed to
+        # distinct zones rather than one chained marker path.
+        x_in = profiler_marker(x, "[START] [MoE]")
+
+        x_r = profiler_marker(x_in, "[START] [MoE] Routing")
+        scores, _topk_values, topk_indices = self.compute_routing(x_r)
 
         # ── 3. Build dense per-token expert mask via scatter ──
         # Scatter ones at topk indices into a zero tensor to produce a
@@ -202,8 +221,8 @@ class MoE(AbstractModuleBase):
         device = x.get_value().device()
         topk_indices_u32 = ttnn.typecast(topk_indices, ttnn.DataType.UINT32)
         topk_indices_u32 = ttnn.to_layout(topk_indices_u32, ttnn.ROW_MAJOR_LAYOUT)
-        expert_mask_all = ttnn.zeros([B, 1, S, self.num_experts], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, device)
-        expert_src = ttnn.ones([B, 1, S, self.n_activated], ttnn.DataType.BFLOAT16, ttnn.Layout.ROW_MAJOR, device)
+        expert_mask_all = ttnn.zeros([B, 1, S, self.num_experts], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, device)
+        expert_src = ttnn.ones([B, 1, S, self.n_activated], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, device)
         expert_mask_all = ttnn.scatter(expert_mask_all, -1, topk_indices_u32, expert_src)
         expert_mask_all = ttnn.to_layout(expert_mask_all, ttnn.TILE_LAYOUT)
 
@@ -223,12 +242,16 @@ class MoE(AbstractModuleBase):
         batch_counts = ttnn.sum(mask_bs_flat, dim=-2, keepdim=True)  # [1, 1, 1, num_experts]
         new_counts = ttnn.add(self._token_counts.tensor.get_value(), batch_counts)
         self._token_counts.tensor.set_value(new_counts)
+        scores = profiler_marker(scores, "[END] [MoE] Routing")
 
         # ── 5. Per-expert weighted outputs ──
         output = None
+        x_e = profiler_marker(x_in, "[START] [MoE] Experts")
 
         for expert_idx in range(self.num_experts):
-            expert_out = self.experts[expert_idx](x)
+            x_exp = profiler_marker(x_e, "[START] [MoE] Expert")
+            expert_out = self.experts[expert_idx](x_exp)
+            expert_out = profiler_marker(expert_out, "[END] [MoE] Expert")
 
             if self.score_func == "sigmoid":
                 # routing_weights is already mask-zero'd for unselected
@@ -257,13 +280,38 @@ class MoE(AbstractModuleBase):
                 output = ttml.ops.binary.add(output, weighted)
 
         if output is None:
-            output = ttml.autograd.create_tensor(ttml.core.zeros_like(x.get_value()))
+            output = ttml.autograd.create_tensor(ttml.core.zeros_like(x_in.get_value()))
+
+        output = profiler_marker(output, "[END] [MoE] Experts")
 
         # ── 5. Shared experts ──
         if self.shared_experts is not None:
-            output = ttml.ops.binary.add(output, self.shared_experts(x))
+            x_s = profiler_marker(x_in, "[START] [MoE] SharedExp")
+            shared_out = self.shared_experts(x_s)
+            shared_out = profiler_marker(shared_out, "[END] [MoE] SharedExp")
+            output = ttml.ops.binary.add(output, shared_out)
 
+        output = profiler_marker(output, "[END] [MoE]")
         return output
+
+    def read_activation_probabilities(self) -> np.ndarray:
+        """Non-destructive read of the current per-expert activation probabilities.
+
+        Returns the fraction of tokens for which each expert was selected,
+        accumulated across all forward passes since the last
+        ``update_expert_bias`` (which resets ``_token_counts``). Shape:
+        ``(num_experts,)``, dtype ``float32``, values in ``[0, 1]``.
+
+        Uses the self-normalising identity
+        ``sum(counts) == n_activated * total_tokens`` so no batch-size /
+        grad-accum bookkeeping is required at the call site.
+        """
+        counts = ttnn.to_torch(self._token_counts.tensor.get_value())
+        counts_np = counts.float().cpu().numpy().flatten()
+        total = float(counts_np.sum())
+        if total <= 0.0:
+            return np.zeros_like(counts_np, dtype=np.float32)
+        return (counts_np * float(self.n_activated) / total).astype(np.float32)
 
     def update_expert_bias(self, coeff: float = 0.001) -> None:
         """Auxiliary-loss-free load balancing (DeepSeek-V3 style).

--- a/tt-train/sources/ttml/ttml/models/deepseek/moe.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/moe.py
@@ -167,15 +167,14 @@ class MoE(AbstractModuleBase):
             # Build group mask [B, 1, S, num_experts] via scatter + repeat_interleave.
             # Scatter needs UINT32 indices in ROW_MAJOR layout.
             b, _, s, _ = list(biased.shape)
-            top_group_indices_u32 = ttnn.typecast(top_group_indices, ttnn.DataType.UINT32)
-            top_group_indices_u32 = ttnn.to_layout(top_group_indices_u32, ttnn.ROW_MAJOR_LAYOUT)
+            top_group_indices = ttnn.to_layout(top_group_indices, ttnn.ROW_MAJOR_LAYOUT)
             group_mask = ttnn.zeros(
                 [b, 1, s, self.n_groups], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, biased.device()
             )
             group_src = ttnn.ones(
                 [b, 1, s, self.n_limited_groups], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, biased.device()
             )
-            group_mask = ttnn.scatter(group_mask, -1, top_group_indices_u32, group_src)
+            group_mask = ttnn.scatter(group_mask, -1, top_group_indices, group_src)
             group_mask = ttnn.repeat(group_mask, ttnn.Shape([1, 1, 1, experts_per_group]))
             group_mask = ttnn.to_layout(group_mask, ttnn.TILE_LAYOUT)
             neg_inf = ttnn.multiply(ttnn.subtract(group_mask, 1.0), 1e9)
@@ -207,11 +206,10 @@ class MoE(AbstractModuleBase):
         # one-hot-per-selected-expert mask [B, 1, S, num_experts] in a single
         # op instead of num_experts independent eq/sum/gt/typecast chains.
         device = x.get_value().device()
-        topk_indices_u32 = ttnn.typecast(topk_indices, ttnn.DataType.UINT32)
-        topk_indices_u32 = ttnn.to_layout(topk_indices_u32, ttnn.ROW_MAJOR_LAYOUT)
+        topk_indices = ttnn.to_layout(topk_indices, ttnn.ROW_MAJOR_LAYOUT)
         expert_mask_all = ttnn.zeros([B, 1, S, self.num_experts], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, device)
         expert_src = ttnn.ones([B, 1, S, self.n_activated], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, device)
-        expert_mask_all = ttnn.scatter(expert_mask_all, -1, topk_indices_u32, expert_src)
+        expert_mask_all = ttnn.scatter(expert_mask_all, -1, topk_indices, expert_src)
         expert_mask_all = ttnn.to_layout(expert_mask_all, ttnn.TILE_LAYOUT)
 
         # ── 4. Routing weights ──


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

We have deepseek training, but MoE routing is quite slow. Most of the MoE execution time (~55%) is spent on routing.

This PR optimizes routing: instead of looping over all experts and all groups to generate masks, we use scatter and topk output to build the mask.

Loss on nano deepseek training is identical to before. 

#### Performance

For tiny deepseek, this makes routing ~8 times faster. 

Name | Moe Routing [ms] | MoE duration [ms] | Routing / MoE [%] | Routing Speed-up vs baseline | Duration [ms] | Total Speed-up vs. baseline
-- | -- | -- | -- | -- | -- | --
Baseline (deepseek PR) | 32.87 | 59.63 | 55.12 | N/A | 430.7 | N/A
Optimized Routing | 4.1 | 31.04 | 13.21 | 8.0 | 373.52 | 1.15

Note: With Fill pad optimization: https://github.com/tenstorrent/tt-metal/pull/42673

Name | Moe Routing [ms] | MoE duration [ms] | Routing / MoE [%] | Routing Speed-up vs baseline | Duration [ms] | Total Speed-up vs. baseline
-- | -- | -- | -- | -- | -- | --
Baseline + FillPad | 11.98 | 38.74 | 30.92 | 2.7 | 388.8 | 1.11
Optimized Routing + FillPad | 1.42 | 28.36 | 5.01 | 23.1 | 368.4 | 1.17


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/train-moe-routing-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/train-moe-routing-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmaurice/train-moe-routing-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmaurice/train-moe-routing-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/train-moe-routing-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/train-moe-routing-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/train-moe-routing-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/train-moe-routing-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmaurice/train-moe-routing-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmaurice/train-moe-routing-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/train-moe-routing-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/train-moe-routing-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/train-moe-routing-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/train-moe-routing-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/train-moe-routing-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/train-moe-routing-improvements)