### PR TITLE
Auto-Mapper bug fix : Align `generate_rank_bindings` with ControlPlane (Galaxy pinnings, MGD host ranks, logging)

### DIFF
--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -87,7 +87,7 @@ jobs:
           TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_galaxy_xyz_cluster_desc.yaml TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.TestControlPlaneInitNoMGD
 
           # Custom MGD topologies
-          TT_METAL_SLOW_DISPATCH_MODE=1 tt-run --mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_6u_cluster_desc.yaml --mesh-graph-descriptor tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_8x4_2x2_hosts_mesh_graph_descriptor.textproto --mpi-args "--allow-run-as-root"  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.TestControlPlaneInitNoMGD
+          TT_METAL_SLOW_DISPATCH_MODE=1 tt-run --mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_galaxy_xyz_cluster_desc.yaml --mesh-graph-descriptor tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_8x4_2x2_hosts_mesh_graph_descriptor.textproto --mpi-args "--allow-run-as-root"  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.TestControlPlaneInitNoMGD
 
           # Multi-host tests
           # Dual Galaxy

--- a/tools/scaleout/src/generate_rank_bindings.cpp
+++ b/tools/scaleout/src/generate_rank_bindings.cpp
@@ -21,8 +21,8 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/distributed_context.hpp>
-#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper_utils.hpp>
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/fabric/physical_system_discovery.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
@@ -208,7 +208,7 @@ void print_physical_adjacency_map(
  * This function:
  * 1. Builds physical multi-mesh graph from PSD, PGD, and MGD
  * 2. Builds logical multi-mesh graph from MGD (via MeshGraph)
- * 3. Configures topology mapping with strict mode and disabled rank bindings
+ * 3. Configures topology mapping (strict mode, UBB galaxy + MGD pinnings when applicable, rank bindings on)
  * 4. Runs map_multi_mesh_to_physical
  * 5. Returns the mapping result
  */
@@ -243,7 +243,28 @@ TopologyMappingResult run_topology_mapping(
         config.hostname_to_asics[desc.host_name].insert(asic_id);
     }
 
-    // Extract pinnings from MGD and add to config (same as control plane)
+    const std::size_t world_size = static_cast<std::size_t>(
+        *tt::tt_metal::distributed::multihost::DistributedContext::get_current_world()->size());
+
+    // UBB Galaxy fixed corner pinnings (align with ControlPlane when building TopologyMappingConfig)
+    if (cluster.is_ubb_galaxy()) {
+        for (const auto& mesh_id : mesh_graph.get_all_mesh_ids()) {
+            const auto& mesh_shape = mesh_graph.get_mesh_shape(mesh_id);
+            const bool is_1d = mesh_shape[0] == 1 || mesh_shape[1] == 1;
+            const std::size_t mesh_chip_count = mesh_shape.mesh_size();
+            if (!is_1d && mesh_chip_count % 32 == 0) {
+                auto mesh_pinnings =
+                    get_galaxy_fixed_asic_position_pinnings_for_mesh(mesh_id, mesh_shape, world_size == 1);
+                for (const auto& [fabric_node, positions] : mesh_pinnings) {
+                    for (const auto& pos : positions) {
+                        config.pinnings.emplace_back(pos, fabric_node);
+                    }
+                }
+            }
+        }
+    }
+
+    // Extract pinnings from MGD and add to config (after galaxy pinnings, same order as control plane)
     const auto& pinnings = mgd.get_pinnings();
     for (const auto& [pos, fabric_node] : pinnings) {
         config.pinnings.emplace_back(pos, fabric_node);

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -465,6 +465,19 @@ TopologyMappingResult map_multi_mesh_to_physical(
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank = {},
     const std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>>& fabric_node_id_to_mesh_rank = {});
 
+/**
+ * @brief Fixed ASIC position pinnings for UBB Galaxy meshes (corners; optional hard pin of logical node 0).
+ *
+ * Matches ControlPlane / TopologyMapper when `cluster.is_ubb_galaxy()`: for non-1D meshes whose device count is a
+ * multiple of 32, pins fabric corner nodes to tray/ASIC layout so QSFP links align. Used when building
+ * `TopologyMappingConfig::pinnings` (one (AsicPosition, FabricNodeId) per allowed physical position per corner).
+ *
+ * @param hard_pin_node_0 If true, pins NW corner to tray 1 / ASIC 1 only (e.g. single-process run); MGD pinnings for
+ *                        fabric node 0 can override if merged after.
+ */
+std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> get_galaxy_fixed_asic_position_pinnings_for_mesh(
+    MeshId mesh_id, const ::tt::tt_metal::distributed::MeshShape& mesh_shape, bool hard_pin_node_0 = false);
+
 }  // namespace tt::tt_metal::experimental::tt_fabric
 
 // Formatter for LogicalExitNode to enable fmt::format debugging

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -61,60 +61,13 @@
 #include "tt_metal/fabric/serialization/port_descriptor_serialization.hpp"
 #include "tt_metal/fabric/serialization/intermesh_connections_serialization.hpp"
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
+#include <tt-metalium/experimental/fabric/topology_mapper_utils.hpp>
 #include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp"
 
 namespace tt::tt_fabric {
 
 namespace {
-
-// Generate fixed ASIC position pinnings for Galaxy topology to ensure QSFP links align with fabric mesh corner nodes.
-// This is a performance optimization to ensure that MGD mapping does not bisect a device.
-//
-// * o o * < Corners pinned with *
-// o o o o
-// o o o o
-// o o o o
-// o o o o
-// o o o o
-// o o o o
-// * o o * < Corners pinned with *
-// Generate fixed ASIC position pinnings for a single mesh in UBB galaxy systems.
-// For UBB galaxy runs with 32 chips, it can optionally hard pin fabric node id 0 to asic 1 tray 1.
-// If MGD pinnings are provided for fabric node id 0, MGD pinnings take precedence and hard pinning is skipped.
-std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> get_galaxy_fixed_asic_position_pinnings_for_mesh(
-    MeshId mesh_id, const MeshShape& mesh_shape, bool hard_pin_node_0 = false) {
-    std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> fixed_asic_position_pinnings;
-
-    // Get all 4 possible corners ASIC positions
-    std::vector<AsicPosition> corner_asic_positions;
-    corner_asic_positions.emplace_back(AsicPosition{1, 1});  // Top left corner
-    corner_asic_positions.emplace_back(AsicPosition{2, 1});  // Top right corner
-    corner_asic_positions.emplace_back(AsicPosition{3, 1});  // Bottom left corner
-    corner_asic_positions.emplace_back(AsicPosition{4, 1});  // Bottom right corner
-
-    // Generate corner fabric node IDs for this mesh
-    std::vector<FabricNodeId> corner_fabric_node_ids;
-    corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, 0});
-    corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, mesh_shape[1] - 1});
-    corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, mesh_shape[1] * (mesh_shape[0] - 1)});
-    corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, (mesh_shape[1] * mesh_shape[0]) - 1});
-
-    fixed_asic_position_pinnings.reserve(corner_fabric_node_ids.size());
-    for (const auto& corner_fabric_node_id : corner_fabric_node_ids) {
-        // Special case: Hard pin NW corner (fabric node id 0) to asic 1 tray 1 if requested
-        // This is only used when MGD pinnings are not provided for fabric node id 0
-        if (corner_fabric_node_id == FabricNodeId{MeshId{0}, 0} && hard_pin_node_0) {
-            fixed_asic_position_pinnings.emplace_back(
-                corner_fabric_node_id, std::vector<AsicPosition>{AsicPosition{1, 1}});
-            continue;
-        }
-
-        fixed_asic_position_pinnings.emplace_back(corner_fabric_node_id, corner_asic_positions);
-    }
-
-    return fixed_asic_position_pinnings;
-}
 
 template <typename CONNECTIVITY_MAP_T>
 void build_golden_link_counts(
@@ -498,7 +451,8 @@ void ControlPlane::init_control_plane(
                 // Only apply galaxy pinnings if mesh has multiple of 32 chips and is not 1D
                 if (!is_1d && mesh_chip_count % 32 == 0) {
                     auto mesh_pinnings =
-                        get_galaxy_fixed_asic_position_pinnings_for_mesh(mesh_id, mesh_shape, world_size == 1);
+                        tt::tt_metal::experimental::tt_fabric::get_galaxy_fixed_asic_position_pinnings_for_mesh(
+                            mesh_id, mesh_shape, world_size == 1);
                     fixed_asic_position_pinnings.insert(
                         fixed_asic_position_pinnings.end(), mesh_pinnings.begin(), mesh_pinnings.end());
                 }
@@ -608,7 +562,8 @@ void ControlPlane::init_control_plane_auto_discovery() {
             // Only apply galaxy pinnings if mesh has multiple of 32 chips and is not 1D
             if (!is_1d && mesh_chip_count % 32 == 0) {
                 auto mesh_pinnings =
-                    get_galaxy_fixed_asic_position_pinnings_for_mesh(mesh_id, mesh_shape, world_size == 1);
+                    tt::tt_metal::experimental::tt_fabric::get_galaxy_fixed_asic_position_pinnings_for_mesh(
+                        mesh_id, mesh_shape, world_size == 1);
                 fixed_asic_position_pinnings.insert(
                     fixed_asic_position_pinnings.end(), mesh_pinnings.begin(), mesh_pinnings.end());
             }

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -1702,4 +1702,36 @@ TopologyMappingResult map_multi_mesh_to_physical(
     return result;
 }
 
+std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> get_galaxy_fixed_asic_position_pinnings_for_mesh(
+    MeshId mesh_id, const tt::tt_metal::distributed::MeshShape& mesh_shape, bool hard_pin_node_0) {
+    using tt::tt_metal::ASICLocation;
+    using tt::tt_metal::TrayID;
+    std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> fixed_asic_position_pinnings;
+
+    std::vector<AsicPosition> corner_asic_positions;
+    corner_asic_positions.emplace_back(AsicPosition{TrayID{1u}, ASICLocation{1u}});
+    corner_asic_positions.emplace_back(AsicPosition{TrayID{2u}, ASICLocation{1u}});
+    corner_asic_positions.emplace_back(AsicPosition{TrayID{3u}, ASICLocation{1u}});
+    corner_asic_positions.emplace_back(AsicPosition{TrayID{4u}, ASICLocation{1u}});
+
+    std::vector<FabricNodeId> corner_fabric_node_ids;
+    corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, 0});
+    corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, mesh_shape[1] - 1});
+    corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, mesh_shape[1] * (mesh_shape[0] - 1)});
+    corner_fabric_node_ids.emplace_back(FabricNodeId{mesh_id, (mesh_shape[1] * mesh_shape[0]) - 1});
+
+    fixed_asic_position_pinnings.reserve(corner_fabric_node_ids.size());
+    for (const auto& corner_fabric_node_id : corner_fabric_node_ids) {
+        if (corner_fabric_node_id == FabricNodeId{MeshId{0}, 0} && hard_pin_node_0) {
+            fixed_asic_position_pinnings.emplace_back(
+                corner_fabric_node_id, std::vector<AsicPosition>{AsicPosition{TrayID{1u}, ASICLocation{1u}}});
+            continue;
+        }
+
+        fixed_asic_position_pinnings.emplace_back(corner_fabric_node_id, corner_asic_positions);
+    }
+
+    return fixed_asic_position_pinnings;
+}
+
 }  // namespace tt::tt_metal::experimental::tt_fabric


### PR DESCRIPTION
## Fixing issue https://github.com/tenstorrent/tt-metal/issues/41503
## Summary

Aligns **`generate_rank_bindings`** with **ControlPlane** for UBB Galaxy topology mapping: shared galaxy corner-pinning helper, explicit MGD-centric behavior for rank bindings, and clearer post-mapping logs (including tray IDs per logical host partition).

## Changes

### Shared Galaxy pinning (`get_galaxy_fixed_asic_position_pinnings_for_mesh`)

- Moved the UBB Galaxy fixed ASIC corner pinning logic into `topology_mapper_utils.hpp` / `topology_mapper_utils.cpp` (`tt::tt_metal::experimental::tt_fabric`).
- **Control plane** now calls this shared API instead of a local duplicate in `control_plane.cpp` (both call sites updated).

### `generate_rank_bindings` / `run_topology_mapping`

- Applies the **same UBB Galaxy rules** as ControlPlane: `cluster.is_ubb_galaxy()`, mesh not 1D, device count multiple of 32.
- Expands galaxy pinnings into `TopologyMappingConfig::pinnings` as `(AsicPosition, FabricNodeId)` pairs, **before** MGD pinnings (same ordering as the control-plane path).
- Documents that logical `mesh_host_rank` / `host_topology` come from the **MGD**, not Phase 1 MPI size; keeps physical `asic_id_to_mesh_rank` empty (UNSET) so the solver follows the MGD.
- **Sort order** for rank-binding rows: **mesh_id → mesh_host_rank → PSD rank → hostname** so multi-host MGDs are not ordered only by physical PSD rank.
- **Optional check**: warns if the number of extracted rank-binding rows does not match the sum of MGD host slots.
- **Logging**: after mapping, logs **distinct tray IDs per** `(mesh_id, PSD hostname, mesh_host_rank)` partition so it is clear which trays each Phase-2-style process owns.
- Uses **`world_size`** from `DistributedContext::get_current_world()` for `hard_pin_node_0` (`world_size == 1`), matching ControlPlane.

### Topology mapper

- Intentionally **no** MGD-specific stripping of `asic_id_to_mesh_rank` in `topology_mapper.cpp`; MGD alignment for Phase 1 generation lives in **`generate_rank_bindings`** as requested.

## Testing

- Added test in cpu-only-tests-impl.yaml to verify that the changes in this PR to regression test BH Galaxy 8x4 2x2 hosts mesh graph descriptor.

## Notes for reviewers

- Galaxy behavior is centralized in `topology_mapper_utils` to keep **ControlPlane**, **TopologyMapper** inputs, and **generate_rank_bindings** in sync.
- Mock / multi-host MGD workflows may need to re-run Phase 1 (`generate_rank_bindings`) if cached rank bindings or mappings were produced before these pinning and ordering changes.
