### PR TITLE
Bugfix: topology mapper failure from teardown

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -282,7 +282,10 @@ void MetalContext::initialize(
 
     init_risc_fw_context_descriptor(num_hw_cqs_, worker_l1_size_);
     risc_firmware_initializer_ = std::make_unique<RiscFirmwareInitializer>(
-        risc_fw_context_descriptor_, std::bind(&MetalContext::get_control_plane, this), *dispatch_core_manager_);
+        risc_fw_context_descriptor_,
+        std::bind(&MetalContext::get_control_plane, this),
+        std::bind(&MetalContext::is_control_plane_initialized, this),
+        *dispatch_core_manager_);
 
     risc_firmware_initializer_->run_async_build_phase(device_ids);
 
@@ -558,6 +561,13 @@ const DispatchMemMap& MetalContext::dispatch_mem_map(const CoreType& core_type) 
 tt::tt_fabric::ControlPlane& MetalContext::get_control_plane() {
     TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
     return MetalEnvAccessor(*env_).impl().get_control_plane();
+}
+
+bool MetalContext::is_control_plane_initialized() const {
+    if (env_ == nullptr) {
+        return false;
+    }
+    return MetalEnvAccessor(*env_).impl().is_control_plane_initialized();
 }
 
 void MetalContext::initialize_control_plane() {

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -133,6 +133,7 @@ public:
     // Delegates to MetalEnv assigned to this context
     void initialize_control_plane();
     tt::tt_fabric::ControlPlane& get_control_plane();
+    bool is_control_plane_initialized() const;
     distributed::SystemMesh& get_system_mesh();
 
     const distributed::multihost::DistributedContext& global_distributed_context();

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -322,6 +322,11 @@ void MetalEnvImpl::initialize_control_plane() {
     initialize_control_plane_impl();
 }
 
+bool MetalEnvImpl::is_control_plane_initialized() const noexcept {
+    std::lock_guard<std::mutex> lock(control_plane_mutex_);
+    return control_plane_ != nullptr;
+}
+
 void MetalEnvImpl::initialize_control_plane_impl() {
     if (custom_mesh_graph_desc_path_.has_value()) {
         log_debug(tt::LogDistributed, "Using custom mesh graph descriptor: {}", custom_mesh_graph_desc_path_.value());

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -266,7 +266,13 @@ void MetalEnvImpl::teardown_fabric_config() {
     this->fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     this->get_cluster().configure_ethernet_cores_for_fabric_routers(this->fabric_config_);
     this->num_fabric_active_routing_planes_ = 0;
-    this->get_control_plane().clear_fabric_context();
+
+    // getter will lazily create a control plane if one doesn't exist,
+    // which leads to topology mapper failures on t3k
+    std::lock_guard lock{control_plane_mutex_};
+    if (control_plane_) {
+        control_plane_->clear_fabric_context();
+    }
 }
 
 void MetalEnvImpl::initialize_fabric_config() {

--- a/tt_metal/impl/context/metal_env_impl.hpp
+++ b/tt_metal/impl/context/metal_env_impl.hpp
@@ -72,6 +72,9 @@ public:
     // --- Control plane ---
     tt::tt_fabric::ControlPlane& get_control_plane();
     void initialize_control_plane();
+    // Non-lazy check: returns true if control plane is currently constructed (not reset).
+    // Safe to call without triggering lazy initialization.
+    bool is_control_plane_initialized() const noexcept;
 
     // --- Custom topology ---
     // Need to call set_fabric_config to reinit the control plane after calling this
@@ -121,7 +124,7 @@ private:
     bool force_reinit_ = false;
 
     // --- Control plane / system mesh ---
-    std::mutex control_plane_mutex_;
+    mutable std::mutex control_plane_mutex_;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
     std::unique_ptr<distributed::SystemMesh> system_mesh_;
 

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -435,10 +435,18 @@ void RiscFirmwareInitializer::reset_cores(tt::ChipId device_id) {
 
 void RiscFirmwareInitializer::assert_cores(tt::ChipId device_id) {
     assert_tensix_workers_impl(device_id);
-    if (!hal_.get_eth_fw_is_cooperative()) {
-        assert_active_ethernet_cores_to_reset(device_id);
+    // assert_active_ethernet_cores_to_reset and assert_inactive_ethernet_cores both
+    // call get_control_plane_(), which may lazily re-initialize the control plane with
+    // stale routing tables if it was externally reset (e.g. by set_default_fabric_topology
+    // in a test fixture TearDown). Guard with is_control_plane_initialized_ to skip these
+    // calls when the control plane is no longer valid.
+    const bool cp_valid = is_control_plane_initialized_ && is_control_plane_initialized_();
+    if (cp_valid) {
+        if (!hal_.get_eth_fw_is_cooperative()) {
+            assert_active_ethernet_cores_to_reset(device_id);
+        }
+        assert_inactive_ethernet_cores(device_id);
     }
-    assert_inactive_ethernet_cores(device_id);
     assert_dram_cores(device_id);
 }
 

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -42,9 +42,11 @@ namespace tt::tt_metal {
 RiscFirmwareInitializer::RiscFirmwareInitializer(
     std::shared_ptr<const ContextDescriptor> descriptor,
     const GetControlPlaneFn& get_control_plane,
+    const IsControlPlaneInitializedFn& is_control_plane_initialized,
     dispatch_core_manager& dispatch_core_manager) :
     FirmwareInitializer(std::move(descriptor)),
     get_control_plane_(get_control_plane),
+    is_control_plane_initialized_(is_control_plane_initialized),
     dispatch_core_manager_(dispatch_core_manager),
     num_hw_cqs_(static_cast<uint8_t>(descriptor_->num_cqs())) {
     const Hal& hal = descriptor_->hal();
@@ -193,7 +195,14 @@ void RiscFirmwareInitializer::teardown_simulator_ethernet_cores() {
 void RiscFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& /*init_done*/) {
     auto all_devices = cluster_.all_chip_ids();
 
-    teardown_simulator_ethernet_cores();
+    // Guard all control plane accesses: the control plane may have been externally
+    // reset (e.g. by set_default_fabric_topology in fixture TearDown) before this
+    // atexit-path teardown runs. Calling get_control_plane_() with a null control
+    // plane triggers lazy re-initialization with stale routing data → crash.
+    const bool cp_valid = is_control_plane_initialized_ && is_control_plane_initialized_();
+    if (cp_valid) {
+        teardown_simulator_ethernet_cores();
+    }
 
     if (!cluster_.is_mock_or_emulated()) {
         for (tt::ChipId device_id : all_devices) {
@@ -202,7 +211,7 @@ void RiscFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& /*ini
         }
         // Set internal routing to false to exit active ethernet FW & go back to base FW
         // Must be last
-        if (get_control_plane_) {
+        if (get_control_plane_ && cp_valid) {
             cluster_.set_internal_routing_info_for_ethernet_cores(this->get_control_plane_(), false);
         }
     }

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.hpp
@@ -29,10 +29,16 @@ public:
 
     ~RiscFirmwareInitializer() override;
 
+    // Predicate that returns true only when the ControlPlane is currently constructed.
+    // Used to guard get_control_plane calls during teardown when the control plane
+    // may have been externally reset (e.g. by set_default_fabric_topology).
+    using IsControlPlaneInitializedFn = std::function<bool()>;
+
     // ControlPlane may change from init to teardown. use a getter function to always get the latest ControlPlane.
     RiscFirmwareInitializer(
         std::shared_ptr<const ContextDescriptor> descriptor,
         const GetControlPlaneFn& get_control_plane,
+        const IsControlPlaneInitializedFn& is_control_plane_initialized,
         dispatch_core_manager& dispatch_core_manager);
 
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
@@ -94,6 +100,7 @@ private:
     void teardown_simulator_ethernet_cores();
 
     GetControlPlaneFn get_control_plane_;
+    IsControlPlaneInitializedFn is_control_plane_initialized_;
     dispatch_core_manager& dispatch_core_manager_;
     uint8_t num_hw_cqs_;
     size_t worker_l1_unreserved_start_;


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Problem: control plane getting naively cleared ends up lazily creating one during teardown, which leads to topology mapper failures.

Fix: Guard with a lock and only clear if the control plane actually exists.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

- [x] T3k Fast Tests https://github.com/tenstorrent/tt-metal/actions/runs/24809402866/job/72611672360
- [x] T3k ttmetal_tests https://github.com/tenstorrent/tt-metal/actions/runs/24799983055

---

## Changes in this branch

Three fixes preventing atexit teardown crashes when tests use `set_default_fabric_topology()` in their fixtures.

### Root cause

`T3kCustomMeshGraphFabric2DFixture::TearDown()` calls `set_default_fabric_topology()`, which resets `control_plane_` to `nullptr`. When the atexit handler fires afterward, `MetalContext::teardown()` → `RiscFirmwareInitializer::teardown()` blindly calls `get_control_plane_()`, which lazily re-initializes the control plane with stale routing tables, causing `std::out_of_range` in `unordered_map::at`.

### Fixes

**1. Bugfix: dont make fabric when tearing down fabric** (`819a42e7ee`)
- `metal_env.cpp`: skip fabric re-initialization if teardown is already in progress.

**2. Guard `RiscFirmwareInitializer::teardown()` against null control plane** (`8e29e66411`)
- Added `IsControlPlaneInitializedFn` predicate (non-lazy null check) to `RiscFirmwareInitializer`.
- Guards `teardown_simulator_ethernet_cores()` and `set_internal_routing_info_for_ethernet_cores()` — skips control-plane-dependent work when it has been externally reset before atexit runs.
- Fixes: https://github.com/tenstorrent/tt-metal/actions/runs/24799957249/job/72585010884

**3. Guard `assert_cores()` ethernet calls against null control plane** (`45ea4f10b3`)
- The previous fix missed that `assert_cores()` also calls `assert_active_ethernet_cores_to_reset()` and `assert_inactive_ethernet_cores()`, both of which invoke `get_control_plane_()` unconditionally.
- Added `is_control_plane_initialized_()` check in `assert_cores()` before either ethernet-assert helper. Tensix and DRAM asserts are unaffected.
- Fixes: https://github.com/tenstorrent/tt-metal/actions/runs/24806068213/job/72601818286

### Files changed

| File | Change |
|------|--------|
| `tt_metal/impl/context/metal_env.cpp` | Skip fabric init during teardown; skip CP-dependent work when CP is null |
| `tt_metal/impl/context/metal_context.cpp` | Wire up `IsControlPlaneInitializedFn` |
| `tt_metal/impl/context/metal_context.hpp` | Declare predicate |
| `tt_metal/impl/context/metal_env_impl.hpp` | Expose `is_control_plane_initialized()` |
| `tt_metal/impl/device/firmware/risc_firmware_initializer.cpp` | Guard teardown and assert_cores paths |
| `tt_metal/impl/device/firmware/risc_firmware_initializer.hpp` | Add `IsControlPlaneInitializedFn` member |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-fix-fabric-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-fix-fabric-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-fix-fabric-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-fix-fabric-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-fix-fabric-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-fix-fabric-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/0-fix-fabric-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/0-fix-fabric-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-fix-fabric-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-fix-fabric-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-fix-fabric-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-fix-fabric-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-fix-fabric-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-fix-fabric-teardown)