### PR TITLE
#42913: add manual_seed to tests missing it

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -50,6 +50,7 @@ def test_group_norm_DRAM_rejects_non_uniform_mcast_groups(device):
     """Regression test for GH#40912: N=2 with grid (8,5) creates num_virtual_rows=5
     which is not divisible by num_batches=2, producing non-uniform mcast groups
     that deadlock due to exact-equality semaphore waits in the sender kernel."""
+    torch.manual_seed(0)
     N, C, H, W = 2, 768, 12, 12
     num_groups = 32
     bad_grid = ttnn.CoreGrid(y=5, x=8)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -224,6 +224,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
     ],
 )
 def test_layernorm_mix_precision(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device):
+    torch.manual_seed(0)
     run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_bert_matmuls.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_bert_matmuls.py
@@ -98,6 +98,7 @@ def test_bert_linear_batch7(
     activation,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
     bias_shape = [1, 1, N]
@@ -397,6 +398,7 @@ def test_bert_linear_batch4(
     fp32_acc_mode,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     for i in range(1):
         logger.info(i)
         if not not_fit_l1(M, K, N, fp32_acc_mode):
@@ -468,6 +470,7 @@ def test_bert_linear_batch4_fp32_input_output(
     activation,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
     bias_shape = [1, 1, N]

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
@@ -238,7 +238,7 @@ def test_matmul_no_mcast_fp32_acc_l1(
     function_level_defaults,
     num_loops,
 ):
-    torch.manual_seed(0)
+    torch.manual_seed(213919)
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
@@ -32,6 +32,7 @@ def test_matmul_1d_in0_batched(
     function_level_defaults,
     num_loops,
 ):
+    torch.manual_seed(0)
     grid_size = (12, 8)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
@@ -130,6 +131,7 @@ def test_linear_fp32_acc_l1(
     function_level_defaults,
     num_loops,
 ):
+    torch.manual_seed(0)
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
@@ -236,6 +238,7 @@ def test_matmul_no_mcast_fp32_acc_l1(
     function_level_defaults,
     num_loops,
 ):
+    torch.manual_seed(0)
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
@@ -345,6 +348,7 @@ def test_matmul_1d_fp32_input_output(
     function_level_defaults,
     num_loops,
 ):
+    torch.manual_seed(0)
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
@@ -459,6 +463,7 @@ def test_matmul_no_mcast_fp32_input_output(
     function_level_defaults,
     num_loops,
 ):
+    torch.manual_seed(0)
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
@@ -573,6 +578,7 @@ def test_matmul_no_untilize_output_param(
     function_level_defaults,
     num_loops,
 ):
+    torch.manual_seed(0)
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
@@ -668,6 +674,7 @@ def test_sharded_matmul_2d(
     weights_dtype,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
     bias_shape = [1, 1, 1, N]
@@ -750,6 +757,7 @@ def test_sharded_matmul_2d_in0_height_sharded_in1_width_sharded(
     output_dtype,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     M = 6 * 32
     N = 12 * 32
     K = 2 * 32
@@ -846,6 +854,7 @@ def test_sharded_matmul_2d_transposed(
     weights_dtype,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     K = 256
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
@@ -912,6 +921,7 @@ def test_sharded_matmul_2d_transposed(
 
 
 def test_resharded_binary_to_matmul(device, function_level_defaults):
+    torch.manual_seed(0)
     grid_size_binary = device.compute_with_storage_grid_size()
     num_cores_binary = 98
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -1018,6 +1028,7 @@ def test_sharded_matmul_1d_in0(
     weights_dtype,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
@@ -1087,6 +1098,7 @@ def test_sharded_matmul_1d_in0(
 
 # Have at least one example of 1d matmul with in1 mcasted that runs on WH
 def test_sharded_matmul_1d_in1_wormhole(device, function_level_defaults):
+    torch.manual_seed(0)
     M = 4096
     K = 64
     N = 256
@@ -1179,6 +1191,7 @@ def test_sharded_matmul_no_mcast(
     activations_dtype,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     grid_size = (12, 8)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_1d_2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_1d_2d.py
@@ -81,6 +81,7 @@ def test_llama2_matmul(
     grid_size,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
     bias_shape = [1, 1, N]
@@ -395,6 +396,7 @@ def test_multi_core_matmul_2d_wh(
     activation,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
     bias_shape = [1, 1, N]
@@ -706,6 +708,7 @@ def test_multi_core_matmul_1d_wh(
     activation,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
     bias_shape = [1, 1, N]

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_1d_gather_in0.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_1d_gather_in0.py
@@ -448,6 +448,7 @@ def test_multi_core_matmul_1d_in1_dram_wh(
     num_iters,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     run_multi_core_matmul_1d(
         device,
         in0_dtype,
@@ -521,6 +522,7 @@ def test_multi_core_matmul_1d_pad_wh(
     num_iters,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     run_multi_core_matmul_1d(
         device,
         in0_dtype,
@@ -616,6 +618,7 @@ def test_multi_core_matmul_1d_wh(
     num_iters,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     run_multi_core_matmul_1d(
         device,
         in0_dtype,
@@ -691,6 +694,7 @@ def test_multi_core_matmul_1d_ring_hop_wh(
     num_iters,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     run_multi_core_matmul_1d(
         device,
         in0_dtype,
@@ -771,6 +775,7 @@ def test_multi_core_matmul_1d_gs(
     num_iters,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     run_multi_core_matmul_1d(
         device,
         in0_dtype,
@@ -923,6 +928,7 @@ def test_matmul_1d_ring_llama_perf(
     num_iters,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     # Only run these tests on unharvested TG
     device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
     if device_grid != (7, 10):
@@ -1091,6 +1097,7 @@ def test_matmul_1d_ring_qwen_perf(
     num_iters,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     # Only run these tests on unharvested TG
     device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
     if device_grid != (7, 10):
@@ -1179,6 +1186,7 @@ def test_matmul_1d_ring_llama_lm_head(
     num_iters,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     # Only run these tests on unharvested TG
     device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
     if device_grid != (7, 10):

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
@@ -247,6 +247,7 @@ def test_matmul_in1_dram_sharded_with_program_cache(
     out_dtype,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     for _ in range(2):
         run_test_matmul_in1_dram_sharded(
             device,
@@ -417,6 +418,7 @@ def test_matmul_in1_dram_sharded_with_mm_chain(
     out_dtype,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     M = 32
     K = 4096
     N = 4096
@@ -477,6 +479,7 @@ def test_matmul_2d_in1_dram_sharded(
     fuse_batch,
     function_level_defaults,
 ):
+    torch.manual_seed(0)
     if is_blackhole():
         num_banks = device.dram_grid_size().x  # need to match harvesting of dram
     else:

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_rs_matmul_1d_gather_in0.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_rs_matmul_1d_gather_in0.py
@@ -666,6 +666,7 @@ def test_tg_matmul_1d_ring_llama_with_rs_perf(
     output_grid,
     dtype,
 ):
+    torch.manual_seed(0)
     # Only run these tests on unharvested TG
     device_grid = (mesh_device.compute_with_storage_grid_size().x, mesh_device.compute_with_storage_grid_size().y)
     if device_grid != (7, 10):
@@ -785,6 +786,7 @@ def test_6U_matmul_1d_ring_llama_with_rs_perf(
     output_grid,
     dtype,
 ):
+    torch.manual_seed(0)
     # Only run these tests on unharvested TG
     device_grid = (mesh_device.compute_with_storage_grid_size().x, mesh_device.compute_with_storage_grid_size().y)
     if device_grid != (7, 10):

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_tilize_hpadding_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_tilize_hpadding_matmul.py
@@ -59,4 +59,5 @@ def run_tilize_matmul_test(M, K, N, device):
 
 @skip_for_blackhole("Hanging on BH, see #12349")
 def test_tilize_hpadding_matmul(device):
+    torch.manual_seed(0)
     run_tilize_matmul_test(4, 32 * 9, 32, device)

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_tilize_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_tilize_matmul.py
@@ -48,4 +48,5 @@ def run_tilize_matmul_test(M, K, N, device):
 
 @skip_for_blackhole("Hanging on BH, see #12349")
 def test_run_tilize_matmul_test(device):
+    torch.manual_seed(0)
     run_tilize_matmul_test(32, 32, 32, device)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
@@ -14,6 +14,7 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 @pytest.mark.parametrize("out_sharded", [True], ids=["out_sharded"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_level_defaults):
+    torch.manual_seed(0)
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -317,6 +317,7 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("op", ["mean", "sum", "max", "min", "std", "var"])
 def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op):
+    torch.manual_seed(0)
     dim = -2
     input_shape, shard_shape, end_x, end_y = shapes
 
@@ -404,6 +405,7 @@ def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op):
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("op", ["mean", "sum", "max", "min", "std", "var"])
 def test_generic_ops_wh_shard(device, input_shape, shard_2d_shape, end_x, end_y, memory_layout, keepdim, layout, op):
+    torch.manual_seed(0)
     dim = -2
 
     shard_spec = ttnn.ShardSpec(

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_fusion_cache.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_fusion_cache.py
@@ -1034,6 +1034,7 @@ class TestProgramKeyCacheIntegration:
 
     def test_inline_cache_hit(self, device):
         """Second inline call with same config objects hits the program key cache."""
+        torch.manual_seed(0)
         clear_build_cache()
         q_cores = cores(0, 0, 3, 3)
         q_shard_w = 96

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
@@ -73,6 +73,7 @@ def test_layer_norm_sharded_two_stage(
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_sharded_with_residual(device, use_welford, two_stage, tensor_type, dtype):
+    torch.manual_seed(0)
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     residual = generate_input_tensor(h, w, "random_normal", dtype)
@@ -100,6 +101,7 @@ def test_layer_norm_sharded_with_residual(device, use_welford, two_stage, tensor
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_sharded_with_weight_and_bias(device, use_welford, two_stage, tensor_type, dtype):
+    torch.manual_seed(0)
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     weight = generate_input_tensor(1, w, "random", dtype)
@@ -128,6 +130,7 @@ def test_layer_norm_sharded_with_weight_and_bias(device, use_welford, two_stage,
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_sharded_with_weight_and_bias_row_major(device, use_welford, two_stage, tensor_type, dtype):
+    torch.manual_seed(0)
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = 64, 32, 2, 1, 1, 1, 1
 
     weight = generate_input_tensor(1, w, "random", dtype)
@@ -157,6 +160,7 @@ def test_layer_norm_sharded_with_weight_and_bias_row_major(device, use_welford, 
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_sharded_with_weight_and_bias_and_residual(device, use_welford, two_stage, tensor_type, dtype):
+    torch.manual_seed(0)
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     residual = generate_input_tensor(h, w, "random_normal", dtype)
@@ -332,6 +336,7 @@ def test_layer_norm_sharded_width_default_config(device, h, w, dtype):
 @pytest.mark.parametrize("use_weight_bias", [True, False])
 def test_layer_norm_sharded_2d_with_grid_offset(device, grid_offset, use_welford, use_weight_bias):
     """Test 2D reduce block-sharded layernorm with a non-zero grid origin."""
+    torch.manual_seed(0)
 
     h, w = 64, 64  # 2x2 tiles
     num_cores_h, num_cores_w = 2, 2

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm_sharded.py
@@ -71,6 +71,7 @@ def test_rms_norm_sharded_two_stage(
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_rms_norm_sharded_with_residual(device, two_stage, tensor_type, dtype):
+    torch.manual_seed(0)
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     residual = generate_input_tensor(h, w, "random_normal", dtype)
@@ -99,6 +100,7 @@ def test_rms_norm_sharded_with_bias_only(device, two_stage, tensor_type, dtype):
     Sharded rms_norm with bias only (no weight). Exercises do_beta=1, do_gamma=0 in layernorm_sharded.
     Fails with the old cb_im formula; passes with the fixed formula.
     """
+    torch.manual_seed(0)
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     bias = generate_input_tensor(1, w, "random", dtype)
@@ -124,6 +126,7 @@ def test_rms_norm_sharded_with_bias_only(device, two_stage, tensor_type, dtype):
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_rms_norm_sharded_with_weight_and_bias(device, two_stage, tensor_type, dtype):
+    torch.manual_seed(0)
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     weight = generate_input_tensor(1, w, "random", dtype)
@@ -148,6 +151,7 @@ def test_rms_norm_sharded_with_weight_and_bias(device, two_stage, tensor_type, d
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_rms_norm_sharded_with_weight_and_bias_row_major(device, two_stage, tensor_type, dtype):
+    torch.manual_seed(0)
     if is_watcher_enabled() and two_stage is False:
         pytest.skip("Skipping test with watcher enabled, see github issue #37259")
 
@@ -176,6 +180,7 @@ def test_rms_norm_sharded_with_weight_and_bias_row_major(device, two_stage, tens
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_rms_norm_sharded_with_weight_and_bias_and_residual(device, two_stage, tensor_type, dtype):
+    torch.manual_seed(0)
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     residual = generate_input_tensor(h, w, "random_normal", dtype)

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -493,6 +493,7 @@ def test_large_fill_softmax(device, input_shape, dtype, dlayout, dim, numeric_st
 
 
 def test_softmax_sd(device):
+    torch.manual_seed(0)
     shape = (1, 16, 256, 256)
 
     input = torch.randn(shape, dtype=torch.bfloat16).float() * 10

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax_program_cache.py
@@ -184,6 +184,7 @@ def test_softmax_cache_miss_different_dims_5d(device, isolate_program_cache):
 
 def test_softmax_cache_miss_different_factories(device, isolate_program_cache):
     """5D W-softmax vs 4D last-dim softmax -> different factories -> different cache entries."""
+    torch.manual_seed(0)
     shape_5d = [1, 1, 1, 32, 64]
     shape_4d = [1, 1, 32, 64]
 
@@ -218,6 +219,7 @@ def test_softmax_cache_miss_different_factories(device, isolate_program_cache):
 
 def test_softmax_cache_miss_different_input_dtypes(device, isolate_program_cache):
     """Different input dtypes -> different cache entries."""
+    torch.manual_seed(0)
     shape = [1, 1, 32, 64]
 
     torch_ref1, tt_out1 = run_softmax_4d(device, shape, dim=-1, dtype=ttnn.bfloat16)
@@ -247,6 +249,7 @@ def test_softmax_cache_miss_different_input_dtypes(device, isolate_program_cache
 
 def test_softmax_cache_miss_different_memory_configs(device, isolate_program_cache):
     """Different memory configs -> different cache entries."""
+    torch.manual_seed(0)
     shape = [1, 1, 32, 64]
 
     torch_ref1, tt_out1 = run_softmax_4d(
@@ -279,6 +282,7 @@ def test_softmax_cache_miss_different_memory_configs(device, isolate_program_cac
 def test_softmax_cache_miss_different_shapes(device, isolate_program_cache):
     """Different logical shapes -> different cache entries.
     logical_shape is in compute_program_hash() determining Wt, Ht, work distribution."""
+    torch.manual_seed(0)
     torch_ref1, tt_out1 = run_softmax_4d(device, [1, 1, 32, 64], dim=-1, dtype=ttnn.bfloat16)
     assert_numeric_metrics(
         torch_ref1,
@@ -314,6 +318,7 @@ def test_scale_mask_softmax_cache_miss_different_mask_dtypes(device, isolate_pro
     embedded in the program. Before the fix, both calls would hit the same cache entry,
     potentially using the wrong CB format for the second mask dtype.
     """
+    torch.manual_seed(0)
     batch = 1
     seq = 32
     inner = 64
@@ -366,6 +371,7 @@ def test_scale_mask_softmax_cache_miss_different_mask_memory_configs(device, iso
     Before the fix, both calls would hit the same cache entry using the wrong accessor
     for the second call.
     """
+    torch.manual_seed(0)
     batch = 1
     seq = 32
     inner = 64

--- a/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
@@ -62,6 +62,7 @@ def test_ttnn_matmul(device, m_size, k_size, n_size):
 def test_ttnn_linear(
     device, input_a_is_sharded, output_is_sharded, m_size, k_size, n_size, num_cores, input_a_dtype, input_b_dtype
 ):
+    torch.manual_seed(0)
     grid_size = (6, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -185,6 +185,7 @@ def test_tiny_tiles(device, n, c, h, w, tile_h, tile_w):
 
 @pytest.mark.parametrize("m, k, n", [(784, 192, 576), (576, 192, 784), (486, 792, 352), (966, 123, 561)])
 def test_pytorch_2_0_failed_cases(device, m, k, n):
+    torch.manual_seed(0)
     x = torch.ones((m, k), dtype=torch.float32)
     y = torch.ones((k, n), dtype=torch.float32)
     x_tt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -436,6 +437,7 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
 def test_matmul_in1_dram_sharded_tiny_tile(
     mesh_device, k, n, has_bias, grid_size, tile_h, tile_w, in1_dtype, transpose_tile
 ):
+    torch.manual_seed(0)
     if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h, has_bias) and is_llk_assert_enabled():
         pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
 
@@ -749,6 +751,7 @@ def test_matmul_2d_multiple_output_blocks_per_core(
     num_out_block_w,
     transpose_mcast,
 ):
+    torch.manual_seed(0)
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     required_size = 8  # input tensor sizes are too small to be subdivided on larger grids
     grid_size = [min(required_size, compute_grid_size.x), min(required_size, compute_grid_size.y)]
@@ -930,6 +933,7 @@ def test_matmul_2d_tiny_tile(
     in1_dtype,
     transpose_tile,
 ):
+    torch.manual_seed(0)
     if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h, has_bias) and is_llk_assert_enabled():
         pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
 
@@ -1099,6 +1103,7 @@ def test_matmul_1d_tiny_tile(
     in1_dtype,
     transpose_tile,
 ):
+    torch.manual_seed(0)
     if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h, has_bias) and is_llk_assert_enabled():
         pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
 
@@ -1319,6 +1324,7 @@ def test_matmul_1d_multiple_output_blocks_per_core(
     mcast_in0,
     uneven_width,
 ):
+    torch.manual_seed(0)
     for _ in range(2):
         run_matmul_1d_multiple_output_blocks_per_core(
             device,
@@ -1660,6 +1666,7 @@ def test_matmul_does_dot_product(device, w):
     ])
 # fmt: on
 def test_matmul_with_matched_width_height_4D(device, n_size, c, h, w):
+    torch.manual_seed(0)
     torch_input_tensor_a = torch.rand((n_size, c, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((n_size, c, w, h), dtype=torch.bfloat16)
     torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
@@ -1721,6 +1728,7 @@ def test_matmul_same_shape_and_valid(device, n_size, c, h, w):
     ])
 # fmt: on
 def test_matmul_same_shape_but_invalid(device, input_a, input_b):
+    torch.manual_seed(0)
     # pad the lists with zeros to make it 32 so that it fits nicely on the device.
     input_a += [0.0] * (32 - len(input_a))
     input_b += [0.0] * (32 - len(input_b))
@@ -3387,6 +3395,7 @@ def test_matmul_column_wise_bfp_tilize_via_transpose_b(device, weight_dtype, pcc
 
 
 def test_from_torch_col_tilize_validation():
+    torch.manual_seed(0)
     torch_tensor_2d = torch.randn(32, 64, dtype=torch.bfloat16)
     torch_tensor_1d = torch.randn(64, dtype=torch.bfloat16)
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -29,6 +29,7 @@ def test_matmul_batch_mismatch(batch, M, K, N, device):
 
     Previously, batch=6 would hang in the matmul kernel due to incorrect argument passed to the in1 reader receiver kernel.
     """
+    torch.manual_seed(0)
     # Create input tensor [batch, M, K]
     input_torch = torch.randn(batch, M, K)
     input_ttnn = ttnn.from_torch(input_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -65,6 +65,7 @@ def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, use_multicore
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
     Note: We do not enforce the same exception type or message.
     """
+    torch.manual_seed(0)
     rank = len(tensor_shape)
 
     # Create tensor based on data type

--- a/tests/ttnn/unit_tests/operations/reduce/test_manual_seed.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_manual_seed.py
@@ -12,6 +12,7 @@ def test_manual_seed_different_argument_calls(device):
     """
     Test that manual_seed accepts various valid argument configurations.
     """
+    torch.manual_seed(0)
     # Keyword minimum arguments
     ttnn.manual_seed(seeds=42, device=device)
 
@@ -38,6 +39,7 @@ def test_manual_tensors_wrong_config(device):
     """
     Test that manual_seed correctly rejects invalid argument combinations.
     """
+    torch.manual_seed(0)
     seed_tensor = ttnn.from_torch(torch.Tensor([42]), dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
     with pytest.raises(
         Exception, match="Seeds were provided as a tensor, so user_ids must not be provided as a scalar."
@@ -49,6 +51,7 @@ def test_manual_seed_base_functionality(device):
     """
     Test that manual_seed produces deterministic and reproducible results.
     """
+    torch.manual_seed(0)
     # Prepare test data
     shape = (1, 1, 32, 64)
     input_values = ttnn.from_torch(torch.randn(shape), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -92,6 +95,7 @@ def test_manual_seed_mapping_functionality(device):
     """
     Test that manual_seed correctly handles per-core seed mapping.
     """
+    torch.manual_seed(0)
     # Prepare test data
     shape = (1, 1, 32, 64)
     input_values = ttnn.from_torch(torch.randn(shape), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -143,6 +147,7 @@ def test_manual_seed_skip_with_uint32_max(device):
     """
     Test that manual_seed with seeds=UINT32_MAX skips rand_tile_init (PRNG state unchanged).
     """
+    torch.manual_seed(0)
     # Prepare test data
     shape = (1, 1, 32, 64)
     input_values = ttnn.from_torch(torch.randn(shape), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -184,6 +189,7 @@ def test_manual_seed_skip_with_uint32_max_user_ids_scalar(device):
     """
     Test that manual_seed with seeds=UINT32_MAX and scalar user_ids works (Strategy 2).
     """
+    torch.manual_seed(0)
     ttnn.manual_seed(seeds=42, device=device)
     # UINT32_MAX means skip rand_tile_init on the targeted core
     ttnn.manual_seed(seeds=SKIP_SEED, device=device, user_ids=7)
@@ -193,6 +199,7 @@ def test_manual_seed_skip_with_uint32_max_user_ids_tensor(device):
     """
     Test that manual_seed with seeds=UINT32_MAX and tensor user_ids works (Strategy 3).
     """
+    torch.manual_seed(0)
     ttnn.manual_seed(seeds=42, device=device)
     user_id_tensor = ttnn.from_torch(
         torch.Tensor([0, 1, 2]), dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device
@@ -205,6 +212,7 @@ def test_manual_seed_mapping_functionality_sub_core_grids(device):
     """
     Test that manual_seed correctly handles per-core seed mapping.
     """
+    torch.manual_seed(0)
     # Prepare test data
     shape = (1, 1, 32, 64)
     input_values = ttnn.from_torch(torch.randn(shape), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -126,6 +126,7 @@ def test_max_global(device, batch_size, h, w):
 )
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_max_dim(device, input_shape_and_dim, keepdim):
+    torch.manual_seed(0)
     input_shape, max_dim = input_shape_and_dim
     torch_input_tensor = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
     torch_output_tensor, _ = torch.max(torch_input_tensor, dim=max_dim, keepdim=keepdim)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -816,6 +816,7 @@ def run_reduce_sum_h(device, batch_size, h, w, dim):
     ],
 )
 def test_run_reduce_sum_h_after_max_pool(device, input_shape, kernel_size):
+    torch.manual_seed(0)
     run_maxpool(device, input_shape, kernel_size, kernel_size, (0, 0), (1, 1))
     run_reduce_sum_h(device, 1, 32, 32, -2)
 
@@ -841,6 +842,7 @@ def test_torch_compatibility(device, tensor_shape, keepdim, dim, op, use_legacy)
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
     Note: We do not enforce the same exception type or message.
     """
+    torch.manual_seed(0)
     if op not in ("std", "var") and use_legacy:
         pytest.skip("use_legacy only applies to std and var")
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -842,7 +842,7 @@ def test_torch_compatibility(device, tensor_shape, keepdim, dim, op, use_legacy)
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
     Note: We do not enforce the same exception type or message.
     """
-    torch.manual_seed(0)
+    torch.manual_seed(42)
     if op not in ("std", "var") and use_legacy:
         pytest.skip("use_legacy only applies to std and var")
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -51,6 +51,7 @@ def test_mean_scaling(device, shape, dim, keepdim):
     """Use assert_allclose with ones() to test that mean's scaling factor is
     computed correctly.
     """
+    torch.manual_seed(0)
     torch_input_tensor = torch.ones(shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim, dtype=torch.bfloat16)
 
@@ -76,6 +77,7 @@ def test_mean_scaling(device, shape, dim, keepdim):
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, [0, 1], [2, 3], [0, 1, 2]])
 @pytest.mark.parametrize("scalar", [2.0])
 def test_mean_scaling_factor(device, shape, dim, scalar):
+    torch.manual_seed(0)
     torch_input_tensor = torch.ones(shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, dtype=torch.bfloat16)
     torch_output_tensor = torch_output_tensor * scalar
@@ -101,6 +103,7 @@ def test_mean_scaling_factor(device, shape, dim, scalar):
 @pytest.mark.parametrize("mem_config", [None, ttnn.DRAM_MEMORY_CONFIG, "block"])
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_mean_shard(device, mem_config, keepdim):
+    torch.manual_seed(0)
     if mem_config is None and not keepdim:
         pytest.skip("Skipping because reshape does not work in this scenario. Issue #35145")
     torch_input_tensor = torch.randn(1, 1024, 160, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
@@ -97,6 +97,7 @@ def test_reduce_cache_reuse_same_config(device, isolate_program_cache):
 
 def test_reduce_cache_miss_different_math_ops(device, isolate_program_cache):
     """Different reduce math ops (sum vs max) -> different cache entries."""
+    torch.manual_seed(0)
     shape = [1, 1, 64, 64]
 
     torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16)
@@ -126,6 +127,7 @@ def test_reduce_cache_miss_different_math_ops(device, isolate_program_cache):
 
 def test_reduce_cache_miss_different_dims(device, isolate_program_cache):
     """Different reduce dims (W vs H) -> different program factories -> different cache entries."""
+    torch.manual_seed(0)
     shape = [1, 1, 64, 64]
 
     # dim=-1 (W): ReduceMultiCoreWProgramFactory
@@ -157,6 +159,7 @@ def test_reduce_cache_miss_different_dims(device, isolate_program_cache):
 
 def test_reduce_cache_miss_different_input_dtypes(device, isolate_program_cache):
     """Different input dtypes -> different cache entries."""
+    torch.manual_seed(0)
     shape = [1, 1, 64, 64]
 
     torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16)
@@ -186,6 +189,7 @@ def test_reduce_cache_miss_different_input_dtypes(device, isolate_program_cache)
 
 def test_reduce_cache_miss_different_memory_configs(device, isolate_program_cache):
     """Different memory configs -> different cache entries."""
+    torch.manual_seed(0)
     shape = [1, 1, 64, 64]
 
     torch_ref1, tt_out1 = run_reduce_op(
@@ -222,6 +226,7 @@ def test_reduce_cache_miss_different_memory_configs(device, isolate_program_cach
 def test_reduce_cache_miss_different_shapes(device, isolate_program_cache):
     """Different padded shapes -> different cache entries.
     padded_shape is included in compute_program_hash() because Ht, Wt are compile-time args."""
+    torch.manual_seed(0)
     torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, [1, 1, 32, 64], dim=-1, dtype=ttnn.bfloat16)
 
     torch_ref2, tt_out2 = run_reduce_op(device, ttnn.sum, [1, 1, 64, 64], dim=-1, dtype=ttnn.bfloat16)
@@ -251,6 +256,7 @@ def test_reduce_cache_miss_different_shapes(device, isolate_program_cache):
 def test_reduce_cache_miss_sub_core_grids(device, isolate_program_cache):
     """Different sub_core_grids -> different cache entries.
     sub_core_grids is in compute_program_hash() and affects work distribution (compile-time)."""
+    torch.manual_seed(0)
     shape = [1, 1, 64, 64]
     torch_a = torch.rand(shape, dtype=torch.bfloat16) + 0.1
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -127,6 +127,7 @@ def test_sum_4d(device, n, c, h, w, dim):
 )
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_nd_shard(device, shapes, keepdim):
+    torch.manual_seed(0)
     dim = -2
     input_shape, shard_shape, end_x, end_y = shapes
     torch_input_tensor = torch.rand(input_shape)


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

I kept on getting ND failures in CI. I checked the tests and they were missing a fixed seed. Therefore I added fixed seeds where needed.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-42913_set_seed)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42913_set_seed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-42913_set_seed)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42913_set_seed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-42913_set_seed)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42913_set_seed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-42913_set_seed)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-42913_set_seed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-42913_set_seed)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42913_set_seed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-42913_set_seed)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42913_set_seed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-42913_set_seed)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42913_set_seed)