### PR TITLE
Fix CB silent collision with per-core tensors

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
@@ -643,6 +643,7 @@ def test_per_core_cb_collision_errors_on_same_cores(mesh_device, use_from_torch)
     # Allocate I/O first so lockstep places them at top of L1 (no per-core ranges to avoid yet).
     io_tensors = _make_io_tensors(mesh_device, same_grid)
     _per_core_tensor = _alloc_large_per_core_tensor(mesh_device, same_grid, use_from_torch=use_from_torch)
+    assert _per_core_tensor is not None  # keep alive until CB validation runs
 
     # Huge CB on the SAME cores as the per-core tensor: should trip validate_circular_buffer_region.
     with pytest.raises(RuntimeError, match=r"clash|circular buffer|L1"):
@@ -705,11 +706,19 @@ def _try_compressed_per_core_collision(mesh_device, per_core_grid, cb_grid):
     the next test's gc.collect."""
     io_tensors = _make_io_tensors(mesh_device, cb_grid)
     _ct = _alloc_large_per_core_compressed_tensor(mesh_device, per_core_grid)
-    # Multi-format CompressedTensor's per-core size depends on which format the assigner chose
-    # per tile (bfp4 = 576 B/tile, bfp8 = 1088 B/tile). Use a CB big enough that even the smallest
-    # per-core allocation still collides.
+    assert _ct is not None  # keep alive until CB validation runs
+    # CB sized as a fraction of the device's reported worker L1, so collision detection scales
+    # with architecture instead of relying on a hardcoded ~1.4 MB bank assumption. ~70% of L1
+    # leaves the CB alone fitting on disjoint cores, while per-core (sized at ~80% of L1 in
+    # _alloc_large_per_core_compressed_tensor) + this CB > 100% → guaranteed collision when
+    # they share cores, regardless of which format multi-format CompressedTensor's assigner
+    # chose per tile (bfp4 = 576 B/tile, bfp8 = 1088 B/tile).
+    worker_l1 = ttnn._ttnn.reports.get_device_info(mesh_device).worker_l1_size
+    # CB total_size must be divisible by page_size (bfloat16 tile = 32*32*2 = 2048 B).
+    page_size = ttnn.Tile((32, 32)).get_tile_size(ttnn.bfloat16)
+    cb_bytes = (worker_l1 * 70 // 100) // page_size * page_size
     try:
-        _run_cb_heavy_noop_program(io_tensors, cb_grid, cb_total_size_bytes=1024 * 1024)
+        _run_cb_heavy_noop_program(io_tensors, cb_grid, cb_total_size_bytes=cb_bytes)
         return None
     except RuntimeError as e:
         return str(e)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
@@ -544,3 +544,103 @@ def test_4d_per_core_shard_dim0_dim2(mesh_device):
     pcc = metric_value(x.numpy(), recovered.numpy(), "pcc")
     print(f"4D per-core shard dim0/dim2 PCC: {pcc:.6f}")
     assert pcc > 0.98, f"PCC {pcc:.6f} too low"
+
+
+# ---------------------------------------------------------------------------
+# Per-core tensor ↔ CB collision tests
+# ---------------------------------------------------------------------------
+
+
+def _make_huge_per_core_tensor(mesh_device, grid, shard_bytes=1_200_000):
+    """Allocate a per-core L1 tensor that consumes ~shard_bytes on each core in `grid`.
+    Uses experimental_to_single_device so the per_core_allocation flag is actually honored
+    (ttnn.from_torch + mesh_mapper silently falls back to lockstep)."""
+    num_cores = grid.num_cores()
+    shard_spec = ttnn.ShardSpec(grid, [1, shard_bytes], ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+    mem_config.experimental_set_per_core_allocation(True)
+    data = torch.zeros(1, shard_bytes * num_cores, dtype=torch.uint8)
+    host_tensor = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT)
+    coord = ttnn.MeshCoordinate(0, 0)
+    return ttnn._ttnn.tensor.experimental_to_single_device(host_tensor, mesh_device, coord, mem_config)
+
+
+def _make_io_tensors(mesh_device, cb_core_grid):
+    """Pre-allocate minimal I/O tensors required by generic_op on `cb_core_grid`."""
+    tile = 32
+    io_shape = (tile, tile * cb_core_grid.num_cores())
+    io_mem = _make_sharded_mem_config(io_shape, ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, cb_core_grid)
+    in_t = ttnn.from_torch(
+        torch.zeros(io_shape), device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, memory_config=io_mem
+    )
+    out_t = ttnn.from_torch(
+        torch.zeros(io_shape), device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, memory_config=io_mem
+    )
+    return in_t, out_t
+
+
+def _run_cb_heavy_noop_program(io_tensors, cb_core_grid, cb_total_size_bytes):
+    """Launch a dummy generic_op on `cb_core_grid` with a single CB sized `cb_total_size_bytes`.
+    The kernel is a noop (blank.cpp); the program exists solely to force CB placement validation.
+    Caller must pre-allocate I/O tensors (before any per-core allocation) to avoid lockstep being
+    pushed low by per-core-avoidance logic."""
+    tile = 32
+    tile_obj = ttnn.Tile((tile, tile))
+    page_size = tile_obj.get_tile_size(ttnn.bfloat16)
+    cb_fmt = ttnn.CBFormatDescriptor(
+        buffer_index=0, data_format=ttnn.bfloat16, page_size=page_size, tile=ttnn.TileDescriptor(tile_obj)
+    )
+    cb_desc = ttnn.CBDescriptor(total_size=cb_total_size_bytes, core_ranges=cb_core_grid, format_descriptors=[cb_fmt])
+    # Dispatch needs all 3 RISCs configured (NCRISC + BRISC + TRISC) even if kernels are blank;
+    # otherwise launch crashes on the un-bound cores.
+    reader = ttnn.KernelDescriptor(
+        kernel_source="tt_metal/kernels/dataflow/blank.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=cb_core_grid,
+        config=ttnn.DataMovementConfigDescriptor(
+            processor=ttnn.DataMovementProcessor.RISCV_1, noc=ttnn.NOC.RISCV_0_default
+        ),
+    )
+    writer = ttnn.KernelDescriptor(
+        kernel_source="tt_metal/kernels/dataflow/blank.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=cb_core_grid,
+        config=ttnn.DataMovementConfigDescriptor(
+            processor=ttnn.DataMovementProcessor.RISCV_0, noc=ttnn.NOC.RISCV_1_default
+        ),
+    )
+    compute = ttnn.KernelDescriptor(
+        kernel_source="tt_metal/kernels/compute/blank.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=cb_core_grid,
+        config=ttnn.ComputeConfigDescriptor(),
+    )
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], cbs=[cb_desc])
+    return ttnn.generic_op(list(io_tensors), program)
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_per_core_cb_collision_errors_on_same_cores(mesh_device):
+    """CB validation should reject a program whose CBs land on cores already filled by a per-core tensor."""
+    same_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
+    # Allocate I/O first so lockstep places them at top of L1 (no per-core ranges to avoid yet).
+    io_tensors = _make_io_tensors(mesh_device, same_grid)
+    _huge = _make_huge_per_core_tensor(mesh_device, same_grid)
+
+    # Huge CB on the SAME cores as the per-core tensor: should trip validate_circular_buffer_region.
+    with pytest.raises(RuntimeError, match=r"clash|circular buffer|L1"):
+        _run_cb_heavy_noop_program(io_tensors, same_grid, cb_total_size_bytes=512 * 1024)
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_per_core_cb_no_collision_on_disjoint_cores(mesh_device):
+    """Per-core tensor on cores A should not tighten CB budgets for a program on disjoint cores B."""
+    a_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
+    b_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(3, 0))])
+    # Allocate I/O first so lockstep places them at top of L1 (no per-core ranges to avoid yet).
+    io_tensors = _make_io_tensors(mesh_device, b_grid)
+    # _huge = _make_huge_per_core_tensor(mesh_device, a_grid)
+
+    # Same-size CB, but on cores B (disjoint from A). Should succeed: per-core tensor on A must
+    # not tighten B's budget.
+    _run_cb_heavy_noop_program(io_tensors, b_grid, cb_total_size_bytes=512 * 1024)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
@@ -646,7 +646,7 @@ def test_per_core_cb_collision_errors_on_same_cores(mesh_device, use_from_torch)
 
     # Huge CB on the SAME cores as the per-core tensor: should trip validate_circular_buffer_region.
     with pytest.raises(RuntimeError, match=r"clash|circular buffer|L1"):
-        _run_cb_heavy_noop_program(io_tensors, same_grid, cb_total_size_bytes=512 * 1024)
+        _run_cb_heavy_noop_program(io_tensors, same_grid, cb_total_size_bytes=1024 * 1024)
 
 
 @pytest.mark.parametrize("use_from_torch", [False, True], ids=["experimental_to_single_device", "from_torch_replicate"])
@@ -661,18 +661,21 @@ def test_per_core_cb_no_collision_on_disjoint_cores(mesh_device, use_from_torch)
 
     # Same-size CB, but on cores B (disjoint from A). Should succeed: per-core tensor on A must
     # not tighten B's budget.
-    _run_cb_heavy_noop_program(io_tensors, b_grid, cb_total_size_bytes=512 * 1024)
+    _run_cb_heavy_noop_program(io_tensors, b_grid, cb_total_size_bytes=1024 * 1024)
 
 
 def _alloc_large_per_core_compressed_tensor(mesh_device, grid):
-    """Allocate a CompressedTensor with per_core_allocation=True consuming ~1.2 MB per core.
-    CompressedTensor allocates the source bfloat16 size (with ~6% overhead), not the compressed
-    bfp8 size, so we size for raw bfloat16 budget."""
+    """Allocate a CompressedTensor with per_core_allocation=True. Sized to consume ~80% of L1
+    after bfp8 compression (the larger-per-tile of the two formats), to repro the segfault
+    that the copilot-style derived-from-worker_l1 sizing originally triggered."""
     num_devices = mesh_device.get_num_devices()
     tile = 32
-    # Target ~1.2 MB per core after width-shard:
-    #   32 rows * shard_w cols * 2 B (bfloat16) ≈ 1.2 MB → shard_w ≈ 18750, tile-aligned to 18752.
-    shard_w = (18752 // tile) * tile
+    worker_l1 = ttnn._ttnn.reports.get_device_info(mesh_device).worker_l1_size
+    target_per_core_bytes = worker_l1 * 80 // 100
+    # Canonical bfp8 tile size: 1024 mantissa B + 64 shared-exp B = 1088 B/tile.
+    bfp8_tile_bytes = 1088
+    tiles_per_shard = max(1, target_per_core_bytes // bfp8_tile_bytes)
+    shard_w = tiles_per_shard * tile
     total_w = shard_w * grid.num_cores()
     # Shard data on dim 0 across mesh devices so each device gets `tile` rows.
     x = torch.randn(tile * num_devices, total_w)
@@ -703,11 +706,10 @@ def _try_compressed_per_core_collision(mesh_device, per_core_grid, cb_grid):
     io_tensors = _make_io_tensors(mesh_device, cb_grid)
     _ct = _alloc_large_per_core_compressed_tensor(mesh_device, per_core_grid)
     # Multi-format CompressedTensor's per-core size depends on which format the assigner chose
-    # per tile (bfp4 ~544 B/tile, bfp8 ~1056 B/tile). Use a CB big enough that even the smallest
-    # per-core allocation collides: 1.1 MB CB + ~319 KB per-core (all-bfp4 worst case) > 1.4 MB
-    # bank → guaranteed collision.
+    # per tile (bfp4 = 576 B/tile, bfp8 = 1088 B/tile). Use a CB big enough that even the smallest
+    # per-core allocation still collides.
     try:
-        _run_cb_heavy_noop_program(io_tensors, cb_grid, cb_total_size_bytes=1100 * 1024)
+        _run_cb_heavy_noop_program(io_tensors, cb_grid, cb_total_size_bytes=1024 * 1024)
         return None
     except RuntimeError as e:
         return str(e)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
@@ -676,9 +676,7 @@ def _alloc_large_per_core_compressed_tensor(mesh_device, grid):
     total_w = shard_w * grid.num_cores()
     # Shard data on dim 0 across mesh devices so each device gets `tile` rows.
     x = torch.randn(tile * num_devices, total_w)
-    # Single format: bfp8 only. Multi-format (e.g. ["bfp8","bfp4"]) creates non-uniform per-bank
-    # sizes which the per-core allocator path doesn't handle (orthogonal bug — segfaults at GC).
-    assigner = CompressedTensorAssigner(metric="pcc", threshold=0.9, formats=["bfp8"])
+    assigner = CompressedTensorAssigner(metric="pcc", threshold=0.99, formats=["bfp8", "bfp4"])
     mem_config = _make_sharded_mem_config(
         (tile, total_w), ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, grid
     )
@@ -692,21 +690,36 @@ def _alloc_large_per_core_compressed_tensor(mesh_device, grid):
     )
 
 
+def _try_compressed_per_core_collision(mesh_device, per_core_grid, cb_grid):
+    """Allocate IO + per-core CompressedTensor + run CB program. Returns the captured error
+    message if generic_op raised, else None.
+
+    NOTE: this is intentionally a separate function so its locals (io_tensors, _ct) live in
+    THIS frame. When this function returns, the frame is released along with all per-device
+    per-core buffers — while mesh_device is still alive. Putting these allocations directly in
+    the test function would have any later assert / pytest.fail capture them via the failure
+    traceback, pinning the buffers past the function-scoped mesh_device's teardown and crashing
+    the next test's gc.collect."""
+    io_tensors = _make_io_tensors(mesh_device, cb_grid)
+    _ct = _alloc_large_per_core_compressed_tensor(mesh_device, per_core_grid)
+    # Multi-format CompressedTensor's per-core size depends on which format the assigner chose
+    # per tile (bfp4 ~544 B/tile, bfp8 ~1056 B/tile). Use a CB big enough that even the smallest
+    # per-core allocation collides: 1.1 MB CB + ~319 KB per-core (all-bfp4 worst case) > 1.4 MB
+    # bank → guaranteed collision.
+    try:
+        _run_cb_heavy_noop_program(io_tensors, cb_grid, cb_total_size_bytes=1100 * 1024)
+        return None
+    except RuntimeError as e:
+        return str(e)
+
+
 @pytest.mark.parametrize("mesh_device", [(4, 2)], indirect=True)
 def test_compressed_per_core_cb_collision_errors_on_same_cores(mesh_device):
     """Same as test_per_core_cb_collision_errors_on_same_cores but using CompressedTensor."""
     same_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
-    io_tensors = _make_io_tensors(mesh_device, same_grid)
-    _ct = _alloc_large_per_core_compressed_tensor(mesh_device, same_grid)
-
-    # try/except, NOT pytest.raises: pytest.raises retains the ExceptionInfo (and its traceback,
-    # which pins this frame's locals — io_tensors, _ct — past mesh_device fixture teardown,
-    # crashing later destructors). try/except auto-clears the exception/traceback on block exit.
-    try:
-        _run_cb_heavy_noop_program(io_tensors, same_grid, cb_total_size_bytes=512 * 1024)
-        pytest.fail("Expected RuntimeError from CB validator (collision with per-core tensor)")
-    except RuntimeError as e:
-        assert any(s in str(e) for s in ("clash", "circular buffer", "L1")), f"Unexpected error: {e}"
+    err = _try_compressed_per_core_collision(mesh_device, same_grid, same_grid)
+    assert err is not None, "Expected RuntimeError from CB validator (collision with per-core tensor)"
+    assert any(s in err for s in ("clash", "circular buffer", "L1")), f"Unexpected error: {err}"
 
 
 @pytest.mark.parametrize("mesh_device", [(4, 2)], indirect=True)
@@ -714,7 +727,5 @@ def test_compressed_per_core_cb_no_collision_on_disjoint_cores(mesh_device):
     """Same as test_per_core_cb_no_collision_on_disjoint_cores but using CompressedTensor."""
     a_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
     b_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(3, 0))])
-    io_tensors = _make_io_tensors(mesh_device, b_grid)
-    _ct = _alloc_large_per_core_compressed_tensor(mesh_device, a_grid)
-
-    _run_cb_heavy_noop_program(io_tensors, b_grid, cb_total_size_bytes=512 * 1024)
+    err = _try_compressed_per_core_collision(mesh_device, a_grid, b_grid)
+    assert err is None, f"Expected no error on disjoint cores, but got: {err}"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
@@ -551,15 +551,29 @@ def test_4d_per_core_shard_dim0_dim2(mesh_device):
 # ---------------------------------------------------------------------------
 
 
-def _make_huge_per_core_tensor(mesh_device, grid, shard_bytes=1_200_000):
-    """Allocate a per-core L1 tensor that consumes ~shard_bytes on each core in `grid`.
-    Uses experimental_to_single_device so the per_core_allocation flag is actually honored
-    (ttnn.from_torch + mesh_mapper silently falls back to lockstep)."""
-    num_cores = grid.num_cores()
+def _per_core_mem_config(grid, shard_bytes):
+    """Build a width-sharded MemoryConfig with experimental per-core allocation enabled."""
     shard_spec = ttnn.ShardSpec(grid, [1, shard_bytes], ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
     mem_config.experimental_set_per_core_allocation(True)
-    data = torch.zeros(1, shard_bytes * num_cores, dtype=torch.uint8)
+    return mem_config
+
+
+def _alloc_large_per_core_tensor(mesh_device, grid, use_from_torch, shard_bytes=1_200_000):
+    """Allocate a per-core L1 tensor consuming ~shard_bytes per core in `grid`.
+    `use_from_torch=True` → ttnn.from_torch + ReplicateTensorToMesh (allocated on every mesh device).
+    `use_from_torch=False` → experimental_to_single_device (allocated on coord (0,0) only)."""
+    mem_config = _per_core_mem_config(grid, shard_bytes)
+    data = torch.zeros(1, shard_bytes * grid.num_cores(), dtype=torch.uint8)
+    if use_from_torch:
+        return ttnn.from_torch(
+            data,
+            dtype=ttnn.uint8,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            memory_config=mem_config,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
     host_tensor = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT)
     coord = ttnn.MeshCoordinate(0, 0)
     return ttnn._ttnn.tensor.experimental_to_single_device(host_tensor, mesh_device, coord, mem_config)
@@ -616,31 +630,91 @@ def _run_cb_heavy_noop_program(io_tensors, cb_core_grid, cb_total_size_bytes):
         config=ttnn.ComputeConfigDescriptor(),
     )
     program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], cbs=[cb_desc])
+    # SPMD: dispatch to the entire mesh. The CB validator iterates all local device allocators,
+    # so it will catch per-core collisions on whichever coord(s) host them.
     return ttnn.generic_op(list(io_tensors), program)
 
 
-@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
-def test_per_core_cb_collision_errors_on_same_cores(mesh_device):
+@pytest.mark.parametrize("use_from_torch", [False, True], ids=["experimental_to_single_device", "from_torch_replicate"])
+@pytest.mark.parametrize("mesh_device", [(4, 2)], indirect=True)
+def test_per_core_cb_collision_errors_on_same_cores(mesh_device, use_from_torch):
     """CB validation should reject a program whose CBs land on cores already filled by a per-core tensor."""
     same_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
     # Allocate I/O first so lockstep places them at top of L1 (no per-core ranges to avoid yet).
     io_tensors = _make_io_tensors(mesh_device, same_grid)
-    _huge = _make_huge_per_core_tensor(mesh_device, same_grid)
+    _per_core_tensor = _alloc_large_per_core_tensor(mesh_device, same_grid, use_from_torch=use_from_torch)
 
     # Huge CB on the SAME cores as the per-core tensor: should trip validate_circular_buffer_region.
     with pytest.raises(RuntimeError, match=r"clash|circular buffer|L1"):
         _run_cb_heavy_noop_program(io_tensors, same_grid, cb_total_size_bytes=512 * 1024)
 
 
-@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
-def test_per_core_cb_no_collision_on_disjoint_cores(mesh_device):
+@pytest.mark.parametrize("use_from_torch", [False, True], ids=["experimental_to_single_device", "from_torch_replicate"])
+@pytest.mark.parametrize("mesh_device", [(4, 2)], indirect=True)
+def test_per_core_cb_no_collision_on_disjoint_cores(mesh_device, use_from_torch):
     """Per-core tensor on cores A should not tighten CB budgets for a program on disjoint cores B."""
     a_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
     b_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(3, 0))])
     # Allocate I/O first so lockstep places them at top of L1 (no per-core ranges to avoid yet).
     io_tensors = _make_io_tensors(mesh_device, b_grid)
-    # _huge = _make_huge_per_core_tensor(mesh_device, a_grid)
+    _per_core_tensor = _alloc_large_per_core_tensor(mesh_device, a_grid, use_from_torch=use_from_torch)
 
     # Same-size CB, but on cores B (disjoint from A). Should succeed: per-core tensor on A must
     # not tighten B's budget.
+    _run_cb_heavy_noop_program(io_tensors, b_grid, cb_total_size_bytes=512 * 1024)
+
+
+def _alloc_large_per_core_compressed_tensor(mesh_device, grid):
+    """Allocate a CompressedTensor with per_core_allocation=True consuming ~1.2 MB per core.
+    CompressedTensor allocates the source bfloat16 size (with ~6% overhead), not the compressed
+    bfp8 size, so we size for raw bfloat16 budget."""
+    num_devices = mesh_device.get_num_devices()
+    tile = 32
+    # Target ~1.2 MB per core after width-shard:
+    #   32 rows * shard_w cols * 2 B (bfloat16) ≈ 1.2 MB → shard_w ≈ 18750, tile-aligned to 18752.
+    shard_w = (18752 // tile) * tile
+    total_w = shard_w * grid.num_cores()
+    # Shard data on dim 0 across mesh devices so each device gets `tile` rows.
+    x = torch.randn(tile * num_devices, total_w)
+    # Single format: bfp8 only. Multi-format (e.g. ["bfp8","bfp4"]) creates non-uniform per-bank
+    # sizes which the per-core allocator path doesn't handle (orthogonal bug — segfaults at GC).
+    assigner = CompressedTensorAssigner(metric="pcc", threshold=0.9, formats=["bfp8"])
+    mem_config = _make_sharded_mem_config(
+        (tile, total_w), ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, grid
+    )
+    return CompressedTensor.from_torch(
+        x,
+        assigner,
+        device=mesh_device,
+        memory_config=mem_config,
+        per_core_allocation=True,
+        mesh_mapper_config=ttnn.MeshMapperConfig([ttnn.PlacementShard(0)]),
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(4, 2)], indirect=True)
+def test_compressed_per_core_cb_collision_errors_on_same_cores(mesh_device):
+    """Same as test_per_core_cb_collision_errors_on_same_cores but using CompressedTensor."""
+    same_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
+    io_tensors = _make_io_tensors(mesh_device, same_grid)
+    _ct = _alloc_large_per_core_compressed_tensor(mesh_device, same_grid)
+
+    # try/except, NOT pytest.raises: pytest.raises retains the ExceptionInfo (and its traceback,
+    # which pins this frame's locals — io_tensors, _ct — past mesh_device fixture teardown,
+    # crashing later destructors). try/except auto-clears the exception/traceback on block exit.
+    try:
+        _run_cb_heavy_noop_program(io_tensors, same_grid, cb_total_size_bytes=512 * 1024)
+        pytest.fail("Expected RuntimeError from CB validator (collision with per-core tensor)")
+    except RuntimeError as e:
+        assert any(s in str(e) for s in ("clash", "circular buffer", "L1")), f"Unexpected error: {e}"
+
+
+@pytest.mark.parametrize("mesh_device", [(4, 2)], indirect=True)
+def test_compressed_per_core_cb_no_collision_on_disjoint_cores(mesh_device):
+    """Same as test_per_core_cb_no_collision_on_disjoint_cores but using CompressedTensor."""
+    a_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
+    b_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(3, 0))])
+    io_tensors = _make_io_tensors(mesh_device, b_grid)
+    _ct = _alloc_large_per_core_compressed_tensor(mesh_device, a_grid)
+
     _run_cb_heavy_noop_program(io_tensors, b_grid, cb_total_size_bytes=512 * 1024)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_tensor_multi_device.py
@@ -659,6 +659,7 @@ def test_per_core_cb_no_collision_on_disjoint_cores(mesh_device, use_from_torch)
     # Allocate I/O first so lockstep places them at top of L1 (no per-core ranges to avoid yet).
     io_tensors = _make_io_tensors(mesh_device, b_grid)
     _per_core_tensor = _alloc_large_per_core_tensor(mesh_device, a_grid, use_from_torch=use_from_torch)
+    assert _per_core_tensor is not None  # keep alive until CB validation runs
 
     # Same-size CB, but on cores B (disjoint from A). Should succeed: per-core tensor on A must
     # not tighten B's budget.

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -410,7 +410,16 @@ void AllocatorImpl::dump_memory_blocks(const BufferType& buffer_type, std::ostre
 std::optional<DeviceAddr> AllocatorImpl::get_lowest_occupied_l1_address(uint32_t bank_id) const {
     std::lock_guard<std::mutex> lock(mutex_);
     // l1_manager always sits below l1_small_manager in the address space, so there is no need to check l1_small_manager
-    return l1_manager_->lowest_occupied_address(bank_id);
+    using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+    auto lowest = l1_manager_->lowest_occupied_address(bank_id, AllocatorID{0});
+    // In HYBRID mode, also check this bank's per-core allocator (AllocatorID{bank_id+1}) since it may have occupied
+    if (config_->allocator_mode == AllocatorMode::HYBRID) {
+        auto per_core = l1_manager_->lowest_occupied_address(bank_id, AllocatorID{bank_id + 1});
+        if (per_core.has_value()) {
+            lowest = lowest.has_value() ? std::make_optional(std::min(*lowest, *per_core)) : per_core;
+        }
+    }
+    return lowest;
 }
 
 void AllocatorImpl::shrink_allocator_size(const BufferType& buffer_type, DeviceAddr shrink_size, bool bottom_up) {

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -412,7 +412,8 @@ std::optional<DeviceAddr> AllocatorImpl::get_lowest_occupied_l1_address(uint32_t
     // l1_manager always sits below l1_small_manager in the address space, so there is no need to check l1_small_manager
     using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
     auto lowest = l1_manager_->lowest_occupied_address(bank_id, AllocatorID{0});
-    // In HYBRID mode, also check this bank's per-core allocator (AllocatorID{bank_id+1}) since it may have occupied
+    // In HYBRID mode, also check this bank's per-core allocator (AllocatorID{bank_id + 1}), since it may
+    // have occupied a lower address range in this bank.
     if (config_->allocator_mode == AllocatorMode::HYBRID) {
         auto per_core = l1_manager_->lowest_occupied_address(bank_id, AllocatorID{bank_id + 1});
         if (per_core.has_value()) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1318,7 +1318,7 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     // allocator). Collect the physical allocators we must consult so we can see per-core state.
     std::vector<AllocatorImpl*> physical_allocators;
     if (hybrid_mode) {
-        if (auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
+        if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
             for (IDevice* dev : mesh->get_devices()) {
                 physical_allocators.push_back(dev->allocator_impl().get());
             }
@@ -1348,11 +1348,8 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
             lowest_address = std::nullopt;
             for (const auto& core : cb_allocator.core_range) {
                 for (auto* phys_alloc : physical_allocators) {
-                    const auto& bank_ids = phys_alloc->get_bank_ids_from_logical_core(BufferType::L1, core);
-                    if (bank_ids.empty()) {
-                        continue;
-                    }
-                    auto addr = phys_alloc->get_lowest_occupied_l1_address(bank_ids[0]);
+                    auto bank_id = phys_alloc->get_bank_ids_from_logical_core(BufferType::L1, core).front();
+                    auto addr = phys_alloc->get_lowest_occupied_l1_address(bank_id);
                     if (addr.has_value()) {
                         lowest_address =
                             lowest_address.has_value() ? std::make_optional(std::min(*lowest_address, *addr)) : addr;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1311,6 +1311,21 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     std::optional<DeviceAddr> lowest_address =
         device->lowest_occupied_compute_l1_address(this->determine_sub_device_ids(device));
     uint32_t max_l1_size = device->l1_size_per_core();
+    const auto& allocator = device->allocator_impl();
+    const bool hybrid_mode = allocator->get_config().allocator_mode == AllocatorMode::HYBRID;
+
+    // In HYBRID mode, per-core allocations live on each per-device allocator (not the mesh
+    // allocator). Collect the physical allocators we must consult so we can see per-core state.
+    std::vector<AllocatorImpl*> physical_allocators;
+    if (hybrid_mode) {
+        if (auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
+            for (IDevice* dev : mesh->get_devices()) {
+                physical_allocators.push_back(dev->allocator_impl().get());
+            }
+        } else {
+            physical_allocators.push_back(allocator.get());
+        }
+    }
 
     for (const CircularBufferAllocator& cb_allocator : this->cb_allocators_) {
         if (cb_allocator.l1_regions.empty()) {
@@ -1324,6 +1339,26 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
                 cb_allocator.core_range.str(),
                 cb_region_end,
                 max_l1_size);
+        }
+        if (hybrid_mode) {
+            // Per-core allocations (experimental_set_per_core_allocation) can land at different
+            // addresses per core, so query only the banks this CB covers on each physical allocator.
+            // Prevents per-core tensors on unrelated cores from spuriously tightening this CB's
+            // budget, and lets us see per-core state that lives on per-device (not mesh) allocators.
+            lowest_address = std::nullopt;
+            for (const auto& core : cb_allocator.core_range) {
+                for (auto* phys_alloc : physical_allocators) {
+                    const auto& bank_ids = phys_alloc->get_bank_ids_from_logical_core(BufferType::L1, core);
+                    if (bank_ids.empty()) {
+                        continue;
+                    }
+                    auto addr = phys_alloc->get_lowest_occupied_l1_address(bank_ids[0]);
+                    if (addr.has_value()) {
+                        lowest_address =
+                            lowest_address.has_value() ? std::make_optional(std::min(*lowest_address, *addr)) : addr;
+                    }
+                }
+            }
         }
         if (lowest_address.has_value() and lowest_address.value() < cb_region_end) {
             TT_THROW(


### PR DESCRIPTION
### Summary
When creating CBs without backing tensor, it will use a new cb allocator and allocate from bottom-up, then it will check the collision with the device allocator, if overlap then fatal out. 
This flow doesn't work if it collides with per-core tensors, as they use separate allocators each bank, and cb allocator doesn't check on per-core allocators.

Change to check the per-bank allocation when we set hybrid mode. added test to let it fatal out and capture in the test. 

### Notes for reviewers
Shouldn't block deepseek-b1 since they use cbs with backing tensors always .

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yugao/cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yugao/cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yugao/cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yugao/cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yugao/cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yugao/cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/cb)