### PR TITLE
#41309: `ttnn.slice` failing for specific shape with watcher on

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1468,3 +1468,38 @@ def test_issue_38841_regression(device):
     tt_output_torch = ttnn.to_torch(tt_output)
 
     assert_with_pcc(torch_expected, tt_output_torch, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "input_shape, begins, ends, step",
+    [
+        [(1, 8190, 1, 128), [0, 0, 0, 0], [1, 8190, 1, 128], [1, 1, 1, 2]],
+    ],
+)
+def test_slice_large_tensor_stride_last_dim(device, input_shape, begins, ends, step):
+    """Test slice with stride in last dimension on large tensor (1, 8190, 1, 128)"""
+
+    torch.manual_seed(2003)
+
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_output = ttnn.slice(tt_input, begins, ends, step)
+
+    torch_output = torch_input[
+        begins[0] : ends[0] : step[0],
+        begins[1] : ends[1] : step[1],
+        begins[2] : ends[2] : step[2],
+        begins[3] : ends[3] : step[3],
+    ]
+
+    tt_output_torch = ttnn.to_torch(tt_output)
+
+    assert_with_pcc(torch_output, tt_output_torch, 0.99)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1476,8 +1476,8 @@ def test_issue_38841_regression(device):
         [(1, 8190, 1, 128), [0, 0, 0, 0], [1, 8190, 1, 128], [1, 1, 1, 2]],
     ],
 )
-def test_slice_large_tensor_stride_last_dim(device, input_shape, begins, ends, step):
-    """Test slice with stride in last dimension on large tensor (1, 8190, 1, 128)"""
+def test_issue_42753_regression(device, input_shape, begins, ends, step):
+    """Regression test for issue #42753: slicing shape (1, 8190, 1, 128)."""
 
     torch.manual_seed(2003)
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -50,9 +50,9 @@ SliceRmStrideProgramFactory::cached_program_t SliceRmStrideProgramFactory::creat
     }
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t actual_output_w = output_shape[-1];
-    uint32_t output_bytes_per_row = actual_output_w * element_size;
-    uint32_t cb_page_size = output_bytes_per_row;
+    uint32_t actual_input_w = input_shape[-1];
+    uint32_t input_bytes_per_row = actual_input_w * element_size;
+    uint32_t cb_page_size = input_bytes_per_row;
 
     auto src_buffer_alignment = input_tensor.buffer()->alignment();
     auto dst_buffer_alignment = output.buffer()->alignment();


### PR DESCRIPTION
### Summary
[Link to Issue](https://github.com/tenstorrent/tt-metal/issues/42753)

Fixing a CB overflow in `ttnn.slice` for the parameters shown below:
```
INPUT_SHAPE = (1, 8190, 1, 128)
BEGINS = [0, 0, 0, 0]
ENDS = [1, 8190, 1, 128]
STEP = [1, 1, 1, 2]
```
The CB calculation previously used the the output tensor width for calculation, however the reader needs to temporarily store the full input row before perfoming in place slicing, therefore it should be calculated with the input tensor width instead.

Ran full `tests/ttnn/unit_tests/operations/data_movement/test_slice.py` suite with watcher on, 410 passed, 37 skipped.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/slice-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smeydanshahiTT/slice-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=smeydanshahiTT/slice-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:smeydanshahiTT/slice-hang)
