### PR TITLE
Fix ttsim data movement group: replace slow gather test, skip crashing concat

### DIFF
--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -24,7 +24,7 @@
     tests/ttnn/unit_tests/operations/data_movement/test_repeat.py::test_pc_with_different_shapes_in_sequence
     tests/ttnn/unit_tests/operations/data_movement/test_embedding.py::test_base_case
     tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py::test_embedding_bw_with_program_cache
-    tests/ttnn/unit_tests/operations/data_movement/test_gather.py::test_gather_multirow
+    tests/ttnn/unit_tests/operations/data_movement/test_gather.py::test_gather_general
     tests/ttnn/unit_tests/operations/data_movement/test_tosa_scatter.py::test_tosa_scatter_normal
     tests/ttnn/unit_tests/operations/data_movement/test_clone.py::test_clone_callback
     tests/ttnn/unit_tests/operations/data_movement/test_sort.py::test_sort_indices

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -41,6 +41,11 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
 
 blackhole:
+  # UINT32 tiled concat crash — segfault in ttsim for 4D UINT32 tensors on BH.
+  # Skipping full test function because parametrized ID contains parens/brackets
+  # that break the skip-list shell interpolation.
+  - tests/ttnn/unit_tests/operations/data_movement/test_concat.py::test_tiled_concat
+
   # Job-level timeouts
   - tests/ttnn/unit_tests/operations/conv/test_conv2d.py
   - tests/ttnn/unit_tests/operations/conv/test_conv3d.py


### PR DESCRIPTION
## Summary
- Replace `test_gather_multirow` with `test_gather_general` in the data movement sanity group — the multirow test uses tensors too large for ttsim (`[64, 64, 4096]` = 16.7M elements), causing 30+ min runtime and job cancellation
- Skip `test_tiled_concat[UINT32, [[1,1,4,4],[1,1,4,4]], -1]` on blackhole ttsim — crashes with segfault. The interleaved concat path is pure data movement (no compute kernel), and INT32 with identical tile size/alignment passes fine, pointing to a ttsim simulator issue with the UInt32 data format enum on blackhole

## Test plan
- [x] ttsim wormhole data movement group passes: https://github.com/tenstorrent/tt-metal/actions/runs/24812562147/job/72621054986
- [ ] ttsim blackhole data movement group passes (with skip): https://github.com/tenstorrent/tt-metal/actions/runs/24814547436 (in progress)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ntarafdar/fix-ttsim-gather-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ntarafdar/fix-ttsim-gather-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ntarafdar/fix-ttsim-gather-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ntarafdar/fix-ttsim-gather-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ntarafdar/fix-ttsim-gather-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ntarafdar/fix-ttsim-gather-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ntarafdar/fix-ttsim-gather-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ntarafdar/fix-ttsim-gather-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ntarafdar/fix-ttsim-gather-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ntarafdar/fix-ttsim-gather-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ntarafdar/fix-ttsim-gather-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ntarafdar/fix-ttsim-gather-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ntarafdar/fix-ttsim-gather-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ntarafdar/fix-ttsim-gather-timeout)