### PR TITLE
refactor(llk): replace bool untilize+tilize with PackMode enum in pack layer

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -26,6 +26,7 @@
 // TODO NC: Remove as the part of tt-metal#34499
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
+    constexpr PackMode mode = untilize ? PackMode::Untilize : tilize ? PackMode::Tilize : PackMode::Default;
     const std::uint32_t output_id = get_output_id(output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -33,7 +34,7 @@ inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles =
     const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_mop_config_<untilize, zero_output, tilize>(
+    _llk_pack_mop_config_<mode, zero_output>(
         pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
@@ -49,7 +50,7 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /*untilize*/>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -64,13 +65,14 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
 template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>
 inline void llk_pack_untilize_hw_configure(
     const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
+    constexpr PackMode mode = untilize ? PackMode::Untilize : tilize ? PackMode::Tilize : PackMode::Default;
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const bool partial_face = get_output_partial_face(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize, tilize>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, mode>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -102,6 +104,7 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1, const std::uint32_t input_operand = 0) {
+    constexpr PackMode mode = untilize ? PackMode::Untilize : tilize ? PackMode::Tilize : PackMode::Default;
     // TODO (https://github.com/tenstorrent/tt-metal/issues/18948): Revisit for narrow_tile
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -118,7 +121,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
     // 8-bit datums (Int8, UInt8, Fp8_e4m3, Lf8) do not require the tilize workaround on Blackhole.
     const std::uint32_t src_format = static_cast<std::uint32_t>(unpack_src_format[input_operand]);
     const bool is_input_8bit_format = IS_8BIT_FORMAT(src_format);
-    _llk_pack_init_<untilize, zero_output, tilize>(
+    _llk_pack_init_<mode, zero_output>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         face_r_dim,
@@ -129,7 +132,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
         num_tiles,
         is_input_8bit_format);
 #else
-    _llk_pack_init_<untilize, zero_output, tilize>(
+    _llk_pack_init_<mode, zero_output>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         face_r_dim,
@@ -420,7 +423,7 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
                 .Threshold = 0,
             }};
 
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
             pack_src_format[output_id],
             pack_dst_format[output_id],
             tile_size,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -25,9 +25,9 @@
  *************************************************************************/
 
 // TODO NC: Remove as the part of tt-metal#34499
-template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
+template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
-    constexpr PackMode mode = untilize ? PackMode::Untilize : PackMode::Default;
+    constexpr PackMode mode = untilize ? PackMode::Untilize : tilize ? PackMode::Tilize : PackMode::Default;
     const std::uint32_t output_id = get_output_id(output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -100,9 +100,9 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
     llk_pack_untilize_hw_configure<is_fp32_dest_acc_en, untilize>(&llk_pack_params, face_r_dim, num_faces);
 }
 
-template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
+template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1) {
-    constexpr PackMode mode = untilize ? PackMode::Untilize : PackMode::Default;
+    constexpr PackMode mode = untilize ? PackMode::Untilize : tilize ? PackMode::Tilize : PackMode::Default;
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -27,13 +27,14 @@
 // TODO NC: Remove as the part of tt-metal#34499
 template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
 inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
+    constexpr PackMode mode = untilize ? PackMode::Untilize : PackMode::Default;
     const std::uint32_t output_id = get_output_id(output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_mop_config_<untilize, zero_output>(
+    _llk_pack_mop_config_<mode, zero_output>(
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
@@ -49,7 +50,7 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /*untilize*/>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -63,13 +64,14 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
 template <bool is_fp32_dest_acc_en, bool untilize = false>
 inline void llk_pack_untilize_hw_configure(
     const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
+    constexpr PackMode mode = untilize ? PackMode::Untilize : PackMode::Default;
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, mode>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -100,6 +102,7 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
 inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1) {
+    constexpr PackMode mode = untilize ? PackMode::Untilize : PackMode::Default;
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
@@ -111,7 +114,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
             pack_src_format[output_id], pack_dst_format[output_id], face_r_dim)),
         "");
 
-    _llk_pack_init_<untilize, zero_output>(
+    _llk_pack_init_<mode, zero_output>(
         pack_dst_format[output_id],
         pack_src_format[output_id],
         face_r_dim,
@@ -480,7 +483,7 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
                 .Threshold = 0,
             }};
 
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
             pack_src_format[output_id],
             pack_dst_format[output_id],
             tile_size,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -40,12 +40,12 @@ class Packer(BasePacker):
     ) -> str:
         stage = operation.stage_id
         dest_acc = config.dest_acc.cpp_enum_value
-        bh_tilize = operation.bh_tilize.cpp_enum_value
+        bh_pack_mode = operation.bh_tilize.pack_mode_value
         face_r_dim = operation.face_r_dim
         num_faces = operation.num_faces
         dest_sync = f"DstSync::Sync{operation.dest_sync.name}"
         return (
-            f"    _llk_pack_init_<false, false, {bh_tilize}>(\n"
+            f"    _llk_pack_init_<{bh_pack_mode}, false>(\n"
             f"        pack_dst_format{stage}, pack_dst_format{stage}, {face_r_dim}, TILE_C_DIM, {num_faces}, false, false\n"
             f"    );\n"
             f"    _llk_pack_dest_init_<{dest_sync}, {dest_acc}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -361,7 +361,7 @@ class ComputePipeline:
         self, operation: "FusedOperation", config: "GlobalConfig"
     ) -> str:
         stage = operation.stage_id
-        bh_tilize = operation.bh_tilize.cpp_enum_value
+        bh_pack_mode = operation.bh_tilize.pack_mode_value
         dest_acc = config.dest_acc.cpp_enum_value
         pack_size = operation.tile_size_pack
         face_r_dim = operation.face_r_dim
@@ -370,13 +370,13 @@ class ComputePipeline:
         if stage == 1:
             if config.architecture == ChipArchitecture.BLACKHOLE:
                 code = (
-                    f"_llk_pack_hw_configure_<{dest_acc}, false, {bh_tilize}>(\n"
+                    f"_llk_pack_hw_configure_<{dest_acc}, {bh_pack_mode}>(\n"
                     f"pack_src_format{stage}, pack_dst_format{stage}, {pack_size}, {face_r_dim}, TILE_C_DIM, {num_faces}\n"
                     f");\n"
                 )
             elif config.architecture == ChipArchitecture.WORMHOLE:
                 code = (
-                    f"_llk_pack_hw_configure_<{dest_acc}, false>(\n"
+                    f"_llk_pack_hw_configure_<{dest_acc}, PackMode::Default>(\n"
                     f"pack_src_format{stage}, pack_dst_format{stage}, {pack_size}, {face_r_dim}, {num_faces}\n"
                     f");\n"
                 )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
@@ -43,7 +43,7 @@ class Packer(BasePacker):
         num_faces = operation.num_faces
         dest_sync = f"DstSync::Sync{operation.dest_sync.name}"
         return (
-            f"    _llk_pack_init_<false, false>(\n"
+            f"    _llk_pack_init_<PackMode::Default, false>(\n"
             f"        pack_dst_format{stage}, {face_r_dim}, {num_faces}\n"
             f"    );\n"
             f"    _llk_pack_dest_init_<{dest_sync}, {dest_acc}, false>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -322,6 +322,13 @@ class Tilize(Enum):
         else:
             return "false"
 
+    @property
+    def pack_mode_value(self):
+        if self.value == True:
+            return "PackMode::Tilize"
+        else:
+            return "PackMode::Default"
+
 
 class FastMode(Enum):
     Yes = True

--- a/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_pack_untilize.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_pack_untilize.cpp
@@ -87,11 +87,11 @@ void run_kernel(RUNTIME_PARAMETERS /*params*/)
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false>(formats.pack_src, formats.pack_dst, tile_size);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
     _llk_pack_untilize_init_<ct_dim>(formats.pack_src, formats.pack_dst, FACE_R_DIM, 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, tile_size);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en, UNTILIZE>();
     _llk_pack_untilize_init_<ct_dim>(formats.pack_dst, FACE_R_DIM, 4);
 #endif

--- a/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_unary.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_unary.cpp
@@ -88,12 +88,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 {
     // Configure packer hardware
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/ai_gen/reduce_sfpu_unary.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/reduce_sfpu_unary.cpp
@@ -125,12 +125,12 @@ void run_kernel(RUNTIME_PARAMETERS /*params*/)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
     _llk_pack_reduce_mask_config_<false, REDUCE_DIM>();

--- a/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
@@ -93,12 +93,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const bool TILIZE   = false; // Input to pack is already in tile format
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(formats.pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default, false>(formats.pack_dst);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false>(formats.pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats.pack_dst);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en, UNTILIZE>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
@@ -80,7 +80,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 0 /* tile_size */);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 0 /* tile_size */);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
     // Ugly but we are converting one 4 face tile into two 2 face tiles side by side
     _llk_pack_untilize_init_<BLOCK_CT_DIM * 2, FULL_CT_DIM * 2, false, TILE_C_DIM, true>(

--- a/tt_metal/tt-llk/tests/sources/eltwise_bcast_col_custom_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_bcast_col_custom_perf.cpp
@@ -156,7 +156,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-        _llk_pack_init_<false, false>(formats.pack_dst);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
@@ -161,7 +161,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-        _llk_pack_init_<false, false>(formats.pack_dst);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -277,9 +277,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * num_faces);
 
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
 #else
-        _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, num_faces);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, num_faces);
 #endif
         // Initialize destination for packing
         _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
@@ -154,18 +154,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
     // BH configure_pack uses partial_face for BFP exp_section_size, but narrow_tile is unused (defaults to false)
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, false /* narrow_tile */);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
 
         formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);
 #endif
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces);
 #else
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);
 #endif
 
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
@@ -93,12 +93,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false /* zero_output */>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
@@ -70,12 +70,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<false, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, 4);
-    _llk_pack_init_<false, false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4);
+    _llk_pack_hw_configure_<false, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, 4);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
-    _llk_pack_hw_configure_<false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, 4);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, 4);
+    _llk_pack_hw_configure_<false, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, 4);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, 4);
     _llk_pack_dest_init_<DstSync::SyncHalf, false, false>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -124,12 +124,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, tilize_en>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_<false, false, tilize_en>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, tilize_en ? PackMode::Tilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<tilize_en ? PackMode::Tilize : PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -275,9 +275,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * num_faces);
 
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
 #else
-        _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, num_faces);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, num_faces);
 #endif
         // Initialize destination for packing
         _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -111,12 +111,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_NUM_FACES);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_NUM_FACES);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en, false>();
 #endif
     LLK_ASSERT(

--- a/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
@@ -217,7 +217,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
             formats.pack_src,
             formats.pack_dst,
             TILE_SIZE_PACK,
@@ -225,7 +225,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             TILE_C_DIM,
             num_faces,
             PARTIAL_FACE_PACK);
-        _llk_pack_init_<false, false, false>(
+        _llk_pack_init_<PackMode::Default, false>(
             formats.pack_dst,
             in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM,
             TILE_C_DIM,
@@ -233,9 +233,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             false /* partial_face parameter is unused on BH */);
         _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
             formats.pack_src, formats.pack_dst, TILE_SIZE_PACK, in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM, num_faces, PARTIAL_FACE_PACK);
-        _llk_pack_init_<false, false>(formats.pack_dst, in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM, num_faces, PARTIAL_FACE_PACK);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM, num_faces, PARTIAL_FACE_PACK);
         _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en, false>();
 #endif
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
@@ -115,7 +115,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src,
         formats.pack_dst,
         params.TILE_SIZE_PACK,
@@ -123,7 +123,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         TILE_C_DIM,
         params.num_faces,
         params.PARTIAL_FACE_PACK);
-    _llk_pack_init_<false, false, false>(
+    _llk_pack_init_<PackMode::Default, false>(
         formats.pack_dst,
         params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
         TILE_C_DIM,
@@ -131,14 +131,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         false /* partial_face parameter is unused on BH */);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src,
         formats.pack_dst,
         params.TILE_SIZE_PACK,
         params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
         params.num_faces,
         params.PARTIAL_FACE_PACK);
-    _llk_pack_init_<false, false>(
+    _llk_pack_init_<PackMode::Default, false>(
         formats.pack_dst, params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, params.num_faces, params.PARTIAL_FACE_PACK);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en, false>();
 #endif

--- a/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
@@ -153,7 +153,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-        _llk_pack_init_<false, false>(formats.pack_dst);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
@@ -125,12 +125,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     int run = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<false, false, false>(formats_array[run].pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<PackMode::Default, false>(formats_array[run].pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<false, false>(formats_array[run].pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<PackMode::Default, false>(formats_array[run].pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
 #endif
 
@@ -144,7 +144,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(formats_array[run].pack_src, formats_array[run].pack_dst, params.TILE_SIZE_PACK);
 
-    _llk_pack_init_<false, false>(formats_array[run].pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats_array[run].pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/matmul_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_custom_test.cpp
@@ -104,12 +104,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
-    _llk_pack_init_<false /* untilize */, false /* zero_output */, false /* tilize */>(formats.pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false /* untilize */>();
 #endif
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
@@ -74,11 +74,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false>(formats.pack_src, formats.pack_dst, tile_size);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_dest_init_<sync, is_fp32_dest_acc_en>();
     _llk_pack_untilize_init_<ct_dim>(formats.pack_src, formats.pack_dst, FACE_R_DIM, 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, tile_size);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_dest_init_<sync, is_fp32_dest_acc_en, UNTILIZE>();
     _llk_pack_untilize_init_<ct_dim>(formats.pack_dst, FACE_R_DIM, 4);
 #endif

--- a/tt_metal/tt-llk/tests/sources/matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_test.cpp
@@ -99,12 +99,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
-    _llk_pack_init_<false, false, false>(formats.pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
 #endif
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -158,12 +158,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     int run = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
 #ifdef ARCH_BLACKHOLE
     const bool TILIZE = true;
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(formats_array[run].pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default, false>(formats_array[run].pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false>(formats_array[run].pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats_array[run].pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>();
 #endif
 
@@ -186,7 +186,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         tile_size); // need to reconfigure data formats_array for next pack, also calls set_packer_strides to readjust strides after pack tilizing
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false, false>(formats_array[run].pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats_array[run].pack_dst);
 #endif
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
@@ -70,12 +70,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_test.cpp
@@ -80,12 +80,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
@@ -215,12 +215,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, FACE_R_DIM, TILE_C_DIM, 4);
-        _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, false, false, TILE_CNT);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, FACE_R_DIM, TILE_C_DIM, 4);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, false, false, TILE_CNT);
         reconfigure_packer_l1_acc(L1_ACC);
 #else
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, FACE_R_DIM, 4);
-        _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, 4, false, false, NUM_TILES_IN_BLOCK);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, FACE_R_DIM, 4);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, 4, false, false, NUM_TILES_IN_BLOCK);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
 #endif
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
@@ -127,16 +127,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int num_blocks         = params.NUM_BLOCKS;
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, tilize_en>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, tilize_en ? PackMode::Tilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
 
-    _llk_pack_init_<false, false, tilize_en>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces, false, false, num_tiles_in_block);
+    _llk_pack_init_<tilize_en ? PackMode::Tilize : PackMode::Default, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces, false, false, num_tiles_in_block);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     reconfigure_packer_l1_acc(params.L1_ACC);
 
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, params.num_faces, false, false, num_tiles_in_block);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, params.num_faces, false, false, num_tiles_in_block);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
     reconfigure_packer_l1_acc(params.L1_ACC);
 #endif

--- a/tt_metal/tt-llk/tests/sources/pack_rows_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_rows_test.cpp
@@ -96,7 +96,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     const bool UNTILIZE = false;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else

--- a/tt_metal/tt-llk/tests/sources/pack_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_test.cpp
@@ -105,14 +105,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, tilize_en>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, tilize_en ? PackMode::Tilize : PackMode::Default>(
         formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces, false, false, params.RELU_CONFIG);
-    _llk_pack_init_<false, false, tilize_en>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<tilize_en ? PackMode::Tilize : PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces, false, false, params.RELU_CONFIG);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, params.num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #endif
     const std::uint32_t num_tiles_in_block = params.NUM_TILES_IN_BLOCK;

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
@@ -127,11 +127,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int num_blocks         = params.NUM_BLOCKS;
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces);
 
     // Standard init sets addr_mods and strides for the tile shape.
-    _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, false, false, 1);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, false, false, 1);
 
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     reconfigure_packer_l1_acc(params.L1_ACC);
@@ -143,8 +143,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // the tile shape (face_r_dim, num_faces).
     _llk_pack_block_contiguous_mop_config_<>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.num_faces);
-    _llk_pack_init_<false, false>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
@@ -130,9 +130,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
     // --- Phase 1: Init for standard 32x32 tiles ---
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, 4);
 
-    _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4, false, false, 1);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4, false, false, 1);
 
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     reconfigure_packer_l1_acc(params.L1_ACC);
@@ -140,16 +140,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // --- Phase 2: Full re-init for the actual tiny tile dims ---
     // This overwrites the 32x32 config established in Phase 1, testing
     // that the transition from one tile shape to another is correct.
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces);
 
-    _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, false, false, 1);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, false, false, 1);
 
     // Replace MOP with the block-contiguous version (REPLAY + W-per-tile).
     _llk_pack_block_contiguous_mop_config_<>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.num_faces);
-    _llk_pack_init_<false, false>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
@@ -196,11 +196,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
 
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         _llk_pack_untilize_init_<BLOCK_CT_DIM, FULL_CT_DIM>(formats.pack_src, formats.pack_dst, FACE_R_DIM, 4);
 #else
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>();
         _llk_pack_untilize_init_<BLOCK_CT_DIM, FULL_CT_DIM>(formats.pack_dst, FACE_R_DIM, 4);
 #endif

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
@@ -137,11 +137,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t base_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false>(formats.pack_src, formats.pack_dst, NUM_DATUMS_IN_TILE /* tile_size */);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, NUM_DATUMS_IN_TILE /* tile_size */);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
     _llk_pack_untilize_init_<BLOCK_CT_DIM, FULL_CT_DIM>(formats.pack_src, formats.pack_dst, FACE_R_DIM, params.num_faces);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, NUM_DATUMS_IN_TILE /* tile_size */);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, NUM_DATUMS_IN_TILE /* tile_size */);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en, UNTILIZE>();
     _llk_pack_untilize_init_<BLOCK_CT_DIM, FULL_CT_DIM>(formats.pack_dst, FACE_R_DIM, params.num_faces);
 #endif

--- a/tt_metal/tt-llk/tests/sources/reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_test.cpp
@@ -130,17 +130,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, false /* narrow_tile */);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);
 #endif
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces);
+    _llk_pack_init_<PackMode::Default, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces);
 #else
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);
+    _llk_pack_init_<PackMode::Default, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);
 #endif
 
     _llk_pack_reduce_mask_config_<false, REDUCE_DIM>();

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -217,12 +217,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_src_format0 = ckernel::to_underlying(DataFormat::Float16_b);
     const std::uint32_t pack_dst_format0 = ckernel::to_underlying(DataFormat::Float16_b);
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<false, false, false>(pack_src_format0, pack_dst_format0, 128);
-    _llk_pack_init_<false, false, false>(pack_dst_format0, pack_dst_format0, 16, TILE_C_DIM, 4, false, false);
+    _llk_pack_hw_configure_<false, PackMode::Default>(pack_src_format0, pack_dst_format0, 128);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format0, pack_dst_format0, 16, TILE_C_DIM, 4, false, false);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
-    _llk_pack_hw_configure_<false, false>(pack_src_format0, pack_dst_format0, 128);
-    _llk_pack_init_<false, false>(pack_dst_format0);
+    _llk_pack_hw_configure_<false, PackMode::Default>(pack_src_format0, pack_dst_format0, 128);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format0);
     _llk_pack_dest_init_<DstSync::SyncHalf, false, false>();
 #endif
     for (std::uint32_t batch = 0; batch < 1; ++batch)
@@ -243,10 +243,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_dst_format1 = ckernel::to_underlying(DataFormat::Float16_b);
     _llk_pack_reconfig_data_format_<false, false>(pack_src_format1, pack_dst_format1, 128);
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false, false>(pack_dst_format1, pack_dst_format1, 16, TILE_C_DIM, 4, false, false);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format1, pack_dst_format1, 16, TILE_C_DIM, 4, false, false);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
-    _llk_pack_init_<false, false>(pack_dst_format1);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format1);
     _llk_pack_dest_init_<DstSync::SyncHalf, false, false>();
 #endif
     _llk_pack_reduce_mask_config_<false, ckernel::ReduceDim::REDUCE_ROW>();
@@ -269,10 +269,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_dst_format2 = ckernel::to_underlying(DataFormat::Float16_b);
     _llk_pack_reconfig_data_format_<false, false>(pack_src_format2, pack_dst_format2, 128);
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false, false>(pack_dst_format2, pack_dst_format2, 16, TILE_C_DIM, 4, false, false);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format2, pack_dst_format2, 16, TILE_C_DIM, 4, false, false);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
-    _llk_pack_init_<false, false>(pack_dst_format2);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format2);
     _llk_pack_dest_init_<DstSync::SyncHalf, false, false>();
 #endif
     for (std::uint32_t batch = 0; batch < 1; ++batch)
@@ -293,10 +293,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_dst_format3 = ckernel::to_underlying(DataFormat::Float16_b);
     _llk_pack_reconfig_data_format_<false, false>(pack_src_format3, pack_dst_format3, 128);
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false, false>(pack_dst_format3, pack_dst_format3, 16, TILE_C_DIM, 4, false, false);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format3, pack_dst_format3, 16, TILE_C_DIM, 4, false, false);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
-    _llk_pack_init_<false, false>(pack_dst_format3);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format3);
     _llk_pack_dest_init_<DstSync::SyncHalf, false, false>();
 #endif
     for (std::uint32_t batch = 0; batch < 1; ++batch)

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
@@ -94,12 +94,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16);
 #endif
 
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
@@ -183,12 +183,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-        _llk_pack_init_<false, false>(formats.pack_dst);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
@@ -216,12 +216,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         // Configure packer hardware
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-        _llk_pack_init_<false, false>(formats.pack_dst);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
         // Initialize destination for packing
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -101,12 +101,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     // Configure packer hardware
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
     // Initialize destination for packing
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
@@ -154,12 +154,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -172,12 +172,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
     const bool TILIZE = true;
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(formats_array[run].pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default, false>(formats_array[run].pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false>(formats_array[run].pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats_array[run].pack_dst);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>();
 #endif
 
@@ -193,8 +193,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                                                // Now unpacker's wait condition is satisfied, allowing it to begin processing data from L1.
     run = 1;                                   // second L1-to-L1 run, we access the second set of formats_array in our array
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, !TILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false, !TILIZE>(formats_array[run].pack_dst);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : (!TILIZE) ? PackMode::Tilize : PackMode::Default>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : (!TILIZE) ? PackMode::Tilize : PackMode::Default, false>(formats_array[run].pack_dst);
 #endif
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -449,15 +449,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef ARCH_BLACKHOLE
                         _llk_pack_hw_configure_<
                             is_fp32_dest_acc_en,
-                            false,  // untilize
-                            false>( // tilize
+                            PackMode::Default>(
                             pack_src_format,
                             pack_dst_format,
                             16 * 16 * 4);
 #else
                         _llk_pack_hw_configure_<
                             is_fp32_dest_acc_en,
-                            false>( // untilize
+                            PackMode::Default>(
                             pack_src_format,
                             pack_dst_format,
                             16 * 16 * 4);
@@ -484,7 +483,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
                     }
 
-                    _llk_pack_init_<false, false>(pack_dst_format);
+                    _llk_pack_init_<PackMode::Default, false>(pack_dst_format);
 
                     const int tile_dest_offset = stage_index * NUM_TILES_PER_STAGE;
 

--- a/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
@@ -108,12 +108,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_<false, false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, false>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
@@ -153,12 +153,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(PACK_FMT, PACK_FMT, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(PACK_FMT, PACK_FMT, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(PACK_FMT, PACK_FMT, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(PACK_FMT, PACK_FMT, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<false, false>(PACK_FMT);
+    _llk_pack_init_<PackMode::Default, false>(PACK_FMT);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
@@ -129,13 +129,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Test configuration constants
     constexpr DstSync sync_mode = DstSync::SyncHalf;
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM * params.TEST_FACE_C_DIM * 4, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_<false, false>(formats.pack_dst, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM * params.TEST_FACE_C_DIM * 4, params.TEST_FACE_R_DIM, params.num_faces);
-    _llk_pack_init_<false, false>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
 #endif
 
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_test.cpp
@@ -80,12 +80,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<false, false>(formats.pack_dst);
+    _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
@@ -112,7 +112,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src,
         formats.pack_dst,
         params.TILE_SIZE_PACK,
@@ -120,7 +120,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         TILE_C_DIM,
         params.num_faces,
         params.PARTIAL_FACE_PACK);
-    _llk_pack_init_<false, false, false>(
+    _llk_pack_init_<PackMode::Default, false>(
         formats.pack_dst,
         params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
         TILE_C_DIM,
@@ -128,14 +128,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         false /* partial_face parameter is unused on BH */);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
         formats.pack_src,
         formats.pack_dst,
         params.TILE_SIZE_PACK,
         params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
         params.num_faces,
         params.PARTIAL_FACE_PACK);
-    _llk_pack_init_<false, false>(
+    _llk_pack_init_<PackMode::Default, false>(
         formats.pack_dst, params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, params.num_faces, params.PARTIAL_FACE_PACK);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en, false>();
 #endif

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
@@ -211,12 +211,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
 
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-        _llk_pack_init_<UNTILIZE, false, TILIZE>(formats.pack_dst);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_init_<UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-        _llk_pack_init_<UNTILIZE, false>(formats.pack_dst);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>();
 #endif
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -134,12 +134,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DATUM_COUNT = 16 * 16 * params.num_faces;
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats.pack_src, formats.pack_dst, DATUM_COUNT, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default>(formats.pack_src, formats.pack_dst, DATUM_COUNT, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, DATUM_COUNT, FACE_R_DIM, params.num_faces);
-    _llk_pack_init_<UNTILIZE, false>(formats.pack_dst, FACE_R_DIM, params.num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, DATUM_COUNT, FACE_R_DIM, params.num_faces);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
@@ -122,12 +122,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
     const bool TILIZE = true;
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false /* tilize */>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(
         formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, num_faces);
 
     const bool is_8bit_format = IS_8BIT_FORMAT(formats.unpack_A_src);
 
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : TILIZE ? PackMode::Tilize : PackMode::Default, false>(
         formats.pack_src,
         formats.pack_dst,
         FACE_R_DIM,
@@ -139,8 +139,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         is_8bit_format /* skip_bh_tilize_workaround */);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, num_faces);
-    _llk_pack_init_<UNTILIZE, false>(formats.pack_dst, FACE_R_DIM, num_faces);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, num_faces);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats.pack_dst, FACE_R_DIM, num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
@@ -136,7 +136,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
 
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-        _llk_pack_init_<false, false>(formats.pack_dst);
+        _llk_pack_init_<PackMode::Default, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_untilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_untilize_perf.cpp
@@ -157,12 +157,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
 
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-        _llk_pack_init_<UNTILIZE, false, false>(formats.pack_dst);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-        _llk_pack_init_<UNTILIZE, false>(formats.pack_dst);
+        _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+        _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>();
 #endif
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/unpack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_untilize_test.cpp
@@ -89,12 +89,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const bool UNTILIZE = false;
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE ? PackMode::Untilize : PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-    _llk_pack_init_<UNTILIZE, false>(formats.pack_dst);
+    _llk_pack_init_<UNTILIZE ? PackMode::Untilize : PackMode::Default, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -271,4 +271,11 @@ enum class BinaryOp : std::uint8_t
     ADD_TOP_ROW   = 10
 };
 
+enum class PackMode
+{
+    Default  = 0,
+    Untilize = 1,
+    Tilize   = 2,
+};
+
 } // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -297,7 +297,7 @@ __attribute__((noinline)) bool is_packer_to_L1_conversion_supported(const DataFo
     return is_packer_to_L1_early_conversion_supported(in_reg, out_l1) || is_packer_to_L1_late_conversion_supported(in_reg, out_l1);
 }
 
-template <bool untilize = false, bool tilize = false>
+template <PackMode mode = PackMode::Default>
 inline void set_packer_strides(const std::uint32_t pack_src_format, const std::uint32_t tile_c_dim)
 {
     std::uint32_t x_stride = (pack_src_format & 0x3) == to_underlying(DataFormat::Float32)   ? 4
@@ -306,9 +306,11 @@ inline void set_packer_strides(const std::uint32_t pack_src_format, const std::u
     std::uint32_t y_stride = FACE_C_DIM * x_stride;
     std::uint32_t w_stride = TILE_NUM_FACES * FACE_C_DIM * FACE_R_DIM * x_stride;
 
-    // Untilize mode has 2 packer interfaces active, so z counter needs to jump by 2
+    // Untilize/Tilize modes have 2 packer interfaces active, so z counter needs to jump by 2
     // faces, since z counter is only 1 bit (can't be programmed to inc by 2)
-    const std::uint32_t z_stride = ((untilize ^ tilize) && (tile_c_dim == TILE_C_DIM)) ? 2 * FACE_R_DIM * y_stride : FACE_R_DIM * y_stride;
+    const std::uint32_t z_stride =
+        ((mode == PackMode::Untilize || mode == PackMode::Tilize) && (tile_c_dim == TILE_C_DIM)) ? 2 * FACE_R_DIM * y_stride
+                                                                                                  : FACE_R_DIM * y_stride;
 
     TT_SETDMAREG(0, LOWER_HALFWORD((y_stride << PCK0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT)), 0, LO_16(p_gpr_pack::TMP0)); // x-stride not used!
     TT_SETDMAREG(0, UPPER_HALFWORD((y_stride << PCK0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT)), 0, HI_16(p_gpr_pack::TMP0));
@@ -320,7 +322,7 @@ inline void set_packer_strides(const std::uint32_t pack_src_format, const std::u
     TTI_NOP;
     TTI_NOP;
 
-    if constexpr (tilize && !untilize)
+    if constexpr (mode == PackMode::Tilize)
     {
         const std::uint32_t z_stride_ch1 = FACE_R_DIM * y_stride;
         TT_SETDMAREG(0, LOWER_HALFWORD((z_stride_ch1 << PCK0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT)), 0, LO_16(p_gpr_pack::TMP1));
@@ -565,7 +567,7 @@ inline void reconfig_packer_data_format(
     set_packer_strides(pack_output_src_format, tile_c_dim);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>
+template <bool is_fp32_dest_acc_en, PackMode mode = PackMode::Default>
 inline void configure_pack(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -587,7 +589,7 @@ inline void configure_pack(
 
     const std::uint32_t pack_output_src_format = masked_data_format(pack_src_format);
 
-    set_packer_strides<untilize, tilize>(pack_src_format, tile_c_dim);
+    set_packer_strides<mode>(pack_src_format, tile_c_dim);
 
     t6_mutex_acquire(mutex::REG_RMW);
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -17,10 +17,10 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
-template <bool untilize = false, bool tilize = false>
+template <PackMode mode = PackMode::Default>
 inline void _llk_pack_configure_addrmod_()
 {
-    if constexpr (untilize && !tilize)
+    if constexpr (mode == PackMode::Untilize)
     {
         /*  Y src & Y dest inc by 1 to give strided increments:
             Rows: 0, 16, 1, 17, 2, 18, ........ 15, 31
@@ -35,7 +35,7 @@ inline void _llk_pack_configure_addrmod_()
         addr_mod_pack_t {.y_src = {.incr = 0, .clr = 1}, .y_dst = {.incr = 0, .clr = 1}, .z_src = {.incr = 0, .clr = 1}, .z_dst = {.incr = 0, .clr = 1}}.set(
             ADDR_MOD_2);
     }
-    else if constexpr (tilize && !untilize)
+    else if constexpr (mode == PackMode::Tilize)
     {
         addr_mod_pack_t {.y_src = {.incr = 4}, .y_dst = {.incr = 2}, .z_src = {.incr = 0}, .z_dst = {.incr = 0}}.set(ADDR_MOD_0);
 
@@ -69,7 +69,7 @@ inline void _llk_pack_configure_addrmod_()
     }
 }
 
-template <bool untilize = false, bool zero_output = false, bool tilize = false>
+template <PackMode mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_mop_config_(
     [[maybe_unused]] const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim           = FACE_R_DIM,
@@ -86,7 +86,7 @@ inline void _llk_pack_mop_config_(
     constexpr std::uint32_t MEGAROW          = 1;
     constexpr std::uint32_t ZERO_OUTPUT_FLAG = zero_output ? p_pacr::P_ZERO_OUTPUT_ENABLED : p_pacr::P_ZERO_OUTPUT_DISABLED;
 
-    if constexpr (untilize && !tilize)
+    if constexpr (mode == PackMode::Untilize)
     {
         const std::uint32_t PACK_INTF_SEL  = (tile_c_dim < TILE_C_DIM) ? p_pacr::SINGLE_INTF_ACTIVE : p_pacr::TWO_INTFS_ACTIVE;
         const std::uint32_t MOP_INNER_LOOP = face_r_dim;
@@ -137,7 +137,7 @@ inline void _llk_pack_mop_config_(
             1));
         tmp.program();
     }
-    else if constexpr (tilize && !untilize)
+    else if constexpr (mode == PackMode::Tilize)
     {
         const std::uint32_t PACK_INTF_SEL_0 = 0b0101;
         const std::uint32_t PACK_INTF_SEL_1 = 0b1010;
@@ -332,7 +332,7 @@ inline void _llk_pack_reconfig_data_format_(
 
     if constexpr (is_tile_dim_reconfig_en)
     {
-        _llk_pack_mop_config_<false, false>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        _llk_pack_mop_config_<PackMode::Default, false>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
     }
 }
 
@@ -342,9 +342,9 @@ inline void _llk_pack_set_fp32_dest_acc_(bool enable)
     cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
 }
 
-// If using 8bit datums for unpack src. tilize must be set to false because we skip the blackhole workaround which involves unswizzling rows in the tile,
+// If using 8bit datums for unpack src. mode must not be Tilize because we skip the blackhole workaround which involves unswizzling rows in the tile,
 // and this unswizzling is not needed for 8bit datums as they are not affected by the blackhole issue.
-template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>
+template <bool is_fp32_dest_acc_en, PackMode mode = PackMode::Default>
 inline void _llk_pack_hw_configure_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -357,12 +357,11 @@ inline void _llk_pack_hw_configure_(
     const std::uint32_t relu_config = 0)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    configure_pack<is_fp32_dest_acc_en, untilize, tilize>(
+    configure_pack<is_fp32_dest_acc_en, mode>(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, relu_config);
 }
 
-// TODO NC: Clean up as the part of tt-metal#34587
-template <bool untilize = false, bool zero_output = false, bool tilize = false>
+template <PackMode mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim = FACE_R_DIM,
@@ -373,12 +372,11 @@ inline void _llk_pack_init_(
     const std::uint32_t num_tiles  = 1)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    _llk_pack_configure_addrmod_<untilize, tilize>();
-    _llk_pack_mop_config_<untilize, zero_output, tilize>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    _llk_pack_configure_addrmod_<mode>();
+    _llk_pack_mop_config_<mode, zero_output>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
-// TODO NC: Clean up as the part of tt-metal#34587
-template <bool untilize = false, bool zero_output = false, bool tilize = false>
+template <PackMode mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -403,18 +401,20 @@ inline void _llk_pack_init_(
 
     // 8bit datums in the unpack src format are not affected by the blackhole issue,
     // so we can skip the workaround which involves unswizzling rows in the tile.
+    // When skipping the workaround we strip Tilize from the mode (Untilize is preserved).
     if (skip_bh_tilize_workaround)
     {
-        _llk_pack_configure_addrmod_<untilize, false /* tilize */>();
-        _llk_pack_mop_config_<untilize, zero_output, false /* tilize */>(
+        constexpr PackMode workaround_mode = (mode == PackMode::Untilize) ? PackMode::Untilize : PackMode::Default;
+        _llk_pack_configure_addrmod_<workaround_mode>();
+        _llk_pack_mop_config_<workaround_mode, zero_output>(
             pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
-        set_packer_strides<untilize, false /* tilize */>(pack_src_format, tile_c_dim);
+        set_packer_strides<workaround_mode>(pack_src_format, tile_c_dim);
     }
     else
     {
-        _llk_pack_configure_addrmod_<untilize, tilize>();
-        _llk_pack_mop_config_<untilize, zero_output, tilize>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
-        set_packer_strides<untilize, tilize>(pack_src_format, tile_c_dim);
+        _llk_pack_configure_addrmod_<mode>();
+        _llk_pack_mop_config_<mode, zero_output>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        set_packer_strides<mode>(pack_src_format, tile_c_dim);
     }
 
     TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -256,4 +256,11 @@ enum class BinaryOp : std::uint8_t
     ADD_TOP_ROW   = 10
 };
 
+enum class PackMode
+{
+    Default  = 0,
+    Untilize = 1,
+    Tilize   = 2,
+};
+
 } // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -674,7 +674,7 @@ inline void reconfig_packer_data_format(
     set_packer_strides(pack_src_format);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize>
+template <bool is_fp32_dest_acc_en, PackMode mode = PackMode::Default>
 inline void configure_pack(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -748,9 +748,10 @@ inline void configure_pack(
 
     const std::uint32_t face_dim = face_r_dim * FACE_C_DIM;
 
+    static_assert(mode != PackMode::Tilize, "Tilize pack mode not supported on Wormhole B0");
     // To untilize narrow tile (32x16) we just pack 2 faces back to back
     // Number of datums to pack per row
-    const std::uint32_t pack_x_dim = (narrow_tile || !untilize) ? face_dim : FACE_R_DIM;
+    const std::uint32_t pack_x_dim = (narrow_tile || mode != PackMode::Untilize) ? face_dim : FACE_R_DIM;
 
     TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -70,16 +70,17 @@ inline std::uint32_t _llk_pack_output_addr_offset_words_(
     return tile_size >> 4;
 }
 
-template <bool untilize = false>
+template <PackMode mode = PackMode::Default>
 inline void _llk_pack_configure_addrmod_()
 {
+    static_assert(mode != PackMode::Tilize, "Tilize pack mode not supported on Wormhole B0");
     addr_mod_pack_t {
         .y_src = {.incr = 15}, // 4-bit value so max is 15. incadcxy will increment it by 1
         .y_dst = {.incr = 1},
     }
         .set(ADDR_MOD_0);
 
-    if constexpr (untilize)
+    if constexpr (mode == PackMode::Untilize)
     {
         addr_mod_pack_t {
             .y_src = {.incr = 1, .clr = 0, .cr = 1},
@@ -105,7 +106,7 @@ inline void _llk_pack_configure_addrmod_()
         .set(ADDR_MOD_2);
 }
 
-template <bool untilize = false, bool zero_output = false>
+template <PackMode mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_mop_config_(
     const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim = FACE_R_DIM,
@@ -114,10 +115,11 @@ inline void _llk_pack_mop_config_(
     const bool narrow_tile         = false,
     const std::uint32_t num_tiles  = 1)
 {
+    static_assert(mode != PackMode::Tilize, "Tilize pack mode not supported on Wormhole B0");
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     LLK_ASSERT(num_tiles >= 1, "num_tiles must be >= 1");
 
-    if constexpr (!untilize)
+    if constexpr (mode != PackMode::Untilize)
     {
         if (num_tiles > 1)
         {
@@ -139,7 +141,7 @@ inline void _llk_pack_mop_config_(
     llk_pack_internal::configured_num_tiles   = num_tiles;
     llk_pack_internal::configured_zero_output = ZERO_OUTPUT_FLAG;
 
-    if constexpr (!untilize)
+    if constexpr (mode != PackMode::Untilize)
     {
         if (partial_face && IS_BFP_FORMAT(pack_dst_format))
         {
@@ -215,7 +217,7 @@ inline void _llk_pack_reconfig_data_format_(
 
     if constexpr (is_tile_dim_reconfig_en)
     {
-        _llk_pack_mop_config_<false, false>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        _llk_pack_mop_config_<PackMode::Default, false>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
     }
 }
 
@@ -225,7 +227,7 @@ inline void _llk_pack_set_fp32_dest_acc_(bool enable)
     cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false>
+template <bool is_fp32_dest_acc_en, PackMode mode = PackMode::Default>
 inline void _llk_pack_hw_configure_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -237,11 +239,10 @@ inline void _llk_pack_hw_configure_(
     const std::uint32_t relu_config = 0)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    configure_pack<is_fp32_dest_acc_en, untilize>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile, relu_config);
+    configure_pack<is_fp32_dest_acc_en, mode>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile, relu_config);
 }
 
-// TODO NC: Clean up as the part of tt-metal#34587
-template <bool untilize = false, bool zero_output = false>
+template <PackMode mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim = FACE_R_DIM,
@@ -250,18 +251,18 @@ inline void _llk_pack_init_(
     const bool narrow_tile         = false,
     const std::uint32_t num_tiles  = 1)
 {
+    static_assert(mode != PackMode::Tilize, "Tilize pack mode not supported on Wormhole B0");
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    _llk_pack_configure_addrmod_<untilize>();
-    _llk_pack_mop_config_<untilize, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    _llk_pack_configure_addrmod_<mode>();
+    _llk_pack_mop_config_<mode, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
 
     set_packer_l1_offset(pack_dst_format, face_r_dim);
     const std::uint32_t face_dim   = face_r_dim * FACE_C_DIM;
-    const std::uint32_t pack_x_dim = (narrow_tile || !untilize) ? face_dim : FACE_R_DIM;
+    const std::uint32_t pack_x_dim = (narrow_tile || mode != PackMode::Untilize) ? face_dim : FACE_R_DIM;
     TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
 }
 
-// TODO NC: Clean up as the part of tt-metal#34587
-template <bool untilize = false, bool zero_output = false>
+template <PackMode mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_dst_format,
     const std::uint32_t pack_src_format,
@@ -271,13 +272,14 @@ inline void _llk_pack_init_(
     const bool narrow_tile        = false,
     const std::uint32_t num_tiles = 1)
 {
+    static_assert(mode != PackMode::Tilize, "Tilize pack mode not supported on Wormhole B0");
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    _llk_pack_configure_addrmod_<untilize>();
-    _llk_pack_mop_config_<untilize, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    _llk_pack_configure_addrmod_<mode>();
+    _llk_pack_mop_config_<mode, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
 
     set_packer_l1_offset(pack_dst_format);
     const std::uint32_t face_dim   = face_r_dim * FACE_C_DIM;
-    const std::uint32_t pack_x_dim = (narrow_tile || !untilize) ? face_dim : FACE_R_DIM;
+    const std::uint32_t pack_x_dim = (narrow_tile || mode != PackMode::Untilize) ? face_dim : FACE_R_DIM;
     TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
 }
 
@@ -514,7 +516,7 @@ inline void _llk_pack_fast_tilize_uninit_(
     // for some reason short inits avoid the packer init (probably since it is usually the same)
     // but that means calling it here with reasonable defaults is needed
     // it just initializes the address mods and mop
-    _llk_pack_init_<false, false>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile);
+    _llk_pack_init_<PackMode::Default, false>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
 inline void _llk_pack_fast_tilize_block_(


### PR DESCRIPTION
### Summary

Replaces the two-boolean template parameter pattern `bool untilize, bool tilize` in internal `_llk_pack_*` functions with a single `enum class PackMode { Default, Untilize, Tilize }` for both Blackhole and Wormhole B0 architectures.

Public-facing `llk_*` wrapper APIs retain `bool` parameters and translate to `PackMode` internally via:
```cpp
constexpr PackMode mode = untilize ? PackMode::Untilize : tilize ? PackMode::Tilize : PackMode::Default;
```

Wormhole B0 does not support tilize packing in hardware, so all internal WH functions gain a `static_assert(mode != PackMode::Tilize, "Tilize pack mode not supported on Wormhole B0")` guard.

Closes #34587

### Notes for reviewers

- `_llk_pack_` (the tile-pack operation) is intentionally left with `bool untilize` — it has no `tilize` parameter and is outside the scope of this refactor.
- The `PackMode` enum is defined in `ckernel_defs.h` for both architectures (after the existing `BinaryOp` enum).
- All ~55 test sources under `tests/sources/` are updated; `#ifdef ARCH_BLACKHOLE` / `#else` blocks have arch-appropriate translations.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/34587-pack-mode-enum)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/34587-pack-mode-enum)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/34587-pack-mode-enum)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/34587-pack-mode-enum)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/34587-pack-mode-enum)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/34587-pack-mode-enum)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/34587-pack-mode-enum)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/34587-pack-mode-enum)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/34587-pack-mode-enum)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/34587-pack-mode-enum)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/34587-pack-mode-enum)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/34587-pack-mode-enum)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/34587-pack-mode-enum)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/34587-pack-mode-enum)