### PR TITLE
feat(sfpu): extend Quasar abs to Int8/UInt8/Int32/MX formats

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_abs_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_abs_quasar.py
@@ -6,7 +6,12 @@ from typing import List
 
 import pytest
 import torch
-from helpers.format_config import DataFormat, FormatConfig
+from helpers.format_config import (
+    MXFP8_E4M3_MAX_NORMAL,
+    MXFP8_E5M2_MAX_NORMAL,
+    DataFormat,
+    FormatConfig,
+)
 from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
 from helpers.llk_params import (
     DataCopyType,
@@ -34,6 +39,43 @@ from helpers.test_variant_parameters import (
 from helpers.utils import passed_test
 
 
+def _prepare_int8_abs_inputs(src_A: torch.Tensor, src_B: torch.Tensor) -> torch.Tensor:
+    """
+    Int8 stimulus for abs. Range is clamped to [-127, 127] to avoid the
+    unrepresentable -128 (Dest int8 is sign+magnitude — -128 has no sign+mag
+    encoding and is saturated to -127 at unpack, breaking bit-exact compare).
+    Uses src_A magnitude and src_B sign to reuse the shared stimulus seeding.
+    """
+    # Map whatever dtype generate_stimuli produced into a usable integer range.
+    # src_A may be float or int depending on prior conversions; coerce to int32
+    # for arithmetic, then clamp + cast to int8.
+    magnitudes = src_A.to(torch.int32).abs() % 128  # [0, 127]
+    signs = torch.where(src_B.to(torch.int32) % 2 == 0, 1, -1)
+    values = (signs * magnitudes).clamp(-127, 127).to(torch.int8)
+    return values
+
+
+def _prepare_uint8_abs_inputs(src_A: torch.Tensor) -> torch.Tensor:
+    """
+    UInt8 stimulus for abs. Abs is identity for unsigned values, so the full
+    0-255 range is valid; just ensure the tensor is the right dtype.
+    """
+    return src_A.to(torch.int32).abs().clamp(0, 255).to(torch.uint8)
+
+
+def _prepare_int32_abs_inputs(src_A: torch.Tensor, src_B: torch.Tensor) -> torch.Tensor:
+    """
+    Int32 stimulus for abs. Dest int32 is sign+magnitude, so 0x80000000 is
+    unrepresentable (saturated to 0x7FFFFFFF at unpack). Clamp to
+    [-(2^31 - 1), 2^31 - 1] so the torch golden matches HW bit-exact.
+    """
+    int32_max = 2**31 - 1
+    magnitudes = src_A.to(torch.int64).abs() % (int32_max + 1)  # [0, 2^31-1]
+    signs = torch.where(src_B.to(torch.int64) % 2 == 0, 1, -1)
+    values = (signs * magnitudes).clamp(-int32_max, int32_max).to(torch.int32)
+    return values
+
+
 def prepare_abs_inputs(
     src_A: torch.Tensor,
     src_B: torch.Tensor,
@@ -56,14 +98,37 @@ def prepare_abs_inputs(
     Returns:
         Prepared tensor with safe values for abs
     """
+    if input_format == DataFormat.Int8:
+        return _prepare_int8_abs_inputs(src_A, src_B)
+    if input_format == DataFormat.UInt8:
+        return _prepare_uint8_abs_inputs(src_A)
+    if input_format == DataFormat.Int32:
+        return _prepare_int32_abs_inputs(src_A, src_B)
+
     input_torch_format = format_dict[input_format]
     output_torch_format = format_dict[output_format]
     input_finfo = torch.finfo(input_torch_format)
     output_finfo = torch.finfo(output_torch_format)
 
+    def _mx_elem_max(df: DataFormat) -> float:
+        if df == DataFormat.MxFp8R:
+            return MXFP8_E5M2_MAX_NORMAL
+        if df == DataFormat.MxFp8P:
+            return MXFP8_E4M3_MAX_NORMAL
+        raise ValueError(f"not an MX format: {df}")
+
     # For abs, output magnitude equals input magnitude, so we need values that
-    # fit in BOTH input and output formats
-    max_safe_value = min(input_finfo.max, output_finfo.max) * 0.9
+    # fit in BOTH input and output formats. MX formats have their own element
+    # max (not queryable via torch.finfo on bfloat16).
+    cap_from_input = (
+        _mx_elem_max(input_format) if input_format.is_mx_format() else input_finfo.max
+    )
+    cap_from_output = (
+        _mx_elem_max(output_format)
+        if output_format.is_mx_format()
+        else output_finfo.max
+    )
+    max_safe_value = min(cap_from_input, cap_from_output) * 0.9
 
     # Special handling for bfloat16: limit to reasonable bounds to avoid
     # precision issues at extreme values
@@ -146,6 +211,23 @@ def _is_invalid_quasar_combination(
     if in_fmt.is_integer() != out_fmt.is_integer():
         return True
 
+    # Cross-width integer conversions (e.g. Int32 -> Int8, UInt8 -> Int32) aren't
+    # abs-testable: 8->32 requires dest_acc=Yes (invalid for 8-bit SFPU input
+    # path, rejected by format inference) and 32->8 passes through the packer's
+    # Int32 conversion path, which saturates rather than preserving the abs
+    # value. Restrict to same-width integer pairs (Int8<->UInt8, Int32<->Int32).
+    if in_fmt.is_integer() and out_fmt.is_integer() and in_fmt.size != out_fmt.size:
+        return True
+
+    # 8-bit integer data lives in 16-bit Dest (1 datum per row); dest_acc=Yes
+    # uses 32-bit Dest mode intended for Float32/Int32 accumulation and is not
+    # meaningful for 8-bit integer data paths.
+    if (
+        in_fmt in (DataFormat.Int8, DataFormat.UInt8)
+        and dest_acc == DestAccumulation.Yes
+    ):
+        return True
+
     return False
 
 
@@ -164,11 +246,15 @@ def generate_sfpu_abs_combinations(
     for fmt in formats_list:
         in_fmt = fmt.input_format
 
-        dest_acc_modes = (
-            (DestAccumulation.Yes,)
-            if in_fmt.is_32_bit()
-            else (DestAccumulation.No, DestAccumulation.Yes)
-        )
+        if in_fmt.is_32_bit():
+            dest_acc_modes = (DestAccumulation.Yes,)
+        elif in_fmt.is_mx_format():
+            # MX tiles unpack to Float16_b in Dest; 32-bit Dest accumulation is
+            # not the intended path.
+            dest_acc_modes = (DestAccumulation.No,)
+        else:
+            dest_acc_modes = (DestAccumulation.No, DestAccumulation.Yes)
+
         for dest_acc in dest_acc_modes:
             # Skip invalid format combinations for Quasar
             if _is_invalid_quasar_combination(fmt, dest_acc):
@@ -195,6 +281,11 @@ SFPU_ABS_FORMATS = input_output_formats(
         DataFormat.Float16,
         DataFormat.Float32,
         DataFormat.Float16_b,
+        DataFormat.Int8,
+        DataFormat.UInt8,
+        DataFormat.Int32,
+        DataFormat.MxFp8R,
+        DataFormat.MxFp8P,
     ]
 )
 
@@ -234,15 +325,24 @@ def test_sfpu_abs_quasar(formats_dest_acc_implied_math_input_dims):
 
     num_faces = 4
 
-    generate_golden = get_golden_generator(UnarySFPUGolden)
-    golden_tensor = generate_golden(
-        MathOperation.Abs,
-        src_A,
-        formats.output_format,
-        dest_acc,
-        formats.input_format,
-        input_dimensions,
-    )
+    if formats.input_format.is_integer():
+        # UnarySFPUGolden has no integer branch (it casts through Float16_b for
+        # non-MX, non-Float16 inputs at dest_acc=No), which would drop integer
+        # semantics. Abs on the clamped integer stimulus is an exact
+        # element-wise op, so compute the golden directly in the input dtype.
+        golden_tensor = (
+            torch.abs(src_A).flatten().to(format_dict[formats.output_format])
+        )
+    else:
+        generate_golden = get_golden_generator(UnarySFPUGolden)
+        golden_tensor = generate_golden(
+            MathOperation.Abs,
+            src_A,
+            formats.output_format,
+            dest_acc,
+            formats.input_format,
+            input_dimensions,
+        )
 
     unpack_to_dest = (
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_abs_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_abs_quasar_test.cpp
@@ -158,9 +158,40 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Apply SFPU abs (SFPABS) in-place on Dest for each tile.
     // Tile index must match the one used by the producer (datacopy above, or
     // UNPACK-to-Dest), so it is offset by params.DST_INDEX.
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    //
+    // Dispatch on Dest format. Integer formats (Int8/UInt8/Int32) need
+    // SFPLOAD/SFPSTORE with the matching int sfpmem mode because Dest stores
+    // signed ints as sign+magnitude (not 2's complement). Float and MX paths
+    // use DEFAULT and let ALU_FORMAT_SPEC_REG pick the load format. The test
+    // harness has no compile-time format template, so the branch is runtime
+    // but each arm resolves to a fully-inlined template instantiation.
+    if (src_format == DataFormat::Int8)
     {
-        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_abs_, params.DST_INDEX + i, num_sfpu_iterations);
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_abs_<DataFormat::Int8>, params.DST_INDEX + i, num_sfpu_iterations);
+        }
+    }
+    else if (src_format == DataFormat::UInt8)
+    {
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_abs_<DataFormat::UInt8>, params.DST_INDEX + i, num_sfpu_iterations);
+        }
+    }
+    else if (src_format == DataFormat::Int32)
+    {
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_abs_<DataFormat::Int32>, params.DST_INDEX + i, num_sfpu_iterations);
+        }
+    }
+    else
+    {
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_abs_<DataFormat::Float32>, params.DST_INDEX + i, num_sfpu_iterations);
+        }
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
@@ -343,6 +343,7 @@ struct p_sfpu
         constexpr static std::uint32_t FP32   = 0b0011; // stored data will be interpreted as fp32 format
         constexpr static std::uint32_t INT32  = 0b0100; // stored data will be interpreted as int32 (sign + magnitude) format
         constexpr static std::uint32_t UINT8  = 0b0101; // stored data will be interpreted as unsigned int8 format
+        constexpr static std::uint32_t INT8   = 0b0101; // signed int8 (sign + magnitude); same bits as UINT8 per Quasar ISA
         constexpr static std::uint32_t UINT16 = 0b0110; // stored data will be interpreted as unsigned int16 format
                                                         // TODO - Luka: add the other formats
     };

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_abs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_abs.h
@@ -12,27 +12,58 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates ABS for number of rows of output SFPU ops (Quasar = 2 rows)
+// Calculates ABS for number of rows of output SFPU ops (Quasar = 2 rows).
+//
+// Template dispatch on the Dest-register data format. For Int8, Dest stores
+// signed 8-bit data in sign+magnitude layout (see Confluence "Dest storage
+// formats", page 80674824), so SFPLOAD must use INT8 mode (0b0101) to extract
+// sign+mag into LREG. SFPABS_MOD1_FLOAT then clears the sign bit — this is the
+// "sign-magnitude/float" variant per the SFPABS ISA page (1612186129) and is
+// correct for both IEEE floats and sign+mag integers. All other formats go
+// through SFPLOAD DEFAULT mode (format picked up from ALU_FORMAT_SPEC_REG).
+template <DataFormat fmt = DataFormat::Float32>
 inline void _calculate_abs_sfp_rows_()
 {
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+    if constexpr (fmt == DataFormat::Int8 || fmt == DataFormat::UInt8)
+    {
+        // Dest int8 is sign+magnitude; UInt8 sits in the same SFPLOAD mode bits
+        // (0b0101) with bit 15 always 0, so the sign+mag path degenerates to
+        // pass-through for unsigned data.
+        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT8, ADDR_MOD_7, 0, 0);
+        TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPABS_MOD1_FLOAT);
+        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::INT8, ADDR_MOD_7, 0, 0);
+    }
+    else if constexpr (fmt == DataFormat::Int32)
+    {
+        // Dest int32 is sign+magnitude (see Dest storage formats, page 80674824).
+        // Smallest negative (-2^31) is saturated to -(2^31-1) at unpack — callers
+        // must clamp stimuli to avoid hitting this edge.
+        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, 0);
+        TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPABS_MOD1_FLOAT);
+        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, 0);
+    }
+    else
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
 
-    // Float absolute value (clears sign bit). Use the named constant from
-    // sfpi_constants.h — SFPABS_MOD1_INT would do integer 2's-complement abs,
-    // which is wrong for float data.
-    TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPABS_MOD1_FLOAT);
+        // Float absolute value (clears sign bit). Use the named constant from
+        // sfpi_constants.h — SFPABS_MOD1_INT would do integer 2's-complement abs,
+        // which is wrong for float data.
+        TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPABS_MOD1_FLOAT);
 
-    // Store result back to destination
-    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+        // Store result back to destination
+        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+    }
 }
 
 // Implements element-wise absolute value: abs(x)
+template <DataFormat fmt = DataFormat::Float32>
 inline void _calculate_abs_(const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_abs_sfp_rows_();
+        _calculate_abs_sfp_rows_<fmt>();
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }


### PR DESCRIPTION
### Summary

The Quasar `abs` SFPU kernel (introduced in #42645) previously supported only
Float16 / Float16_b / Float32. This extends it to the rest of the Dest-valid
format set on Quasar: **Int8, UInt8, Int32, MxFp8R, MxFp8P**. Test matrix
grows from 84 → 192 variants; all pass bit-exact for integer formats
(`atol=rtol=0`).

### Notes for reviewers

**Where to focus**: `tt_llk_quasar/common/inc/experimental/ckernel_sfpu_abs.h` —
the template dispatch.

Key decisions / non-obvious bits:

- **`SFPABS_MOD1_FLOAT` is used for the integer paths too.** Quasar Dest stores
  signed ints as **sign+magnitude** (see Confluence "Dest storage formats"
  p.80674824, and assembly.yaml SFPLOAD instr_mod0 table). SFPLOAD INT8/INT32
  modes sign+mag-convert on load, so LREG content is sign+mag.
  `SFPABS_MOD1_FLOAT` clears bit 31 — correct for sign+mag as well as IEEE
  floats. `SFPABS_MOD1_INT` would only be right for 2's-complement LREG
  content, which we never have.

- **Float path is byte-identical.** The three pre-existing float formats fall
  into the `else` branch with an unchanged TTI sequence; the original 77 float
  variants rerun green.

- **Test-source dispatch is a runtime branch** on `formats.math` selecting the
  right template instantiation. The test harness has no compile-time
  input-format template, but each arm is a fully-inlined template
  instantiation, so emitted code per case is identical to an `if constexpr`.

- **Stimuli clamping** — Dest int8 saturates `-128 → -127` at unpack (not
  representable in sign+mag); int32 analogously saturates `0x80000000`. To
  keep `torch.abs` as the golden, stimuli are clamped to `[-127, 127]` for
  Int8 and `[-(2^31 - 1), 2^31 - 1]` for Int32.

- **Integer goldens bypass `UnarySFPUGolden`**, which casts integer inputs
  through Float16_b for non-MX cases (losing int semantics). Replaced with
  `torch.abs` for any `is_integer()` input.

- **Cross-width integer pairs (Int8/UInt8 ↔ Int32) are excluded**: 8→32 fails
  Quasar format-inference (dest-width conflict), 32→8 requires a typecast step
  the abs kernel doesn't emit (packer saturates every value to 127). Documented
  in `_is_invalid_quasar_combination`. Out of scope for abs alone; would need
  a chained abs+SFPCAST kernel.

- **New constant**: `p_sfpu::sfpmem::INT8 = 0b0101` in `ckernel_instr_params.h`
  — alias for the existing `UINT8` (same bits; Quasar ISA `assembly.yaml`
  calls this mode INT8).

- **Deferred (not in this PR)**:
  - **Int16** — no signed Int16 SFPLOAD mode exposed in Quasar
    `assembly.yaml` or `_sfpu_sfpmem_type_<FMT>()`. Would need ISA or SW
    fallback work.
  - **UInt16** — not in `VALID_QUASAR_DEST_REG_FORMATS`.
  - **Tf32** — no existing stimulus / golden precedent for Tf32 in the Quasar
    test suite.

### Test plan

- [x] Re-run original 77 float variants — all pass (no regression).
- [x] Run full 192-variant matrix on Quasar simulator — all pass.
- [x] Confirm \`dest_acc=Yes\` / \`unpack_to_dest=True\` paths for Int32.
- [x] Confirm MX variants require \`implied_math_format=Yes\` (existing gating).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/abs-sfpu-int-mx-formats)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/abs-sfpu-int-mx-formats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/abs-sfpu-int-mx-formats)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/abs-sfpu-int-mx-formats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/abs-sfpu-int-mx-formats)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/abs-sfpu-int-mx-formats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/abs-sfpu-int-mx-formats)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/abs-sfpu-int-mx-formats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/abs-sfpu-int-mx-formats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/abs-sfpu-int-mx-formats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/abs-sfpu-int-mx-formats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/abs-sfpu-int-mx-formats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/abs-sfpu-int-mx-formats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/abs-sfpu-int-mx-formats)