### PR TITLE
Fix create_venv.sh --force not passing --clear to uv venv

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -305,7 +305,11 @@ echo "  Python version: ${VENV_PYTHON_VERSION}"
 # Install Python via uv and create virtual environment
 echo "Installing Python ${VENV_PYTHON_VERSION} via uv..."
 uv python install "${VENV_PYTHON_VERSION}"
-uv venv --link-mode copy --relocatable --managed-python --python "${VENV_PYTHON_VERSION}" "$PYTHON_ENV_DIR"
+UV_VENV_ARGS=(--link-mode copy --relocatable --managed-python --python "${VENV_PYTHON_VERSION}")
+if [[ "$FORCE_OVERWRITE" == "true" ]]; then
+    UV_VENV_ARGS+=(--clear)
+fi
+uv venv "${UV_VENV_ARGS[@]}" "$PYTHON_ENV_DIR"
 
 # Patch activate for POSIX sh (Docker/CI use /bin/sh; relocatable activate uses $BASH_SOURCE)
 # Use 'if' to prevent set -e from exiting on patch failure


### PR DESCRIPTION
### Summary
When --force was specified, the script warned about overwriting but did not pass --clear to uv venv, causing it to fail when the target directory already existed.

Fixes #42736

### Notes for reviewers
- Ran ./create_venv.sh --force with an existing python_env/ directory — venv was successfully recreated

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/fix-create-venv-force)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/fix-create-venv-force)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tcheda/fix-create-venv-force)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tcheda/fix-create-venv-force)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/fix-create-venv-force)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/fix-create-venv-force)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/fix-create-venv-force)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/fix-create-venv-force)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/fix-create-venv-force)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/fix-create-venv-force)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/fix-create-venv-force)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/fix-create-venv-force)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/fix-create-venv-force)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/fix-create-venv-force)