### PR TITLE
Qwen3-32B FF2 AG+MM: add BH Galaxy tuned config

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -21,7 +21,7 @@ from models.tt_transformers.tt.common import (
     nearest_multiple,
 )
 from typing import Tuple
-from models.common.utility_functions import nearest_32
+from models.common.utility_functions import nearest_32, is_blackhole
 from pathlib import Path
 from models.demos.llama3_70b_galaxy.tt.load_checkpoints import (
     load_hf_state_dict,
@@ -755,20 +755,43 @@ class TtQwenModelArgs(TtModelArgs):
             #  Only used when seq_len >= 4096
             def prefill_ff2_minimal_matmul_config(seq_len):
                 """
-                Qwen3-32B FF2 fused AG+MM config (WH Galaxy, 8x4 mesh, cluster_axis=1).
+                Qwen3-32B FF2 fused AG+MM config (Galaxy, 8x4 mesh, cluster_axis=1).
 
                 Tuned via tests/ttnn/unit_tests/operations/ccl/sweep_qwen3_ff2_agmm.py.
-                Winner at both 4k and 8k (end-to-end TTFT improvement vs non-fused):
-                  grid=(6,8), M=8, K=5, N=5, sub=(1,5)   -> +7.7% at 4k, +8.6% at 8k
+
+                WH Galaxy (3-4 eth links/tray-pair):
+                  grid=(6,8), M=8, K=5, N=5, sub=(1,5)   -> +7.7% 4k, +8.6% 8k TTFT
+                  (num_links=3 auto-derived from grid_x=6, 2 workers/link)
+
+                BH Galaxy (2 eth links/tray-pair cap):
+                  grid=(8,8), M=8, K=5, N=5, sub=(8,1)
+                  - num_links=2 auto-derived (BH tray-pair cap), 4 workers/link
+                    (workers_per_link in {1,2,3} hits the same CCL core-range
+                    overlap bug that WH sees at grid_x in {2,4,8})
+                  - sub=(8,1) beats (1,5)/(4,2)/(2,4) by maximizing M-unroll in
+                    dest regs when M-per-core (16 tiles) >> N-per-core (5 tiles).
+                  - Sweeps over extra Tensix cores, smaller K_block, finer
+                    M_block, larger N_block, and num_buffers_per_channel all
+                    landed within noise or slower than this config.
+                  End-to-end 4k prefill TTFT (ISL=3864, batch=1):
+                    non-fused baseline:       542.5 ms / 7121 t/s
+                    WH-config on BH:          530.1 ms / 7289 t/s (+2.3%)
+                    BH-tuned (this config):   527.8 ms / 7322 t/s (+2.7% total)
 
                 Key constraints (shape-derived, divisibility):
                   K_block | K_tiles_per_device (= 25)        => K_block in {1, 5, 25}
                   N_block | N_tiles            (= 40)
                   sub_h * sub_w <= 8, sub_h | M_block, sub_w | N_block
-                  grid_x=6 forces num_links=3 (via line_all_gather_matmul auto-derive);
-                    grid_x in {2,4,8} hits a CCL core-range overlap bug, grid_x=5 loses
-                    bandwidth with num_links=1.
                 """
+                if is_blackhole():
+                    return ttnn.MinimalMatmulConfig(
+                        M_block_size=8,
+                        K_block_size=5,
+                        N_block_size=5,
+                        subblock_h=8,
+                        subblock_w=1,
+                        compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+                    )
                 return ttnn.MinimalMatmulConfig(
                     M_block_size=8,
                     K_block_size=5,


### PR DESCRIPTION
Adds a BH Galaxy variant of the fused `all_gather_minimal_matmul_async` config used by the Qwen3-32B FF2 prefill path. WH path is untouched — selection is gated on `is_blackhole()`.

`workers_per_link in {1,2,3}` on `(8,8)` hits the same CCL core-range overlap bug WH sees at `grid_x in {2,4,8}`, so `workers=4` (from `grid_x=8`) is the only stable choice on BH.

### End-to-end 4k prefill TTFT (ISL=3864, batch=1, `bh-glx-prefill-4k`)

| Config                     | TTFT      | Throughput  |
|----------------------------|-----------|-------------|
| non-fused baseline         | 542.5 ms  | 7121 t/s    |
| WH-config on BH            | 530.1 ms  | 7289 t/s    |
| BH-tuned (this PR)         | 527.8 ms  | 7322 t/s    |

Most of the win comes from the fusion itself (already landed via #42692). BH-specific tuning adds ~2.3 ms (0.4%) on top; sweeps over `M_block`, finer `K_block`, larger `N_block`, and `num_buffers_per_channel` all landed within noise.

### Scope / dependencies

- On WH this PR is a no-op.
- End-to-end BH functionality depends on the rest of the BH Qwen3-32B enablement (ssinghal/qwen3_bh — `use_prefetcher=False`, linear CCL topology, BH-specific SDPA grid). This PR just adds the tuned op config so BH picks it up once that work lands.
- Base branch: `tvardhineni/llama70b-AG+MM` (#41837).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=moritztng/qwen_agmm_bh_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moritztng/qwen_agmm_bh_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=moritztng/qwen_agmm_bh_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:moritztng/qwen_agmm_bh_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=moritztng/qwen_agmm_bh_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moritztng/qwen_agmm_bh_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=moritztng/qwen_agmm_bh_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moritztng/qwen_agmm_bh_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=moritztng/qwen_agmm_bh_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:moritztng/qwen_agmm_bh_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=moritztng/qwen_agmm_bh_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moritztng/qwen_agmm_bh_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=moritztng/qwen_agmm_bh_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moritztng/qwen_agmm_bh_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=moritztng/qwen_agmm_bh_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moritztng/qwen_agmm_bh_galaxy)