### PR TITLE
deepseek: add @run_for_blackhole to test_skip_nonlocal_experts

### DIFF
--- a/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_moe_post_combine_reduce.py
+++ b/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_moe_post_combine_reduce.py
@@ -206,6 +206,7 @@ def test_sparse_weights(device, k_active):
 # ============================================================================
 
 
+@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
 def test_skip_nonlocal_experts(device):
     """Verify that marking experts as non-local (-1 in dispatch table) produces
     the same result when those experts' combine_output is zero (as in real MoE)."""


### PR DESCRIPTION
## Summary

- `test_skip_nonlocal_experts` was missing the `@run_for_blackhole` decorator that all other tests in this file have
- Causes crash on WH/ttsim: `TT_FATAL: Need 100 cores (3200 tokens / 32 per core) but only 72 cores available`
- Fix: add the same decorator with the same reason string used everywhere else in the file

## Test plan
- [ ] Confirm test is skipped on WH sanity run
- [ ] Confirm test passes on BH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/fix-deepseek-moe-skip-nonlocal-bh-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-deepseek-moe-skip-nonlocal-bh-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/fix-deepseek-moe-skip-nonlocal-bh-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/fix-deepseek-moe-skip-nonlocal-bh-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/fix-deepseek-moe-skip-nonlocal-bh-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-deepseek-moe-skip-nonlocal-bh-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/fix-deepseek-moe-skip-nonlocal-bh-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/fix-deepseek-moe-skip-nonlocal-bh-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/fix-deepseek-moe-skip-nonlocal-bh-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-deepseek-moe-skip-nonlocal-bh-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/fix-deepseek-moe-skip-nonlocal-bh-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-deepseek-moe-skip-nonlocal-bh-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/fix-deepseek-moe-skip-nonlocal-bh-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-deepseek-moe-skip-nonlocal-bh-only)