### PR TITLE
[skip ci] re-apply #42591

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -192,6 +192,35 @@ def test_sdpa_decode_paged_attention(
 @pytest.mark.parametrize(
     "dtype, q_dtype",
     [
+        [ttnn.bfloat8_b, ttnn.bfloat16],
+    ],
+    ids=[
+        "kv_bfp8",
+    ],
+)
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d, grid_size",
+    [
+        [32, 32, 8, 2048, 128, (10, 11)],
+    ],
+    ids=["blackhole_b32_nkv8"],
+)
+@pytest.mark.timeout(120)
+def test_sdpa_decode_kv_head_core_divisibility(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype):
+    """Regression test for github.com/tenstorrent/tt-metal/issues/40978.
+
+    When floor(num_cores_available / B) yields a value that makes ceil(num_kv_heads / uncapped)
+    a non-divisor of num_kv_heads, the old core allocation produced inconsistent counts causing
+    a TT_FATAL crash at output core indexing.
+    """
+    run_test_sdpa_decode_single_iter(
+        device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, cur_pos_tensor=True, sharded_in=False, sharded_out=False
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype, q_dtype",
+    [
         [ttnn.bfloat8_b, ttnn.bfloat8_b],
     ],
     ids=[

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -163,11 +163,14 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     // ========== Core Allocation ==========
     const uint32_t max_cores_per_head =
         program_config.has_value() ? program_config->max_cores_per_head_batch : num_cores_available;
+    TT_FATAL(max_cores_per_head > 0, "max_cores_per_head_batch must be > 0");
     const uint32_t max_num_cores_for_compute = max_cores_per_head * B * num_kv_heads;
     const uint32_t num_cores_per_batch_uncapped = std::min(num_cores_available, max_num_cores_for_compute) / B;
     const uint32_t num_cores_per_head = std::max(1u, num_cores_per_batch_uncapped / num_kv_heads);
-    const uint32_t num_heads_per_core =
-        std::max(1u, (uint32_t)std::ceil((float)num_kv_heads / num_cores_per_batch_uncapped));
+    uint32_t num_heads_per_core = std::max(1u, (uint32_t)std::ceil((float)num_kv_heads / num_cores_per_batch_uncapped));
+    while (num_kv_heads % num_heads_per_core != 0) {
+        num_heads_per_core++;
+    }
     const uint32_t num_cores_per_batch = num_cores_per_head * num_kv_heads / num_heads_per_core;
     const uint32_t num_reducer_cores = num_kv_heads * B / num_heads_per_core;
     const uint32_t num_output_cores = B;


### PR DESCRIPTION
Restore #42591 after GitHub's SNAFU

### Summary
Issue:
https://github.com/tenstorrent/tt-metal/issues/40978#issuecomment-4269226125 SDPA decode encounters a core allocation error when using b=32, num kv heads = 8 with full BH 11x10 grid

```
num_cores_per_batch_uncapped = 110 / 32 = 3
num_heads_per_core = ceil(8 / 3) = 3        ← 8 % 3 != 0
num_cores_per_batch = 1 * 8 / 3 = 2         ← integer truncation
num_active_cores = 1 * 8 * 32 / 3 = 85      ← 85 / 2 = 42 output cores, but B = 32
```

The PR fixes this issue by incrementing num heads per core until it reaches a number divisible by num kv heads such that the kv head computation is divided evenly to each core group

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afuller/restore-42591)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afuller/restore-42591)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=afuller/restore-42591)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:afuller/restore-42591)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afuller/restore-42591)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afuller/restore-42591)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afuller/restore-42591)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afuller/restore-42591)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afuller/restore-42591)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afuller/restore-42591)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afuller/restore-42591)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afuller/restore-42591)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afuller/restore-42591)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afuller/restore-42591)