### PR TITLE
Fix SDPA mask scaling to match PyTorch semantics

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -609,6 +609,69 @@ def test_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
     run_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
 
 
+def run_sdpa_noncausal_randn_bias(device, b, nh, s, d, torch_dtype, ttnn_dtype):
+    torch.manual_seed(1234)
+
+    scale = 1.0 / math.sqrt(d)  # 0.125 for d=64
+
+    Q = torch.randn(b, nh, s, d, dtype=torch_dtype)
+    K = torch.randn(b, nh, s, d, dtype=torch_dtype)
+    V = torch.randn(b, nh, s, d, dtype=torch_dtype)
+    attn_bias = torch.randn(b, nh, s, s, dtype=torch_dtype)
+
+    tt_Q = ttnn.from_torch(
+        Q, dtype=ttnn_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt_K = ttnn.from_torch(
+        K, dtype=ttnn_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt_V = ttnn.from_torch(
+        V, dtype=ttnn_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt_bias = ttnn.from_torch(
+        attn_bias, dtype=ttnn_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    tt_Q = ttnn.to_layout(tt_Q, ttnn.TILE_LAYOUT)
+    tt_K = ttnn.to_layout(tt_K, ttnn.TILE_LAYOUT)
+    tt_V = ttnn.to_layout(tt_V, ttnn.TILE_LAYOUT)
+    tt_bias = ttnn.to_layout(tt_bias, ttnn.TILE_LAYOUT)
+
+    tt_back = ttnn.transformer.scaled_dot_product_attention(
+        tt_Q,
+        tt_K,
+        tt_V,
+        attn_mask=tt_bias,
+        is_causal=False,
+        scale=scale,
+        sliding_window_size=None,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_back = ttnn.to_torch(tt_back)
+
+    gt = torch.nn.functional.scaled_dot_product_attention(
+        Q,
+        K,
+        V,
+        attn_mask=attn_bias,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    )
+
+    out_pass, out_pcc = comp_pcc(gt, tt_back, 0.99)
+    logger.debug(f"b={b} nh={nh} s={s} d={d} dtype={torch_dtype} | PCC={out_pcc}")
+    assert out_pass
+
+
+@pytest.mark.parametrize(
+    "b, nh, s, d",
+    ([1, 12, 197, 64],),
+)
+def test_sdpa_noncausal_randn_bias(device, b, nh, s, d):
+    run_sdpa_noncausal_randn_bias(device, b, nh, s, d, torch.bfloat16, ttnn.bfloat16)
+
+
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b], ids=["bfp8"])
 @pytest.mark.parametrize("q_chunk_size", [128], ids=["q128"])
 @pytest.mark.parametrize("k_chunk_size", [128], ids=["k128"])

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cmath>
 #include <utility>
 
 #include "ttnn/operations/transformer/sdpa/sdpa.hpp"
 
+#include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp"
@@ -34,11 +36,32 @@ ttnn::Tensor scaled_dot_product_attention(
     auto kernel_config_val = init_device_compute_kernel_config(
         input_tensor_q.device()->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi2, true, false, false);
 
+    // PyTorch semantics: softmax(Q·Kᵀ * scale + mask) · V, where `scale` applies
+    // to Q·Kᵀ only and the mask is added unscaled.
+    //
+    // The compute kernel folds `scale` into the softmax exponent as a
+    // performance optimization:
+    //     exp((QK + mask - row_max) * scale)
+    //   = exp(QK*scale + mask*scale - row_max*scale)
+    // which scales the mask along with QK, diverging from PyTorch semantics.
+    //
+    // Pre-multiply the mask by 1/scale so the kernel's subsequent *scale
+    // restores the original mask magnitude inside softmax. QK remains scaled
+    // exactly once.
+    std::optional<ttnn::Tensor> effective_mask = attn_mask;
+    if (attn_mask.has_value()) {
+        const float effective_scale =
+            scale.value_or(1.0f / std::sqrt(static_cast<float>(input_tensor_q.padded_shape()[-1])));
+        if (effective_scale != 1.0f) {
+            effective_mask = ttnn::multiply(attn_mask.value(), 1.0f / effective_scale);
+        }
+    }
+
     return ttnn::prim::sdpa(
         input_tensor_q,
         input_tensor_k,
         input_tensor_v,
-        attn_mask,
+        effective_mask,
         std::nullopt,  // page_table
         attention_sink,
         is_causal,


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-metal/issues/42694

### Problem description

- `ttnn.transformer.scaled_dot_product_attention` diverges from PyTorch's F.scaled_dot_product_attention when scale != 1.0 and a user attn_mask is supplied.
- PyTorch: softmax(Q·Kᵀ * scale + mask) — scale applies to Q·Kᵀ only.
- The compute kernel folds scale into the softmax exponent as: `exp((QK + mask - max) * scale) = exp(QK*scale + mask*scale - max*scale)` ([Code evidence](https://github.com/tenstorrent/tt-metal/blob/kkannan/apr22_fix_sdpa_drop/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp#L1867-L1925)) which silently multiplies the mask by scale too. 
- For any scale < 1, the user's mask is diluted in softmax. 

### What's changed

- Pre-multiply attn_mask by 1/scale in the host wrapper: `exp(QK*scale + (mask/scale)*scale - max*scale) = exp(QK*scale + mask - max*scale)`, restoring PyTorch semantics.               
- Guarded on attn_mask.has_value() && scale != 1.0f.
-  BEiT SDPA PCC: **0.9444 → 0.9941**. 

### Checklist

- [x] L2 Nightly - https://github.com/tenstorrent/tt-metal/actions/runs/24788047149
- [x] Sanity - https://github.com/tenstorrent/tt-metal/actions/runs/24787685958

### Logs

- [apr23_sdpa_before_fix.log](https://github.com/user-attachments/files/26995768/apr23_sdpa_before_fix.log)
- [apr23_sdpa_after_fix.log](https://github.com/user-attachments/files/26995767/apr23_sdpa_after_fix.log)
