### PR TITLE
Deepseek demo prefill agreement accuracy test

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -491,6 +491,7 @@ def run_demo(
     sampling_temperature: float = DEFAULT_SAMPLING_TEMPERATURE,
     sampling_top_k: int = DEFAULT_SAMPLING_TOP_K,
     sampling_top_p: float = DEFAULT_SAMPLING_TOP_P,
+    decode_prefill_verify: bool = False,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -521,6 +522,19 @@ def run_demo(
         raise SystemExit(
             "--sampling-top-k=0 is not supported when sampling on device. Use --sample-on-host. See https://github.com/tenstorrent/tt-metal/issues/40236"
         )
+    if decode_prefill_verify:
+        if random_weights:
+            raise SystemExit("--decode-prefill-verify requires full-model mode (disable --random-weights)")
+        if token_accuracy:
+            raise SystemExit("--decode-prefill-verify cannot be combined with --token-accuracy")
+        if enable_mtp:
+            raise SystemExit("--decode-prefill-verify requires --enable-mtp off (MTP user layout not supported yet)")
+        if sampling_temperature > 0:
+            logger.warning(
+                "decode_prefill_verify: greedy sampling (temperature=0) is recommended so top-1 agreement "
+                "matches decode argmax; continuing with temperature={}",
+                sampling_temperature,
+            )
 
     # Validate model directory per mode
     validate_model_path(
@@ -808,6 +822,25 @@ def run_demo(
                         }
                     )
                 results.append(result)
+
+            if decode_prefill_verify and gen is not None and not random_weights:
+                if gen.enable_mtp:
+                    raise RuntimeError("decode_prefill_verify requires enable_mtp=False on the generator")
+                first_prompt_ids = gen._encode_prompt(prompt_list[0])
+                agreement = gen.verify_decode_prefill_agreement(
+                    first_prompt_ids,
+                    results[0]["tokens"],
+                    user_id=0,
+                    top_k_check=5,
+                )
+                results[0].update(agreement)
+                logger.info(
+                    "Decode/prefill agreement (user 0): top1={:.4f} top5={:.4f} mean_logprob={:.4f} over {} tokens",
+                    agreement["decode_prefill_agreement_top1_rate"],
+                    agreement["decode_prefill_agreement_topk_rate"],
+                    agreement["decode_prefill_agreement_mean_logprob"],
+                    agreement["decode_prefill_agreement_num_tokens"],
+                )
 
             if checkpoint_fh is not None:
                 for i, result in enumerate(results):

--- a/models/demos/deepseek_v3/demo/test_demo_decode_prefill_agreement.py
+++ b/models/demos/deepseek_v3/demo/test_demo_decode_prefill_agreement.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Decode vs trusted prefill self-consistency (see design in task spec).
+
+Phase 1: autoregressive decode on device.
+Phase 2: one prefill forward on ``prompt_ids + generated_ids``.
+Phase 3: each decode token should rank highly in prefill logits at the matching causal row.
+
+Greedy sampling (temperature 0) is required for a meaningful top-1 rate; stochastic sampling can
+pass via top-k / log-prob while top-1 vs prefill argmax is intentionally not asserted.
+
+Thresholds default slightly below the ideal (>90% top-1, >99% top-5) to absorb decode vs
+one-shot prefill numeric drift; override with environment variables if needed.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from models.demos.deepseek_v3.demo.demo import load_prompts_from_json, run_demo
+
+MODEL_PATH = Path(
+    os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized")
+)
+CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
+
+
+def _threshold(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    return float(raw)
+
+
+@pytest.mark.timeout(2400)
+@pytest.mark.requires_device(["DUAL"])
+def test_demo_decode_prefill_agreement_dual_full_demo_8upr(force_recalculate_weight_config: bool):
+    """
+    Same shape as ``dual_full_demo_8upr`` in ``test_demo.py`` (24 prompts, 8 users/row, 129 new tokens),
+    plus ``decode_prefill_verify``: after generation, re-score user 0 with a full-sequence prefill.
+
+    Uses greedy decoding so top-1 agreement (decode token == prefill argmax at that row) is meaningful.
+    """
+    json_path = "models/demos/deepseek_v3/demo/test_prompts.json"
+    max_prompts = 24
+    max_users_per_row = 8
+    max_new_tokens = 129
+
+    prompts = load_prompts_from_json(json_path, max_prompts=max_prompts)
+
+    results = run_demo(
+        prompts=prompts,
+        model_path=MODEL_PATH,
+        cache_dir=CACHE_DIR,
+        random_weights=False,
+        max_new_tokens=max_new_tokens,
+        max_users_per_row=max_users_per_row,
+        repeat_batches=1,
+        enable_trace=True,
+        sample_on_device=True,
+        profile_decode=False,
+        force_recalculate=force_recalculate_weight_config,
+        signpost=True,
+        decode_prefill_verify=True,
+        sampling_temperature=0.0,
+        sampling_top_k=1,
+        sampling_top_p=1.0,
+    )
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    assert requested_system_name is not None, "MESH_DEVICE must be set for demo tests"
+
+    gen0 = results["generations"][0]
+    n_tok = int(gen0["decode_prefill_agreement_num_tokens"])
+    assert n_tok > 0, "Expected at least one generated token for agreement metrics"
+    assert n_tok == len(gen0["tokens"]), "Agreement should cover every decoded token for user 0"
+
+    top1_min = _threshold("DEEPSEEK_DECODE_PREFILL_TOP1_MIN", 0.82)
+    top5_min = _threshold("DEEPSEEK_DECODE_PREFILL_TOP5_MIN", 0.985)
+
+    top1 = float(gen0["decode_prefill_agreement_top1_rate"])
+    top5 = float(gen0["decode_prefill_agreement_topk_rate"])
+    mean_lp = float(gen0["decode_prefill_agreement_mean_logprob"])
+
+    assert top5 >= top5_min, (
+        f"Prefill top-5 containment rate {top5:.4f} below {top5_min:.4f} "
+        f"(decode tokens not in prefill top-5 — likely decode bug or misaligned logits rows)"
+    )
+    assert top1 >= top1_min, (
+        f"Prefill top-1 agreement {top1:.4f} below {top1_min:.4f} "
+        f"(raise DEEPSEEK_DECODE_PREFILL_TOP1_MIN if this is expected drift on your stack)"
+    )
+
+    mean_lp_min = os.getenv("DEEPSEEK_DECODE_PREFILL_MEAN_LOGPROB_MIN")
+    if mean_lp_min is not None and mean_lp_min != "":
+        assert mean_lp >= float(
+            mean_lp_min
+        ), f"Mean log P under prefill {mean_lp:.4f} below floor {float(mean_lp_min):.4f}"
+
+    # Log for CI artifacts / debugging
+    print(
+        f"\nDecode/prefill agreement (user 0): top1={top1:.4f} top5={top5:.4f} "
+        f"mean_logprob={mean_lp:.4f} max_rank={gen0['decode_prefill_agreement_max_rank']} "
+        f"over {n_tok} tokens\n"
+    )

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -2406,6 +2406,101 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         return logits
 
+    def verify_decode_prefill_agreement(
+        self,
+        prompt_ids: list[int],
+        generated_ids: list[int],
+        *,
+        user_id: int = 0,
+        top_k_check: int = 5,
+    ) -> dict:
+        """Score each decode-produced token under a single trusted prefill over ``prompt_ids + generated_ids``.
+
+        For causal LM prefill logits, row ``pos - 1`` predicts the token at sequence index ``pos``.
+        Returns aggregate top-1 / top-``top_k_check`` hit rates and mean log-probability of the decoded
+        tokens under prefill softmax. Intended to catch decode-path bugs (KV, positions) while tolerating
+        small BF16 / kernel drift via top-k rather than raw logit equality.
+
+        Args:
+            prompt_ids: Prompt token ids (same encoding as used for decode).
+            generated_ids: Autoregressive decode output (excluding prompt).
+            user_id: KV / page-table user slot to run verification prefill on.
+            top_k_check: Rank threshold for the "in top-k" rate (default 5).
+
+        Raises:
+            RuntimeError: If ``enable_mtp`` is on (layout / user mapping differs from this helper).
+        """
+        if self.enable_mtp:
+            raise RuntimeError("verify_decode_prefill_agreement does not support MTP-enabled runs yet.")
+
+        p_len = len(prompt_ids)
+        if p_len < 1:
+            raise ValueError("verify_decode_prefill_agreement requires a non-empty prompt_ids sequence")
+        g_len = len(generated_ids)
+        if g_len == 0:
+            return {
+                "decode_prefill_agreement_num_tokens": 0,
+                "decode_prefill_agreement_top1_rate": 1.0,
+                "decode_prefill_agreement_topk_rate": 1.0,
+                "decode_prefill_agreement_topk": int(top_k_check),
+                "decode_prefill_agreement_mean_logprob": 0.0,
+                "decode_prefill_agreement_max_rank": 0,
+            }
+
+        full_ids = list(prompt_ids) + [int(t) for t in generated_ids]
+        actual_len = len(full_ids)
+        padded_len = align_prefill_padded_seq_len(actual_len, self.mesh_device.shape[0])
+        pad_id = self._get_pad_id()
+        row = torch.full((padded_len,), pad_id, dtype=torch.long)
+        row[:actual_len] = torch.tensor(full_ids, dtype=torch.long)
+        tokens_view = row.view(1, 1, -1)
+
+        logits = self._prefill(tokens_view, user_id=user_id, sample_on_device=False)
+        self.ccl.reset_sem_counters()
+
+        if not isinstance(logits, torch.Tensor):
+            raise TypeError("Expected host logits tensor from prefill when sample_on_device=False")
+
+        while logits.dim() > 2 and logits.shape[0] == 1:
+            logits = logits.squeeze(0)
+        if logits.dim() != 2:
+            logits = logits.reshape(logits.shape[0], -1)
+
+        seq_rows, vocab = logits.shape
+        if seq_rows < actual_len:
+            raise RuntimeError(f"Prefill logits sequence dim {seq_rows} shorter than concatenated length {actual_len}")
+        logits_sq = logits[:actual_len].float()
+
+        top1_hits = 0
+        topk_hits = 0
+        log_probs: list[float] = []
+        max_rank = 0
+        k_eff = min(int(top_k_check), int(vocab))
+
+        for j in range(g_len):
+            pos = p_len + j
+            log_row = logits_sq[pos - 1]
+            token_id = int(generated_ids[j])
+            if int(torch.argmax(log_row).item()) == token_id:
+                top1_hits += 1
+            _, topk_idx = torch.topk(log_row, k_eff)
+            if token_id in topk_idx.tolist():
+                topk_hits += 1
+            log_probs.append(float(torch.log_softmax(log_row, dim=-1)[token_id].item()))
+            strictly_better = int((log_row > log_row[token_id]).sum().item())
+            rank = strictly_better + 1
+            max_rank = max(max_rank, rank)
+
+        mean_lp = sum(log_probs) / g_len if g_len else 0.0
+        return {
+            "decode_prefill_agreement_num_tokens": g_len,
+            "decode_prefill_agreement_top1_rate": top1_hits / g_len,
+            "decode_prefill_agreement_topk_rate": topk_hits / g_len,
+            "decode_prefill_agreement_topk": int(top_k_check),
+            "decode_prefill_agreement_mean_logprob": mean_lp,
+            "decode_prefill_agreement_max_rank": int(max_rank),
+        }
+
     def _slice_last_token_logits(
         self, logits: ttnn.Tensor, prompt_len: int, *, expand_to_batch: bool = False
     ) -> ttnn.Tensor:


### PR DESCRIPTION
### Summary
Current accuracy test, teacher-forced demo is only effectively checking prefill functionality, but not as adequately checking the autoregressive decode functionality. Since the majority of the changes are decode based, ie decode optimizations, what this test does is verify decode functionality against prefill functionality. Generated decode output for a prompt is fed back into the model, as prompt + generated_test, and prefill is a verifier. We use prefill's probability distribution to verify how likely a token in decode actually is. Check whether decode's generated token is within top-1 and top-5. The values are aggregated and averaged over prompt. Top-1 > 82% and Top-5 > 98.5% are thresholds.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-demo-decode-acc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-demo-decode-acc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ds-demo-decode-acc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ds-demo-decode-acc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ds-demo-decode-acc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ds-demo-decode-acc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ds-demo-decode-acc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ds-demo-decode-acc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ds-demo-decode-acc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ds-demo-decode-acc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ds-demo-decode-acc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ds-demo-decode-acc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ds-demo-decode-acc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ds-demo-decode-acc-test)