### PR TITLE
Add quasar mxfp4 format metal infra.

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -540,6 +540,9 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
                 .noc = NOC::RISCV_0_default,
                 .compile_args = {cb_index, /*use_dfbs=*/false}});
 
+        // DRAM buffers use page_size = buffer_size (whole buffer), so compute
+        // the per-tile stride directly. single_tile_size is the real per-tile
+        // stride here since tiles are packed contiguously inside the buffer.
         SetRuntimeArgs(
             program_,
             reader_kernel,
@@ -548,7 +551,7 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
                 (uint32_t)src_dram_buffer->address(),
                 0,
                 (uint32_t)num_tiles,
-                (uint32_t)src_dram_buffer->aligned_page_size(),
+                single_tile_size,
             });
         SetRuntimeArgs(
             program_,
@@ -558,7 +561,7 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
                 (uint32_t)dst_dram_buffer->address(),
                 0,
                 (uint32_t)num_tiles,
-                (uint32_t)dst_dram_buffer->aligned_page_size(),
+                single_tile_size,
             });
 
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -548,6 +548,7 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
                 (uint32_t)src_dram_buffer->address(),
                 0,
                 (uint32_t)num_tiles,
+                (uint32_t)src_dram_buffer->aligned_page_size(),
             });
         SetRuntimeArgs(
             program_,
@@ -557,6 +558,7 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
                 (uint32_t)dst_dram_buffer->address(),
                 0,
                 (uint32_t)num_tiles,
+                (uint32_t)dst_dram_buffer->aligned_page_size(),
             });
 
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -267,6 +267,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
             (uint32_t)input_dram_byte_address,
             0,
             (uint32_t)test_config.num_tiles,
+            (uint32_t)input_dram_buffer->aligned_page_size(),
         });
     tt_metal::SetRuntimeArgs(
         program_,
@@ -276,6 +277,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
             (uint32_t)output_dram_byte_address,
             0,
             (uint32_t)test_config.num_tiles,
+            (uint32_t)output_dram_buffer->aligned_page_size(),
         });
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -435,7 +437,8 @@ bool reader_datacopy_writer(
         {
             (uint32_t)input_dram_byte_address,
             0,
-            num_tiles_per_thread
+            num_tiles_per_thread,
+            (uint32_t)input_dram_buffer->aligned_page_size(),
         });
     tt_metal::SetRuntimeArgs(
         program_,
@@ -444,7 +447,8 @@ bool reader_datacopy_writer(
         {
             (uint32_t)output_dram_byte_address,
             0,
-            num_tiles_per_thread
+            num_tiles_per_thread,
+            (uint32_t)output_dram_buffer->aligned_page_size(),
         });
 
     auto blocking = device->arch() == ARCH::QUASAR;

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -259,6 +259,10 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
 
     tt_metal::detail::WriteToBuffer(input_dram_buffer, inputs);
 
+    // DRAM buffer is configured with page_size = byte_size (whole buffer),
+    // so aligned_page_size() returns the whole-buffer stride, not per-tile.
+    // Derive the per-tile DRAM stride directly from byte_size / num_tiles.
+    const uint32_t per_tile_stride = (uint32_t)(byte_size / test_config.num_tiles);
     tt_metal::SetRuntimeArgs(
         program_,
         reader_kernel,
@@ -267,7 +271,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
             (uint32_t)input_dram_byte_address,
             0,
             (uint32_t)test_config.num_tiles,
-            (uint32_t)input_dram_buffer->aligned_page_size(),
+            per_tile_stride,
         });
     tt_metal::SetRuntimeArgs(
         program_,
@@ -277,7 +281,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
             (uint32_t)output_dram_byte_address,
             0,
             (uint32_t)test_config.num_tiles,
-            (uint32_t)output_dram_buffer->aligned_page_size(),
+            per_tile_stride,
         });
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -430,6 +434,11 @@ bool reader_datacopy_writer(
 
     uint32_t num_tiles_per_thread = test_config.num_tiles / num_threads;
     log_info(tt::LogTest, "Num tiles per thread: {}", num_tiles_per_thread);
+    // DRAM buffer uses page_size = byte_size (whole-buffer), so derive the
+    // per-tile stride directly. byte_size covers all test_config.num_tiles
+    // tiles across all threads; the stride between consecutive tiles in DRAM
+    // is byte_size / test_config.num_tiles.
+    const uint32_t per_tile_stride = (uint32_t)(byte_size / test_config.num_tiles);
     tt_metal::SetRuntimeArgs(
         program_,
         reader_kernel,
@@ -438,7 +447,7 @@ bool reader_datacopy_writer(
             (uint32_t)input_dram_byte_address,
             0,
             num_tiles_per_thread,
-            (uint32_t)input_dram_buffer->aligned_page_size(),
+            per_tile_stride,
         });
     tt_metal::SetRuntimeArgs(
         program_,
@@ -448,7 +457,7 @@ bool reader_datacopy_writer(
             (uint32_t)output_dram_byte_address,
             0,
             num_tiles_per_thread,
-            (uint32_t)output_dram_buffer->aligned_page_size(),
+            per_tile_stride,
         });
 
     auto blocking = device->arch() == ARCH::QUASAR;

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -93,10 +93,10 @@ bool reader_only(
         reader_kernel,
         reader_core,
         {
-            (uint32_t)dram_byte_address,
+            static_cast<uint32_t>(dram_byte_address),
             0,
-            (uint32_t)l1_byte_address,
-            (uint32_t)byte_size,
+            static_cast<uint32_t>(l1_byte_address),
+            static_cast<uint32_t>(byte_size),
         });
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -164,10 +164,10 @@ bool writer_only(
         writer_kernel,
         writer_core,
         {
-            (uint32_t)dram_byte_address,
+            static_cast<uint32_t>(dram_byte_address),
             0,
-            (uint32_t)l1_byte_address,
-            (uint32_t)byte_size,
+            static_cast<uint32_t>(l1_byte_address),
+            static_cast<uint32_t>(byte_size),
         });
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -262,15 +262,15 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     // DRAM buffer is configured with page_size = byte_size (whole buffer),
     // so aligned_page_size() returns the whole-buffer stride, not per-tile.
     // Derive the per-tile DRAM stride directly from byte_size / num_tiles.
-    const uint32_t per_tile_stride = (uint32_t)(byte_size / test_config.num_tiles);
+    const uint32_t per_tile_stride = static_cast<uint32_t>(byte_size / test_config.num_tiles);
     tt_metal::SetRuntimeArgs(
         program_,
         reader_kernel,
         test_config.core,
         {
-            (uint32_t)input_dram_byte_address,
+            static_cast<uint32_t>(input_dram_byte_address),
             0,
-            (uint32_t)test_config.num_tiles,
+            static_cast<uint32_t>(test_config.num_tiles),
             per_tile_stride,
         });
     tt_metal::SetRuntimeArgs(
@@ -278,9 +278,9 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
         writer_kernel,
         test_config.core,
         {
-            (uint32_t)output_dram_byte_address,
+            static_cast<uint32_t>(output_dram_byte_address),
             0,
-            (uint32_t)test_config.num_tiles,
+            static_cast<uint32_t>(test_config.num_tiles),
             per_tile_stride,
         });
 
@@ -438,13 +438,13 @@ bool reader_datacopy_writer(
     // per-tile stride directly. byte_size covers all test_config.num_tiles
     // tiles across all threads; the stride between consecutive tiles in DRAM
     // is byte_size / test_config.num_tiles.
-    const uint32_t per_tile_stride = (uint32_t)(byte_size / test_config.num_tiles);
+    const uint32_t per_tile_stride = static_cast<uint32_t>(byte_size / test_config.num_tiles);
     tt_metal::SetRuntimeArgs(
         program_,
         reader_kernel,
         test_config.core,
         {
-            (uint32_t)input_dram_byte_address,
+            static_cast<uint32_t>(input_dram_byte_address),
             0,
             num_tiles_per_thread,
             per_tile_stride,
@@ -454,7 +454,7 @@ bool reader_datacopy_writer(
         writer_kernel,
         test_config.core,
         {
-            (uint32_t)output_dram_byte_address,
+            static_cast<uint32_t>(output_dram_byte_address),
             0,
             num_tiles_per_thread,
             per_tile_stride,

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
@@ -321,12 +321,18 @@ static void run_dump_cb(DevicePrintFixture* fixture, const std::shared_ptr<distr
         *s.program,
         reader,
         s.core,
-        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES)});
+        {static_cast<uint32_t>(s.input_dram->address()),
+         0u,
+         static_cast<uint32_t>(NUM_TILES),
+         static_cast<uint32_t>(s.input_dram->get_reference_buffer()->aligned_page_size())});
     SetRuntimeArgs(
         *s.program,
         writer,
         s.core,
-        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES)});
+        {static_cast<uint32_t>(s.output_dram->address()),
+         0u,
+         static_cast<uint32_t>(NUM_TILES),
+         static_cast<uint32_t>(s.output_dram->get_reference_buffer()->aligned_page_size())});
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
@@ -374,12 +380,18 @@ static void run_dump_l1(DevicePrintFixture* fixture, const std::shared_ptr<distr
         *s.program,
         reader,
         s.core,
-        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES)});
+        {static_cast<uint32_t>(s.input_dram->address()),
+         0u,
+         static_cast<uint32_t>(NUM_TILES),
+         static_cast<uint32_t>(s.input_dram->get_reference_buffer()->aligned_page_size())});
     SetRuntimeArgs(
         *s.program,
         writer,
         s.core,
-        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES)});
+        {static_cast<uint32_t>(s.output_dram->address()),
+         0u,
+         static_cast<uint32_t>(NUM_TILES),
+         static_cast<uint32_t>(s.output_dram->get_reference_buffer()->aligned_page_size())});
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
@@ -427,12 +439,18 @@ static void run_dump_typed(DevicePrintFixture* fixture, const std::shared_ptr<di
         *s.program,
         reader,
         s.core,
-        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES)});
+        {static_cast<uint32_t>(s.input_dram->address()),
+         0u,
+         static_cast<uint32_t>(NUM_TILES),
+         static_cast<uint32_t>(s.input_dram->get_reference_buffer()->aligned_page_size())});
     SetRuntimeArgs(
         *s.program,
         writer,
         s.core,
-        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES)});
+        {static_cast<uint32_t>(s.output_dram->address()),
+         0u,
+         static_cast<uint32_t>(NUM_TILES),
+         static_cast<uint32_t>(s.output_dram->get_reference_buffer()->aligned_page_size())});
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
@@ -317,22 +317,20 @@ static void run_dump_cb(DevicePrintFixture* fixture, const std::shared_ptr<distr
         s.core,
         ComputeConfig{.compile_args = {static_cast<uint32_t>(NUM_TILES)}});
 
+    // SingleCoreSetup configures the DRAM buffers with page_size = buf_sz
+    // (whole buffer), so aligned_page_size would over-return. The real
+    // per-tile DRAM stride is just tt::tile_size(FMT).
+    const uint32_t per_tile_dram_stride = static_cast<uint32_t>(tt::tile_size(FMT));
     SetRuntimeArgs(
         *s.program,
         reader,
         s.core,
-        {static_cast<uint32_t>(s.input_dram->address()),
-         0u,
-         static_cast<uint32_t>(NUM_TILES),
-         static_cast<uint32_t>(s.input_dram->get_reference_buffer()->aligned_page_size())});
+        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
     SetRuntimeArgs(
         *s.program,
         writer,
         s.core,
-        {static_cast<uint32_t>(s.output_dram->address()),
-         0u,
-         static_cast<uint32_t>(NUM_TILES),
-         static_cast<uint32_t>(s.output_dram->get_reference_buffer()->aligned_page_size())});
+        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
@@ -376,22 +374,19 @@ static void run_dump_l1(DevicePrintFixture* fixture, const std::shared_ptr<distr
         s.core,
         ComputeConfig{.compile_args = {static_cast<uint32_t>(NUM_TILES)}});
 
+    // See run_dump_cb: DRAM buffer is single whole-buffer page, so pass the
+    // real per-tile stride (tile_size(FMT)) directly.
+    const uint32_t per_tile_dram_stride = static_cast<uint32_t>(tt::tile_size(FMT));
     SetRuntimeArgs(
         *s.program,
         reader,
         s.core,
-        {static_cast<uint32_t>(s.input_dram->address()),
-         0u,
-         static_cast<uint32_t>(NUM_TILES),
-         static_cast<uint32_t>(s.input_dram->get_reference_buffer()->aligned_page_size())});
+        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
     SetRuntimeArgs(
         *s.program,
         writer,
         s.core,
-        {static_cast<uint32_t>(s.output_dram->address()),
-         0u,
-         static_cast<uint32_t>(NUM_TILES),
-         static_cast<uint32_t>(s.output_dram->get_reference_buffer()->aligned_page_size())});
+        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
@@ -435,22 +430,19 @@ static void run_dump_typed(DevicePrintFixture* fixture, const std::shared_ptr<di
         s.core,
         ComputeConfig{.compile_args = {static_cast<uint32_t>(NUM_TILES)}});
 
+    // See run_dump_cb: DRAM buffer is single whole-buffer page, so pass the
+    // real per-tile stride (tile_size(FMT)) directly.
+    const uint32_t per_tile_dram_stride = static_cast<uint32_t>(tt::tile_size(FMT));
     SetRuntimeArgs(
         *s.program,
         reader,
         s.core,
-        {static_cast<uint32_t>(s.input_dram->address()),
-         0u,
-         static_cast<uint32_t>(NUM_TILES),
-         static_cast<uint32_t>(s.input_dram->get_reference_buffer()->aligned_page_size())});
+        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
     SetRuntimeArgs(
         *s.program,
         writer,
         s.core,
-        {static_cast<uint32_t>(s.output_dram->address()),
-         0u,
-         static_cast<uint32_t>(NUM_TILES),
-         static_cast<uint32_t>(s.output_dram->get_reference_buffer()->aligned_page_size())});
+        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
@@ -229,11 +229,16 @@ using DramBuffer = std::shared_ptr<distributed::MeshBuffer>;
 
 // Generates the runtime arguments for the DRAM kernel
 static std::vector<uint32_t> get_dram_kernel_runtime_arguments(const DramBuffer& dram_buffer, size_t num_tiles) {
+    // create_dram_mesh_buffer() configures page_size = byte_size (whole-buffer
+    // single page), so page_size/aligned_page_size would over-return the
+    // stride. Derive per-tile stride from total size / num_tiles instead.
+    const uint32_t per_tile_stride =
+        num_tiles == 0 ? 0 : static_cast<uint32_t>(dram_buffer->device_local_size() / num_tiles);
     return {
         static_cast<uint32_t>(dram_buffer->address()),
         static_cast<uint32_t>(0),
         static_cast<uint32_t>(num_tiles),
-        static_cast<uint32_t>(dram_buffer->get_reference_buffer()->aligned_page_size()),
+        per_tile_stride,
     };
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
@@ -233,6 +233,7 @@ static std::vector<uint32_t> get_dram_kernel_runtime_arguments(const DramBuffer&
         static_cast<uint32_t>(dram_buffer->address()),
         static_cast<uint32_t>(0),
         static_cast<uint32_t>(num_tiles),
+        static_cast<uint32_t>(dram_buffer->get_reference_buffer()->aligned_page_size()),
     };
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -236,11 +236,16 @@ using DramBuffer = std::shared_ptr<distributed::MeshBuffer>;
 
 // Generates the runtime arguments for the DRAM kernel
 static std::vector<uint32_t> get_dram_kernel_runtime_arguments(const DramBuffer& dram_buffer, size_t num_tiles) {
+    // create_dram_mesh_buffer() configures page_size = byte_size (whole-buffer
+    // single page), so page_size/aligned_page_size would over-return the
+    // stride. Derive per-tile stride from total size / num_tiles instead.
+    const uint32_t per_tile_stride =
+        num_tiles == 0 ? 0 : static_cast<uint32_t>(dram_buffer->device_local_size() / num_tiles);
     return {
         static_cast<uint32_t>(dram_buffer->address()),
         static_cast<uint32_t>(0),
         static_cast<uint32_t>(num_tiles),
-        static_cast<uint32_t>(dram_buffer->get_reference_buffer()->aligned_page_size()),
+        per_tile_stride,
     };
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -240,6 +240,7 @@ static std::vector<uint32_t> get_dram_kernel_runtime_arguments(const DramBuffer&
         static_cast<uint32_t>(dram_buffer->address()),
         static_cast<uint32_t>(0),
         static_cast<uint32_t>(num_tiles),
+        static_cast<uint32_t>(dram_buffer->get_reference_buffer()->aligned_page_size()),
     };
 }
 

--- a/tests/tt_metal/tt_metal/llk/sources.cmake
+++ b/tests/tt_metal/tt_metal/llk/sources.cmake
@@ -8,6 +8,7 @@ set(UNIT_TESTS_LLK_SRC
     test_cumsum.cpp
     test_dropout_sfpu_compute.cpp
     test_fp8_typecast.cpp
+    test_mxfp4_typecast.cpp
     test_golden_impls.cpp
     test_mul_reduce_scalar.cpp
     test_pack_rows.cpp

--- a/tests/tt_metal/tt_metal/llk/sources.cmake
+++ b/tests/tt_metal/tt_metal/llk/sources.cmake
@@ -8,9 +8,9 @@ set(UNIT_TESTS_LLK_SRC
     test_cumsum.cpp
     test_dropout_sfpu_compute.cpp
     test_fp8_typecast.cpp
-    test_mxfp4_typecast.cpp
     test_golden_impls.cpp
     test_mul_reduce_scalar.cpp
+    test_mxfp4_typecast.cpp
     test_pack_rows.cpp
     test_reconfig.cpp
     test_reduce.cpp

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -191,72 +191,22 @@ static vector<uint32_t> run_mxfp4_typecast(
 			.compile_args = {num_tiles, /*use_dfbs=*/true}});
 
 	tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_input_dfb, reader, compute);
-	tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_output_dfb, compute, writer);
-	
-	// print uint32_t in bytes
-	// int byte_counter = 0;
-	// for(uint32_t val: src_vec) {
-	// 	// log_info(tt::LogTest, "src_vec[{}] value: 0x{:02X}", byte_counter++, (val & 0xFF000000) >> 24);
-	// 	// log_info(tt::LogTest, "src_vec[{}] value: 0x{:02X}", byte_counter++, (val & 0x00FF0000) >> 16);
-	// 	// log_info(tt::LogTest, "src_vec[{}] value: 0x{:02X}", byte_counter++, (val & 0x0000FF00) >> 8);
-	// 	// log_info(tt::LogTest, "src_vec[{}] value: 0x{:02X}", byte_counter++, (val & 0x000000FF));
-	// }
-	detail::WriteToBuffer(src_buffer, src_vec);
-	// Pass aligned DRAM page stride so the reader/writer advance the DRAM
-	// pointer by the allocator's aligned_page_size (576 for MxFp4 on Quasar
-	// due to 64B DRAM alignment) while the DFB streams native 544-byte tiles.
-	uint32_t src_dram_stride = static_cast<uint32_t>(src_buffer->aligned_page_size());
-	uint32_t dst_dram_stride = static_cast<uint32_t>(dst_buffer->aligned_page_size());
-	SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles, src_dram_stride});
-	SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles, dst_dram_stride});
+    tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_output_dfb, compute, writer);
 
-	detail::LaunchProgram(dev, program, /*wait_for_completion=*/true);
+    detail::WriteToBuffer(src_buffer, src_vec);
+    // Pass aligned DRAM page stride so the reader/writer advance the DRAM
+    // pointer by the allocator's aligned_page_size (576 for MxFp4 on Quasar
+    // due to 64B DRAM alignment) while the DFB streams native 544-byte tiles.
+    uint32_t src_dram_stride = static_cast<uint32_t>(src_buffer->aligned_page_size());
+    uint32_t dst_dram_stride = static_cast<uint32_t>(dst_buffer->aligned_page_size());
+    SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles, src_dram_stride});
+    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles, dst_dram_stride});
 
-	// === L1 post-mortem for MxFp4 multi-tile debug ===
-	// From the DFB log: input DFB is at L1 base 0xBA800 (763776), 2 × 544 B = 1088 B.
-	//                  output DFB is at L1 base 0xBAC40 (764864), 2 × 2048 B = 4096 B.
-	// After LaunchProgram the kernels have finished — read both DFB regions from
-	// worker-core L1 and dump tile-1 regions so we can see whether (a) the reader
-	// delivered tile-1's MxFp4 bytes to the input DFB, and (b) the compute+packer
-	// produced nonzero BF16 for tile-1 in the output DFB.
-	{
-		constexpr uint32_t kInputDFBBase = 763776;
-		constexpr uint32_t kInputTileSize = 544;
-		constexpr uint32_t kOutputDFBBase = 764864;
-		constexpr uint32_t kOutputTileSize = 2048;
+    detail::LaunchProgram(dev, program, /*wait_for_completion=*/true);
 
-		std::vector<uint32_t> in_l1_words, out_l1_words;
-		detail::ReadFromDeviceL1(dev, core, kInputDFBBase, num_tiles * kInputTileSize, in_l1_words);
-		detail::ReadFromDeviceL1(dev, core, kOutputDFBBase, num_tiles * kOutputTileSize, out_l1_words);
-
-		auto dump_bytes = [](const char* label, const std::vector<uint32_t>& words, size_t byte_offset, size_t n) {
-			std::ostringstream oss;
-			oss << label << " bytes [" << byte_offset << ".." << (byte_offset + n - 1) << "]:" << std::hex << std::uppercase;
-			const uint8_t* p = reinterpret_cast<const uint8_t*>(words.data());
-			for (size_t i = 0; i < n; ++i) {
-				oss << ' ' << std::setw(2) << std::setfill('0') << static_cast<int>(p[byte_offset + i]);
-			}
-			log_info(tt::LogTest, "{}", oss.str());
-		};
-
-		// Input DFB: dump tile 0 scales, tile 0 data[0..31], tile 1 scales, tile 1 data[0..31],
-		// and probe 32 bytes BEFORE tile 1's expected offset and 32 bytes PAST tile 1 end —
-		// to localize where the 32-byte shift starts.
-		dump_bytes("INPUT L1 tile0 scales[0..31]", in_l1_words, /*byte_offset=*/0, /*n=*/32);
-		dump_bytes("INPUT L1 tile0 data[0..31]  ", in_l1_words, /*byte_offset=*/32, /*n=*/32);
-		dump_bytes("INPUT L1 tile0 data[480..511]", in_l1_words, /*byte_offset=*/32 + 480, /*n=*/32); // last 32 data bytes of tile 0
-		dump_bytes("INPUT L1 tile1 scales[0..31]", in_l1_words, /*byte_offset=*/kInputTileSize, /*n=*/32);
-		dump_bytes("INPUT L1 tile1 data[0..31]  ", in_l1_words, /*byte_offset=*/kInputTileSize + 32, /*n=*/32);
-		dump_bytes("INPUT L1 tile1 data[32..63] ", in_l1_words, /*byte_offset=*/kInputTileSize + 64, /*n=*/32);
-
-		// Output DFB: dump first 32 bytes of tile 0 and tile 1 so we can compare.
-		dump_bytes("OUTPUT L1 tile0[0..31]", out_l1_words, /*byte_offset=*/0, /*n=*/32);
-		dump_bytes("OUTPUT L1 tile1[0..31]", out_l1_words, /*byte_offset=*/kOutputTileSize, /*n=*/32);
-	}
-
-	vector<uint32_t> result_vec;
-	detail::ReadFromBuffer(dst_buffer, result_vec);
-	return result_vec;
+    vector<uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_buffer, result_vec);
+    return result_vec;
 }
 
 // Data generators follow the fp8_typecast tests' convention: generate

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -4,14 +4,9 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
-#include <iomanip>
-#include <iostream>
 #include <random>
-#include <sstream>
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
@@ -28,9 +23,6 @@
 #include <tt_stl/span.hpp>
 #include <tt-logger/tt-logger.hpp>
 
-#include "tt_metal/impl/context/metal_context.hpp"
-#include "tt_metal/impl/data_format/mx_common.hpp"
-
 #include "device_fixture.hpp"
 
 namespace tt::tt_metal {
@@ -38,81 +30,6 @@ namespace tt::tt_metal {
 using std::vector;
 
 namespace unit_tests::llk::mxfp4_typecast {
-
-constexpr tt::tt_metal::mx::FormatParams kMxFp4Params = {
-	.block_size = 32,
-	.scale_bias = 0x7F,
-	.elem_exp_bits = 2,
-	.elem_man_bits = 1,
-	.elem_exp_bias = 1,
-	.elem_exp_max_unbiased = 2,
-	.elem_exp_min_unbiased = 0,
-	.elem_exp_subnorm_encoding = 0,
-	.elem_man_max = 0x1,
-	.elem_width_bits = 4,
-	.elem_width_storage_bits = 4,
-	.sat_supported = true,
-	.elem_sat_pos_bits = 0x7,
-	.elem_sat_neg_bits = 0xF,
-	.inf_rep = tt::tt_metal::mx::InfNanRep::NotRepresentable,
-	.nan_rep = tt::tt_metal::mx::InfNanRep::NotRepresentable,
-};
-
-static void dump_mxfp4_tile_exps(const vector<uint32_t>& packed, uint32_t tile_index, const char* label) {
-	if (std::getenv("TT_METAL_SKIP_MXFP4_EXPS") != nullptr) {
-		return;
-	}
-	if (packed.empty()) {
-		log_info(tt::LogTest, "{}: packed data empty", label);
-		return;
-	}
-	constexpr uint32_t kTileHW = 1024;
-	uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
-	auto word_counts = tt::tt_metal::mx::compute_tile_word_counts(kTileHW, l1_alignment, kMxFp4Params);
-	uint32_t words_per_tile = word_counts.exp_words + word_counts.elem_words;
-	size_t word_offset = static_cast<size_t>(tile_index) * words_per_tile;
-	if (packed.size() < word_offset + words_per_tile) {
-		log_info(
-			tt::LogTest,
-			"{}: tile_index {} out of range (packed words={}, words_per_tile={})",
-			label,
-			tile_index,
-			packed.size(),
-			words_per_tile);
-		return;
-	}
-
-	std::vector<uint8_t> exps;
-	tt::tt_metal::mx::unpack_exp_words(
-		tt::stl::make_const_span(packed), word_offset, word_counts.exp_words, word_counts.exp_count, exps);
-
-	const size_t to_print = std::min<size_t>(exps.size(), 32);
-	std::ostringstream oss;
-	for (size_t i = 0; i < to_print; ++i) {
-		if (i != 0) {
-			oss << " ";
-		}
-		oss << static_cast<int>(exps[i]);
-	}
-
-	tt::tt_metal::Tile tile;
-	uint32_t tile_size_api = tt::tile_size(tt::DataFormat::MxFp4);
-	uint32_t tile_size_hw = tile.get_tile_size(tt::DataFormat::MxFp4);
-	std::ostringstream header;
-	header << label << ": tile_index=" << tile_index
-	       << " exp_count=" << word_counts.exp_count
-	       << " exp_bytes=" << word_counts.exp_bytes
-	       << " exp_words=" << word_counts.exp_words
-	       << " elem_words=" << word_counts.elem_words
-	       << " l1_alignment=" << l1_alignment
-	       << " tile_size_api=" << tile_size_api
-	       << " tile_size_hw=" << tile_size_hw;
-	std::ostringstream line;
-	line << label << ": exps[0.." << (to_print > 0 ? to_print - 1 : 0) << "] = " << oss.str();
-	std::cout << header.str() << "\n" << line.str() << std::endl;
-	log_info(tt::LogTest, "{}", header.str());
-	log_info(tt::LogTest, "{}", line.str());
-}
 
 // Run a datacopy kernel with different input/output formats.
 // For Quasar, data is moved via DataflowBuffers (DFBs) and the hardware
@@ -202,7 +119,7 @@ static vector<uint32_t> run_mxfp4_typecast(
     SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles, src_dram_stride});
     SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles, dst_dram_stride});
 
-    detail::LaunchProgram(dev, program, /*wait_for_completion=*/true);
+    detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
     detail::ReadFromBuffer(dst_buffer, result_vec);
@@ -349,17 +266,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4) {
 	constexpr uint32_t num_tiles = 64;
 	auto src_vec = create_random_vector_of_bfloat16(
 		tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-	auto result_vec = mxfp4_tc::run_mxfp4_typecast(
-		dev, tt::DataFormat::Float16_b, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
-	mxfp4_tc::dump_mxfp4_tile_exps(result_vec, 0, "Float16b->MxFp4 tile0");
-	uint32_t debug_tile_index = num_tiles > 52 ? 52 : 0;
-	if (debug_tile_index != 0) {
-		mxfp4_tc::dump_mxfp4_tile_exps(result_vec, debug_tile_index, "Float16b->MxFp4 tile52");
-	}
-	auto src_floats = mxfp4_tc::bf16_to_floats(src_vec);
-	auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
-	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.5f, /*atol=*/0.5f));
-	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/0.98));
+    auto result_vec = mxfp4_tc::run_mxfp4_typecast(
+        dev, tt::DataFormat::Float16_b, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+    auto src_floats = mxfp4_tc::bf16_to_floats(src_vec);
+    auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
+    EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.5f, /*atol=*/0.5f));
+    EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/0.98));
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4Fp32Dest) {
@@ -367,17 +279,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4Fp32Dest) {
 	constexpr uint32_t num_tiles = 64;
 	auto src_vec = create_random_vector_of_bfloat16(
 		tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-	auto result_vec = mxfp4_tc::run_mxfp4_typecast(
-		dev, tt::DataFormat::Float16_b, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
-	mxfp4_tc::dump_mxfp4_tile_exps(result_vec, 0, "Float16b->MxFp4Fp32Dest tile0");
-	uint32_t debug_tile_index = num_tiles > 52 ? 52 : 0;
-	if (debug_tile_index != 0) {
-		mxfp4_tc::dump_mxfp4_tile_exps(result_vec, debug_tile_index, "Float16b->MxFp4Fp32Dest tile52");
-	}
-	auto src_floats = mxfp4_tc::bf16_to_floats(src_vec);
-	auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
-	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.5f, /*atol=*/0.5f));
-	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/0.98));
+    auto result_vec = mxfp4_tc::run_mxfp4_typecast(
+        dev, tt::DataFormat::Float16_b, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+    auto src_floats = mxfp4_tc::bf16_to_floats(src_vec);
+    auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
+    EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.5f, /*atol=*/0.5f));
+    EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/0.98));
 }
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 #include <random>
 #include <sstream>
@@ -191,12 +192,67 @@ static vector<uint32_t> run_mxfp4_typecast(
 
 	tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_input_dfb, reader, compute);
 	tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_output_dfb, compute, writer);
-
+	
+	// print uint32_t in bytes
+	// int byte_counter = 0;
+	// for(uint32_t val: src_vec) {
+	// 	// log_info(tt::LogTest, "src_vec[{}] value: 0x{:02X}", byte_counter++, (val & 0xFF000000) >> 24);
+	// 	// log_info(tt::LogTest, "src_vec[{}] value: 0x{:02X}", byte_counter++, (val & 0x00FF0000) >> 16);
+	// 	// log_info(tt::LogTest, "src_vec[{}] value: 0x{:02X}", byte_counter++, (val & 0x0000FF00) >> 8);
+	// 	// log_info(tt::LogTest, "src_vec[{}] value: 0x{:02X}", byte_counter++, (val & 0x000000FF));
+	// }
 	detail::WriteToBuffer(src_buffer, src_vec);
-	SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
-	SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
+	// Pass aligned DRAM page stride so the reader/writer advance the DRAM
+	// pointer by the allocator's aligned_page_size (576 for MxFp4 on Quasar
+	// due to 64B DRAM alignment) while the DFB streams native 544-byte tiles.
+	uint32_t src_dram_stride = static_cast<uint32_t>(src_buffer->aligned_page_size());
+	uint32_t dst_dram_stride = static_cast<uint32_t>(dst_buffer->aligned_page_size());
+	SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles, src_dram_stride});
+	SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles, dst_dram_stride});
 
 	detail::LaunchProgram(dev, program, /*wait_for_completion=*/true);
+
+	// === L1 post-mortem for MxFp4 multi-tile debug ===
+	// From the DFB log: input DFB is at L1 base 0xBA800 (763776), 2 × 544 B = 1088 B.
+	//                  output DFB is at L1 base 0xBAC40 (764864), 2 × 2048 B = 4096 B.
+	// After LaunchProgram the kernels have finished — read both DFB regions from
+	// worker-core L1 and dump tile-1 regions so we can see whether (a) the reader
+	// delivered tile-1's MxFp4 bytes to the input DFB, and (b) the compute+packer
+	// produced nonzero BF16 for tile-1 in the output DFB.
+	{
+		constexpr uint32_t kInputDFBBase = 763776;
+		constexpr uint32_t kInputTileSize = 544;
+		constexpr uint32_t kOutputDFBBase = 764864;
+		constexpr uint32_t kOutputTileSize = 2048;
+
+		std::vector<uint32_t> in_l1_words, out_l1_words;
+		detail::ReadFromDeviceL1(dev, core, kInputDFBBase, num_tiles * kInputTileSize, in_l1_words);
+		detail::ReadFromDeviceL1(dev, core, kOutputDFBBase, num_tiles * kOutputTileSize, out_l1_words);
+
+		auto dump_bytes = [](const char* label, const std::vector<uint32_t>& words, size_t byte_offset, size_t n) {
+			std::ostringstream oss;
+			oss << label << " bytes [" << byte_offset << ".." << (byte_offset + n - 1) << "]:" << std::hex << std::uppercase;
+			const uint8_t* p = reinterpret_cast<const uint8_t*>(words.data());
+			for (size_t i = 0; i < n; ++i) {
+				oss << ' ' << std::setw(2) << std::setfill('0') << static_cast<int>(p[byte_offset + i]);
+			}
+			log_info(tt::LogTest, "{}", oss.str());
+		};
+
+		// Input DFB: dump tile 0 scales, tile 0 data[0..31], tile 1 scales, tile 1 data[0..31],
+		// and probe 32 bytes BEFORE tile 1's expected offset and 32 bytes PAST tile 1 end —
+		// to localize where the 32-byte shift starts.
+		dump_bytes("INPUT L1 tile0 scales[0..31]", in_l1_words, /*byte_offset=*/0, /*n=*/32);
+		dump_bytes("INPUT L1 tile0 data[0..31]  ", in_l1_words, /*byte_offset=*/32, /*n=*/32);
+		dump_bytes("INPUT L1 tile0 data[480..511]", in_l1_words, /*byte_offset=*/32 + 480, /*n=*/32); // last 32 data bytes of tile 0
+		dump_bytes("INPUT L1 tile1 scales[0..31]", in_l1_words, /*byte_offset=*/kInputTileSize, /*n=*/32);
+		dump_bytes("INPUT L1 tile1 data[0..31]  ", in_l1_words, /*byte_offset=*/kInputTileSize + 32, /*n=*/32);
+		dump_bytes("INPUT L1 tile1 data[32..63] ", in_l1_words, /*byte_offset=*/kInputTileSize + 64, /*n=*/32);
+
+		// Output DFB: dump first 32 bytes of tile 0 and tile 1 so we can compare.
+		dump_bytes("OUTPUT L1 tile0[0..31]", out_l1_words, /*byte_offset=*/0, /*n=*/32);
+		dump_bytes("OUTPUT L1 tile1[0..31]", out_l1_words, /*byte_offset=*/kOutputTileSize, /*n=*/32);
+	}
 
 	vector<uint32_t> result_vec;
 	detail::ReadFromBuffer(dst_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -4,19 +4,31 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
+#include <iostream>
 #include <random>
+#include <sstream>
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/buffer.hpp>
-#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
-#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mxfp4.hpp>
+#include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
+#include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+#include "tt_metal/impl/context/metal_context.hpp"
+#include "tt_metal/impl/data_format/mx_common.hpp"
 
 #include "device_fixture.hpp"
 
@@ -26,144 +38,371 @@ using std::vector;
 
 namespace unit_tests::llk::mxfp4_typecast {
 
+constexpr tt::tt_metal::mx::FormatParams kMxFp4Params = {
+	.block_size = 32,
+	.scale_bias = 0x7F,
+	.elem_exp_bits = 2,
+	.elem_man_bits = 1,
+	.elem_exp_bias = 1,
+	.elem_exp_max_unbiased = 2,
+	.elem_exp_min_unbiased = 0,
+	.elem_exp_subnorm_encoding = 0,
+	.elem_man_max = 0x1,
+	.elem_width_bits = 4,
+	.elem_width_storage_bits = 4,
+	.sat_supported = true,
+	.elem_sat_pos_bits = 0x7,
+	.elem_sat_neg_bits = 0xF,
+	.inf_rep = tt::tt_metal::mx::InfNanRep::NotRepresentable,
+	.nan_rep = tt::tt_metal::mx::InfNanRep::NotRepresentable,
+};
+
+static void dump_mxfp4_tile_exps(const vector<uint32_t>& packed, uint32_t tile_index, const char* label) {
+	if (std::getenv("TT_METAL_SKIP_MXFP4_EXPS") != nullptr) {
+		return;
+	}
+	if (packed.empty()) {
+		log_info(tt::LogTest, "{}: packed data empty", label);
+		return;
+	}
+	constexpr uint32_t kTileHW = 1024;
+	uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
+	auto word_counts = tt::tt_metal::mx::compute_tile_word_counts(kTileHW, l1_alignment, kMxFp4Params);
+	uint32_t words_per_tile = word_counts.exp_words + word_counts.elem_words;
+	size_t word_offset = static_cast<size_t>(tile_index) * words_per_tile;
+	if (packed.size() < word_offset + words_per_tile) {
+		log_info(
+			tt::LogTest,
+			"{}: tile_index {} out of range (packed words={}, words_per_tile={})",
+			label,
+			tile_index,
+			packed.size(),
+			words_per_tile);
+		return;
+	}
+
+	std::vector<uint8_t> exps;
+	tt::tt_metal::mx::unpack_exp_words(
+		tt::stl::make_const_span(packed), word_offset, word_counts.exp_words, word_counts.exp_count, exps);
+
+	const size_t to_print = std::min<size_t>(exps.size(), 32);
+	std::ostringstream oss;
+	for (size_t i = 0; i < to_print; ++i) {
+		if (i != 0) {
+			oss << " ";
+		}
+		oss << static_cast<int>(exps[i]);
+	}
+
+	tt::tt_metal::Tile tile;
+	uint32_t tile_size_api = tt::tile_size(tt::DataFormat::MxFp4);
+	uint32_t tile_size_hw = tile.get_tile_size(tt::DataFormat::MxFp4);
+	std::ostringstream header;
+	header << label << ": tile_index=" << tile_index
+	       << " exp_count=" << word_counts.exp_count
+	       << " exp_bytes=" << word_counts.exp_bytes
+	       << " exp_words=" << word_counts.exp_words
+	       << " elem_words=" << word_counts.elem_words
+	       << " l1_alignment=" << l1_alignment
+	       << " tile_size_api=" << tile_size_api
+	       << " tile_size_hw=" << tile_size_hw;
+	std::ostringstream line;
+	line << label << ": exps[0.." << (to_print > 0 ? to_print - 1 : 0) << "] = " << oss.str();
+	std::cout << header.str() << "\n" << line.str() << std::endl;
+	log_info(tt::LogTest, "{}", header.str());
+	log_info(tt::LogTest, "{}", line.str());
+}
+
+// Run a datacopy kernel with different input/output formats.
+// For Quasar, data is moved via DataflowBuffers (DFBs) and the hardware
+// unpacker/packer performs the format conversion implicitly.
 static vector<uint32_t> run_mxfp4_typecast(
-    IDevice* dev,
-    tt::DataFormat input_fmt,
-    tt::DataFormat output_fmt,
-    const vector<uint32_t>& src_vec,
-    uint32_t num_tiles) {
-    Program program = CreateProgram();
-    CoreCoord core = {0, 0};
+	IDevice* dev,
+	tt::DataFormat input_fmt,
+	tt::DataFormat output_fmt,
+	const vector<uint32_t>& src_vec,
+	uint32_t num_tiles,
+	bool fp32_dest_acc_en) {
+	Program program = CreateProgram();
+	CoreCoord core = {0, 0};
 
-    uint32_t input_tile_size = tt::tile_size(input_fmt);
-    uint32_t output_tile_size = tt::tile_size(output_fmt);
+	uint32_t input_tile_size = tt::tile_size(input_fmt);
+	uint32_t output_tile_size = tt::tile_size(output_fmt);
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = num_tiles * input_tile_size,
-        .page_size = input_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_buffer = CreateBuffer(src_config);
+	InterleavedBufferConfig src_config{
+		.device = dev,
+		.size = num_tiles * input_tile_size,
+		.page_size = input_tile_size,
+		.buffer_type = BufferType::DRAM};
+	auto src_buffer = CreateBuffer(src_config);
 
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = num_tiles * output_tile_size,
-        .page_size = output_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_buffer = CreateBuffer(dst_config);
+	InterleavedBufferConfig dst_config{
+		.device = dev,
+		.size = num_tiles * output_tile_size,
+		.page_size = output_tile_size,
+		.buffer_type = BufferType::DRAM};
+	auto dst_buffer = CreateBuffer(dst_config);
 
-    tt_metal::experimental::dfb::DataflowBufferConfig l1_input_dfb_config = {
-        .entry_size = input_tile_size,
-        .num_entries = 2,
-        .num_producers = 1,
-        .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = true,
-        .data_format = input_fmt};
+	// DFB configs for Quasar.
+	tt_metal::experimental::dfb::DataflowBufferConfig l1_input_dfb_config = {
+		.entry_size = input_tile_size,
+		.num_entries = 2,
+		.num_producers = 1,
+		.pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+		.num_consumers = 1,
+		.cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+		.enable_implicit_sync = true,
+		.data_format = input_fmt};
+	tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
+		.entry_size = output_tile_size,
+		.num_entries = 2,
+		.num_producers = 1,
+		.pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+		.num_consumers = 1,
+		.cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+		.enable_implicit_sync = true,
+		.data_format = output_fmt};
 
-    tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
-        .entry_size = output_tile_size,
-        .num_entries = 2,
-        .num_producers = 1,
-        .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = true,
-        .data_format = output_fmt};
+	uint32_t l1_input_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, l1_input_dfb_config);
+	uint32_t l1_output_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, l1_output_dfb_config);
 
-    uint32_t l1_input_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, l1_input_dfb_config);
-    uint32_t l1_output_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, l1_output_dfb_config);
+	KernelHandle reader = tt_metal::experimental::quasar::CreateKernel(
+		program,
+		"tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
+		core,
+		tt_metal::experimental::quasar::QuasarDataMovementConfig{
+			.num_threads_per_cluster = 1, .compile_args = {l1_input_dfb, /*use_dfbs=*/true}});
 
-    KernelHandle reader = tt_metal::experimental::quasar::CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
-        core,
-        tt_metal::experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 1, .compile_args = {l1_input_dfb, /*use_dfbs=*/1}});
+	KernelHandle writer = tt_metal::experimental::quasar::CreateKernel(
+		program,
+		"tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
+		core,
+		tt_metal::experimental::quasar::QuasarDataMovementConfig{
+			.num_threads_per_cluster = 1, .compile_args = {l1_output_dfb, /*use_dfbs=*/true}});
 
-    KernelHandle writer = tt_metal::experimental::quasar::CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
-        core,
-        tt_metal::experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 1, .compile_args = {l1_output_dfb, /*use_dfbs=*/1}});
+	KernelHandle compute = CreateKernel(
+		program,
+		"tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
+		core,
+		tt_metal::experimental::quasar::QuasarComputeConfig{
+			.num_threads_per_cluster = 1,
+			.fp32_dest_acc_en = fp32_dest_acc_en,
+			.compile_args = {num_tiles, /*use_dfbs=*/true}});
 
-    KernelHandle compute = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
-        core,
-        tt_metal::experimental::quasar::QuasarComputeConfig{
-            .num_threads_per_cluster = 1, .compile_args = {num_tiles, /*use_dfbs=*/1}});
+	tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_input_dfb, reader, compute);
+	tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_output_dfb, compute, writer);
 
-    tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_input_dfb, reader, compute);
-    tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_output_dfb, compute, writer);
+	detail::WriteToBuffer(src_buffer, src_vec);
+	SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
+	SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
 
-    detail::WriteToBuffer(src_buffer, src_vec);
-    SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
-    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
+	detail::LaunchProgram(dev, program, /*wait_for_completion=*/true);
 
-    detail::LaunchProgram(dev, program, true);
-
-    vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
-    return result_vec;
+	vector<uint32_t> result_vec;
+	detail::ReadFromBuffer(dst_buffer, result_vec);
+	return result_vec;
 }
 
+// Data generators follow the fp8_typecast tests' convention: generate
+// row-major floats in U(0, rand_max_float) + offset, then pack into tiles.
 static vector<uint32_t> create_random_vector_of_mxfp4(
-    uint32_t num_tiles, int rand_max_float, int seed, float offset = 0.0f) {
-    constexpr uint32_t tile_elements = 1024;
-    std::mt19937 rng(seed);
-    std::uniform_real_distribution<float> dist(0.0f, static_cast<float>(rand_max_float));
+	uint32_t num_bytes, int rand_max_float, int seed, float offset = 0.0f) {
+	uint32_t single_tile_size = tt::tile_size(tt::DataFormat::MxFp4);
+	TT_FATAL(
+		num_bytes % single_tile_size == 0,
+		"num_bytes {} must be divisible by MXFP4 tile_size {}",
+		num_bytes,
+		single_tile_size);
+	uint32_t num_tiles = num_bytes / single_tile_size;
 
-    vector<float> fp32_vec(num_tiles * tile_elements, 0.0f);
-    for (float& val : fp32_vec) {
-        val = dist(rng) + offset;
-    }
+	std::mt19937 rng(seed);
+	std::uniform_real_distribution<float> dist(0.0f, static_cast<float>(rand_max_float));
 
-    return pack_as_mxfp4_tiles(tt::stl::make_const_span(fp32_vec), /*row_major_input=*/true);
+	constexpr uint32_t kNumFloatsPerTile = 1024;
+	vector<float> fp32_vec(num_tiles * kNumFloatsPerTile);
+	for (float& v : fp32_vec) {
+		v = dist(rng) + offset;
+	}
+
+	vector<uint32_t> packed = pack_as_mxfp4_tiles(tt::stl::make_const_span(fp32_vec), /*row_major_input=*/true);
+	TT_FATAL(
+		packed.size() * sizeof(uint32_t) == num_tiles * single_tile_size,
+		"MXFP4 packed size {} bytes does not match expected {} bytes",
+		packed.size() * sizeof(uint32_t),
+		num_tiles * single_tile_size);
+	return packed;
 }
+
+// --- Format-to-float unpackers ---
 
 static vector<float> mxfp4_to_floats(const vector<uint32_t>& packed) {
-    return unpack_mxfp4_tiles_into_float_vec(tt::stl::make_const_span(packed), /*row_major_output=*/false);
+	return unpack_mxfp4_tiles_into_float_vec(tt::stl::make_const_span(packed), /*row_major_output=*/false);
 }
 
 static vector<float> bf16_to_floats(const vector<uint32_t>& packed) {
-    auto bf16_vec = unpack_uint32_vec_into_bfloat16_vec(packed);
-    vector<float> floats;
-    floats.reserve(bf16_vec.size());
-    for (const auto& v : bf16_vec) {
-        floats.push_back(static_cast<float>(v));
-    }
-    return floats;
+	auto bf16_vec = unpack_uint32_vec_into_bfloat16_vec(packed);
+	vector<float> floats;
+	floats.reserve(bf16_vec.size());
+	for (const auto& v : bf16_vec) {
+		floats.push_back(static_cast<float>(v));
+	}
+	return floats;
 }
 
+// --- Validation ---
+
 static bool check_floats_close(const vector<float>& a, const vector<float>& b, float rtol, float atol) {
-    if (a.size() != b.size()) {
-        return false;
-    }
-    for (size_t i = 0; i < a.size(); i++) {
-        if (!is_close(a[i], b[i], rtol, atol)) {
+	if (a.size() != b.size()) {
+		return false;
+	}
+	for (size_t i = 0; i < a.size(); i++) {
+		if (!is_close(a[i], b[i], rtol, atol)) {
+			log_info(tt::LogTest, "check_floats_close: mismatch at index {} - a[i] = {}, b[i] = {}", i, a[i], b[i]);
             return false;
-        }
-    }
-    return true;
+		}
+	}
+	return true;
+}
+
+static double compute_pcc(const vector<float>& a, const vector<float>& b) {
+	if (a.size() != b.size() || a.empty()) {
+		return 0.0;
+	}
+	const size_t n = a.size();
+	double sum_a = 0.0, sum_b = 0.0;
+	double sum_a2 = 0.0, sum_b2 = 0.0, sum_ab = 0.0;
+	for (size_t i = 0; i < n; i++) {
+		double ai = a[i], bi = b[i];
+		sum_a += ai;
+		sum_b += bi;
+		sum_a2 += ai * ai;
+		sum_b2 += bi * bi;
+		sum_ab += ai * bi;
+	}
+	double denom_a = (n * sum_a2) - (sum_a * sum_a);
+	double denom_b = (n * sum_b2) - (sum_b * sum_b);
+	if (denom_a == 0.0 || denom_b == 0.0) {
+		return 1.0;
+	}
+	return (n * sum_ab - sum_a * sum_b) / std::sqrt(denom_a * denom_b);
+}
+
+static bool check_pcc(const vector<float>& a, const vector<float>& b, double min_pcc) {
+	double pcc = compute_pcc(a, b);
+	if (pcc < min_pcc) {
+		log_info(tt::LogTest, "check_pcc: PCC = {} < min_pcc = {}", pcc, min_pcc);
+		return false;
+	}
+	return true;
 }
 
 }  // namespace unit_tests::llk::mxfp4_typecast
 
-using namespace unit_tests::llk::mxfp4_typecast;
+namespace mxfp4_tc = unit_tests::llk::mxfp4_typecast;
 
-TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMxFp4ToFloat16b) {
-    IDevice* dev = devices_[0]->get_devices()[0];
-    constexpr uint32_t num_tiles = 16;
-    auto src_vec = create_random_vector_of_mxfp4(num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+// ============================================================================
+// MXFP4 → Float16_b
+// Widening conversion: every MXFP4 value should be representable in BF16.
+// Expected: no precision loss → rtol=0.0, atol=0.0.
+// ============================================================================
 
-    auto result_vec = run_mxfp4_typecast(dev, tt::DataFormat::MxFp4, tt::DataFormat::Float16_b, src_vec, num_tiles);
+TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16b) {
+	IDevice* dev = devices_[0]->get_devices()[0];
+	constexpr uint32_t num_tiles = 64;
+	auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
+		tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+	auto result_vec = mxfp4_tc::run_mxfp4_typecast(
+		dev, tt::DataFormat::MxFp4, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+	auto src_floats = mxfp4_tc::mxfp4_to_floats(src_vec);
+	auto dst_floats = mxfp4_tc::bf16_to_floats(result_vec);
+	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
 
-    auto src_floats = mxfp4_to_floats(src_vec);
-    auto dst_floats = bf16_to_floats(result_vec);
-    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16bFp32Dest) {
+	IDevice* dev = devices_[0]->get_devices()[0];
+	constexpr uint32_t num_tiles = 64;
+	auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
+		tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+	auto result_vec = mxfp4_tc::run_mxfp4_typecast(
+		dev, tt::DataFormat::MxFp4, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+	auto src_floats = mxfp4_tc::mxfp4_to_floats(src_vec);
+	auto dst_floats = mxfp4_tc::bf16_to_floats(result_vec);
+	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+// ============================================================================
+// Float16_b → MXFP4
+// Narrowing conversion: BF16 → MXFP4 introduces quantization.
+// Tolerances are intentionally loose to account for block-scaling behavior.
+// ============================================================================
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4) {
+	IDevice* dev = devices_[0]->get_devices()[0];
+	constexpr uint32_t num_tiles = 64;
+	auto src_vec = create_random_vector_of_bfloat16(
+		tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+	auto result_vec = mxfp4_tc::run_mxfp4_typecast(
+		dev, tt::DataFormat::Float16_b, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+	mxfp4_tc::dump_mxfp4_tile_exps(result_vec, 0, "Float16b->MxFp4 tile0");
+	uint32_t debug_tile_index = num_tiles > 52 ? 52 : 0;
+	if (debug_tile_index != 0) {
+		mxfp4_tc::dump_mxfp4_tile_exps(result_vec, debug_tile_index, "Float16b->MxFp4 tile52");
+	}
+	auto src_floats = mxfp4_tc::bf16_to_floats(src_vec);
+	auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
+	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.5f, /*atol=*/0.5f));
+	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/0.98));
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4Fp32Dest) {
+	IDevice* dev = devices_[0]->get_devices()[0];
+	constexpr uint32_t num_tiles = 64;
+	auto src_vec = create_random_vector_of_bfloat16(
+		tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+	auto result_vec = mxfp4_tc::run_mxfp4_typecast(
+		dev, tt::DataFormat::Float16_b, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+	mxfp4_tc::dump_mxfp4_tile_exps(result_vec, 0, "Float16b->MxFp4Fp32Dest tile0");
+	uint32_t debug_tile_index = num_tiles > 52 ? 52 : 0;
+	if (debug_tile_index != 0) {
+		mxfp4_tc::dump_mxfp4_tile_exps(result_vec, debug_tile_index, "Float16b->MxFp4Fp32Dest tile52");
+	}
+	auto src_floats = mxfp4_tc::bf16_to_floats(src_vec);
+	auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
+	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.5f, /*atol=*/0.5f));
+	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/0.98));
+}
+
+// ============================================================================
+// MXFP4 → MXFP4 (identity)
+// Same format on both sides. The round-trip should be lossless.
+// ============================================================================
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4) {
+	IDevice* dev = devices_[0]->get_devices()[0];
+	constexpr uint32_t num_tiles = 64;
+	auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
+		tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+	auto result_vec = mxfp4_tc::run_mxfp4_typecast(
+		dev, tt::DataFormat::MxFp4, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+	auto src_floats = mxfp4_tc::mxfp4_to_floats(src_vec);
+	auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
+	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4Fp32Dest) {
+	IDevice* dev = devices_[0]->get_devices()[0];
+	constexpr uint32_t num_tiles = 64;
+	auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
+		tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+	auto result_vec = mxfp4_tc::run_mxfp4_typecast(
+		dev, tt::DataFormat::MxFp4, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+	auto src_floats = mxfp4_tc::mxfp4_to_floats(src_vec);
+	auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
+	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mxfp4.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt_stl/span.hpp>
+
+#include "device_fixture.hpp"
+
+namespace tt::tt_metal {
+
+using std::vector;
+
+namespace unit_tests::llk::mxfp4_typecast {
+
+static vector<uint32_t> run_mxfp4_typecast(
+    IDevice* dev,
+    tt::DataFormat input_fmt,
+    tt::DataFormat output_fmt,
+    const vector<uint32_t>& src_vec,
+    uint32_t num_tiles) {
+    Program program = CreateProgram();
+    CoreCoord core = {0, 0};
+
+    uint32_t input_tile_size = tt::tile_size(input_fmt);
+    uint32_t output_tile_size = tt::tile_size(output_fmt);
+
+    InterleavedBufferConfig src_config{
+        .device = dev,
+        .size = num_tiles * input_tile_size,
+        .page_size = input_tile_size,
+        .buffer_type = BufferType::DRAM};
+    auto src_buffer = CreateBuffer(src_config);
+
+    InterleavedBufferConfig dst_config{
+        .device = dev,
+        .size = num_tiles * output_tile_size,
+        .page_size = output_tile_size,
+        .buffer_type = BufferType::DRAM};
+    auto dst_buffer = CreateBuffer(dst_config);
+
+    tt_metal::experimental::dfb::DataflowBufferConfig l1_input_dfb_config = {
+        .entry_size = input_tile_size,
+        .num_entries = 2,
+        .num_producers = 1,
+        .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = true,
+        .data_format = input_fmt};
+
+    tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
+        .entry_size = output_tile_size,
+        .num_entries = 2,
+        .num_producers = 1,
+        .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = true,
+        .data_format = output_fmt};
+
+    uint32_t l1_input_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, l1_input_dfb_config);
+    uint32_t l1_output_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, l1_output_dfb_config);
+
+    KernelHandle reader = tt_metal::experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
+        core,
+        tt_metal::experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1, .compile_args = {l1_input_dfb, /*use_dfbs=*/1}});
+
+    KernelHandle writer = tt_metal::experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
+        core,
+        tt_metal::experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1, .compile_args = {l1_output_dfb, /*use_dfbs=*/1}});
+
+    KernelHandle compute = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
+        core,
+        tt_metal::experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 1, .compile_args = {num_tiles, /*use_dfbs=*/1}});
+
+    tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_input_dfb, reader, compute);
+    tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_output_dfb, compute, writer);
+
+    detail::WriteToBuffer(src_buffer, src_vec);
+    SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
+    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
+
+    detail::LaunchProgram(dev, program, true);
+
+    vector<uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_buffer, result_vec);
+    return result_vec;
+}
+
+static vector<uint32_t> create_random_vector_of_mxfp4(
+    uint32_t num_tiles, int rand_max_float, int seed, float offset = 0.0f) {
+    constexpr uint32_t tile_elements = 1024;
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(0.0f, static_cast<float>(rand_max_float));
+
+    vector<float> fp32_vec(num_tiles * tile_elements, 0.0f);
+    for (float& val : fp32_vec) {
+        val = dist(rng) + offset;
+    }
+
+    return pack_as_mxfp4_tiles(tt::stl::make_const_span(fp32_vec), /*row_major_input=*/true);
+}
+
+static vector<float> mxfp4_to_floats(const vector<uint32_t>& packed) {
+    return unpack_mxfp4_tiles_into_float_vec(tt::stl::make_const_span(packed), /*row_major_output=*/false);
+}
+
+static vector<float> bf16_to_floats(const vector<uint32_t>& packed) {
+    auto bf16_vec = unpack_uint32_vec_into_bfloat16_vec(packed);
+    vector<float> floats;
+    floats.reserve(bf16_vec.size());
+    for (const auto& v : bf16_vec) {
+        floats.push_back(static_cast<float>(v));
+    }
+    return floats;
+}
+
+static bool check_floats_close(const vector<float>& a, const vector<float>& b, float rtol, float atol) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.size(); i++) {
+        if (!is_close(a[i], b[i], rtol, atol)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace unit_tests::llk::mxfp4_typecast
+
+using namespace unit_tests::llk::mxfp4_typecast;
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMxFp4ToFloat16b) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 16;
+    auto src_vec = create_random_vector_of_mxfp4(num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+
+    auto result_vec = run_mxfp4_typecast(dev, tt::DataFormat::MxFp4, tt::DataFormat::Float16_b, src_vec, num_tiles);
+
+    auto src_floats = mxfp4_to_floats(src_vec);
+    auto dst_floats = bf16_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -219,6 +219,96 @@ static bool check_pcc(const vector<float>& a, const vector<float>& b, double min
 	return true;
 }
 
+// --- Special-case rule testing infrastructure ---
+//
+// Helpers for hand-crafting raw MXFP4 tile bytes and reading raw BF16 outputs.
+// Used to verify hardware spec rules (block-exp = 0xFF, "leave as is" for
+// unit_exp = all-1, over/underflow) that random-data tests don't exercise.
+
+struct TileLayout {
+    size_t total_words = 0;
+    size_t exp_bytes = 0;  // byte offset where the elem region begins
+};
+
+// Pack an all-zero tile to discover the runtime tile layout (which depends on
+// HAL L1 alignment), then derive exp_bytes from the resulting word count.
+static TileLayout get_mxfp4_tile_layout() {
+    constexpr uint32_t kTileHW = 1024;
+    std::vector<float> zeros(kTileHW, 0.0f);
+    auto packed = pack_as_mxfp4_tiles(tt::stl::make_const_span(zeros), /*row_major_input=*/true);
+    const size_t elem_words = kTileHW / 8;  // 8 nibbles per uint32
+    const size_t exp_words = packed.size() - elem_words;
+    return TileLayout{.total_words = packed.size(), .exp_bytes = exp_words * 4};
+}
+
+struct ScalePatch {
+    uint32_t block_idx;
+    uint8_t scale_byte;
+};
+struct ElemPatch {
+    uint32_t elem_idx;
+    uint8_t elem_nibble;  // low 4 bits used
+};
+
+// Build a single-tile packed MXFP4 buffer: all 32 scale bytes set to
+// scale_default, all 1024 elem nibbles set to elem_nibble_default, then
+// patches applied. elem_idx is in face-major order; even indices live in
+// the low nibble of their byte, odd indices in the high nibble.
+static vector<uint32_t> build_mxfp4_tile_raw(
+    const TileLayout& layout,
+    uint8_t scale_default,
+    uint8_t elem_nibble_default,
+    std::initializer_list<ScalePatch> scale_patches,
+    std::initializer_list<ElemPatch> elem_patches) {
+    vector<uint32_t> packed(layout.total_words, 0);
+    auto* bytes = reinterpret_cast<uint8_t*>(packed.data());
+    for (uint32_t s = 0; s < 32; ++s) {
+        bytes[s] = scale_default;
+    }
+    const uint8_t default_byte =
+        static_cast<uint8_t>((elem_nibble_default & 0x0F) | ((elem_nibble_default & 0x0F) << 4));
+    for (uint32_t b = 0; b < 512; ++b) {
+        bytes[layout.exp_bytes + b] = default_byte;
+    }
+    for (const auto& p : scale_patches) {
+        TT_FATAL(p.block_idx < 32, "block_idx {} out of range", p.block_idx);
+        bytes[p.block_idx] = p.scale_byte;
+    }
+    for (const auto& p : elem_patches) {
+        TT_FATAL(p.elem_idx < 1024, "elem_idx {} out of range", p.elem_idx);
+        const uint32_t byte_idx = p.elem_idx / 2;
+        const uint32_t shift = (p.elem_idx % 2) * 4;
+        const uint8_t nib = p.elem_nibble & 0x0F;
+        const uint32_t off = layout.exp_bytes + byte_idx;
+        bytes[off] = static_cast<uint8_t>((bytes[off] & ~(0x0Fu << shift)) | (static_cast<uint32_t>(nib) << shift));
+    }
+    return packed;
+}
+
+// Extract raw BF16 bits at face-major position `i` from a packed BF16 readback.
+// BF16 readback packs two values per uint32 (LSB = lower index, MSB = higher).
+static uint16_t bf16_raw_at(const vector<uint32_t>& packed, uint32_t i) {
+    return static_cast<uint16_t>((packed[i / 2] >> ((i % 2) * 16)) & 0xFFFFu);
+}
+
+enum class Bf16Class { Zero, Subnormal, Normal, PosInf, NegInf, NaN };
+
+static Bf16Class classify_bf16(uint16_t bits) {
+    uint16_t sign = (bits >> 15) & 0x1u;
+    uint16_t exp = (bits >> 7) & 0xFFu;
+    uint16_t mant = bits & 0x7Fu;
+    if (exp == 0xFF) {
+        if (mant == 0) {
+            return sign ? Bf16Class::NegInf : Bf16Class::PosInf;
+        }
+        return Bf16Class::NaN;
+    }
+    if (exp == 0) {
+        return mant == 0 ? Bf16Class::Zero : Bf16Class::Subnormal;
+    }
+    return Bf16Class::Normal;
+}
+
 }  // namespace unit_tests::llk::mxfp4_typecast
 
 namespace mxfp4_tc = unit_tests::llk::mxfp4_typecast;
@@ -316,6 +406,81 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4Fp32Dest) {
 	auto dst_floats = mxfp4_tc::mxfp4_to_floats(result_vec);
 	EXPECT_TRUE(mxfp4_tc::check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
 	EXPECT_TRUE(mxfp4_tc::check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+// ============================================================================
+// Device special-case tests for hardware MXFP4 → BF16 typecast.
+// MXFP4 (E2M1) is finite-only — every "unit_exp = all 1" pattern is a normal
+// finite value (4.0 or 6.0 with sign), so spec rule "leave as is" applies to
+// all such elements. Block-exp = 0xFF still emits NaN; over/underflow follow
+// BF16 saturation.
+//
+// Nibble legend (sign:1 exp:2 mant:1, bias=1):
+//   0x0 = +0          0x8 = -0
+//   0x1 = +0.5 sub    0x9 = -0.5 sub
+//   0x2 = +1.0        0xA = -1.0
+//   0x3 = +1.5        0xB = -1.5
+//   0x4 = +2.0        0xC = -2.0
+//   0x5 = +3.0        0xD = -3.0
+//   0x6 = +4.0  (unit exp=all 1, mant=0) "leave as is"
+//   0x7 = +6.0  (unit exp=all 1, mant=1) max normal, "leave as is"
+//   0xE = -4.0
+//   0xF = -6.0
+// ============================================================================
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToBf16SpecialCases) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    auto layout = mxfp4_tc::get_mxfp4_tile_layout();
+
+    // Block 0: scale = 0xFF → all 32 elements should be NaN (rule 1).
+    // Block 1: scale = 1. elem 32-35: 0x6, 0x7, 0xE, 0xF — every "unit exp =
+    //          all 1" pattern (mant=0 / mant=all 1, both signs). All should
+    //          appear in BF16 unchanged.
+    // Block 2: scale = 2^127 (block_exp_biased=0xFE). elem 64-65: ±max normal
+    //          → 6.0 * 2^127 ≈ 2^129.6, overflows BF16 → ±Inf.
+    // Block 3: scale = 1. elem 96: 0x2 (+1.0) — sanity, must remain finite.
+    // Block 4: scale = 2^-127 (block_exp_biased=0x00). elem 128-129: ±0.5
+    //          subnormal → ±2^-128, below BF16 normal range. Rule 3
+    //          ("< -127 → Zero") expects flush; if silicon retains BF16
+    //          subnormal precision instead, that's still spec-conformant
+    //          for fp32-range arithmetic, so accept either.
+    auto packed = mxfp4_tc::build_mxfp4_tile_raw(
+        layout,
+        /*scale_default=*/0x7F,
+        /*elem_nibble_default=*/0x0,
+        {{0, 0xFF}, {1, 0x7F}, {2, 0xFE}, {3, 0x7F}, {4, 0x00}},
+        {{32, 0x6}, {33, 0x7}, {34, 0xE}, {35, 0xF}, {64, 0x7}, {65, 0xF}, {96, 0x2}, {128, 0x1}, {129, 0x9}});
+
+    auto result = mxfp4_tc::run_mxfp4_typecast(
+        dev,
+        tt::DataFormat::MxFp4,
+        tt::DataFormat::Float16_b,
+        packed,
+        /*num_tiles=*/1,
+        /*fp32_dest_acc_en=*/false);
+
+    using Cls = mxfp4_tc::Bf16Class;
+    for (uint32_t i = 0; i < 32; ++i) {
+        EXPECT_EQ(mxfp4_tc::classify_bf16(mxfp4_tc::bf16_raw_at(result, i)), Cls::NaN)
+            << "block 0 (NaN-scale) elem " << i;
+    }
+    EXPECT_EQ(mxfp4_tc::bf16_raw_at(result, 32), 0x4080u);  // +4.0
+    EXPECT_EQ(mxfp4_tc::bf16_raw_at(result, 33), 0x40C0u);  // +6.0
+    EXPECT_EQ(mxfp4_tc::bf16_raw_at(result, 34), 0xC080u);  // -4.0
+    EXPECT_EQ(mxfp4_tc::bf16_raw_at(result, 35), 0xC0C0u);  // -6.0
+    EXPECT_EQ(mxfp4_tc::classify_bf16(mxfp4_tc::bf16_raw_at(result, 64)), Cls::PosInf);
+    EXPECT_EQ(mxfp4_tc::classify_bf16(mxfp4_tc::bf16_raw_at(result, 65)), Cls::NegInf);
+    EXPECT_EQ(mxfp4_tc::bf16_raw_at(result, 96), 0x3F80u);  // +1.0
+    {
+        const auto bits_pos = mxfp4_tc::bf16_raw_at(result, 128);
+        const auto cls_pos = mxfp4_tc::classify_bf16(bits_pos);
+        EXPECT_TRUE(cls_pos == Cls::Zero || cls_pos == Cls::Subnormal)
+            << "elem 128 expected Zero/Subnormal, got bits=0x" << std::hex << bits_pos;
+        const auto bits_neg = mxfp4_tc::bf16_raw_at(result, 129);
+        const auto cls_neg = mxfp4_tc::classify_bf16(bits_neg);
+        EXPECT_TRUE(cls_neg == Cls::Zero || cls_neg == Cls::Subnormal)
+            << "elem 129 expected Zero/Subnormal, got bits=0x" << std::hex << bits_neg;
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -471,16 +471,15 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToBf16SpecialCases) {
     EXPECT_EQ(mxfp4_tc::classify_bf16(mxfp4_tc::bf16_raw_at(result, 64)), Cls::PosInf);
     EXPECT_EQ(mxfp4_tc::classify_bf16(mxfp4_tc::bf16_raw_at(result, 65)), Cls::NegInf);
     EXPECT_EQ(mxfp4_tc::bf16_raw_at(result, 96), 0x3F80u);  // +1.0
-    {
-        const auto bits_pos = mxfp4_tc::bf16_raw_at(result, 128);
-        const auto cls_pos = mxfp4_tc::classify_bf16(bits_pos);
-        EXPECT_TRUE(cls_pos == Cls::Zero || cls_pos == Cls::Subnormal)
-            << "elem 128 expected Zero/Subnormal, got bits=0x" << std::hex << bits_pos;
-        const auto bits_neg = mxfp4_tc::bf16_raw_at(result, 129);
-        const auto cls_neg = mxfp4_tc::classify_bf16(bits_neg);
-        EXPECT_TRUE(cls_neg == Cls::Zero || cls_neg == Cls::Subnormal)
-            << "elem 129 expected Zero/Subnormal, got bits=0x" << std::hex << bits_neg;
-    }
+
+    const auto bits_pos = mxfp4_tc::bf16_raw_at(result, 128);
+    const auto cls_pos = mxfp4_tc::classify_bf16(bits_pos);
+    EXPECT_TRUE(cls_pos == Cls::Zero || cls_pos == Cls::Subnormal)
+        << "elem 128 expected Zero/Subnormal, got bits=0x" << std::hex << bits_pos;
+    const auto bits_neg = mxfp4_tc::bf16_raw_at(result, 129);
+    const auto cls_neg = mxfp4_tc::classify_bf16(bits_neg);
+    EXPECT_TRUE(cls_neg == Cls::Zero || cls_neg == Cls::Subnormal)
+        << "elem 129 expected Zero/Subnormal, got bits=0x" << std::hex << bits_neg;
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -667,8 +667,16 @@ static void run_quasar_tilize_untilize_test(
     }
     detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-    SetRuntimeArgs(program, reader, core, {dram_buffer_src_addr, (uint32_t)0, num_tiles});
-    SetRuntimeArgs(program, writer, core, {dram_buffer_dst_addr, (uint32_t)0, num_tiles});
+    SetRuntimeArgs(
+        program,
+        reader,
+        core,
+        {dram_buffer_src_addr, (uint32_t)0, num_tiles, (uint32_t)src_dram_buffer->aligned_page_size()});
+    SetRuntimeArgs(
+        program,
+        writer,
+        core,
+        {dram_buffer_dst_addr, (uint32_t)0, num_tiles, (uint32_t)dst_dram_buffer->aligned_page_size()});
 
     detail::LaunchProgram(dev, program, true);
 

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -667,16 +667,13 @@ static void run_quasar_tilize_untilize_test(
     }
     detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-    SetRuntimeArgs(
-        program,
-        reader,
-        core,
-        {dram_buffer_src_addr, (uint32_t)0, num_tiles, (uint32_t)src_dram_buffer->aligned_page_size()});
-    SetRuntimeArgs(
-        program,
-        writer,
-        core,
-        {dram_buffer_dst_addr, (uint32_t)0, num_tiles, (uint32_t)dst_dram_buffer->aligned_page_size()});
+    // This test configures the DRAM buffers as a single whole-buffer page, so
+    // aligned_page_size() returns the whole-buffer stride rather than per-tile.
+    // Compute the real per-tile DRAM stride directly from the buffer size.
+    const uint32_t src_tile_stride_bytes = src_dram_buffer_size / num_tiles;
+    const uint32_t dst_tile_stride_bytes = dst_dram_buffer_size / num_tiles;
+    SetRuntimeArgs(program, reader, core, {dram_buffer_src_addr, (uint32_t)0, num_tiles, src_tile_stride_bytes});
+    SetRuntimeArgs(program, writer, core, {dram_buffer_dst_addr, (uint32_t)0, num_tiles, dst_tile_stride_bytes});
 
     detail::LaunchProgram(dev, program, true);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -19,6 +19,13 @@ void kernel_main() {
     uint32_t src_addr  = get_arg_val<uint32_t>(0); // global base address
     uint32_t src_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    // DRAM page stride: the allocator may round page_size up (e.g. to
+    // NOC_DRAM_READ_ALIGNMENT_BYTES = 64 on Quasar), so tiles are spaced
+    // further apart in DRAM than their native size. Callers pass
+    // Buffer::aligned_page_size() here; the kernel advances the DRAM
+    // pointer by this stride while the DFB/CB still streams native-size
+    // tiles into L1.
+    uint32_t dram_page_stride = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t ublock_size_tiles = 1;
 
@@ -34,7 +41,7 @@ void kernel_main() {
     if constexpr (use_dfbs) {
         experimental::DataflowBuffer dfb(cb_id);
         uint32_t ublock_size_bytes = dfb.get_entry_size();
-        uint32_t tlocal_src_addr = src_addr + (producer_idx * ublock_size_bytes);
+        uint32_t tlocal_src_addr = src_addr + (producer_idx * dram_page_stride);
 
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
 #ifdef ARCH_QUASAR
@@ -45,7 +52,7 @@ void kernel_main() {
             noc.async_read_barrier();
             dfb.push_back(ublock_size_tiles);
 #endif
-            tlocal_src_addr += dfb.get_stride_size();
+            tlocal_src_addr += dram_page_stride;
         }
         dfb.finish();
     }
@@ -59,7 +66,7 @@ void kernel_main() {
             noc.async_read(src_dram, cb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = src_addr}, {});
             noc.async_read_barrier();
             cb.push_back(ublock_size_tiles);
-            src_addr += ublock_size_bytes;
+            src_addr += dram_page_stride;
         }
     }
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -41,6 +41,11 @@ void kernel_main() {
     if constexpr (use_dfbs) {
         experimental::DataflowBuffer dfb(cb_id);
         uint32_t ublock_size_bytes = dfb.get_entry_size();
+        // stride_factor = stride_in_entries: how many entry-sized slots one
+        // producer skips per tile. For a DFB with N producers interleaved
+        // round-robin, stride_factor = N, and each producer walks DRAM tiles
+        // [producer_idx, producer_idx+N, producer_idx+2N, ...].
+        uint32_t stride_factor = dfb.get_stride_size() / ublock_size_bytes;
         uint32_t tlocal_src_addr = src_addr + (producer_idx * dram_page_stride);
 
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
@@ -52,7 +57,7 @@ void kernel_main() {
             noc.async_read_barrier();
             dfb.push_back(ublock_size_tiles);
 #endif
-            tlocal_src_addr += dram_page_stride;
+            tlocal_src_addr += dram_page_stride * stride_factor;
         }
         dfb.finish();
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -17,10 +17,12 @@ void kernel_main() {
     uint32_t dst_addr  = get_arg_val<uint32_t>(0); // global base address
     uint32_t dst_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    // See direct_reader_unary.cpp for why this is separate from the DFB
-    // entry size: the DRAM allocator may round page_size up to NoC DRAM
-    // alignment, so DRAM stride can exceed native tile size. Callers pass
-    // Buffer::aligned_page_size() here.
+    // DRAM page stride: the allocator may round page_size up (e.g. to
+    // NOC_DRAM_READ_ALIGNMENT_BYTES = 64 on Quasar), so tiles are spaced
+    // further apart in DRAM than their native size. Callers pass
+    // Buffer::aligned_page_size() here; the kernel advances the DRAM
+    // pointer by this stride while the DFB/CB still streams native-size
+    // tiles into L1.
     uint32_t dram_page_stride = get_arg_val<uint32_t>(3);
 
     uint32_t ublock_size_tiles = 1;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -40,6 +40,11 @@ void kernel_main() {
     if constexpr (use_dfbs) {
         experimental::DataflowBuffer dfb(cb_id);
         uint32_t ublock_size_bytes = dfb.get_entry_size();
+        // stride_factor = stride_in_entries: how many entry-sized slots one
+        // consumer skips per tile. For a DFB with N consumers interleaved
+        // round-robin, stride_factor = N, and each consumer walks DRAM tiles
+        // [consumer_idx, consumer_idx+N, consumer_idx+2N, ...].
+        uint32_t stride_factor = dfb.get_stride_size() / ublock_size_bytes;
 
         uint32_t tlocal_dst_addr = dst_addr + (consumer_idx * dram_page_stride);
 
@@ -52,7 +57,7 @@ void kernel_main() {
             noc.async_write_barrier();
             dfb.pop_front(ublock_size_tiles);
 #endif
-            tlocal_dst_addr += dram_page_stride;
+            tlocal_dst_addr += dram_page_stride * stride_factor;
         }
 
         dfb.finish();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -17,6 +17,11 @@ void kernel_main() {
     uint32_t dst_addr  = get_arg_val<uint32_t>(0); // global base address
     uint32_t dst_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    // See direct_reader_unary.cpp for why this is separate from the DFB
+    // entry size: the DRAM allocator may round page_size up to NoC DRAM
+    // alignment, so DRAM stride can exceed native tile size. Callers pass
+    // Buffer::aligned_page_size() here.
+    uint32_t dram_page_stride = get_arg_val<uint32_t>(3);
 
     uint32_t ublock_size_tiles = 1;
 
@@ -34,7 +39,7 @@ void kernel_main() {
         experimental::DataflowBuffer dfb(cb_id);
         uint32_t ublock_size_bytes = dfb.get_entry_size();
 
-        uint32_t tlocal_dst_addr = dst_addr + (consumer_idx * ublock_size_bytes);
+        uint32_t tlocal_dst_addr = dst_addr + (consumer_idx * dram_page_stride);
 
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
 #ifdef ARCH_QUASAR
@@ -45,7 +50,7 @@ void kernel_main() {
             noc.async_write_barrier();
             dfb.pop_front(ublock_size_tiles);
 #endif
-            tlocal_dst_addr += dfb.get_stride_size();
+            tlocal_dst_addr += dram_page_stride;
         }
 
         dfb.finish();
@@ -64,7 +69,7 @@ void kernel_main() {
             noc.async_write(cb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = dst_addr});
             noc.async_write_barrier();
             cb.pop_front(ublock_size_tiles);
-            dst_addr += ublock_size_bytes;
+            dst_addr += dram_page_stride;
         }
     }
 #endif

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -109,8 +109,16 @@ static void run_pack_relu_test(IDevice* dev, uint32_t relu_config, const std::fu
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 1.0f, 0xCAFE);
     detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-    SetRuntimeArgs(program, reader, core, {dram_buffer_src_addr, 0, num_tiles});
-    SetRuntimeArgs(program, writer, core, {dram_buffer_dst_addr, 0, num_tiles});
+    SetRuntimeArgs(
+        program,
+        reader,
+        core,
+        {dram_buffer_src_addr, 0, num_tiles, static_cast<uint32_t>(src_dram_buffer->aligned_page_size())});
+    SetRuntimeArgs(
+        program,
+        writer,
+        core,
+        {dram_buffer_dst_addr, 0, num_tiles, static_cast<uint32_t>(dst_dram_buffer->aligned_page_size())});
     SetRuntimeArgs(program, compute, core, {relu_config});
 
     detail::LaunchProgram(dev, program, true);

--- a/tt_metal/api/tt-metalium/mxfp4.hpp
+++ b/tt_metal/api/tt-metalium/mxfp4.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/tile.hpp>
+#include <tt_stl/span.hpp>
+
+#include <optional>
+#include <vector>
+
+template <typename T>
+std::vector<uint32_t> pack_as_mxfp4_tiles(
+    tt::stl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
+
+std::vector<float> unpack_mxfp4_tiles_into_float_vec(
+    tt::stl::Span<const uint32_t> mxfp4_tiles,
+    bool row_major_output,
+    const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -33,6 +33,7 @@ enum class DataFormat : uint8_t {
     Bfp2_b = 15,
     Lf8 = 10,
     Fp8_e4m3 = 26,
+    MxFp4 = 22,
     Int8 = 14,
     Tf32 = 4,
     UInt8 = 30,
@@ -66,6 +67,7 @@ constexpr static uint32_t datum_size(const DataFormat& format) {
         case DataFormat::Bfp4_b:
         case DataFormat::Bfp8:
         case DataFormat::Bfp8_b: throw std::invalid_argument("datum for bfp2, bfp4, bfp8 is invalid");
+        case DataFormat::MxFp4: throw std::invalid_argument("datum for mxfp4 is invalid");
         case DataFormat::Float16:
         case DataFormat::Float16_b: return 2;
         case DataFormat::Float32: return 4;
@@ -103,6 +105,7 @@ constexpr static uint32_t tile_size(const DataFormat& format) {
         case DataFormat::Bfp4_b: return (128 * 4) + (16 * 4);
         case DataFormat::Bfp8:
         case DataFormat::Bfp8_b: return (256 * 4) + (16 * 4);
+        case DataFormat::MxFp4: return (1024 / 2) + 32;
         case DataFormat::Float16:
         case DataFormat::Float16_b: return (1024 * 2);
         case DataFormat::Float32: return (1024 * 4);

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -105,7 +105,7 @@ constexpr static uint32_t tile_size(const DataFormat& format) {
         case DataFormat::Bfp4_b: return (128 * 4) + (16 * 4);
         case DataFormat::Bfp8:
         case DataFormat::Bfp8_b: return (256 * 4) + (16 * 4);
-        case DataFormat::MxFp4: return (1024 / 2) + 32;
+        case DataFormat::MxFp4: return (1024 / 2) + 32;  // 544 bytes: 32 scales (1 per 32-elem block) + 512 data
         case DataFormat::Float16:
         case DataFormat::Float16_b: return (1024 * 2);
         case DataFormat::Float32: return (1024 * 4);

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -99,6 +99,7 @@ bool is_supported_quasar(tt::DataFormat format) {
         case tt::DataFormat::Int16:
         case tt::DataFormat::Int32:
         case tt::DataFormat::Lf8:
+        case tt::DataFormat::MxFp4:
         case tt::DataFormat::RawUInt8:
         case tt::DataFormat::RawUInt16:
         case tt::DataFormat::RawUInt32:

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -135,6 +135,7 @@ std::ostream& tt::operator<<(std::ostream& os, const DataFormat& format) {
         case DataFormat::UInt8: os << "UInt8"; break;
         case DataFormat::Lf8: os << "Lf8"; break;
         case DataFormat::Fp8_e4m3: os << "Fp8_e4m3"; break;
+        case DataFormat::MxFp4: os << "MxFp4"; break;
         case DataFormat::UInt16: os << "UInt16"; break;
         case DataFormat::Int16: os << "Int16"; break;
         case DataFormat::UInt32: os << "UInt32"; break;

--- a/tt_metal/impl/data_format/mx_common.cpp
+++ b/tt_metal/impl/data_format/mx_common.cpp
@@ -1,0 +1,378 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mx_common.hpp"
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <limits>
+
+#include <tt_stl/assert.hpp>
+
+#include "math.hpp"
+
+namespace tt::tt_metal::mx {
+
+RoundResult round_ties_even(uint32_t input_mantissa, int output_width, int input_width) {
+    if (output_width < 0) {
+        return {0, 0};
+    }
+    if (input_width == output_width) {
+        return {input_mantissa, 0};
+    }
+    const int shift_out = input_width - output_width;
+    if (shift_out <= 0) {
+        uint32_t mask = (output_width >= 32) ? 0xFFFFFFFFu : ((1u << output_width) - 1u);
+        return {input_mantissa & mask, 0};
+    }
+    uint32_t rounded_bits = input_mantissa & ((1u << shift_out) - 1u);
+    uint32_t rounded_msb = (rounded_bits >> (shift_out - 1)) & 0x1u;
+    uint32_t rounded_lsbs = rounded_bits & ((1u << (shift_out - 1)) - 1u);
+    uint32_t mantissa_lsb = (input_mantissa >> shift_out) & 0x1u;
+
+    uint32_t round_inc = 0;
+    if (rounded_msb && rounded_lsbs != 0) {
+        round_inc = 1;
+    } else if (rounded_msb && rounded_lsbs == 0) {
+        round_inc = mantissa_lsb;
+    }
+
+    if (output_width == 0) {
+        round_inc = (rounded_msb && rounded_lsbs != 0) ? 1 : 0;
+        output_width = 1;
+    }
+
+    uint32_t new_mantissa = (input_mantissa >> shift_out) + round_inc;
+    uint32_t mask = (output_width >= 32) ? 0xFFFFFFFFu : ((1u << output_width) - 1u);
+    return {new_mantissa & mask, new_mantissa >> output_width};
+}
+
+BlockScaleResult compute_block_scale(
+    tt::stl::Span<const float> values, size_t block_offset, const FormatParams& params, bool exp_rnd_en) {
+    TT_ASSERT(block_offset + params.block_size <= values.size());
+
+    float max_abs = 0.0f;
+    bool all_nan = true;
+    bool all_inf_or_zero = true;
+    bool any_inf = false;
+
+    for (uint32_t i = 0; i < params.block_size; ++i) {
+        float v = values[block_offset + i];
+        if (!std::isnan(v)) {
+            all_nan = false;
+        }
+        if (std::isinf(v)) {
+            any_inf = true;
+        }
+        if (!(std::isinf(v) || std::isnan(v) || v == 0.0f)) {
+            all_inf_or_zero = false;
+        }
+        float v_abs = (std::isnan(v) || std::isinf(v)) ? 0.0f : std::abs(v);
+        max_abs = std::max(max_abs, v_abs);
+    }
+
+    int max_abs_exp = (max_abs == 0.0f) ? 0 : static_cast<int>(std::floor(std::log2(max_abs)));
+    int shared_exp = max_abs_exp;
+    int shared_exp_adj_for_elem_max = -127;
+
+    if (shared_exp - params.elem_exp_max_unbiased >= -127) {
+        if (exp_rnd_en && shared_exp < 127) {
+            shared_exp += 1;
+        }
+        shared_exp_adj_for_elem_max = shared_exp - params.elem_exp_max_unbiased;
+    } else if (exp_rnd_en && shared_exp < 127) {
+        shared_exp_adj_for_elem_max = -127;
+    }
+
+    int shared_exp_biased = shared_exp_adj_for_elem_max + params.scale_bias;
+    if (all_nan) {
+        shared_exp_biased = 0xFF;
+    } else if (all_inf_or_zero && any_inf) {
+        shared_exp_biased = 0xFE;
+    }
+
+    float scale = std::ldexp(1.0f, shared_exp_adj_for_elem_max);
+    return {static_cast<uint8_t>(shared_exp_biased), scale};
+}
+
+uint32_t compute_exp_count(uint32_t elem_count, const FormatParams& params) {
+    TT_ASSERT(params.block_size > 0, "MX block size must be > 0");
+    TT_ASSERT(elem_count % params.block_size == 0, "MX element count must be divisible by block size");
+    return elem_count / params.block_size;
+}
+
+uint32_t compute_exp_bytes(uint32_t exp_count, uint32_t l1_alignment) { return tt::round_up(exp_count, l1_alignment); }
+
+uint32_t compute_elem_words(uint32_t elem_count, const FormatParams& params) {
+    TT_ASSERT(params.elem_width_storage_bits > 0, "MX element storage width must be > 0");
+    uint32_t bits = elem_count * static_cast<uint32_t>(params.elem_width_storage_bits);
+    return (bits + 31) / 32;
+}
+
+TileWordCounts compute_tile_word_counts(uint32_t elem_count, uint32_t l1_alignment, const FormatParams& params) {
+    TileWordCounts counts;
+    counts.exp_count = compute_exp_count(elem_count, params);
+    counts.exp_bytes = compute_exp_bytes(counts.exp_count, l1_alignment);
+    counts.exp_words = counts.exp_bytes / 4;
+    counts.elem_words = compute_elem_words(elem_count, params);
+    return counts;
+}
+
+uint32_t convert_to_mx_elem_bits(float datum, const FormatParams& params) {
+    uint32_t ui32 = std::bit_cast<uint32_t>(datum);
+    uint8_t sign = static_cast<uint8_t>((ui32 >> 31) & 0x1u);
+    uint32_t fp32_exp_biased = (ui32 >> 23) & 0xFFu;
+    uint32_t fp32_mant = ui32 & 0x7FFFFFu;
+
+    bool fp32_is_zero = (fp32_exp_biased == 0) && (fp32_mant == 0);
+    if (fp32_is_zero) {
+        uint32_t elem_sign_bit = static_cast<uint32_t>(sign) << (params.elem_man_bits + params.elem_exp_bits);
+        return elem_sign_bit;
+    }
+
+    if (std::isinf(datum)) {
+        if (params.inf_rep != InfNanRep::NotRepresentable) {
+            uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
+            uint32_t man = 0;
+            uint32_t sign_bit = static_cast<uint32_t>(sign) << (params.elem_man_bits + params.elem_exp_bits);
+            return sign_bit | (exp_all_ones << params.elem_man_bits) | man;
+        }
+        if (params.sat_supported) {
+            return sign ? params.elem_sat_neg_bits : params.elem_sat_pos_bits;
+        }
+        return 0;
+    }
+
+    if (std::isnan(datum)) {
+        if (params.nan_rep == InfNanRep::ExpAllOnesManNonZero) {
+            uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
+            uint32_t man = 1u;
+            return (exp_all_ones << params.elem_man_bits) | man;
+        }
+        if (params.nan_rep == InfNanRep::ExpAllOnesManAllOnes) {
+            uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
+            uint32_t man = (1u << params.elem_man_bits) - 1u;
+            return (exp_all_ones << params.elem_man_bits) | man;
+        }
+        return 0;
+    }
+
+    uint32_t mant_exp_adjusted = 0;
+    uint32_t elem_exp_biased = 0;
+
+    if (fp32_exp_biased != 0) {
+        int elem_exp_unbiased = static_cast<int>(fp32_exp_biased) - 127;
+        TT_ASSERT(elem_exp_unbiased <= params.elem_exp_max_unbiased, "MX element exponent out of range after scaling");
+
+        int mant_width = params.elem_man_bits;
+        auto [mant_round, exp_inc] = round_ties_even(fp32_mant, mant_width, 23);
+        uint32_t elem_mant_shifted = mant_round;
+        int elem_exp_unbiased_adj = elem_exp_unbiased + static_cast<int>(exp_inc);
+        mant_exp_adjusted = elem_mant_shifted;
+
+        if (elem_exp_unbiased_adj < params.elem_exp_min_unbiased) {
+            elem_exp_unbiased_adj -= static_cast<int>(exp_inc);
+            uint32_t mant_with_hb = fp32_mant | (1u << 23);
+            int shift = std::abs(params.elem_exp_min_unbiased - elem_exp_unbiased_adj);
+            uint32_t mant_exp_adjusted_pre = mant_with_hb >> shift;
+            auto [mant_round_sub, exp_inc_sub] = round_ties_even(mant_exp_adjusted_pre, mant_width, 24);
+            mant_exp_adjusted = mant_round_sub;
+            elem_exp_unbiased_adj =
+                -params.elem_exp_bias + params.elem_exp_subnorm_encoding + static_cast<int>(exp_inc_sub);
+        }
+
+        if ((elem_exp_unbiased_adj > params.elem_exp_max_unbiased) ||
+            (elem_exp_unbiased_adj == params.elem_exp_max_unbiased && elem_mant_shifted > params.elem_man_max)) {
+            elem_exp_unbiased_adj = params.elem_exp_max_unbiased;
+            mant_exp_adjusted = params.elem_man_max;
+        }
+
+        elem_exp_biased = static_cast<uint32_t>(elem_exp_unbiased_adj + params.elem_exp_bias);
+    } else {
+        mant_exp_adjusted = 0;
+        elem_exp_biased = 0;
+    }
+
+    uint32_t elem_bits = (elem_exp_biased << params.elem_man_bits) | (mant_exp_adjusted & params.elem_man_max);
+    if (sign) {
+        elem_bits |= static_cast<uint32_t>(1u << (params.elem_man_bits + params.elem_exp_bits));
+    }
+    return elem_bits;
+}
+
+float convert_from_mx_elem_bits(uint32_t elem_bits, uint8_t scale_exp_biased, const FormatParams& params) {
+    if (scale_exp_biased == 0xFF) {
+        return std::numeric_limits<float>::quiet_NaN();
+    }
+
+    uint32_t elem_man_mask = (1u << params.elem_man_bits) - 1u;
+    uint32_t elem_man = elem_bits & elem_man_mask;
+    uint32_t sign_bit = elem_bits >> (params.elem_man_bits + params.elem_exp_bits);
+    uint32_t elem_exp_biased = (elem_bits >> params.elem_man_bits) & ((1u << params.elem_exp_bits) - 1u);
+
+    uint32_t exp_all_ones = (params.elem_exp_bits == 0) ? 0 : ((1u << params.elem_exp_bits) - 1u);
+    uint32_t man_all_ones = elem_man_mask;
+
+    if (params.inf_rep == InfNanRep::ExpAllOnesManZero) {
+        if (elem_exp_biased == exp_all_ones && elem_man == 0) {
+            return sign_bit ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity();
+        }
+    }
+
+    if (params.nan_rep == InfNanRep::ExpAllOnesManNonZero) {
+        if (elem_exp_biased == exp_all_ones && elem_man != 0) {
+            return std::numeric_limits<float>::quiet_NaN();
+        }
+    } else if (params.nan_rep == InfNanRep::ExpAllOnesManAllOnes) {
+        if (elem_exp_biased == exp_all_ones && elem_man == man_all_ones) {
+            return std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+
+    uint32_t elem_man_one = 1u << params.elem_man_bits;
+    bool include_hidden_bit = (elem_exp_biased == static_cast<uint32_t>(params.elem_exp_subnorm_encoding));
+    uint32_t elem_man_with_int_bit = include_hidden_bit ? elem_man : (elem_man | elem_man_one);
+
+    int elem_exp_unbiased = 0;
+    if (!(elem_exp_biased == 0 && elem_man_with_int_bit == 0)) {
+        elem_exp_unbiased = static_cast<int>(elem_exp_biased) - params.elem_exp_bias;
+    }
+
+    float sign_f = (sign_bit != 0) ? -1.0f : 1.0f;
+    float exp_f = (elem_exp_biased != static_cast<uint32_t>(params.elem_exp_subnorm_encoding))
+                      ? std::ldexp(1.0f, elem_exp_unbiased)
+                      : std::ldexp(1.0f, params.elem_exp_min_unbiased);
+    float man_f = static_cast<float>(elem_man_with_int_bit) / static_cast<float>(elem_man_one);
+
+    return sign_f * exp_f * man_f;
+}
+
+void pack_exp_words(const std::vector<uint8_t>& exps, uint32_t exp_words, std::vector<uint32_t>& out) {
+    uint32_t exp_index = 0;
+    for (uint32_t w = 0; w < exp_words; ++w) {
+        uint32_t word = 0;
+        for (uint32_t b = 0; b < 4; ++b) {
+            uint32_t exp_val = exp_index < exps.size() ? exps[exp_index++] : 0;
+            word |= (exp_val << (8 * b));
+        }
+        out.push_back(word);
+    }
+}
+
+void pack_elem_words(
+    const std::vector<uint8_t>& elems, uint32_t elem_words, const FormatParams& params, std::vector<uint32_t>& out) {
+    uint32_t elem_index = 0;
+    uint32_t mask = (params.elem_width_bits >= 32) ? 0xFFFFFFFFu : ((1u << params.elem_width_bits) - 1u);
+
+    if (params.elem_width_storage_bits == 8) {
+        uint32_t shift = static_cast<uint32_t>(params.elem_width_storage_bits - params.elem_width_bits);
+        uint32_t word = 0;
+        for (uint32_t i = 0; i < elem_words * 4; ++i) {
+            uint32_t elem_val = elem_index < elems.size() ? (elems[elem_index++] & mask) : 0;
+            word |= elem_val << (shift + (i % 4) * 8);
+            if ((i % 4) == 3) {
+                out.push_back(word);
+                word = 0;
+            }
+        }
+        return;
+    }
+
+    if (params.elem_width_storage_bits == 4) {
+        uint32_t word = 0;
+        for (uint32_t i = 0; i < elem_words * 8; ++i) {
+            uint32_t elem_val = elem_index < elems.size() ? (elems[elem_index++] & mask) : 0;
+            word |= elem_val << ((i % 8) * 4);
+            if ((i % 8) == 7) {
+                out.push_back(word);
+                word = 0;
+            }
+        }
+        return;
+    }
+
+    if (params.elem_width_storage_bits == 2) {
+        uint32_t word = 0;
+        for (uint32_t i = 0; i < elem_words * 16; ++i) {
+            uint32_t elem_val = elem_index < elems.size() ? (elems[elem_index++] & mask) : 0;
+            word |= elem_val << ((i % 16) * 2);
+            if ((i % 16) == 15) {
+                out.push_back(word);
+                word = 0;
+            }
+        }
+        return;
+    }
+
+    TT_THROW("Unsupported MX element storage width {}", params.elem_width_storage_bits);
+}
+
+void unpack_exp_words(
+    tt::stl::Span<const uint32_t> words,
+    size_t& word_offset,
+    uint32_t exp_words,
+    uint32_t exp_count,
+    std::vector<uint8_t>& out) {
+    out.clear();
+    out.reserve(exp_count);
+    for (uint32_t w = 0; w < exp_words; ++w) {
+        uint32_t word = words[word_offset++];
+        for (uint32_t b = 0; b < 4 && out.size() < exp_count; ++b) {
+            out.push_back(static_cast<uint8_t>((word >> (8 * b)) & 0xFFu));
+        }
+    }
+}
+
+void unpack_elem_words(
+    tt::stl::Span<const uint32_t> words,
+    size_t& word_offset,
+    uint32_t elem_words,
+    uint32_t elem_count,
+    const FormatParams& params,
+    std::vector<uint8_t>& out) {
+    out.clear();
+    out.reserve(elem_count);
+
+    uint32_t mask = (params.elem_width_bits >= 32) ? 0xFFFFFFFFu : ((1u << params.elem_width_bits) - 1u);
+
+    if (params.elem_width_storage_bits == 8) {
+        uint32_t shift = static_cast<uint32_t>(params.elem_width_storage_bits - params.elem_width_bits);
+        for (uint32_t w = 0; w < elem_words; ++w) {
+            uint32_t word = words[word_offset++];
+            for (uint32_t b = 0; b < 4 && out.size() < elem_count; ++b) {
+                uint32_t elem_val = (word >> (8 * b)) & 0xFFu;
+                elem_val = (elem_val >> shift) & mask;
+                out.push_back(static_cast<uint8_t>(elem_val));
+            }
+        }
+        return;
+    }
+
+    if (params.elem_width_storage_bits == 4) {
+        for (uint32_t w = 0; w < elem_words; ++w) {
+            uint32_t word = words[word_offset++];
+            for (uint32_t b = 0; b < 8 && out.size() < elem_count; ++b) {
+                uint32_t elem_val = (word >> (4 * b)) & 0xFu;
+                out.push_back(static_cast<uint8_t>(elem_val & mask));
+            }
+        }
+        return;
+    }
+
+    if (params.elem_width_storage_bits == 2) {
+        for (uint32_t w = 0; w < elem_words; ++w) {
+            uint32_t word = words[word_offset++];
+            for (uint32_t b = 0; b < 16 && out.size() < elem_count; ++b) {
+                uint32_t elem_val = (word >> (2 * b)) & 0x3u;
+                out.push_back(static_cast<uint8_t>(elem_val & mask));
+            }
+        }
+        return;
+    }
+
+    TT_THROW("Unsupported MX element storage width {}", params.elem_width_storage_bits);
+}
+
+}  // namespace tt::tt_metal::mx

--- a/tt_metal/impl/data_format/mx_common.cpp
+++ b/tt_metal/impl/data_format/mx_common.cpp
@@ -19,34 +19,24 @@ RoundResult round_ties_even(uint32_t input_mantissa, int output_width, int input
     if (output_width < 0) {
         return {0, 0};
     }
-    if (input_width == output_width) {
-        return {input_mantissa, 0};
+    auto mask_of = [](int w) -> uint32_t { return (w >= 32) ? 0xFFFFFFFFu : ((1u << w) - 1u); };
+    // No rounding needed: output is at least as wide as input.
+    if (output_width >= input_width) {
+        return {input_mantissa & mask_of(output_width), 0};
     }
-    const int shift_out = input_width - output_width;
-    if (shift_out <= 0) {
-        uint32_t mask = (output_width >= 32) ? 0xFFFFFFFFu : ((1u << output_width) - 1u);
-        return {input_mantissa & mask, 0};
-    }
-    uint32_t rounded_bits = input_mantissa & ((1u << shift_out) - 1u);
-    uint32_t rounded_msb = (rounded_bits >> (shift_out - 1)) & 0x1u;
-    uint32_t rounded_lsbs = rounded_bits & ((1u << (shift_out - 1)) - 1u);
-    uint32_t mantissa_lsb = (input_mantissa >> shift_out) & 0x1u;
-
-    uint32_t round_inc = 0;
-    if (rounded_msb && rounded_lsbs != 0) {
-        round_inc = 1;
-    } else if (rounded_msb && rounded_lsbs == 0) {
-        round_inc = mantissa_lsb;
-    }
-
+    const int shift_out = input_width - output_width;  // 1..32
+    const uint32_t shifted = (shift_out >= 32) ? 0u : (input_mantissa >> shift_out);
+    const uint32_t round_bit = (input_mantissa >> (shift_out - 1)) & 1u;
+    const uint32_t sticky = input_mantissa & mask_of(shift_out - 1);  // 0 when shift_out == 1
+    const uint32_t lsb = shifted & 1u;                                // 0 when output_width == 0
+    // Round up iff round bit is set AND (any sticky bit OR kept LSB is 1).
+    const uint32_t round_inc = round_bit & ((sticky != 0 ? 1u : 0u) | lsb);
+    const uint32_t new_mantissa = shifted + round_inc;
     if (output_width == 0) {
-        round_inc = (rounded_msb && rounded_lsbs != 0) ? 1 : 0;
-        output_width = 1;
+        // Whole rounded value is overflow; mantissa field is empty.
+        return {0, new_mantissa};
     }
-
-    uint32_t new_mantissa = (input_mantissa >> shift_out) + round_inc;
-    uint32_t mask = (output_width >= 32) ? 0xFFFFFFFFu : ((1u << output_width) - 1u);
-    return {new_mantissa & mask, new_mantissa >> output_width};
+    return {new_mantissa & mask_of(output_width), new_mantissa >> output_width};
 }
 
 BlockScaleResult compute_block_scale(
@@ -278,12 +268,14 @@ float convert_from_mx_elem_bits(uint32_t elem_bits, uint8_t scale_exp_biased, co
 }
 
 void pack_exp_words(const std::vector<uint8_t>& exps, uint32_t exp_words, std::vector<uint32_t>& out) {
-    uint32_t exp_index = 0;
+    out.reserve(out.size() + exp_words);
+    const size_t exps_length = exps.size();
     for (uint32_t w = 0; w < exp_words; ++w) {
         uint32_t word = 0;
-        for (uint32_t b = 0; b < 4; ++b) {
-            uint32_t exp_val = exp_index < exps.size() ? exps[exp_index++] : 0;
-            word |= (exp_val << (8 * b));
+        const size_t base = size_t(w) * 4;
+        const size_t take = (exps_length > base) ? std::min<size_t>(4, exps_length - base) : 0;
+        for (size_t b = 0; b < take; ++b) {
+            word |= uint32_t(exps[base + b]) << (8 * b);
         }
         out.push_back(word);
     }
@@ -334,8 +326,10 @@ void unpack_exp_words(
     out.clear();
     out.reserve(exp_count);
     for (uint32_t w = 0; w < exp_words; ++w) {
-        uint32_t word = words[word_offset++];
-        for (uint32_t b = 0; b < 4 && out.size() < exp_count; ++b) {
+        const uint32_t word = words[word_offset++];
+        const size_t base = size_t(w) * 4;
+        const size_t take = (exp_count > base) ? std::min<size_t>(4, exp_count - base) : 0;
+        for (size_t b = 0; b < take; ++b) {
             out.push_back(static_cast<uint8_t>((word >> (8 * b)) & 0xFFu));
         }
     }

--- a/tt_metal/impl/data_format/mx_common.cpp
+++ b/tt_metal/impl/data_format/mx_common.cpp
@@ -53,27 +53,46 @@ BlockScaleResult compute_block_scale(
     tt::stl::Span<const float> values, size_t block_offset, const FormatParams& params, bool exp_rnd_en) {
     TT_ASSERT(block_offset + params.block_size <= values.size());
 
-    float max_abs = 0.0f;
+    // Track the maximum finite |v| as raw IEEE-754 bits so we can extract its
+    // exponent directly without going through std::log2/std::floor. For two
+    // finite non-negative floats, the one with the larger raw bit pattern is
+    // also the larger value, so a uint32_t max suffices.
+    uint32_t max_abs_bits = 0;
     bool all_nan = true;
     bool all_inf_or_zero = true;
     bool any_inf = false;
 
     for (uint32_t i = 0; i < params.block_size; ++i) {
-        float v = values[block_offset + i];
-        if (!std::isnan(v)) {
-            all_nan = false;
+        uint32_t bits = std::bit_cast<uint32_t>(values[block_offset + i]);
+        uint32_t abs_bits = bits & 0x7FFFFFFFu;
+        uint32_t exp_field = abs_bits >> 23;
+        uint32_t mant_field = abs_bits & 0x7FFFFFu;
+        bool is_nan = (exp_field == 0xFFu) && (mant_field != 0);
+        bool is_inf = (exp_field == 0xFFu) && (mant_field == 0);
+        bool is_zero = (abs_bits == 0u);
+
+        all_nan = all_nan && is_nan;
+        any_inf = any_inf || is_inf;
+        all_inf_or_zero = all_inf_or_zero && (is_inf || is_nan || is_zero);
+
+        if (!is_nan && !is_inf && abs_bits > max_abs_bits) {
+            max_abs_bits = abs_bits;
         }
-        if (std::isinf(v)) {
-            any_inf = true;
-        }
-        if (!(std::isinf(v) || std::isnan(v) || v == 0.0f)) {
-            all_inf_or_zero = false;
-        }
-        float v_abs = (std::isnan(v) || std::isinf(v)) ? 0.0f : std::abs(v);
-        max_abs = std::max(max_abs, v_abs);
     }
 
-    int max_abs_exp = (max_abs == 0.0f) ? 0 : static_cast<int>(std::floor(std::log2(max_abs)));
+    // floor(log2(max_abs)) computed from the IEEE-754 exponent field directly.
+    // Subnormals (exp_field == 0) are rare in MX inputs; fall back to std::log2
+    // there to preserve the original semantics without complicating the hot path.
+    int max_abs_exp = 0;
+    if (max_abs_bits != 0) {
+        uint32_t exp_field = max_abs_bits >> 23;
+        if (exp_field != 0) {
+            max_abs_exp = static_cast<int>(exp_field) - 127;
+        } else {
+            float max_abs = std::bit_cast<float>(max_abs_bits);
+            max_abs_exp = static_cast<int>(std::floor(std::log2(max_abs)));
+        }
+    }
     int shared_exp = max_abs_exp;
     int shared_exp_adj_for_elem_max = -127;
 
@@ -93,8 +112,7 @@ BlockScaleResult compute_block_scale(
         shared_exp_biased = 0xFE;
     }
 
-    float scale = std::ldexp(1.0f, shared_exp_adj_for_elem_max);
-    return {static_cast<uint8_t>(shared_exp_biased), scale};
+    return {static_cast<uint8_t>(shared_exp_biased), shared_exp_adj_for_elem_max};
 }
 
 uint32_t compute_exp_count(uint32_t elem_count, const FormatParams& params) {
@@ -132,8 +150,14 @@ uint32_t convert_to_mx_elem_bits(float datum, const FormatParams& params) {
         return elem_sign_bit;
     }
 
-    if (std::isinf(datum)) {
-        if (params.inf_rep != InfNanRep::NotRepresentable) {
+    // Use the already-extracted exponent/mantissa fields rather than std::isinf
+    // and std::isnan, which on most libc implementations involve an extra
+    // function call (and may go through fpclassify).
+    bool fp32_is_inf = (fp32_exp_biased == 0xFFu) && (fp32_mant == 0u);
+    bool fp32_is_nan = (fp32_exp_biased == 0xFFu) && (fp32_mant != 0u);
+
+    if (fp32_is_inf) {
+        if (params.inf_rep != InfNanRepresentation::NotRepresentable) {
             uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
             uint32_t man = 0;
             uint32_t sign_bit = static_cast<uint32_t>(sign) << (params.elem_man_bits + params.elem_exp_bits);
@@ -145,13 +169,13 @@ uint32_t convert_to_mx_elem_bits(float datum, const FormatParams& params) {
         return 0;
     }
 
-    if (std::isnan(datum)) {
-        if (params.nan_rep == InfNanRep::ExpAllOnesManNonZero) {
+    if (fp32_is_nan) {
+        if (params.nan_rep == InfNanRepresentation::ExpAllOnesManNonZero) {
             uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
             uint32_t man = 1u;
             return (exp_all_ones << params.elem_man_bits) | man;
         }
-        if (params.nan_rep == InfNanRep::ExpAllOnesManAllOnes) {
+        if (params.nan_rep == InfNanRepresentation::ExpAllOnesManAllOnes) {
             uint32_t exp_all_ones = (1u << params.elem_exp_bits) - 1u;
             uint32_t man = (1u << params.elem_man_bits) - 1u;
             return (exp_all_ones << params.elem_man_bits) | man;
@@ -176,7 +200,11 @@ uint32_t convert_to_mx_elem_bits(float datum, const FormatParams& params) {
             elem_exp_unbiased_adj -= static_cast<int>(exp_inc);
             uint32_t mant_with_hb = fp32_mant | (1u << 23);
             int shift = std::abs(params.elem_exp_min_unbiased - elem_exp_unbiased_adj);
-            uint32_t mant_exp_adjusted_pre = mant_with_hb >> shift;
+            // Right-shifting a uint32_t by >= 32 is undefined behaviour.
+            // For very small inputs (|v| << block max) shift can exceed the 24
+            // significant bits of mant_with_hb, in which case the result is
+            // unconditionally zero.
+            uint32_t mant_exp_adjusted_pre = (shift >= 24) ? 0u : (mant_with_hb >> shift);
             auto [mant_round_sub, exp_inc_sub] = round_ties_even(mant_exp_adjusted_pre, mant_width, 24);
             mant_exp_adjusted = mant_round_sub;
             elem_exp_unbiased_adj =
@@ -215,17 +243,17 @@ float convert_from_mx_elem_bits(uint32_t elem_bits, uint8_t scale_exp_biased, co
     uint32_t exp_all_ones = (params.elem_exp_bits == 0) ? 0 : ((1u << params.elem_exp_bits) - 1u);
     uint32_t man_all_ones = elem_man_mask;
 
-    if (params.inf_rep == InfNanRep::ExpAllOnesManZero) {
+    if (params.inf_rep == InfNanRepresentation::ExpAllOnesManZero) {
         if (elem_exp_biased == exp_all_ones && elem_man == 0) {
             return sign_bit ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity();
         }
     }
 
-    if (params.nan_rep == InfNanRep::ExpAllOnesManNonZero) {
+    if (params.nan_rep == InfNanRepresentation::ExpAllOnesManNonZero) {
         if (elem_exp_biased == exp_all_ones && elem_man != 0) {
             return std::numeric_limits<float>::quiet_NaN();
         }
-    } else if (params.nan_rep == InfNanRep::ExpAllOnesManAllOnes) {
+    } else if (params.nan_rep == InfNanRepresentation::ExpAllOnesManAllOnes) {
         if (elem_exp_biased == exp_all_ones && elem_man == man_all_ones) {
             return std::numeric_limits<float>::quiet_NaN();
         }
@@ -263,6 +291,7 @@ void pack_exp_words(const std::vector<uint8_t>& exps, uint32_t exp_words, std::v
 
 void pack_elem_words(
     const std::vector<uint8_t>& elems, uint32_t elem_words, const FormatParams& params, std::vector<uint32_t>& out) {
+    TT_ASSERT(params.elem_width_storage_bits >= params.elem_width_bits);
     uint32_t elem_index = 0;
     uint32_t mask = (params.elem_width_bits >= 32) ? 0xFFFFFFFFu : ((1u << params.elem_width_bits) - 1u);
 
@@ -286,19 +315,6 @@ void pack_elem_words(
             uint32_t elem_val = elem_index < elems.size() ? (elems[elem_index++] & mask) : 0;
             word |= elem_val << ((i % 8) * 4);
             if ((i % 8) == 7) {
-                out.push_back(word);
-                word = 0;
-            }
-        }
-        return;
-    }
-
-    if (params.elem_width_storage_bits == 2) {
-        uint32_t word = 0;
-        for (uint32_t i = 0; i < elem_words * 16; ++i) {
-            uint32_t elem_val = elem_index < elems.size() ? (elems[elem_index++] & mask) : 0;
-            word |= elem_val << ((i % 16) * 2);
-            if ((i % 16) == 15) {
                 out.push_back(word);
                 word = 0;
             }
@@ -332,6 +348,7 @@ void unpack_elem_words(
     uint32_t elem_count,
     const FormatParams& params,
     std::vector<uint8_t>& out) {
+    TT_ASSERT(params.elem_width_storage_bits >= params.elem_width_bits);
     out.clear();
     out.reserve(elem_count);
 
@@ -355,17 +372,6 @@ void unpack_elem_words(
             uint32_t word = words[word_offset++];
             for (uint32_t b = 0; b < 8 && out.size() < elem_count; ++b) {
                 uint32_t elem_val = (word >> (4 * b)) & 0xFu;
-                out.push_back(static_cast<uint8_t>(elem_val & mask));
-            }
-        }
-        return;
-    }
-
-    if (params.elem_width_storage_bits == 2) {
-        for (uint32_t w = 0; w < elem_words; ++w) {
-            uint32_t word = words[word_offset++];
-            for (uint32_t b = 0; b < 16 && out.size() < elem_count; ++b) {
-                uint32_t elem_val = (word >> (2 * b)) & 0x3u;
                 out.push_back(static_cast<uint8_t>(elem_val & mask));
             }
         }

--- a/tt_metal/impl/data_format/mx_common.hpp
+++ b/tt_metal/impl/data_format/mx_common.hpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <tt_stl/span.hpp>
+
+namespace tt::tt_metal::mx {
+
+enum class InfNanRep : uint8_t {
+    NotRepresentable = 0,
+    ExpAllOnesManZero,
+    ExpAllOnesManNonZero,
+    ExpAllOnesManAllOnes,
+};
+
+struct FormatParams {
+    uint32_t block_size = 32;
+    int scale_bias = 0x7F;
+    int elem_exp_bits = 0;
+    int elem_man_bits = 0;
+    int elem_exp_bias = 0;
+    int elem_exp_max_unbiased = 0;
+    int elem_exp_min_unbiased = 0;
+    int elem_exp_subnorm_encoding = 0;
+    uint32_t elem_man_max = 0;
+    int elem_width_bits = 0;
+    int elem_width_storage_bits = 0;
+    bool sat_supported = false;
+    uint32_t elem_sat_pos_bits = 0;
+    uint32_t elem_sat_neg_bits = 0;
+    InfNanRep inf_rep = InfNanRep::NotRepresentable;
+    InfNanRep nan_rep = InfNanRep::NotRepresentable;
+};
+
+struct RoundResult {
+    uint32_t mantissa = 0;
+    uint32_t overflow = 0;
+};
+
+struct BlockScaleResult {
+    uint8_t shared_exp_biased = 0;
+    float scale = 1.0f;
+};
+
+struct TileWordCounts {
+    uint32_t exp_count = 0;
+    uint32_t exp_bytes = 0;
+    uint32_t exp_words = 0;
+    uint32_t elem_words = 0;
+};
+
+RoundResult round_ties_even(uint32_t input_mantissa, int output_width, int input_width = 23);
+
+BlockScaleResult compute_block_scale(
+    tt::stl::Span<const float> values, size_t block_offset, const FormatParams& params, bool exp_rnd_en = false);
+
+uint32_t compute_exp_count(uint32_t elem_count, const FormatParams& params);
+uint32_t compute_exp_bytes(uint32_t exp_count, uint32_t l1_alignment);
+uint32_t compute_elem_words(uint32_t elem_count, const FormatParams& params);
+TileWordCounts compute_tile_word_counts(uint32_t elem_count, uint32_t l1_alignment, const FormatParams& params);
+
+uint32_t convert_to_mx_elem_bits(float datum, const FormatParams& params);
+float convert_from_mx_elem_bits(uint32_t elem_bits, uint8_t scale_exp_biased, const FormatParams& params);
+
+void pack_exp_words(const std::vector<uint8_t>& exps, uint32_t exp_words, std::vector<uint32_t>& out);
+void pack_elem_words(
+    const std::vector<uint8_t>& elems, uint32_t elem_words, const FormatParams& params, std::vector<uint32_t>& out);
+
+void unpack_exp_words(
+    tt::stl::Span<const uint32_t> words,
+    size_t& word_offset,
+    uint32_t exp_words,
+    uint32_t exp_count,
+    std::vector<uint8_t>& out);
+void unpack_elem_words(
+    tt::stl::Span<const uint32_t> words,
+    size_t& word_offset,
+    uint32_t elem_words,
+    uint32_t elem_count,
+    const FormatParams& params,
+    std::vector<uint8_t>& out);
+
+}  // namespace tt::tt_metal::mx

--- a/tt_metal/impl/data_format/mx_common.hpp
+++ b/tt_metal/impl/data_format/mx_common.hpp
@@ -11,7 +11,7 @@
 
 namespace tt::tt_metal::mx {
 
-enum class InfNanRep : uint8_t {
+enum class InfNanRepresentation : uint8_t {
     NotRepresentable = 0,
     ExpAllOnesManZero,
     ExpAllOnesManNonZero,
@@ -33,8 +33,8 @@ struct FormatParams {
     bool sat_supported = false;
     uint32_t elem_sat_pos_bits = 0;
     uint32_t elem_sat_neg_bits = 0;
-    InfNanRep inf_rep = InfNanRep::NotRepresentable;
-    InfNanRep nan_rep = InfNanRep::NotRepresentable;
+    InfNanRepresentation inf_rep = InfNanRepresentation::NotRepresentable;
+    InfNanRepresentation nan_rep = InfNanRepresentation::NotRepresentable;
 };
 
 struct RoundResult {
@@ -44,7 +44,10 @@ struct RoundResult {
 
 struct BlockScaleResult {
     uint8_t shared_exp_biased = 0;
-    float scale = 1.0f;
+    // Unbiased shared exponent. Effective scale is 2^shared_exp_adj — kept as
+    // an int so callers can ldexp directly and avoid building/dividing by a
+    // float power of two.
+    int shared_exp_adj = 0;
 };
 
 struct TileWordCounts {

--- a/tt_metal/impl/data_format/mxfp4.cpp
+++ b/tt_metal/impl/data_format/mxfp4.cpp
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/mxfp4.hpp>
+#include <tt-metalium/bfloat16.hpp>
+
+#include <cmath>
+#include <optional>
+#include <vector>
+
+#include <tt_stl/assert.hpp>
+#include <tt_stl/span.hpp>
+
+#include "constants.hpp"
+#include "hal_types.hpp"
+#include "impl/context/metal_context.hpp"
+#include "mx_common.hpp"
+#include "tile.hpp"
+#include "tracy/Tracy.hpp"
+
+namespace {
+
+constexpr tt::tt_metal::mx::FormatParams kMxFp4Params = {
+    .block_size = 32,
+    .scale_bias = 0x7F,
+    .elem_exp_bits = 2,
+    .elem_man_bits = 1,
+    .elem_exp_bias = 1,
+    .elem_exp_max_unbiased = 2,
+    .elem_exp_min_unbiased = 0,
+    .elem_exp_subnorm_encoding = 0,
+    .elem_man_max = 0x1,
+    .elem_width_bits = 4,
+    .elem_width_storage_bits = 4,
+    .sat_supported = true,
+    .elem_sat_pos_bits = 0x7,
+    .elem_sat_neg_bits = 0xF,
+    .inf_rep = tt::tt_metal::mx::InfNanRep::NotRepresentable,
+    .nan_rep = tt::tt_metal::mx::InfNanRep::NotRepresentable,
+};
+
+}  // namespace
+
+template <typename T>
+std::vector<uint32_t> pack_as_mxfp4_tiles(
+    tt::stl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
+    ZoneScoped;
+
+    auto tile_H = tile.has_value() ? tile->get_tile_shape()[0] : tt::constants::TILE_HEIGHT;
+    auto tile_W = tile.has_value() ? tile->get_tile_shape()[1] : tt::constants::TILE_WIDTH;
+    auto face_H = tile.has_value() ? tile->get_face_shape()[0] : tt::constants::FACE_HEIGHT;
+    auto face_W = tile.has_value() ? tile->get_face_shape()[1] : tt::constants::FACE_WIDTH;
+    auto tile_HW = tile_H * tile_W;
+    auto subtiles_in_tile_row = tile_H / face_H;
+    auto subtiles_in_tile_col = tile_W / face_W;
+
+    TT_ASSERT(
+        tile_HW % kMxFp4Params.block_size == 0,
+        "MXFP4 tile must be a multiple of {} elements",
+        kMxFp4Params.block_size);
+    TT_ASSERT(data.size() % tile_HW == 0, "Input size must be a multiple of tile size");
+
+    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
+    auto word_counts = tt::tt_metal::mx::compute_tile_word_counts(tile_HW, l1_alignment, kMxFp4Params);
+    uint32_t exp_count = word_counts.exp_count;
+    uint32_t exp_words = word_counts.exp_words;
+    uint32_t elem_words = word_counts.elem_words;
+
+    uint32_t num_tiles = data.size() / tile_HW;
+    std::vector<uint32_t> packed;
+    packed.reserve(num_tiles * (exp_words + elem_words));
+
+    size_t linear_index = 0;
+
+    for (uint32_t tile_index = 0; tile_index < num_tiles; ++tile_index) {
+        std::vector<float> tile_values;
+        tile_values.reserve(tile_HW);
+
+        if (row_major_input) {
+            for (uint32_t tr = 0; tr < subtiles_in_tile_row; ++tr) {
+                for (uint32_t tc = 0; tc < subtiles_in_tile_col; ++tc) {
+                    for (uint32_t i = 0; i < face_H; ++i) {
+                        uint32_t row = tr * face_H + i;
+                        for (uint32_t j = 0; j < face_W; ++j) {
+                            uint32_t col = tc * face_W + j;
+                            size_t data_index = (row * tile_W) + col + (tile_index * tile_HW);
+                            tile_values.push_back(static_cast<float>(data[data_index]));
+                        }
+                    }
+                }
+            }
+        } else {
+            for (uint32_t i = 0; i < tile_HW; ++i) {
+                tile_values.push_back(static_cast<float>(data[linear_index++]));
+            }
+        }
+
+        std::vector<uint8_t> exps;
+        exps.reserve(exp_count);
+        std::vector<uint8_t> elems;
+        elems.reserve(tile_HW);
+
+        for (uint32_t blk_idx = 0; blk_idx < exp_count; ++blk_idx) {
+            auto block_scale = tt::tt_metal::mx::compute_block_scale(
+                tt::stl::Span<const float>(tile_values.data(), tile_values.size()),
+                blk_idx * kMxFp4Params.block_size,
+                kMxFp4Params);
+            exps.push_back(block_scale.shared_exp_biased);
+
+            float scale = block_scale.scale;
+            for (uint32_t i = 0; i < kMxFp4Params.block_size; ++i) {
+                float v = tile_values[blk_idx * kMxFp4Params.block_size + i];
+                float scaled = v / scale;
+                elems.push_back(static_cast<uint8_t>(tt::tt_metal::mx::convert_to_mx_elem_bits(scaled, kMxFp4Params)));
+            }
+        }
+
+        tt::tt_metal::mx::pack_exp_words(exps, exp_words, packed);
+        tt::tt_metal::mx::pack_elem_words(elems, elem_words, kMxFp4Params, packed);
+    }
+
+    return packed;
+}
+
+template std::vector<uint32_t> pack_as_mxfp4_tiles<bfloat16>(
+    tt::stl::Span<const bfloat16> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile);
+
+template std::vector<uint32_t> pack_as_mxfp4_tiles<float>(
+    tt::stl::Span<const float> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile);
+
+template std::vector<uint32_t> pack_as_mxfp4_tiles<int32_t>(
+    tt::stl::Span<const int32_t> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile);
+
+template std::vector<uint32_t> pack_as_mxfp4_tiles<uint32_t>(
+    tt::stl::Span<const uint32_t> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile);
+
+template std::vector<uint32_t> pack_as_mxfp4_tiles<uint8_t>(
+    tt::stl::Span<const uint8_t> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile);
+
+template std::vector<uint32_t> pack_as_mxfp4_tiles<uint16_t>(
+    tt::stl::Span<const uint16_t> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile);
+
+std::vector<float> unpack_mxfp4_tiles_into_float_vec(
+    tt::stl::Span<const uint32_t> mxfp4_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
+    ZoneScoped;
+
+    auto tile_H = tile.has_value() ? tile->get_tile_shape()[0] : tt::constants::TILE_HEIGHT;
+    auto tile_W = tile.has_value() ? tile->get_tile_shape()[1] : tt::constants::TILE_WIDTH;
+    auto face_H = tile.has_value() ? tile->get_face_shape()[0] : tt::constants::FACE_HEIGHT;
+    auto face_W = tile.has_value() ? tile->get_face_shape()[1] : tt::constants::FACE_WIDTH;
+    auto tile_HW = tile_H * tile_W;
+    auto subtiles_in_tile_row = tile_H / face_H;
+    auto subtiles_in_tile_col = tile_W / face_W;
+
+    TT_ASSERT(
+        tile_HW % kMxFp4Params.block_size == 0,
+        "MXFP4 tile must be a multiple of {} elements",
+        kMxFp4Params.block_size);
+
+    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
+    auto word_counts = tt::tt_metal::mx::compute_tile_word_counts(tile_HW, l1_alignment, kMxFp4Params);
+    uint32_t exp_count = word_counts.exp_count;
+    uint32_t exp_bytes = word_counts.exp_bytes;
+    uint32_t exp_words = word_counts.exp_words;
+    uint32_t elem_words = word_counts.elem_words;
+
+    uint32_t tile_size_bytes = exp_bytes + (elem_words * 4);
+    uint32_t total_bytes = mxfp4_tiles.size() * 4;
+    TT_ASSERT(total_bytes % tile_size_bytes == 0, "Input size must be a multiple of MXFP4 tile size");
+    uint32_t num_tiles = total_bytes / tile_size_bytes;
+
+    std::vector<float> output;
+    output.resize(num_tiles * tile_HW);
+    size_t linear_index = 0;
+
+    size_t word_offset = 0;
+    for (uint32_t tile_index = 0; tile_index < num_tiles; ++tile_index) {
+        std::vector<uint8_t> exps;
+        tt::tt_metal::mx::unpack_exp_words(mxfp4_tiles, word_offset, exp_words, exp_count, exps);
+
+        std::vector<uint8_t> elems;
+        tt::tt_metal::mx::unpack_elem_words(mxfp4_tiles, word_offset, elem_words, tile_HW, kMxFp4Params, elems);
+
+        std::vector<float> tile_values;
+        tile_values.resize(tile_HW);
+        for (uint32_t i = 0; i < tile_HW; ++i) {
+            uint8_t scale_exp_biased = exps[i / kMxFp4Params.block_size];
+            int scale_exp_unbiased = static_cast<int>(scale_exp_biased) - kMxFp4Params.scale_bias;
+            float elem_pre_scale =
+                tt::tt_metal::mx::convert_from_mx_elem_bits(elems[i], scale_exp_biased, kMxFp4Params);
+            float scale = std::ldexp(1.0f, scale_exp_unbiased);
+            tile_values[i] = elem_pre_scale * scale;
+        }
+
+        if (row_major_output) {
+            size_t tile_base = tile_index * tile_HW;
+            size_t idx = 0;
+            for (uint32_t tr = 0; tr < subtiles_in_tile_row; ++tr) {
+                for (uint32_t tc = 0; tc < subtiles_in_tile_col; ++tc) {
+                    for (uint32_t i = 0; i < face_H; ++i) {
+                        uint32_t row = tr * face_H + i;
+                        for (uint32_t j = 0; j < face_W; ++j) {
+                            uint32_t col = tc * face_W + j;
+                            output[tile_base + row * tile_W + col] = tile_values[idx++];
+                        }
+                    }
+                }
+            }
+        } else {
+            for (float v : tile_values) {
+                output[linear_index++] = v;
+            }
+        }
+    }
+
+    return output;
+}

--- a/tt_metal/impl/data_format/mxfp4.cpp
+++ b/tt_metal/impl/data_format/mxfp4.cpp
@@ -161,14 +161,12 @@ std::vector<float> unpack_mxfp4_tiles_into_float_vec(
     uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
     auto word_counts = tt::tt_metal::mx::compute_tile_word_counts(tile_HW, l1_alignment, kMxFp4Params);
     uint32_t exp_count = word_counts.exp_count;
-    uint32_t exp_bytes = word_counts.exp_bytes;
     uint32_t exp_words = word_counts.exp_words;
     uint32_t elem_words = word_counts.elem_words;
 
-    uint32_t tile_size_bytes = exp_bytes + (elem_words * 4);
-    uint32_t total_bytes = mxfp4_tiles.size() * 4;
-    TT_ASSERT(total_bytes % tile_size_bytes == 0, "Input size must be a multiple of MXFP4 tile size");
-    uint32_t num_tiles = total_bytes / tile_size_bytes;
+    uint32_t tile_size_words = exp_words + elem_words;
+    TT_ASSERT(mxfp4_tiles.size() % tile_size_words == 0, "Input size must be a multiple of MXFP4 tile size");
+    uint32_t num_tiles = mxfp4_tiles.size() / tile_size_words;
 
     std::vector<float> output;
     output.resize(num_tiles * tile_HW);

--- a/tt_metal/impl/data_format/mxfp4.cpp
+++ b/tt_metal/impl/data_format/mxfp4.cpp
@@ -36,8 +36,8 @@ constexpr tt::tt_metal::mx::FormatParams kMxFp4Params = {
     .sat_supported = true,
     .elem_sat_pos_bits = 0x7,
     .elem_sat_neg_bits = 0xF,
-    .inf_rep = tt::tt_metal::mx::InfNanRep::NotRepresentable,
-    .nan_rep = tt::tt_metal::mx::InfNanRep::NotRepresentable,
+    .inf_rep = tt::tt_metal::mx::InfNanRepresentation::NotRepresentable,
+    .nan_rep = tt::tt_metal::mx::InfNanRepresentation::NotRepresentable,
 };
 
 }  // namespace
@@ -73,9 +73,17 @@ std::vector<uint32_t> pack_as_mxfp4_tiles(
 
     size_t linear_index = 0;
 
+    std::vector<float> tile_values;
+    tile_values.reserve(tile_HW);
+    std::vector<uint8_t> exps;
+    exps.reserve(exp_count);
+    std::vector<uint8_t> elems;
+    elems.reserve(tile_HW);
+
     for (uint32_t tile_index = 0; tile_index < num_tiles; ++tile_index) {
-        std::vector<float> tile_values;
-        tile_values.reserve(tile_HW);
+        tile_values.clear();
+        exps.clear();
+        elems.clear();
 
         if (row_major_input) {
             for (uint32_t tr = 0; tr < subtiles_in_tile_row; ++tr) {
@@ -96,22 +104,20 @@ std::vector<uint32_t> pack_as_mxfp4_tiles(
             }
         }
 
-        std::vector<uint8_t> exps;
-        exps.reserve(exp_count);
-        std::vector<uint8_t> elems;
-        elems.reserve(tile_HW);
-
         for (uint32_t blk_idx = 0; blk_idx < exp_count; ++blk_idx) {
+            // TODO: once we start testing stochastic rounding for exponents,
+            // add a mechanism that passes exp_rnd_en to compute_block_scale.
             auto block_scale = tt::tt_metal::mx::compute_block_scale(
                 tt::stl::Span<const float>(tile_values.data(), tile_values.size()),
                 blk_idx * kMxFp4Params.block_size,
                 kMxFp4Params);
             exps.push_back(block_scale.shared_exp_biased);
 
-            float scale = block_scale.scale;
+            int scale_exp = block_scale.shared_exp_adj;
+            uint32_t base = blk_idx * kMxFp4Params.block_size;
             for (uint32_t i = 0; i < kMxFp4Params.block_size; ++i) {
-                float v = tile_values[blk_idx * kMxFp4Params.block_size + i];
-                float scaled = v / scale;
+                float v = tile_values[base + i];
+                float scaled = std::ldexp(v, -scale_exp);
                 elems.push_back(static_cast<uint8_t>(tt::tt_metal::mx::convert_to_mx_elem_bits(scaled, kMxFp4Params)));
             }
         }
@@ -173,22 +179,28 @@ std::vector<float> unpack_mxfp4_tiles_into_float_vec(
     size_t linear_index = 0;
 
     size_t word_offset = 0;
-    for (uint32_t tile_index = 0; tile_index < num_tiles; ++tile_index) {
-        std::vector<uint8_t> exps;
-        tt::tt_metal::mx::unpack_exp_words(mxfp4_tiles, word_offset, exp_words, exp_count, exps);
 
-        std::vector<uint8_t> elems;
+    std::vector<uint8_t> exps;
+    exps.reserve(exp_count);
+    std::vector<uint8_t> elems;
+    elems.reserve(tile_HW);
+    std::vector<float> tile_values;
+    tile_values.resize(tile_HW);
+
+    for (uint32_t tile_index = 0; tile_index < num_tiles; ++tile_index) {
+        tt::tt_metal::mx::unpack_exp_words(mxfp4_tiles, word_offset, exp_words, exp_count, exps);
         tt::tt_metal::mx::unpack_elem_words(mxfp4_tiles, word_offset, elem_words, tile_HW, kMxFp4Params, elems);
 
-        std::vector<float> tile_values;
-        tile_values.resize(tile_HW);
-        for (uint32_t i = 0; i < tile_HW; ++i) {
-            uint8_t scale_exp_biased = exps[i / kMxFp4Params.block_size];
+        for (uint32_t blk = 0; blk < exp_count; ++blk) {
+            uint8_t scale_exp_biased = exps[blk];
             int scale_exp_unbiased = static_cast<int>(scale_exp_biased) - kMxFp4Params.scale_bias;
-            float elem_pre_scale =
-                tt::tt_metal::mx::convert_from_mx_elem_bits(elems[i], scale_exp_biased, kMxFp4Params);
-            float scale = std::ldexp(1.0f, scale_exp_unbiased);
-            tile_values[i] = elem_pre_scale * scale;
+            uint32_t base = blk * kMxFp4Params.block_size;
+            for (uint32_t j = 0; j < kMxFp4Params.block_size; ++j) {
+                uint32_t i = base + j;
+                float elem_pre_scale =
+                    tt::tt_metal::mx::convert_from_mx_elem_bits(elems[i], scale_exp_biased, kMxFp4Params);
+                tile_values[i] = std::ldexp(elem_pre_scale, scale_exp_unbiased);
+            }
         }
 
         if (row_major_output) {

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -77,6 +77,13 @@ uint32_t Tile::get_tile_size(const DataFormat& format) const {
         case DataFormat::Bfp4_b: return (tile_hw / 2) + aligned_exp_size;
         case DataFormat::Bfp8:
         case DataFormat::Bfp8_b: return tile_hw + aligned_exp_size;
+        case DataFormat::MxFp4: {
+            constexpr uint32_t kMxBlockSize = 32;
+            TT_ASSERT(tile_hw % kMxBlockSize == 0, "MXFP4 tile size must be a multiple of 32 elements");
+            uint32_t exp_bytes = tt::round_up(tile_hw / kMxBlockSize, l1_alignment);
+            uint32_t elem_bytes = tile_hw / 2;
+            return exp_bytes + elem_bytes;
+        }
         case DataFormat::Float16:
         case DataFormat::Float16_b: return (tile_hw * 2);
         case DataFormat::Float32: return (tile_hw * 4);

--- a/tt_metal/impl/flatbuffer/base_types.fbs
+++ b/tt_metal/impl/flatbuffer/base_types.fbs
@@ -54,6 +54,7 @@ enum DataFormat : uint8 {
   Bfp2_b = 15,
   Lf8 = 10,
   Fp8_e4m3 = 26, // 0x1A in decimal
+  MxFp4 = 22,
   Int8 = 14,
   Tf32 = 4,
   UInt8 = 30,

--- a/tt_metal/impl/flatbuffer/base_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/base_types_from_flatbuffer.cpp
@@ -78,6 +78,7 @@ tt::DataFormat from_flatbuffer(flatbuffer::DataFormat input) {
         case flatbuffer::DataFormat::Bfp2_b: return tt::DataFormat::Bfp2_b;
         case flatbuffer::DataFormat::Lf8: return tt::DataFormat::Lf8;
         case flatbuffer::DataFormat::Fp8_e4m3: return tt::DataFormat::Fp8_e4m3;
+        case flatbuffer::DataFormat::MxFp4: return tt::DataFormat::MxFp4;
         case flatbuffer::DataFormat::Int8: return tt::DataFormat::Int8;
         case flatbuffer::DataFormat::Tf32: return tt::DataFormat::Tf32;
         case flatbuffer::DataFormat::UInt8: return tt::DataFormat::UInt8;

--- a/tt_metal/impl/flatbuffer/base_types_to_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/base_types_to_flatbuffer.cpp
@@ -81,6 +81,7 @@ flatbuffer::DataFormat to_flatbuffer(tt::DataFormat input) {
         case tt::DataFormat::Bfp2_b: return flatbuffer::DataFormat::Bfp2_b;
         case tt::DataFormat::Lf8: return flatbuffer::DataFormat::Lf8;
         case tt::DataFormat::Fp8_e4m3: return flatbuffer::DataFormat::Fp8_e4m3;
+        case tt::DataFormat::MxFp4: return flatbuffer::DataFormat::MxFp4;
         case tt::DataFormat::Int8: return flatbuffer::DataFormat::Int8;
         case tt::DataFormat::Tf32: return flatbuffer::DataFormat::Tf32;
         case tt::DataFormat::UInt8: return flatbuffer::DataFormat::UInt8;

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -39,6 +39,8 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/blockfloat_common.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/mx_common.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/mxfp4.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/float8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/int8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tile.cpp

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -39,10 +39,10 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/blockfloat_common.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/mx_common.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/mxfp4.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/float8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/int8.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/mx_common.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/mxfp4.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/uint8.cpp

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -220,6 +220,10 @@ DataFormat get_single_pack_src_format(
         pack_src_format = DataFormat::Invalid;
     } else if (data_format == DataFormat::Fp8_e4m3) {
         pack_src_format = is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
+    } else if (data_format == DataFormat::MxFp4) {
+        pack_src_format = fp32_dest_acc_en
+            ? DataFormat::Float32
+            : (is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16);
     } else if (fp32_dest_acc_en) {
         if (arch == tt::ARCH::QUASAR && !tt::is_integer_format(data_format)) {
             pack_src_format = DataFormat::Float32;

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -225,9 +225,12 @@ DataFormat get_single_pack_src_format(
     } else if (data_format == DataFormat::Fp8_e4m3) {
         pack_src_format = is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
     } else if (data_format == DataFormat::MxFp4) {
-        pack_src_format = fp32_dest_acc_en
-            ? DataFormat::Float32
-            : (is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16);
+        if (fp32_dest_acc_en) {
+            pack_src_format = DataFormat::Float32;
+        } else {
+            pack_src_format =
+                is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
+        }
     } else if (fp32_dest_acc_en) {
         if (arch == tt::ARCH::QUASAR && !tt::is_integer_format(data_format)) {
             pack_src_format = DataFormat::Float32;

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -19,7 +19,7 @@ static const std::set<DataFormat> ALL_VALID_FORMATS = {
     DataFormat::Bfp8,      DataFormat::Bfp8_b,   DataFormat::Bfp4,      DataFormat::Bfp4_b,  DataFormat::Bfp2,
     DataFormat::Bfp2_b,    DataFormat::Float16,  DataFormat::Float16_b, DataFormat::Float32, DataFormat::RawUInt32,
     DataFormat::RawUInt16, DataFormat::RawUInt8, DataFormat::Tf32,      DataFormat::Lf8,     DataFormat::Fp8_e4m3,
-    DataFormat::MxFp4,     DataFormat::Int8,     DataFormat::Int16,    DataFormat::Int32,    DataFormat::UInt8,    
+    DataFormat::MxFp4,     DataFormat::Int8,     DataFormat::Int16,     DataFormat::Int32,   DataFormat::UInt8,
     DataFormat::UInt32,    DataFormat::UInt16,
 };
 

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -19,7 +19,8 @@ static const std::set<DataFormat> ALL_VALID_FORMATS = {
     DataFormat::Bfp8,      DataFormat::Bfp8_b,   DataFormat::Bfp4,      DataFormat::Bfp4_b,  DataFormat::Bfp2,
     DataFormat::Bfp2_b,    DataFormat::Float16,  DataFormat::Float16_b, DataFormat::Float32, DataFormat::RawUInt32,
     DataFormat::RawUInt16, DataFormat::RawUInt8, DataFormat::Tf32,      DataFormat::Lf8,     DataFormat::Fp8_e4m3,
-    DataFormat::Int8,      DataFormat::Int16,    DataFormat::Int32,    DataFormat::UInt8,     DataFormat::UInt32,  DataFormat::UInt16,
+    DataFormat::MxFp4,     DataFormat::Int8,     DataFormat::Int16,    DataFormat::Int32,    DataFormat::UInt8,    
+    DataFormat::UInt32,    DataFormat::UInt16,
 };
 
 static const std::unordered_map<DataFormat, DataFormat> CONVERT_EXP_WIDTH = {
@@ -44,7 +45,7 @@ bool is_exp_b_format(DataFormat data_format) {
     return (
         (data_format == DataFormat::Tf32 || data_format == DataFormat::Float16_b) ||
         (data_format == DataFormat::Bfp8_b) || (data_format == DataFormat::Bfp4_b) ||
-        (data_format == DataFormat::Bfp2_b));
+        (data_format == DataFormat::Bfp2_b) || (data_format == DataFormat::MxFp4));
 }
 
 ExpPrecision get_exp_precision(DataFormat data_format) {

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -131,9 +131,9 @@ DataFormat get_single_unpack_dst_format(
     }
 
     if (src_format == DataFormat::MxFp4) {
-        dst_format = DataFormat::Float16_b;
+        dst_format = DataFormat::Float16_b;  // Fixed unpack_dst format for mx formats.
     }
-    
+
     return dst_format;
 }
 

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -130,6 +130,10 @@ DataFormat get_single_unpack_dst_format(
         dst_format = unpack_conditional_dst_format;
     }
 
+    if (src_format == DataFormat::MxFp4) {
+        dst_format = DataFormat::Float16_b;
+    }
+    
     return dst_format;
 }
 

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -41,6 +41,8 @@ bool is_bfp_format(DataFormat data_format) {
         (data_format == DataFormat::Bfp2_b) || (data_format == DataFormat::Bfp2));
 }
 
+bool is_mx_format(DataFormat data_format) { return (data_format == DataFormat::MxFp4); }
+
 bool is_exp_b_format(DataFormat data_format) {
     return (
         (data_format == DataFormat::Tf32 || data_format == DataFormat::Float16_b) ||
@@ -130,7 +132,7 @@ DataFormat get_single_unpack_dst_format(
         dst_format = unpack_conditional_dst_format;
     }
 
-    if (src_format == DataFormat::MxFp4) {
+    if (is_mx_format(src_format)) {
         dst_format = DataFormat::Float16_b;  // Fixed unpack_dst format for mx formats.
     }
 
@@ -224,13 +226,6 @@ DataFormat get_single_pack_src_format(
         pack_src_format = DataFormat::Invalid;
     } else if (data_format == DataFormat::Fp8_e4m3) {
         pack_src_format = is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
-    } else if (data_format == DataFormat::MxFp4) {
-        if (fp32_dest_acc_en) {
-            pack_src_format = DataFormat::Float32;
-        } else {
-            pack_src_format =
-                is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
-        }
     } else if (fp32_dest_acc_en) {
         if (arch == tt::ARCH::QUASAR && !tt::is_integer_format(data_format)) {
             pack_src_format = DataFormat::Float32;
@@ -292,6 +287,9 @@ DataFormat get_single_pack_src_format(
             } else {
                 pack_src_format = is_exp_b_format(data_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8;
             }
+        } else if (is_mx_format(data_format)) {
+            pack_src_format =
+                is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
         } else {
             pack_src_format = data_format;
         }
@@ -307,6 +305,11 @@ DataFormat get_single_pack_src_format(
             } else {
                 pack_src_format_tmp = is_exp_b_format(data_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8;
             }
+        }
+
+        if (is_mx_format(data_format)) {
+            pack_src_format_tmp =
+                is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
         }
 
         if (pack_src_format_tmp != DataFormat::Float32) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -467,6 +467,12 @@ ComputedDataFormats compute_data_formats(const JitBuildOptions& options, tt::ARC
         unpack_conditional_dst_format = DataFormat::Tf32;
     }
 
+    if (std::any_of(desc.buf_dataformat_arr.begin(), desc.buf_dataformat_arr.end(), [](DataFormat f) {
+            return f == DataFormat::MxFp4;
+        })) {
+        TT_FATAL(arch == tt::ARCH::QUASAR, "MxFp4 format is only supported on Quasar");
+    }
+
     tt::check_valid_formats_in_out_data_formats(desc.buf_dataformat_arr);
     auto [unpack_src_formats_all_cbs, unpack_dst_formats_all_cbs] = generate_unpack_data_formats(
         desc, unpack_conditional_dst_format, options.fp32_dest_acc_en, options.unpack_to_dest_mode, max_cbs);


### PR DESCRIPTION
### Summary
Issue: https://github.com/tenstorrent/tt-metal/issues/41081

Added MxFp4 format to be used in metal for quasar.

### Notes for reviewers
The full tile of MxFp4 is 544 bytes long. 

In metal we write the tiles to DRAM and then from DRAM to L1 in tests and other way around.

When we use dataflow kernels, we always give them the stride (how much to skip to get to the next tile). So far this has always been the same for both DRAM and L1. 

However, DRAM has to have tiles aligned to pages (64 byte alignment). Regardless of what we give as a stride parameter (Tile size) it will always choose it's own stride based on this one and write to DRAM with this stride. In all cases this stride was the same value as the tile size parameter since they were always aligned to 64 bytes.

In our case however, we need MxFp4 tiles consecutively written 544 bytes after 544 bytes. 544 is not divisible by 64. Therefore DRAM was always resorting to aligning it to 576 when writing  to itself.

It was writting into DRAM that way but when it came to kernels actually reading the data and transferring it to L1, they used our 544 parameter and for every tile that's not the first one, we had the 32 bytes of garbage (576 - 544 = 32).

We had to therefore split the parameter and make a stride for DRAM reading (576) and a stride for L1 (544).

Therefore we had to add this parameter to be passed in all tests that use 
tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
and
tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp

to make the calls consistent across the repo even though most tests don't use that parameter as they always have the alignment correctly set.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=uvelimirovic/add_quasar_MXFP4_format_metal_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:uvelimirovic/add_quasar_MXFP4_format_metal_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=uvelimirovic/add_quasar_MXFP4_format_metal_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:uvelimirovic/add_quasar_MXFP4_format_metal_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=uvelimirovic/add_quasar_MXFP4_format_metal_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:uvelimirovic/add_quasar_MXFP4_format_metal_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=uvelimirovic/add_quasar_MXFP4_format_metal_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:uvelimirovic/add_quasar_MXFP4_format_metal_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=uvelimirovic/add_quasar_MXFP4_format_metal_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:uvelimirovic/add_quasar_MXFP4_format_metal_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=uvelimirovic/add_quasar_MXFP4_format_metal_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:uvelimirovic/add_quasar_MXFP4_format_metal_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=uvelimirovic/add_quasar_MXFP4_format_metal_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:uvelimirovic/add_quasar_MXFP4_format_metal_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=uvelimirovic/add_quasar_MXFP4_format_metal_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:uvelimirovic/add_quasar_MXFP4_format_metal_infra)