### PR TITLE
ds_prefill (resolve 25K ISL OOM on BH GLX)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -96,7 +96,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device, mesh_shape=mesh_device.shape, dims=(0, -1)  # SP on axis 0, TP on axis 1
             ),
-            layout=ttnn.ROW_MAJOR_LAYOUT,
+            layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             dtype=ttnn.bfloat16,
         )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -192,7 +192,7 @@ def test_ttnn_moe(
     tt_x = ttnn.from_torch(
         x,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_device.shape, dims=(0, -1)),
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        layout=ttnn.TILE_LAYOUT,
         device=mesh_device,
         dtype=ttnn.bfloat16,
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -52,6 +52,8 @@ PCC_THRESHOLD = 0.99
 # Input sources: "random" = random token IDs, "json_prompts" = test_prompts_1024.json,
 # or any InfiniteBench subset name (downloaded on first use via infinitebench_prompt fixture).
 INFINITEBENCH_SUBSET_NAMES = {"passkey", "kv_retrieval", "longdialogue_qa_eng", "longbook_qa_eng"}
+SEQ_LEN_1K = 1024
+SEQ_LEN_25K = 25 * 1024
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="Requires Blackhole.")
@@ -62,7 +64,7 @@ INFINITEBENCH_SUBSET_NAMES = {"passkey", "kv_retrieval", "longdialogue_qa_eng", 
     ["json_prompts", "abc_1k", "random", "passkey", "kv_retrieval", "longdialogue_qa_eng", "longbook_qa_eng"],
 )
 @pytest.mark.parametrize("pcc_validation", [True, False], ids=["pcc", "smoke"])
-@pytest.mark.parametrize("isl_total", [1024, 6400])
+@pytest.mark.parametrize("isl_total", [SEQ_LEN_1K, SEQ_LEN_25K])
 @pytest.mark.parametrize(
     "num_layers",
     [
@@ -79,6 +81,7 @@ INFINITEBENCH_SUBSET_NAMES = {"passkey", "kv_retrieval", "longdialogue_qa_eng", 
     ],
     ids=["e64_cf4_host", "e256_cf32_host", "e256_cf32_device"],
 )
+@pytest.mark.parametrize("num_iterations", [1])
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
     [
@@ -120,6 +123,7 @@ def test_prefill_transformer(
     num_links,
     topology,
     pcc_validation,
+    num_iterations,
     input_source,
     use_pretrained,
     return_kv_cache,
@@ -349,8 +353,12 @@ def test_prefill_transformer(
     profiler.start("tt_forward")
     logger.info("Running TtPrefillTransformer forward...")
     do_return_kv = pcc_validation and return_kv_cache
-    result = transformer(tt_tokens, tt_kvpe_cache, return_intermediates=pcc_validation, read_profiler=True)
-    ttnn.synchronize_device(mesh_device)
+    for i in range(num_iterations):
+        logger.info(f"Starting iteration: {i}")
+        result = transformer(tt_tokens, tt_kvpe_cache, return_intermediates=pcc_validation, read_profiler=True)
+        logger.info(f"Starting completion sync on iteration: {i}")
+        ttnn.synchronize_device(mesh_device)
+
     profiler.end("tt_forward")
     logger.info("Forward pass completed successfully")
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -341,11 +341,10 @@ class TtMoe(LightweightModule):
         # Gate: compute weights/indices/offsets/counts from x
         # ========================================
         # Reshape 3D -> 2D for gate: (batch, seq, emb) -> (batch*seq, emb)
-        x_for_gate = ttnn.reshape(x, (x.shape[0] * x.shape[1], x.shape[2]))
-        x_for_gate = ttnn.to_layout(x_for_gate, ttnn.TILE_LAYOUT)
 
-        scores, indices, gate_logits, tt_expert_offsets, tt_expert_token_counts = self.gate(x_for_gate)
-        ttnn.deallocate(x_for_gate)  # x_for_gate is no longer needed.
+        scores, indices, gate_logits, tt_expert_offsets, tt_expert_token_counts = self.gate(
+            ttnn.view(x, (x.shape[0] * x.shape[1], x.shape[2]))
+        )
         gate_logits = (
             ttnn.to_memory_config(gate_logits, ttnn.DRAM_MEMORY_CONFIG)
             if return_intermediates
@@ -402,18 +401,17 @@ class TtMoe(LightweightModule):
         # ========================================
         # Shared expert expects replicated input (full emb_dim)
         # Convert x to TILE_LAYOUT for shared expert
-        x_tiled = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
-        logger.debug(f"[TtMoe.forward] x_tiled shape: {x_tiled.shape}")
+        logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
 
-        shared_output = self.shared_expert(x_tiled)
-        ttnn.deallocate(x_tiled)  # x_tiled is only used for shared expert, deallocate immediately
+        shared_output = self.shared_expert(x)
         logger.debug(f"[TtMoe.forward] Shared expert output shape: {shared_output.shape}")
 
         # ========================================
         # Step 2: Dispatch (enabled)
         # ========================================
         # Dispatch expects full emb_dim on each device (x already has this)
-
+        x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)  # to be overlaped with dispatch
+        logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
         dispatched_buffer, metadata = self.dispatch_module(
             x,
             scores,
@@ -432,15 +430,15 @@ class TtMoe(LightweightModule):
         # Dispatch output is (1, dispatch_group_size_per_device, experts_per_chip, max_tokens, emb_dim)
         # Routed expert expects (experts_per_chip, max_tokens, emb_dim)
         # Squeeze the first two dimensions
-        dispatched_buffer_squeezed = ttnn.squeeze(dispatched_buffer, dim=0)
-        dispatched_buffer_squeezed = ttnn.squeeze(dispatched_buffer_squeezed, dim=0)
-        logger.debug(f"[TtMoe.forward] dispatched_buffer_squeezed shape: {dispatched_buffer_squeezed.shape}")
 
         # Convert dispatched_buffer to TILE_LAYOUT for routed experts
-        dispatched_buffer_tiled = ttnn.to_layout(dispatched_buffer_squeezed, ttnn.TILE_LAYOUT)
-        logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer_tiled.shape}")
+        dispatched_buffer = ttnn.to_layout(
+            ttnn.squeeze(ttnn.squeeze(dispatched_buffer, dim=0), dim=0), ttnn.TILE_LAYOUT
+        )
+        logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer.shape}")
 
-        expert_outputs = self.routed_expert(dispatched_buffer_tiled, tt_expert_token_counts)
+        expert_outputs = self.routed_expert(dispatched_buffer, tt_expert_token_counts)
+        ttnn.deallocate(dispatched_buffer)
         logger.debug(f"[TtMoe.forward] expert_outputs shape: {expert_outputs.shape}")
 
         # Add back the batch dimensions for combine

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -419,7 +419,7 @@ class TtMoe(LightweightModule):
             tt_expert_offsets,
             self.tt_expert_dispatch_table,
         )
-        ttnn.deallocate(x)
+        x = ttnn.deallocate(x)
         scores = ttnn.to_memory_config(scores, ttnn.DRAM_MEMORY_CONFIG)
         indices = ttnn.to_memory_config(indices, ttnn.DRAM_MEMORY_CONFIG)
         logger.debug(f"[TtMoe.forward] Dispatch output: buffer={dispatched_buffer.shape}, metadata={metadata.shape}")
@@ -438,7 +438,14 @@ class TtMoe(LightweightModule):
         logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer.shape}")
 
         expert_outputs = self.routed_expert(dispatched_buffer, tt_expert_token_counts)
-        ttnn.deallocate(dispatched_buffer)
+
+        if not return_intermediates:
+            dispatched_buffer = ttnn.deallocate(dispatched_buffer)
+        else:
+            # add squeezed dimenisions back for intermediates to match original dispatch output shape
+            dispatched_buffer = ttnn.unsqueeze(dispatched_buffer, dim=0)
+            dispatched_buffer = ttnn.unsqueeze(dispatched_buffer, dim=0)
+
         logger.debug(f"[TtMoe.forward] expert_outputs shape: {expert_outputs.shape}")
 
         # Add back the batch dimensions for combine

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_block.py
@@ -359,11 +359,9 @@ class TtPrefillBlock(LightweightModule):
     def _moe_path(self, ffn_norm_out: ttnn.Tensor) -> ttnn.Tensor:
         """MoE FFN path: 4D TILE → 3D ROW_MAJOR → MoE → 3D TILE → 4D TILE."""
         moe_input = ttnn.squeeze(ffn_norm_out, dim=0)
-        moe_input = ttnn.to_layout(moe_input, ttnn.ROW_MAJOR_LAYOUT)
 
         moe_out, _ = self.ffn(moe_input)
 
-        moe_out = ttnn.to_layout(moe_out, ttnn.TILE_LAYOUT)
         moe_out = ttnn.unsqueeze(moe_out, dim=0)
         return moe_out
 


### PR DESCRIPTION
### Summary

Enable 25K in-sequence length on Blackhole Galaxy by reshuffling some of the buffers/ops in prefill TtMoe
Also, enable looping capability on test_prefill_transformer.py.

Tested locally on Blackhole. Running regression testing via DeepSeek prefill pipelines below.

### DeepSeek Prefill Pipeline Status

  [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)           
                                                                                                                                                                                                                                                                                                              
  [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)                                       
                                                                                                                                                                                                                                                                                                              
  [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)
                                                                                                                                                                                                                                                                                                              
  [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)    

### Notes for reviewers

- Change tested locally on Blackhole
- Not yet integrated in CI
- Running regression testing via all 4 DeepSeek prefill pipelines above

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-prefill-25K-enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-prefill-25K-enabled)