### PR TITLE
[Skip ci ] Fix codeowners Slack ping skipping pending teams

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -2156,10 +2156,36 @@ jobs:
               team_files=$(echo "$team_entry" | cut -d':' -f2-)
               sorted_files=$(echo "$team_files" | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')
 
-              # Check combined approval for this file set
-              has_approval="${FILES_HAS_APPROVAL[$sorted_files]}"
-              if [ "$has_approval" = "true" ]; then
-                echo "Team $team already approved (combined check), skipping"
+              # Per-file approval check (matches comment/summary logic):
+              # For each file this team owns, gather ALL owners of that file
+              # (from any team/individual) and check if any approved.
+              # Only skip the team if ALL its files are individually covered.
+              all_team_files_approved=true
+              IFS=',' read -ra TEAM_FILES_ARRAY <<< "$team_files"
+              for tfile in "${TEAM_FILES_ARRAY[@]}"; do
+                [ -z "$tfile" ] && continue
+                file_approved=false
+                # Check all file sets in FILES_TO_MEMBERS for this individual file
+                for fset in "${!FILES_TO_MEMBERS[@]}"; do
+                  if echo "$fset" | tr ',' '\n' | grep -Fqx -- "$tfile"; then
+                    # This file set contains our file — check its members
+                    IFS=',' read -ra FSET_MEMBERS <<< "${FILES_TO_MEMBERS[$fset]}"
+                    for member in "${FSET_MEMBERS[@]}"; do
+                      [ -z "$member" ] && continue
+                      if echo "$APPROVED_REVIEWERS" | tr ',' '\n' | grep -qx "$member"; then
+                        file_approved=true
+                        break 2
+                      fi
+                    done
+                  fi
+                done
+                if [ "$file_approved" = false ]; then
+                  all_team_files_approved=false
+                  break
+                fi
+              done
+              if [ "$all_team_files_approved" = true ]; then
+                echo "Team $team: all files have at least one approved owner, skipping"
                 continue
               fi
 


### PR DESCRIPTION
## Summary
- Fix bug where Slack ping logic skips pending teams due to overly aggressive file-set-level approval overlap check
- The old `FILES_HAS_APPROVAL` combined check marked a team's entire file set as approved if ANY overlapping file set had an approved reviewer — even if only some files overlapped
- Replace with per-file approval logic (matching the comment/summary behavior): for each file the team owns, gather all owners from any team and check if any approved. Only skip the team if ALL its files are individually covered

## Root Cause
The Slack ping step used `FILES_HAS_APPROVAL[$sorted_files]` which operates at file-set granularity with an overlap expansion. If infra owns `{B, C}` and eltwise owns `{A, B}`, an eltwise member approving would cause the overlap check to mark infra's entire set `{B, C}` as approved — even though file `C` has no approved owner.

The comment/summary section correctly uses per-file approval: for each file, it gathers ALL owners across all groups and checks if any approved. A team is only marked approved if ALL its files are individually covered. The Slack ping now uses the same logic.

## Test plan
- [ ] Verify on a PR where shared files are approved but team has additional unapproved files — team should still be pinged
- [ ] Verify on PR #42737 scenario: eltwise approves shared files, but infra/ttnn-core have unapproved files — they should get pinged
- [ ] Verify that if ALL files a team owns are approved (by any owner), the team is correctly skipped
- [ ] Verify cross-team approval on shared files still works (if file co-owned by A and B, approval by A member covers B for that file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)