### PR TITLE
[skip ci] re-apply PR #42430

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
@@ -13,6 +13,7 @@
 #include "api/compute/bcast.h"
 #endif
 
+#include "api/compute/eltwise_binary.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 
 FORCE_INLINE void reload_from_cb_to_dst(
@@ -111,6 +112,7 @@ void kernel_main() {
 #ifdef FUSE_BIAS
     constexpr uint32_t bias_cb_id = tt::CBIndex::c_3;
     constexpr uint32_t mm_out_cb_id = mm_partials_cb_id;
+    constexpr bool row_broadcast_bias = (bool)get_compile_time_arg_val(14);
 #else
     constexpr uint32_t mm_out_cb_id = untilize_mode_out_cb_id;
 #endif
@@ -300,7 +302,11 @@ void kernel_main() {
 #endif
 
         reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
-        add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
+        if constexpr (row_broadcast_bias) {
+            add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
+        } else {
+            add_tiles_init(mm_partials_cb_id, bias_cb_id);
+        }
         // reconfigure unpacker df for src B
         cb_wait_front(bias_cb_id, in1_per_core_w);
         for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
@@ -310,10 +316,14 @@ void kernel_main() {
                 cb_wait_front(mm_partials_cb_id, out_subblock_num_tiles);
                 tile_regs_acquire();
                 for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
-                    uint32_t bcast_tile_idx = in1_index_subblock_offset;
+                    uint32_t bias_tile_idx = in1_index_subblock_offset;
                     for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
-                        add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, bcast_tile_idx, i);
-                        bcast_tile_idx++;
+                        if constexpr (row_broadcast_bias) {
+                            add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, bias_tile_idx, i);
+                        } else {
+                            add_tiles(mm_partials_cb_id, bias_cb_id, i, bias_tile_idx, i);
+                        }
+                        bias_tile_idx++;
                     }
                 }
 // if there's no SFPU fusion, we commit the regs so packer can start packing

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_bert_matmuls.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_bert_matmuls.py
@@ -274,8 +274,13 @@ def run_bert_linear_batch4(
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config_DRAM, tt_dtype=ttnn.bfloat8_b)
 
     output_mem_config = sharded_mem_config if out_sharded else interleaved_mem_config_L1
-    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config_L1, tt_dtype=ttnn.bfloat8_b)[0]
-
+    bias_t = ttnn.from_torch(
+        bias.reshape(bias_shape),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=interleaved_mem_config_L1,
+    )
     if in0_sharded:
         in0_t = ttnn.interleaved_to_sharded(
             in0_t,
@@ -518,8 +523,13 @@ def test_bert_linear_batch4_fp32_input_output(
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config_DRAM, tt_dtype=ttnn.float32)
 
     output_mem_config = interleaved_mem_config_DRAM
-    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config_DRAM, tt_dtype=ttnn.float32)[0]
-
+    bias_t = ttnn.from_torch(
+        bias.reshape(bias_shape),
+        dtype=ttnn.float32,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=interleaved_mem_config_L1,
+    )
     program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -98,10 +98,8 @@ def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_s
     torch_input_tensor_b = torch.randn((batch_size, channel_b, k_size, n_size), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor_a @ torch_input_tensor_b
     if has_bias:
-        torch_input_tensor_c = torch.randn((1, 1, TILE_HEIGHT, n_size), dtype=torch.bfloat16)
-        _torch_input_tensor_c = torch.repeat_interleave(
-            torch_input_tensor_c, torch_output_tensor.shape[2] // TILE_HEIGHT, dim=2
-        )
+        torch_input_tensor_c = torch.randn((1, 1, 1, n_size), dtype=torch.bfloat16)
+        _torch_input_tensor_c = torch.repeat_interleave(torch_input_tensor_c, torch_output_tensor.shape[2], dim=2)
         torch_output_tensor = torch_output_tensor + _torch_input_tensor_c
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
@@ -159,8 +159,13 @@ def test_linear_fp32_acc_l1(
 
         in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=activations_dtype)
         in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)
-        bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)[0]
-
+        bias_t = ttnn.from_torch(
+            bias.reshape(bias_shape),
+            dtype=weights_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=interleaved_mem_config,
+        )
         output_mem_config = sharded_mem_config if out_sharded else interleaved_mem_config
 
         if in0_sharded:
@@ -376,7 +381,13 @@ def test_matmul_1d_fp32_input_output(
 
         in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=activations_dtype)
         in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)
-        bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)[0]
+        bias_t = ttnn.from_torch(
+            bias.reshape(bias_shape),
+            dtype=weights_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=interleaved_mem_config,
+        )
 
         output_mem_config = sharded_mem_config if out_sharded else interleaved_mem_config
 
@@ -701,8 +712,13 @@ def test_sharded_matmul_2d(
 
     in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=activations_dtype)
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)
-    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)[0]
-
+    bias_t = ttnn.from_torch(
+        bias.reshape(bias_shape),
+        dtype=weights_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=interleaved_mem_config,
+    )
     output_mem_config = sharded_mem_config if out_sharded else interleaved_mem_config
 
     if in0_sharded:
@@ -788,7 +804,13 @@ def test_sharded_matmul_2d_in0_height_sharded_in1_width_sharded(
     # Generate the tensor
     in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=activations_dtype)
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)
-    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)[0]
+    bias_t = ttnn.from_torch(
+        bias.reshape(bias_shape),
+        dtype=weights_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=interleaved_mem_config,
+    )
 
     if in0_sharded:
         in0_t = ttnn.interleaved_to_sharded(
@@ -1055,8 +1077,13 @@ def test_sharded_matmul_1d_in0(
 
     in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=activations_dtype)
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)
-    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)[0]
-
+    bias_t = ttnn.from_torch(
+        bias.reshape(bias_shape),
+        dtype=weights_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=interleaved_mem_config,
+    )
     output_mem_config = sharded_mem_config if out_sharded else interleaved_mem_config
 
     if in0_sharded:
@@ -1129,7 +1156,13 @@ def test_sharded_matmul_1d_in1_wormhole(device, function_level_defaults):
 
     in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=dtype)
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=dtype)
-    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=dtype)[0]
+    bias_t = ttnn.from_torch(
+        bias.reshape(bias_shape),
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=interleaved_mem_config,
+    )
 
     output_mem_config = sharded_mem_config
 

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
@@ -551,7 +551,6 @@ def test_matmul_2d_in1_dram_sharded(
     if has_bias:
         bias = torch.ones(bias_shape).bfloat16().float()
         bias_padded = bias.unsqueeze(2)
-        bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, 32 - bias_padded.size(2)), "constant", 0)
         bias_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
         bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
         bias_shard_spec = ttnn.ShardSpec(bias_shard_grid, bias_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -8,8 +8,16 @@ import ttnn
 from ttnn.operations.activations import get_golden_function_for_activation
 from loguru import logger
 
+from models.common.utility_functions import (
+    torch_random,
+    is_blackhole,
+    skip_for_blackhole,
+    is_llk_assert_enabled,
+    skip_for_slow_dispatch,
+)
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
-from models.common.utility_functions import torch_random, skip_for_slow_dispatch
+from tests.ttnn.unit_tests.operations.matmul.test_matmul import is_tiny_tile_combo_supported
+
 
 pytestmark = pytest.mark.use_module_device
 
@@ -960,4 +968,345 @@ def test_linear_bias_cb_estimation_with_large_n_small_k(device, batch_size, seq_
         frobenius_threshold=0.001 * k_size,
         pcc_threshold=0.99,
         check_ulp=False,
+    )
+
+
+def run_linear_bias_broadcast(device, a, b, bias=None, optional_output=None):
+    a_tt = ttnn.from_torch(a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    b_tt = ttnn.from_torch(b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    bias_tt = None
+    if bias is not None:
+        bias_tt = ttnn.from_torch(bias, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    optional_tt = None
+    if optional_output is not None:
+        optional_tt = ttnn.from_torch(optional_output, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result = ttnn.linear(a_tt, b_tt, bias=bias_tt, optional_output_tensor=optional_tt)
+    return ttnn.to_torch(result)
+
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape, bias_shape",
+    [
+        ((256, 1024), (1024, 512), (1, 1, 512)),
+        ((1, 1024), (1024, 512), (1, 512, 512)),
+        ((2, 16, 32), (2, 32, 8), None),
+        ((32, 64), (64, 16), (1, 17, 16)),  # Broadcast error: Invalid dimension"
+    ],
+)
+def test_linear_bias_broadcast(device, a_shape, b_shape, bias_shape):
+    torch.manual_seed(0)
+
+    a = torch.randn(*a_shape, dtype=torch.bfloat16)
+    b = torch.randn(*b_shape, dtype=torch.bfloat16)
+
+    if bias_shape is not None:
+        bias = torch.randn(*bias_shape, dtype=torch.bfloat16)
+    else:
+        bias = None
+
+    torch_failed = False
+    try:
+        if bias_shape is None:
+            expected = torch.matmul(a, b)
+        else:
+            expected = torch.matmul(a, b) + bias
+
+    except Exception:
+        torch_failed = True
+
+    if torch_failed:
+        with pytest.raises(Exception):
+            run_linear_bias_broadcast(device, a, b, bias)
+    else:
+        result = run_linear_bias_broadcast(device, a, b, bias)
+        assert result.shape == expected.shape
+        assert_numeric_metrics(
+            expected, result, pcc_threshold=0.999, check_ulp=False, check_frobenius=False, check_allclose=False
+        )
+
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape, bias_shape, optional_shape",
+    [
+        ((8, 64), (64, 4), (1, 1, 4), (1, 1, 1, 8, 4)),
+        ((8, 64), (64, 4), (1, 1, 4), (1, 3, 8)),  # Invalid optional output tensor
+    ],
+)
+def test_linear_bias_broadcast_with_optional_shape(device, a_shape, b_shape, bias_shape, optional_shape):
+    torch.manual_seed(0)
+
+    a = torch.randn(*a_shape, dtype=torch.bfloat16)
+    b = torch.randn(*b_shape, dtype=torch.bfloat16)
+    bias = torch.randn(*bias_shape, dtype=torch.bfloat16)
+
+    optional = None
+    if optional_shape is not None:
+        optional = torch.empty(*optional_shape, dtype=torch.bfloat16)
+
+    torch_failed = False
+    try:
+        expected = torch.matmul(a, b) + bias
+    except Exception:
+        torch_failed = True
+
+    if torch_failed:
+        with pytest.raises(Exception):
+            run_linear_bias_broadcast(device, a, b, bias, optional)
+    else:
+        if expected.numel() != optional.numel():
+            with pytest.raises(Exception):
+                run_linear_bias_broadcast(device, a, b, bias, optional)
+        else:
+            result = run_linear_bias_broadcast(device, a, b, bias, optional)
+
+            if optional_shape is not None:
+                assert result.shape == optional_shape
+            else:
+                assert result.shape == expected.shape
+
+
+@pytest.mark.parametrize("bias_rank", [0, 1, 2, 3, 4])
+@pytest.mark.parametrize("m,k,n", [(32, 32, 32)])
+def test_linear_broadcast_bias_ranks(device, m, k, n, bias_rank):
+    """
+    ``ttnn.linear`` with broadcastable bias shapes (logical rank 0-4) vs torch ``matmul + bias``.
+    """
+
+    if bias_rank == 0:
+        pytest.skip(f"Rank-0 bias linear not supported")
+
+    torch.manual_seed(0)
+    torch_input = torch.randn((m, k), dtype=torch.bfloat16)
+    torch_weight = torch.randn((n, k), dtype=torch.bfloat16)
+    if bias_rank == 1:
+        torch_bias = torch.randn((n,), dtype=torch.bfloat16)
+    elif bias_rank == 2:
+        torch_bias = torch.randn((1, n), dtype=torch.bfloat16)
+    elif bias_rank == 3:
+        torch_bias = torch.randn((1, 1, n), dtype=torch.bfloat16)
+    else:
+        torch_bias = torch.randn((1, 1, 1, n), dtype=torch.bfloat16)
+
+    torch_mat = torch.matmul(torch_input, torch_weight.T)
+    torch_output = torch_mat + torch_bias
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    weight_tensor = ttnn.from_torch(
+        torch_weight, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    bias_tensor = ttnn.from_torch(
+        torch_bias, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    output_tensor = ttnn.linear(input_tensor, weight_tensor, bias=bias_tensor, transpose_b=True)
+
+    output = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output, output, pcc=0.99)
+
+
+def _skip_unless_fused_full_mn_tiny_tile_supported(transpose_tile, tile_w, tile_h):
+    if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h, True) and is_llk_assert_enabled():
+        pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
+
+
+def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
+    remainder = num % lcm
+    if remainder == 0:
+        return num
+    padding_needed = lcm - remainder
+    padded_number = num + padding_needed
+    return padded_number
+
+
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #31385")
+@pytest.mark.parametrize("k_dram", [128, 256])
+@pytest.mark.parametrize(
+    "m,n,tile_h,tile_w,transpose_tile",
+    [
+        (32, 32, 32, 32, False),
+        (16, 32, 16, 32, False),
+    ],
+)
+def test_linear_fused_non_broadcast_bias_dram_sharded_in1(device, k_dram, m, n, tile_h, tile_w, transpose_tile):
+    """Fused bias [1,1,M,N] with MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig (grid 1x1)."""
+    _skip_unless_fused_full_mn_tiny_tile_supported(transpose_tile, tile_w, tile_h)
+    torch.manual_seed(0)
+    in1_dtype = ttnn.bfloat16
+    num_banks = device.dram_grid_size().x if is_blackhole() else 12
+    n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_banks)
+    in0_shape = [1, 1, m, k_dram]
+    in1_shape = [1, 1, k_dram, n]
+    in1_shard_shape = [k_dram, n_padded // num_banks]
+    num_cores = 1
+    in0_block_w = k_dram // num_cores // 32
+    out_block_h = m // tile_h
+    out_block_w = n // num_cores // tile_w
+    sharded_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+    )
+    in0 = torch.randn(in0_shape).bfloat16().float()
+    in1 = torch.randn(in1_shape).bfloat16().float()
+    in0_memory_config = ttnn.create_sharded_memory_config(
+        (1, 1, m, k_dram),
+        core_grid=ttnn.CoreGrid(y=1, x=1),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    in0_t = ttnn.from_torch(
+        in0,
+        tile=ttnn.Tile((tile_h, 32)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in0_memory_config,
+    )
+    in1_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
+    in1_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), in1_shard_grid)})
+    in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    in1_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec)
+    in1_t = ttnn.from_torch(
+        in1,
+        tile=ttnn.Tile((32, tile_w), transpose_tile=transpose_tile),
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in1_memory_config,
+    )
+    bias_dram = torch.randn([1, 1, m, n]).bfloat16().float()
+    bias_shard_shape = [tile_h, n_padded // num_banks]
+    bias_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
+    bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
+    bias_shard_spec = ttnn.ShardSpec(bias_shard_grid, bias_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    bias_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, bias_shard_spec)
+    bias_t = ttnn.from_torch(
+        bias_dram,
+        tile=ttnn.Tile((tile_h, tile_w)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=bias_mem_config,
+    )
+    dram_program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+        in0_block_w=in0_block_w // 4,
+        per_core_M=out_block_h,
+        per_core_N=out_block_w,
+        fused_activation=None,
+    )
+    dram_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    output_dram = ttnn.linear(
+        in0_t,
+        in1_t,
+        bias=bias_t,
+        program_config=dram_program_config,
+        memory_config=sharded_mem_config,
+        dtype=ttnn.bfloat16,
+        compute_kernel_config=dram_compute_kernel_config,
+        output_tile=ttnn.Tile([tile_h, tile_w]),
+    )
+    pt_dram = in0 @ in1 + bias_dram
+    for o in ttnn.get_device_tensors(output_dram):
+        assert_numeric_metrics(
+            pt_dram,
+            ttnn.to_torch(o),
+            atol=0.004 * k_dram,
+            rtol=0.227 * k_dram,
+            frobenius_threshold=0.001 * k_dram,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
+
+
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #31385")
+@pytest.mark.parametrize("m,k,n", [(32, 32, 32), (32, 64, 32)])
+def test_linear_fused_non_broadcast_bias_width_sharded_in0_in1(device, m, k, n):
+    """Fused bias [1,1,M,N] with width-sharded activations/weights/bias and 1D mcast program config."""
+    _skip_unless_fused_full_mn_tiny_tile_supported(False, 32, 32)
+    torch.manual_seed(0)
+    num_act = num_mm = 1
+    core_range = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    mem_config_weights = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_range, [k, n // num_mm], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mem_config_bias = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_range, [32, n // num_mm], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mem_config_input = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_range, [m, k // num_act], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    sharded_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    input_tensor = torch.randn([1, 1, m, k], dtype=torch.bfloat16)
+    tt_input = ttnn.as_tensor(
+        input_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config_input,
+    )
+    weights_tensor = torch.randn([1, 1, k, n], dtype=torch.bfloat16)
+    weight_tt = ttnn.as_tensor(
+        weights_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config_weights,
+    )
+    bias_tensor = torch.randn([1, 1, m, n], dtype=torch.bfloat16) * 2.0
+    bias_tt = ttnn.as_tensor(
+        bias_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config_bias,
+    )
+    sharded_program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        in0_block_w=k // num_mm // 32,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=m // 32,
+        per_core_N=n // 32,
+        mcast_in0=True,
+        fused_activation=None,
+        fuse_batch=True,
+    )
+    tt_out = ttnn.linear(
+        tt_input,
+        weight_tt,
+        bias=bias_tt,
+        memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+        program_config=sharded_program_config,
+        compute_kernel_config=sharded_compute_kernel_config,
+    )
+    matmul_ref = torch.matmul(input_tensor, weights_tensor) + bias_tensor
+    tt_mm_out = ttnn.to_torch(ttnn.from_device(tt_out))
+    assert_numeric_metrics(
+        matmul_ref,
+        tt_mm_out,
+        atol=0.018 * k,
+        rtol=2.57 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=0.993,
     )

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -586,7 +586,19 @@ def test_matmul_in1_dram_sharded_tiny_tile(
 
 
 def run_matmul_2d_multiple_output_blocks_per_core(
-    device, b, m, k, n, has_bias, grid_size, in0_sharded, out_sharded, num_out_block_h, num_out_block_w, transpose_mcast
+    device,
+    b,
+    m,
+    k,
+    n,
+    has_bias,
+    grid_size,
+    in0_sharded,
+    out_sharded,
+    num_out_block_h,
+    num_out_block_w,
+    transpose_mcast,
+    bias_layout="broadcast",
 ):
     if in0_sharded or out_sharded:
         fuse_batch = True
@@ -604,7 +616,12 @@ def run_matmul_2d_multiple_output_blocks_per_core(
 
     in0_shape = [b, 1, m, k]
     in1_shape = [b, 1, k, n]
-    bias_shape = [1, 1, n]
+    if bias_layout == "broadcast":
+        bias_shape = [1, 1, 1, n]
+    elif bias_layout == "full_mn":
+        bias_shape = [1, 1, m, n]
+    else:
+        raise ValueError(f"Unknown bias_layout: {bias_layout}")
 
     if transpose_mcast:
         in0_block_w = k // grid_size[1] // 32
@@ -649,10 +666,8 @@ def run_matmul_2d_multiple_output_blocks_per_core(
 
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
-        bias_padded = bias.unsqueeze(2)
-        bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, 32 - bias_padded.size(2)), "constant", 0)
         bias_t = ttnn.from_torch(
-            bias_padded,
+            bias,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=device,
@@ -787,11 +802,28 @@ def test_matmul_2d_multiple_output_blocks_per_core(
 
 
 def run_matmul_2d_tiny_tile(
-    device, m, k, n, has_bias, grid_size, tile_h, tile_w, in0_sharded, out_sharded, in1_dtype, transpose_tile
+    device,
+    m,
+    k,
+    n,
+    has_bias,
+    grid_size,
+    tile_h,
+    tile_w,
+    in0_sharded,
+    out_sharded,
+    in1_dtype,
+    transpose_tile,
+    bias_layout="broadcast",
 ):
     in0_shape = [1, 1, m, k]
     in1_shape = [1, 1, k, n]
-    bias_shape = [1, 1, n]
+    if bias_layout == "broadcast":
+        bias_shape = [1, 1, 1, n]
+    elif bias_layout == "full_mn":
+        bias_shape = [1, 1, m, n]
+    else:
+        raise ValueError(f"Unknown bias_layout: {bias_layout}")
 
     in0_block_w = k // grid_size[0] // 32
     out_block_h = m // grid_size[1] // tile_h
@@ -829,10 +861,8 @@ def run_matmul_2d_tiny_tile(
 
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
-        bias_padded = bias.unsqueeze(2)
-        bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, tile_h - bias_padded.size(2)), "constant", 0)
         bias_t = ttnn.from_torch(
-            bias_padded,
+            bias,
             tile=ttnn.Tile((tile_h, tile_w)),
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
@@ -955,11 +985,28 @@ def test_matmul_2d_tiny_tile(
 
 
 def run_matmul_1d_tiny_tile(
-    device, m, k, n, has_bias, grid_size, tile_h, tile_w, in0_sharded, out_sharded, in1_dtype, transpose_tile
+    device,
+    m,
+    k,
+    n,
+    has_bias,
+    grid_size,
+    tile_h,
+    tile_w,
+    in0_sharded,
+    out_sharded,
+    in1_dtype,
+    transpose_tile,
+    bias_layout="broadcast",
 ):
     in0_shape = [1, 1, m, k]
     in1_shape = [1, 1, k, n]
-    bias_shape = [1, 1, n]
+    if bias_layout == "broadcast":
+        bias_shape = [1, 1, 1, n]
+    elif bias_layout == "full_mn":
+        bias_shape = [1, 1, m, n]
+    else:
+        raise ValueError(f"Unknown bias_layout: {bias_layout}")
 
     num_cores = grid_size[0] * grid_size[1]
 
@@ -999,10 +1046,8 @@ def run_matmul_1d_tiny_tile(
 
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
-        bias_padded = bias.unsqueeze(2)
-        bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, tile_h - bias_padded.size(2)), "constant", 0)
         bias_t = ttnn.from_torch(
-            bias_padded,
+            bias,
             tile=ttnn.Tile((tile_h, tile_w)),
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
@@ -1075,6 +1120,98 @@ def run_matmul_1d_tiny_tile(
         frobenius_threshold=0.001 * k,
         pcc_threshold=0.999,
         check_ulp=False,
+    )
+
+
+def _skip_unless_fused_full_mn_tiny_tile_supported(transpose_tile, tile_w, tile_h):
+    if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h, True) and is_llk_assert_enabled():
+        pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
+
+
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #31385")
+@pytest.mark.parametrize(
+    "m,k,n,tile_h,tile_w,transpose_tile",
+    [
+        (32, 32, 32, 32, 32, False),
+        (16, 32, 32, 16, 32, False),
+    ],
+)
+@pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
+def test_linear_fused_non_broadcast_bias_2d_mcast_tiny_tile(mesh_device, m, k, n, tile_h, tile_w, transpose_tile):
+    """Fused bias [1,1,M,N] on MatmulMultiCoreReuseMultiCastProgramConfig (2D mcast tiny tile)."""
+    _skip_unless_fused_full_mn_tiny_tile_supported(transpose_tile, tile_w, tile_h)
+    torch.manual_seed(0)
+    grid_1 = (1, 1)
+    run_matmul_2d_tiny_tile(
+        mesh_device,
+        m,
+        k,
+        n,
+        True,
+        grid_1,
+        tile_h,
+        tile_w,
+        True,
+        True,
+        ttnn.bfloat16,
+        transpose_tile,
+        bias_layout="full_mn",
+    )
+
+
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #31385")
+@pytest.mark.parametrize(
+    "m,k,n,tile_h,tile_w,transpose_tile",
+    [
+        (32, 32, 32, 32, 32, False),
+        (16, 32, 32, 16, 32, False),
+    ],
+)
+@pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
+def test_linear_fused_non_broadcast_bias_1d_mcast_tiny_tile(mesh_device, m, k, n, tile_h, tile_w, transpose_tile):
+    """Fused bias [1,1,M,N] on MatmulMultiCoreReuseMultiCast1DProgramConfig (1D mcast tiny tile)."""
+    _skip_unless_fused_full_mn_tiny_tile_supported(transpose_tile, tile_w, tile_h)
+    torch.manual_seed(0)
+    grid_1 = (1, 1)
+    run_matmul_1d_tiny_tile(
+        mesh_device,
+        m,
+        k,
+        n,
+        True,
+        grid_1,
+        tile_h,
+        tile_w,
+        True,
+        True,
+        ttnn.bfloat16,
+        transpose_tile,
+        bias_layout="full_mn",
+    )
+
+
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #31385")
+@pytest.mark.parametrize("m,k,n", [(32, 32, 32), (32, 64, 32)])
+@pytest.mark.parametrize("transpose_mcast", [False, True])
+@pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
+def test_linear_fused_non_broadcast_bias_2d_mesh_multiple_blocks(mesh_device, transpose_mcast, m, k, n):
+    """Fused bias [1,1,M,N] on mesh 2D multi-block MatmulMultiCoreReuseMultiCastProgramConfig."""
+    torch.manual_seed(0)
+    grid_1 = (1, 1)
+    run_matmul_2d_multiple_output_blocks_per_core(
+        mesh_device,
+        1,
+        m,
+        k,
+        n,
+        True,
+        grid_1,
+        False,
+        False,
+        1,
+        1,
+        transpose_mcast,
+        bias_layout="full_mn",
     )
 
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -134,7 +134,7 @@ def _run_matmul_2d_interleaved_in0_sharded_in1(
         )
 
         if has_bias:
-            bias_shape = [1, 1, tile_h, n]
+            bias_shape = [1, 1, 1, n]
             bias_torch = torch.randn(bias_shape, dtype=torch.bfloat16)
             bias_t = ttnn.from_torch(
                 bias_torch,
@@ -318,7 +318,7 @@ def _run_matmul_2d_interleaved_in0_sharded_in1(
         output_tensor = output_tensor[:, :, :seq_len, :n]
         pt_out = torch.matmul(in0, in1)
         if has_bias:
-            num_bias_repeats = (seq_len + tile_h - 1) // tile_h
+            num_bias_repeats = seq_len
             bias_repeated = torch.repeat_interleave(bias_torch, num_bias_repeats, dim=2)
             bias_repeated = bias_repeated[:, :, :seq_len, :]  # match pt_out length (padded repeat can exceed)
             pt_out = pt_out + bias_repeated

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -64,7 +64,8 @@ create_program_batch_sharded(
     tt::DataFormat output_data_format,
     bool untilize_out,
     bool skip_compute,
-    bool skip_write_back) {
+    bool skip_write_back,
+    bool row_broadcast_bias) {
     log_debug(tt::LogOp, "Batch-sharded DRAM matmul");
     log_debug(tt::LogOp, "B: {}, M: {}, K: {}, N: {}", B, M, K, N);
     log_debug(tt::LogOp, "per_core_M: {}, per_core_N: {}, in0_block_w: {}", per_core_M, per_core_N, in0_block_w);
@@ -475,6 +476,9 @@ create_program_batch_sharded(
         0u,                      // get_batch_from_reader
         0u,                      // in0_transpose_tile
     };
+    if (bias_buffer != nullptr) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
 
     // Create kernels on all cores in bounding box
     // Runtime args control which cores are active workers vs idle
@@ -670,6 +674,8 @@ matmul_multi_core_reuse_batched_hs_dram_sharded_optimized_(
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
+    const bool row_broadcast_bias = operations::matmul::utilities::fused_matmul_bias_row_broadcastable(bias);
+
     tt::tt_metal::IDevice* device =
         reuse_batched_hs_dram_sharded_optimized_helpers::get_device_for_dram_banks(a, mesh_coord);
 
@@ -789,8 +795,9 @@ matmul_multi_core_reuse_batched_hs_dram_sharded_optimized_(
         bias_data_format,
         output_data_format,
         untilize_out,
-        false,   // skip_compute
-        false);  // skip_write_back
+        false,  // skip_compute
+        false,  // skip_write_back
+        row_broadcast_bias);
 }
 
 MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::cached_mesh_workload_t

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -106,6 +106,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     bool output_is_sharded,
     bool untilize_out,
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias,
     CoreCoord sub_device_start_core = {0, 0}) {
     using tt::tt_metal::num_cores_to_corerangeset;
 
@@ -687,6 +688,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
+    if (bias_buffer != nullptr) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
 
     // Create compute kernel
     // bool fp32_dest_acc_en = false;
@@ -1097,6 +1101,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     bool in0_is_sharded,
     bool output_is_sharded,
     bool untilize_out,
+    bool row_broadcast_bias,
     CoreCoord sub_device_start_core = {0, 0}) {
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
@@ -1559,6 +1564,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
+    if (bias_buffer != nullptr) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
 
     // Create compute kernel
     // bool fp32_dest_acc_en = false;
@@ -2903,6 +2911,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
+    const bool row_broadcast_bias = operations::matmul::utilities::fused_matmul_bias_row_broadcastable(bias);
+
     tt_metal::IDevice* device = a.device();
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
@@ -3104,6 +3114,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             output.memory_config().is_sharded(),
             untilize_out,
             fused_op_signaler,
+            row_broadcast_bias,
             sub_device_start_core);
     }
     return reuse_mcast_1d_optimized_helpers::process_mcast_in1_program_and_create_override_variables(
@@ -3147,6 +3158,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
         a.memory_config().is_sharded(),
         output.memory_config().is_sharded(),
         untilize_out,
+        row_broadcast_bias,
         sub_device_start_core);
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -67,6 +67,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     tt::DataFormat output_data_format,
     bool untilize_out,
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
+    bool row_broadcast_bias,
     CoreCoord sub_device_start_core = {0, 0}) {
     using namespace tt;
     using tt::tt_metal::TensorMemoryLayout;
@@ -855,6 +856,9 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         false,         // get_batch_from_reader
         in0_transpose_tile,
     };
+    if (bias_buffer != nullptr) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
 
     // Create compute kernel
     // bool fp32_dest_acc_en = true;
@@ -1630,6 +1634,8 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
+    const bool row_broadcast_bias = operations::matmul::utilities::fused_matmul_bias_row_broadcastable(bias);
+
     tt_metal::IDevice* device = a.device();
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
@@ -1773,6 +1779,7 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
         output_data_format,
         untilize_out,
         fused_op_signaler,
+        row_broadcast_bias,
         sub_device_start_core);
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -62,7 +62,8 @@ create_program_dram_sharded(
     bool untilize_out,
     bool skip_compute,
     bool skip_in0_mcast,
-    bool skip_write_back) {
+    bool skip_write_back,
+    bool row_broadcast_bias) {
     log_debug(tt::LogOp, "math_fidelity: {}", math_fidelity);
     log_debug(tt::LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
     log_debug(tt::LogOp, "math_approx_mode: {}", math_approx_mode);
@@ -455,6 +456,9 @@ create_program_dram_sharded(
         false,         // get_batch_from_reader
         false,         // in0_transpose_tile
     };
+    if (bias_buffer != nullptr) {
+        compute_kernel_args.push_back(row_broadcast_bias ? 1u : 0u);
+    }
 
     // Create compute kernel
     auto mm_kernel = tt_metal::CreateKernel(
@@ -952,6 +956,8 @@ matmul_multi_core_reuse_dram_sharded_optimized_(
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
+    const bool row_broadcast_bias = operations::matmul::utilities::fused_matmul_bias_row_broadcastable(bias);
+
     tt::tt_metal::IDevice* device = reuse_dram_sharded_optimized_helpers::get_device_for_dram_banks(a, mesh_coord);
 
     TT_FATAL(
@@ -1070,7 +1076,8 @@ matmul_multi_core_reuse_dram_sharded_optimized_(
         untilize_out,
         skip_compute,
         skip_in0_mcast,
-        skip_write_back);
+        skip_write_back,
+        row_broadcast_bias);
 }
 
 MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::cached_mesh_workload_t

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -15,12 +15,15 @@
 #include "api/compute/bcast.h"
 #endif
 
+#include "api/compute/eltwise_binary.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 
 // Please update
 // tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
 // when making any changes to this file.
 // Have to keep a copy because cannot import ttnn into tests/tt_metal.
+// With FUSE_BIAS: row_broadcast_bias (row-broadcast vs elementwise add_tiles) is compile-time arg 18 here;
+// the perf copy uses index 14 (different compile-time arg layout).
 
 /**
  * @brief Transposes a block of tiles from one circular buffer to another.
@@ -197,6 +200,8 @@ void kernel_main() {
     constexpr uint32_t bias_cb_id = get_named_compile_time_arg_val("cb_bias");
     constexpr uint32_t bias_ntiles = get_named_compile_time_arg_val("bias_ntiles");
     constexpr uint32_t mm_out_cb_id = mm_partials_cb_id;
+    // true: row-0 broadcast ([N] / [...,1,N]); false: elementwise add_tiles (bias has multiple M rows).
+    constexpr bool row_broadcast_bias = (bool)get_compile_time_arg_val(18);
     experimental::CircularBuffer bias_cb(bias_cb_id);
 #else
     constexpr uint32_t mm_out_cb_id = untilize_mode_out_cb_id;
@@ -436,9 +441,12 @@ void kernel_main() {
 #ifdef PACKER_L1_ACC
                 PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
-
                 reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
-                add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
+                if constexpr (row_broadcast_bias) {
+                    add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
+                } else {
+                    add_tiles_init(mm_partials_cb_id, bias_cb_id);
+                }
                 // Reader only pushes bias once when num_blocks_w_dim == 1;
                 // the tiles stay in the CB for reuse across bh/batch iterations.
                 if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
@@ -451,10 +459,14 @@ void kernel_main() {
                         mm_partials_cb.wait_front(out_subblock_num_tiles);
                         tile_regs_acquire();
                         for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
-                            uint32_t bcast_tile_idx = in1_index_subblock_offset;
+                            uint32_t bias_tile_idx = in1_index_subblock_offset;
                             for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
-                                add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, bcast_tile_idx, i);
-                                bcast_tile_idx++;
+                                if constexpr (row_broadcast_bias) {
+                                    add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, bias_tile_idx, i);
+                                } else {
+                                    add_tiles(mm_partials_cb_id, bias_cb_id, i, bias_tile_idx, i);
+                                }
+                                bias_tile_idx++;
                             }
                         }
 // if there's no SFPU fusion, we commit the regs so packer can start packing

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -319,13 +319,30 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
 
     if (optional_bias.has_value()) {
         const auto& bias = optional_bias.value();
+        const auto& out_shape = output_tensor_spec.logical_shape();
+        const auto& bias_shape = bias.logical_shape();
+        const int rank_out = static_cast<int>(out_shape.rank());
+        const int rank_bias = static_cast<int>(bias_shape.rank());
+        const int largest_rank = std::max(rank_out, rank_bias);
+        for (int i = -1; i >= -largest_rank; --i) {
+            const uint32_t dim_out = (i >= -rank_out) ? out_shape[i] : 1;
+            const uint32_t dim_bias = (i >= -rank_bias) ? bias_shape[i] : 1;
+            TT_FATAL(
+                dim_bias == 1 || dim_bias == dim_out,
+                "Fused matmul bias is not broadcastable to matmul output at aligned dimension index {} "
+                "(output logical dim {}, bias logical dim {}). output_shape={}, bias_shape={}",
+                i,
+                dim_out,
+                dim_bias,
+                out_shape,
+                bias_shape);
+        }
         auto bias_tile_shape = bias.tensor_spec().tile().get_tile_shape();
         TT_FATAL(
             (bias_tile_shape[0] == in0_tile.get_height() && bias_tile_shape[1] == in1_tile.get_width()),
             "Input tile dims must have inner dim equal to 32 due to llk "
             "constraints");
         TT_FATAL(bias.layout() == Layout::TILE, "Unsupported input layout");
-        const auto& bias_shape = bias.logical_shape();
         const auto& bias_shape_padded = bias.padded_shape();
         uint32_t bias_batch_size = get_batch_size(bias_shape);
         TT_FATAL(bias_batch_size == 1, "Unsupported bias shape: batch size not equal to 1.");

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -170,6 +170,28 @@ ttnn::Shape compute_matmul_output_shape(
     return output_shape;
 }
 
+ttnn::Shape compute_matmul_with_bias_output_shape(const ttnn::Shape& matmul_shape, const ttnn::Shape& bias_shape) {
+    int rank_a = static_cast<int>(matmul_shape.rank());
+    int rank_b = static_cast<int>(bias_shape.rank());
+    int max_rank = std::max(rank_a, rank_b);
+
+    std::vector<uint32_t> result_shape(max_rank);
+
+    for (int i = 0; i < max_rank; ++i) {
+        int idx_a = rank_a - max_rank + i;
+        int idx_b = rank_b - max_rank + i;
+
+        uint32_t dim_a = (idx_a >= 0) ? matmul_shape[idx_a] : 1;
+        uint32_t dim_b = (idx_b >= 0) ? bias_shape[idx_b] : 1;
+
+        TT_FATAL(dim_a == dim_b || dim_a == 1 || dim_b == 1, "Broadcast error: Invalid dimension");
+
+        result_shape[i] = std::max(dim_a, dim_b);
+    }
+
+    return ttnn::Shape(result_shape);
+}
+
 tt::tt_metal::Tile get_output_tile(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::Tile& in0_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -17,6 +18,24 @@ namespace ttnn::operations::matmul::utilities {
 // 2 = double buffer, 3 = triple buffer, etc.
 // Allows easily changing buffering strategy in one place for relevant factories.
 constexpr uint32_t MCAST_INPUT_BUFFERING_DEPTH = 2;
+
+/**
+ * @brief True when fused matmul bias add can use the row-broadcast kernel path.
+ *
+ * Broadcast applies when there is no distinct row axis (rank < 2, e.g. vector bias) or the
+ * logical row dimension is 1 (shape[-2] == 1, e.g. [..., 1, N]). Otherwise the bias has multiple
+ * logical rows and the fused kernel must use elementwise add_tiles.
+ */
+inline bool fused_matmul_bias_row_broadcastable(const std::optional<const Tensor>& bias) {
+    if (!bias.has_value()) {
+        return false;
+    }
+    const auto& shape = bias->logical_shape();
+    if (shape.rank() < 2) {
+        return true;
+    }
+    return shape[-2] == 1;
+}
 
 uint32_t get_estimated_size_of_cbs(
     uint32_t per_core_M,
@@ -54,6 +73,17 @@ bool is_input_batched(const ttnn::Shape& shape);
  */
 ttnn::Shape compute_matmul_output_shape(
     const Tensor& input_tensor_a, const Tensor& input_tensor_b, bool transpose_a, bool transpose_b);
+
+/*
+ * @brief Computes the output shape of a matmul operation with bias given two input shapes
+ *
+ * Determines the output shape based on the broadcasting rules for matrix multiplication with bias:
+ *
+ * @param matmul_shape The shape of the matmul operation
+ * @param bias_shape The shape of the bias tensor
+ * @return Shape of the resulting tensor after matmul with bias
+ */
+ttnn::Shape compute_matmul_with_bias_output_shape(const ttnn::Shape& matmul_shape, const ttnn::Shape& bias_shape);
 
 using Activation = std::variant<std::string, ttnn::operations::unary::UnaryWithParam>;
 std::optional<ttnn::operations::unary::UnaryWithParam> get_fused_activation(

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -262,6 +262,26 @@ static ttnn::Tensor bound_matmul(
             optional_output_tensor);
     }
 
+    const auto& matmul_shape = utilities::compute_matmul_output_shape(
+        input_tensor_a, input_tensor_b, attributes.transpose_a, attributes.transpose_b);
+
+    ttnn::Shape result_shape = (bias.has_value()) ? utilities::compute_matmul_with_bias_output_shape(
+                                                        matmul_shape, bias.value().logical_shape())
+                                                  : matmul_shape;
+
+    if (optional_output_tensor.has_value()) {
+        const auto& desired_shape = optional_output_tensor->logical_shape();
+        uint64_t desired_vol = optional_output_tensor->logical_shape().volume();
+        uint64_t current_vol = std::accumulate(result_shape.begin(), result_shape.end(), 1ULL, std::multiplies<>());
+
+        TT_FATAL(desired_vol == current_vol, "Invalid optional output tensor");
+
+        output_tensor = ttnn::reshape(output_tensor, desired_shape);
+
+    } else if (bias.has_value()) {
+        output_tensor = ttnn::reshape(output_tensor, result_shape);
+    }
+
     if (parameters.user_fused_activation.has_value() && !parameters.user_core_coord.has_value()) {
         const UnaryWithParam& activation = parameters.user_fused_activation.value();
 


### PR DESCRIPTION
Restore #42430 after GitHub's SNAFU

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afuller/restore-42430)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afuller/restore-42430)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=afuller/restore-42430)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:afuller/restore-42430)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afuller/restore-42430)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afuller/restore-42430)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afuller/restore-42430)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afuller/restore-42430)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afuller/restore-42430)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afuller/restore-42430)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afuller/restore-42430)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afuller/restore-42430)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afuller/restore-42430)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afuller/restore-42430)