### PR TITLE
Fix model tracer to fail pipeline on pytest failures and show results in job summary

### DIFF
--- a/.github/workflows/ttnn-run-model-trace.yaml
+++ b/.github/workflows/ttnn-run-model-trace.yaml
@@ -396,9 +396,9 @@ jobs:
         run: |
           RESULTS_FILE="model_tracer/traced_operations/_test_results.json"
           if [[ ! -f "$RESULTS_FILE" ]]; then
-            echo "### Pytest Results — \`$SLUG\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "> No test results file found (test may not have started)." >> $GITHUB_STEP_SUMMARY
+            echo "### Pytest Results — \`$SLUG\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> No test results file found (test may not have started)." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 

--- a/.github/workflows/ttnn-run-model-trace.yaml
+++ b/.github/workflows/ttnn-run-model-trace.yaml
@@ -388,6 +388,63 @@ jobs:
             echo "trace_uid=$TRACE_UID" >> $GITHUB_OUTPUT
           fi
 
+      - name: Write pytest results to job summary
+        if: always()
+        env:
+          SLUG: ${{ matrix.slug }}
+          TEST_PATH: ${{ matrix.test_path }}
+        run: |
+          RESULTS_FILE="model_tracer/traced_operations/_test_results.json"
+          if [[ ! -f "$RESULTS_FILE" ]]; then
+            echo "### Pytest Results — \`$SLUG\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "> No test results file found (test may not have started)." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          python3 - <<'PY'
+          import json
+          import os
+
+          with open("model_tracer/traced_operations/_test_results.json") as f:
+              r = json.load(f)
+
+          passed = r.get("passed", 0)
+          failed = r.get("failed", 0)
+          total = r.get("total", 0)
+          exit_code = r.get("exit_code", "?")
+          slug = os.environ["SLUG"]
+          test_path = r.get("test_path", os.environ.get("TEST_PATH", ""))
+
+          if failed > 0:
+              status_icon = ":x:"
+              verdict = "FAILED"
+          elif passed > 0:
+              status_icon = ":white_check_mark:"
+              verdict = "PASSED"
+          else:
+              status_icon = ":warning:"
+              verdict = "UNKNOWN"
+
+          summary = f"""### {status_icon} Pytest Results — `{slug}`
+
+          | Metric | Value |
+          |---|---|
+          | Test Path | `{test_path}` |
+          | Passed | {passed} |
+          | Failed | {failed} |
+          | Total | {total} |
+          | Exit Code | {exit_code} |
+          | Verdict | **{verdict}** |
+          """
+
+          import textwrap
+          summary = textwrap.dedent(summary)
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write(summary)
+          PY
+
       - name: Write leg status sidecar
         if: always()
         env:
@@ -418,6 +475,18 @@ jobs:
               except Exception as exc:
                   stats["parse_error"] = str(exc)
 
+          test_stats = {"passed": None, "failed": None, "total": None}
+          results_file = "model_tracer/traced_operations/_test_results.json"
+          if os.path.isfile(results_file):
+              try:
+                  with open(results_file) as f:
+                      tr = json.load(f)
+                  test_stats["passed"] = tr.get("passed", 0)
+                  test_stats["failed"] = tr.get("failed", 0)
+                  test_stats["total"] = tr.get("total", 0)
+              except Exception:
+                  pass
+
           record = {
               "slug": os.environ["SLUG"],
               "test_path": os.environ["TEST_PATH"],
@@ -426,6 +495,7 @@ jobs:
               "outcome": os.environ.get("TRACE_OUTCOME") or "skipped",
               "trace_uid": os.environ.get("TRACE_UID") or None,
               "stats": stats,
+              "test_stats": test_stats,
           }
           out_path = f"/work/leg-status/{record['slug']}.json"
           with open(out_path, "w") as f:
@@ -847,6 +917,8 @@ jobs:
           rows = []
           success = 0
           failed = 0
+          total_tests_passed = 0
+          total_tests_failed = 0
           status_dir = Path("leg_status")
           if status_dir.is_dir():
               for p in sorted(status_dir.glob("*.json")):
@@ -859,9 +931,16 @@ jobs:
                   success += int(ok)
                   failed += int(not ok)
                   hf = rec.get("hf_model") or ""
+                  ts = rec.get("test_stats", {}) or {}
+                  tp = ts.get("passed")
+                  tf = ts.get("failed")
+                  total_tests_passed += tp or 0
+                  total_tests_failed += tf or 0
+                  test_col = f"{tp or 0} passed, {tf or 0} failed" if tp is not None else "-"
                   rows.append(
                       f"| {icon} | `{rec.get('slug')}` | `{rec.get('test_path')}` | "
-                      f"`{hf}` | {rec.get('stats', {}).get('unique_operations') or '-'} | "
+                      f"`{hf}` | {test_col} | "
+                      f"{rec.get('stats', {}).get('unique_operations') or '-'} | "
                       f"{rec.get('stats', {}).get('total_configurations') or '-'} | "
                       f"`{rec.get('trace_uid') or '-'}` |"
                   )
@@ -871,6 +950,7 @@ jobs:
               "",
               f"- Models requested: **{os.environ.get('MODEL_COUNT', '?')}**",
               f"- Succeeded: **{success}** / Failed: **{failed}**",
+              f"- Pytest totals: **{total_tests_passed} passed**, **{total_tests_failed} failed**",
               f"- Load to DB: **{os.environ.get('LOAD_TO_DB', 'false')}**",
               f"- Run Validation: **{os.environ.get('RUN_VALIDATION', 'false')}**",
           ]
@@ -882,10 +962,10 @@ jobs:
               lines.append(f"- Homogenized `trace_uid`: **`{trace_uid}`**")
           lines.extend([
               "",
-              "| Status | Slug | test_path | HF_MODEL | Unique ops | Total configs | Leg trace_uid |",
-              "|---|---|---|---|---|---|---|",
+              "| Status | Slug | test_path | HF_MODEL | Pytest Results | Unique ops | Total configs | Leg trace_uid |",
+              "|---|---|---|---|---|---|---|---|",
           ])
-          lines.extend(rows or ["| — | (no leg sidecars found) | | | | | |"])
+          lines.extend(rows or ["| — | (no leg sidecars found) | | | | | | |"])
 
           summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
           if summary_path:

--- a/model_tracer/generic_ops_tracer.py
+++ b/model_tracer/generic_ops_tracer.py
@@ -911,8 +911,10 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
 
     # Persist test results as a sidecar JSON so CI can surface them in
     # the GitHub job summary even when the trace step itself fails.
-    test_results_file = os.path.join(output_dir, "_test_results.json")
-    os.makedirs(output_dir, exist_ok=True)
+    test_results_dir = os.path.dirname(output_dir) if output_dir.endswith(".json") else output_dir
+    test_results_dir = test_results_dir or "."
+    test_results_file = os.path.join(test_results_dir, "_test_results.json")
+    os.makedirs(test_results_dir, exist_ok=True)
     try:
         with open(test_results_file, "w") as f:
             json.dump(
@@ -926,8 +928,8 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
                 f,
                 indent=2,
             )
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Failed to write test results sidecar: %s", exc, exc_info=True)
 
     return {
         "success": result.returncode == 0,
@@ -1269,9 +1271,7 @@ Examples (Import existing traces):
         if not args.load and "test_stats" in result:
             stats = result["test_stats"]
             if stats["total"] > 0:
-                print(
-                    f"Test Results: ✅ {stats['passed']} passed, ❌ {stats['failed']} failed (Total: {stats['total']})"
-                )
+                print(f"Test Results: ✅ {stats['passed']} passed, ❌ {stats['failed']} failed (Total: {stats['total']})")
             else:
                 # Fallback if we couldn't parse the output
                 print(f"Test Result: {'✅ PASSED' if result['success'] else '❌ FAILED'}")

--- a/model_tracer/generic_ops_tracer.py
+++ b/model_tracer/generic_ops_tracer.py
@@ -24,19 +24,20 @@ Examples (Standalone Python):
     python generic_ops_tracer.py /path/to/script.py --output-dir ./my_traces
 """
 
-import sys
-import os
-import subprocess
-import json
+import argparse
 import copy
 import hashlib
+import json
+import logging
+import os
 import re
+import subprocess
+import sys
 import uuid
-from tqdm import tqdm
-import argparse
 from datetime import datetime
 from pathlib import Path
-import logging
+
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -814,7 +815,7 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
         if extra_args:
             print(f"📎 Passing additional arguments: {' '.join(extra_args)}")
 
-        cmd = [python_cmd, "-m", "pytest", test_path, "-v", "-s", "--trace-params"] + extra_args
+        cmd = [python_cmd, "-m", "pytest", test_path, "-v", "-s", "--timeout=0", "--trace-params"] + extra_args
     else:
         print(f"✅ No pytest cases detected, running as standalone Python script...")
         cmd = [python_cmd, test_path, "--trace-params"] + extra_args
@@ -830,8 +831,8 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
 
     # Run the command with custom environment (always show live output now)
     # Use a custom command wrapper with tee to capture output while showing it live
-    import tempfile
     import re
+    import tempfile
 
     # Create a temp file to capture output
     tmp_output_fd, tmp_output_path = tempfile.mkstemp(suffix=".log", text=True)
@@ -841,10 +842,11 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
         # Build command with tee to show output live AND save to file
         # Convert cmd list to properly quoted string for shell
         cmd_str = " ".join(f'"{arg}"' if " " in arg else arg for arg in cmd)
-        tee_cmd = f"{cmd_str} 2>&1 | tee {tmp_output_path}"
+        tee_cmd = f"set -o pipefail; {cmd_str} 2>&1 | tee {tmp_output_path}"
 
-        # Run with shell=True to use tee
-        result = subprocess.run(tee_cmd, shell=True, cwd=BASE_DIR, text=True, env=env)
+        # Run with shell=True to use tee; use bash for pipefail support so we
+        # get the pytest exit code instead of tee's (always-zero) exit code.
+        result = subprocess.run(tee_cmd, shell=True, executable="/bin/bash", cwd=BASE_DIR, text=True, env=env)
 
         # Read the captured output to parse test statistics
         with open(tmp_output_path, "r") as f:
@@ -906,6 +908,26 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
     metadata_file = os.path.join(trace_dir, "_trace_metadata.json")
     with open(metadata_file, "w") as f:
         json.dump(metadata, f, indent=2)
+
+    # Persist test results as a sidecar JSON so CI can surface them in
+    # the GitHub job summary even when the trace step itself fails.
+    test_results_file = os.path.join(output_dir, "_test_results.json")
+    os.makedirs(output_dir, exist_ok=True)
+    try:
+        with open(test_results_file, "w") as f:
+            json.dump(
+                {
+                    "test_path": test_path,
+                    "exit_code": result.returncode,
+                    "passed": test_stats["passed"],
+                    "failed": test_stats["failed"],
+                    "total": test_stats["total"],
+                },
+                f,
+                indent=2,
+            )
+    except Exception:
+        pass
 
     return {
         "success": result.returncode == 0,
@@ -1247,7 +1269,9 @@ Examples (Import existing traces):
         if not args.load and "test_stats" in result:
             stats = result["test_stats"]
             if stats["total"] > 0:
-                print(f"Test Results: ✅ {stats['passed']} passed, ❌ {stats['failed']} failed (Total: {stats['total']})")
+                print(
+                    f"Test Results: ✅ {stats['passed']} passed, ❌ {stats['failed']} failed (Total: {stats['total']})"
+                )
             else:
                 # Fallback if we couldn't parse the output
                 print(f"Test Result: {'✅ PASSED' if result['success'] else '❌ FAILED'}")
@@ -1459,8 +1483,17 @@ Examples (Import existing traces):
             # Fix memory config shard_spec entries in the master JSON
             fix_memory_config_in_json(master_file)
 
-        # Always return 0 (success) as long as we processed traces
-        # Test failures don't affect tracer success
+        # Fail the pipeline if the underlying test run had any failures.
+        # This ensures CI catches pytest failures instead of silently
+        # succeeding just because traces were collected.
+        if not args.load and not result.get("success", True):
+            stats = result.get("test_stats", {})
+            if stats.get("failed", 0) > 0:
+                print(f"\n❌ Failing because {stats['failed']} test(s) failed")
+            else:
+                print(f"\n❌ Failing because test process exited with code {result.get('exit_code', 1)}")
+            return 1
+
         return 0
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- The `ttnn run model trace` workflow was silently succeeding even when all pytest cases failed (e.g. 9 failed, 0 passed) because the tracer always returned exit code 0
- The `cmd | tee` pipeline swallowed pytest's exit code (tee always returns 0), and the default 300s pytest-timeout was killing long-running model traces

## Changes
- **`--timeout=0`** added to the pytest invocation so pytest-timeout does not kill long-running model traces
- **`set -o pipefail` + bash** so the tee pipeline preserves pytest's real exit code instead of always returning 0
- **Fail on test failures**: tracer now returns exit code 1 when any pytest test fails (traces are still collected and saved before failing)
- **`_test_results.json` sidecar**: written by the tracer with `passed`/`failed`/`total` counts
- **GitHub job summary**: new `if: always()` workflow step renders a markdown table showing pytest results (passed/failed/total/verdict) in the Actions job summary
- **Leg status sidecar + batch summary**: `test_stats` included in leg sidecars and a new "Pytest Results" column in the batch summary table

## Test plan
- [x] Verified with dummy failing tests (2 pass, 2 fail) → tracer exits 1, reports `❌ 2 failed`
- [x] Verified with dummy all-passing tests (2 pass) → tracer correctly reports `✅ 2 passed, ❌ 0 failed`
- [x] Verified `--timeout=0` is passed to pytest (visible in test output)
- [x] Run the `ttnn run model trace` workflow to confirm job summary renders correctly on GitHub

## Validation runs
- https://github.com/tenstorrent/tt-metal/actions/runs/24875109209