### PR TITLE
Revert "Enable kernel cache for ttsim tests (#42707)"

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -378,7 +378,6 @@ jobs:
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ttsim.yaml
-    secrets: inherit
     with:
       basic-docker-image: ${{ needs.build.outputs.basic-dev-docker-image }}
       test-docker-image: ${{ needs.build.outputs.ci-test-docker-image }}

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -195,8 +195,7 @@ jobs:
   ttnn-pytests:
     needs: define-ttsim-ttnn-tests
     if: ${{ inputs.run-ttsim-integration-tests }}
-    runs-on: tt-ubuntu-2204-large-stable
-    environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
+    runs-on: ubuntu-latest
     env:
       TTSIM_SKIP_LIST_YAML: tests/pipeline_reorg/ttsim-skip-list.yaml
     timeout-minutes: ${{ matrix.test-group.timeout || inputs.job-timeout }}
@@ -241,10 +240,6 @@ jobs:
         with:
           path: .
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          # Kernel ccache uses separate Redis backend (REDIS_CCACHE_*) from build ccache (REDIS_*)
-          # This allows different retention policies for runtime JIT vs. C++ build artifacts
-          redis-ccache-storage: redis://${{ vars.REDIS_CCACHE_USER }}:${{ secrets.REDIS_CCACHE_PASSWORD }}@${{ vars.REDIS_CCACHE_HOST }}:${{ vars.REDIS_CCACHE_PORT }}|read-only=${{ vars.REDIS_CCACHE_IS_READONLY }}
-          enable-kernel-ccache: true
 
       - name: Apply ttsim WH workaround patches
         run: |
@@ -304,19 +299,11 @@ jobs:
           ${{ matrix.test-group.serial_cmd }} -p no:timeout --lf --lfnf=all --tb=long -v ${{ steps.skip-list.outputs.skip_args }} || true
           exit 1
 
-      - name: 📊 CCache Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "::group::CCache Statistics"
-          ccache --show-stats || echo "ccache stats not available"
-          echo "::endgroup::"
-
   ttsim-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}
-    runs-on: tt-ubuntu-2204-large-stable
+    runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.job-timeout }}
     name: "TTSim C++ tests - ${{ matrix.arch }}"
-    environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -352,10 +339,6 @@ jobs:
           path: .
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          enable-kernel-ccache: true
-          # Kernel ccache uses separate Redis backend (REDIS_CCACHE_*) from build ccache (REDIS_*)
-          # This allows different retention policies for runtime JIT vs. C++ build artifacts
-          redis-ccache-storage: redis://${{ vars.REDIS_CCACHE_USER }}:${{ secrets.REDIS_CCACHE_PASSWORD }}@${{ vars.REDIS_CCACHE_HOST }}:${{ vars.REDIS_CCACHE_PORT }}|read-only=${{ vars.REDIS_CCACHE_IS_READONLY }}
 
       - name: Compute ttsim asset name
         id: ttsim-asset
@@ -399,20 +382,11 @@ jobs:
             ./build/test/tt_metal/unit_tests_eth --gtest_filter="BlackholeSingleCardFixture.IdleEthKernelOnIdleErisc1"
             ./build/test/tt_metal/unit_tests_eth --gtest_filter="BlackholeSingleCardFixture.IdleEthKernelOnBothIdleEriscs"
           fi
-
-      - name: 📊 CCache Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "::group::CCache Statistics"
-          ccache --show-stats || echo "ccache stats not available"
-          echo "::endgroup::"
-
   ttsim-galaxy-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}
     runs-on: tt-ubuntu-2204-large-stable
     timeout-minutes: ${{ inputs.job-timeout }}
     name: "TTSim Galaxy C++ tests - ${{ matrix.arch }}"
-    environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -451,10 +425,6 @@ jobs:
           path: .
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          enable-kernel-ccache: true
-          # Kernel ccache uses separate Redis backend (REDIS_CCACHE_*) from build ccache (REDIS_*)
-          # This allows different retention policies for runtime JIT vs. C++ build artifacts
-          redis-ccache-storage: redis://${{ vars.REDIS_CCACHE_USER }}:${{ secrets.REDIS_CCACHE_PASSWORD }}@${{ vars.REDIS_CCACHE_HOST }}:${{ vars.REDIS_CCACHE_PORT }}|read-only=${{ vars.REDIS_CCACHE_IS_READONLY }}
 
       - name: Compute ttsim asset name
         id: ttsim-asset
@@ -480,10 +450,3 @@ jobs:
         run: |
           ./build/test/tt_metal/unit_tests_api --gtest_filter="*StreamRegWrite*"
           ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"
-
-      - name: 📊 CCache Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "::group::CCache Statistics"
-          ccache --show-stats || echo "ccache stats not available"
-          echo "::endgroup::"


### PR DESCRIPTION
This reverts commit f457ab255a9b1ce1ab090bcf84341fca358404f0.

### Summary
Revert because cpu runners queue times are bad

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dpopov-revert-ttsim-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dpopov-revert-ttsim-kernel-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dpopov-revert-ttsim-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dpopov-revert-ttsim-kernel-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dpopov-revert-ttsim-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dpopov-revert-ttsim-kernel-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dpopov-revert-ttsim-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dpopov-revert-ttsim-kernel-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dpopov-revert-ttsim-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dpopov-revert-ttsim-kernel-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dpopov-revert-ttsim-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dpopov-revert-ttsim-kernel-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dpopov-revert-ttsim-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dpopov-revert-ttsim-kernel-cache)