### PR TITLE
Remove bad test case from test_mcast

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast.py
@@ -70,21 +70,6 @@ from models.demos.deepseek_v3_b1.micro_ops.mcast.op import McastSingleCore
             ),
             ttnn.NOC.NOC_1,
         ),  # loopback test for testing, not used in model
-        (
-            14336,
-            ttnn.CoreCoord(12, 9),
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7)),
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(8, 9)),
-                }
-            ),
-            ttnn.CoreRange(
-                ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(12, 9),
-            ),
-            ttnn.NOC.NOC_1,
-        ),  # mcast greater than burst size
     ],
 )
 def test_mcast(device, width, mcast_core, mcast_receivers, mcast_grid, noc):

--- a/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
@@ -72,6 +72,7 @@ FORCE_INLINE void mcast_send_set_state(uint32_t src_local_addr, uint64_t dst_noc
     }
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_BRCST_EXCLUDE, 0);
     if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
     }
     if constexpr (set_addresses) {
@@ -109,6 +110,7 @@ FORCE_INLINE void mcast_send_with_state(uint32_t src_local_addr, uint32_t dst_lo
     while (!noc_cmd_buf_ready(noc, cmd_buf));
 
     if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
     }
     if constexpr (set_addresses) {


### PR DESCRIPTION
### Summary
Mcast op does not support greater than burst size txns. There was a test case added using larger than burst size since there were changes to make mcast to support this that was reverted.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/mcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/mcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/mcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/mcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/mcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/mcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/mcast)