### PR TITLE
Fix DeepSeek MoE expert stacked regressions

### DIFF
--- a/models/demos/deepseek_v3/tests/test_bspm_demo.py
+++ b/models/demos/deepseek_v3/tests/test_bspm_demo.py
@@ -323,9 +323,15 @@ def _assert_experts_convert_weights_uses_stacked_inputs(
     )
 
     assert requested_names == ["gate_proj.weight", "down_proj.weight", "up_proj.weight"]
-    assert torch.equal(sharded_tensors["w1_experts.input_tensor_b"], expected_tensors["gate_proj"].unsqueeze(0))
-    assert torch.equal(sharded_tensors["w2_experts.input_tensor_b"], expected_tensors["down_proj"].unsqueeze(0))
-    assert torch.equal(sharded_tensors["w3_experts.input_tensor_b"], expected_tensors["up_proj"].unsqueeze(0))
+    assert torch.equal(
+        sharded_tensors["w1_experts.input_tensor_b"], expected_tensors["gate_proj"].unsqueeze(0).transpose(-1, -2)
+    )
+    assert torch.equal(
+        sharded_tensors["w2_experts.input_tensor_b"], expected_tensors["down_proj"].unsqueeze(0).transpose(-1, -2)
+    )
+    assert torch.equal(
+        sharded_tensors["w3_experts.input_tensor_b"], expected_tensors["up_proj"].unsqueeze(0).transpose(-1, -2)
+    )
 
 
 def test_bspm_state_dict_applies_overrides_to_stacked_expert_weights():

--- a/models/demos/deepseek_v3/tests/test_hf_model_utils.py
+++ b/models/demos/deepseek_v3/tests/test_hf_model_utils.py
@@ -504,7 +504,7 @@ def test_unload_weight_from_lazy_state_dict_evicts_stacked_alias_cache(tmp_path:
 
     load_weight(expert_key, target_tensor)
     assert expert_key in state_dict._cache
-    assert stacked_key in state_dict._cache
+    assert stacked_key not in state_dict._cache
 
     unload_weight(expert_key, target_tensor)
     assert target_tensor.numel() == 0

--- a/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
+++ b/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
@@ -466,6 +466,27 @@ def test_stacked_expert_alias_contains_rejects_out_of_range_experts(tmp_path: Pa
         _ = state[missing_expert_key]
 
 
+def test_cached_stacked_expert_alias_respects_layer_filter(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_tensor}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state = load_state_dict(model_dir, "")
+    expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
+
+    assert torch.equal(state[expert_key], stacked_tensor[1])
+    filtered_view = state.view_with_prefix("", num_layers=2)
+
+    assert expert_key not in filtered_view
+    with pytest.raises(KeyError):
+        _ = filtered_view[expert_key]
+
+
 def test_lazy_state_dict_rejects_mixed_expert_checkpoint(tmp_path: Path):
     model_dir = tmp_path / "model"
     model_dir.mkdir(parents=True, exist_ok=True)
@@ -549,8 +570,8 @@ def test_evict_alias_releases_unpinned_stacked_tensor(tmp_path: Path):
     expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
 
     assert torch.equal(state[expert_key], stacked_tensor[1])
-    assert stacked_key in state._cache
     assert expert_key in state._cache
+    assert stacked_key not in state._cache
 
     state.evict(expert_key)
 

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -52,14 +52,44 @@ def create_combined_state_dict(module_path: str, model_path: Path, state_dict: d
     """
     parts = module_path.split(".")
     base_path = ".".join(parts[:-1])
+    container_name = base_path.split(".")[-1]
     s, e = module_path.split(".")[-1].split("-")
     s, e = int(s), int(e)
+    stacked_prefix = ".".join(parts[:-2] + ["experts_stacked"]) + "."
+    stacked_state_dict = sub_state_dict(state_dict, stacked_prefix)
+    stacked_projection_names = ("gate_proj.weight", "down_proj.weight", "up_proj.weight")
+    present_stacked_projection_names = tuple(name for name in stacked_projection_names if name in stacked_state_dict)
+
     out_state_dict = {}
+    if present_stacked_projection_names:
+        if present_stacked_projection_names != stacked_projection_names:
+            missing_projection_names = sorted(set(stacked_projection_names) - set(present_stacked_projection_names))
+            raise ValueError(
+                "Checkpoint mixes stacked and legacy expert weights in reference model setup: "
+                f"missing stacked projections {missing_projection_names} under '{stacked_prefix}'"
+            )
+
+        for projection_name in stacked_projection_names:
+            stacked_weight = stacked_state_dict[projection_name]
+            if stacked_weight.ndim != 3:
+                raise ValueError(
+                    f"Expected stacked expert weight '{stacked_prefix}{projection_name}' to have rank 3, "
+                    f"got {stacked_weight.ndim}"
+                )
+            if stacked_weight.shape[0] <= e:
+                raise ValueError(
+                    f"Expected stacked expert weight '{stacked_prefix}{projection_name}' to contain expert {e}, "
+                    f"got {stacked_weight.shape[0]} experts"
+                )
+            for expert_idx in range(s, e + 1):
+                out_state_dict[f"{container_name}.{expert_idx}.{projection_name}"] = stacked_weight[expert_idx]
+        return out_state_dict
+
     for i in range(s, e + 1):
         module_path_i = f"{base_path}.{i}"
         state_dict_i = sub_state_dict(state_dict, module_path_i + ".")
         for k, v in state_dict_i.items():
-            k_ = f"{base_path.split('.')[-1]}.{i}.{k}"
+            k_ = f"{container_name}.{i}.{k}"
             out_state_dict[k_] = v
 
     return out_state_dict
@@ -236,6 +266,49 @@ def test_convert_weights_rejects_partial_stacked_expert_checkpoint(monkeypatch: 
             tmp_path,
             _FakeMeshDevice(),
         )
+
+
+def test_create_combined_state_dict_uses_stacked_expert_weights():
+    class _ViewableStateDict(dict):
+        def view_with_prefix(self, prefix: str, num_layers: int | None = None):
+            return {k[len(prefix) :]: v for k, v in self.items() if k.startswith(prefix)}
+
+    state_dict = _ViewableStateDict(
+        {
+            "model.layers.3.mlp.experts_stacked.gate_proj.weight": torch.arange(24, dtype=torch.bfloat16).reshape(
+                3, 2, 4
+            ),
+            "model.layers.3.mlp.experts_stacked.down_proj.weight": torch.arange(24, 48, dtype=torch.bfloat16).reshape(
+                3, 2, 4
+            ),
+            "model.layers.3.mlp.experts_stacked.up_proj.weight": torch.arange(48, 72, dtype=torch.bfloat16).reshape(
+                3, 2, 4
+            ),
+        }
+    )
+
+    combined_state_dict = create_combined_state_dict("model.layers.3.mlp.experts.1-2", Path("."), state_dict)
+
+    assert set(combined_state_dict) == {
+        "experts.1.gate_proj.weight",
+        "experts.1.down_proj.weight",
+        "experts.1.up_proj.weight",
+        "experts.2.gate_proj.weight",
+        "experts.2.down_proj.weight",
+        "experts.2.up_proj.weight",
+    }
+    assert torch.equal(
+        combined_state_dict["experts.1.gate_proj.weight"],
+        state_dict["model.layers.3.mlp.experts_stacked.gate_proj.weight"][1],
+    )
+    assert torch.equal(
+        combined_state_dict["experts.2.down_proj.weight"],
+        state_dict["model.layers.3.mlp.experts_stacked.down_proj.weight"][2],
+    )
+    assert torch.equal(
+        combined_state_dict["experts.2.up_proj.weight"],
+        state_dict["model.layers.3.mlp.experts_stacked.up_proj.weight"][2],
+    )
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -113,7 +113,7 @@ class Experts(AbstractModule):
             ttnn_name: {
                 "input_tensor_b": shard_and_save(
                     output_path / f"{ttnn_name}.input_tensor_b",
-                    _load_expert_weight(hf_name).unsqueeze(0).contiguous(),
+                    _load_expert_weight(hf_name).unsqueeze(0).transpose(-1, -2).contiguous(),
                     shard_dims=(1, 1),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat8_b if hf_name == "down_proj" else ttnn.bfloat4_b,
@@ -164,19 +164,16 @@ class Experts(AbstractModule):
             "mesh_device": MeshDeviceStub(mesh_device.shape),
             "w1_experts": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                transpose_b=True,
                 memory_config=output_memory_config,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             ),
             "w2_experts": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                transpose_b=True,
                 memory_config=output_memory_config,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "w3_experts": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                transpose_b=True,
                 memory_config=output_memory_config,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             ),

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -237,6 +237,20 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             self._pinned_cache_keys.add(full_key)
         return tensor
 
+    def _load_stacked_expert_tensor(self, stacked_full_key: str, expert_idx: int) -> torch.Tensor:
+        if stacked_full_key in self._cache:
+            return self._cache[stacked_full_key][expert_idx]
+
+        filename = self._full_to_file[stacked_full_key]
+        filepath = self._model_path / filename
+        if not filepath.exists():
+            raise KeyError(
+                f"Attempted to load weight {stacked_full_key} from file {filepath} but the file does not exist."
+            )
+
+        handle = self._get_handle(filename)
+        return handle.get_slice(stacked_full_key)[expert_idx]
+
     def _passes_layer_filter(self, full_key: str) -> bool:
         if self._num_layers is None:
             return True
@@ -278,11 +292,10 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         """
         full_key = self._full_key(key)
         if full_key in self._cache:
-            if (
-                full_key in self._full_to_file
-                and self._passes_layer_filter(full_key)
-                and self._exposes_physical_key(full_key)
-            ):
+            if full_key not in self._full_to_file:
+                if self._resolve_stacked_expert_alias(full_key) is not None:
+                    return self._cache[full_key]
+            if self._passes_layer_filter(full_key) and self._exposes_physical_key(full_key):
                 self._pinned_cache_keys.add(full_key)
                 return self._cache[full_key]
         if (
@@ -299,8 +312,7 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         stacked_full_key, expert_idx = alias
         if expert_idx >= self._get_stacked_num_experts(stacked_full_key):
             raise KeyError(key)
-        stacked_tensor = self._load_tensor(stacked_full_key, pin_cache=False)
-        tensor = stacked_tensor[expert_idx]
+        tensor = self._load_stacked_expert_tensor(stacked_full_key, expert_idx)
         self._cache[full_key] = tensor
         return tensor
 


### PR DESCRIPTION
## Summary
- fix stacked DeepSeek MoE reference setup so real-weight expert tests slice `experts_stacked.*` directly instead of repeatedly materializing legacy per-expert aliases
- restore pre-quantization transpose semantics for MoE expert weights so BF4/BF8 conversion matches the last known-good behavior
- add focused regression coverage for stacked alias caching, layer-filter visibility, BSPM stacked inputs, and stacked reference assembly

## Root Cause
- `#42150` switched DeepSeek MoE to stacked checkpoints, but the real-weight test reference path still iterated legacy per-expert aliases and timed out on stacked tensors
- the same change also moved the expert-weight transpose from conversion time to runtime via `transpose_b=True`, which changed the BF4/BF8 conversion path and likely caused the remaining PCC regression after the timeout fix

## Issue
Fixes #42965

## Testing
- `pre-commit run --files models/demos/deepseek_v3/tests/test_bspm_demo.py models/demos/deepseek_v3/tests/test_hf_model_utils.py models/demos/deepseek_v3/tests/test_lazy_state_dict.py models/demos/deepseek_v3/tests/test_moe_experts.py models/demos/deepseek_v3/tt/experts.py models/demos/deepseek_v3/utils/lazy_state_dict.py`
- `python3 -m py_compile models/demos/deepseek_v3/tt/experts.py models/demos/deepseek_v3/utils/lazy_state_dict.py models/demos/deepseek_v3/tests/test_moe_experts.py models/demos/deepseek_v3/tests/test_lazy_state_dict.py models/demos/deepseek_v3/tests/test_hf_model_utils.py models/demos/deepseek_v3/tests/test_bspm_demo.py`
- `git diff --check`
- current-head CI: [all-static-checks run 24850727010](https://github.com/tenstorrent/tt-metal/actions/runs/24850727010), [galaxy-deepseek-tests run 24850777785](https://github.com/tenstorrent/tt-metal/actions/runs/24850777785)
- local `pytest` selectors could not be run on this machine because the Python environment is missing `pytest`, `torch`, `safetensors`, `loguru`, and `transformers`

## CI Badge
[![All static checks (yieldthought/42965-deepseek-moe-pcc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml/badge.svg?branch=yieldthought%2F42965-deepseek-moe-pcc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml?query=branch%3Ayieldthought%2F42965-deepseek-moe-pcc-fix)
[![Galaxy DeepSeek tests (yieldthought/42965-deepseek-moe-pcc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2F42965-deepseek-moe-pcc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ayieldthought%2F42965-deepseek-moe-pcc-fix)
