### PR TITLE
Implement warmup flow for demo

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -27,12 +27,18 @@ from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import (
     DEFAULT_MAX_SEQ_LEN,
+    DEFAULT_PREFILL_WARMUP_MODE_DEMO,
+    DEFAULT_PREFILL_WARMUP_MODE_VLLM,
     DEFAULT_SAMPLING_TEMPERATURE,
     DEFAULT_SAMPLING_TOP_K,
     DEFAULT_SAMPLING_TOP_P,
+    PREFILL_WARMUP_MODE_LINEAR_ADDITIVE,
+    PREFILL_WARMUP_MODE_LINEAR_MULTIPLES,
     USERS_PER_ROW,
     align_prefill_padded_seq_len,
+    align_up,
     even_int_div,
+    get_min_alignment_value_for_prefill,
     make_deepseek_sampling_args,
 )
 from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
@@ -200,6 +206,10 @@ class DeepseekGenerator(WarmupForwardMixin):
                 model_max_seq_len,
             )
         self.hf_config.max_seq_len = requested_max_seq_len
+        assert (
+            self.hf_config.max_seq_len % ttnn.TILE_SIZE == 0
+        ), f"hf_config.max_seq_len {self.hf_config.max_seq_len} must be TILE_SIZE={ttnn.TILE_SIZE} aligned"
+
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
             try:
@@ -305,24 +315,113 @@ class DeepseekGenerator(WarmupForwardMixin):
         self._prepare_weight_configs(cache_dir)
         self._assert_mtp_available()
 
-    def _get_prefill_warmup_prompt_lens(self) -> list[int]:
+    def warmup_model(self, min_token_len: int, max_token_len: int):
+        if not self.vllm_context:
+            # Phase 1: Warmup (i) prefill and (ii) decode without trace
+            logger.debug(f"Phase 1: (i) Warmup prefill without trace for demo")
+            self.warmup_model_prefill(
+                kv_cache=None,
+                enable_trace=False,
+                can_sample_on_device=False,
+                non_greedy_decoding_on_device=False,
+                min_token_len=min_token_len,
+                max_token_len=max_token_len,
+                sample_on_device=self.sample_on_device,
+            )
+            logger.debug(f"Phase 1: (ii) Warmup decode without trace for demo")
+            self._warmup_model_decode_demo(enable_trace=False, sample_on_device=self.sample_on_device)
+
+            if self.enable_trace:
+                # Phase 2: Warmup decode with trace (deepseek does not support prefill with trace)
+                logger.debug(f"Phase 2: Warmup decode with trace for demo")
+                self._warmup_model_decode_demo(enable_trace=True, sample_on_device=self.sample_on_device)
+            else:
+                logger.debug("Demo was initiated without trace, skipping Phase 2: Warmup decode with trace")
+            logger.info("Warmup completed for demo mode")
+
+        else:
+            logger.info("vLLM runs its own warmup, no need to warmup explicitly for vLLM context")
+
+    def _warmup_model_decode_demo(self, enable_trace: bool, sample_on_device: bool):
+        warmup_tokens = torch.zeros(self.batch_size, dtype=torch.int32)
+        warmup_start_pos = torch.zeros(self.batch_size, dtype=torch.int32)
+        decode_logits = self.decode_forward(
+            tokens=warmup_tokens,
+            start_pos=warmup_start_pos,
+            enable_trace=enable_trace,
+            page_table=None,
+            sample_on_device=sample_on_device,
+        )
+
+        if sample_on_device:
+            self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
+        else:
+            self._sample_on_host(decode_logits)
+
+    def _get_default_prefill_warmup_mode(self) -> str:
+        return DEFAULT_PREFILL_WARMUP_MODE_VLLM if self.vllm_context else DEFAULT_PREFILL_WARMUP_MODE_DEMO
+
+    def _get_prefill_warmup_token_lens(self, min_prompt_len: int = 0, max_prompt_len: int = 0) -> list[int]:
         """Build and cache supported prefill warmup lengths.
 
-        The list starts at ``ttnn.TILE_SIZE`` and doubles each step
-        (tile, 2*tile, 4*tile, ...), then includes ``hf_config.max_seq_len``
-        to guarantee coverage of the configured maximum sequence length.
-        Returned values are unique and sorted in ascending order.
+        Args:
+            min_prompt_len: Minimum prompt length to consider (inclusive). Rounded
+                up to the prefill alignment value for warmup generation.
+            max_prompt_len: Maximum prompt length to consider. If ``<= 0``, uses
+                ``self.hf_config.max_seq_len`` and rounds up to the same alignment.
+
+        Supported modes:
+            - ``LINEAR_ADDITIVE``: ``tile, 2*tile, 3*tile, ...``
+              Dense warmup coverage with more warmup compile/runtime cost.
+            - ``LINEAR_MULTIPLES``: ``tile, 2*tile, 4*tile, 8*tile, ...``
+              Geometric warmup coverage with fewer warmup points and more runtime padding.
+
+        Returns:
+            A unique, ascending list of prompt lengths aligned to the prefill
+            boundary. The list always includes the effective upper bound.
         """
-        if hasattr(self, "_prefill_warmup_prompt_lens"):
-            return self._prefill_warmup_prompt_lens
+        mode = self._get_default_prefill_warmup_mode()
+        alignment_value = get_min_alignment_value_for_prefill(self.mesh_device.shape[0])
+        upper_bound = max_prompt_len if max_prompt_len > 0 else self.hf_config.max_seq_len
+
+        upper_bound = align_up(upper_bound, alignment_value)
+        lower_bound = align_up(min_prompt_len, alignment_value)
+
+        assert (
+            upper_bound <= self.hf_config.max_seq_len
+        ), f"Upper bound {upper_bound} can not exceed model max seq len {self.hf_config.max_seq_len}"
+        assert (
+            lower_bound <= self.hf_config.max_seq_len
+        ), f"Lower bound {lower_bound} can not exceed model max seq len {self.hf_config.max_seq_len}"
+        cache_key = (lower_bound, upper_bound, mode)
+        cache = getattr(self, "_prefill_warmup_prompt_lens_cache", {})
+        if cache_key in cache:
+            return cache[cache_key]
+
         prompt_lens_set: set[int] = set()
-        prompt_len = ttnn.TILE_SIZE
-        while prompt_len <= self.hf_config.max_seq_len:
-            prompt_lens_set.add(prompt_len)
-            prompt_len *= 2
-        prompt_lens_set.add(self.hf_config.max_seq_len)
-        self._prefill_warmup_prompt_lens = sorted(prompt_lens_set)
-        return self._prefill_warmup_prompt_lens
+        if mode == PREFILL_WARMUP_MODE_LINEAR_ADDITIVE:
+            prompt_len = lower_bound
+            while prompt_len <= upper_bound:
+                prompt_lens_set.add(prompt_len)
+                prompt_len += alignment_value
+        elif mode == PREFILL_WARMUP_MODE_LINEAR_MULTIPLES:
+            multiple = 1
+            while alignment_value * multiple < lower_bound:
+                multiple *= 2
+            while alignment_value * multiple <= upper_bound:
+                prompt_lens_set.add(alignment_value * multiple)
+                multiple *= 2
+        else:
+            raise ValueError(
+                f"Unsupported warmup prompt_len mode '{mode}'. "
+                "Expected one of ['LINEAR_ADDITIVE', 'LINEAR_MULTIPLES']."
+            )
+
+        prompt_lens_set.add(upper_bound)
+        prompt_lens = sorted(prompt_lens_set)
+        cache[cache_key] = prompt_lens
+        self._prefill_warmup_prompt_lens_cache = cache
+        return prompt_lens
 
     def _validate_and_initialize_sampling(
         self,
@@ -1801,6 +1900,24 @@ class DeepseekGenerator(WarmupForwardMixin):
         profiler.end("tokenizing")
 
         logger.info(f"Lengths of {lengths.shape} (encoded) prompts: {lengths}")
+        padded_seq_len = int(tokens_batched.shape[-1])
+        # For demo the entire batch of prompts are padded to the same max length,
+        # so we warmup the model with only one prefill length i.e. min and max are the same.
+        # Once https://github.com/tenstorrent/tt-metal/issues/43099 is fixed, we can use the actual min lengths of the prompts
+        min_token_len = padded_seq_len
+        max_token_len = padded_seq_len
+        assert (
+            max_token_len <= self.hf_config.max_seq_len
+        ), f"Max prompt length {max_token_len} exceeds model max seq len {self.hf_config.max_seq_len}"
+
+        if self.signpost:
+            signpost(header="warmup_model")
+        profiler.start("warmup_model")
+        self.warmup_model(min_token_len, max_token_len)
+        profiler.end("warmup_model")
+        if self.signpost:
+            signpost(header="warmup_model")
+
         decode_steps_for_stats = 0
         decode_forward_passes = 0
         decode_step_active_masks_for_stats: List[List[bool]] = []
@@ -2258,16 +2375,16 @@ class DeepseekGenerator(WarmupForwardMixin):
     def _pad_seq_len_to_warmup_prompt_lens(self, seq_len: int) -> int:
         """Return the smallest supported prefill length >= seq_len.
 
-        Raise ValueError if seq_len is larger than all values in the list
-        returned by _get_prefill_warmup_prompt_lens().
+        Raises:
+            ValueError: If seq_len exceeds every value returned by
+                _get_prefill_warmup_token_lens().
         """
-        for supported_len in self._get_prefill_warmup_prompt_lens():
+        warmup_token_lens = self._get_prefill_warmup_token_lens()
+        for supported_len in warmup_token_lens:
             if seq_len <= supported_len:
                 return supported_len
 
-        raise ValueError(
-            f"seq_len {seq_len} is greater than all supported prefill lengths {self._get_prefill_warmup_prompt_lens()}"
-        )
+        raise ValueError(f"seq_len {seq_len} is greater than all supported prefill lengths {warmup_token_lens}")
 
     def _prefill(
         self,
@@ -2297,7 +2414,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             # prefill warmup is performed for all supported prompt lengths in the list returned by _get_prefill_warmup_prompt_lens()
             # We need to pad the seq_len to the closest supported warmup prompt length, otherwise memory corruption can happen.
             # The memory corruption happens when any new device memory is allocated when trace is active.
-            max_supported_seq_len = max(self._get_prefill_warmup_prompt_lens())
+            max_supported_seq_len = max(self._get_prefill_warmup_token_lens())
             if seq_len > max_supported_seq_len:
                 raise ValueError(
                     f"seq_len {seq_len} is greater than {max_supported_seq_len}. "
@@ -2751,16 +2868,11 @@ class DeepseekGenerator(WarmupForwardMixin):
         """Allocate persistent inputs, capture trace for one decode iteration, and store trace state."""
         assert self._trace_id is None, "Trace already captured"
 
-        # 1) Warm-up compile run (no trace) to keep compilation out of capture
-        logger.info("Running warm-up decode step (no trace)...")
-        if self.signpost:
-            signpost(header="decode_warmup")
-        _ = self._decode_step(init_tokens, positions, page_tables=page_tables, sample_on_device=False)
-        ttnn.synchronize_device(self.mesh_device)
-        if self.signpost:
-            signpost(header="decode_warmup")
+        # vLLM handles warmup calls internally, so we don't need to do anything here.
+        # For demo mode, we need to do warmup explicitly.
+        # So, overall it's expected that the warmup is done before capturing the trace.
 
-        # 2) Allocate persistent device inputs
+        # 1) Allocate persistent device inputs
         self._trace_tokens = self._tt_from_tokens_step(init_tokens)
         self._trace_positions = ttnn.from_torch(
             positions,
@@ -2779,7 +2891,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             self._trace_page_tables_to_use = self._get_page_tables()
         ttnn.synchronize_device(self.mesh_device)
 
-        # 3) Capture decode graph
+        # 2) Capture decode graph
         self.ccl.reset_sem_counters()
         logger.info("Begin capturing decode trace...")
         if self.signpost:
@@ -2815,7 +2927,8 @@ class DeepseekGenerator(WarmupForwardMixin):
     ) -> ttnn.Tensor | torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
-        self.enable_trace = enable_trace
+        if self.vllm_context:
+            self.enable_trace = enable_trace
 
         if not enable_trace:
             return self._decode_step(tokens, start_pos, page_table, sample_on_device)
@@ -2936,22 +3049,36 @@ class DeepseekGenerator(WarmupForwardMixin):
         num_pages = max(1, (prompt_len + page_size - 1) // page_size)
         return torch.arange(num_pages, dtype=torch.int32).unsqueeze(0)
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device) -> None:
+    def warmup_model_prefill(
+        self,
+        kv_cache,
+        enable_trace,
+        can_sample_on_device,
+        non_greedy_decoding_on_device,
+        min_token_len: int = 0,
+        max_token_len: int = 0,
+        sample_on_device: bool | None = None,
+    ) -> None:
         if enable_trace:
             logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator; skipping warmup.")
             return
 
         user_id = 0
-        for sample_on_device in [False, True]:
-            for prompt_len in self._get_prefill_warmup_prompt_lens():
-                tokens = torch.zeros(1, prompt_len, dtype=torch.int32)
+        if sample_on_device is None or self.vllm_context:
+            sample_on_device_list = [False, True]
+        else:
+            sample_on_device_list = [sample_on_device]
+
+        for sample_on_device in sample_on_device_list:
+            for token_len in self._get_prefill_warmup_token_lens(min_token_len, max_token_len):
+                vocab = int(getattr(self.hf_config, "vocab_size", 129280))
+                tokens = torch.randint(vocab, (1, token_len), dtype=torch.int32)
+                tokens, _ = self._pad_batch(tokens, 1)
                 # TODO: MTP path warmup needed?
-                page_table = self._build_warmup_page_table(prompt_len)
                 prefill_logits = self._prefill(
                     tokens=tokens,
                     user_id=user_id,
                     sample_on_device=sample_on_device,
-                    page_table=page_table,
                     return_last_hidden=False,
                 )
                 if sample_on_device:
@@ -2961,8 +3088,21 @@ class DeepseekGenerator(WarmupForwardMixin):
                         enable_trace=enable_trace,
                     )
 
-                    prefill_logits = self._slice_last_token_logits(prefill_logits, prompt_len, expand_to_batch=True)
+                    prefill_logits = self._slice_last_token_logits(prefill_logits, token_len, expand_to_batch=True)
                     self._sample_tokens_device(prefill_logits, user_slots=[user_id])
+
+        # Warmup creates temporary page tables; clean them up to free memory.
+        try:
+            if self.page_tables_tt is not None:
+                for i, page_table in enumerate(self.page_tables_tt):
+                    try:
+                        ttnn.deallocate(page_table)
+                    except Exception as e:
+                        logger.warning(f"Failed to deallocate warmup page table {i}: {e}")
+                self.page_tables_tt = None
+            self.base_page_table_host = None
+        except Exception as e:
+            logger.warning(f"Failed to cleanup warmup page tables: {e}")
 
         logger.info("Prefill warmup completed.")
 

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -38,6 +38,15 @@ def is_quad_mesh_env() -> bool:
     return os.getenv("MESH_DEVICE") == "QUAD"
 
 
+# We cann't warmup prefill for all possible prompt lengths, only warmup for the selective prompt lengths.
+# LINEAR_ADDITIVE: tile, 2*tile, 3*tile, ... hf_config.max_seq_len
+# LINEAR_MULTIPLES: tile, 2*tile, 4*tile, 8*tile, ... hf_config.max_seq_len
+PREFILL_WARMUP_MODE_LINEAR_ADDITIVE = "LINEAR_ADDITIVE"
+PREFILL_WARMUP_MODE_LINEAR_MULTIPLES = "LINEAR_MULTIPLES"
+DEFAULT_PREFILL_WARMUP_MODE_VLLM = PREFILL_WARMUP_MODE_LINEAR_MULTIPLES
+DEFAULT_PREFILL_WARMUP_MODE_DEMO = PREFILL_WARMUP_MODE_LINEAR_ADDITIVE
+
+
 def is_quad_mesh(mesh_device: ttnn.MeshDevice) -> bool:
     """Check whether the mesh device has a QUAD configuration (16x8)."""
     return mesh_device.shape[0] == 16 and mesh_device.shape[1] == 8
@@ -61,6 +70,17 @@ DEFAULT_SAMPLING_TOP_P = 0.95
 DEFAULT_SAMPLING_TOP_K = 32
 
 
+def align_up(value: int, align_value: int) -> int:
+    """Round value up to the next multiple of align_value, with a minimum of align_value."""
+    return max(align_value, (value + align_value - 1) // align_value * align_value)
+
+
+def get_min_alignment_value_for_prefill(rows: int) -> int:
+    """for quad mesh, we need to align each seq_len chunk per row to the tile size
+    for other meshes, we align the entire seq_len to the tile size"""
+    return int(ttnn.TILE_SIZE) * rows if rows == 16 else int(ttnn.TILE_SIZE)
+
+
 def align_prefill_padded_seq_len(seq_len: int, num_mesh_rows: int) -> int:
     """Round ``seq_len`` up to a multiple of ``TILE_SIZE * num_mesh_rows`` (mesh axis 0).
 
@@ -71,10 +91,8 @@ def align_prefill_padded_seq_len(seq_len: int, num_mesh_rows: int) -> int:
     rows = int(num_mesh_rows)
     if rows <= 0:
         raise ValueError(f"num_mesh_rows must be > 0, got {num_mesh_rows!r}")
-    # for quad mesh, we need to align each seq_len chunk per row to the tile size
-    # for other meshes, we align the entire seq_len to the tile size
-    alignment = int(ttnn.TILE_SIZE) * rows if rows == 16 else int(ttnn.TILE_SIZE)
-    return ((seq_len_i + alignment - 1) // alignment) * alignment
+    alignment = get_min_alignment_value_for_prefill(num_mesh_rows)
+    return align_up(seq_len_i, alignment)
 
 
 def make_deepseek_sampling_args(


### PR DESCRIPTION
## Summary

- Added a demo warmup flow that runs prefill and decode warmups and added a dedicated decode warmup helper in generator.py.
- Introduced configurable prefill warmup token-length generation with alignment logic, additive/multiples modes, and caching; used it to align warmup and padding behavior.
- Added alignment helpers and warmup mode constants in config_helpers.py, and tightened prefill alignment calculations.

## Test plan
ran quad (demo, stress, TF), dual (demo): all good. o/p generated is good. vLLM online inf is also good.
quad TF demo asserts, but demo o/p is good..