### PR TITLE
Add K-chain 2D multicast for MLA in Ring Joint SDPA

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+/**
+ * ChainLink: Unified abstraction for store-and-forward chaining.
+ *
+ * Each core in a chain is a "link" that can receive from upstream and forward downstream.
+ *
+ * Template parameters:
+ * - mcast_enabled: selects multicast vs unicast forwarding at compile time
+ * - is_head_level: true = head chain (matches batch AND head), false = batch chain (matches batch only)
+ *
+ * @param signal_target_x/y: Where receivers send "ready" signal
+ *   - Unicast mode: previous core's sender semaphore
+ *   - Mcast mode: injector's sender semaphore
+ * @param next_core_x/y: Where to forward data in unicast mode
+ * @param mcast_start_x/y, mcast_end_x/y: Multicast rectangle bounds (injector only)
+ */
+template <bool mcast_enabled, bool is_head_level>
+class ChainLink {
+public:
+    // Participation flags
+    const bool is_participant;
+    const bool is_injector;
+    const bool is_sink;
+
+    // Chain scope matching
+    const uint32_t chain_batch;
+    const uint32_t chain_head;  // Only checked when is_head_level
+    const uint32_t next_core_q_chunks;
+
+    ChainLink(
+        bool is_participant,
+        bool is_injector,
+        bool is_sink,
+        uint32_t sender_sem_addr,
+        uint32_t receiver_sem_addr,
+        uint32_t valid_sem_addr,
+        uint32_t signal_target_x,
+        uint32_t signal_target_y,
+        uint32_t next_core_x,
+        uint32_t next_core_y,
+        uint32_t mcast_start_x,
+        uint32_t mcast_start_y,
+        uint32_t mcast_end_x,
+        uint32_t mcast_end_y,
+        uint32_t mcast_num_dests,
+        uint32_t mcast_sender_wait,
+        uint32_t chunk_tiles,
+        uint32_t tile_bytes,
+        uint32_t chain_batch,
+        uint32_t chain_head,
+        uint32_t next_core_q_chunks) :
+        is_participant(is_participant),
+        is_injector(is_injector),
+        is_sink(is_sink),
+        chain_batch(chain_batch),
+        chain_head(chain_head),
+        next_core_q_chunks(next_core_q_chunks),
+        sender_sem_ptr_(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr)),
+        receiver_sem_ptr_(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr)),
+        valid_sem_addr_(valid_sem_addr),
+        sender_sem_noc_addr_(get_noc_addr(signal_target_x, signal_target_y, sender_sem_addr)),
+        receiver_sem_noc_addr_(0),
+        mcast_base_noc_addr_(0),
+        mcast_sem_noc_addr_(0),
+        sender_wait_count_(1),
+        mcast_num_dests_(mcast_num_dests),
+        chunk_tiles_(chunk_tiles),
+        tile_bytes_(tile_bytes),
+        next_core_x_(next_core_x),
+        next_core_y_(next_core_y) {
+        // Initialize valid semaphore
+        volatile tt_l1_ptr uint32_t* valid_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(valid_sem_addr);
+        *valid_sem_ptr = VALID;
+
+        if constexpr (mcast_enabled) {
+            if (is_injector) {
+                mcast_base_noc_addr_ =
+                    get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, 0);
+                mcast_sem_noc_addr_ = mcast_base_noc_addr_ | receiver_sem_addr;
+                sender_wait_count_ = mcast_sender_wait;
+            }
+        } else {
+            receiver_sem_noc_addr_ = get_noc_addr(next_core_x, next_core_y, receiver_sem_addr);
+        }
+    }
+
+    /**
+     * Check if this core should receive data from upstream.
+     * Head-level chains match (batch, head), batch-level chains match batch only.
+     * In mcast mode, skip batch check: mcast is only enabled for B=1, and padded
+     * iterations may have garbage nb values from out-of-bounds global_q_chunk.
+     */
+    bool should_receive(uint32_t nb, uint32_t nq) const {
+        if (!is_participant || is_injector) {
+            return false;
+        }
+        if constexpr (!mcast_enabled) {
+            if (nb != chain_batch) {
+                return false;
+            }
+        }
+        if constexpr (is_head_level) {
+            if (nq != chain_head) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check if this core should forward data to downstream.
+     * Also checks iteration count against next core's expected reads.
+     * In mcast mode, skip batch check (see should_receive comment).
+     */
+    bool should_forward(uint32_t nb, uint32_t nq, uint32_t q_iter_local) const {
+        if (!is_participant || is_sink) {
+            return false;
+        }
+        if constexpr (!mcast_enabled) {
+            if (nb != chain_batch) {
+                return false;
+            }
+        }
+        if constexpr (is_head_level) {
+            if (nq != chain_head) {
+                return false;
+            }
+        }
+        if (q_iter_local >= next_core_q_chunks) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Receive data from upstream link (called by non-injector participants).
+     * Protocol: signal sender that we're ready, then wait for data.
+     */
+    void receive() const {
+        noc_semaphore_set(receiver_sem_ptr_, INVALID);
+        noc_semaphore_inc(sender_sem_noc_addr_, 1);
+        noc_semaphore_wait(receiver_sem_ptr_, VALID);
+    }
+
+    /**
+     * Forward data to downstream link(s) using default chunk size.
+     * In mcast mode: wait for all receivers, then broadcast.
+     * In unicast mode: wait for next receiver, then point-to-point transfer.
+     */
+    void forward(uint32_t cb_addr) const { forward(cb_addr, chunk_tiles_, tile_bytes_); }
+
+    /**
+     * Forward data to downstream link(s) with explicit size.
+     * Use this when the data size differs from the default (e.g., K using head chain).
+     */
+    void forward(uint32_t cb_addr, uint32_t num_tiles, uint32_t tile_bytes) const {
+        if constexpr (mcast_enabled) {
+            noc_semaphore_wait(sender_sem_ptr_, sender_wait_count_);
+            noc_semaphore_set(sender_sem_ptr_, 0);
+            uint64_t mcast_addr = mcast_base_noc_addr_ | cb_addr;
+            noc_async_write_multicast(cb_addr, mcast_addr, num_tiles * tile_bytes, mcast_num_dests_, true);
+            noc_semaphore_set_multicast(valid_sem_addr_, mcast_sem_noc_addr_, mcast_num_dests_);
+        } else {
+            noc_semaphore_wait(sender_sem_ptr_, 1);
+            noc_semaphore_set(sender_sem_ptr_, 0);
+            uint64_t unicast_addr = get_noc_addr(next_core_x_, next_core_y_, cb_addr);
+            noc_async_write(cb_addr, unicast_addr, num_tiles * tile_bytes);
+            noc_async_writes_flushed();
+            noc_semaphore_set_remote(valid_sem_addr_, receiver_sem_noc_addr_);
+        }
+    }
+
+private:
+    // Semaphore pointers (derived from addresses in constructor)
+    volatile tt_l1_ptr uint32_t* sender_sem_ptr_;
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr_;
+
+    // Semaphore L1 address (needed for mcast set_multicast)
+    uint32_t valid_sem_addr_;
+
+    // NOC addresses (computed in constructor)
+    uint64_t sender_sem_noc_addr_;
+    uint64_t receiver_sem_noc_addr_;
+    uint64_t mcast_base_noc_addr_;
+    uint64_t mcast_sem_noc_addr_;
+
+    // Configuration
+    uint32_t sender_wait_count_;
+    uint32_t mcast_num_dests_;
+    uint32_t chunk_tiles_;
+    uint32_t tile_bytes_;
+    uint32_t next_core_x_;
+    uint32_t next_core_y_;
+};

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
@@ -136,9 +136,11 @@ public:
         tile_bytes_(tile_bytes),
         next_core_x_(next_core_x),
         next_core_y_(next_core_y) {
-        // Initialize valid semaphore
-        volatile tt_l1_ptr uint32_t* valid_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(valid_sem_addr);
-        *valid_sem_ptr = VALID;
+        // Initialize valid semaphore (skip if address is 0 to avoid corrupting memory)
+        if (valid_sem_addr != 0) {
+            volatile tt_l1_ptr uint32_t* valid_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(valid_sem_addr);
+            *valid_sem_ptr = VALID;
+        }
 
         if constexpr (mcast_enabled) {
             if (is_injector) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
@@ -8,6 +8,66 @@
 #include "api/dataflow/dataflow_api.h"
 
 /**
+ * ChainConfig: Runtime args for store-and-forward chain configuration.
+ * Mirrors the append_to_args() layout in ring_joint_sdpa_program_factory.cpp.
+ */
+struct ChainConfig {
+    bool participates = false;
+    bool is_injector = false;
+    bool is_sink = false;
+    uint32_t batch = 0;
+    uint32_t head = 0;
+    uint32_t prev_physical_x = 0;
+    uint32_t prev_physical_y = 0;
+    uint32_t next_physical_x = 0;
+    uint32_t next_physical_y = 0;
+    uint32_t next_core_q_chunks = 0;
+    uint32_t mcast_start_x = 0;
+    uint32_t mcast_start_y = 0;
+    uint32_t mcast_end_x = 0;
+    uint32_t mcast_end_y = 0;
+    uint32_t injector_physical_x = 0;
+    uint32_t injector_physical_y = 0;
+    uint32_t mcast_num_dests = 0;
+    uint32_t mcast_sender_wait = 0;
+
+    // Read 18 args in canonical order matching append_to_args()
+    static ChainConfig read_from_args(uint32_t& argidx) {
+        ChainConfig cfg;
+        cfg.participates = static_cast<bool>(get_arg_val<uint32_t>(argidx++));
+        cfg.is_injector = static_cast<bool>(get_arg_val<uint32_t>(argidx++));
+        cfg.is_sink = static_cast<bool>(get_arg_val<uint32_t>(argidx++));
+        cfg.batch = get_arg_val<uint32_t>(argidx++);
+        cfg.head = get_arg_val<uint32_t>(argidx++);
+        cfg.prev_physical_x = get_arg_val<uint32_t>(argidx++);
+        cfg.prev_physical_y = get_arg_val<uint32_t>(argidx++);
+        cfg.next_physical_x = get_arg_val<uint32_t>(argidx++);
+        cfg.next_physical_y = get_arg_val<uint32_t>(argidx++);
+        cfg.next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
+        cfg.mcast_start_x = get_arg_val<uint32_t>(argidx++);
+        cfg.mcast_start_y = get_arg_val<uint32_t>(argidx++);
+        cfg.mcast_end_x = get_arg_val<uint32_t>(argidx++);
+        cfg.mcast_end_y = get_arg_val<uint32_t>(argidx++);
+        cfg.injector_physical_x = get_arg_val<uint32_t>(argidx++);
+        cfg.injector_physical_y = get_arg_val<uint32_t>(argidx++);
+        cfg.mcast_num_dests = get_arg_val<uint32_t>(argidx++);
+        cfg.mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
+        return cfg;
+    }
+
+    // Compute signal target based on mcast mode
+    template <bool mcast_enabled>
+    uint32_t signal_target_x() const {
+        return mcast_enabled ? injector_physical_x : prev_physical_x;
+    }
+
+    template <bool mcast_enabled>
+    uint32_t signal_target_y() const {
+        return mcast_enabled ? injector_physical_y : prev_physical_y;
+    }
+};
+
+/**
  * ChainLink: Unified abstraction for store-and-forward chaining.
  *
  * Each core in a chain is a "link" that can receive from upstream and forward downstream.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
@@ -168,6 +168,7 @@ public:
             uint64_t mcast_addr = mcast_base_noc_addr_ | cb_addr;
             noc_async_write_multicast(cb_addr, mcast_addr, num_tiles * tile_bytes, mcast_num_dests_, true);
             noc_semaphore_set_multicast(valid_sem_addr_, mcast_sem_noc_addr_, mcast_num_dests_);
+            noc_async_writes_flushed();
         } else {
             noc_semaphore_wait(sender_sem_ptr_, 1);
             noc_semaphore_set(sender_sem_ptr_, 0);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -12,6 +12,9 @@ void kernel_main() {
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
     constexpr uint32_t NHK = get_compile_time_arg_val(2);
+    // K chain selection: batch chain when NHK == 1 (MLA mode), else head chain
+    // Derived from NHK to enable conditional arg layout (saves resources when unused)
+    constexpr bool k_uses_batch_chain = (NHK == 1);
     constexpr uint32_t DHt = get_compile_time_arg_val(3);
     constexpr uint32_t vDHt = get_compile_time_arg_val(4);
     constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
@@ -56,48 +59,16 @@ void kernel_main() {
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
     const uint32_t q_per_core = global_q_end - global_q_start;
 
-    // Head chain runtime args (unified layout: participates, is_injector, is_sink,
-    // batch, head, prev_x/y, next_x/y, next_q_chunks, mcast_start_x/y, mcast_end_x/y,
-    // injector_x/y, mcast_num_dests, mcast_sender_wait)
-    const uint32_t v_is_chain_participant = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_is_injector = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_is_sink = get_arg_val<uint32_t>(argidx++);
-    const uint32_t chain_batch = get_arg_val<uint32_t>(argidx++);
-    const uint32_t chain_head = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_prev_physical_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_prev_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_next_physical_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_next_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_mcast_start_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_mcast_start_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_mcast_end_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_mcast_end_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_injector_physical_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_injector_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_mcast_num_dests = get_arg_val<uint32_t>(argidx++);
-    const uint32_t v_mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
+    // Head chain runtime args (always present)
+    const ChainConfig head_cfg = ChainConfig::read_from_args(argidx);
 
-    // Batch chain runtime args (same unified layout; head field is unused for batch-level chains)
-    const uint32_t k_is_chain_participant = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_is_injector = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_is_sink = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_chain_batch = get_arg_val<uint32_t>(argidx++);
-    argidx++;  // head field unused for batch-level K chain
-    const uint32_t k_prev_physical_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_prev_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_next_physical_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_next_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_next_core_total_reads = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_mcast_start_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_mcast_start_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_mcast_end_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_mcast_end_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_injector_physical_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_injector_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_mcast_num_dests = get_arg_val<uint32_t>(argidx++);
-    const uint32_t k_mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
-    const uint32_t max_q_per_core = get_arg_val<uint32_t>(argidx++);
+    // Batch chain runtime args (only present when k_uses_batch_chain / NHK == 1)
+    ChainConfig batch_cfg;  // default zero-initialized
+    uint32_t max_q_per_core = 0;
+    if constexpr (k_uses_batch_chain) {
+        batch_cfg = ChainConfig::read_from_args(argidx);
+        max_q_per_core = get_arg_val<uint32_t>(argidx++);
+    }
 
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         true, /* wait_for_op_signal */
@@ -115,18 +86,28 @@ void kernel_main() {
         get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 2));
     constexpr bool head_mcast_enabled = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 3) == 1;
 
-    // Batch chain semaphores (batch-level chain, only active when NHK == 1)
-    uint32_t batch_sender_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 4));
-    uint32_t batch_receiver_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 5));
-    uint32_t batch_valid_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 6));
-    constexpr bool batch_mcast_enabled =
-        get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 7) == 1;
+    // Batch chain semaphores (only present when k_uses_batch_chain / NHK == 1)
+    // Initialize to 0; will be overwritten if k_uses_batch_chain
+    uint32_t batch_sender_semaphore_addr = 0;
+    uint32_t batch_receiver_semaphore_addr = 0;
+    uint32_t batch_valid_semaphore_addr = 0;
 
-    // K chain selection: batch chain when NHK == 1, else head chain
-    constexpr bool k_uses_batch_chain = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 8) == 1;
+    // batch_mcast_enabled: read from compile-time args if present, else false (for template instantiation)
+    constexpr bool batch_mcast_enabled = []() {
+        if constexpr (k_uses_batch_chain) {
+            return get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 7) == 1;
+        }
+        return false;
+    }();
+
+    if constexpr (k_uses_batch_chain) {
+        batch_sender_semaphore_addr =
+            get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 4));
+        batch_receiver_semaphore_addr =
+            get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 5));
+        batch_valid_semaphore_addr =
+            get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 6));
+    }
 
     // TODO: CB indices below are hardcoded and duplicated from the program factory.
     // They should be passed as compile-time args so the factory is the single source of truth.
@@ -143,51 +124,51 @@ void kernel_main() {
 
     // Head chain (head-level): matches (batch, head), used by V and optionally K
     ChainLink<head_mcast_enabled, true> head_chain(
-        static_cast<bool>(v_is_chain_participant),
-        static_cast<bool>(v_is_injector),
-        static_cast<bool>(v_is_sink),
+        head_cfg.participates,
+        head_cfg.is_injector,
+        head_cfg.is_sink,
         head_sender_semaphore_addr,
         head_receiver_semaphore_addr,
         head_valid_semaphore_addr,
-        head_mcast_enabled ? v_injector_physical_x : v_prev_physical_x,
-        head_mcast_enabled ? v_injector_physical_y : v_prev_physical_y,  // signal_target
-        v_next_physical_x,
-        v_next_physical_y,  // next_core (unicast target)
-        v_mcast_start_x,
-        v_mcast_start_y,
-        v_mcast_end_x,
-        v_mcast_end_y,
-        v_mcast_num_dests,
-        v_mcast_sender_wait,
+        head_cfg.signal_target_x<head_mcast_enabled>(),
+        head_cfg.signal_target_y<head_mcast_enabled>(),
+        head_cfg.next_physical_x,
+        head_cfg.next_physical_y,
+        head_cfg.mcast_start_x,
+        head_cfg.mcast_start_y,
+        head_cfg.mcast_end_x,
+        head_cfg.mcast_end_y,
+        head_cfg.mcast_num_dests,
+        head_cfg.mcast_sender_wait,
         v_chunk_tiles,
         v_tile_bytes,
-        chain_batch,
-        chain_head,
-        v_next_core_q_chunks);
+        head_cfg.batch,
+        head_cfg.head,
+        head_cfg.next_core_q_chunks);
 
     // Batch chain (batch-level): matches batch only, used by K when NHK == 1 (MLA mode)
     ChainLink<batch_mcast_enabled, false> batch_chain(
-        static_cast<bool>(k_is_chain_participant),
-        static_cast<bool>(k_is_injector),
-        static_cast<bool>(k_is_sink),
+        batch_cfg.participates,
+        batch_cfg.is_injector,
+        batch_cfg.is_sink,
         batch_sender_semaphore_addr,
         batch_receiver_semaphore_addr,
         batch_valid_semaphore_addr,
-        batch_mcast_enabled ? k_injector_physical_x : k_prev_physical_x,
-        batch_mcast_enabled ? k_injector_physical_y : k_prev_physical_y,  // signal_target
-        k_next_physical_x,
-        k_next_physical_y,  // next_core (unicast target)
-        k_mcast_start_x,
-        k_mcast_start_y,  // mcast_start
-        k_mcast_end_x,
-        k_mcast_end_y,  // mcast_end
-        k_mcast_num_dests,
-        k_mcast_sender_wait,
+        batch_cfg.signal_target_x<batch_mcast_enabled>(),
+        batch_cfg.signal_target_y<batch_mcast_enabled>(),
+        batch_cfg.next_physical_x,
+        batch_cfg.next_physical_y,
+        batch_cfg.mcast_start_x,
+        batch_cfg.mcast_start_y,
+        batch_cfg.mcast_end_x,
+        batch_cfg.mcast_end_y,
+        batch_cfg.mcast_num_dests,
+        batch_cfg.mcast_sender_wait,
         k_chunk_tiles,
         k_tile_bytes,
-        k_chain_batch,
+        batch_cfg.batch,
         0,  // chain_head unused for batch-level chain
-        k_next_core_total_reads);
+        batch_cfg.next_core_q_chunks);
 
     // V always uses head chain
     auto& v_chain = head_chain;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -387,7 +387,10 @@ void kernel_main() {
                     k_chain.forward(cb_k_start_address, k_chunk_tiles, k_tile_bytes);
                 }
 
-                // Skip Q, V reads and V forward for padded iterations (K mcast sync only)
+                // Skip Q, V reads and V forward for padded iterations (K mcast sync only).
+                // Note: cb_push_back is intentionally skipped — without it, the write pointer
+                // doesn't advance, so cb_reserve_back returns the same address each iteration.
+                // This lets the buffer act as a reusable staging area for the mcast.
                 if (is_padded_iter) {
                     continue;
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "dataflow_common.hpp"
+#include "chain_link.hpp"
 #include "fused_op_receiver.hpp"
 
 void kernel_main() {
@@ -55,20 +56,48 @@ void kernel_main() {
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
     const uint32_t q_per_core = global_q_end - global_q_start;
 
-    const uint32_t is_chain_participant = get_arg_val<uint32_t>(argidx++);
-    const uint32_t is_injector = get_arg_val<uint32_t>(argidx++);
-    const uint32_t is_sink = get_arg_val<uint32_t>(argidx++);
+    // Head chain runtime args (unified layout: participates, is_injector, is_sink,
+    // batch, head, prev_x/y, next_x/y, next_q_chunks, mcast_start_x/y, mcast_end_x/y,
+    // injector_x/y, mcast_num_dests, mcast_sender_wait)
+    const uint32_t v_is_chain_participant = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_is_injector = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_is_sink = get_arg_val<uint32_t>(argidx++);
     const uint32_t chain_batch = get_arg_val<uint32_t>(argidx++);
     const uint32_t chain_head = get_arg_val<uint32_t>(argidx++);
-    const uint32_t chain_q_chunk_start = get_arg_val<uint32_t>(argidx++);
-    const uint32_t chain_q_chunk_count = get_arg_val<uint32_t>(argidx++);
-    const uint32_t prev_physical_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t prev_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t next_physical_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t next_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
-    const uint32_t mcast_num_dests = get_arg_val<uint32_t>(argidx++);
-    const uint32_t mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_prev_physical_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_prev_physical_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_next_physical_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_next_physical_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_mcast_start_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_mcast_start_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_mcast_end_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_mcast_end_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_injector_physical_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_injector_physical_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_mcast_num_dests = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
+
+    // Batch chain runtime args (same unified layout; head field is unused for batch-level chains)
+    const uint32_t k_is_chain_participant = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_is_injector = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_is_sink = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_chain_batch = get_arg_val<uint32_t>(argidx++);
+    argidx++;  // head field unused for batch-level K chain
+    const uint32_t k_prev_physical_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_prev_physical_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_next_physical_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_next_physical_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_next_core_total_reads = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_mcast_start_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_mcast_start_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_mcast_end_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_mcast_end_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_injector_physical_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_injector_physical_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_mcast_num_dests = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
+    const uint32_t max_q_per_core = get_arg_val<uint32_t>(argidx++);
 
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         true, /* wait_for_op_signal */
@@ -76,48 +105,28 @@ void kernel_main() {
 
     // After fused-op receiver consumed its runtime args, remaining RT args are S&F chain metadata
 
-    // Compile-time semaphore ids and mcast flag are appended after all TensorAccessorArgs()
-    uint32_t sender_semaphore_addr =
+    // Compile-time semaphore ids and chain flags are appended after all TensorAccessorArgs()
+    // Head chain semaphores (head-level chain, always built)
+    uint32_t head_sender_semaphore_addr =
         get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset()));
-    uint32_t receiver_semaphore_addr =
+    uint32_t head_receiver_semaphore_addr =
         get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 1));
-    uint32_t valid_semaphore_addr =
+    uint32_t head_valid_semaphore_addr =
         get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 2));
-    constexpr bool mcast_enabled = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 3) == 1;
+    constexpr bool head_mcast_enabled = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 3) == 1;
 
-    // VALID sem used to write L1-L1 valid semaphore
-    volatile tt_l1_ptr uint32_t* valid_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(valid_semaphore_addr);
-    *(valid_semaphore_addr_ptr) = VALID;
+    // Batch chain semaphores (batch-level chain, only active when NHK == 1)
+    uint32_t batch_sender_semaphore_addr =
+        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 4));
+    uint32_t batch_receiver_semaphore_addr =
+        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 5));
+    uint32_t batch_valid_semaphore_addr =
+        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 6));
+    constexpr bool batch_mcast_enabled =
+        get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 7) == 1;
 
-    volatile tt_l1_ptr uint32_t* receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_addr);
-
-    volatile tt_l1_ptr uint32_t* sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_semaphore_addr);
-
-    uint64_t receiver_semaphore_noc_addr = 0;
-    uint64_t mcast_base_noc_addr = 0;
-    uint64_t mcast_sem_noc_addr = 0;
-    uint32_t sender_wait_count = 1;
-
-    const uint64_t sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
-
-    if constexpr (mcast_enabled) {
-        if (is_injector) {
-            // prev_physical = mcast_start (first receiver), next_physical = mcast_end (last receiver)
-            mcast_base_noc_addr = get_noc_multicast_addr(
-                prev_physical_x,
-                prev_physical_y,
-                next_physical_x,
-                next_physical_y,
-                0);  // addr=0; will OR in actual L1 addr at use site
-            mcast_sem_noc_addr = mcast_base_noc_addr | receiver_semaphore_addr;
-            sender_wait_count = mcast_sender_wait;
-        }
-    } else {
-        receiver_semaphore_noc_addr = get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
-    }
+    // K chain selection: batch chain when NHK == 1, else head chain
+    constexpr bool k_uses_batch_chain = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 8) == 1;
 
     // TODO: CB indices below are hardcoded and duplicated from the program factory.
     // They should be passed as compile-time args so the factory is the single source of truth.
@@ -131,6 +140,67 @@ void kernel_main() {
 
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
     constexpr uint32_t v_chunk_tiles = Sk_chunk_t * vDHt;
+
+    // Head chain (head-level): matches (batch, head), used by V and optionally K
+    ChainLink<head_mcast_enabled, true> head_chain(
+        static_cast<bool>(v_is_chain_participant),
+        static_cast<bool>(v_is_injector),
+        static_cast<bool>(v_is_sink),
+        head_sender_semaphore_addr,
+        head_receiver_semaphore_addr,
+        head_valid_semaphore_addr,
+        head_mcast_enabled ? v_injector_physical_x : v_prev_physical_x,
+        head_mcast_enabled ? v_injector_physical_y : v_prev_physical_y,  // signal_target
+        v_next_physical_x,
+        v_next_physical_y,  // next_core (unicast target)
+        v_mcast_start_x,
+        v_mcast_start_y,
+        v_mcast_end_x,
+        v_mcast_end_y,
+        v_mcast_num_dests,
+        v_mcast_sender_wait,
+        v_chunk_tiles,
+        v_tile_bytes,
+        chain_batch,
+        chain_head,
+        v_next_core_q_chunks);
+
+    // Batch chain (batch-level): matches batch only, used by K when NHK == 1 (MLA mode)
+    ChainLink<batch_mcast_enabled, false> batch_chain(
+        static_cast<bool>(k_is_chain_participant),
+        static_cast<bool>(k_is_injector),
+        static_cast<bool>(k_is_sink),
+        batch_sender_semaphore_addr,
+        batch_receiver_semaphore_addr,
+        batch_valid_semaphore_addr,
+        batch_mcast_enabled ? k_injector_physical_x : k_prev_physical_x,
+        batch_mcast_enabled ? k_injector_physical_y : k_prev_physical_y,  // signal_target
+        k_next_physical_x,
+        k_next_physical_y,  // next_core (unicast target)
+        k_mcast_start_x,
+        k_mcast_start_y,  // mcast_start
+        k_mcast_end_x,
+        k_mcast_end_y,  // mcast_end
+        k_mcast_num_dests,
+        k_mcast_sender_wait,
+        k_chunk_tiles,
+        k_tile_bytes,
+        k_chain_batch,
+        0,  // chain_head unused for batch-level chain
+        k_next_core_total_reads);
+
+    // V always uses head chain
+    auto& v_chain = head_chain;
+
+    // K uses batch chain when NHK == 1 (MLA), else head chain (compile-time IIFE selection)
+    auto& k_chain = [&]() -> auto& {
+        if constexpr (k_uses_batch_chain) {
+            return batch_chain;
+        } else {
+            return head_chain;
+        }
+    }();
+
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / qk_subblock_h;
     constexpr bool use_q_subblock_push = (q_num_subblocks > 1);
     constexpr uint32_t q_heads_per_k = NH / NHK;
@@ -215,7 +285,17 @@ void kernel_main() {
             }
         }
 
-        for (uint32_t q_iter = 0; global_q_start + q_iter < global_q_end; ++q_iter) {
+        // When K mcast is enabled, loop max_q_per_core times to stay synchronized with injector
+        // Cores with less work do padded iterations (K mcast sync only, no real work)
+        const uint32_t loop_q_count = (k_uses_batch_chain && batch_mcast_enabled) ? max_q_per_core : q_per_core;
+
+        for (uint32_t q_iter = 0; q_iter < loop_q_count; ++q_iter) {
+            // Check if this is a real iteration (has actual work) or padded (K mcast sync only)
+            const bool is_padded_iter = (q_iter >= q_per_core);
+
+            // Calculate global_q_chunk for all iterations (including padded).
+            // For padded iterations, global index may be out of bounds, but q_chunk = global_q_chunk % num_q_chunks
+            // gives a valid position that correctly determines whether to skip this iteration.
             uint32_t global_q_chunk = remap_q_index(global_q_start + q_iter, num_q_chunks, use_zigzag_balancing);
 
             // global_q_chunk is index into `B * NH * num_q_chunks`. Need to get nb, nq, q_chunk from this.
@@ -230,6 +310,8 @@ void kernel_main() {
             // Balanced causal skip: this Q chunk is handled by the paired device. Reader sends
             // nothing (no Q, no K/V) — compute's normalize-only path on the last ring iter does
             // not read Q (normalize uses only restored sum/out).
+            // Skip logic applies to all iterations (including padded) so injector and receivers
+            // make the same skip decisions, keeping K mcast sync aligned.
             if (balanced_skip_q) {
                 continue;
             }
@@ -247,11 +329,8 @@ void kernel_main() {
                 q_end_seq_tile = local_padded_Nt;
             }
 
-            // Chain forwarding conditions are k_chunk-invariant — compute once before the KV loop
+            // Iteration counter for chain forwarding decisions
             const uint32_t q_iter_local = q_iter;
-            const bool should_forward = is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
-                                        (q_iter_local < next_core_q_chunks);
-            const bool should_receive = is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
 
             // When q_per_core == 1, Q is identical across ring iterations: compute keeps it
             // fronted in the CB, so we only need to read it once on the first active ring iteration.
@@ -304,14 +383,14 @@ void kernel_main() {
                     }
                 }
 
-                // K: get data into CB buffer
+                // K: either read locally (injector or not participant) or receive from chain
                 cb_reserve_back(cb_k_in, k_chunk_tiles);
                 uint32_t cb_k_start_address = get_write_ptr(cb_k_in);
-                if (should_receive) {
-                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                if (k_chain.should_receive(nb, nq)) {
+                    k_chain.receive();
                 } else {
+                    // Injector or non-participant: read K from DRAM
+                    // For padded iterations, injector still reads K to broadcast to receivers
                     fetch_block(
                         kv_chunk_is_joint ? joint_k_generator
                                           : (ring_iter == 0 ? local_k_generator : gathered_k_generator),
@@ -323,29 +402,14 @@ void kernel_main() {
                     );
                 }
 
-                // Forward K to next core(s) before push_back — prevents compute from
-                // popping the buffer while the mcast is still reading from it.
-                if (should_forward) {
-                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                    if constexpr (mcast_enabled) {
-                        uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
-                        noc_async_write_multicast(
-                            cb_k_start_address,
-                            k_mcast_addr,
-                            k_chunk_tiles * k_tile_bytes,
-                            mcast_num_dests,
-                            true /* linked: semaphore mcast follows */);
-                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                    } else {
-                        uint64_t k_unicast_data_addr =
-                            get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
-                        noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
-                    }
-                    noc_async_writes_flushed();
-                    if constexpr (!mcast_enabled) {
-                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
-                    }
+                // Forward K chunk via chain (uses K's data size explicitly)
+                if (k_chain.should_forward(nb, nq, q_iter_local)) {
+                    k_chain.forward(cb_k_start_address, k_chunk_tiles, k_tile_bytes);
+                }
+
+                // Skip Q, V reads and V forward for padded iterations (K mcast sync only)
+                if (is_padded_iter) {
+                    continue;
                 }
 
                 // Make K available to compute
@@ -383,13 +447,11 @@ void kernel_main() {
                     q_pushed = true;
                 }
 
-                // V: get data into CB buffer
+                // V: either read locally (injector or not participant) or receive from chain
                 cb_reserve_back(cb_v_in, v_chunk_tiles);
                 uint32_t cb_v_start_address = get_write_ptr(cb_v_in);
-                if (should_receive) {
-                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                if (v_chain.should_receive(nb, nq)) {
+                    v_chain.receive();
                 } else {
                     fetch_block(
                         kv_chunk_is_joint ? joint_v_generator
@@ -404,27 +466,8 @@ void kernel_main() {
 
                 // Forward V to next core(s) before push_back — prevents compute from
                 // popping the buffer while the mcast is still reading from it.
-                if (should_forward) {
-                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                    if constexpr (mcast_enabled) {
-                        uint64_t v_mcast_addr = mcast_base_noc_addr | cb_v_start_address;
-                        noc_async_write_multicast(
-                            cb_v_start_address,
-                            v_mcast_addr,
-                            v_chunk_tiles * v_tile_bytes,
-                            mcast_num_dests,
-                            true /* linked: semaphore mcast follows */);
-                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                    } else {
-                        uint64_t v_unicast_data_addr =
-                            get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
-                        noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
-                    }
-                    noc_async_writes_flushed();
-                    if constexpr (!mcast_enabled) {
-                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
-                    }
+                if (v_chain.should_forward(nb, nq, q_iter_local)) {
+                    v_chain.forward(cb_v_start_address);
                 }
 
                 // Make V available to compute

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -351,7 +351,6 @@ void kernel_main() {
                     // This is a KV chunk on spatial input beyond the logical N, and not joint KV. Skip it.
                     continue;
                 }
-                KV_chunks_processed_in_iter++;
 
                 Slice k_slice;
                 Slice v_slice;
@@ -414,6 +413,7 @@ void kernel_main() {
 
                 // Make K available to compute
                 cb_push_back(cb_k_in, k_chunk_tiles);
+                KV_chunks_processed_in_iter++;
 
                 // Download Q on the first K iteration — after K is downloaded and forwarded.
                 // Push Q one subblock at a time so compute can start QK matmul incrementally.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -364,7 +364,14 @@ void kernel_main() {
                 }
 
                 // K: either read locally (injector or not participant) or receive from chain
-                cb_reserve_back(cb_k_in, k_chunk_tiles);
+                if constexpr (k_uses_batch_chain && batch_mcast_enabled) {
+                    // Ensures that compute has completed with the previous K chunk before we overwrite the buffer with
+                    // the next K chunk for mcast.
+                    const uint32_t reserve_tiles = is_padded_iter ? 2 * k_chunk_tiles : k_chunk_tiles;
+                    cb_reserve_back(cb_k_in, reserve_tiles);
+                } else {
+                    cb_reserve_back(cb_k_in, k_chunk_tiles);
+                }
                 uint32_t cb_k_start_address = get_write_ptr(cb_k_in);
                 if (k_chain.should_receive(nb, nq)) {
                     k_chain.receive();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -478,16 +478,26 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         }
     };
 
-    const auto head_sems = ChainSemaphores::create(program, core_grid);   // head chain (V, optionally K)
-    const auto batch_sems = ChainSemaphores::create(program, core_grid);  // batch chain (K in MLA mode)
+    // K chain selection: batch chain when NHK == 1 (MLA mode), else head chain
+    // Computed early to gate resource allocation
+    const bool k_uses_batch_chain = (NHK == 1);
+
+    const auto head_sems = ChainSemaphores::create(program, core_grid);  // head chain (V, optionally K)
+    // Only create batch semaphores for MLA mode (NHK == 1)
+    std::optional<ChainSemaphores> batch_sems;
+    if (k_uses_batch_chain) {
+        batch_sems = ChainSemaphores::create(program, core_grid);  // batch chain (K in MLA mode)
+    }
 
     // Append semaphore ids to reader compile-time args (must match reader kernel expectations)
+    // Kernel derives k_uses_batch_chain from NHK, so batch chain args are conditionally present
     const auto sem_args_offset = reader_compile_time_args.size();
     head_sems.append_to_compile_args(reader_compile_time_args);
     reader_compile_time_args.push_back(0);  // head_mcast_enabled placeholder (patched after chain construction)
-    batch_sems.append_to_compile_args(reader_compile_time_args);
-    reader_compile_time_args.push_back(0);  // batch_mcast_enabled placeholder (patched after chain construction)
-    reader_compile_time_args.push_back(0);  // k_uses_batch_chain placeholder (patched after chain construction)
+    if (k_uses_batch_chain) {
+        batch_sems->append_to_compile_args(reader_compile_time_args);
+        reader_compile_time_args.push_back(0);  // batch_mcast_enabled placeholder (patched after chain construction)
+    }
 
     std::vector<uint32_t> writer_compile_time_args = {
         B,
@@ -1262,15 +1272,14 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         }
     }
 
-    // Update mcast and chain selection compile-time args
+    // Update mcast compile-time args
     const bool head_mcast_enabled = (mcast_chains > 0);
-    const bool k_uses_batch_chain = (NHK == 1);  // MLA mode: K uses batch chain; otherwise uses head chain
 
     reader_compile_time_args[sem_args_offset + 3] = head_mcast_enabled ? 1 : 0;
-    // When K uses head chain (non-MLA), align batch_mcast_enabled with head_mcast_enabled so types match
-    reader_compile_time_args[sem_args_offset + 7] =
-        k_uses_batch_chain ? (k_mcast_enabled ? 1 : 0) : (head_mcast_enabled ? 1 : 0);
-    reader_compile_time_args[sem_args_offset + 8] = k_uses_batch_chain ? 1 : 0;
+    // Batch chain args only present when k_uses_batch_chain (NHK == 1)
+    if (k_uses_batch_chain) {
+        reader_compile_time_args[sem_args_offset + 7] = k_mcast_enabled ? 1 : 0;
+    }
 
     log_info(tt::LogOp, "V chain mode: head ({})", head_mcast_enabled ? "mcast" : "unicast");
     if (k_uses_batch_chain) {
@@ -1357,9 +1366,11 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         // Head chain (V chain, optionally K in non-MLA): 18 args via unified layout
         head_chain.append_to_args(reader_args);
 
-        // Batch chain (K chain in MLA mode): 18 args via unified layout + 1 for loop padding
-        batch_chain.append_to_args(reader_args);
-        reader_args.push_back(max_global_q_count);  // For K mcast loop padding
+        // Batch chain (K chain in MLA mode): 18 args + 1 for loop padding (only when NHK == 1)
+        if (k_uses_batch_chain) {
+            batch_chain.append_to_args(reader_args);
+            reader_args.push_back(max_global_q_count);  // For K mcast loop padding
+        }
 
         // Inject fused-op synchronization RT args (AllGather) here; it will append to reader_args
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(reader_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -455,17 +455,39 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     /**
      * Create semaphores used for L1-L1 store-and-forward of KV between cores.
+     * ChainSemaphores groups the three semaphore IDs for a single chain and handles
+     * creation and compile-time arg appending together.
      */
-    auto sender_semaphore_id = CreateSemaphore(program, core_grid, INVALID);
-    auto receiver_semaphore_id = CreateSemaphore(program, core_grid, INVALID);
-    auto valid_semaphore_id = CreateSemaphore(program, core_grid, VALID);
+    struct ChainSemaphores {
+        uint32_t sender_id;
+        uint32_t receiver_id;
+        uint32_t valid_id;
+
+        static ChainSemaphores create(Program& prog, const CoreRange& grid) {
+            return {
+                CreateSemaphore(prog, grid, INVALID),
+                CreateSemaphore(prog, grid, INVALID),
+                CreateSemaphore(prog, grid, VALID),
+            };
+        }
+
+        void append_to_compile_args(std::vector<uint32_t>& args) const {
+            args.push_back(sender_id);
+            args.push_back(receiver_id);
+            args.push_back(valid_id);
+        }
+    };
+
+    const auto head_sems = ChainSemaphores::create(program, core_grid);   // head chain (V, optionally K)
+    const auto batch_sems = ChainSemaphores::create(program, core_grid);  // batch chain (K in MLA mode)
 
     // Append semaphore ids to reader compile-time args (must match reader kernel expectations)
     const auto sem_args_offset = reader_compile_time_args.size();
-    reader_compile_time_args.push_back(sender_semaphore_id);
-    reader_compile_time_args.push_back(receiver_semaphore_id);
-    reader_compile_time_args.push_back(valid_semaphore_id);
-    reader_compile_time_args.push_back(0);  // mcast_enabled placeholder (patched after chain construction)
+    head_sems.append_to_compile_args(reader_compile_time_args);
+    reader_compile_time_args.push_back(0);  // head_mcast_enabled placeholder (patched after chain construction)
+    batch_sems.append_to_compile_args(reader_compile_time_args);
+    reader_compile_time_args.push_back(0);  // batch_mcast_enabled placeholder (patched after chain construction)
+    reader_compile_time_args.push_back(0);  // k_uses_batch_chain placeholder (patched after chain construction)
 
     std::vector<uint32_t> writer_compile_time_args = {
         B,
@@ -763,24 +785,55 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         uint32_t head_work_index = 0;
     };
 
-    struct CoreChainInfo {
+    // Unified chain configuration for both head-level (V chain, K in non-MLA) and batch-level (K in MLA) chains
+    struct ChainConfig {
+        // Core participation flags
         bool participates = false;
         bool is_injector = false;
         bool is_sink = false;
+
+        // Chain scope: batch is always used; head distinguishes head-level vs batch-level
         uint32_t batch = 0;
-        uint32_t head = 0;
-        uint32_t q_chunk_start = 0;
-        uint32_t q_chunk_count = 0;
+        uint32_t head = 0;  // 0 for batch-level chains (K in MLA mode)
+
+        // Linear chain topology
         CoreCoord prev_physical = CoreCoord{0, 0};
         CoreCoord next_physical = CoreCoord{0, 0};
         uint32_t next_core_q_chunks = 0;
-        bool use_mcast = false;
-        uint32_t mcast_num_dests = 0;
-        uint32_t mcast_sender_wait = 0;
+
+        // Multicast configuration (1D for V, 2D for K)
+        CoreCoord mcast_start = CoreCoord{0, 0};        // Rectangle start (physical)
+        CoreCoord mcast_end = CoreCoord{0, 0};          // Rectangle end (physical)
+        CoreCoord injector_physical = CoreCoord{0, 0};  // Injector's coords (for receiver sem addr in mcast)
+        uint32_t mcast_num_dests = 0;                   // Receivers count (excludes self)
+        uint32_t mcast_sender_wait = 0;                 // Semaphore wait count
+
+        // Append runtime args in canonical order
+        void append_to_args(std::vector<uint32_t>& args) const {
+            args.push_back(static_cast<uint32_t>(participates));
+            args.push_back(static_cast<uint32_t>(is_injector));
+            args.push_back(static_cast<uint32_t>(is_sink));
+            args.push_back(batch);
+            args.push_back(head);
+            args.push_back(static_cast<uint32_t>(prev_physical.x));
+            args.push_back(static_cast<uint32_t>(prev_physical.y));
+            args.push_back(static_cast<uint32_t>(next_physical.x));
+            args.push_back(static_cast<uint32_t>(next_physical.y));
+            args.push_back(next_core_q_chunks);
+            args.push_back(static_cast<uint32_t>(mcast_start.x));
+            args.push_back(static_cast<uint32_t>(mcast_start.y));
+            args.push_back(static_cast<uint32_t>(mcast_end.x));
+            args.push_back(static_cast<uint32_t>(mcast_end.y));
+            args.push_back(static_cast<uint32_t>(injector_physical.x));
+            args.push_back(static_cast<uint32_t>(injector_physical.y));
+            args.push_back(mcast_num_dests);
+            args.push_back(mcast_sender_wait);
+        }
     };
 
     std::vector<CoreWork> core_work(num_cores);
-    std::vector<CoreChainInfo> core_chain_info(num_cores);
+    std::vector<ChainConfig> head_chain_configs(num_cores);   // V chain (head-level), optionally K in non-MLA
+    std::vector<ChainConfig> batch_chain_configs(num_cores);  // K chain (batch-level) in MLA mode
     const uint32_t total_heads = B * NH;
     std::vector<std::vector<HeadSegmentRef>> head_segments(total_heads);
 
@@ -857,66 +910,65 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         next_global_chunk += chunk_count;
     }
 
-    // Construct chains: for each head that spans >= 2 cores, pick first core
-    // with single head segment as injector. Linear forward traversal only —
-    // no wrap-around (wrapping back would pull in straddling cores whose
-    // q_iter_local is inflated by prior-head work, causing deadlock).
-    // Injector reselection for DRAM channel spreading is deferred to the
-    // mcast eligibility pass below.
-    for (auto& segments : head_segments) {
-        if (segments.size() < 2) {
-            continue;
+    // Helper: build a linear chain from sorted (core_idx, q_chunk_count) pairs.
+    // - chain_segs[i].second = q iterations the i-th core will process in this chain scope
+    // - injector = first core with head_work.size() == 1 (single head segment = no straddling)
+    // - no wrap-around: wrapping would inflate q_iter_local and cause deadlock
+    // - injector reselection for mcast is done separately in the mcast eligibility pass
+    using ChainSegment = std::pair<uint32_t, uint32_t>;  // (core_idx, q_chunk_count)
+    auto build_linear_chain = [](const std::vector<ChainSegment>& chain_segs,
+                                 uint32_t batch,
+                                 uint32_t head,
+                                 std::vector<ChainConfig>& chain_configs,
+                                 const std::vector<CoreWork>& core_work) -> bool {
+        if (chain_segs.size() < 2) {
+            return false;
         }
-
-        std::optional<std::size_t> chain_start_idx;
-        for (std::size_t idx = 0; idx + 1 < segments.size(); ++idx) {
-            const auto& seg = segments.at(idx);
-            const auto& work = core_work.at(seg.core_idx);
-            if (work.global_q_count == 0) {
+        std::optional<size_t> injector_pos;
+        for (size_t idx = 0; idx + 1 < chain_segs.size(); ++idx) {
+            if (core_work[chain_segs[idx].first].global_q_count == 0) {
                 continue;
             }
-            if (work.head_work.size() == 1) {
-                chain_start_idx = idx;
+            if (core_work[chain_segs[idx].first].head_work.size() == 1) {
+                injector_pos = idx;
                 break;
             }
         }
+        if (!injector_pos.has_value()) {
+            return false;
+        }
+        const size_t start = *injector_pos;
+        for (size_t idx = start; idx < chain_segs.size(); ++idx) {
+            uint32_t ci = chain_segs[idx].first;
+            auto& cfg = chain_configs[ci];
+            cfg.participates = true;
+            cfg.batch = batch;
+            cfg.head = head;
+            cfg.is_injector = (idx == start);
+            cfg.is_sink = (idx == chain_segs.size() - 1);
+            if (idx > start) {
+                cfg.prev_physical = core_work[chain_segs[idx - 1].first].physical_core;
+            }
+            if (idx + 1 < chain_segs.size()) {
+                cfg.next_physical = core_work[chain_segs[idx + 1].first].physical_core;
+                cfg.next_core_q_chunks = chain_segs[idx + 1].second;
+            }
+        }
+        return true;
+    };
 
-        if (!chain_start_idx.has_value()) {
+    // Build head chains (V chain): one per (batch, head) pair that spans >= 2 cores.
+    for (uint32_t head_id = 0; head_id < static_cast<uint32_t>(head_segments.size()); ++head_id) {
+        const auto& segs = head_segments[head_id];
+        if (segs.size() < 2) {
             continue;
         }
-
-        const std::size_t start = chain_start_idx.value();
-        for (std::size_t idx = start; idx < segments.size(); ++idx) {
-            const auto& seg = segments.at(idx);
-            const uint32_t core_idx = seg.core_idx;
-            const auto& work = core_work.at(core_idx);
-            const auto& hw = work.head_work.at(seg.head_work_index);
-            auto& chain = core_chain_info.at(core_idx);
-
-            chain.participates = true;
-            chain.batch = hw.batch;
-            chain.head = hw.head;
-            chain.q_chunk_start = hw.q_chunk_start;
-            chain.q_chunk_count = hw.q_chunk_count;
-
-            if (idx == start) {
-                chain.is_injector = true;
-            }
-            if (idx == segments.size() - 1) {
-                chain.is_sink = true;
-            }
-
-            if (idx > start) {
-                const uint32_t prev_core_idx = segments.at(idx - 1).core_idx;
-                chain.prev_physical = core_work.at(prev_core_idx).physical_core;
-            }
-            if (idx + 1 < segments.size()) {
-                const uint32_t next_core_idx = segments.at(idx + 1).core_idx;
-                chain.next_physical = core_work.at(next_core_idx).physical_core;
-                const auto& next_hw = core_work.at(next_core_idx).head_work.at(segments.at(idx + 1).head_work_index);
-                chain.next_core_q_chunks = next_hw.q_chunk_count;
-            }
+        std::vector<ChainSegment> chain_segs;
+        chain_segs.reserve(segs.size());
+        for (const auto& seg : segs) {
+            chain_segs.emplace_back(seg.core_idx, core_work[seg.core_idx].head_work[seg.head_work_index].q_chunk_count);
         }
+        build_linear_chain(chain_segs, head_id / NH, head_id % NH, head_chain_configs, core_work);
     }
 
     // Third pass: Check multicast eligibility and configure mcast for eligible chains
@@ -935,12 +987,15 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                 continue;
             }
 
+            // Gather chain participants with their per-head q_chunk_count
             std::vector<uint32_t> chain_core_indices;
+            std::vector<uint32_t> chain_q_counts;
             for (const auto& seg : segments) {
-                if (seg.core_idx < core_chain_info.size() && core_chain_info[seg.core_idx].participates &&
-                    core_chain_info[seg.core_idx].batch == (head_id / NH) &&
-                    core_chain_info[seg.core_idx].head == (head_id % NH)) {
+                if (seg.core_idx < head_chain_configs.size() && head_chain_configs[seg.core_idx].participates &&
+                    head_chain_configs[seg.core_idx].batch == (head_id / NH) &&
+                    head_chain_configs[seg.core_idx].head == (head_id % NH)) {
                     chain_core_indices.push_back(seg.core_idx);
+                    chain_q_counts.push_back(core_work[seg.core_idx].head_work[seg.head_work_index].q_chunk_count);
                 }
             }
 
@@ -999,10 +1054,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
             }
 
             // Eligibility condition 3: All chain cores must have the same q_chunk_count.
-            const uint32_t ref_q_chunks = core_chain_info[chain_core_indices[0]].q_chunk_count;
+            const uint32_t ref_q_chunks = chain_q_counts[0];
             bool uniform_q_mcast = true;
-            for (size_t ci = 1; ci < chain_core_indices.size(); ++ci) {
-                if (core_chain_info[chain_core_indices[ci]].q_chunk_count != ref_q_chunks) {
+            for (size_t ci = 1; ci < chain_q_counts.size(); ++ci) {
+                if (chain_q_counts[ci] != ref_q_chunks) {
                     uniform_q_mcast = false;
                     break;
                 }
@@ -1027,7 +1082,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                 // Find current injector
                 uint32_t injector_idx = cand.core_indices[0];
                 for (const auto& ci : cand.core_indices) {
-                    if (core_chain_info[ci].is_injector) {
+                    if (head_chain_configs[ci].is_injector) {
                         injector_idx = ci;
                         break;
                     }
@@ -1041,10 +1096,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                     uint32_t best_idx = cand.core_indices[target_offset];
                     if (best_idx != injector_idx) {
                         // Clear old injector, set new one
-                        core_chain_info[injector_idx].is_injector = false;
-                        core_chain_info[injector_idx].is_sink = true;
-                        core_chain_info[best_idx].is_injector = true;
-                        core_chain_info[best_idx].is_sink = false;
+                        head_chain_configs[injector_idx].is_injector = false;
+                        head_chain_configs[injector_idx].is_sink = true;
+                        head_chain_configs[best_idx].is_injector = true;
+                        head_chain_configs[best_idx].is_sink = false;
                         injector_idx = best_idx;
                     }
                 }
@@ -1059,14 +1114,13 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                 const uint32_t injector_y = core_work[injector_idx].physical_core.y;
                 const CoreCoord rect_start = CoreCoord{min_x, injector_y};
                 const CoreCoord rect_end = CoreCoord{max_x, injector_y};
+                const CoreCoord injector_phys = core_work[injector_idx].physical_core;
 
-                const uint32_t mcast_num_dests = num_receivers;
-
-                auto& injector_chain = core_chain_info[injector_idx];
-                injector_chain.use_mcast = true;
-                injector_chain.prev_physical = rect_start;
-                injector_chain.next_physical = rect_end;
-                injector_chain.mcast_num_dests = mcast_num_dests;
+                auto& injector_chain = head_chain_configs[injector_idx];
+                injector_chain.mcast_start = rect_start;
+                injector_chain.mcast_end = rect_end;
+                injector_chain.injector_physical = injector_phys;
+                injector_chain.mcast_num_dests = num_receivers;
                 injector_chain.mcast_sender_wait = num_receivers;
                 injector_chain.next_core_q_chunks = cand.ref_q_chunks;
 
@@ -1074,10 +1128,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                     if (ci == injector_idx) {
                         continue;
                     }
-                    auto& receiver_chain = core_chain_info[ci];
-                    receiver_chain.use_mcast = true;
-                    receiver_chain.prev_physical = core_work[injector_idx].physical_core;
-                    receiver_chain.next_physical = CoreCoord{0, 0};
+                    auto& receiver_chain = head_chain_configs[ci];
+                    receiver_chain.mcast_start = rect_start;
+                    receiver_chain.mcast_end = rect_end;
+                    receiver_chain.injector_physical = injector_phys;
                     receiver_chain.next_core_q_chunks = 0;
                     receiver_chain.is_sink = true;
                 }
@@ -1089,7 +1143,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                     num_receivers,
                     injector_idx,
                     core_work[injector_idx].physical_core.x,
-                    mcast_num_dests,
+                    num_receivers,
                     rect_start.x,
                     rect_start.y,
                     rect_end.x,
@@ -1104,8 +1158,129 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
             static_cast<uint32_t>(candidates.size()));
     }
 
-    // Update mcast_enabled compile-time arg now that chain construction is complete
-    reader_compile_time_args[sem_args_offset + 3] = (mcast_chains > 0) ? 1 : 0;
+    // Build batch chains (K chain): one per batch when NHK == 1 (MLA case).
+    // K is shared across all heads, so all active cores in a batch form one chain.
+    // Note: device op validates NHK == NVH || NHK == 1, so NHK == 1 is the only case where
+    // K is shared across every head. Guard deliberately rejects GQA (which would need group-scoped chains).
+    // Sorted by physical position for a stable unicast ordering (overwritten by mcast pass if eligible).
+    if (NHK == 1) {
+        std::map<uint32_t, std::vector<uint32_t>> batch_to_cores;
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            if (core_work[i].global_q_count == 0) {
+                continue;
+            }
+            for (const auto& hw : core_work[i].head_work) {
+                batch_to_cores[hw.batch].push_back(i);
+                break;  // Each core only counted once per batch
+            }
+        }
+
+        for (auto& [batch, core_indices] : batch_to_cores) {
+            std::sort(core_indices.begin(), core_indices.end(), [&](uint32_t a, uint32_t b) {
+                const auto& pa = core_work[a].physical_core;
+                const auto& pb = core_work[b].physical_core;
+                return (pa.y < pb.y) || (pa.y == pb.y && pa.x < pb.x);
+            });
+
+            // K scope is per-batch (head=0 unused); work count = total q iterations per core
+            std::vector<ChainSegment> chain_segs;
+            chain_segs.reserve(core_indices.size());
+            for (uint32_t ci : core_indices) {
+                chain_segs.emplace_back(ci, core_work[ci].global_q_count);
+            }
+            if (build_linear_chain(chain_segs, batch, 0, batch_chain_configs, core_work)) {
+                log_debug(tt::LogOp, "K unicast chain for batch {}: {} cores", batch, chain_segs.size());
+            }
+        }
+    }
+
+    // K multicast pass: check if full grid can use 2D multicast for K
+    // Enabled when NHK == 1 (MLA mode) and B == 1 (single batch)
+    // The logical grid is always a rectangle by construction (CoreRange from 0,0 to grid_size-1)
+    bool k_mcast_enabled = false;
+    uint32_t max_global_q_count = 0;
+    std::string k_mcast_fallback_reason;
+
+    if (NHK != 1) {
+        // Not MLA mode - no K sharing needed
+    } else if (B > 1) {
+        k_mcast_fallback_reason = "B > 1 (multi-batch not supported)";
+    } else if (num_cores < 2) {
+        k_mcast_fallback_reason = "num_cores < 2";
+    } else {
+        // Find injector (core with max work)
+        uint32_t injector_idx = 0;
+        for (uint32_t ci = 0; ci < num_cores; ++ci) {
+            if (core_work[ci].global_q_count > max_global_q_count) {
+                max_global_q_count = core_work[ci].global_q_count;
+                injector_idx = ci;
+            }
+        }
+
+        if (max_global_q_count == 0) {
+            k_mcast_fallback_reason = "no work (max_global_q_count == 0)";
+        } else {
+            k_mcast_enabled = true;
+            uint32_t num_receivers = num_cores - 1;
+            CoreCoord injector_physical = core_work[injector_idx].physical_core;
+
+            // Get physical bounds from logical grid corners
+            // Logical grid is always rectangular: (0,0) to (grid_size.x-1, grid_size.y-1)
+            CoreCoord phys_start = device->worker_core_from_logical_core(CoreCoord{0, 0});
+            CoreCoord phys_end = device->worker_core_from_logical_core(CoreCoord{grid_size.x - 1, grid_size.y - 1});
+
+            // Configure multicast for ALL cores
+            for (uint32_t ci = 0; ci < num_cores; ++ci) {
+                auto& kc = batch_chain_configs[ci];
+                kc.participates = true;  // All cores participate in K mcast
+                kc.mcast_start = phys_start;
+                kc.mcast_end = phys_end;
+                kc.injector_physical = injector_physical;
+                kc.batch = 0;  // Single batch case
+
+                kc.is_injector = (ci == injector_idx);
+                kc.is_sink = !kc.is_injector;  // All non-injectors are sinks in mcast
+
+                if (kc.is_injector) {
+                    kc.mcast_num_dests = num_receivers;
+                    kc.mcast_sender_wait = num_receivers;
+                    // Injector forwards on every iteration (loop padded to max_q_per_core)
+                    kc.next_core_q_chunks = max_global_q_count;
+                }
+            }
+
+            log_debug(
+                tt::LogOp,
+                "K mcast enabled: {} cores, injector=core {} (max_q={}), rect ({},{}) to ({},{})",
+                num_cores,
+                injector_idx,
+                max_global_q_count,
+                phys_start.x,
+                phys_start.y,
+                phys_end.x,
+                phys_end.y);
+        }
+    }
+
+    // Update mcast and chain selection compile-time args
+    const bool head_mcast_enabled = (mcast_chains > 0);
+    const bool k_uses_batch_chain = (NHK == 1);  // MLA mode: K uses batch chain; otherwise uses head chain
+
+    reader_compile_time_args[sem_args_offset + 3] = head_mcast_enabled ? 1 : 0;
+    // When K uses head chain (non-MLA), align batch_mcast_enabled with head_mcast_enabled so types match
+    reader_compile_time_args[sem_args_offset + 7] =
+        k_uses_batch_chain ? (k_mcast_enabled ? 1 : 0) : (head_mcast_enabled ? 1 : 0);
+    reader_compile_time_args[sem_args_offset + 8] = k_uses_batch_chain ? 1 : 0;
+
+    log_info(tt::LogOp, "V chain mode: head ({})", head_mcast_enabled ? "mcast" : "unicast");
+    if (k_uses_batch_chain) {
+        log_info(
+            tt::LogOp,
+            "K chain mode: batch ({})",
+            k_mcast_enabled ? "mcast" : fmt::format("unicast, {}", k_mcast_fallback_reason));
+    } else {
+        log_info(tt::LogOp, "K chain mode: head (NHK != 1, {})", head_mcast_enabled ? "mcast" : "unicast");
+    }
 
     // Create kernels (deferred until after chain construction for mcast_enabled flag)
     auto reader_kernels_id = CreateKernel(
@@ -1159,41 +1334,32 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
             global_q_end,
         };
         // Append chain runtime args for store-and-forward
-        const auto& chain = core_chain_info.at(i);
+        const auto& head_chain = head_chain_configs.at(i);
+        const auto& batch_chain = batch_chain_configs.at(i);
 
         log_debug(
             tt::LogOp,
-            "core logical=({},{})->phys=({},{}), q=[{},{}), chain={{part:{}, inj:{}, sink:{}, "
-            "b:{}, h:{}, q_start:{}, q_cnt:{}, next_cnt:{}}}",
+            "core logical=({},{})->phys=({},{}), q=[{},{}), head_chain={{part:{}, inj:{}, sink:{}, "
+            "b:{}, h:{}, next_cnt:{}}}",
             core.x,
             core.y,
             core_work.at(i).physical_core.x,
             core_work.at(i).physical_core.y,
             global_q_start,
             global_q_end,
-            chain.participates,
-            chain.is_injector,
-            chain.is_sink,
-            chain.batch,
-            chain.head,
-            chain.q_chunk_start,
-            chain.q_chunk_count,
-            chain.next_core_q_chunks);
+            head_chain.participates,
+            head_chain.is_injector,
+            head_chain.is_sink,
+            head_chain.batch,
+            head_chain.head,
+            head_chain.next_core_q_chunks);
 
-        reader_args.push_back(static_cast<uint32_t>(chain.participates));
-        reader_args.push_back(static_cast<uint32_t>(chain.is_injector));
-        reader_args.push_back(static_cast<uint32_t>(chain.is_sink));
-        reader_args.push_back(chain.batch);
-        reader_args.push_back(chain.head);
-        reader_args.push_back(chain.q_chunk_start);
-        reader_args.push_back(chain.q_chunk_count);
-        reader_args.push_back(static_cast<uint32_t>(chain.prev_physical.x));
-        reader_args.push_back(static_cast<uint32_t>(chain.prev_physical.y));
-        reader_args.push_back(static_cast<uint32_t>(chain.next_physical.x));
-        reader_args.push_back(static_cast<uint32_t>(chain.next_physical.y));
-        reader_args.push_back(chain.next_core_q_chunks);
-        reader_args.push_back(chain.mcast_num_dests);
-        reader_args.push_back(chain.mcast_sender_wait);
+        // Head chain (V chain, optionally K in non-MLA): 18 args via unified layout
+        head_chain.append_to_args(reader_args);
+
+        // Batch chain (K chain in MLA mode): 18 args via unified layout + 1 for loop padding
+        batch_chain.append_to_args(reader_args);
+        reader_args.push_back(max_global_q_count);  // For K mcast loop padding
 
         // Inject fused-op synchronization RT args (AllGather) here; it will append to reader_args
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(reader_args);


### PR DESCRIPTION
In MLA mode (NHK==1), K is shared across all heads. Previously every head-chain injector on the compute grid read K from DRAM independently, multiplying DRAM reads by the number of chain injectors. Since the kernel is DRAM-bandwidth bound, this was one of the primary bottlenecks.

Changes:
- Single K-injector reads K from DRAM and multicasts to the full compute grid via noc_async_write_multicast. All other cores receive from L1.
- When B==1 (single batch) the injector is selected as the core with maximum work
- Non-uniform work is handled via loop padding: all cores iterate max_q_per_core times; padded iterations participate in K sync but skip Q/V work.
- Introduces ChainLink<mcast_enabled, is_head_level> in chain_link.hpp: a unified template abstraction used by both the V head-chain (1D mcast) and the K batch-chain (2D mcast).
- K selects the appropriate chain at compile time: NHK==1 (MLA)  → batch chain (ChainLink<*, false>)
    Otherwise     → head chain  (ChainLink<*, true>, same as V)

Performance impact, measured on Blackhole 4x2 (8 devices, BF16 Q / BF8 KV, balanced mode):

  mla_100k (seq=102k, q=160, k=160): 46.7% → 51.8% Math Util (+5.1 pp), 12.948 → 11.683 ms (-9.8%)
  mla_128k (seq=262k, q=128, k=128): 44.1% → 46.3% Math Util (+2.2 pp), 22.449 → 21.398 ms (-4.7%)
  Non-MLA (wan2, videogen):           no regression (≤ ±0.4 pp / ±0.4%)

## Test plan

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [ ] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [ ] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasilijevic/chaining_k_v_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasilijevic/chaining_k_v_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasilijevic/chaining_k_v_pr)