### PR TITLE
codegen/session_cost: exclude cache tokens from total

### DIFF
--- a/tt_metal/tt-llk/codegen/scripts/session_cost.py
+++ b/tt_metal/tt-llk/codegen/scripts/session_cost.py
@@ -200,7 +200,7 @@ def _aggregate(
         output=out,
         cache_read=cr,
         cache_creation=cc,
-        total=inp + out + cr + cc,
+        total=inp + out,
         cost_usd=round(cost, 6),
     )
 
@@ -306,12 +306,7 @@ def main(argv: list[str] | None = None) -> int:
                 totals[k] += sub_t[k]
             totals["cost_usd"] += sub_t["cost_usd"]
 
-    totals["total"] = (
-        totals["input"]
-        + totals["output"]
-        + totals["cache_read"]
-        + totals["cache_creation"]
-    )
+    totals["total"] = totals["input"] + totals["output"]
     totals["cost_usd"] = round(totals["cost_usd"], 6)
 
     if args.log_dir:


### PR DESCRIPTION
## Summary
- Count only input + output tokens in the session total; cache reads and cache creation are billed separately and were inflating the headline token number.

## Test plan
- [ ] Run `session_cost.py` against a log directory and confirm `total` matches `input + output`.

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanomanovic/2304-codegen-token-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanomanovic/2304-codegen-token-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanomanovic/2304-codegen-token-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanomanovic/2304-codegen-token-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanomanovic/2304-codegen-token-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanomanovic/2304-codegen-token-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanomanovic/2304-codegen-token-fix) |