### PR TITLE
BugFix: Add tensix_sync to unary/binary op init to prevent stale REG2FLOP race

### DIFF
--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -30,6 +30,14 @@ namespace ckernel {
 // clang-format on
 ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
 #ifndef ARCH_QUASAR
+    // Drain any pending coprocessor instructions before reconfiguring the packer.
+    // Without this, a stale REG2FLOP left in the coprocessor queue by a prior
+    // operation (e.g. tilize) can be processed by the tensix_sync() inside
+    // llk_pack_dest_init *after* we have already written the correct pack config,
+    // overwriting it with the stale value.  Flushing here ensures stale entries
+    // complete before our correct config writes arrive.
+    tensix_sync();
+
     state_configure(icb0, icb1, ocb, call_line);
 
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
@@ -17,6 +17,14 @@ namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
 #ifndef ARCH_QUASAR
+    // Drain any pending coprocessor instructions before reconfiguring the packer.
+    // Without this, a stale REG2FLOP left in the coprocessor queue by a prior
+    // operation (e.g. tilize) can be processed by the tensix_sync() inside
+    // llk_pack_dest_init *after* we have already written the correct pack config,
+    // overwriting it with the stale value.  Flushing here ensures stale entries
+    // complete before our correct config writes arrive.
+    tensix_sync();
+
     state_configure<Operand::SRCA, Operand::PACK>(icb, ocb, call_line);
 
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, true>(icb)));


### PR DESCRIPTION
### Summary
Relates to #42610

A stale REG2FLOP left in the coprocessor queue by a prior operation (e.g. tilize) can be processed by the tensix_sync() inside llk_pack_dest_init *after* the correct pack config has been written, overwriting it with the stale value and causing incorrect packer behaviour (bad PCC or CB bounds assertion).

Flushing with tensix_sync() at the start of unary_op_init_common and binary_op_init_common ensures all stale entries complete before the correct config writes arrive.

Fixes test hangs/failures in test_sampling_callback and test_edgecase_dims_eltwise_broadcast_matrix_math when running with TT_METAL_LLK_ASSERTS=1 TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS=1

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mateusznowakTT/42610_tensix_sync_init_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mateusznowakTT/42610_tensix_sync_init_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mateusznowakTT/42610_tensix_sync_init_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mateusznowakTT/42610_tensix_sync_init_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mateusznowakTT/42610_tensix_sync_init_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mateusznowakTT/42610_tensix_sync_init_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mateusznowakTT/42610_tensix_sync_init_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mateusznowakTT/42610_tensix_sync_init_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mateusznowakTT/42610_tensix_sync_init_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mateusznowakTT/42610_tensix_sync_init_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mateusznowakTT/42610_tensix_sync_init_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mateusznowakTT/42610_tensix_sync_init_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mateusznowakTT/42610_tensix_sync_init_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mateusznowakTT/42610_tensix_sync_init_fix)