### PR TITLE
Bug fix: runtime unit timeouts, schedules, and disable known-broken tests

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -110,11 +110,11 @@ runtime:
     bh_quietbox: 5
     bh_loudbox: 5
   unit:
-    wh_n150_civ2: 174
-    wh_n300_civ2: 72
-    bh_p150b_civ2: 169
+    wh_n150_civ2: 217
+    wh_n300_civ2: 74
+    bh_p150b_civ2: 205
     bh_p150b_civ2_viommu: 5
-    bh_p100a_civ2_viommu: 72
+    bh_p100a_civ2_viommu: 74
     bh_quietbox: 20
     wh_galaxy: 35
   integration:

--- a/.github/workflows/runtime-integration-tests.yaml
+++ b/.github/workflows/runtime-integration-tests.yaml
@@ -1,6 +1,10 @@
 name: "(Runtime) Integration Tests"
 
+# Nightly schedule restores coverage previously run via L2 Nightly; staggered to reduce runner contention.
+# Manual validation completed before enabling (see PR #40962 discussion).
 on:
+  schedule:
+    - cron: "0 5 * * *" # 05:00 UTC daily
   workflow_dispatch:
     inputs:
       wormhole:

--- a/.github/workflows/runtime-perf-tests.yaml
+++ b/.github/workflows/runtime-perf-tests.yaml
@@ -1,6 +1,10 @@
 name: "(Runtime) Performance Tests"
 
+# Weekly schedule for dispatch perf baselines; staggered to reduce runner contention.
+# Manual validation completed before enabling (see PR #40962 discussion).
 on:
+  schedule:
+    - cron: "0 6 * * 0" # 06:00 UTC every Sunday
   workflow_dispatch:
     inputs:
       wormhole:

--- a/.github/workflows/runtime-sanity-tests.yaml
+++ b/.github/workflows/runtime-sanity-tests.yaml
@@ -1,6 +1,10 @@
 name: "(Runtime) Sanity Tests"
 
+# Nightly schedule restores coverage previously run via L2 Nightly; staggered to reduce runner contention.
+# Manual validation completed before enabling (see PR #40962 discussion).
 on:
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC daily
   workflow_dispatch:
     inputs:
       wormhole:

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -1,6 +1,10 @@
 name: "(Runtime) Unit Tests"
 
+# Nightly schedule restores coverage previously run via L2 Nightly; staggered to reduce runner contention.
+# Manual validation completed before enabling (see PR #40962 discussion).
 on:
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC daily
   workflow_dispatch:
     inputs:
       wormhole:

--- a/tests/pipeline_reorg/runtime_integration_tests.yaml
+++ b/tests/pipeline_reorg/runtime_integration_tests.yaml
@@ -114,8 +114,9 @@
   team: runtime
 
 # --- Sweep Tests ---
+# NOTE: erfc filtered — ttnn.erfc dropped fast_and_approximate_mode in #42737 (Apr 24); test still passes the kwarg. Re-enable once test or API is updated.
 - name: runtime_fd_python_sweep
-  cmd: pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/ -xvvv
+  cmd: pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/ -xvvv -k 'not (test_run_eltwise_erf_ops and erfc)'
   skus:
     wh_n150_civ2:
       timeout: 45

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -53,9 +53,9 @@
   cmd: ./build/test/tt_metal/unit_tests_data_movement --gtest_filter='-*NIGHTLY_*:*NocEstimator*'
   skus:
     wh_n150_civ2:
-      timeout: 8
+      timeout: 40
     bh_p150b_civ2:
-      timeout: 8
+      timeout: 40
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
@@ -69,9 +69,9 @@
     ./build/test/tt_metal/unit_tests_jit_build
   skus:
     wh_n150_civ2:
-      timeout: 8
+      timeout: 12
     bh_p150b_civ2:
-      timeout: 8
+      timeout: 12
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
@@ -141,7 +141,7 @@
   cmd: ./build/test/tt_metal/distributed/distributed_unit_tests
   skus:
     wh_n150_civ2:
-      timeout: 8
+      timeout: 15
     bh_p150b_civ2:
       timeout: 8
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
@@ -247,11 +247,11 @@
     wh_n150_civ2:
       timeout: 10
     wh_n300_civ2:
-      timeout: 10
+      timeout: 12
     bh_p150b_civ2:
       timeout: 10
     bh_p100a_civ2_viommu:
-      timeout: 10
+      timeout: 12
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -59,13 +59,15 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# --- Context, Device, Misc, NOC, JIT Build ---
+# --- Context, Device, Misc, JIT Build ---
+# NOTE: unit_tests_noc temporarily disabled — TestDynamicNoCOneProgram deadlocks
+# (CHIP_IN_USE_0_PCIe self-deadlock). Reproduces locally. Binary was never on CI
+# before this reorg. Re-enable once the owner fixes the hang.
 - name: runtime_core
   cmd: |
     ./build/test/tt_metal/unit_tests_context
     ./build/test/tt_metal/unit_tests_device
     ./build/test/tt_metal/unit_tests_misc
-    ./build/test/tt_metal/unit_tests_noc
     ./build/test/tt_metal/unit_tests_jit_build
   skus:
     wh_n150_civ2:
@@ -76,8 +78,12 @@
   team: runtime
 
 # --- Integration Tests ---
+# NOTE: TensixMatmulMultiCoreMultiDRAM temporarily filtered — writer_matmul_tile_layout.cpp
+# uses TensorAccessorArgs<0>() without KERNEL_COMPILE_TIME_ARGS (latent since #27647,
+# 2025-09-03). Binary was never on CI before this reorg. Re-enable once the kernel/host
+# call is fixed.
 - name: runtime_integration
-  cmd: ./build/test/tt_metal/unit_tests_integration
+  cmd: ./build/test/tt_metal/unit_tests_integration --gtest_filter='-MeshDispatchFixture.TensixMatmulMultiCoreMultiDRAM'
   skus:
     wh_n150_civ2:
       timeout: 8
@@ -99,13 +105,16 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# --- Debug Tools (DPrint, Watcher, Inspector, NOC Debugging, Clean Init) ---
+# --- Debug Tools (DPrint, Watcher, Inspector, Clean Init) ---
+# NOTE: unit_tests_noc_debugging temporarily disabled — 9 of 17 tests deterministically
+# fail on BH (11 on WH); debugger reports zero issues where violations are intentionally
+# injected. Pre-existing breakage; was on cpp-post-commit Nightly L2 with auto-triage:false
+# so failures went unnoticed. Re-enable once the NOC debug detection is fixed.
 - name: runtime_debug_tools
   cmd: |
     ./tests/scripts/run_tools_tests.sh
     ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter='*'
     ./build/test/tt_metal/unit_tests_inspector --gtest_filter='*'
-    TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES=1 ./build/test/tt_metal/unit_tests_noc_debugging --gtest_filter='*'
   skus:
     wh_n150_civ2:
       timeout: 12

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -76,16 +76,16 @@
   team: runtime
 
 # --- Integration Tests ---
-# NOTE: unit_tests_integration disabled (matmul JIT + SFPU device hang).
-- name: runtime_integration
-  cmd: echo "unit_tests_integration disabled"
-  skus:
-    wh_n150_civ2:
-      timeout: 1
-    bh_p150b_civ2:
-      timeout: 1
-  owner_id: U099A7FMKL2 # Manish Sudumbrekar
-  team: runtime
+# NOTE: unit_tests_integration disabled (matmul JIT + SFPU device hang). Re-add when fixed.
+# - name: runtime_integration
+#   cmd: ./build/test/tt_metal/unit_tests_integration
+#   skus:
+#     wh_n150_civ2:
+#       timeout: 8
+#     bh_p150b_civ2:
+#       timeout: 8
+#   owner_id: U099A7FMKL2 # Manish Sudumbrekar
+#   team: runtime
 
 # --- LLK + SFPI Tests ---
 - name: runtime_llk

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -60,12 +60,10 @@
   team: runtime
 
 # --- Context, Device, Misc, JIT Build ---
-# NOTE: unit_tests_noc temporarily disabled — TestDynamicNoCOneProgram deadlocks
-# (CHIP_IN_USE_0_PCIe self-deadlock). Reproduces locally. Binary was never on CI
-# before this reorg. Re-enable once the owner fixes the hang.
+# NOTE: unit_tests_noc dropped, mock-coexistence tests filtered (#39849).
 - name: runtime_core
   cmd: |
-    ./build/test/tt_metal/unit_tests_context
+    ./build/test/tt_metal/unit_tests_context --gtest_filter='-MetalContextIntegrationTest.MockDeviceOnly:MetalContextIntegrationTest.Coexisting*:MetalContextIntegrationTest.ForkMockAndRealDevice'
     ./build/test/tt_metal/unit_tests_device
     ./build/test/tt_metal/unit_tests_misc
     ./build/test/tt_metal/unit_tests_jit_build
@@ -78,17 +76,14 @@
   team: runtime
 
 # --- Integration Tests ---
-# NOTE: TensixMatmulMultiCoreMultiDRAM temporarily filtered — writer_matmul_tile_layout.cpp
-# uses TensorAccessorArgs<0>() without KERNEL_COMPILE_TIME_ARGS (latent since #27647,
-# 2025-09-03). Binary was never on CI before this reorg. Re-enable once the kernel/host
-# call is fixed.
+# NOTE: unit_tests_integration disabled (matmul JIT + SFPU device hang).
 - name: runtime_integration
-  cmd: ./build/test/tt_metal/unit_tests_integration --gtest_filter='-MeshDispatchFixture.TensixMatmulMultiCoreMultiDRAM'
+  cmd: echo "unit_tests_integration disabled"
   skus:
     wh_n150_civ2:
-      timeout: 8
+      timeout: 1
     bh_p150b_civ2:
-      timeout: 8
+      timeout: 1
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
@@ -106,10 +101,7 @@
   team: runtime
 
 # --- Debug Tools (DPrint, Watcher, Inspector, Clean Init) ---
-# NOTE: unit_tests_noc_debugging temporarily disabled — 9 of 17 tests deterministically
-# fail on BH (11 on WH); debugger reports zero issues where violations are intentionally
-# injected. Pre-existing breakage; was on cpp-post-commit Nightly L2 with auto-triage:false
-# so failures went unnoticed. Re-enable once the NOC debug detection is fixed.
+# NOTE: unit_tests_noc_debugging disabled (NOC debug detection broken); re-enable once owner fixes.
 - name: runtime_debug_tools
   cmd: |
     ./tests/scripts/run_tools_tests.sh


### PR DESCRIPTION
## Summary

Follow-up fixes for the runtime unit pipelines. Three groups of changes:

**1. Timeout calibration** (commit `4788b58`)
Calibrates per-SKU timeouts for jobs that were repeatedly hitting CI caps; updates matching `runtime.unit` entries in `.github/time_budget.yaml` so budget checks stay consistent.
- `runtime_data_movement`
- `runtime_core`
- `runtime_distributed` (WH)
- `runtime_sd_llk` (WH N300 + BH P100A V-IOMMU)

**2. Pipeline visibility & schedules** (commit `4788b58`)
- Adds `(Runtime) Sanity tests` to the PR-description CI badge injection list.
- Enables runtime pipeline schedules:
  - Nightly: Runtime Sanity / Runtime Unit / Runtime Integration
  - Weekly: Runtime Performance

**3. Disable known-broken tests** (commits `98c32ae` and `efc0a78`)
The runtime reorg (#40962) added several binaries to CI for the first time; they had been built but never exercised on `origin/main` before. Each one surfaced a deterministic latent bug. Disabling in this PR unblocks the runtime pipelines while owners fix the underlying issues. All disables are marked with one-line `NOTE` comments referencing the failure mode for easy re-enable.
- `runtime_core`: dropped `unit_tests_noc` (`TestDynamicNoCOneProgram` self-deadlocks on `CHIP_IN_USE_0_PCIe`).
- `runtime_core`: filter mock-coexistence tests in `unit_tests_context` (`MockDeviceOnly`, `Coexisting*`, `ForkMockAndRealDevice`) — leaks the physical `MetalContext`, causes the next test to deadlock on the PCIe lock; documented as #39849.
- `runtime_integration`: disabled `unit_tests_integration` — matmul kernel JIT compile failure (`TensorAccessorArgs<0>()` without `KERNEL_COMPILE_TIME_ARGS`) and SFPU/relu device hang ("device is unrecoverable") that no `--gtest_filter` can recover from.
- `runtime_debug_tools`: dropped `unit_tests_noc_debugging` (NOC debug detection reports zero issues for tests that intentionally inject violations).

## Why

After moving runtime coverage into dedicated runtime pipelines, several Runtime Unit jobs were consistently failing for two unrelated reasons:
- Some jobs hit overly tight per-job timeout caps even on green runs → addressed by item (1).
- Some binaries that were built but never previously executed on CI exposed deterministic latent failures the moment the reorg started running them → addressed by item (3).

Item (2) just makes the pipelines visible at the PR-status level and puts them on a sensible schedule per team alignment.

## Files changed

- `tests/pipeline_reorg/runtime_unit_tests.yaml`
- `.github/time_budget.yaml`
- `.github/workflows/pr-description-inject-branch-name.yaml`
- `.github/workflows/runtime-sanity-tests.yaml`
- `.github/workflows/runtime-unit-tests.yaml`
- `.github/workflows/runtime-integration-tests.yaml`
- `.github/workflows/runtime-perf-tests.yaml`

## Test plan

- [x] Trigger `(Runtime) Unit Tests` on this branch and confirm calibrated jobs no longer hit timeout caps.
- [x] Verify each disabled/filtered test no longer surfaces in CI logs (runtime_core / runtime_integration / runtime_debug_tools).
- [x] Confirm the 5 silicon-only tests in `unit_tests_context` (`Legacy`, `HelloWorld`, `HelloWorldQueryThenCreate`, `ForkWithDisjointDevices`, `MeshDevicePropagatesContextId`) continue to run.
- [x] Trigger `(Runtime) Sanity Tests` and verify the runtime sanity badge appears in the injected PR CI status section.
- [ ] Validate runtime schedules trigger as intended (nightly for sanity/unit/integration, weekly for perf).



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/runtime-pipeline-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/runtime-pipeline-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/runtime-pipeline-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/runtime-pipeline-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/runtime-pipeline-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/runtime-pipeline-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/runtime-pipeline-followups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/runtime-pipeline-followups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/runtime-pipeline-followups)