### PR TITLE
#42997: use lcm for cb sizing to handle all combinations for neg reduction

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -130,22 +130,36 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
 
     if (operation_attributes.negate) {
         // The reduce_h_neg kernel pushes ntiles tiles per inner-loop iteration
-        // via push_back(ntiles).  ntiles equals chunk_size for full chunks and
-        // (Wt_per_core % chunk_size) for a partial last chunk.  The CB FIFO
-        // write pointer only wraps when it exactly reaches fifo_limit, so the
-        // CB size must be a multiple of every push size that occurs.  Use the
-        // LCM of chunk_size and each partial-chunk size to guarantee clean
-        // wrapping.
-        uint32_t negate_cb_tiles = chunk_size;
-        auto align_to_partial = [&](uint32_t cols_per_core) {
-            uint32_t partial = cols_per_core % chunk_size;
-            if (partial > 0) {
-                negate_cb_tiles = std::lcm(negate_cb_tiles, partial);
+        // via push_back(ntiles).  The CB FIFO write pointer only wraps when it
+        // exactly reaches fifo_limit, so the CB size must be a multiple of
+        // every push size that occurs.
+        //
+        // For a core with Wt_per_core columns and row_chunk == chunk_size:
+        //   - Wt_per_core >= chunk_size: push sizes are chunk_size (full
+        //     chunks) and Wt_per_core % chunk_size (partial last chunk).
+        //   - Wt_per_core < chunk_size:  the only push size is Wt_per_core
+        //     (no full-sized chunk ever occurs).
+        //
+        // Compute the LCM of only the push sizes that actually occur across
+        // both core groups to avoid unnecessarily inflating the CB allocation.
+        uint32_t negate_cb_tiles = 1;
+        auto include_push_sizes = [&](uint32_t cols_per_core) {
+            if (cols_per_core == 0) {
+                return;
+            }
+            if (cols_per_core >= chunk_size) {
+                negate_cb_tiles = std::lcm(negate_cb_tiles, chunk_size);
+                uint32_t partial = cols_per_core % chunk_size;
+                if (partial > 0) {
+                    negate_cb_tiles = std::lcm(negate_cb_tiles, partial);
+                }
+            } else {
+                negate_cb_tiles = std::lcm(negate_cb_tiles, cols_per_core);
             }
         };
-        align_to_partial(num_cols_per_core_group_1);
+        include_push_sizes(num_cols_per_core_group_1);
         if (num_cols_per_core_group_2 > 0) {
-            align_to_partial(num_cols_per_core_group_2);
+            include_push_sizes(num_cols_per_core_group_2);
         }
 
         uint32_t acc_cb_index = CBIndex::c_4;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <cmath>
+#include <numeric>
 
 namespace ttnn::prim {
 
@@ -128,15 +129,35 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
 
     if (operation_attributes.negate) {
+        // The reduce_h_neg kernel pushes ntiles tiles per inner-loop iteration
+        // via push_back(ntiles).  ntiles equals chunk_size for full chunks and
+        // (Wt_per_core % chunk_size) for a partial last chunk.  The CB FIFO
+        // write pointer only wraps when it exactly reaches fifo_limit, so the
+        // CB size must be a multiple of every push size that occurs.  Use the
+        // LCM of chunk_size and each partial-chunk size to guarantee clean
+        // wrapping.
+        uint32_t negate_cb_tiles = chunk_size;
+        auto align_to_partial = [&](uint32_t cols_per_core) {
+            uint32_t partial = cols_per_core % chunk_size;
+            if (partial > 0) {
+                negate_cb_tiles = std::lcm(negate_cb_tiles, partial);
+            }
+        };
+        align_to_partial(num_cols_per_core_group_1);
+        if (num_cols_per_core_group_2 > 0) {
+            align_to_partial(num_cols_per_core_group_2);
+        }
+
         uint32_t acc_cb_index = CBIndex::c_4;
         tt_metal::CircularBufferConfig cb_acc_config =
-            tt_metal::CircularBufferConfig(chunk_size * dst_single_tile_size, {{acc_cb_index, dst_cb_data_format}})
+            tt_metal::CircularBufferConfig(negate_cb_tiles * dst_single_tile_size, {{acc_cb_index, dst_cb_data_format}})
                 .set_page_size(acc_cb_index, dst_single_tile_size);
         tt_metal::CreateCircularBuffer(program, all_cores, cb_acc_config);
 
         uint32_t ineg_cb_index = CBIndex::c_5;
         tt_metal::CircularBufferConfig cb_ineg_config =
-            tt_metal::CircularBufferConfig(chunk_size * dst_single_tile_size, {{ineg_cb_index, dst_cb_data_format}})
+            tt_metal::CircularBufferConfig(
+                negate_cb_tiles * dst_single_tile_size, {{ineg_cb_index, dst_cb_data_format}})
                 .set_page_size(ineg_cb_index, dst_single_tile_size);
         tt_metal::CreateCircularBuffer(program, all_cores, cb_ineg_config);
     }


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #42997 

As part of testing new CB asserts in bbradel-0_skip_assert_failures. / https://github.com/tenstorrent/tt-metal/pull/42612 there was an error in CI for the reduce h neg kernel. This is the fix:
https://github.com/tenstorrent/tt-metal/actions/runs/24838156720/job/72707112696
```
FAILED tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py::test_min_multi_dim[input_shape=(3, 6, 40, 64, 32)] - RuntimeError: TT_THROW @ /project/tt_metal/impl/dispatch/system_memory_manager.cpp:723: tt::exception
```

AI Summary:
Fix CB FIFO overflow in reduce_h_neg for partial tile chunks

The reduce_h_neg compute kernel pushes ntiles tiles per inner-loop iteration via push_back(ntiles). When the per-core column count (Wt) is not a multiple of chunk_size, the last chunk has ntiles < chunk_size. The CB FIFO write pointer only wraps when it exactly reaches fifo_limit, so repeated pushes of a size that doesn't evenly divide the CB capacity cause the write pointer to accumulate past the remaining linear space, triggering:

LLK_ASSERT(remaining >= num_words, "CB push_back: fifo_wr_ptr would exceed fifo_limit")
For example, with chunk_size=4 and ntiles=3 (partial chunk), the CB holds 4 tiles (512 words). After the first push_back(3) (384 words), only 128 words remain — insufficient for the second push_back(3).

Fix: Size the c_4 (acc) and c_5 (ineg) circular buffers to LCM(chunk_size, partial_chunk_size) tiles instead of chunk_size tiles. This guarantees the write pointer always reaches fifo_limit exactly, enabling clean wrap-around regardless of partial chunk sizes. The worst-case increase for the common chunk_size=4 path is 3x (12 tiles, ~48KB for both CBs).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-42997_neg_lcm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42997_neg_lcm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-42997_neg_lcm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42997_neg_lcm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-42997_neg_lcm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42997_neg_lcm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-42997_neg_lcm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-42997_neg_lcm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-42997_neg_lcm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42997_neg_lcm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-42997_neg_lcm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42997_neg_lcm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-42997_neg_lcm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42997_neg_lcm)