### PR TITLE
fix(test): correct unrealistic bfloat16 tolerances in test_reduce_cache_miss_sub_core_grids

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
@@ -273,19 +273,19 @@ def test_reduce_cache_miss_sub_core_grids(device, isolate_program_cache):
     assert_numeric_metrics(
         torch_ref,
         ttnn.to_torch(tt_out1),
-        pcc_threshold=0.9999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
+        pcc_threshold=0.999,
+        rtol=0.007,
+        atol=0.25,
+        frobenius_threshold=0.001,
     )
     # test for equivalance
     assert_numeric_metrics(
         torch_ref,
         ttnn.to_torch(tt_out2),
-        pcc_threshold=0.9999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
+        pcc_threshold=0.999,
+        rtol=0.007,
+        atol=0.25,
+        frobenius_threshold=0.001,
     )
 
     assert device.cache_entries_counter.total == 2

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
@@ -278,7 +278,7 @@ def test_reduce_cache_miss_sub_core_grids(device, isolate_program_cache):
         atol=0.25,
         frobenius_threshold=0.001,
     )
-    # test for equivalance
+    # test for equivalence
     assert_numeric_metrics(
         torch_ref,
         ttnn.to_torch(tt_out2),


### PR DESCRIPTION
## Summary

- Fixes #42932: `test_reduce_cache_miss_sub_core_grids` used `atol=1e-06, rtol=1e-06` for bfloat16 reduction output, which is physically impossible — for bfloat16 sums in range ~33–43, one ULP ≈ 0.25, four orders of magnitude larger than the old threshold
- Updated tolerances to match `test_reduce_cache_miss_different_input_dtypes` in the same file, which already has correct bfloat16 values
- Test already had `torch.manual_seed(0)` to prevent random-seed-driven flakiness

**Before (wrong):**
```python
pcc_threshold=0.9999, rtol=1e-06, atol=1e-06, frobenius_threshold=1e-09
```

**After (correct for bfloat16):**
```python
pcc_threshold=0.999, rtol=0.007, atol=0.25, frobenius_threshold=0.001
```

## Test plan

- [x] `test_reduce_cache_miss_sub_core_grids` verified passing on WH ttsim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mateusznowakTT/42932_fix_reduce_cache_miss_tolerances)