### PR TITLE
[quasar] Extract _is_invalid_quasar_combination into helpers/constraints

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_nonlinear_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_nonlinear_quasar.py
@@ -16,7 +16,11 @@ from helpers.llk_params import (
     UnpackerEngine,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    input_output_formats,
+    is_invalid_quasar_sfpu_format_combination,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -32,41 +36,6 @@ from helpers.test_variant_parameters import (
     UNPACKER_ENGINE_SEL,
 )
 from helpers.utils import passed_test
-
-
-def _is_invalid_quasar_combination(
-    fmt: FormatConfig, dest_acc: DestAccumulation
-) -> bool:
-    """
-    Check if format combination is invalid for Quasar.
-
-    Args:
-        fmt: Format configuration with input and output formats
-        dest_acc: Destination accumulation mode
-
-    Returns:
-        True if the combination is invalid, False otherwise
-    """
-    in_fmt = fmt.input_format
-    out_fmt = fmt.output_format
-
-    # Quasar packer does not support non-Float32 to Float32 conversion when dest_acc=No
-    if (
-        in_fmt != DataFormat.Float32
-        and out_fmt == DataFormat.Float32
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    # Quasar SFPU with Float32 input and Float16 output requires dest_acc=Yes
-    if (
-        in_fmt == DataFormat.Float32
-        and out_fmt == DataFormat.Float16
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    return False
 
 
 def generate_sfpu_nonlinear_combinations(
@@ -92,7 +61,7 @@ def generate_sfpu_nonlinear_combinations(
         )
         for dest_acc in dest_acc_modes:
             # Skip invalid format combinations for Quasar
-            if _is_invalid_quasar_combination(fmt, dest_acc):
+            if is_invalid_quasar_sfpu_format_combination(fmt, dest_acc):
                 continue
 
             for dest_sync in dest_sync_modes:

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_rsqrt_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_rsqrt_quasar.py
@@ -16,7 +16,11 @@ from helpers.llk_params import (
     UnpackerEngine,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    input_output_formats,
+    is_invalid_quasar_sfpu_format_combination,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -32,41 +36,6 @@ from helpers.test_variant_parameters import (
     UNPACKER_ENGINE_SEL,
 )
 from helpers.utils import passed_test
-
-
-def _is_invalid_quasar_combination(
-    fmt: FormatConfig, dest_acc: DestAccumulation
-) -> bool:
-    """
-    Check if format combination is invalid for Quasar.
-
-    Args:
-        fmt: Format configuration with input and output formats
-        dest_acc: Destination accumulation mode
-
-    Returns:
-        True if the combination is invalid, False otherwise
-    """
-    in_fmt = fmt.input_format
-    out_fmt = fmt.output_format
-
-    # Quasar packer does not support non-Float32 to Float32 conversion when dest_acc=No
-    if (
-        in_fmt != DataFormat.Float32
-        and out_fmt == DataFormat.Float32
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    # Quasar SFPU with Float32 input and Float16 output requires dest_acc=Yes
-    if (
-        in_fmt == DataFormat.Float32
-        and out_fmt == DataFormat.Float16
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    return False
 
 
 def generate_sfpu_rsqrt_combinations(
@@ -92,7 +61,7 @@ def generate_sfpu_rsqrt_combinations(
         )
         for dest_acc in dest_acc_modes:
             # Skip invalid format combinations for Quasar
-            if _is_invalid_quasar_combination(fmt, dest_acc):
+            if is_invalid_quasar_sfpu_format_combination(fmt, dest_acc):
                 continue
 
             for dest_sync in dest_sync_modes:

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_square_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_square_quasar.py
@@ -17,7 +17,11 @@ from helpers.llk_params import (
     UnpackerEngine,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    input_output_formats,
+    is_invalid_quasar_sfpu_format_combination,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -114,41 +118,6 @@ def prepare_square_inputs(
     return result
 
 
-def _is_invalid_quasar_combination(
-    fmt: FormatConfig, dest_acc: DestAccumulation
-) -> bool:
-    """
-    Check if format combination is invalid for Quasar.
-
-    Args:
-        fmt: Format configuration with input and output formats
-        dest_acc: Destination accumulation mode
-
-    Returns:
-        True if the combination is invalid, False otherwise
-    """
-    in_fmt = fmt.input_format
-    out_fmt = fmt.output_format
-
-    # Quasar packer does not support non-Float32 to Float32 conversion when dest_acc=No
-    if (
-        in_fmt != DataFormat.Float32
-        and out_fmt == DataFormat.Float32
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    # Quasar SFPU with Float32 input and Float16 output requires dest_acc=Yes
-    if (
-        in_fmt == DataFormat.Float32
-        and out_fmt == DataFormat.Float16
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    return False
-
-
 def generate_sfpu_square_combinations(
     formats_list: List[FormatConfig],
 ):
@@ -172,7 +141,7 @@ def generate_sfpu_square_combinations(
         )
         for dest_acc in dest_acc_modes:
             # Skip invalid format combinations for Quasar
-            if _is_invalid_quasar_combination(fmt, dest_acc):
+            if is_invalid_quasar_sfpu_format_combination(fmt, dest_acc):
                 continue
 
             for dest_sync in dest_sync_modes:


### PR DESCRIPTION
### Summary
Four Quasar SFPU tests (`test_sfpu_square_quasar.py`, `test_isolate_sfpu_square_quasar.py`, `test_sfpu_rsqrt_quasar.py`, `test_sfpu_nonlinear_quasar.py`) each carried a local copy of the same `_is_invalid_quasar_combination` helper — identical body, ~33 lines per file. This PR lifts the shared body into `helpers/constraints.is_invalid_quasar_sfpu_format_combination` and deletes the four duplicates.

Net diff: +43 / −145 (−102 lines).

Relates to #42645 (skotaracTT review comment).

### Notes for reviewers
- New helper covers only the two rules shared verbatim across all four copies; per-op additional constraints (e.g., integer/float mixing) stay at the call site.
- Function renamed on the way in (`is_invalid_quasar_sfpu_format_combination`) — dropped the leading underscore since it's now a public helper, and added the `sfpu` qualifier so it's distinguishable from future Quasar format-combination filters.
- Not included in this PR: the not-yet-merged `test_sfpu_abs_quasar.py` from #42645, which has one extra integer/float-mix check on top of the two common rules. That file should be updated in the abs PR to call the new helper + keep its extra check inline.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-invalid-combo-helper)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/quasar-sfpu-invalid-combo-helper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-invalid-combo-helper)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/quasar-sfpu-invalid-combo-helper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-invalid-combo-helper)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/quasar-sfpu-invalid-combo-helper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-invalid-combo-helper)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/quasar-sfpu-invalid-combo-helper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-invalid-combo-helper)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/quasar-sfpu-invalid-combo-helper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-invalid-combo-helper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/quasar-sfpu-invalid-combo-helper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-invalid-combo-helper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/quasar-sfpu-invalid-combo-helper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-invalid-combo-helper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/quasar-sfpu-invalid-combo-helper)