### PR TITLE
#42972: fix up slice rm stride bug

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp"
 
+#include <algorithm>
 #include <optional>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -50,9 +50,11 @@ SliceRmStrideProgramFactory::cached_program_t SliceRmStrideProgramFactory::creat
     }
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t actual_input_w = input_shape[-1];
     uint32_t actual_output_w = output_shape[-1];
+    uint32_t input_bytes_per_row = actual_input_w * element_size;
     uint32_t output_bytes_per_row = actual_output_w * element_size;
-    uint32_t cb_page_size = output_bytes_per_row;
+    uint32_t cb_page_size = std::max(input_bytes_per_row, output_bytes_per_row);
 
     auto src_buffer_alignment = input_tensor.buffer()->alignment();
     auto dst_buffer_alignment = output.buffer()->alignment();


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #42972 

When testing bbradel-38930_cb_check found a bug in slice with watcher enabled for `tests/ttnn/unit_tests/operations/data_movement/test_slice.py::test_slice_usecase1[layout=Layout.ROW_MAJOR]`

AI summary:

Bug: In slice_program_factory_rm_stride.cpp, the circular buffer page size was calculated using only the output row width:


slice_program_factory_rm_stride.cpp
Lines 53-55
    uint32_t actual_output_w = output_shape[-1];
    uint32_t output_bytes_per_row = actual_output_w * element_size;
    uint32_t cb_page_size = output_bytes_per_row;
However, the reader kernel (reader_multicore_slice_4d.cpp) reads the full input row into the CB first, then slices in-place:


reader_multicore_slice_4d.cpp
Lines 152-153
                uint64_t input_row_noc_addr = s0.get_noc_addr(input_row_idx);
                noc_async_read(input_row_noc_addr, l1_write_addr, input_bytes_per_row);
When the width step > 1 (as in [..., ::2, ::2]), the input row is larger than the output row (1280 bytes vs 640 bytes), causing the NOC read to overflow the circular buffer.

Fix: Size the CB page to the maximum of input and output row widths, so the full input row fits before in-place slicing:

uint32_t cb_page_size = std::max(input_bytes_per_row, output_bytes_per_row);
This is a one-line change in slice_program_factory_rm_stride.cpp (line 57). It ensures the CB can always hold the full input row that the reader kernel needs, regardless of the step parameter.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Tested locally that test_slice.py passes:
```
...
SKIPPED [1] tests/ttnn/unit_tests/operations/data_movement/test_slice.py:1112: Requested more devices than available. Test not applicable for machine
======================================================== 408 passed, 38 skipped in 173.89s (0:02:53) =========================================================
```

Will run Sanity.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-42972_slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42972_slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-42972_slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42972_slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-42972_slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42972_slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-42972_slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-42972_slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-42972_slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42972_slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-42972_slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42972_slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-42972_slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42972_slice)