### PR TITLE
Descriptor framework prep: SmallVector types, string_view, and cached work split

### DIFF
--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -339,6 +339,45 @@ Both must succeed with zero errors.
 
 ---
 
+## Performance best practices
+
+The ProgramDescriptor path calls `create_descriptor` on **every dispatch** (cache hit or miss).
+Everything built inside it — CBDescriptors, KernelDescriptors, CoreRangeSet copies,
+runtime arg vectors — is allocation overhead. Follow these patterns to keep it fast.
+
+### Use constexpr kernel paths
+
+Never build kernel paths with string concatenation. Always use `static constexpr const char*`:
+
+```cpp
+// BAD — heap allocation on every dispatch
+const std::string kernels_dir = "ttnn/cpp/ttnn/operations/my_op/device/kernels/";
+reader_desc.kernel_source = kernels_dir + "reader.cpp";
+
+// GOOD — zero cost
+static constexpr const char* READER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/my_op/device/kernels/reader.cpp";
+reader_desc.kernel_source = READER_KERNEL_PATH;
+```
+
+`kernel_source` is `std::string_view` — it must point to a string that outlives the descriptor.
+`static constexpr const char*` satisfies this.
+
+### Use KernelDescriptor type aliases for args
+
+Use `KernelDescriptor::CompileTimeArgs` and `KernelDescriptor::CoreRuntimeArgs` instead of
+`std::vector<uint32_t>`. These are `SmallVector` types that avoid heap allocation for small ops:
+
+```cpp
+// BAD
+std::vector<uint32_t> compile_time_args{cb_id};
+
+// GOOD
+KernelDescriptor::CompileTimeArgs compile_time_args{cb_id};
+```
+
+---
+
 ## Common pitfalls
 
 1. **Namespace resolution after moving factories.** If factories move to a different

--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -345,23 +345,22 @@ The ProgramDescriptor path calls `create_descriptor` on **every dispatch** (cach
 Everything built inside it — CBDescriptors, KernelDescriptors, CoreRangeSet copies,
 runtime arg vectors — is allocation overhead. Follow these patterns to keep it fast.
 
-### Use constexpr kernel paths
+### Prefer constexpr kernel paths
 
-Never build kernel paths with string concatenation. Always use `static constexpr const char*`:
+Prefer `static constexpr const char*` over runtime string concatenation for kernel paths.
+`kernel_source` is `std::string`, so each assignment copies — but starting from constexpr
+storage avoids the CPU + heap cost of formatting/concatenating the path per dispatch:
 
 ```cpp
-// BAD — heap allocation on every dispatch
+// BAD — formats/concatenates a new std::string every dispatch
 const std::string kernels_dir = "ttnn/cpp/ttnn/operations/my_op/device/kernels/";
 reader_desc.kernel_source = kernels_dir + "reader.cpp";
 
-// GOOD — zero cost
+// GOOD — path data lives in read-only storage; only one copy into the descriptor
 static constexpr const char* READER_KERNEL_PATH =
     "ttnn/cpp/ttnn/operations/my_op/device/kernels/reader.cpp";
 reader_desc.kernel_source = READER_KERNEL_PATH;
 ```
-
-`kernel_source` is `std::string_view` — it must point to a string that outlives the descriptor.
-`static constexpr const char*` satisfies this.
 
 ### Use KernelDescriptor type aliases for args
 

--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -376,6 +376,26 @@ std::vector<uint32_t> compile_time_args{cb_id};
 KernelDescriptor::CompileTimeArgs compile_time_args{cb_id};
 ```
 
+### Use cached_split_work_to_cores instead of manual grid/split calls
+
+Never call `device->compute_with_storage_grid_size()`, `split_work_to_cores()`, and
+`grid_to_cores()` separately. Use the framework cache instead — it caches the device grid
+(which never changes) and the work split result per thread:
+
+```cpp
+// BAD — recomputes grid + split + cores on every dispatch
+auto grid = device->compute_with_storage_grid_size();
+auto [num_cores, all_cores, cg1, cg2, upcg1, upcg2] = split_work_to_cores(grid, units);
+auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+
+// GOOD — one call, cached per thread
+const auto& ws = cached_split_work_to_cores(device, units_to_divide);
+// ws.num_cores, ws.all_cores, ws.core_group_1, ws.core_group_2,
+// ws.units_per_core_group_1, ws.units_per_core_group_2, ws.cores
+```
+
+See `ttnn/cpp/ttnn/operations/randn/device/randn_program_factory.cpp` for usage.
+
 ---
 
 ## Common pitfalls

--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -345,22 +345,38 @@ The ProgramDescriptor path calls `create_descriptor` on **every dispatch** (cach
 Everything built inside it — CBDescriptors, KernelDescriptors, CoreRangeSet copies,
 runtime arg vectors — is allocation overhead. Follow these patterns to keep it fast.
 
-### Prefer constexpr kernel paths
+### Prefer string literals for kernel paths
 
-Prefer `static constexpr const char*` over runtime string concatenation for kernel paths.
-`kernel_source` is `std::string`, so each assignment copies — but starting from constexpr
-storage avoids the CPU + heap cost of formatting/concatenating the path per dispatch:
+Don't build kernel paths at runtime — string concatenation and `fmt::format` allocate per
+dispatch. `kernel_source` is `std::string` (the descriptor owns the path), so the only
+unavoidable cost is one copy into the descriptor; starting from a string literal keeps
+that copy cheap and the path data lives in read-only program storage:
 
 ```cpp
 // BAD — formats/concatenates a new std::string every dispatch
 const std::string kernels_dir = "ttnn/cpp/ttnn/operations/my_op/device/kernels/";
 reader_desc.kernel_source = kernels_dir + "reader.cpp";
 
-// GOOD — path data lives in read-only storage; only one copy into the descriptor
-static constexpr const char* READER_KERNEL_PATH =
-    "ttnn/cpp/ttnn/operations/my_op/device/kernels/reader.cpp";
-reader_desc.kernel_source = READER_KERNEL_PATH;
+// GOOD — single copy from a string literal
+reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/my_op/device/kernels/reader.cpp";
 ```
+
+If a helper picks among several paths (e.g. for different dtypes), return
+`std::string_view` and use `"..."sv` literals — `string_view` carries the size at compile
+time, so converting to `std::string` skips the runtime `strlen` that `const char*` requires:
+
+```cpp
+std::string_view kernel_for(DataType dt) {
+    using namespace std::string_view_literals;
+    switch (dt) {
+        case DataType::BFLOAT16: return "path/to/bf16_kernel.cpp"sv;
+        default:                 return "path/to/default_kernel.cpp"sv;
+    }
+}
+```
+
+Avoid `static constexpr const char*` locals for paths — string literals already have
+static storage, and the `static` only adds an unnecessary shared pointer between calls.
 
 ### Use KernelDescriptor type aliases for args
 

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -144,7 +144,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpArgmaxSingleCore) {
 }
 
 TEST_F(TTNNFixtureWithDevice, TestGenericOpUnaryReluSharded) {
-    const std::vector<std::pair<std::string, std::string>> defines_relu = {
+    const KernelDescriptor::Defines defines_relu = {
         {"SFPU_OP_CHAIN_0", "SFPU_OP_CHAIN_0_INIT_0 SFPU_OP_CHAIN_0_FUNC_0"},
         {"SFPU_OP_CHAIN_0_FUNC_0", "relu_tile(0);"},
         {"SFPU_OP_CHAIN_0_INIT_0", "relu_tile_init();"},
@@ -264,7 +264,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpUnaryReluSharded) {
 }
 
 TEST_F(TTNNFixtureWithDevice, TestGenericOpBinaryEltwiseAdd) {
-    const std::vector<std::pair<std::string, std::string>> defines_eltwise_add = {
+    const KernelDescriptor::Defines defines_eltwise_add = {
         {"ELTWISE_OP", "add_tiles"},
         {"ELTWISE_OP_TYPE", "EltwiseBinaryType::ELWADD"},
     };
@@ -693,7 +693,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpMatmul) {
 }
 
 TEST_F(TTNNFixtureWithDevice, TestGenericOpEltwiseSFPU) {
-    const std::vector<std::pair<std::string, std::string>> sfpu_defines = {
+    const KernelDescriptor::Defines sfpu_defines = {
         {"SFPU_OP_EXP_INCLUDE", "1"}, {"SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);"}};
 
     uint32_t num_tiles = 4;
@@ -805,7 +805,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpEltwiseSFPU) {
 TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
     log_info(tt::LogTest, "Running {}", __func__);
 
-    const std::vector<std::pair<std::string, std::string>> sfpu_defines = {
+    const KernelDescriptor::Defines sfpu_defines = {
         {"SFPU_OP_EXP_INCLUDE", "1"}, {"SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);"}};
 
     ttnn::Shape shape{1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
@@ -843,7 +843,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
 
     ProgramDescriptor program_descriptor = {
         .kernels =
-            {{
+            {KernelDescriptor{
                  .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
                                   "reader_unary_interleaved_start_id.cpp",
                  .core_ranges = device_cores,
@@ -851,7 +851,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
                  .runtime_args = {{{0, 0}, {device_input_tensor_1.buffer()->address(), num_tiles, 0u}}},
                  .config = tt::tt_metal::ReaderConfigDescriptor{},
              },
-             {
+             KernelDescriptor{
                  .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
                                   "writer_unary_interleaved_start_id.cpp",
                  .core_ranges = device_cores,
@@ -859,7 +859,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
                  .runtime_args = {{{0, 0}, {device_output_tensor_1.buffer()->address(), num_tiles, 0u}}},
                  .config = tt::tt_metal::WriterConfigDescriptor{},
              },
-             {
+             KernelDescriptor{
                  .kernel_source = "tt_metal/kernels/compute/eltwise_sfpu.cpp",
                  .core_ranges = device_cores,
                  .compile_time_args = {num_tiles, 1},
@@ -923,7 +923,7 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCacheCommonRuntimeArgs) {
     // args to be empty, so calling it on a reused program crashes.
     log_info(tt::LogTest, "Running {}", __func__);
 
-    const std::vector<std::pair<std::string, std::string>> sfpu_defines = {
+    const KernelDescriptor::Defines sfpu_defines = {
         {"SFPU_OP_EXP_INCLUDE", "1"}, {"SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);"}};
 
     ttnn::Shape shape{1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
@@ -961,37 +961,35 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCacheCommonRuntimeArgs) {
     // Use common_runtime_args on the reader kernel — the kernel reads per-core
     // args for the buffer address, and the common args are unused padding, but
     // the descriptor infrastructure must handle them on cache hits without crashing.
-    ProgramDescriptor program_descriptor = {
-        .kernels =
-            {{
-                 .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
-                                  "reader_unary_interleaved_start_id.cpp",
-                 .core_ranges = device_cores,
-                 .compile_time_args = reader_ct_args,
-                 .runtime_args = {{{0, 0}, {device_input_tensor_1.buffer()->address(), num_tiles, 0u}}},
-                 .common_runtime_args = {device_input_tensor_1.buffer()->address(), num_tiles, 0u},
-                 .config = tt::tt_metal::ReaderConfigDescriptor{},
-             },
-             {
-                 .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
-                                  "writer_unary_interleaved_start_id.cpp",
-                 .core_ranges = device_cores,
-                 .compile_time_args = writer_ct_args,
-                 .runtime_args = {{{0, 0}, {device_output_tensor_1.buffer()->address(), num_tiles, 0u}}},
-                 .common_runtime_args = {device_output_tensor_1.buffer()->address(), num_tiles, 0u},
-                 .config = tt::tt_metal::WriterConfigDescriptor{},
-             },
-             {
-                 .kernel_source = "tt_metal/kernels/compute/eltwise_sfpu.cpp",
-                 .core_ranges = device_cores,
-                 .compile_time_args = {num_tiles, 1},
-                 .defines = sfpu_defines,
-                 .runtime_args = {{{0, 0}, {}}},
-                 .config = tt::tt_metal::ComputeConfigDescriptor{},
-             }},
-        .semaphores = {},
-        .cbs = {input_cb_descriptor, output_cb_descriptor},
-    };
+    ProgramDescriptor program_descriptor;
+    program_descriptor.kernels.push_back(KernelDescriptor{
+        .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+                         "reader_unary_interleaved_start_id.cpp",
+        .core_ranges = device_cores,
+        .compile_time_args = reader_ct_args,
+        .runtime_args = {{{0, 0}, {device_input_tensor_1.buffer()->address(), num_tiles, 0u}}},
+        .common_runtime_args = {device_input_tensor_1.buffer()->address(), num_tiles, 0u},
+        .config = tt::tt_metal::ReaderConfigDescriptor{},
+    });
+    program_descriptor.kernels.push_back(KernelDescriptor{
+        .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+                         "writer_unary_interleaved_start_id.cpp",
+        .core_ranges = device_cores,
+        .compile_time_args = writer_ct_args,
+        .runtime_args = {{{0, 0}, {device_output_tensor_1.buffer()->address(), num_tiles, 0u}}},
+        .common_runtime_args = {device_output_tensor_1.buffer()->address(), num_tiles, 0u},
+        .config = tt::tt_metal::WriterConfigDescriptor{},
+    });
+    program_descriptor.kernels.push_back(KernelDescriptor{
+        .kernel_source = "tt_metal/kernels/compute/eltwise_sfpu.cpp",
+        .core_ranges = device_cores,
+        .compile_time_args = {num_tiles, 1},
+        .defines = sfpu_defines,
+        .runtime_args = {{{0, 0}, {}}},
+        .config = tt::tt_metal::ComputeConfigDescriptor{},
+    });
+    program_descriptor.cbs.push_back(input_cb_descriptor);
+    program_descriptor.cbs.push_back(output_cb_descriptor);
 
     // Run 1: Cache miss — creates program, sets common_runtime_args for the first time
     log_info(tt::LogTest, "Run 1: Cache miss with common_runtime_args");
@@ -1255,7 +1253,8 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
     auto worker_fwd_virtual = mesh_device_->worker_core_from_logical_core(worker_fwd_core);
     auto worker_bwd_virtual = mesh_device_->worker_core_from_logical_core(worker_bwd_core);
 
-    auto mux_ct_args = mux_config.get_fabric_mux_compile_time_args();
+    auto mux_ct_args_vec = mux_config.get_fabric_mux_compile_time_args();
+    KernelDescriptor::CompileTimeArgs mux_ct_args(mux_ct_args_vec.begin(), mux_ct_args_vec.end());
 
     // =========================================================================
     // Build MeshProgramDescriptor for each device in the 1x4 line
@@ -1284,7 +1283,7 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         };
 
         // Common CT args for reader/writer
-        std::vector<uint32_t> common_ct_args = {
+        KernelDescriptor::CompileTimeArgs common_ct_args = {
             ring_size,
             ring_index,
             static_cast<uint32_t>(sender_cb_index),
@@ -1306,12 +1305,12 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         };
 
         // Reader CT args
-        std::vector<uint32_t> reader_ct_args = common_ct_args;
+        KernelDescriptor::CompileTimeArgs reader_ct_args = common_ct_args;
         tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_ct_args);
         tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(reader_ct_args);
 
         // Writer CT args
-        std::vector<uint32_t> writer_ct_args = common_ct_args;
+        KernelDescriptor::CompileTimeArgs writer_ct_args = common_ct_args;
         // fabric_mux_connection_ct_args
         writer_ct_args.push_back(mux_config.get_num_buffers(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL));
         writer_ct_args.push_back(
@@ -1440,31 +1439,36 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         }
 
         // Kernel Descriptors
-        program_desc.kernels.push_back({
+        program_desc.kernels.push_back(KernelDescriptor{
             .kernel_source =
                 "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp",
             .core_ranges = worker_cores,
             .compile_time_args = reader_ct_args,
-            .runtime_args = {{worker_fwd_core, fwd_reader_rt}, {worker_bwd_core, bwd_reader_rt}},
+            .runtime_args =
+                {{worker_fwd_core, KernelDescriptor::CoreRuntimeArgs(fwd_reader_rt.begin(), fwd_reader_rt.end())},
+                 {worker_bwd_core, KernelDescriptor::CoreRuntimeArgs(bwd_reader_rt.begin(), bwd_reader_rt.end())}},
             .config = tt::tt_metal::ReaderConfigDescriptor{},
         });
 
-        program_desc.kernels.push_back({
+        program_desc.kernels.push_back(KernelDescriptor{
             .kernel_source =
                 "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp",
             .core_ranges = worker_cores,
             .compile_time_args = writer_ct_args,
             .defines = {{"USE_WORKER_MUX", "1"}},
-            .runtime_args = {{worker_fwd_core, fwd_writer_rt}, {worker_bwd_core, bwd_writer_rt}},
+            .runtime_args =
+                {{worker_fwd_core, KernelDescriptor::CoreRuntimeArgs(fwd_writer_rt.begin(), fwd_writer_rt.end())},
+                 {worker_bwd_core, KernelDescriptor::CoreRuntimeArgs(bwd_writer_rt.begin(), bwd_writer_rt.end())}},
             .config = tt::tt_metal::WriterConfigDescriptor{},
         });
 
         if (has_forward) {
-            program_desc.kernels.push_back({
+            program_desc.kernels.push_back(KernelDescriptor{
                 .kernel_source = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
                 .core_ranges = mux_fwd_core_set,
                 .compile_time_args = mux_ct_args,
-                .runtime_args = {{mux_fwd_core, fwd_mux_rt}},
+                .runtime_args =
+                    {{mux_fwd_core, KernelDescriptor::CoreRuntimeArgs(fwd_mux_rt.begin(), fwd_mux_rt.end())}},
                 .config =
                     tt::tt_metal::DataMovementConfigDescriptor{
                         .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
@@ -1472,11 +1476,12 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
             });
         }
         if (has_backward) {
-            program_desc.kernels.push_back({
+            program_desc.kernels.push_back(KernelDescriptor{
                 .kernel_source = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
                 .core_ranges = mux_bwd_core_set,
                 .compile_time_args = mux_ct_args,
-                .runtime_args = {{mux_bwd_core, bwd_mux_rt}},
+                .runtime_args =
+                    {{mux_bwd_core, KernelDescriptor::CoreRuntimeArgs(bwd_mux_rt.begin(), bwd_mux_rt.end())}},
                 .config =
                     tt::tt_metal::DataMovementConfigDescriptor{
                         .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
@@ -1533,7 +1538,7 @@ TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
 
     auto worker_mem_map = this->generate_worker_mem_map(sender_device, topology);
 
-    std::vector<uint32_t> compile_time_args = {
+    KernelDescriptor::CompileTimeArgs compile_time_args = {
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
         worker_mem_map.notification_mailbox_address,
@@ -1584,7 +1589,9 @@ TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
         api_type);
 
     // NOW set the complete runtime args on the kernel (after append has added connection args)
-    sender_program_descriptor.kernels[kernel_id].runtime_args = {{sender_logical_core, sender_runtime_args}};
+    sender_program_descriptor.kernels[kernel_id].runtime_args = {
+        {sender_logical_core,
+         KernelDescriptor::CoreRuntimeArgs(sender_runtime_args.begin(), sender_runtime_args.end())}};
 
     ProgramDescriptor receiver_program_descriptor;
 
@@ -1598,7 +1605,9 @@ TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
         .kernel_source = "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_receiver.cpp",
         .core_ranges = {receiver_logical_core},
         .compile_time_args = compile_time_args,
-        .runtime_args = {{receiver_logical_core, receiver_runtime_args}},
+        .runtime_args =
+            {{receiver_logical_core,
+              KernelDescriptor::CoreRuntimeArgs(receiver_runtime_args.begin(), receiver_runtime_args.end())}},
         .common_runtime_args = {},
         .config = tt::tt_metal::DataMovementConfigDescriptor{},
     };

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -216,6 +216,12 @@ public:
         std::optional<bool> bottom_up = std::nullopt,
         std::optional<SubDeviceId> sub_device_id = std::nullopt);
 
+    // Creates a non-owning view of an existing buffer on a different device, reusing
+    // source's address. Used by MeshBuffer to create per-device handles without
+    // re-allocating. Routes through Buffer::create(...) to preserve all side effects
+    // of construction (validation, LightMetal capture, Inspector registration).
+    static std::shared_ptr<Buffer> create_device_view(IDevice* device, const Buffer& source);
+
     // Creates a view of the region of the buffer.
     // The view is a new buffer (unless the region is the entire buffer) that shares the same underlying device memory.
     // The view keeps the underlying buffer alive as long as the view is alive.

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -17,6 +17,7 @@
 
 #include <bitset>
 #include <optional>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -117,10 +118,10 @@ struct CommonBufferBinding {
 struct KernelDescriptor {
     // TODO: investigate using SmallVector here, using std::vector for now to abide size constraint
     // in tt_stl/tt_stl/reflection.hpp:185:23
-    using CompileTimeArgs = std::vector<uint32_t>;
+    using CompileTimeArgs = ttsl::SmallVector<uint32_t, 16>;
     using NamedCompileTimeArgs = std::vector<std::pair<std::string, uint32_t>>;
-    using Defines = std::vector<std::pair<std::string, std::string>>;
-    using CoreRuntimeArgs = std::vector<uint32_t>;
+    using Defines = ttsl::SmallVector<std::pair<std::string, std::string>, 4>;
+    using CoreRuntimeArgs = ttsl::SmallVector<uint32_t, 8>;
     using RuntimeArgs = std::vector<std::pair<CoreCoord, CoreRuntimeArgs>>;
     using CommonRuntimeArgs = CoreRuntimeArgs;
     using BufferBindings = ttsl::SmallVector<BufferBinding, 4>;
@@ -129,7 +130,7 @@ struct KernelDescriptor {
         variant<ReaderConfigDescriptor, WriterConfigDescriptor, DataMovementConfigDescriptor, ComputeConfigDescriptor>;
     enum class SourceType { FILE_PATH, SOURCE_CODE };
 
-    std::string kernel_source;
+    std::string_view kernel_source;
     SourceType source_type = SourceType::FILE_PATH;
 
     CoreRangeSet core_ranges;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -116,8 +116,13 @@ struct CommonBufferBinding {
 };
 
 struct KernelDescriptor {
-    // TODO: investigate using SmallVector here, using std::vector for now to abide size constraint
-    // in tt_stl/tt_stl/reflection.hpp:185:23
+    // SmallVector inline sizes — picked to cover the common case without heap allocation
+    // while keeping the overall KernelDescriptor size within the 1312-byte storage_t limit
+    // imposed by the reflection system (see tt_stl/reflection.hpp:185).
+    //   CompileTimeArgs: 16 — typical kernel has 1 CB id + TensorAccessorArgs (~4-10 fields)
+    //   Defines:          4 — most ops have 0-3 #define pairs
+    //   CoreRuntimeArgs:  8 — per-core runtime args typically fit in 2-6 uint32_t
+    // RuntimeArgs stays std::vector: growing its inline size blows the reflection size budget.
     using CompileTimeArgs = ttsl::SmallVector<uint32_t, 16>;
     using NamedCompileTimeArgs = std::vector<std::pair<std::string, uint32_t>>;
     using Defines = ttsl::SmallVector<std::pair<std::string, std::string>, 4>;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -17,7 +17,6 @@
 
 #include <bitset>
 #include <optional>
-#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -135,7 +134,7 @@ struct KernelDescriptor {
         variant<ReaderConfigDescriptor, WriterConfigDescriptor, DataMovementConfigDescriptor, ComputeConfigDescriptor>;
     enum class SourceType { FILE_PATH, SOURCE_CODE };
 
-    std::string_view kernel_source;
+    std::string kernel_source;
     SourceType source_type = SourceType::FILE_PATH;
 
     CoreRangeSet core_ranges;

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -36,6 +36,12 @@ public:
     static TensorAccessorArgs create_dram_interleaved();
     static TensorAccessorArgs create_l1_interleaved();
 
+    // append_to is templated to avoid forcing a single container type on callers, but the
+    // implementation lives in tensor_accessor_args.cpp with explicit instantiations. Only the
+    // following container types are supported; calling with any other type will fail at link time:
+    //   - std::vector<uint32_t>
+    //   - KernelDescriptor::CompileTimeArgs  (ttsl::SmallVector<uint32_t, 16>)
+    //   - KernelDescriptor::CoreRuntimeArgs  (ttsl::SmallVector<uint32_t, 8>)
     template <typename ArgsVec>
     void append_to(ArgsVec& compile_time_args) const;
     template <typename ArgsVec1, typename ArgsVec2>

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -36,8 +36,10 @@ public:
     static TensorAccessorArgs create_dram_interleaved();
     static TensorAccessorArgs create_l1_interleaved();
 
-    void append_to(std::vector<uint32_t>& compile_time_args) const;
-    void append_to(std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const;
+    template <typename ArgsVec>
+    void append_to(ArgsVec& compile_time_args) const;
+    template <typename ArgsVec1, typename ArgsVec2>
+    void append_to(ArgsVec1& compile_time_args, ArgsVec2& common_runtime_args) const;
 
     std::vector<uint32_t> get_compile_time_args() const;
     std::vector<uint32_t> get_common_runtime_args() const;

--- a/tt_metal/api/tt-metalium/work_split.hpp
+++ b/tt_metal/api/tt-metalium/work_split.hpp
@@ -16,6 +16,25 @@
 
 namespace tt::tt_metal {
 
+class IDevice;
+
+// Cached result of split_work_to_cores + grid_to_cores.
+// Use cached_split_work_to_cores() to obtain one — never construct directly.
+struct CachedWorkSplit {
+    uint32_t num_cores = 0;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1 = 0;
+    uint32_t units_per_core_group_2 = 0;
+    std::vector<CoreCoord> cores;
+};
+
+// Returns a cached work split for the given device and units_to_divide.
+// Caches device→grid mapping and (grid, units)→split result per thread.
+// Safe to call from any op's create_descriptor — no per-op boilerplate needed.
+const CachedWorkSplit& cached_split_work_to_cores(IDevice* device, uint32_t units_to_divide, bool row_wise = false);
+
 uint32_t merge_num_sticks_to_read(uint32_t num_sticks_to_read, uint32_t stick_size_bytes, uint32_t max_read_size);
 
 // Given a number of tiles and number of cores available

--- a/tt_metal/api/tt-metalium/work_split.hpp
+++ b/tt_metal/api/tt-metalium/work_split.hpp
@@ -16,8 +16,6 @@
 
 namespace tt::tt_metal {
 
-class IDevice;
-
 // Cached result of split_work_to_cores + grid_to_cores.
 // Use cached_split_work_to_cores() to obtain one — never construct directly.
 struct CachedWorkSplit {
@@ -30,10 +28,17 @@ struct CachedWorkSplit {
     std::vector<CoreCoord> cores;
 };
 
-// Returns a cached work split for the given device and units_to_divide.
-// Caches device→grid mapping and (grid, units)→split result per thread.
-// Safe to call from any op's create_descriptor — no per-op boilerplate needed.
-const CachedWorkSplit& cached_split_work_to_cores(IDevice* device, uint32_t units_to_divide, bool row_wise = false);
+// Returns a cached work split for the given grid and units_to_divide.
+// The cache lives in thread_local storage; on every call the cached entry is
+// validated against the full key (grid_x, grid_y, units, row_wise) and
+// recomputed on miss.
+//
+// The caller is responsible for choosing the right grid:
+//   - For full-device dispatch: pass device->compute_with_storage_grid_size().
+//   - For sub-device dispatch:  pass the sub-device's worker grid (or use
+//     split_work_to_cores directly with a CoreRangeSet — this helper handles
+//     the rectangular-grid case only).
+const CachedWorkSplit& cached_split_work_to_cores(CoreCoord grid_size, uint32_t units_to_divide, bool row_wise = false);
 
 uint32_t merge_num_sticks_to_read(uint32_t num_sticks_to_read, uint32_t stick_size_bytes, uint32_t max_read_size);
 

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -169,9 +169,19 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
 }
 
 void MeshBuffer::initialize_device_buffers() {
-    auto init_device_buffer_at_address = [this](const MeshCoordinate& coord) {
+    // If we have a backing buffer, create lightweight device views instead of full Buffer::create.
+    // For per-core allocation or externally-owned buffers, fall back to the full path.
+    auto* backing = get_backing_buffer();
+    bool use_fast_path =
+        backing != nullptr && !per_core_allocation::is_per_core_allocation(device_local_config_.sharding_args);
+
+    auto init_device_buffer_at_address = [this, backing, use_fast_path](const MeshCoordinate& coord) {
+        auto* physical_device = device()->impl().get_device(coord);
+        if (use_fast_path) {
+            return Buffer::create_device_view(physical_device, *backing);
+        }
         std::shared_ptr<Buffer> buffer = Buffer::create(
-            device()->impl().get_device(coord),
+            physical_device,
             address_,
             device_local_size_,
             device_local_config_.page_size,

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -379,6 +379,26 @@ std::shared_ptr<Buffer> Buffer::create(
     return buffer;
 }
 
+std::shared_ptr<Buffer> Buffer::create_device_view(IDevice* device, const Buffer& source) {
+    // Route through the standard Buffer::create(...) factory so all side effects of
+    // construction are preserved — validation, LightMetal CaptureBufferCreate trace,
+    // Inspector global-id registration. The earlier lightweight ctor skipped these,
+    // which broke per-device alias buffer tracking and caused CCL all-gather/all-reduce
+    // hangs on multi-card Blackhole. The address-supplied form of Buffer::create()
+    // doesn't allocate (just sets address_ and allocation_status_), so the cost is
+    // essentially a few TT_FATAL checks plus one Inspector trace call — a few
+    // hundred nanoseconds, well within the noise of the descriptor-prep perf budget.
+    return Buffer::create(
+        device,
+        source.address_,
+        source.size_,
+        source.page_size_,
+        source.buffer_type_,
+        BufferShardingArgs(source.buffer_distribution_spec_, source.shard_spec_, source.buffer_layout_),
+        source.bottom_up_,
+        /*sub_device_id=*/std::nullopt);
+}
+
 std::shared_ptr<Buffer> Buffer::view(const BufferRegion& region) {
     TT_FATAL(region.offset % page_size() == 0, "Region offset must be a multiple of page size");
     TT_FATAL(region.size % page_size() == 0, "Region size must be a multiple of page size");

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -7,13 +7,15 @@
 #include <limits>
 
 #include <tt-metalium/device.hpp>
+#include <tt_stl/small_vector.hpp>
 
 namespace tt::tt_metal {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
+template <typename ArgsVec>
 void append_sharded_args(
-    const Buffer& buffer, tensor_accessor::ArgsConfig args_config, std::vector<uint32_t>& args, bool is_runtime) {
+    const Buffer& buffer, tensor_accessor::ArgsConfig args_config, ArgsVec& args, bool is_runtime) {
     TT_FATAL(buffer.buffer_distribution_spec(), "Buffer must have a buffer distribution spec");
 
     const auto& buffer_distribution_spec = buffer.buffer_distribution_spec().value();
@@ -151,8 +153,8 @@ void TensorAccessorArgs::update_args_config() {
     }
 }
 
-void TensorAccessorArgs::append_to(
-    std::vector<uint32_t>& compile_time_args, std::vector<uint32_t>& common_runtime_args) const {
+template <typename ArgsVec1, typename ArgsVec2>
+void TensorAccessorArgs::append_to(ArgsVec1& compile_time_args, ArgsVec2& common_runtime_args) const {
     if (args_config_.test(tensor_accessor::ArgConfig::Sharded)) {
         CMAKE_UNIQUE_NAMESPACE::append_sharded_args(*buffer_, args_config_, compile_time_args, /* is_runtime */ false);
         CMAKE_UNIQUE_NAMESPACE::append_sharded_args(*buffer_, args_config_, common_runtime_args, /* is_runtime */ true);
@@ -168,7 +170,8 @@ void TensorAccessorArgs::append_to(
     }
 }
 
-void TensorAccessorArgs::append_to(std::vector<uint32_t>& compile_time_args) const {
+template <typename ArgsVec>
+void TensorAccessorArgs::append_to(ArgsVec& compile_time_args) const {
     TT_FATAL(
         (args_config_ & tensor_accessor::ArgConfig::Runtime).raw() == 0,
         "Common runtime arguments are required for ArgsConfig {}",
@@ -211,5 +214,16 @@ std::vector<uint32_t> TensorAccessorArgs::get_common_runtime_args() const {
     }
     return common_runtime_args;
 }
+
+// Explicit template instantiations for append_to
+// std::vector<uint32_t> (legacy callers)
+template void TensorAccessorArgs::append_to<std::vector<uint32_t>>(std::vector<uint32_t>&) const;
+template void TensorAccessorArgs::append_to<std::vector<uint32_t>, std::vector<uint32_t>>(
+    std::vector<uint32_t>&, std::vector<uint32_t>&) const;
+
+// SmallVector instantiations for KernelDescriptor::CompileTimeArgs and CommonRuntimeArgs
+template void TensorAccessorArgs::append_to<ttsl::SmallVector<uint32_t, 16>>(ttsl::SmallVector<uint32_t, 16>&) const;
+template void TensorAccessorArgs::append_to<ttsl::SmallVector<uint32_t, 16>, ttsl::SmallVector<uint32_t, 8>>(
+    ttsl::SmallVector<uint32_t, 16>&, ttsl::SmallVector<uint32_t, 8>&) const;
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/work_split_cache.cpp
+++ b/tt_metal/impl/dispatch/work_split_cache.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/device.hpp>
+
+#include <unordered_map>
+
+namespace tt::tt_metal {
+
+const CachedWorkSplit& cached_split_work_to_cores(IDevice* device, uint32_t units_to_divide, bool row_wise) {
+    // Cache device → grid (never changes for a given device)
+    static thread_local std::unordered_map<IDevice*, CoreCoord> grid_cache;
+
+    // Single-entry cache for (grid, units, row_wise) → work split result
+    struct CacheEntry {
+        uint32_t grid_x = 0, grid_y = 0, units = 0;
+        bool row_wise = false;
+        CachedWorkSplit result;
+
+        bool matches(uint32_t gx, uint32_t gy, uint32_t u, bool rw) const {
+            return grid_x == gx && grid_y == gy && units == u && row_wise == rw;
+        }
+    };
+    static thread_local CacheEntry work_cache;
+
+    // Resolve grid from device (cached — grid never changes for a given device)
+    auto [it, inserted] = grid_cache.try_emplace(device, CoreCoord{0, 0});
+    if (inserted) {
+        it->second = device->compute_with_storage_grid_size();
+    }
+    const auto& grid = it->second;
+
+    // Check work split cache
+    if (!work_cache.matches(grid.x, grid.y, units_to_divide, row_wise)) {
+        auto [nc, ac, cg1, cg2, upcg1, upcg2] = split_work_to_cores(grid, units_to_divide, row_wise);
+        work_cache.grid_x = grid.x;
+        work_cache.grid_y = grid.y;
+        work_cache.units = units_to_divide;
+        work_cache.row_wise = row_wise;
+        work_cache.result.num_cores = nc;
+        work_cache.result.all_cores = std::move(ac);
+        work_cache.result.core_group_1 = std::move(cg1);
+        work_cache.result.core_group_2 = std::move(cg2);
+        work_cache.result.units_per_core_group_1 = upcg1;
+        work_cache.result.units_per_core_group_2 = upcg2;
+        work_cache.result.cores = grid_to_cores(nc, grid.x, grid.y, row_wise);
+    }
+
+    return work_cache.result;
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/work_split_cache.cpp
+++ b/tt_metal/impl/dispatch/work_split_cache.cpp
@@ -3,52 +3,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/device.hpp>
-
-#include <unordered_map>
 
 namespace tt::tt_metal {
 
-const CachedWorkSplit& cached_split_work_to_cores(IDevice* device, uint32_t units_to_divide, bool row_wise) {
-    // Cache device → grid (never changes for a given device)
-    static thread_local std::unordered_map<IDevice*, CoreCoord> grid_cache;
-
-    // Single-entry cache for (grid, units, row_wise) → work split result
+const CachedWorkSplit& cached_split_work_to_cores(CoreCoord grid_size, uint32_t units_to_divide, bool row_wise) {
+    // Single-entry thread-local cache keyed on (grid, units, row_wise).
+    // Sub-device callers must pass their sub-device's grid here — this helper
+    // does not introspect the device.
     struct CacheEntry {
         uint32_t grid_x = 0, grid_y = 0, units = 0;
         bool row_wise = false;
+        bool populated = false;
         CachedWorkSplit result;
 
         bool matches(uint32_t gx, uint32_t gy, uint32_t u, bool rw) const {
-            return grid_x == gx && grid_y == gy && units == u && row_wise == rw;
+            return populated && grid_x == gx && grid_y == gy && units == u && row_wise == rw;
         }
     };
-    static thread_local CacheEntry work_cache;
+    static thread_local CacheEntry cache;
 
-    // Resolve grid from device (cached — grid never changes for a given device)
-    auto [it, inserted] = grid_cache.try_emplace(device, CoreCoord{0, 0});
-    if (inserted) {
-        it->second = device->compute_with_storage_grid_size();
-    }
-    const auto& grid = it->second;
-
-    // Check work split cache
-    if (!work_cache.matches(grid.x, grid.y, units_to_divide, row_wise)) {
-        auto [nc, ac, cg1, cg2, upcg1, upcg2] = split_work_to_cores(grid, units_to_divide, row_wise);
-        work_cache.grid_x = grid.x;
-        work_cache.grid_y = grid.y;
-        work_cache.units = units_to_divide;
-        work_cache.row_wise = row_wise;
-        work_cache.result.num_cores = nc;
-        work_cache.result.all_cores = std::move(ac);
-        work_cache.result.core_group_1 = std::move(cg1);
-        work_cache.result.core_group_2 = std::move(cg2);
-        work_cache.result.units_per_core_group_1 = upcg1;
-        work_cache.result.units_per_core_group_2 = upcg2;
-        work_cache.result.cores = grid_to_cores(nc, grid.x, grid.y, row_wise);
+    if (!cache.matches(grid_size.x, grid_size.y, units_to_divide, row_wise)) {
+        auto [nc, ac, cg1, cg2, upcg1, upcg2] = split_work_to_cores(grid_size, units_to_divide, row_wise);
+        cache.grid_x = grid_size.x;
+        cache.grid_y = grid_size.y;
+        cache.units = units_to_divide;
+        cache.row_wise = row_wise;
+        cache.populated = true;
+        cache.result.num_cores = nc;
+        cache.result.all_cores = std::move(ac);
+        cache.result.core_group_1 = std::move(cg1);
+        cache.result.core_group_2 = std::move(cg2);
+        cache.result.units_per_core_group_1 = upcg1;
+        cache.result.units_per_core_group_2 = upcg2;
+        cache.result.cores = grid_to_cores(nc, grid_size.x, grid_size.y, row_wise);
     }
 
-    return work_cache.result;
+    return cache.result;
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -373,9 +373,10 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
             kernel_descriptor.config);
 
         auto kernel_handle =
-            is_file
-                ? CreateKernel(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config)
-                : CreateKernelFromString(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config);
+            is_file ? CreateKernel(
+                          *this, std::string(kernel_descriptor.kernel_source), kernel_descriptor.core_ranges, config)
+                    : CreateKernelFromString(
+                          *this, std::string(kernel_descriptor.kernel_source), kernel_descriptor.core_ranges, config);
 
         for (const auto& [core_coord, core_runtime_args] : kernel_descriptor.runtime_args) {
             SetRuntimeArgs(*this, kernel_handle, core_coord, core_runtime_args);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -373,10 +373,9 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
             kernel_descriptor.config);
 
         auto kernel_handle =
-            is_file ? CreateKernel(
-                          *this, std::string(kernel_descriptor.kernel_source), kernel_descriptor.core_ranges, config)
-                    : CreateKernelFromString(
-                          *this, std::string(kernel_descriptor.kernel_source), kernel_descriptor.core_ranges, config);
+            is_file
+                ? CreateKernel(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config)
+                : CreateKernelFromString(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config);
 
         for (const auto& [core_coord, core_runtime_args] : kernel_descriptor.runtime_args) {
             SetRuntimeArgs(*this, kernel_handle, core_coord, core_runtime_args);

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -20,6 +20,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/mock_device_util.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/dispatch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/work_split_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/memory_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/mesh_buffer.cpp

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -99,7 +99,7 @@ public:
 
     size_t size() const { return args_.size(); }
 
-    auto& at(size_t idx) { return args_[idx]; }
+    auto& at(size_t idx) { return args_.at(idx); }
 
     void clear() { args_.clear(); }
 

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -50,14 +50,14 @@ public:
         CoreCoord target(x_, y);
         for (auto& [coord, vec] : args_) {
             if (coord == target) {
-                vec = values;  // Update existing
+                vec.assign(values.begin(), values.end());  // Update existing
                 return;
             }
         }
-        args_.push_back({target, values});  // Append if not found
+        args_.push_back({target, {values.begin(), values.end()}});  // Append if not found
     }
 
-    std::vector<uint32_t>& get_item(size_t y) {
+    tt::tt_metal::KernelDescriptor::CoreRuntimeArgs& get_item(size_t y) {
         CoreCoord target(x_, y);
         for (auto& [coord, values] : args_) {
             if (coord == target) {
@@ -69,12 +69,12 @@ public:
     }
 
     void extend_item(size_t y, const std::vector<uint32_t>& values) {
-        std::vector<uint32_t>& target_vec = get_item(y);
+        auto& target_vec = get_item(y);
         target_vec.insert(target_vec.end(), values.begin(), values.end());
     }
 
     void append_item(size_t y, uint32_t value) {
-        std::vector<uint32_t>& target_vec = get_item(y);
+        auto& target_vec = get_item(y);
         target_vec.push_back(value);
     }
 
@@ -90,14 +90,16 @@ public:
 
     RuntimeArgsColProxy get_col(size_t x) { return RuntimeArgsColProxy(args_, x); }
 
-    void append(const CoreCoord& coord, const std::vector<uint32_t>& values) { args_.push_back({coord, values}); }
+    void append(const CoreCoord& coord, const std::vector<uint32_t>& values) {
+        args_.push_back({coord, {values.begin(), values.end()}});
+    }
 
     tt::tt_metal::KernelDescriptor::RuntimeArgs& get() { return args_; }
     const tt::tt_metal::KernelDescriptor::RuntimeArgs& get() const { return args_; }
 
     size_t size() const { return args_.size(); }
 
-    std::pair<CoreCoord, std::vector<uint32_t>>& at(size_t idx) { return args_.at(idx); }
+    auto& at(size_t idx) { return args_[idx]; }
 
     void clear() { args_.clear(); }
 

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -89,21 +89,26 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
 
     // ---- Kernels ----
 
-    const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/";
+    static constexpr const char* READER_KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/reader_bernoulli.cpp";
+    static constexpr const char* WRITER_KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/writer_bernoulli.cpp";
+    static constexpr const char* COMPUTE_KERNEL_PATH =
+        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/compute_bernoulli.cpp";
 
     // Reader kernel
-    std::vector<uint32_t> reader_compile_time_args{in_cb_id};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{in_cb_id};
     TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
-    reader_desc.kernel_source = kernels_dir_path + "reader_bernoulli.cpp";
+    reader_desc.kernel_source = READER_KERNEL_PATH;
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = reader_compile_time_args;
     reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer kernel
-    std::vector<uint32_t> writer_compile_time_args{in_cb_id, intermed_cb_id, intermed1_cb_id};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{in_cb_id, intermed_cb_id, intermed1_cb_id};
     TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
     KernelDescriptor::Defines writer_defines;
@@ -119,7 +124,7 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     }
 
     KernelDescriptor writer_desc;
-    writer_desc.kernel_source = kernels_dir_path + "writer_bernoulli.cpp";
+    writer_desc.kernel_source = WRITER_KERNEL_PATH;
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = writer_compile_time_args;
@@ -127,13 +132,13 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
 
     // Compute kernel
-    const std::vector<uint32_t> compute_compile_time_args{intermed_cb_id};
+    const KernelDescriptor::CompileTimeArgs compute_compile_time_args{intermed_cb_id};
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
     KernelDescriptor compute_desc;
-    compute_desc.kernel_source = kernels_dir_path + "compute_bernoulli.cpp";
+    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = all_cores;
     compute_desc.compile_time_args = compute_compile_time_args;

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -89,19 +89,12 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
 
     // ---- Kernels ----
 
-    static constexpr const char* READER_KERNEL_PATH =
-        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/reader_bernoulli.cpp";
-    static constexpr const char* WRITER_KERNEL_PATH =
-        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/writer_bernoulli.cpp";
-    static constexpr const char* COMPUTE_KERNEL_PATH =
-        "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/compute_bernoulli.cpp";
-
     // Reader kernel
     KernelDescriptor::CompileTimeArgs reader_compile_time_args{in_cb_id};
     TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
-    reader_desc.kernel_source = READER_KERNEL_PATH;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/reader_bernoulli.cpp";
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = reader_compile_time_args;
@@ -124,7 +117,7 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     }
 
     KernelDescriptor writer_desc;
-    writer_desc.kernel_source = WRITER_KERNEL_PATH;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/writer_bernoulli.cpp";
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = writer_compile_time_args;
@@ -138,7 +131,7 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
     KernelDescriptor compute_desc;
-    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/bernoulli/device/kernels/compute_bernoulli.cpp";
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = all_cores;
     compute_desc.compile_time_args = compute_compile_time_args;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -270,7 +270,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
 
     // --- Reader Kernel Descriptor ---
     // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> reader_compile_time_args = {num_dims};
+    tt::tt_metal::KernelDescriptor::CompileTimeArgs reader_compile_time_args = {num_dims};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
@@ -285,7 +285,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     accumulated_total_per_dim[0] = num_total_Xt;
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
-    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
+    tt::tt_metal::KernelDescriptor::CommonRuntimeArgs reader_common_args(1 + (num_dims * 2));
     reader_common_args[0] = src0_buffer->address();
     uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
     uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
@@ -315,12 +315,12 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             // no-op core
-            std::vector<uint32_t> reader_args(2 + num_dims, 0);
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs reader_args(2 + num_dims, 0);
             reader_runtime_args.emplace_back(core, std::move(reader_args));
             continue;
         }
 
-        std::vector<uint32_t> reader_args(2 + num_dims);
+        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs reader_args(2 + num_dims);
         // Compute per-dim indices for this core's starting position
         reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
         uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
@@ -352,7 +352,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
 
     // --- Writer Kernel Descriptor ---
     // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> writer_compile_time_args = {};
+    tt::tt_metal::KernelDescriptor::CompileTimeArgs writer_compile_time_args = {};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
@@ -366,12 +366,14 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             // no-op core
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            writer_runtime_args.emplace_back(core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{0, 0, 0});
             continue;
         }
 
         writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+            core,
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
+                dst_buffer->address(), num_tiles_per_core, num_tiles_written});
         num_tiles_written += num_tiles_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -157,7 +157,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastHeightAndWidthMu
     // ---- Kernel compile-time args and defines ----
 
     std::map<std::string, std::string> reader_defines;
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     std::map<std::string, std::string> bcast_compute_defines = bcast_op_utils::get_defines(BcastOpDim::HW, bcast_math);
     if (bnc1) {
         reader_defines["BCAST_SCALAR"] = "1";
@@ -186,7 +186,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastHeightAndWidthMu
     if (output_sharded) {
         writer_defines["OUT_SHARDED"] = "1";
     }
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {output_cb_index};
     tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     // ---- Reader kernel ----

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -169,17 +169,19 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastHeightAndWidthMu
         TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     }
 
-    std::string reader_kernel_path;
+    static constexpr const char* READER_HW_INTERLEAVED =
+        "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
+        "reader_bcast_hw_interleaved_partitioned.cpp";
+    static constexpr const char* READER_SCALAR_INTERLEAVED =
+        "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
+        "reader_bcast_scalar_interleaved_partitioned.cpp";
+    std::string_view reader_kernel_path;
     if (src1_buffer != nullptr) {
         TT_FATAL(src1_buffer->buffer_layout() == TensorMemoryLayout::INTERLEAVED, "src1_buffer must be interleaved");
         TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
-        reader_kernel_path =
-            "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
-            "reader_bcast_hw_interleaved_partitioned.cpp";
+        reader_kernel_path = READER_HW_INTERLEAVED;
     } else {
-        reader_kernel_path =
-            "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
-            "reader_bcast_scalar_interleaved_partitioned.cpp";
+        reader_kernel_path = READER_SCALAR_INTERLEAVED;
     }
 
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -175,7 +175,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastHeightAndWidthMu
     static constexpr const char* READER_SCALAR_INTERLEAVED =
         "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
         "reader_bcast_scalar_interleaved_partitioned.cpp";
-    std::string_view reader_kernel_path;
+    std::string reader_kernel_path;
     if (src1_buffer != nullptr) {
         TT_FATAL(src1_buffer->buffer_layout() == TensorMemoryLayout::INTERLEAVED, "src1_buffer must be interleaved");
         TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -169,19 +169,17 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastHeightAndWidthMu
         TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     }
 
-    static constexpr const char* READER_HW_INTERLEAVED =
-        "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
-        "reader_bcast_hw_interleaved_partitioned.cpp";
-    static constexpr const char* READER_SCALAR_INTERLEAVED =
-        "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
-        "reader_bcast_scalar_interleaved_partitioned.cpp";
-    std::string reader_kernel_path;
+    const char* reader_kernel_path = nullptr;
     if (src1_buffer != nullptr) {
         TT_FATAL(src1_buffer->buffer_layout() == TensorMemoryLayout::INTERLEAVED, "src1_buffer must be interleaved");
         TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
-        reader_kernel_path = READER_HW_INTERLEAVED;
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
+            "reader_bcast_hw_interleaved_partitioned.cpp";
     } else {
-        reader_kernel_path = READER_SCALAR_INTERLEAVED;
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/"
+            "reader_bcast_scalar_interleaved_partitioned.cpp";
     }
 
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
@@ -129,11 +129,11 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastHeightMultiCore:
 
     // ---- Kernel compile-time args ----
 
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args;
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     std::map<std::string, std::string> bcast_defines = bcast_op_utils::get_defines(BcastOpDim::H, bcast_math);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
@@ -157,7 +157,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastHeightMultiCoreS
 
     // ---- Kernel compile-time args ----
 
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {(uint32_t)src0_cb_index};
     TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
@@ -146,7 +146,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastHeightMultiCoreS
 
     // ---- Kernel compile-time args ----
 
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {(uint32_t)src0_cb_index};
     TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
@@ -129,11 +129,11 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::BroadcastWidthMultiCore::
 
     // ---- Kernel compile-time args ----
 
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args;
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     std::map<std::string, std::string> bcast_defines = bcast_op_utils::get_defines(BcastOpDim::W, bcast_math);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -161,7 +161,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::ElementWiseMultiCore::cre
     // ---- Kernel compile-time args and defines ----
 
     std::map<std::string, std::string> reader_defines;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_or_width_sharded};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {(std::uint32_t)block_or_width_sharded};
     if (src0_sharded) {
         reader_defines["IN0_SHARDED"] = "1";
     } else {
@@ -178,7 +178,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::ElementWiseMultiCore::cre
         writer_defines["OUT_SHARDED"] = "1";
     }
 
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {(std::uint32_t)output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     bool fp32_dest_acc_en = dst_cb_data_format == tt::DataFormat::UInt32 ||

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_sfpu_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_sfpu_pgm_factory.cpp
@@ -158,7 +158,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::ElementWiseMultiCoreSfpu:
     // ---- Kernel compile-time args and defines ----
 
     std::map<std::string, std::string> reader_defines;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_or_width_sharded};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {(std::uint32_t)block_or_width_sharded};
     if (src0_sharded) {
         reader_defines["IN0_SHARDED"] = "1";
     } else {
@@ -175,7 +175,7 @@ tt::tt_metal::ProgramDescriptor BinaryDeviceOperation::ElementWiseMultiCoreSfpu:
         writer_defines["OUT_SHARDED"] = "1";
     }
 
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {(std::uint32_t)output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     bool fp32_dest_acc_en = (dst_cb_data_format == tt::DataFormat::Float32) ||

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -664,8 +664,8 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     }
 
     // WRITER KERNEL DESCRIPTOR
-    std::vector<uint32_t> writer_compile_time_args;
-    std::vector<uint32_t> writer_common_runtime_args;
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
+    KernelDescriptor::CommonRuntimeArgs writer_common_runtime_args;
     tt::tt_metal::TensorAccessorArgs(*c_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
     writer_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
@@ -797,8 +797,8 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     };
 
     // READER KERNEL DESCRIPTOR
-    std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> reader_common_runtime_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
+    KernelDescriptor::CommonRuntimeArgs reader_common_runtime_args;
     tt::tt_metal::TensorAccessorArgs(*a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_compile_time_args, reader_common_runtime_args);
     tt::tt_metal::TensorAccessorArgs(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -78,9 +78,9 @@ std::string BinaryNgKernelConfig::bcast_input_str() const {
     return "";
 }
 
-std::string_view get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op) {
-    // All return values are string literals with static storage duration so the returned
-    // std::string_view remains valid for the lifetime of the program.
+std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op) {
+    // Path constants are declared constexpr so the string data lives in read-only storage;
+    // each call copies into a std::string (safe for descriptor ownership).
     static constexpr const char* READER_NO_BCAST_NG =
         "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp";
     static constexpr const char* READER_ROW_BCAST_NG =

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -78,70 +78,118 @@ std::string BinaryNgKernelConfig::bcast_input_str() const {
     return "";
 }
 
-std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op) {
-    constexpr std::string_view root = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels";
-    constexpr std::string_view root_ng = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng";
-    constexpr std::string_view dataflow = "{}/dataflow/{}";
-    constexpr std::string_view compute = "{}/compute/{}";
+std::string_view get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op) {
+    // All return values are string literals with static storage duration so the returned
+    // std::string_view remains valid for the lifetime of the program.
+    static constexpr const char* READER_NO_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp";
+    static constexpr const char* READER_ROW_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp";
+    static constexpr const char* READER_COL_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp";
+    static constexpr const char* READER_ROW_COL_MIXED_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/"
+        "reader_interleaved_row_col_mixed_bcast.cpp";
+    static constexpr const char* READER_SCALAR_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp";
+    static constexpr const char* READER_RM_NO_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp";
+    static constexpr const char* READER_RM_ROW_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp";
+    static constexpr const char* READER_RM_COL_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp";
+    static constexpr const char* READER_RM_ROW_COL_MIXED_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/"
+        "reader_interleaved_rm_row_col_mixed_bcast.cpp";
+    static constexpr const char* READER_RM_SCALAR_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp";
+    static constexpr const char* READER_RM_SCALAR_OP_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp";
+    static constexpr const char* WRITER_RM_NO_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp";
+    static constexpr const char* WRITER_NO_BCAST_NG =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp";
+    static constexpr const char* READER_NO_BCAST =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp";
+    static constexpr const char* WRITER_SCALAR =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp";
+
+    static constexpr const char* COMPUTE_NO_BCAST_WHERE =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp";
+    static constexpr const char* COMPUTE_NO_BCAST_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp";
+    static constexpr const char* COMPUTE_NO_BCAST_FPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp";
+
+    static constexpr const char* COMPUTE_BCAST_WHERE =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp";
+    static constexpr const char* COMPUTE_BCAST_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp";
+    static constexpr const char* COMPUTE_BCAST_FPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp";
+
+    static constexpr const char* COMPUTE_SCALAR_WHERE =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar";
+    static constexpr const char* COMPUTE_SCALAR_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp";
+    static constexpr const char* COMPUTE_SCALAR_FPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp";
+
+    static constexpr const char* COMPUTE_ROW_BCAST_NG_WHERE =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp";
+    static constexpr const char* COMPUTE_ROW_BCAST_NG_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp";
+    static constexpr const char* COMPUTE_ROW_BCAST_NG_FPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp";
+
+    static constexpr const char* COMPUTE_COL_BCAST_NG_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp";
+    static constexpr const char* COMPUTE_COL_BCAST_NG_FPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp";
+
+    static constexpr const char* COMPUTE_SCALAR_BCAST_NG_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp";
+    static constexpr const char* COMPUTE_SCALAR_BCAST_NG_FPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp";
+
+    static constexpr const char* COMPUTE_ROW_COL_BCAST_NG_WHERE =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp";
+    static constexpr const char* COMPUTE_ROW_COL_BCAST_NG_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp";
+    static constexpr const char* COMPUTE_ROW_COL_BCAST_NG_FPU =
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp";
 
     switch (kernel_name) {
-        case KernelName::ReaderNoBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_no_bcast.cpp");
-        case KernelName::ReaderRowBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_row_bcast.cpp");
-        case KernelName::ReaderColBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_col_bcast.cpp");
-        case KernelName::ReaderRowBColABcastNg:
-            return fmt::format(dataflow, root_ng, "reader_interleaved_row_col_mixed_bcast.cpp");
-        case KernelName::ReaderScalarBcastNg:
-            return fmt::format(dataflow, root_ng, "reader_interleaved_scalar_bcast.cpp");
-        case KernelName::ReaderRmNoBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_rm_no_bcast.cpp");
-        case KernelName::ReaderRmRowBcastNg:
-            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_row_bcast.cpp");
-        case KernelName::ReaderRmColBcastNg:
-            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_col_bcast.cpp");
-        case KernelName::ReaderRmRowBColABcastNg:
-            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_row_col_mixed_bcast.cpp");
-        case KernelName::ReaderRmScalarBcastNg:
-            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_scalar_bcast.cpp");
-        case KernelName::ReaderRmScalarOpNg:
-            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_scalar_op.cpp");
-        case KernelName::WriterRmNoBcastNg: return fmt::format(dataflow, root_ng, "writer_interleaved_rm_no_bcast.cpp");
-        case KernelName::WriterNoBcastNg: return fmt::format(dataflow, root_ng, "writer_interleaved_no_bcast.cpp");
-        case KernelName::ReaderNoBcast: return fmt::format(dataflow, root, "reader_interleaved_no_bcast.cpp");
-        case KernelName::WriterScalar: return fmt::format(dataflow, root, "writer_interleaved_scalar.cpp");
+        case KernelName::ReaderNoBcastNg: return READER_NO_BCAST_NG;
+        case KernelName::ReaderRowBcastNg: return READER_ROW_BCAST_NG;
+        case KernelName::ReaderColBcastNg: return READER_COL_BCAST_NG;
+        case KernelName::ReaderRowBColABcastNg: return READER_ROW_COL_MIXED_BCAST_NG;
+        case KernelName::ReaderScalarBcastNg: return READER_SCALAR_BCAST_NG;
+        case KernelName::ReaderRmNoBcastNg: return READER_RM_NO_BCAST_NG;
+        case KernelName::ReaderRmRowBcastNg: return READER_RM_ROW_BCAST_NG;
+        case KernelName::ReaderRmColBcastNg: return READER_RM_COL_BCAST_NG;
+        case KernelName::ReaderRmRowBColABcastNg: return READER_RM_ROW_COL_MIXED_BCAST_NG;
+        case KernelName::ReaderRmScalarBcastNg: return READER_RM_SCALAR_BCAST_NG;
+        case KernelName::ReaderRmScalarOpNg: return READER_RM_SCALAR_OP_NG;
+        case KernelName::WriterRmNoBcastNg: return WRITER_RM_NO_BCAST_NG;
+        case KernelName::WriterNoBcastNg: return WRITER_NO_BCAST_NG;
+        case KernelName::ReaderNoBcast: return READER_NO_BCAST;
+        case KernelName::WriterScalar: return WRITER_SCALAR;
         case KernelName::ComputeNoBcast:
-            return fmt::format(
-                compute,
-                root,
-                is_where_op ? "eltwise_where_no_bcast.cpp"
-                            : (is_sfpu ? "eltwise_binary_sfpu_no_bcast.cpp" : "eltwise_binary_no_bcast.cpp"));
+            return is_where_op ? COMPUTE_NO_BCAST_WHERE : (is_sfpu ? COMPUTE_NO_BCAST_SFPU : COMPUTE_NO_BCAST_FPU);
         case KernelName::ComputeBcast:
-            return fmt::format(
-                compute,
-                root,
-                is_where_op ? "eltwise_where_sfpu.cpp" : (is_sfpu ? "eltwise_binary_sfpu.cpp" : "eltwise_binary.cpp"));
+            return is_where_op ? COMPUTE_BCAST_WHERE : (is_sfpu ? COMPUTE_BCAST_SFPU : COMPUTE_BCAST_FPU);
         case KernelName::ComputeScalar:
-            return fmt::format(
-                compute,
-                root,
-                is_where_op ? "eltwise_where_sfpu_scalar"
-                            : (is_sfpu ? "eltwise_binary_sfpu_scalar.cpp" : "eltwise_binary_scalar.cpp"));
+            return is_where_op ? COMPUTE_SCALAR_WHERE : (is_sfpu ? COMPUTE_SCALAR_SFPU : COMPUTE_SCALAR_FPU);
         case KernelName::ComputeRowBcastNg:
-            return fmt::format(
-                compute,
-                root_ng,
-                is_where_op ? "eltwise_where_sfpu_row_bcast.cpp"
-                            : (is_sfpu ? "eltwise_binary_sfpu_row_bcast.cpp" : "eltwise_binary_row_bcast.cpp"));
-        case KernelName::ComputeColBcastNg:
-            return fmt::format(
-                compute, root_ng, is_sfpu ? "eltwise_binary_sfpu_col_bcast.cpp" : "eltwise_binary_col_bcast.cpp");
+            return is_where_op ? COMPUTE_ROW_BCAST_NG_WHERE
+                               : (is_sfpu ? COMPUTE_ROW_BCAST_NG_SFPU : COMPUTE_ROW_BCAST_NG_FPU);
+        case KernelName::ComputeColBcastNg: return is_sfpu ? COMPUTE_COL_BCAST_NG_SFPU : COMPUTE_COL_BCAST_NG_FPU;
         case KernelName::ComputeScalarBcastNg:
-            return fmt::format(
-                compute, root_ng, is_sfpu ? "eltwise_binary_sfpu_scalar_bcast.cpp" : "eltwise_binary_scalar_bcast.cpp");
+            return is_sfpu ? COMPUTE_SCALAR_BCAST_NG_SFPU : COMPUTE_SCALAR_BCAST_NG_FPU;
         case KernelName::ComputeRowColBcastNg:
-            return fmt::format(
-                compute,
-                root_ng,
-                is_where_op ? "eltwise_where_sfpu_row_col_bcast.cpp"
-                            : (is_sfpu ? "eltwise_binary_sfpu_row_col_bcast.cpp" : "eltwise_binary_row_col_bcast.cpp"));
+            return is_where_op ? COMPUTE_ROW_COL_BCAST_NG_WHERE
+                               : (is_sfpu ? COMPUTE_ROW_COL_BCAST_NG_SFPU : COMPUTE_ROW_COL_BCAST_NG_FPU);
         default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -78,118 +78,77 @@ std::string BinaryNgKernelConfig::bcast_input_str() const {
     return "";
 }
 
-std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op) {
-    // Path constants are declared constexpr so the string data lives in read-only storage;
-    // each call copies into a std::string (safe for descriptor ownership).
-    static constexpr const char* READER_NO_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp";
-    static constexpr const char* READER_ROW_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp";
-    static constexpr const char* READER_COL_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp";
-    static constexpr const char* READER_ROW_COL_MIXED_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/"
-        "reader_interleaved_row_col_mixed_bcast.cpp";
-    static constexpr const char* READER_SCALAR_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp";
-    static constexpr const char* READER_RM_NO_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp";
-    static constexpr const char* READER_RM_ROW_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp";
-    static constexpr const char* READER_RM_COL_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp";
-    static constexpr const char* READER_RM_ROW_COL_MIXED_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/"
-        "reader_interleaved_rm_row_col_mixed_bcast.cpp";
-    static constexpr const char* READER_RM_SCALAR_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp";
-    static constexpr const char* READER_RM_SCALAR_OP_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp";
-    static constexpr const char* WRITER_RM_NO_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp";
-    static constexpr const char* WRITER_NO_BCAST_NG =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp";
-    static constexpr const char* READER_NO_BCAST =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp";
-    static constexpr const char* WRITER_SCALAR =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp";
-
-    static constexpr const char* COMPUTE_NO_BCAST_WHERE =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp";
-    static constexpr const char* COMPUTE_NO_BCAST_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp";
-    static constexpr const char* COMPUTE_NO_BCAST_FPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp";
-
-    static constexpr const char* COMPUTE_BCAST_WHERE =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp";
-    static constexpr const char* COMPUTE_BCAST_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp";
-    static constexpr const char* COMPUTE_BCAST_FPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp";
-
-    static constexpr const char* COMPUTE_SCALAR_WHERE =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar";
-    static constexpr const char* COMPUTE_SCALAR_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp";
-    static constexpr const char* COMPUTE_SCALAR_FPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp";
-
-    static constexpr const char* COMPUTE_ROW_BCAST_NG_WHERE =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp";
-    static constexpr const char* COMPUTE_ROW_BCAST_NG_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp";
-    static constexpr const char* COMPUTE_ROW_BCAST_NG_FPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp";
-
-    static constexpr const char* COMPUTE_COL_BCAST_NG_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp";
-    static constexpr const char* COMPUTE_COL_BCAST_NG_FPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp";
-
-    static constexpr const char* COMPUTE_SCALAR_BCAST_NG_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp";
-    static constexpr const char* COMPUTE_SCALAR_BCAST_NG_FPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp";
-
-    static constexpr const char* COMPUTE_ROW_COL_BCAST_NG_WHERE =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp";
-    static constexpr const char* COMPUTE_ROW_COL_BCAST_NG_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp";
-    static constexpr const char* COMPUTE_ROW_COL_BCAST_NG_FPU =
-        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp";
-
+std::string_view get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op) {
+    using namespace std::string_view_literals;
     switch (kernel_name) {
-        case KernelName::ReaderNoBcastNg: return READER_NO_BCAST_NG;
-        case KernelName::ReaderRowBcastNg: return READER_ROW_BCAST_NG;
-        case KernelName::ReaderColBcastNg: return READER_COL_BCAST_NG;
-        case KernelName::ReaderRowBColABcastNg: return READER_ROW_COL_MIXED_BCAST_NG;
-        case KernelName::ReaderScalarBcastNg: return READER_SCALAR_BCAST_NG;
-        case KernelName::ReaderRmNoBcastNg: return READER_RM_NO_BCAST_NG;
-        case KernelName::ReaderRmRowBcastNg: return READER_RM_ROW_BCAST_NG;
-        case KernelName::ReaderRmColBcastNg: return READER_RM_COL_BCAST_NG;
-        case KernelName::ReaderRmRowBColABcastNg: return READER_RM_ROW_COL_MIXED_BCAST_NG;
-        case KernelName::ReaderRmScalarBcastNg: return READER_RM_SCALAR_BCAST_NG;
-        case KernelName::ReaderRmScalarOpNg: return READER_RM_SCALAR_OP_NG;
-        case KernelName::WriterRmNoBcastNg: return WRITER_RM_NO_BCAST_NG;
-        case KernelName::WriterNoBcastNg: return WRITER_NO_BCAST_NG;
-        case KernelName::ReaderNoBcast: return READER_NO_BCAST;
-        case KernelName::WriterScalar: return WRITER_SCALAR;
+        case KernelName::ReaderNoBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp"sv;
+        case KernelName::ReaderRowBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp"sv;
+        case KernelName::ReaderColBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp"sv;
+        case KernelName::ReaderRowBColABcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp"sv;
+        case KernelName::ReaderScalarBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp"sv;
+        case KernelName::ReaderRmNoBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp"sv;
+        case KernelName::ReaderRmRowBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp"sv;
+        case KernelName::ReaderRmColBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp"sv;
+        case KernelName::ReaderRmRowBColABcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp"sv;
+        case KernelName::ReaderRmScalarBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp"sv;
+        case KernelName::ReaderRmScalarOpNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp"sv;
+        case KernelName::WriterRmNoBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp"sv;
+        case KernelName::WriterNoBcastNg:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp"sv;
+        case KernelName::ReaderNoBcast:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp"sv;
+        case KernelName::WriterScalar:
+            return "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp"sv;
         case KernelName::ComputeNoBcast:
-            return is_where_op ? COMPUTE_NO_BCAST_WHERE : (is_sfpu ? COMPUTE_NO_BCAST_SFPU : COMPUTE_NO_BCAST_FPU);
+            return is_where_op
+                       ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp"sv
+                       : (is_sfpu
+                              ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp"sv
+                              : "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp"sv);
         case KernelName::ComputeBcast:
-            return is_where_op ? COMPUTE_BCAST_WHERE : (is_sfpu ? COMPUTE_BCAST_SFPU : COMPUTE_BCAST_FPU);
+            return is_where_op
+                       ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp"sv
+                       : (is_sfpu
+                              ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp"sv
+                              : "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp"sv);
         case KernelName::ComputeScalar:
-            return is_where_op ? COMPUTE_SCALAR_WHERE : (is_sfpu ? COMPUTE_SCALAR_SFPU : COMPUTE_SCALAR_FPU);
+            return is_where_op
+                       ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar"sv
+                       : (is_sfpu
+                              ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp"sv
+                              : "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp"sv);
         case KernelName::ComputeRowBcastNg:
-            return is_where_op ? COMPUTE_ROW_BCAST_NG_WHERE
-                               : (is_sfpu ? COMPUTE_ROW_BCAST_NG_SFPU : COMPUTE_ROW_BCAST_NG_FPU);
-        case KernelName::ComputeColBcastNg: return is_sfpu ? COMPUTE_COL_BCAST_NG_SFPU : COMPUTE_COL_BCAST_NG_FPU;
+            return is_where_op
+                       ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp"sv
+                       : (is_sfpu
+                              ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp"sv
+                              : "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp"sv);
+        case KernelName::ComputeColBcastNg:
+            return is_sfpu
+                       ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp"sv
+                       : "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp"sv;
         case KernelName::ComputeScalarBcastNg:
-            return is_sfpu ? COMPUTE_SCALAR_BCAST_NG_SFPU : COMPUTE_SCALAR_BCAST_NG_FPU;
+            return is_sfpu
+                       ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp"sv
+                       : "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp"sv;
         case KernelName::ComputeRowColBcastNg:
-            return is_where_op ? COMPUTE_ROW_COL_BCAST_NG_WHERE
-                               : (is_sfpu ? COMPUTE_ROW_COL_BCAST_NG_SFPU : COMPUTE_ROW_COL_BCAST_NG_FPU);
+            return is_where_op
+                       ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp"sv
+                       : (is_sfpu
+                              ? "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp"sv
+                              : "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp"sv);
         default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -49,7 +49,7 @@ struct BinaryNgKernelConfig {
     std::optional<uint32_t> bcast_input;
 };
 
-std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op);
+std::string_view get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op);
 
 struct OpConfig {
     enum class FpuBinaryOp { ADD, SUB, MUL };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -49,7 +49,7 @@ struct BinaryNgKernelConfig {
     std::optional<uint32_t> bcast_input;
 };
 
-std::string_view get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op);
+std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op);
 
 struct OpConfig {
     enum class FpuBinaryOp { ADD, SUB, MUL };

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -295,56 +295,96 @@ TernaryKernelConfig::TernaryKernelConfig(
     TT_FATAL(false, "Invalid ternary operation type, variant or broadcast type combination");
 }
 
-std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
-    constexpr std::string_view root = "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels";
-    constexpr std::string_view dataflow = "{}/dataflow/{}";
-    constexpr std::string_view compute = "{}/compute/{}";
+std::string_view get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
+    // All return values are string literals with static storage duration so the returned
+    // std::string_view remains valid for the lifetime of the program.
+    static constexpr const char* READER_NOSUBTILEBCAST_TTT =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp";
+    static constexpr const char* READER_NOBCAST_TST_TTS =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp";
+    static constexpr const char* READER_OUTER_BCAST_TST_TTS =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp";
+    static constexpr const char* READER_SCALAR_BCAST_TST_TTS =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp";
+    static constexpr const char* READER_SCALAR_TTT =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp";
+    static constexpr const char* READER_COLBCAST_TTT =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_colbcast_ttt.cpp";
+    static constexpr const char* READER_COL_BCAST_TST_TTS =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_col_bcast.cpp";
+    static constexpr const char* READER_ROWBCAST_TTT =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_rowbcast_ttt.cpp";
+    static constexpr const char* READER_ROW_BCAST_TST_TTS =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp";
+    static constexpr const char* READER_ROW_COL_BCAST_TTT =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp";
+    static constexpr const char* READER_ROW_COL_BCAST_TST_TTS =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp";
+    static constexpr const char* WRITER_NOBCAST =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_writer_nobcast.cpp";
+    static constexpr const char* COMPUTE_NO_BCAST_TTT =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp";
+    static constexpr const char* COMPUTE_BCAST_TTT =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp";
+    static constexpr const char* COMPUTE_ROW_BCAST_TTT =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp";
+    static constexpr const char* COMPUTE_BCAST_TTS_TST =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp";
+    static constexpr const char* COMPUTE_NO_BCAST_TTS_TST =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp";
+    static constexpr const char* COMPUTE_NO_BCAST_ADDC =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu.cpp";
+    static constexpr const char* COMPUTE_BCAST_ADDC =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu_bcast.cpp";
+    static constexpr const char* COMPUTE_ROW_BCAST_ADDC_FPU =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_rowbcast.cpp";
+    static constexpr const char* COMPUTE_ROW_BCAST_ADDC_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu.cpp";
+
     switch (kernel_name) {
         case KernelName::ReaderNoBcastTTT:
-        case KernelName::ReaderOuterBcastTTT:
-            return fmt::format(dataflow, root, "ternary_reader_nosubtilebcast_ttt.cpp");
+        case KernelName::ReaderOuterBcastTTT: return READER_NOSUBTILEBCAST_TTT;
         case KernelName::ReaderNoBcastTST:
-        case KernelName::ReaderNoBcastTTS: return fmt::format(dataflow, root, "ternary_reader_nobcast_tst_tts.cpp");
+        case KernelName::ReaderNoBcastTTS: return READER_NOBCAST_TST_TTS;
         case KernelName::ReaderOuterBcastTTS:
-        case KernelName::ReaderOuterBcastTST: return fmt::format(dataflow, root, "tst_tts_reader_outer_bcast.cpp");
+        case KernelName::ReaderOuterBcastTST: return READER_OUTER_BCAST_TST_TTS;
         case KernelName::ReaderScalarBcastTTS:
-        case KernelName::ReaderScalarBcastTST: return fmt::format(dataflow, root, "tst_tts_reader_scalar_bcast.cpp");
-        case KernelName::ReaderScalarBcastTTT: return fmt::format(dataflow, root, "ternary_reader_scalar_ttt.cpp");
-        case KernelName::ReaderColBcastTTT: return fmt::format(dataflow, root, "ternary_reader_colbcast_ttt.cpp");
+        case KernelName::ReaderScalarBcastTST: return READER_SCALAR_BCAST_TST_TTS;
+        case KernelName::ReaderScalarBcastTTT: return READER_SCALAR_TTT;
+        case KernelName::ReaderColBcastTTT: return READER_COLBCAST_TTT;
         case KernelName::ReaderColBcastTTS:
-        case KernelName::ReaderColBcastTST: return fmt::format(dataflow, root, "tts_tst_reader_col_bcast.cpp");
-        case KernelName::ReaderRowBcastTTT: return fmt::format(dataflow, root, "ternary_reader_rowbcast_ttt.cpp");
+        case KernelName::ReaderColBcastTST: return READER_COL_BCAST_TST_TTS;
+        case KernelName::ReaderRowBcastTTT: return READER_ROWBCAST_TTT;
         case KernelName::ReaderRowBcastTST:
-        case KernelName::ReaderRowBcastTTS: return fmt::format(dataflow, root, "tts_tst_reader_row_bcast.cpp");
-        case KernelName::ReaderRowColBcastTTT:
-            return fmt::format(dataflow, root, "ternary_reader_row_col_bcast_ttt.cpp");
+        case KernelName::ReaderRowBcastTTS: return READER_ROW_BCAST_TST_TTS;
+        case KernelName::ReaderRowColBcastTTT: return READER_ROW_COL_BCAST_TTT;
         case KernelName::ReaderRowColBcastTTS:
-        case KernelName::ReaderRowColBcastTST: return fmt::format(dataflow, root, "tts_tst_reader_row_col_bcast.cpp");
+        case KernelName::ReaderRowColBcastTST: return READER_ROW_COL_BCAST_TST_TTS;
         case KernelName::WriterNoBcastTernary:
         case KernelName::WriterNoBcast:
-        case KernelName::WriterColBcastTTT: return fmt::format(dataflow, root, "ternary_writer_nobcast.cpp");
-        case KernelName::ComputeNoBcastTTT: return fmt::format(compute, root, "ternary_sfpu_no_bcast_ttt.cpp");
-        case KernelName::ComputeBcastTTT: return fmt::format(compute, root, "ternary_sfpu_col_scalar_bcast_ttt.cpp");
-        case KernelName::ComputeRowBcastTTT: return fmt::format(compute, root, "ternary_sfpu_row_bcast_ttt.cpp");
-        case KernelName::ComputeBcastTTS_TST:
-            return fmt::format(compute, root, "ternary_sfpu_col_scalar_bcast_tts_tst.cpp");
-        case KernelName::ComputeNoBcastTTS_TST: return fmt::format(compute, root, "ternary_sfpu_no_bcast_tts_tst.cpp");
-        case KernelName::ComputeNoBcastAddcOp: return fmt::format(compute, root, "ternary_addc_ops_sfpu.cpp");
-        case KernelName::ComputeBcastAddcOp: return fmt::format(compute, root, "ternary_addc_ops_sfpu_bcast.cpp");
+        case KernelName::WriterColBcastTTT: return WRITER_NOBCAST;
+        case KernelName::ComputeNoBcastTTT: return COMPUTE_NO_BCAST_TTT;
+        case KernelName::ComputeBcastTTT: return COMPUTE_BCAST_TTT;
+        case KernelName::ComputeRowBcastTTT: return COMPUTE_ROW_BCAST_TTT;
+        case KernelName::ComputeBcastTTS_TST: return COMPUTE_BCAST_TTS_TST;
+        case KernelName::ComputeNoBcastTTS_TST: return COMPUTE_NO_BCAST_TTS_TST;
+        case KernelName::ComputeNoBcastAddcOp: return COMPUTE_NO_BCAST_ADDC;
+        case KernelName::ComputeBcastAddcOp: return COMPUTE_BCAST_ADDC;
         case KernelName::ComputeRowBcastAddcOp:
-            return fmt::format(
-                compute, root, is_fpu ? "ternary_addc_ops_fpu_rowbcast.cpp" : "ternary_addc_ops_sfpu.cpp");
+            return is_fpu ? COMPUTE_ROW_BCAST_ADDC_FPU : COMPUTE_ROW_BCAST_ADDC_SFPU;
         default: __builtin_unreachable();
     }
 }
 
-std::string override_addcmul_compute_kernel(KernelName kernel_name) {
-    constexpr std::string_view root = "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels";
-    constexpr std::string_view compute = "{}/compute/{}";
+std::string_view override_addcmul_compute_kernel(KernelName kernel_name) {
+    static constexpr const char* ADDCMUL_INT_SFPU =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp";
+    static constexpr const char* ADDCMUL_INT_SFPU_BCAST =
+        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp";
     switch (kernel_name) {
-        case KernelName::ComputeNoBcastAddcOp: return fmt::format(compute, root, "ternary_addcmul_int_sfpu.cpp");
+        case KernelName::ComputeNoBcastAddcOp: return ADDCMUL_INT_SFPU;
         case KernelName::ComputeBcastAddcOp:
-        case KernelName::ComputeRowBcastAddcOp: return fmt::format(compute, root, "ternary_addcmul_int_sfpu_bcast.cpp");
+        case KernelName::ComputeRowBcastAddcOp: return ADDCMUL_INT_SFPU_BCAST;
         default: __builtin_unreachable();
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -295,7 +295,7 @@ TernaryKernelConfig::TernaryKernelConfig(
     TT_FATAL(false, "Invalid ternary operation type, variant or broadcast type combination");
 }
 
-std::string_view get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
+std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
     // All return values are string literals with static storage duration so the returned
     // std::string_view remains valid for the lifetime of the program.
     static constexpr const char* READER_NOSUBTILEBCAST_TTT =
@@ -376,7 +376,7 @@ std::string_view get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
     }
 }
 
-std::string_view override_addcmul_compute_kernel(KernelName kernel_name) {
+std::string override_addcmul_compute_kernel(KernelName kernel_name) {
     static constexpr const char* ADDCMUL_INT_SFPU =
         "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp";
     static constexpr const char* ADDCMUL_INT_SFPU_BCAST =

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -295,96 +295,72 @@ TernaryKernelConfig::TernaryKernelConfig(
     TT_FATAL(false, "Invalid ternary operation type, variant or broadcast type combination");
 }
 
-std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
-    // All return values are string literals with static storage duration so the returned
-    // std::string_view remains valid for the lifetime of the program.
-    static constexpr const char* READER_NOSUBTILEBCAST_TTT =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp";
-    static constexpr const char* READER_NOBCAST_TST_TTS =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp";
-    static constexpr const char* READER_OUTER_BCAST_TST_TTS =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp";
-    static constexpr const char* READER_SCALAR_BCAST_TST_TTS =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp";
-    static constexpr const char* READER_SCALAR_TTT =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp";
-    static constexpr const char* READER_COLBCAST_TTT =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_colbcast_ttt.cpp";
-    static constexpr const char* READER_COL_BCAST_TST_TTS =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_col_bcast.cpp";
-    static constexpr const char* READER_ROWBCAST_TTT =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_rowbcast_ttt.cpp";
-    static constexpr const char* READER_ROW_BCAST_TST_TTS =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp";
-    static constexpr const char* READER_ROW_COL_BCAST_TTT =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp";
-    static constexpr const char* READER_ROW_COL_BCAST_TST_TTS =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp";
-    static constexpr const char* WRITER_NOBCAST =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_writer_nobcast.cpp";
-    static constexpr const char* COMPUTE_NO_BCAST_TTT =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp";
-    static constexpr const char* COMPUTE_BCAST_TTT =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp";
-    static constexpr const char* COMPUTE_ROW_BCAST_TTT =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp";
-    static constexpr const char* COMPUTE_BCAST_TTS_TST =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp";
-    static constexpr const char* COMPUTE_NO_BCAST_TTS_TST =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp";
-    static constexpr const char* COMPUTE_NO_BCAST_ADDC =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu.cpp";
-    static constexpr const char* COMPUTE_BCAST_ADDC =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu_bcast.cpp";
-    static constexpr const char* COMPUTE_ROW_BCAST_ADDC_FPU =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_rowbcast.cpp";
-    static constexpr const char* COMPUTE_ROW_BCAST_ADDC_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu.cpp";
-
+std::string_view get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
+    using namespace std::string_view_literals;
     switch (kernel_name) {
         case KernelName::ReaderNoBcastTTT:
-        case KernelName::ReaderOuterBcastTTT: return READER_NOSUBTILEBCAST_TTT;
+        case KernelName::ReaderOuterBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp"sv;
         case KernelName::ReaderNoBcastTST:
-        case KernelName::ReaderNoBcastTTS: return READER_NOBCAST_TST_TTS;
+        case KernelName::ReaderNoBcastTTS:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp"sv;
         case KernelName::ReaderOuterBcastTTS:
-        case KernelName::ReaderOuterBcastTST: return READER_OUTER_BCAST_TST_TTS;
+        case KernelName::ReaderOuterBcastTST:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp"sv;
         case KernelName::ReaderScalarBcastTTS:
-        case KernelName::ReaderScalarBcastTST: return READER_SCALAR_BCAST_TST_TTS;
-        case KernelName::ReaderScalarBcastTTT: return READER_SCALAR_TTT;
-        case KernelName::ReaderColBcastTTT: return READER_COLBCAST_TTT;
+        case KernelName::ReaderScalarBcastTST:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp"sv;
+        case KernelName::ReaderScalarBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp"sv;
+        case KernelName::ReaderColBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_colbcast_ttt.cpp"sv;
         case KernelName::ReaderColBcastTTS:
-        case KernelName::ReaderColBcastTST: return READER_COL_BCAST_TST_TTS;
-        case KernelName::ReaderRowBcastTTT: return READER_ROWBCAST_TTT;
+        case KernelName::ReaderColBcastTST:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_col_bcast.cpp"sv;
+        case KernelName::ReaderRowBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_rowbcast_ttt.cpp"sv;
         case KernelName::ReaderRowBcastTST:
-        case KernelName::ReaderRowBcastTTS: return READER_ROW_BCAST_TST_TTS;
-        case KernelName::ReaderRowColBcastTTT: return READER_ROW_COL_BCAST_TTT;
+        case KernelName::ReaderRowBcastTTS:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp"sv;
+        case KernelName::ReaderRowColBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp"sv;
         case KernelName::ReaderRowColBcastTTS:
-        case KernelName::ReaderRowColBcastTST: return READER_ROW_COL_BCAST_TST_TTS;
+        case KernelName::ReaderRowColBcastTST:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp"sv;
         case KernelName::WriterNoBcastTernary:
         case KernelName::WriterNoBcast:
-        case KernelName::WriterColBcastTTT: return WRITER_NOBCAST;
-        case KernelName::ComputeNoBcastTTT: return COMPUTE_NO_BCAST_TTT;
-        case KernelName::ComputeBcastTTT: return COMPUTE_BCAST_TTT;
-        case KernelName::ComputeRowBcastTTT: return COMPUTE_ROW_BCAST_TTT;
-        case KernelName::ComputeBcastTTS_TST: return COMPUTE_BCAST_TTS_TST;
-        case KernelName::ComputeNoBcastTTS_TST: return COMPUTE_NO_BCAST_TTS_TST;
-        case KernelName::ComputeNoBcastAddcOp: return COMPUTE_NO_BCAST_ADDC;
-        case KernelName::ComputeBcastAddcOp: return COMPUTE_BCAST_ADDC;
+        case KernelName::WriterColBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_writer_nobcast.cpp"sv;
+        case KernelName::ComputeNoBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp"sv;
+        case KernelName::ComputeBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp"sv;
+        case KernelName::ComputeRowBcastTTT:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp"sv;
+        case KernelName::ComputeBcastTTS_TST:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp"sv;
+        case KernelName::ComputeNoBcastTTS_TST:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp"sv;
+        case KernelName::ComputeNoBcastAddcOp:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu.cpp"sv;
+        case KernelName::ComputeBcastAddcOp:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu_bcast.cpp"sv;
         case KernelName::ComputeRowBcastAddcOp:
-            return is_fpu ? COMPUTE_ROW_BCAST_ADDC_FPU : COMPUTE_ROW_BCAST_ADDC_SFPU;
+            return is_fpu
+                       ? "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_rowbcast.cpp"sv
+                       : "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_sfpu.cpp"sv;
         default: __builtin_unreachable();
     }
 }
 
-std::string override_addcmul_compute_kernel(KernelName kernel_name) {
-    static constexpr const char* ADDCMUL_INT_SFPU =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp";
-    static constexpr const char* ADDCMUL_INT_SFPU_BCAST =
-        "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp";
+std::string_view override_addcmul_compute_kernel(KernelName kernel_name) {
+    using namespace std::string_view_literals;
     switch (kernel_name) {
-        case KernelName::ComputeNoBcastAddcOp: return ADDCMUL_INT_SFPU;
+        case KernelName::ComputeNoBcastAddcOp:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp"sv;
         case KernelName::ComputeBcastAddcOp:
-        case KernelName::ComputeRowBcastAddcOp: return ADDCMUL_INT_SFPU_BCAST;
+        case KernelName::ComputeRowBcastAddcOp:
+            return "ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp"sv;
         default: __builtin_unreachable();
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
@@ -55,9 +55,9 @@ struct TernaryKernelConfig {
     KernelName writer_kernel;
 };
 
-std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu = false);
+std::string_view get_kernel_file_path(KernelName kernel_name, bool is_fpu = false);
 
-std::string override_addcmul_compute_kernel(KernelName kernel_name);
+std::string_view override_addcmul_compute_kernel(KernelName kernel_name);
 
 std::map<std::string, std::string> get_addcmul_int_kernel_defines(DataType dtype);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
@@ -55,9 +55,9 @@ struct TernaryKernelConfig {
     KernelName writer_kernel;
 };
 
-std::string_view get_kernel_file_path(KernelName kernel_name, bool is_fpu = false);
+std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu = false);
 
-std::string_view override_addcmul_compute_kernel(KernelName kernel_name);
+std::string override_addcmul_compute_kernel(KernelName kernel_name);
 
 std::map<std::string, std::string> get_addcmul_int_kernel_defines(DataType dtype);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1096,8 +1096,8 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
     }
 
     // ---- Reader Kernel ----
-    std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> reader_common_runtime_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
+    KernelDescriptor::CommonRuntimeArgs reader_common_runtime_args;
 
     if (variant == TernaryVariant::TTS) {
         // TTS: c_0 = predicate, c_1 = value_true tensor
@@ -1154,8 +1154,8 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
     reader_desc.common_runtime_args = reader_common_runtime_args;
 
     // ---- Writer Kernel ----
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_tensor_cb};
-    std::vector<uint32_t> writer_common_runtime_args;
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {(std::uint32_t)output_tensor_cb};
+    KernelDescriptor::CommonRuntimeArgs writer_common_runtime_args;
     tt::tt_metal::TensorAccessorArgs(*output.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
     writer_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
@@ -1212,7 +1212,7 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
 
     // All variants use the same compile args now
     uint32_t scalar_is_true_value = (variant == TernaryVariant::TST) ? 1 : 0;
-    std::vector<uint32_t> compute_kernel_args = {
+    KernelDescriptor::CompileTimeArgs compute_kernel_args = {
         num_tiles_per_cycle, scalar_is_true_value};  // {num_tiles_per_cycle, scalar_is_true_value}
 
     // Add binary_ng style defines for TTT column broadcast case
@@ -1274,8 +1274,8 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
             kernel_defines[k] = v;
         }
     }
-    std::string compute_kernel_path = use_addcmul_int_kernel ? override_addcmul_compute_kernel(compute_kernel)
-                                                             : get_kernel_file_path(compute_kernel, is_fpu);
+    std::string_view compute_kernel_path = use_addcmul_int_kernel ? override_addcmul_compute_kernel(compute_kernel)
+                                                                  : get_kernel_file_path(compute_kernel, is_fpu);
 
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = compute_kernel_path;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1274,8 +1274,9 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
             kernel_defines[k] = v;
         }
     }
-    std::string_view compute_kernel_path = use_addcmul_int_kernel ? override_addcmul_compute_kernel(compute_kernel)
-                                                                  : get_kernel_file_path(compute_kernel, is_fpu);
+    std::string_view compute_kernel_path = use_addcmul_int_kernel
+                                               ? override_addcmul_compute_kernel(compute_kernel)
+                                               : get_kernel_file_path(compute_kernel, is_fpu);
 
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = compute_kernel_path;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -1005,23 +1005,24 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
 }
 
 std::string_view get_compute_kernel_path(UnaryOpType op_type, std::optional<DataType> input_dtype) {
+    using namespace std::string_view_literals;
     switch (op_type) {
         case UnaryOpType::LGAMMA:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
 
             if (input_dtype.value() == DataType::BFLOAT16) {
-                return "lgamma_fast_kernel.cpp";
+                return "lgamma_fast_kernel.cpp"sv;
             }
-            return "lgamma_kernel.cpp";
-        case UnaryOpType::MISH: return "mish_kernel.cpp";
-        case UnaryOpType::TANHSHRINK: return "tanhshrink_kernel.cpp";
-        case UnaryOpType::IDENTITY: return "eltwise_identity_kernel.cpp";
-        case UnaryOpType::WHERE_TSS: return "where_tss_kernel.cpp";
-        case UnaryOpType::LOGIT: return "logit_kernel.cpp";
-        case UnaryOpType::HARDSWISH: return "hardswish_kernel.cpp";
-        case UnaryOpType::LOGSIGMOID: return "logsigmoid_kernel.cpp";
-        default: return "eltwise_sfpu.cpp";
+            return "lgamma_kernel.cpp"sv;
+        case UnaryOpType::MISH: return "mish_kernel.cpp"sv;
+        case UnaryOpType::TANHSHRINK: return "tanhshrink_kernel.cpp"sv;
+        case UnaryOpType::IDENTITY: return "eltwise_identity_kernel.cpp"sv;
+        case UnaryOpType::WHERE_TSS: return "where_tss_kernel.cpp"sv;
+        case UnaryOpType::LOGIT: return "logit_kernel.cpp"sv;
+        case UnaryOpType::HARDSWISH: return "hardswish_kernel.cpp"sv;
+        case UnaryOpType::LOGSIGMOID: return "logsigmoid_kernel.cpp"sv;
+        default: return "eltwise_sfpu.cpp"sv;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -211,8 +211,8 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
     reader_defines["SRC_SHARDED"] = src_sharded ? "1" : "0";
     reader_defines["RM_INTERLEAVED"] = rm_interleaved ? "1" : "0";
 
-    std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> reader_common_runtime_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
+    KernelDescriptor::CommonRuntimeArgs reader_common_runtime_args;
     TensorAccessorArgs(*src_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_compile_time_args, reader_common_runtime_args);
 
@@ -230,8 +230,8 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
     writer_defines["DST_SHARDED"] = dst_sharded ? "1" : "0";
     writer_defines["RM_INTERLEAVED"] = rm_interleaved ? "1" : "0";
 
-    std::vector<uint32_t> writer_compile_time_args;
-    std::vector<uint32_t> writer_common_runtime_args;
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
+    KernelDescriptor::CommonRuntimeArgs writer_common_runtime_args;
     TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_program_factory.cpp
@@ -82,11 +82,11 @@ ProgramDescriptor TanhBwProgramFactory::create_descriptor(
 
     // ---- Kernel compile-time args ----
 
-    std::vector<uint32_t> reader_compile_time_args = {0};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {0};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     bool fp32_dest_acc_en = (dst_cb_data_format == tt::DataFormat::Float32) ||

--- a/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
@@ -61,7 +61,7 @@ ProgramDescriptor ExampleDeviceOperation::MultiCore::create_descriptor(
     });
 
     // Reader kernel
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
@@ -73,7 +73,7 @@ ProgramDescriptor ExampleDeviceOperation::MultiCore::create_descriptor(
     reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer kernel
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     KernelDescriptor writer_desc;

--- a/ttnn/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
@@ -63,7 +63,7 @@ ProgramDescriptor ExampleDeviceOperation::SingleCore::create_descriptor(
     });
 
     // Reader kernel
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
@@ -75,7 +75,7 @@ ProgramDescriptor ExampleDeviceOperation::SingleCore::create_descriptor(
     reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer kernel
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     KernelDescriptor writer_desc;

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -369,7 +369,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
 
     // Compile time args for reader
-    std::vector<uint32_t> reader_compile_time_args = {
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {
         (std::uint32_t)in0_tensor_stride_w,
         (std::uint32_t)in0_tensor_stride_h,
         (std::uint32_t)in0_tensor_next_block_stride,
@@ -385,7 +385,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
 
     // Compile time args for reader/writer
-    std::vector<uint32_t> reader_writer_compile_time_args = {
+    KernelDescriptor::CompileTimeArgs reader_writer_compile_time_args = {
         (std::uint32_t)in1_tensor_stride_w,
         (std::uint32_t)in1_tensor_stride_h,
         (std::uint32_t)in1_tensor_next_block_stride,
@@ -450,7 +450,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     };
 
     // Compute kernel compile time args (group 1)
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
+    KernelDescriptor::CompileTimeArgs compute_kernel_args_group_1 = {
         in0_block_w,
         in0_num_subblocks,
         in0_block_num_tiles,
@@ -522,7 +522,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
         reader_runtime_args.emplace_back(
             core,
-            std::vector<uint32_t>{
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
                 (uint32_t)in0_buffer->address(),
                 in0_start_tile_id,
                 num_output_blocks_per_core,
@@ -530,7 +530,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
         reader_writer_runtime_args.emplace_back(
             core,
-            std::vector<uint32_t>{
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
                 (uint32_t)in1_buffer->address(),
                 in1_start_tile_id,
                 num_output_blocks_per_core,
@@ -540,9 +540,9 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
         // Compute kernels have no per-core runtime args
         if (i < g1_numcores) {
-            compute_runtime_args_g1.emplace_back(core, std::vector<uint32_t>{});
+            compute_runtime_args_g1.emplace_back(core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{});
         } else {
-            compute_runtime_args_g2.emplace_back(core, std::vector<uint32_t>{});
+            compute_runtime_args_g2.emplace_back(core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{});
         }
 
         num_blocks_written += num_output_blocks_per_core;
@@ -595,7 +595,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
     // Core group 2 compute kernel (if needed)
     if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_kernel_args_group_2 = {
+        KernelDescriptor::CompileTimeArgs compute_kernel_args_group_2 = {
             in0_block_w,
             in0_num_subblocks,
             in0_block_num_tiles,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -374,7 +374,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     const auto fuse_pre_add = b.has_value();
 
     // Build compile time args for reader kernel
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_size};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {(std::uint32_t)block_size};
     if (!large_tensor_needed) {
         reader_compile_time_args.push_back((std::uint32_t)use_welford);
     }
@@ -398,7 +398,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     }
 
     // Build compile time args for writer kernel
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)block_size};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {(std::uint32_t)block_size};
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
     if (input_is_row_major) {
         // RM writer needs elem_size to compute per-row NOC write sizes
@@ -484,7 +484,8 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
 
     // Build compute args
     bool float32_reduction = fp32_dest_acc_en && !legacy_reduction;
-    std::vector<uint32_t> compute_args = {Wt, block_size, gamma.has_value(), beta.has_value(), fp32_dest_acc_en};
+    KernelDescriptor::CompileTimeArgs compute_args = {
+        Wt, block_size, gamma.has_value(), beta.has_value(), fp32_dest_acc_en};
     if (use_welford_and_not_rms_norm) {
         compute_args.push_back(W);
         compute_args.push_back(ttnn::types::TILE_SIZE);
@@ -553,7 +554,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
             (use_welford_and_not_rms_norm && large_tensor_needed) || (use_row_major_kernel && !input_is_row_major);
         const uint32_t reader_start = using_legacy_tile_reader ? tile_offset : curr_row;
 
-        std::vector<uint32_t> reader_args = {
+        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs reader_args = {
             a_addr,
             num_tile_rows_per_core,
             Wt,
@@ -571,12 +572,14 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         // For the RM output writer arg[3] is start_tile_row (starting tile-row index for this core),
         // not the flat tile offset, because the RM writer computes row addresses directly.
         const uint32_t writer_start = input_is_row_major ? curr_row : tile_offset;
-        std::vector<uint32_t> writer_args = {dst_addr, Wt, num_tile_rows_per_core, writer_start};
+        tt::tt_metal::KernelDescriptor::CoreRuntimeArgs writer_args = {
+            dst_addr, Wt, num_tile_rows_per_core, writer_start};
         if (input_is_row_major) {
             writer_args.push_back(H_logical);  // arg[4]
         }
         writer_runtime_args.emplace_back(core, std::move(writer_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
+        compute_runtime_args.emplace_back(
+            core, tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{num_tile_rows_per_core});
 
         curr_row += num_tile_rows_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -453,30 +453,49 @@ KernelPaths KernelPaths::get(
     bool is_pre_all_gather, bool is_post_all_gather, bool use_row_major_kernel, bool use_welford) {
     KernelPaths paths;
 
-    constexpr const char* base_path = "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/";
-
     if (is_pre_all_gather) {
         paths.reader_sender =
-            std::string(base_path) + "dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp";
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp";
         paths.reader_receiver =
-            std::string(base_path) + "dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp";
-        paths.writer = std::string(base_path) + "dataflow/writer_unary_sharded_ln_pre_all_gather.cpp";
-        paths.compute = std::string(base_path) + "compute/layernorm_sharded_pre_allgather.cpp";
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp";
+        paths.writer =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "writer_unary_sharded_ln_pre_all_gather.cpp";
+        paths.compute =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/"
+            "layernorm_sharded_pre_allgather.cpp";
     } else if (is_post_all_gather) {
         paths.reader_sender =
-            std::string(base_path) + "dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp";
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_sender_unary_sharded_ln_post_allgather.cpp";
         paths.reader_receiver =
-            std::string(base_path) + "dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp";
-        paths.writer = use_row_major_kernel ? std::string(base_path) + "dataflow/writer_unary_sharded_ln_rm_gb.cpp"
-                                            : std::string(base_path) + "dataflow/writer_unary_sharded_ln.cpp";
-        paths.compute = std::string(base_path) + "compute/layernorm_sharded_post_allgather.cpp";
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp";
+        paths.writer = use_row_major_kernel ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/"
+                                              "dataflow/writer_unary_sharded_ln_rm_gb.cpp"
+                                            : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/"
+                                              "dataflow/writer_unary_sharded_ln.cpp";
+        paths.compute =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/"
+            "layernorm_sharded_post_allgather.cpp";
     } else {
-        paths.reader_sender = std::string(base_path) + "dataflow/reader_mcast_sender_unary_sharded_ln.cpp";
-        paths.reader_receiver = std::string(base_path) + "dataflow/reader_mcast_receiver_unary_sharded_ln.cpp";
-        paths.writer = use_row_major_kernel ? std::string(base_path) + "dataflow/writer_unary_sharded_ln_rm_gb.cpp"
-                                            : std::string(base_path) + "dataflow/writer_unary_sharded_ln.cpp";
-        paths.compute = use_welford ? std::string(base_path) + "compute/layernorm_sharded_welford.cpp"
-                                    : std::string(base_path) + "compute/layernorm_sharded.cpp";
+        paths.reader_sender =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_sender_unary_sharded_ln.cpp";
+        paths.reader_receiver =
+            "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+            "reader_mcast_receiver_unary_sharded_ln.cpp";
+        paths.writer = use_row_major_kernel ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/"
+                                              "dataflow/writer_unary_sharded_ln_rm_gb.cpp"
+                                            : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/"
+                                              "dataflow/writer_unary_sharded_ln.cpp";
+        paths.compute =
+            use_welford
+                ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/"
+                  "layernorm_sharded_welford.cpp"
+                : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp";
     }
 
     return paths;
@@ -1245,7 +1264,7 @@ bool CoreIndices::is_all_to_all(const RuntimeArgsContext& ctx) const {
     return width_index < ctx.workers.num_cores_all_to_all;
 }
 
-std::vector<uint32_t> build_compute_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_compute_args(
     const CoreIndices& idx, const RuntimeArgsContext& ctx, bool& is_all_to_all_out) {
     std::vector<uint32_t> args{idx.num_reduce_tiles_per_block_h};
     is_all_to_all_out = idx.is_all_to_all(ctx);
@@ -1270,10 +1289,10 @@ std::vector<uint32_t> build_compute_args(
             args.push_back((uint32_t)ctx.num_distributed_devices);
         }
     }
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_reader_sender_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_reader_sender_args(
     const CoreCoord& core, const CoreIndices& idx, const RuntimeArgsContext& ctx, IDevice* device) {
     // Compute mcast range
     CoreCoord mcast_start, mcast_end;
@@ -1327,10 +1346,10 @@ std::vector<uint32_t> build_reader_sender_args(
             args.insert(args.end(), ctx.mcast_noc_y.begin(), ctx.mcast_noc_y.end());
         }
     }
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_reader_receiver_all_to_all_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_reader_receiver_all_to_all_args(
     const CoreCoord& core, const CoreIndices& idx, const RuntimeArgsContext& ctx) {
     std::vector<uint32_t> args;
 
@@ -1365,10 +1384,11 @@ std::vector<uint32_t> build_reader_receiver_all_to_all_args(
             args.insert(args.end(), ctx.mcast_noc_y.begin(), ctx.mcast_noc_y.end());
         }
     }
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_reader_receiver_not_all_to_all_args(const CoreIndices& idx, const RuntimeArgsContext& ctx) {
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_reader_receiver_not_all_to_all_args(
+    const CoreIndices& idx, const RuntimeArgsContext& ctx) {
     std::vector<uint32_t> args;
     args.push_back(false);  // is_last_all_to_all_worker
     args.push_back(idx.all_to_all_worker_tile_offset_bytes);
@@ -1388,14 +1408,14 @@ std::vector<uint32_t> build_reader_receiver_not_all_to_all_args(const CoreIndice
             args.push_back(ctx.mcast_noc_y[0]);
         }
     }
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_write_back_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_write_back_args(
     const RuntimeArgsContext& ctx, uint32_t& current_storage_core, uint32_t& current_storage_core_offset) {
     std::vector<uint32_t> args;
     if (!ctx.is_post_all_gather) {
-        return args;
+        return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
     }
 
     args.push_back(current_storage_core_offset * ctx.out_single_tile_size);
@@ -1425,13 +1445,13 @@ std::vector<uint32_t> build_write_back_args(
         }
     }
     args.insert(args.begin(), num_segments);
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
-std::vector<uint32_t> build_writer_args(
+tt::tt_metal::KernelDescriptor::CoreRuntimeArgs build_writer_args(
     const CoreIndices& idx,
     const RuntimeArgsContext& ctx,
-    const std::vector<uint32_t>& write_back_args,
+    const tt::tt_metal::KernelDescriptor::CoreRuntimeArgs& write_back_args,
     bool is_all_to_all) {
     std::vector<uint32_t> args;
 
@@ -1451,7 +1471,7 @@ std::vector<uint32_t> build_writer_args(
     args.push_back(idx.gamma_tile_start_id);
     args.push_back(idx.beta_tile_start_id);
     args.insert(args.end(), write_back_args.begin(), write_back_args.end());
-    return args;
+    return tt::tt_metal::KernelDescriptor::CoreRuntimeArgs(args.begin(), args.end());
 }
 
 RuntimeArgsResult RuntimeArgsResult::build(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -114,10 +114,10 @@ struct KernelLayout {
 
 // Struct to hold kernel file paths based on operation mode
 struct KernelPaths {
-    std::string reader_sender;
-    std::string reader_receiver;
-    std::string writer;
-    std::string compute;
+    std::string_view reader_sender;
+    std::string_view reader_receiver;
+    std::string_view writer;
+    std::string_view compute;
 
     static KernelPaths get(
         bool is_pre_all_gather, bool is_post_all_gather, bool use_row_major_kernel, bool use_welford);
@@ -244,13 +244,13 @@ struct CompileTimeArgsContext {
 
 // Result of building compile-time args
 struct CompileTimeArgs {
-    std::vector<uint32_t> reader_sender;
-    std::vector<uint32_t> reader_receiver_all_to_all;
-    std::vector<uint32_t> reader_receiver;
-    std::vector<uint32_t> writer_sender;
-    std::vector<uint32_t> writer_receiver;
-    std::vector<uint32_t> compute_all_to_all;
-    std::vector<uint32_t> compute_not_all_to_all;
+    KernelDescriptor::CompileTimeArgs reader_sender;
+    KernelDescriptor::CompileTimeArgs reader_receiver_all_to_all;
+    KernelDescriptor::CompileTimeArgs reader_receiver;
+    KernelDescriptor::CompileTimeArgs writer_sender;
+    KernelDescriptor::CompileTimeArgs writer_receiver;
+    KernelDescriptor::CompileTimeArgs compute_all_to_all;
+    KernelDescriptor::CompileTimeArgs compute_not_all_to_all;
 
     static CompileTimeArgs build(const CompileTimeArgsContext& ctx);
 };
@@ -262,19 +262,19 @@ struct CompileTimeArgs {
 // Struct to hold kernel configuration for building kernel descriptors
 struct KernelConfig {
     // Paths
-    std::string reader_sender_path;
-    std::string reader_receiver_path;
-    std::string writer_path;
-    std::string compute_path;
+    std::string_view reader_sender_path;
+    std::string_view reader_receiver_path;
+    std::string_view writer_path;
+    std::string_view compute_path;
 
     // Compile time args
-    std::vector<uint32_t> reader_sender_ct_args;
-    std::vector<uint32_t> reader_receiver_all_to_all_ct_args;
-    std::vector<uint32_t> reader_receiver_ct_args;
-    std::vector<uint32_t> writer_sender_ct_args;
-    std::vector<uint32_t> writer_receiver_ct_args;
-    std::vector<uint32_t> compute_all_to_all_ct_args;
-    std::vector<uint32_t> compute_not_all_to_all_ct_args;
+    KernelDescriptor::CompileTimeArgs reader_sender_ct_args;
+    KernelDescriptor::CompileTimeArgs reader_receiver_all_to_all_ct_args;
+    KernelDescriptor::CompileTimeArgs reader_receiver_ct_args;
+    KernelDescriptor::CompileTimeArgs writer_sender_ct_args;
+    KernelDescriptor::CompileTimeArgs writer_receiver_ct_args;
+    KernelDescriptor::CompileTimeArgs compute_all_to_all_ct_args;
+    KernelDescriptor::CompileTimeArgs compute_not_all_to_all_ct_args;
 
     // Defines
     KernelDescriptor::Defines reader_sender_defines;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -114,10 +114,10 @@ struct KernelLayout {
 
 // Struct to hold kernel file paths based on operation mode
 struct KernelPaths {
-    std::string_view reader_sender;
-    std::string_view reader_receiver;
-    std::string_view writer;
-    std::string_view compute;
+    std::string reader_sender;
+    std::string reader_receiver;
+    std::string writer;
+    std::string compute;
 
     static KernelPaths get(
         bool is_pre_all_gather, bool is_post_all_gather, bool use_row_major_kernel, bool use_welford);
@@ -262,10 +262,10 @@ struct CompileTimeArgs {
 // Struct to hold kernel configuration for building kernel descriptors
 struct KernelConfig {
     // Paths
-    std::string_view reader_sender_path;
-    std::string_view reader_receiver_path;
-    std::string_view writer_path;
-    std::string_view compute_path;
+    std::string reader_sender_path;
+    std::string reader_receiver_path;
+    std::string writer_path;
+    std::string compute_path;
 
     // Compile time args
     KernelDescriptor::CompileTimeArgs reader_sender_ct_args;


### PR DESCRIPTION
Relates to #42193.

Framework prep: lighter `KernelDescriptor` aliases (SmallVector), `string_view` `kernel_source`, `Buffer::create_device_view`, and a thread-local `cached_split_work_to_cores` utility — establishes the patterns the `BufferBinding` fast cache-hit path builds on across descriptor migrations.

## Tests

All existing descriptor-based ops (bernoulli, slice, matmul, layernorm, examples, eltwise, ternary, binary_ng, unary_ng, tanh_bw, test_generic_op) updated and passing on this branch.

## Performance

Host-side dispatch only, hot cache, n=200×3, median, Wormhole B0. _Numbers refresh in progress — will fill below._

| Op | Legacy main | Descriptor + binding | Δ |
|---|---:|---:|---:|
| representative descriptor op | _TBD_ | _TBD_ | _TBD_ |

### CI Status

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=perf/descriptor-framework-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:perf/descriptor-framework-optimizations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=perf/descriptor-framework-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:perf/descriptor-framework-optimizations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=perf/descriptor-framework-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:perf/descriptor-framework-optimizations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=perf/descriptor-framework-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:perf/descriptor-framework-optimizations)
