### PR TITLE
Add updated HF_HOME path to release-demo-tests-impl.yaml

### DIFF
--- a/.github/workflows/release-demo-tests-impl.yaml
+++ b/.github/workflows/release-demo-tests-impl.yaml
@@ -117,6 +117,7 @@ jobs:
         LOGURU_LEVEL: INFO
         GITHUB_ACTIONS: true
         GTEST_OUTPUT: xml:/work/generated/test_reports/
+        HF_HOME: ${{ (contains(join(matrix.test-group.runs_on, ' '), 'tt-ubuntu') && '') || '/mnt/MLPerf/huggingface' }}
         HF_HUB_CACHE: ${{ (contains(join(matrix.test-group.runs_on, ' '), 'tt-ubuntu') && '') || '/mnt/MLPerf/huggingface/hub' }}
         HF_TOKEN: ${{ (contains(matrix.test-group.sku, 'bh_') && secrets.HUGGINGFACE_TOKEN) || '' }}
         HTTP_PROXY: ${{ (contains(join(matrix.test-group.runs_on, ' '), 'tt-ubuntu') && env.HTTP_PROXY) || '' }}


### PR DESCRIPTION
### Summary
Add updated HF_HOME path: `/mnt/MLPerf/huggingface` in release-demo-tests-impl.yaml instead of using the old default path: `/mnt/MLPerf/tt_dnn-models/`
