### PR TITLE
Overlap CB reconfigs with CCL syncs/waits

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -1731,8 +1731,9 @@ void kernel_main() {
         if constexpr (Core::is_allreduce_sender_core) {
             DeviceZoneScopedN("CCL_SENDER_WRITER");
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+            PacketHeaderPool::reset();
             deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> ccl_writer;
-            ccl_writer.open_connections(ccl_sender_args);
+            ccl_writer.open_connections(ccl_sender_args, false);
             deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
             volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                 get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -692,6 +692,7 @@ void kernel_main() {
         allgather_gather_args.recv_sem_addr = get_named_compile_time_arg_val("allgather_recv_sem_addr");
         allgather_gather_args.r2_src_slot_index = get_named_compile_time_arg_val("allgather_r2_src_slot_index");
     }
+    using AllGatherController = deepseek_b1_ops::AllGather::GatherController<AllGatherGatherCT>;
 
 // ============================================================================
 // BRISC (Writer + Mcast Sender) - WriterConfigDescriptor compiles as BRISC
@@ -2186,6 +2187,7 @@ void kernel_main() {
     uint32_t cur_metadata_addr = get_common_arg_val<uint32_t>(8);
 #endif
 
+    deepseek_b1_ops::AllGather::GatherCompletionState all_gather_completion_state{};
     // ====================================================================
     // Mcast: Initialize persistent mcast
     // ====================================================================
@@ -2646,19 +2648,11 @@ void kernel_main() {
                 constexpr uint32_t out_num_tiles = get_named_compile_time_arg_val("output_num_tiles");
                 cb_wait_front(out_cb, out_num_tiles);
                 allgather_gather_args.local_input_addr = get_read_ptr(out_cb);
-
-                deepseek_b1_ops::AllGather::GatherController<AllGatherGatherCT> allgather_controller;
-                allgather_controller(allgather_gather_args);
-                cb_pop_front(out_cb, out_num_tiles);
+                all_gather_completion_state = AllGatherController::start(allgather_gather_args);
             }
 #elif defined(COMPILE_FOR_TRISC)
             deepseek_b1_ops::AllReduce::Compute<AllReduceComputeCTArgs> ccl_compute;
             ccl_compute(ccl_compute_args);
-#elif defined(COMPILE_FOR_BRISC)
-            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
-            noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("num_ccl_sender_cores"));
-            noc_semaphore_set(ccl_sync_sem, 0);
 #endif
         }
     };
@@ -2998,7 +2992,11 @@ void kernel_main() {
     constexpr uint32_t persistent_next_iter_sem_addr = get_named_compile_time_arg_val("persistent_next_iter_sem_addr");
     uint32_t iteration = 0;
     while (true) {
-        // DPRINT << "ITERATION: " << iteration << ENDL();
+        {
+            DeviceZoneScopedN("MLA_CB_RECONFIG");
+            unified_kernels::reconfig_cb_interfaces(mla_cb_config);
+            setup_mla_sharded_buffers();
+        }
 #if defined(COMPILE_FOR_BRISC)
         if constexpr (persistent_mode) {
             constexpr bool is_bcast_root = get_named_compile_time_arg_val("bcast_is_root") == 1;
@@ -3010,17 +3008,24 @@ void kernel_main() {
         }
 #endif
         {
-            DeviceZoneScopedN("MLA_CB_RECONFIG");
-            unified_kernels::reconfig_cb_interfaces(mla_cb_config);
-            setup_mla_sharded_buffers();
-        }
-        {
             DeviceZoneScopedN("MLA");
             mla_body();
         }
         {
             DeviceZoneScopedN("MOE_CB_RECONFIG");
             unified_kernels::reconfig_cb_interfaces(moe_cb_config);
+            // NCRISC is what pushes the input into MOE, and is the receiver of the All-Gather.
+            // BRISC waits for previous fabric connections to finish, and is the mcaster broadcasting the sync signal.
+            if constexpr (Core::is_allreduce_receiver_core) {
+#if defined(COMPILE_FOR_NCRISC)
+                AllGatherController::wait_for_completion(all_gather_completion_state);
+#elif defined(COMPILE_FOR_BRISC)
+                volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
+                noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("num_ccl_sender_cores"));
+                noc_semaphore_set(ccl_sync_sem, 0);
+#endif
+            }
             setup_moe_sharded_buffers();
         }
         {

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -2576,8 +2576,9 @@ void kernel_main() {
         if constexpr (Core::is_allreduce_sender_core) {
             DeviceZoneScopedN("CCL_SENDER_WRITER");
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+            PacketHeaderPool::reset();
             deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> ccl_writer;
-            ccl_writer.open_connections(ccl_sender_args);
+            ccl_writer.open_connections(ccl_sender_args, false);
             deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
             volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                 get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
@@ -294,27 +294,47 @@ private:
 // Gather controller (NCRISC on gather core)
 // ============================================================================
 
+// Plain-data handoff between the active phase and the drain phase of
+// GatherController. Callers can store this at any scope; the controller
+// itself does not need to live across the split.
+struct GatherCompletionState {
+#if defined(COMPILE_FOR_NCRISC)
+    volatile tt_l1_ptr uint32_t* recv_sem_ptr;
+    uint32_t done_mask;
+#endif
+};
+
 template <typename CTArgs>
 class GatherController {
 public:
-    void operator()(const GatherArgs& args) { impl(args); }
+    // Full synchronous execution (identical to the previous behavior).
+    void operator()(const GatherArgs& args) {
+        GatherCompletionState st = start<false>(args);
+        wait_for_completion<true>(st);
+    }
 
-private:
-    void impl([[maybe_unused]] const GatherArgs& args) {
+    // Active phase: cross-core write to scratch[0], R1 kickoff, self-copy,
+    // R1->R2 bridge (wait on r2_src slot, copy to scratch[1], signal bit 2).
+    // On return the self-copy and scratch[1] writes are still in flight, and
+    // remote peers may still be posting into the output buffer. You must
+    // eventually pass the returned state to wait_for_completion().
+    template <bool barrier = true>
+    static GatherCompletionState start([[maybe_unused]] const GatherArgs& args) {
+        GatherCompletionState st{};
 #if defined(COMPILE_FOR_NCRISC)
         const uint64_t handoff_sem_noc =
             safe_get_noc_addr(args.transport_noc_x, args.transport_noc_y, args.handoff_sem_bank_addr, 0);
         const uint64_t scratch_base_noc =
             safe_get_noc_addr(args.transport_noc_x, args.transport_noc_y, args.transport_scratch_base_addr, 0);
 
-        volatile tt_l1_ptr uint32_t* recv_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_addr);
+        st.recv_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_addr);
 
         const uint32_t self_slot_offset = args.self_slot_index * CTArgs::slice_size_bytes;
         const uint32_t r2_src_slot_offset = args.r2_src_slot_index * CTArgs::slice_size_bytes;
 
         // Track which slots have been handled so the final wait is generic.
-        uint32_t done_mask = 0;
-        done_mask |= (1u << args.self_slot_index);
+        st.done_mask = 0;
+        st.done_mask |= (1u << args.self_slot_index);
 
         // Cross-core write to transport scratch[0] FIRST to unblock R1 ASAP.
         noc_async_write(args.local_input_addr, scratch_base_noc, CTArgs::slice_size_bytes);
@@ -327,8 +347,8 @@ private:
             args.local_input_addr, get_noc_addr(args.output_buffer_addr + self_slot_offset), CTArgs::slice_size_bytes);
 
         // R1→R2 bridge: wait for the slot that must be forwarded.
-        wait_for_slot<CTArgs::num_chunks, CTArgs::recv_sem_bits_per_slot>(recv_sem_ptr, args.r2_src_slot_index);
-        done_mask |= (1u << args.r2_src_slot_index);
+        wait_for_slot<CTArgs::num_chunks, CTArgs::recv_sem_bits_per_slot>(st.recv_sem_ptr, args.r2_src_slot_index);
+        st.done_mask |= (1u << args.r2_src_slot_index);
 
         // Copy received slot to transport scratch[1].
         const uint64_t scratch_r2_noc = scratch_base_noc + CTArgs::slice_size_bytes;
@@ -336,15 +356,28 @@ private:
         noc_async_writes_flushed();
         // Signal bit 2: scratch[1] ready (unblocks R2 on the active RISC)
         noc_semaphore_inc(handoff_sem_noc, 1 << 1);
+        if constexpr (barrier) {
+            noc_async_full_barrier();
+        }
+#endif
+        return st;
+    }
 
+    // Drain: wait for every remaining ring slot, reset recv_sem, fence all
+    // outstanding local NOC ops.
+    template <bool barrier = false>
+    static void wait_for_completion([[maybe_unused]] const GatherCompletionState& st) {
+#if defined(COMPILE_FOR_NCRISC)
         // Wait for all remaining slots (topology-agnostic).
         for (uint32_t slot = 0; slot < CTArgs::ring_size; slot++) {
-            if (!(done_mask & (1u << slot))) {
-                wait_for_slot<CTArgs::num_chunks, CTArgs::recv_sem_bits_per_slot>(recv_sem_ptr, slot);
+            if (!(st.done_mask & (1u << slot))) {
+                wait_for_slot<CTArgs::num_chunks, CTArgs::recv_sem_bits_per_slot>(st.recv_sem_ptr, slot);
             }
         }
-        noc_semaphore_set(recv_sem_ptr, 0);
-        noc_async_full_barrier();
+        noc_semaphore_set(st.recv_sem_ptr, 0);
+        if constexpr (barrier) {
+            noc_async_full_barrier();
+        }
 #endif
     }
 };

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
@@ -315,9 +315,8 @@ public:
 
     // Active phase: cross-core write to scratch[0], R1 kickoff, self-copy,
     // R1->R2 bridge (wait on r2_src slot, copy to scratch[1], signal bit 2).
-    // On return the self-copy and scratch[1] writes are still in flight, and
-    // remote peers may still be posting into the output buffer. You must
-    // eventually pass the returned state to wait_for_completion().
+    // On return the remote peers may still be posting into the output buffer.
+    // You must eventually pass the returned state to wait_for_completion().
     template <bool barrier = true>
     static GatherCompletionState start([[maybe_unused]] const GatherArgs& args) {
         GatherCompletionState st{};
@@ -363,8 +362,7 @@ public:
         return st;
     }
 
-    // Drain: wait for every remaining ring slot, reset recv_sem, fence all
-    // outstanding local NOC ops.
+    // Drain: wait for every remaining ring slot, reset recv_sem
     template <bool barrier = false>
     static void wait_for_completion([[maybe_unused]] const GatherCompletionState& st) {
 #if defined(COMPILE_FOR_NCRISC)


### PR DESCRIPTION
### Summary
We were serializing CB reconfigs with waiting to receive data (AG) as well as the sync semaphores for controlling when fabric connections are finished.
Clean up the wait before moe for semaphore and data, which improves decoder perf, and the wait for semaphore before mla, which improves back to back token perf.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/connections3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/connections3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/connections3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/connections3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/connections3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/connections3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/connections3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/connections3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/connections3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/connections3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/connections3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/connections3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/connections3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/connections3)