### PR TITLE
Fix whisper OSError: redirect HF_DATASETS_CACHE away from read-only MLPerf mount

### DIFF
--- a/models/demos/audio/whisper/demo/demo.py
+++ b/models/demos/audio/whisper/demo/demo.py
@@ -435,9 +435,7 @@ def run_demo_whisper_for_conditional_generation_dataset(
     # Prefer load_from_disk when HF_DATASETS_CACHE is set: it reads Arrow files
     # directly without writing lock files, which avoids EROFS on read-only mounts.
     _cache = os.environ.get("HF_DATASETS_CACHE")
-    _cached_dirs = (
-        glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
-    )
+    _cached_dirs = glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
     ds = (
         load_from_disk(sorted(_cached_dirs)[-1])
         if _cached_dirs

--- a/models/demos/audio/whisper/demo/demo.py
+++ b/models/demos/audio/whisper/demo/demo.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import glob
 import os
 from os import listdir
 from os.path import isfile, join
@@ -10,7 +11,7 @@ from typing import List, Optional, Union
 import jiwer
 import pytest
 import torch
-from datasets import load_dataset
+from datasets import load_dataset, load_from_disk
 from evaluate import load
 from loguru import logger
 from scipy.io import wavfile
@@ -431,7 +432,26 @@ def run_demo_whisper_for_conditional_generation_dataset(
     )
 
     # load data
-    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    # Use load_from_disk() when the Arrow cache exists under HF_HOME/datasets — pure
+    # read, no lock file. Falls back to load_dataset() which writes a lock to
+    # HF_DATASETS_CACHE (=/tmp in CI) if no Arrow cache is found.
+    _hf_datasets = os.path.join(os.environ.get("HF_HOME", ""), "datasets")
+    _arrow_dirs = (
+        [
+            os.path.dirname(p)
+            for p in glob.glob(
+                os.path.join(_hf_datasets, "hf-internal-testing___parquet", "clean-*", "**", "dataset_info.json"),
+                recursive=True,
+            )
+        ]
+        if os.path.isdir(_hf_datasets)
+        else []
+    )
+    ds = (
+        load_from_disk(sorted(_arrow_dirs)[-1])
+        if _arrow_dirs
+        else load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    )
     batch_size = batch_size_per_device * mesh_device.get_num_devices()
     # perform model inference
     total_wer = 0

--- a/models/demos/audio/whisper/demo/demo.py
+++ b/models/demos/audio/whisper/demo/demo.py
@@ -10,7 +10,9 @@ from typing import List, Optional, Union
 import jiwer
 import pytest
 import torch
-from datasets import load_dataset
+import glob
+
+from datasets import load_dataset, load_from_disk
 from evaluate import load
 from loguru import logger
 from scipy.io import wavfile
@@ -431,7 +433,13 @@ def run_demo_whisper_for_conditional_generation_dataset(
     )
 
     # load data
-    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    # Prefer load_from_disk when HF_DATASETS_CACHE is set: it reads Arrow files
+    # directly without writing lock files, which avoids EROFS on read-only mounts.
+    _cache = os.environ.get("HF_DATASETS_CACHE")
+    _cached_dirs = glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
+    ds = load_from_disk(sorted(_cached_dirs)[-1]) if _cached_dirs else load_dataset(
+        "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
+    )
     batch_size = batch_size_per_device * mesh_device.get_num_devices()
     # perform model inference
     total_wer = 0

--- a/models/demos/audio/whisper/demo/demo.py
+++ b/models/demos/audio/whisper/demo/demo.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import glob
 import os
 from os import listdir
 from os.path import isfile, join
@@ -11,7 +10,7 @@ from typing import List, Optional, Union
 import jiwer
 import pytest
 import torch
-from datasets import load_dataset, load_from_disk
+from datasets import load_dataset
 from evaluate import load
 from loguru import logger
 from scipy.io import wavfile
@@ -432,15 +431,7 @@ def run_demo_whisper_for_conditional_generation_dataset(
     )
 
     # load data
-    # Prefer load_from_disk when HF_DATASETS_CACHE is set: it reads Arrow files
-    # directly without writing lock files, which avoids EROFS on read-only mounts.
-    _cache = os.environ.get("HF_DATASETS_CACHE")
-    _cached_dirs = glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
-    ds = (
-        load_from_disk(sorted(_cached_dirs)[-1])
-        if _cached_dirs
-        else load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
-    )
+    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
     batch_size = batch_size_per_device * mesh_device.get_num_devices()
     # perform model inference
     total_wer = 0

--- a/models/demos/audio/whisper/demo/demo.py
+++ b/models/demos/audio/whisper/demo/demo.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import glob
 import os
 from os import listdir
 from os.path import isfile, join
@@ -10,8 +11,6 @@ from typing import List, Optional, Union
 import jiwer
 import pytest
 import torch
-import glob
-
 from datasets import load_dataset, load_from_disk
 from evaluate import load
 from loguru import logger
@@ -436,9 +435,13 @@ def run_demo_whisper_for_conditional_generation_dataset(
     # Prefer load_from_disk when HF_DATASETS_CACHE is set: it reads Arrow files
     # directly without writing lock files, which avoids EROFS on read-only mounts.
     _cache = os.environ.get("HF_DATASETS_CACHE")
-    _cached_dirs = glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
-    ds = load_from_disk(sorted(_cached_dirs)[-1]) if _cached_dirs else load_dataset(
-        "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
+    _cached_dirs = (
+        glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
+    )
+    ds = (
+        load_from_disk(sorted(_cached_dirs)[-1])
+        if _cached_dirs
+        else load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
     )
     batch_size = batch_size_per_device * mesh_device.get_num_devices()
     # perform model inference

--- a/models/demos/audio/whisper/tests/test_whisper_modules.py
+++ b/models/demos/audio/whisper/tests/test_whisper_modules.py
@@ -5,7 +5,10 @@
 import pytest
 import torch
 import transformers
-from datasets import load_dataset
+import glob
+import os
+
+from datasets import load_dataset, load_from_disk
 from loguru import logger
 from transformers import AutoFeatureExtractor, EncoderDecoderCache, WhisperConfig, WhisperModel
 from ttnn.model_preprocessing import preprocess_model_parameters
@@ -566,7 +569,13 @@ def test_ttnn_whisper(
     input_mesh_mapper, weights_mesh_mapper, output_mesh_composer = get_mesh_mappers(mesh_device)
     config = whisper_config_for_tests(model_name)
     feature_extractor = AutoFeatureExtractor.from_pretrained(model_name)
-    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    # Prefer load_from_disk when HF_DATASETS_CACHE is set: it reads Arrow files
+    # directly without writing lock files, which avoids EROFS on read-only mounts.
+    _cache = os.environ.get("HF_DATASETS_CACHE")
+    _cached_dirs = glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
+    ds = load_from_disk(sorted(_cached_dirs)[-1]) if _cached_dirs else load_dataset(
+        "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
+    )
     inputs = feature_extractor(ds[0]["audio"]["array"], sampling_rate=16000, return_tensors="pt")
     input_features = inputs.input_features
     input_features = input_features.repeat(batch_size, 1, 1)

--- a/models/demos/audio/whisper/tests/test_whisper_modules.py
+++ b/models/demos/audio/whisper/tests/test_whisper_modules.py
@@ -572,9 +572,7 @@ def test_ttnn_whisper(
     # Prefer load_from_disk when HF_DATASETS_CACHE is set: it reads Arrow files
     # directly without writing lock files, which avoids EROFS on read-only mounts.
     _cache = os.environ.get("HF_DATASETS_CACHE")
-    _cached_dirs = (
-        glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
-    )
+    _cached_dirs = glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
     ds = (
         load_from_disk(sorted(_cached_dirs)[-1])
         if _cached_dirs

--- a/models/demos/audio/whisper/tests/test_whisper_modules.py
+++ b/models/demos/audio/whisper/tests/test_whisper_modules.py
@@ -2,10 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import glob
+import os
+
 import pytest
 import torch
 import transformers
-from datasets import load_dataset
+from datasets import load_dataset, load_from_disk
 from loguru import logger
 from transformers import AutoFeatureExtractor, EncoderDecoderCache, WhisperConfig, WhisperModel
 from ttnn.model_preprocessing import preprocess_model_parameters
@@ -566,7 +569,26 @@ def test_ttnn_whisper(
     input_mesh_mapper, weights_mesh_mapper, output_mesh_composer = get_mesh_mappers(mesh_device)
     config = whisper_config_for_tests(model_name)
     feature_extractor = AutoFeatureExtractor.from_pretrained(model_name)
-    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    # Use load_from_disk() when the Arrow cache exists under HF_HOME/datasets — pure
+    # read, no lock file. Falls back to load_dataset() which writes a lock to
+    # HF_DATASETS_CACHE (=/tmp in CI) if no Arrow cache is found.
+    _hf_datasets = os.path.join(os.environ.get("HF_HOME", ""), "datasets")
+    _arrow_dirs = (
+        [
+            os.path.dirname(p)
+            for p in glob.glob(
+                os.path.join(_hf_datasets, "hf-internal-testing___parquet", "clean-*", "**", "dataset_info.json"),
+                recursive=True,
+            )
+        ]
+        if os.path.isdir(_hf_datasets)
+        else []
+    )
+    ds = (
+        load_from_disk(sorted(_arrow_dirs)[-1])
+        if _arrow_dirs
+        else load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    )
     inputs = feature_extractor(ds[0]["audio"]["array"], sampling_rate=16000, return_tensors="pt")
     input_features = inputs.input_features
     input_features = input_features.repeat(batch_size, 1, 1)

--- a/models/demos/audio/whisper/tests/test_whisper_modules.py
+++ b/models/demos/audio/whisper/tests/test_whisper_modules.py
@@ -2,12 +2,12 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-import torch
-import transformers
 import glob
 import os
 
+import pytest
+import torch
+import transformers
 from datasets import load_dataset, load_from_disk
 from loguru import logger
 from transformers import AutoFeatureExtractor, EncoderDecoderCache, WhisperConfig, WhisperModel
@@ -572,9 +572,13 @@ def test_ttnn_whisper(
     # Prefer load_from_disk when HF_DATASETS_CACHE is set: it reads Arrow files
     # directly without writing lock files, which avoids EROFS on read-only mounts.
     _cache = os.environ.get("HF_DATASETS_CACHE")
-    _cached_dirs = glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
-    ds = load_from_disk(sorted(_cached_dirs)[-1]) if _cached_dirs else load_dataset(
-        "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
+    _cached_dirs = (
+        glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
+    )
+    ds = (
+        load_from_disk(sorted(_cached_dirs)[-1])
+        if _cached_dirs
+        else load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
     )
     inputs = feature_extractor(ds[0]["audio"]["array"], sampling_rate=16000, return_tensors="pt")
     input_features = inputs.input_features

--- a/models/demos/audio/whisper/tests/test_whisper_modules.py
+++ b/models/demos/audio/whisper/tests/test_whisper_modules.py
@@ -2,13 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import glob
-import os
-
 import pytest
 import torch
 import transformers
-from datasets import load_dataset, load_from_disk
+from datasets import load_dataset
 from loguru import logger
 from transformers import AutoFeatureExtractor, EncoderDecoderCache, WhisperConfig, WhisperModel
 from ttnn.model_preprocessing import preprocess_model_parameters
@@ -569,15 +566,7 @@ def test_ttnn_whisper(
     input_mesh_mapper, weights_mesh_mapper, output_mesh_composer = get_mesh_mappers(mesh_device)
     config = whisper_config_for_tests(model_name)
     feature_extractor = AutoFeatureExtractor.from_pretrained(model_name)
-    # Prefer load_from_disk when HF_DATASETS_CACHE is set: it reads Arrow files
-    # directly without writing lock files, which avoids EROFS on read-only mounts.
-    _cache = os.environ.get("HF_DATASETS_CACHE")
-    _cached_dirs = glob.glob(os.path.join(_cache, "hf-internal-testing___parquet", "clean-*")) if _cache else []
-    ds = (
-        load_from_disk(sorted(_cached_dirs)[-1])
-        if _cached_dirs
-        else load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
-    )
+    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
     inputs = feature_extractor(ds[0]["audio"]["array"], sampling_rate=16000, return_tensors="pt")
     input_features = inputs.input_features
     input_features = input_features.repeat(batch_size, 1, 1)

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -389,7 +389,7 @@
 
 - name: Whisper e2e tests
   cmd: |
-    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/mnt/MLPerf/huggingface/datasets
+    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/tmp/huggingface/datasets
     pytest --timeout=600 models/demos/audio/whisper/demo/demo.py --input-path="models/demos/audio/whisper/demo/dataset/conditional_generation" -k "conditional_generation"
   model: whisper
   skus:

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -389,7 +389,7 @@
 
 - name: Whisper e2e tests
   cmd: |
-    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub
+    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/mnt/MLPerf/huggingface/datasets
     pytest --timeout=600 models/demos/audio/whisper/demo/demo.py --input-path="models/demos/audio/whisper/demo/dataset/conditional_generation" -k "conditional_generation"
   model: whisper
   skus:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -303,7 +303,7 @@
 
 - name: Whisper unit tests
   cmd: |
-    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub
+    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/tmp/huggingface/datasets
     pytest --timeout 600 models/demos/audio/whisper/tests/test_whisper_modules.py
   model: whisper
   skus:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -304,6 +304,8 @@
 - name: Whisper unit tests
   cmd: |
     export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/tmp/huggingface/datasets
+    mkdir -p /tmp/huggingface/datasets
+    ln -sf /mnt/MLPerf/huggingface/datasets/hf-internal-testing___parquet /tmp/huggingface/datasets/hf-internal-testing___parquet
     pytest --timeout 600 models/demos/audio/whisper/tests/test_whisper_modules.py
   model: whisper
   skus:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -303,9 +303,7 @@
 
 - name: Whisper unit tests
   cmd: |
-    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/tmp/huggingface/datasets
-    mkdir -p /tmp/huggingface/datasets
-    ln -sf /mnt/MLPerf/huggingface/datasets/hf-internal-testing___parquet /tmp/huggingface/datasets/hf-internal-testing___parquet
+    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/mnt/MLPerf/huggingface/datasets
     pytest --timeout 600 models/demos/audio/whisper/tests/test_whisper_modules.py
   model: whisper
   skus:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -303,7 +303,7 @@
 
 - name: Whisper unit tests
   cmd: |
-    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/mnt/MLPerf/huggingface/datasets
+    export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/tmp/huggingface/datasets
     pytest --timeout 600 models/demos/audio/whisper/tests/test_whisper_modules.py
   model: whisper
   skus:


### PR DESCRIPTION
## Summary

`test_whisper_modules.py` and `demo.py` call `load_dataset()` which acquires a file lock before reading cached data. Since `HF_HOME=/mnt/MLPerf/huggingface` causes the datasets cache to land on the read-only MLPerf mount, the lock write fails with `OSError: [Errno 30] Read-only file system`.

## Fix

Use `load_from_disk()` instead of `load_dataset()` when the Arrow cache already exists on the MLPerf mount — `load_from_disk()` is a pure read with no lock file writes.

- Glob for `dataset_info.json` recursively under `HF_HOME/datasets/hf-internal-testing___parquet/clean-*/` to locate the Arrow cache at any depth (datasets 2.x stores it at `clean-{h1}/{version}/{fingerprint}/`)
- `HF_HOME` is already set in CI to `/mnt/MLPerf/huggingface`, so the existing cache is found transparently
- Falls back to `load_dataset()` if no Arrow cache is found, with `HF_DATASETS_CACHE=/tmp/huggingface/datasets` so the lock file goes to writable `/tmp`

### One-time MLPerf setup required
The existing Arrow cache was missing `state.json` (created by an older datasets version). Fixed by running `save_to_disk()` into the cache directory on a machine with write access to MLPerf:
```python
from datasets import load_dataset
ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
ds.save_to_disk("/mnt/MLPerf/huggingface/datasets/hf-internal-testing___parquet/clean-fc874e275f4960a3/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec")
```

## Test plan

- [x] Whisper unit tests pass — https://github.com/tenstorrent/tt-metal/actions/runs/24883183737
- [x] Whisper e2e tests pass — https://github.com/tenstorrent/tt-metal/actions/runs/24883185124
- [x] No lock file written — `load_from_disk()` is a pure read of the existing Arrow cache
- [x] Falls back to `load_dataset()` in environments where the Arrow cache is not pre-populated

