### PR TITLE
Adds memory configuration copy to `from_torch_dist_as` function.

### DIFF
--- a/models/common/distribute_as.py
+++ b/models/common/distribute_as.py
@@ -29,11 +29,12 @@ def from_torch_dist_as(
     Distribute a torch.Tensor over a mesh using the same topology as an existing TTNN tensor.
 
     Args:
-        tensor_pt: Source PyTorch tensor on host
-        tensor_tt: Reference TTNN tensor whose topology (placements + distribution shape) will be mirrored
+        from_tensor_pt: Source PyTorch tensor on host.
+        as_tensor_tt: Reference TTNN tensor whose topology (placements + distribution shape) will be mirrored.
+        device: Optional mesh device. If omitted, inferred from ``as_tensor_tt`` when possible.
 
     Returns:
-        A TTNN tensor distributed according to `tensor_tt`'s topology and memory configuration
+        A TTNN tensor distributed according to ``as_tensor_tt``'s topology and memory configuration
         (e.g. height-sharded decode heads).
     """
     mapper, device = _infer_mesh_mapper_from_topology(as_tensor_tt, device=device)

--- a/models/common/distribute_as.py
+++ b/models/common/distribute_as.py
@@ -33,7 +33,8 @@ def from_torch_dist_as(
         tensor_tt: Reference TTNN tensor whose topology (placements + distribution shape) will be mirrored
 
     Returns:
-        A TTNN tensor distributed according to `tensor_tt`'s topology.
+        A TTNN tensor distributed according to `tensor_tt`'s topology and memory configuration
+        (e.g. height-sharded decode heads).
     """
     mapper, device = _infer_mesh_mapper_from_topology(as_tensor_tt, device=device)
 
@@ -41,11 +42,13 @@ def from_torch_dist_as(
     # Pattern 1: Using mesh_mapper without device (tensor stays in host memory) Programming_Mesh_of_Devices_with_TT-NN.md:370-375
     # Then transfer to device separately: Programming_Mesh_of_Devices_with_TT-NN.md:404-405
     # Pattern 2: Using both mesh_mapper and device together (direct to device) llms.md:1204-1218
+    mem_cfg = as_tensor_tt.memory_config()
     return ttnn.from_torch(
         from_tensor_pt,
         dtype=getattr(as_tensor_tt, "dtype", None),
         layout=getattr(as_tensor_tt, "layout", None),
         device=device,
+        memory_config=mem_cfg,
         mesh_mapper=mapper,
     )
 

--- a/models/common/tests/test_distribute_as.py
+++ b/models/common/tests/test_distribute_as.py
@@ -50,6 +50,11 @@ pytestmark = [
         ],
         ids=["row_major_bf16", "tile_bf16", "tile_bf8b", "tile_bf4b"],
     ),
+    pytest.mark.parametrize(
+        "memory_config",
+        [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        ids=["dram", "l1"],
+    ),
 ]
 
 
@@ -95,7 +100,9 @@ def _topology_signature(tt: ttnn.Tensor) -> tuple[tuple[str, tuple[int, ...]], t
 
 
 @pytest.mark.parametrize("storage", ["host", "device"])
-def test_sharded_1d(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, storage: str) -> None:
+def test_sharded_1d(
+    ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, memory_config: ttnn.MemoryConfig, storage: str
+) -> None:
     is_host_ref = storage == "host"
     num_devices = ttnn_mesh_device.get_num_devices()
 
@@ -109,6 +116,7 @@ def test_sharded_1d(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, storage: s
         device=None if is_host_ref else ttnn_mesh_device,
         dtype=dtype,
         layout=layout,
+        memory_config=memory_config,
         mesh_mapper=ttnn.ShardTensorToMesh(ttnn_mesh_device, dim=0),
     )
 
@@ -123,6 +131,7 @@ def test_sharded_1d(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, storage: s
     expected_topology = _topology_signature(ref_tt)
     assert _topology_signature(tt_as) == expected_topology
     assert tt_as.dtype == dtype
+    assert tt_as.memory_config() == memory_config
 
     # Verify round-trip via auto-composition matches the source
     if is_host_ref:
@@ -134,7 +143,14 @@ def test_sharded_1d(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, storage: s
 
 @pytest.mark.parametrize("storage", ["host", "device"])
 @pytest.mark.parametrize("dim", [0, 1, 2, -1])
-def test_sharded_various_dims(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, dim: int, storage: str) -> None:
+def test_sharded_various_dims(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    layout,
+    dtype,
+    memory_config: ttnn.MemoryConfig,
+    dim: int,
+    storage: str,
+) -> None:
     is_host_ref = storage == "host"
     num_devices = ttnn_mesh_device.get_num_devices()
 
@@ -151,6 +167,7 @@ def test_sharded_various_dims(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, 
         device=None if is_host_ref else ttnn_mesh_device,
         dtype=dtype,
         layout=layout,
+        memory_config=memory_config,
         mesh_mapper=ttnn.ShardTensorToMesh(ttnn_mesh_device, dim=dim),
     )
 
@@ -162,6 +179,7 @@ def test_sharded_various_dims(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, 
 
     assert _topology_signature(tt_as) == _topology_signature(ref_tt)
     assert tt_as.dtype == dtype
+    assert tt_as.memory_config() == memory_config
     if is_host_ref:
         torch_auto = to_torch_auto_compose(tt_as, device=ttnn_mesh_device)
     else:
@@ -171,7 +189,14 @@ def test_sharded_various_dims(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, 
 
 @pytest.mark.parametrize("storage", ["host", "device"])
 @pytest.mark.parametrize("dims_pair", [(0, 1), (0, -1), (1, -1)])
-def test_sharded_2d(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, dims_pair: tuple[int, int], storage: str) -> None:
+def test_sharded_2d(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    layout,
+    dtype,
+    memory_config: ttnn.MemoryConfig,
+    dims_pair: tuple[int, int],
+    storage: str,
+) -> None:
     is_host_ref = storage == "host"
     mesh_shape = tuple(ttnn_mesh_device.shape)
     if len(mesh_shape) != 2 and torch.prod(torch.tensor(mesh_shape)).item() <= 1:
@@ -191,7 +216,12 @@ def test_sharded_2d(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, dims_pair:
 
     mapper = ttnn.ShardTensor2dMesh(ttnn_mesh_device, mesh_shape=mesh_shape, dims=(dims_pair[0], dims_pair[1]))
     ref_tt = ttnn.from_torch(
-        ref_input, device=None if is_host_ref else ttnn_mesh_device, dtype=dtype, layout=layout, mesh_mapper=mapper
+        ref_input,
+        device=None if is_host_ref else ttnn_mesh_device,
+        dtype=dtype,
+        layout=layout,
+        memory_config=memory_config,
+        mesh_mapper=mapper,
     )
 
     new_input = ref_input + 1  # change values to avoid accidental equality
@@ -202,6 +232,7 @@ def test_sharded_2d(ttnn_mesh_device: ttnn.MeshDevice, layout, dtype, dims_pair:
 
     assert _topology_signature(tt_as) == _topology_signature(ref_tt)
     assert tt_as.dtype == dtype
+    assert tt_as.memory_config() == memory_config
     if is_host_ref:
         torch_auto = to_torch_auto_compose(tt_as, device=ttnn_mesh_device)
     else:


### PR DESCRIPTION
### Issue

Closes #42950

Adds memory config copy to `from_torch_dist_as` so it's easier to use for debugging. See the issue above for more details.

For "T3K unit tests", relevant test tttv2_fast_unit_tests is passing after rebase.
For "All models tests", model unit, tier 2, wh_llmbox_perf: failing tests were also failing in main.
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=apascual/42950-from_torch_dist_as-mem-config-copy)](https://github.com/tenstorrent/tt-metal/actions/runs/25010804464)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=apascual/42950-from_torch_dist_as-mem-config-copy)](https://github.com/tenstorrent/tt-metal/actions/runs/24898881615)

