### PR TITLE
Fix chunked MLA paged padding reads

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
@@ -51,3 +51,23 @@ def test_flash_mla_prefill(
         use_paged_attention,
         block_size,
     )
+
+
+def test_chunked_flash_mla_prefill_partial_single_page_paged_cache(
+    device,
+    function_level_defaults,
+    reset_seeds,
+):
+    run_flash_mla_prefill_impl(
+        device,
+        batch=1,
+        seq_len=64,
+        nh=32,
+        nkv=1,
+        kv_lora_rank=64,
+        d_rope=64,
+        q_dtype=ttnn.bfloat16,
+        dtype=ttnn.bfloat8_b,
+        use_paged_attention=True,
+        block_size=64,
+    )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -250,6 +250,17 @@ void read_paged_chunk_with_padding(
         }
         physical_tile_id += skip_src_cols;  // Skip src cols if needed
     }
+
+    // Zero out the padding
+    for (uint32_t row = 0; row < dst_rows; ++row) {
+        for (uint32_t col = 0; col < dst_cols; ++col) {
+            if (row < src_rows && col < src_cols) {
+                continue;
+            }
+            uint32_t tile_id = transpose ? col * dst_rows + row : row * dst_cols + col;
+            fill_zeros_async(base_write_ptr + tile_id * tile_bytes, tile_bytes);
+        }
+    }
     noc_async_read_barrier();
     cb_push_back(cb_id, num_tiles);
 }


### PR DESCRIPTION
## Summary
- Zero-fill padded destination tiles in paged chunked SDPA reads before pushing the full K/V chunk CB, matching the non-paged chunk behavior.
- Add a focused chunked MLA prefill regression for a one-page paged cache with a partial K/V chunk.

## Issue
Fixes #42857

## Testing
- `pre-commit run --from-ref origin/main --to-ref HEAD`
- IRD `tt-smi -r` on `yyzc-wh-02`
- `TT_METAL_CACHE=/tmp/... pytest tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py::test_chunked_flash_mla_prefill_partial_single_page_paged_cache -q` (`1 passed`)
- `TT_METAL_CACHE=/tmp/... pytest tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py -q` (`5 passed`)
- Custom test dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/24792482532
- Nightly tt-metal L2 tests, SDPA category on Wormhole + Blackhole: https://github.com/tenstorrent/tt-metal/actions/runs/24797458472
- Galaxy DeepSeek Prefill tests, module scope: https://github.com/tenstorrent/tt-metal/actions/runs/24797458547

## CI Badges
[![Custom test dispatch (yieldthought/issue-fix/42857-chunked-mla-paged-padding-flow35)](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml/badge.svg?branch=yieldthought%2Fissue-fix%2F42857-chunked-mla-paged-padding-flow35)](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml?query=branch%3Ayieldthought%2Fissue-fix%2F42857-chunked-mla-paged-padding-flow35)
[![Nightly tt-metal L2 tests (yieldthought/issue-fix/42857-chunked-mla-paged-padding-flow35)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yieldthought%2Fissue-fix%2F42857-chunked-mla-paged-padding-flow35)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Ayieldthought%2Fissue-fix%2F42857-chunked-mla-paged-padding-flow35)
[![(Galaxy) DeepSeek Prefill tests (yieldthought/issue-fix/42857-chunked-mla-paged-padding-flow35)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=yieldthought%2Fissue-fix%2F42857-chunked-mla-paged-padding-flow35)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch%3Ayieldthought%2Fissue-fix%2F42857-chunked-mla-paged-padding-flow35)
