### PR TITLE
[LLK] Optimize SFPU column reductions with Reduce→Add→Transpose→HalfReduce

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -95,21 +95,6 @@ inline void load_face_data(std::uint32_t upper_face_addr, std::uint32_t lower_fa
 }
 
 /**
- * @brief Perform column-wise summation using transpose and replay buffer
- *
- * Process column sums for both upper and lower face using transpose and replay buffer.
- * @tparam replay_buffer_length The replay buffer index to use (6 for both int and float on Blackhole)
- */
-template <std::uint32_t replay_buffer_length>
-inline void sum_columns()
-{
-    TTI_SFPTRANSP(0, 0, 0, 0);             // Transpose: LREG0-3 → lanes 0-3, LREG4-7 → lanes 0-3 (overlapping)
-    lltt::replay(0, replay_buffer_length); // Column-wise sum within each lreg after transpose
-    TTI_SFPTRANSP(0, 0, 0, 0);             // Transpose back to original register layout
-    lltt::replay(0, replay_buffer_length); // Sum column sums within each face after transpose
-}
-
-/**
  * @brief Perform integer averaging with proper handling of negative numbers
  * @tparam INSTRUCTION_MODE The instruction mode (determines signed vs unsigned)
  *
@@ -169,33 +154,42 @@ inline void perform_reduce_col_sum_avg()
     constexpr std::uint32_t UPPER_FACE_ADDRS[NUM_FACES] = {0, 0, 16, 16};   // Face 0, 0, 1, 1
     constexpr std::uint32_t LOWER_FACE_ADDRS[NUM_FACES] = {32, 32, 48, 48}; // Face 2, 2, 3, 3
     constexpr std::uint32_t COLUMN_OFFSETS[NUM_FACES]   = {0, 2, 0, 2};     // even, odd, even, odd
-    // Optimized approach: Process 4 iterations to handle all column combinations
-    // This reduces operations by processing complementary face pairs simultaneously, less load/store operations
+
+    // Optimized column reduction: Reduce → Add → Transpose → HalfReduce
+    // Instead of the naive Transpose → Reduce → Transpose → Reduce → Add approach, we first reduce
+    // across registers, then add upper+lower faces (all 4 positions carry meaningful partial sums),
+    // then transpose, then do a final half-reduce on LREG0-3 only. This eliminates one transpose
+    // and halves the second reduction pass, saving 4 instructions per iteration.
     for (std::uint32_t i = 0; i < NUM_FACES; i++)
     {
-        // Iteration mapping - Process vertically aligned faces (0+2, 1+3) to optimize column operations:
-        // i=0: even columns, left half  (faces 0 + 2, columns 0,2,4,6,8,10,12,14)
-        // i=1: odd columns,  left half  (faces 0 + 2, columns 1,3,5,7,9,11,13,15)
-        // i=2: even columns, right half (faces 1 + 3, columns 16,18,20,22,24,26,28,30)
-        // i=3: odd columns,  right half (faces 1 + 3, columns 17,19,21,23,25,27,29,31)
-        // Key optimization: Process faces 0+2 and 1+3 (vertically aligned) instead of 0+1 and 2+3
-        // This allows processing all 32 rows of a column at once (16 from upper face + 16 from lower face)
-        // Reduces load/store operations by accumulating all rows into one LREG per column group
-        // Final result stored in top row of upper face (first row in dest) - no intermediate storage needed
         const std::uint32_t upper_face_addr = UPPER_FACE_ADDRS[i];
         const std::uint32_t lower_face_addr = LOWER_FACE_ADDRS[i];
         const std::uint32_t column_offset   = COLUMN_OFFSETS[i];
         load_face_data<INSTRUCTION_MODE>(upper_face_addr, lower_face_addr, column_offset);
-        // Perform column-wise summation (Blackhole uses replay buffer 6 for both int and float)
-        sum_columns<6>();
+
+        // Step 1: Tree-reduce across registers (LREG0-3→LREG0, LREG4-7→LREG4) without transpose.
+        // After this, each of the 4 positions in LREG0 holds the sum of rows at that position
+        // across all 4 loaded LREGs (e.g., LREG0[i] = sum of row[i], row[i+4], row[i+8], row[i+12]).
+        lltt::replay(0, 6);
+
+        // Step 2: Cross-face addition. Unlike the old approach where only position 0 of the
+        // cross-face sum was meaningful, here ALL 4 positions carry useful partial sums.
         if constexpr (is_integer_mode)
         {
-            TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG0, 4); // LREG0 = upper_face_sums + lower_face_sums (int)
+            TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG0, 4); // LREG0 = upper + lower (int)
         }
         else
         {
             TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG0, 0); // LREG0 = upper + lower (float)
         }
+
+        // Step 3: Transpose to rearrange the 4 partial sums for final reduction
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        // Step 4: Final tree-reduce across LREG0-3 only (LREG4-7 no longer needed).
+        // This sums the 4 partial sums into LREG0[0] = total column sum.
+        lltt::replay(6, 3);
+
         // Perform averaging if requested (different for int vs float)
         if constexpr (pool_type == AVG)
         {
@@ -208,7 +202,7 @@ inline void perform_reduce_col_sum_avg()
                 perform_float_average();
             }
         }
-        // Store the final combined column sums
+        // Store the final column sum/average to the first row
         TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, upper_face_addr + column_offset);
     }
 }
@@ -830,7 +824,9 @@ inline void init_reduce_max_min(std::uint32_t num_cols)
 /**
  * @brief Initialization for SFPU reduce SUM and AVG kernels.
  *        Records replay buffers for column-wise summation using tree reduction.
- *        Integer modes use 6 instructions (SFPIADD), float modes use 6 (SFPADD without NOPs for Blackhole).
+ *        Two buffers are recorded:
+ *        - Positions 0-5: Full tree reduce for both LREG groups (used by both col and row reduce)
+ *        - Positions 6-8: Half tree reduce for LREG0-3 only (used by optimized col reduce)
  *
  * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT (FP32, FP16B)
  */
@@ -843,41 +839,45 @@ inline void init_reduce_sum_avg()
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP || INSTRUCTION_MODE == InstrModLoadStore::LO16);
 
-    // Program optimized replay buffer for column summation
-    // This replay buffer is called twice per iteration:
-    // 1st call: After first transpose - operates on transposed data where LREG0-3 and LREG4-7 both map to lanes 0→3
-    // 2nd call: After second transpose - operates on data transposed back to original layout
+    // Record two replay buffers:
+    // Positions 0-5: Full tree reduce (both LREG groups, interleaved for latency hiding)
+    //   - Used by column reduce (first pass) and row reduce
+    // Positions 6-8: Half tree reduce (LREG0-3 only)
+    //   - Used by optimized column reduce (second pass, after cross-face add + transpose)
 
     if constexpr (is_integer_mode)
     {
-        // Integer replay buffer: 6 instructions for column summation
-        lltt::record(0, 6);
+        lltt::record(0, 9);
 
-        // Upper and lower face column summation, interleaved to eliminate read-after-write dependencies.
+        // Full reduce (positions 0-5): interleaved upper/lower face summation
         TTI_SFPIADD(0, p_sfpu::LREG3, p_sfpu::LREG2, 4); // LREG2 = LREG2 + LREG3
         TTI_SFPIADD(0, p_sfpu::LREG7, p_sfpu::LREG6, 4); // LREG6 = LREG6 + LREG7
         TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG1, 4); // LREG1 = LREG1 + LREG2
-
-        // Lower face column summation (LREG4-7)
         TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG5, 4); // LREG5 = LREG5 + LREG6
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4); // LREG0 = LREG0 + LREG1
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG4, 4); // LREG4 = LREG4 + LREG5
+
+        // Half reduce (positions 6-8): upper face only (LREG0-3)
+        TTI_SFPIADD(0, p_sfpu::LREG3, p_sfpu::LREG2, 4); // LREG2 = LREG2 + LREG3
+        TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG1, 4); // LREG1 = LREG1 + LREG2
+        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4); // LREG0 = LREG0 + LREG1
     }
     else
     {
-        // Float replay buffer: 6 instructions (no NOPs needed for Blackhole)
-        lltt::record(0, 6);
+        lltt::record(0, 9);
 
-        // Upper and lower face summation chains, interleaved to eliminate read-after-write dependencies and the need for NOPs.
-        // Step 1 of each chain
+        // Full reduce (positions 0-5): interleaved to eliminate read-after-write dependencies
         TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0); // A1
         TTI_SFPADD(p_sfpu::LREG6, p_sfpu::LCONST_1, p_sfpu::LREG7, p_sfpu::LREG6, 0); // B1
-        // Step 2 of each chain
         TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG1, 0); // A2
         TTI_SFPADD(p_sfpu::LREG5, p_sfpu::LCONST_1, p_sfpu::LREG6, p_sfpu::LREG5, 0); // B2
-        // Step 3 of each chain
         TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0); // A3
         TTI_SFPADD(p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0); // B3
+
+        // Half reduce (positions 6-8): upper face only (LREG0-3), no NOPs needed on Blackhole
+        TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0); // A1
+        TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG1, 0); // A2
+        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0); // A3
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -183,6 +183,7 @@ inline void perform_reduce_col_sum_avg()
             TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG0, 0); // LREG0 = upper + lower (float)
         }
 
+        // Result of column reduction now stored in LREG0 as 4 partial sums
         // Step 3: Transpose to rearrange the 4 partial sums for final reduction
         TTI_SFPTRANSP(0, 0, 0, 0);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -71,21 +71,6 @@ inline void load_face_data(std::uint32_t upper_face_addr, std::uint32_t lower_fa
 }
 
 /**
- * @brief Perform column-wise summation using transpose and replay buffer
- *
- * Process column sums for both upper and lower face using transpose and replay buffer.
- * @tparam replay_buffer_length The replay buffer index to use (6 for int, 12 for float on Wormhole)
- */
-template <std::uint32_t replay_buffer_length>
-inline void sum_columns()
-{
-    TTI_SFPTRANSP(0, 0, 0, 0);             // Transpose: LREG0-3 → lanes 0-3, LREG4-7 → lanes 0-3 (overlapping)
-    lltt::replay(0, replay_buffer_length); // Column-wise sum within each lreg after transpose
-    TTI_SFPTRANSP(0, 0, 0, 0);             // Transpose back to original register layout
-    lltt::replay(0, replay_buffer_length); // Sum column sums within each face after transpose
-}
-
-/**
  * @brief Perform integer averaging with proper handling of negative numbers
  * @tparam INSTRUCTION_MODE The instruction mode (determines signed vs unsigned)
  *
@@ -143,35 +128,47 @@ inline void perform_reduce_col_sum_avg()
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP || INSTRUCTION_MODE == InstrModLoadStore::LO16);
 
-    // Optimized approach: Process 4 iterations to handle all column combinations
-    // This reduces operations by processing complementary face pairs simultaneously, less load/store operations
+    // Optimized column reduction: Reduce → Add → Transpose → HalfReduce
+    // Instead of the naive Transpose → Reduce → Transpose → Reduce → Add approach, we first reduce
+    // across registers, then add upper+lower faces (all 4 positions carry meaningful partial sums),
+    // then transpose, then do a final half-reduce on LREG0-3 only. This eliminates one transpose
+    // and halves the second reduction pass.
     for (std::uint32_t i = 0; i < NUM_FACES; i++)
     {
-        // Iteration mapping - Process vertically aligned faces (0+2, 1+3) to optimize column operations:
-        // i=0: even columns, left half  (faces 0 + 2, columns 0,2,4,6,8,10,12,14)
-        // i=1: odd columns,  left half  (faces 0 + 2, columns 1,3,5,7,9,11,13,15)
-        // i=2: even columns, right half (faces 1 + 3, columns 16,18,20,22,24,26,28,30)
-        // i=3: odd columns,  right half (faces 1 + 3, columns 17,19,21,23,25,27,29,31)
-        // Key optimization: Process faces 0+2 and 1+3 (vertically aligned) instead of 0+1 and 2+3
-        // This allows processing all 32 rows of a column at once (16 from upper face + 16 from lower face)
-        // Reduces load/store operations by accumulating all rows into one LREG per column group
-        // Final result stored in top row of upper face (first row in dest) - no intermediate storage needed
         const std::uint32_t upper_face_addr = UPPER_FACE_ADDRS[i];
         const std::uint32_t lower_face_addr = LOWER_FACE_ADDRS[i];
         const std::uint32_t column_offset   = COLUMN_OFFSETS[i];
         load_face_data<INSTRUCTION_MODE>(upper_face_addr, lower_face_addr, column_offset);
-        // Perform column-wise summation (different replay buffer lengths for int vs float on Wormhole)
+
+        // Step 1: Tree-reduce across registers (LREG0-3→LREG0, LREG4-7→LREG4) without transpose.
+        lltt::replay(0, 6);
+
+        // Step 2: Cross-face addition — all 4 positions carry meaningful partial sums.
         if constexpr (is_integer_mode)
         {
-            sum_columns<6>();                                // Integer replay buffer
-            TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG0, 4); // LREG0 = upper_face_sums + lower_face_sums (int)
+            TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG0, 4); // LREG0 = upper + lower (int)
         }
         else
         {
-            sum_columns<12>();                                                            // Float replay buffer (includes NOPs for Wormhole)
+            TTI_SFPNOP;                                                                   // Wait for LREG4 (2-cycle SFPADD latency)
             TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG0, 0); // LREG0 = upper + lower (float)
-            TTI_SFPNOP;                                                                   // Required for Wormhole
+            TTI_SFPNOP;                                                                   // Wait for LREG0 before SFPTRANSP
         }
+
+        // Step 3: Transpose to rearrange the 4 partial sums for final reduction
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        // Step 4: Final tree-reduce across LREG0-3 only (LREG4-7 no longer needed).
+        if constexpr (is_integer_mode)
+        {
+            lltt::replay(0, 3); // Reuse first 3 positions of sequential integer buffer (A1,A2,A3)
+        }
+        else
+        {
+            lltt::replay(6, 5); // Half reduce with NOPs for 2-cycle SFPADD latency
+            TTI_SFPNOP;         // Wait for LREG0 result before store/average
+        }
+
         // Perform averaging if requested (different for int vs float)
         if constexpr (pool_type == AVG)
         {
@@ -184,7 +181,7 @@ inline void perform_reduce_col_sum_avg()
                 perform_float_average();
             }
         }
-        // Store the final combined column sums
+        // Store the final column sum/average to the first row
         TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, upper_face_addr + column_offset);
     }
 }
@@ -446,14 +443,8 @@ inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset)
             TT_SFPLOAD(p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second);
             TT_SFPLOAD(p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second + 2);
 
-            if constexpr (is_integer_mode)
-            {
-                lltt::replay(0, 6); // Integer replay buffer
-            }
-            else
-            {
-                lltt::replay(0, 12); // Float replay buffer (includes NOPs for Wormhole)
-            }
+            // Replay the full tree-reduce buffer (both int and float use 6 interleaved instructions)
+            lltt::replay(0, 6);
 
             // Horizontal reduction: consolidate all 8 SFPU columns into column 0 (interleaved for latency hiding)
             horizontal_reduce<is_integer_mode>();
@@ -738,7 +729,9 @@ inline void init_reduce_max_min(std::uint32_t num_cols)
 /**
  * @brief Initialization for SFPU reduce SUM and AVG kernels.
  *        Records replay buffers for column-wise summation using tree reduction.
- *        Integer modes use 6 instructions (SFPIADD), float modes use 12 (SFPADD + NOPs for latency).
+ *        Integer: 6 sequential instructions (positions 0-5), first 3 reusable as half-reduce.
+ *        Float: 6 interleaved instructions (positions 0-5) + 5 half-reduce with NOPs (positions 6-10).
+ *        Interleaving eliminates NOPs in the full reduce by using B operations to hide A's 2-cycle latency.
  *
  * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT (FP32, FP16B)
  */
@@ -751,14 +744,10 @@ inline void init_reduce_sum_avg()
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP || INSTRUCTION_MODE == InstrModLoadStore::LO16);
 
-    // Program optimized replay buffer for column summation
-    // This replay buffer is called twice per iteration:
-    // 1st call: After first transpose - operates on transposed data where LREG0-3 and LREG4-7 both map to lanes 0→3
-    // 2nd call: After second transpose - operates on data transposed back to original layout
-
     if constexpr (is_integer_mode)
     {
-        // Integer replay buffer: 6 instructions for column summation
+        // Integer replay buffer: 6 sequential instructions (1-cycle SFPIADD latency, no NOPs needed)
+        // Positions 0-2 form a natural half-reduce for LREG0-3 (reusable via replay(0, 3))
         lltt::record(0, 6);
 
         // Upper face column summation (LREG0-3)
@@ -773,24 +762,25 @@ inline void init_reduce_sum_avg()
     }
     else
     {
-        // Float replay buffer: 12 instructions (includes NOPs for latency)
-        lltt::record(0, 12);
+        // Float replay buffer: 11 instructions total
+        // Positions 0-5: Full reduce, interleaved to eliminate NOPs (B hides A's 2-cycle latency)
+        // Positions 6-10: Half reduce for LREG0-3 only, with NOPs for dependent SFPADD chains
+        lltt::record(0, 11);
 
-        // Upper face column summation (LREG0-3) with float operations
-        TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0); // LREG2 = (LREG2 * 1) + LREG3
-        TTI_SFPNOP;
-        TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG1, 0); // LREG1 = (LREG1 * 1) + LREG2
-        TTI_SFPNOP;
-        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0); // LREG0 = (LREG0 * 1) + LREG1
-        TTI_SFPNOP;
+        // Full reduce (positions 0-5): interleaved upper/lower face summation
+        TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0); // A1
+        TTI_SFPADD(p_sfpu::LREG6, p_sfpu::LCONST_1, p_sfpu::LREG7, p_sfpu::LREG6, 0); // B1 (hides A1 latency)
+        TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG1, 0); // A2
+        TTI_SFPADD(p_sfpu::LREG5, p_sfpu::LCONST_1, p_sfpu::LREG6, p_sfpu::LREG5, 0); // B2 (hides A2 latency)
+        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0); // A3
+        TTI_SFPADD(p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0); // B3 (hides A3 latency)
 
-        // Lower face column summation (LREG4-7) with float operations
-        TTI_SFPADD(p_sfpu::LREG6, p_sfpu::LCONST_1, p_sfpu::LREG7, p_sfpu::LREG6, 0); // LREG6 = (LREG6 * 1) + LREG7
-        TTI_SFPNOP;
-        TTI_SFPADD(p_sfpu::LREG5, p_sfpu::LCONST_1, p_sfpu::LREG6, p_sfpu::LREG5, 0); // LREG5 = (LREG5 * 1) + LREG6
-        TTI_SFPNOP;
-        TTI_SFPADD(p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0); // LREG4 = (LREG4 * 1) + LREG5
-        TTI_SFPNOP;
+        // Half reduce (positions 6-10): upper face only, NOPs required for 2-cycle SFPADD latency
+        TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0); // A1
+        TTI_SFPNOP;                                                                   // Cover A1 latency
+        TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG1, 0); // A2
+        TTI_SFPNOP;                                                                   // Cover A2 latency
+        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0); // A3
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -165,8 +165,13 @@ inline void perform_reduce_col_sum_avg()
         }
         else
         {
-            lltt::replay(6, 5); // Half reduce with NOPs for 2-cycle SFPADD latency
-            TTI_SFPNOP;         // Wait for LREG0 result before store/average
+            lltt::replay(6, 4); // Half reduce with NOP for 2-cycle SFPADD latency
+            if constexpr (pool_type != AVG)
+            {
+                // SUM path: next op is SFPSTORE LREG0, needs NOP to cover SFPADD's 2-cycle latency.
+                // AVG path: first SFPLOADI in perform_float_average() is independent of LREG0 and fills the slot.
+                TTI_SFPNOP;
+            }
         }
 
         // Perform averaging if requested (different for int vs float)
@@ -443,7 +448,7 @@ inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset)
             TT_SFPLOAD(p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second);
             TT_SFPLOAD(p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second + 2);
 
-            // Replay the full tree-reduce buffer (both int and float use 6 interleaved instructions)
+            // Replay the full tree-reduce buffer (both int and float use 6 instructions)
             lltt::replay(0, 6);
 
             // Horizontal reduction: consolidate all 8 SFPU columns into column 0 (interleaved for latency hiding)
@@ -515,13 +520,9 @@ inline void sum_first_columns_across_tiles(std::uint32_t tile_row_base, std::uin
             else
             {
                 TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG0, 0);
-                TTI_SFPNOP; // Required for Wormhole float latency
                 TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG1, 0);
-                TTI_SFPNOP;
                 TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG6, p_sfpu::LREG2, 0);
-                TTI_SFPNOP;
                 TTI_SFPADD(p_sfpu::LREG3, p_sfpu::LCONST_1, p_sfpu::LREG7, p_sfpu::LREG3, 0);
-                TTI_SFPNOP;
             }
         }
 
@@ -762,10 +763,10 @@ inline void init_reduce_sum_avg()
     }
     else
     {
-        // Float replay buffer: 11 instructions total
+        // Float replay buffer: 10 instructions total
         // Positions 0-5: Full reduce, interleaved to eliminate NOPs (B hides A's 2-cycle latency)
-        // Positions 6-10: Half reduce for LREG0-3 only, with NOPs for dependent SFPADD chains
-        lltt::record(0, 11);
+        // Positions 6-9: Half reduce for LREG0-3 only, with NOP for dependent SFPADD chain
+        lltt::record(0, 10);
 
         // Full reduce (positions 0-5): interleaved upper/lower face summation
         TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0); // A1
@@ -775,12 +776,12 @@ inline void init_reduce_sum_avg()
         TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0); // A3
         TTI_SFPADD(p_sfpu::LREG4, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG4, 0); // B3 (hides A3 latency)
 
-        // Half reduce (positions 6-10): upper face only, NOPs required for 2-cycle SFPADD latency
+        // Half reduce (positions 6-9): upper face only, NOP required for 2-cycle SFPADD latency
+        // Reorders A1/A3/A2 so A1 and A3 (disjoint outputs) issue back-to-back; only A3's latency before A2 needs a NOP.
         TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0); // A1
-        TTI_SFPNOP;                                                                   // Cover A1 latency
-        TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG1, 0); // A2
-        TTI_SFPNOP;                                                                   // Cover A2 latency
         TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0); // A3
+        TTI_SFPNOP;                                                                   // Cover A3 latency (A1 is already available)
+        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0); // A2
     }
 }
 


### PR DESCRIPTION
Copy of the existing [LLK PR](https://github.com/tenstorrent/tt-llk/pull/1628)

Replace the naive Transpose→Reduce→Transpose→Reduce→Add column reduction with an optimized Reduce→Add→Transpose→HalfReduce approach that eliminates one transpose and halves the second reduction pass.

Key changes:

Remove sum_columns() helper in favor of inline optimized sequence
Record two replay buffers: full reduce (positions 0-5) and half reduce (positions 6-8 on BH, 6-10 on WH with NOPs)
Interleave A-group (LREG0-3) and B-group (LREG4-7) operations to hide pipeline latency, eliminating 6 NOPs from WH float reduce
Simplify row reduce to always use replay(0, 6) since the interleaved buffer works for both int and float
Instruction savings per column reduce iteration:

BH int/float: 16 instructions saved
WH int: 16 instructions saved
WH float: 52 instructions saved (NOP elimination + algorithm improvement)
Tested: 880/880 sfpu_reduce + 1/1 sfpu_reduce_sdpa + 4284/4284 reduce variants pass on Blackhole hardware

### Summary
Fixes [issue](https://github.com/tenstorrent/tt-llk/pull/1628)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-1141-codegen-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/issue-1141-codegen-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/issue-1141-codegen-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/issue-1141-codegen-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/issue-1141-codegen-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/issue-1141-codegen-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/issue-1141-codegen-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/issue-1141-codegen-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/issue-1141-codegen-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/issue-1141-codegen-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/issue-1141-codegen-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/issue-1141-codegen-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/issue-1141-codegen-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/issue-1141-codegen-v1)