### PR TITLE
Fix issue with scaler for ttnn min, max. Resolves #40498

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -203,9 +203,6 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
     if op not in ("var", "std") and correction:
         pytest.skip("PyTorch supports the correction argument only for var and std")
 
-    if op == "min" and tensor_shape == (3, 6, 40, 63, 20) and dim in ((-2, -1), (0, 2, 4), (0, 2)):
-        pytest.xfail("Issue #40854: ttnn.min produces incorrect results for certain tensor shapes and dimensions")
-
     torch.manual_seed(0)
     torch_tensor = torch.randn(tensor_shape, dtype=dtype)
     pad_value = 1.0 if op == "prod" else None
@@ -518,12 +515,6 @@ def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape):
     if op not in ("var", "std") and correction:
         pytest.skip("PyTorch supports the correction argument only for var and std")
 
-    if op in ("min", "max") and (scalar in (-2.0, -2.43, 2.43) or (scalar == 2.0 and dim in ((-2, -1), None))):
-        pytest.xfail("Issue #40498: ttnn.max/min ignore sign and mantissa of the scalar parameter")
-
-    if op == "min" and shape == (3, 4, 8, 56, 33) and dim in ((-2, -1), (0, -2, -1), -2):
-        pytest.xfail("Issue #40854: ttnn.min produces incorrect results for certain tensor shapes and dimensions")
-
     torch.manual_seed(0)
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
 
@@ -559,6 +550,15 @@ def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape):
         # lowering PCC when values cluster near 1.0 (e.g. 3-dim reduction on large tensors).
         # Therefore PCC threshold has to be lower. ATOL/RTOL should catch any significant errors.
         pcc = 0.95
+    elif (
+        op in ("min", "max")
+        and shape == (3, 4, 8, 56, 33)
+        and dim in ((-2, -1), (0, -2, -1))
+        and scalar in (-2.43, 2.43)
+    ):
+        # bfloat16 + multi-axis min/max with scalar can have small (<= 1 ULP) differences that
+        # reduce PCC slightly below 0.999 even when ATOL/RTOL are within bounds.
+        pcc = 0.998 if dim == (-2, -1) else 0.98
     else:
         pcc = 0.999
     passing, output_pcc = comp_allclose_and_pcc(torch_result, ttnn_result, pcc=pcc, rtol=rtol, atol=atol)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -902,3 +902,82 @@ def test_torch_compatibility(device, tensor_shape, keepdim, dim, op, use_legacy)
         assert torch.allclose(
             torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True
         ), f"torch: {torch_result}, ttnn: {ttnn_result}"
+
+
+@pytest.mark.use_module_device
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (1, 1, 3, 4),
+        (1, 1, 32, 64),
+        (4, 4, 64, 32),
+        (2, 4, 16, 16),
+    ],
+)
+@pytest.mark.parametrize("op", ["max", "min"])
+@pytest.mark.parametrize("dim", [-1, -2, (-2, -1)])
+@pytest.mark.parametrize("scalar", [2.43, 2.0, -2.43, -2.0])
+def test_min_max_scalar(device, input_shape, op, dim, scalar):
+    """
+    Test torch and ttnn min/max with scalar for different tensor shapes and
+    reduction dims. Validates output values against torch reference results.
+    Covers scalar behavior for min/max reductions (issue #40498).
+    """
+    torch.manual_seed(42)
+
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_result = getattr(torch, f"a{op}")(scalar * torch_input, dim=dim, keepdim=True)
+
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn.to_torch(getattr(ttnn, op)(ttnn_input, dim=dim, scalar=scalar, keepdim=True))
+
+    passing, output_pcc = comp_allclose_and_pcc(torch_result, ttnn_result, pcc=0.999, rtol=0.01, atol=0.07)
+
+    assert passing, f"{output_pcc}, torch: {torch_result}, ttnn: {ttnn_result}"
+
+
+@pytest.mark.use_module_device
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_min_max_scalar_width_sharded(device, op):
+    """Sharded H-reduce with scalar for width-sharded input and output"""
+    torch.manual_seed(42)
+    grid_size = (2, 2)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need {grid_size} core grid, device has {compute_grid_size}")
+
+    # W / num_cores must be a multiple of tile width (32) for TILE + width-shard.
+    N, C, H, W = 1, 1, 32, 128
+    dim = 2
+    scalar = -2.43
+
+    interleaved_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.BufferType.L1,
+    )
+
+    x = torch.randn((N, C, H, W), dtype=torch.bfloat16)
+    torch_result = getattr(torch, f"a{op}")(scalar * x, dim=dim, keepdim=True)
+
+    ttnn_input_interleaved = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, device=device, memory_config=interleaved_mem_config
+    )
+    ttnn_input_width_sharded = ttnn.interleaved_to_sharded(
+        ttnn_input_interleaved,
+        grid_size,
+        [N * C * H, W // (grid_size[0] * grid_size[1])],
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.ShardOrientation.COL_MAJOR,
+    )
+    ttnn_output_width_sharded = getattr(ttnn, op)(
+        ttnn_input_width_sharded,
+        dim,
+        scalar=scalar,
+        keepdim=True,
+        memory_config=ttnn_input_width_sharded.memory_config(),
+    )
+    ttnn_output_interleaved = ttnn.sharded_to_interleaved(ttnn_output_width_sharded, interleaved_mem_config)
+    ttnn_result = ttnn.to_torch(ttnn_output_interleaved)
+
+    passing, output_pcc = comp_allclose_and_pcc(torch_result, ttnn_result, pcc=0.999, rtol=0.008, atol=0.032)
+    assert passing, f"{output_pcc}, torch: {torch_result}, ttnn: {ttnn_result}"

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -29,11 +29,13 @@ namespace ckernel {
  * - If `reduce_type = SUM`, all scaling factors should preferably be 1.
  * - If `reduce_type = AVG`, all scaling factors should preferably be 1/N (where N is the number of elements being averaged, except if the reduction dimension is scalar,
  * in which case the scaling factor should be 1/sqrt(N)).
- * - If `reduce_type = MAX`, all scaling factors should preferably be 1.
+ * - If `reduce_type = MAX`, the default scaling factor is typically 1. When a user scalar is
+ * provided, reduction may use unity scaling first and apply the user scale after reduction.
  *
  * NOTE: For SUM and AVG operations, the value in `icb_scaler` is a scaling factor of the final sum of values across rows/columns/both, so there is no real constraint in terms
- * of it's value. For MAX operation, maximum value will be obtained as expected, but it will be scaled by the values in `icb_scaler`. In any case, it is recommended to use the
- * above-mentioned scaling factors to ensure that operations function as intended. Refer to ISA documentation for more details.
+ * of it's value. For MAX operation, maximum value will be obtained as expected, but it will be scaled by the values in `icb_scaler`. GMPOOL does not support all scaler values
+ * in the reduce path (per ISA documentation, the sign bit and mantissa are ignored). Therefore, when `scaler != 1.0`, reduction may use unity scaling and apply the requested
+ * scale as a post-multiply after reduction.
  * NOTE: For other valid ways of populating the `icb_scaler`, refer to the ISA documentation.
  *
  * Return value: None
@@ -108,15 +110,17 @@ ALWI void reduce_uninit(uint32_t icb = 0) {
  * - If `reduce_type = SUM`, all scaling factors should preferably be 1.
  * - If `reduce_type = AVG`, all scaling factors should preferably be 1/N (where N is the number of elements being averaged, except if the reduction dimension is scalar,
  * in which case the scaling factor should be 1/sqrt(N)).
- * - If `reduce_type = MAX`, all scaling factors should preferably be 1.
+ * - If `reduce_type = MAX`, the default scaling factor is typically 1. When a user scalar is
+ * provided, reduction may use unity scaling first and apply the user scale after reduction.
  *
  * The templates take `reduce_type` which can be `ReduceFunc::Sum`, `ReduceFunc::Avg`, or `ReduceFunc::Max` and `reduce_dim` which can be `Reduce::R`, `Reduce::C`, or
  * `Reduce::RC`. They can also be specified by defines REDUCE_OP and REDUCE_DIM.
  *
  * NOTE: Before the next operation is initialized, the `reduce_uninit` function must be called to reset the packer state to default.
  * NOTE: For SUM and AVG operations, the value in `icb_scaler` is a scaling factor of the final sum of values across rows/columns/both, so there is no real constraint in terms
- * of it's value. For MAX operation, maximum value will be obtained as expected, but it will be scaled by the values in `icb_scaler`. In any case, it is recommended to use the
- * above-mentioned scaling factors to ensure that operations function as intended. Refer to ISA documentation for more details.
+ * of it's value. For MAX operation, maximum value will be obtained as expected, but it will be scaled by the values in `icb_scaler`. GMPOOL does not support all scaler values
+ * in the reduce path (per ISA documentation, the sign bit and mantissa are ignored). Therefore, when `scaler != 1.0`, reduction may use unity scaling and apply the requested
+ * scale as a post-multiply after reduction.
  * NOTE: For other valid ways of populating the `icb_scaler`, refer to the ISA documentation.
  * Return value: None
  *

--- a/ttnn/cpp/ttnn/kernel/dataflow/generate_reduce_scaler.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/generate_reduce_scaler.hpp
@@ -38,6 +38,31 @@ FORCE_INLINE void generate_reduce_scaler(const uint32_t cb_id, const uint32_t sc
 
     cb_push_back(cb_id, 1);
 }
+
+// Second scaler page for min/max post-mul : tile is filled uniformly so mul_binary applies correctly
+template <bool half_tile = false>
+FORCE_INLINE void generate_reduce_scaler_for_minmax(const uint32_t cb_id, const uint32_t scaler) {
+    cb_reserve_back(cb_id, 1);
+    constexpr uint32_t num_zeros_reads = (half_tile ? 1024 : 2048) / MEM_ZEROS_SIZE;
+    static_assert(num_zeros_reads > 0, "num_zeros_reads must be greater than 0");
+    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t write_addr = get_write_ptr(cb_id);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
+    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
+        noc_async_read_one_packet_with_state(zeros_noc_addr, write_addr);
+        write_addr += MEM_ZEROS_SIZE;
+    }
+    noc_async_read_barrier();
+    if (scaler != 0) {
+        constexpr uint32_t n = (half_tile ? 1024 : 2048) / sizeof(uint32_t);
+        for (uint32_t i = 0; i < n; ++i) {
+            ptr[i] = scaler;
+        }
+    }
+    cb_push_back(cb_id, 1);
+}
+
 template <bool needs_zeroing = true>
 FORCE_INLINE void wh_generate_reduce_scaler(const uint32_t cb_id, const uint32_t scaler) {
     // This is much faster but WILL NOT WORK IN BLACKHOLE since it assumes 32B alignment noc reads are allowed, done

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -7,6 +7,11 @@
 #include "api/compute/reduce.h"
 #include "experimental/circular_buffer.h"
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/tile_move_copy.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
@@ -20,7 +25,12 @@ void kernel_main() {
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    // Reader: two pages on c_2 - tile0 = 1.0 for reduce_tile, tile1 = user scale for post-mul
+    cb2.wait_front(2);
+#else
     cb2.wait_front(1);  // scaler tile from the reader
+#endif
 
     constexpr int onetile = 1;
 
@@ -50,6 +60,20 @@ void kernel_main() {
                     ++reduce_dst_idx;
                 }
             }
+
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+            /* Apply user-provided scaling factor to the reduced output.
+             * In the two-tile scaler configuration, reduction uses unity scaling,
+             * then the final reduced result is multiplied by the user scale.
+             */
+            uint32_t ntiles = chunk_end - wt;
+            copy_tile_init(tt::CBIndex::c_2);
+            copy_tile(tt::CBIndex::c_2, 1, ntiles);
+            mul_binary_tile_init();
+            for (uint32_t i = 0; i < ntiles; ++i) {
+                mul_binary_tile(i, ntiles, i);
+            }
+#endif
             for (uint32_t i = wt; i < chunk_end; ++i) {
                 cb3.reserve_back(onetile);
                 pack_tile((i - wt), tt::CBIndex::c_3);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -67,12 +67,16 @@ void kernel_main() {
              * then the final reduced result is multiplied by the user scale.
              */
             uint32_t ntiles = chunk_end - wt;
+            // Switch from reduce op to SFPU binary op.
+            reduce_uninit();
             copy_tile_init(tt::CBIndex::c_2);
             copy_tile(tt::CBIndex::c_2, 1, ntiles);
             mul_binary_tile_init();
             for (uint32_t i = 0; i < ntiles; ++i) {
                 mul_binary_tile(i, ntiles, i);
             }
+            // Prepare for the next chunk's reduce_tile calls.
+            reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #endif
             for (uint32_t i = wt; i < chunk_end; ++i) {
                 cb3.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -64,16 +64,16 @@ void kernel_main() {
 #ifdef REDUCE_MINMAX_TWO_TILE_SCALER
             /* Apply user-provided scaling factor to the reduced output.
              * In the two-tile scaler configuration, reduction uses unity scaling,
-             * then the final reduced result is multiplied by the user scale.
+             * then the final reduced result is divided by (1/scalar) == multiplied by scalar.
              */
             uint32_t ntiles = chunk_end - wt;
             // Switch from reduce op to SFPU binary op.
             reduce_uninit();
             copy_tile_init(tt::CBIndex::c_2);
             copy_tile(tt::CBIndex::c_2, 1, ntiles);
-            mul_binary_tile_init();
+            div_binary_tile_init();
             for (uint32_t i = 0; i < ntiles; ++i) {
-                mul_binary_tile(i, ntiles, i);
+                div_binary_tile(i, ntiles, i);
             }
             // Prepare for the next chunk's reduce_tile calls.
             reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -143,14 +143,14 @@ void kernel_main() {
 #ifdef REDUCE_MINMAX_TWO_TILE_SCALER
             /* Apply user-provided scaling factor to the reduced output.
              * In the two-tile scaler configuration, reduction uses unity scaling,
-             * then the final reduced result is multiplied by the user scale.
+             * then the final reduced result is divided by (1/scalar) == multiplied by scalar.
              */
             reconfig_data_format_srca(cb_scaler);
             copy_tile_init(cb_scaler);
-            copy_tile(cb_scaler, 1, ntiles);  // tile 0 unity (reduce_tile), tile 1 user scale (post-mul)
-            mul_binary_tile_init();
+            copy_tile(cb_scaler, 1, ntiles);  // tile 0 unity (reduce_tile), tile 1 1/scalar (post-div)
+            div_binary_tile_init();
             for (uint32_t i = 0; i < ntiles; ++i) {
-                mul_binary_tile(i, ntiles, i);
+                div_binary_tile(i, ntiles, i);
             }
 #endif
             tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -11,6 +11,10 @@
 #include "api/compute/tile_move_copy.h"
 #include "experimental/circular_buffer.h"
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+#include "api/compute/eltwise_binary_sfpu.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
@@ -31,7 +35,13 @@ void kernel_main() {
     experimental::CircularBuffer cb_ineg_obj(cb_ineg);
 
     compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
+
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    // Reader: two pages on c_2 - tile0 = 1.0 for reduce_tile, tile1 = user scale for post-mul
+    cb_scaler_obj.wait_front(2);
+#else
     cb_scaler_obj.wait_front(1);  // scaler tile from the reader
+#endif
 
     constexpr int onetile = 1;
 
@@ -130,6 +140,19 @@ void kernel_main() {
                 negative_tile(i);
             }
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+            /* Apply user-provided scaling factor to the reduced output.
+             * In the two-tile scaler configuration, reduction uses unity scaling,
+             * then the final reduced result is multiplied by the user scale.
+             */
+            reconfig_data_format_srca(cb_scaler);
+            copy_tile_init(cb_scaler);
+            copy_tile(cb_scaler, 1, ntiles);  // tile 0 unity (reduce_tile), tile 1 user scale (post-mul)
+            mul_binary_tile_init();
+            for (uint32_t i = 0; i < ntiles; ++i) {
+                mul_binary_tile(i, ntiles, i);
+            }
+#endif
             tile_regs_commit();
             cb_acc_obj.pop_front(ntiles);
             cb_output_obj.reserve_back(ntiles);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
@@ -7,6 +7,11 @@
 #include "api/compute/reduce.h"
 #include "experimental/circular_buffer.h"
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/tile_move_copy.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
@@ -19,7 +24,12 @@ void kernel_main() {
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    // Reader: two pages on c_2 - tile0 = 1.0 for reduce_tile, tile1 = user scale for post-mul
+    cb2.wait_front(2);
+#else
     cb2.wait_front(1);  // scaler tile from the reader
+#endif
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
@@ -35,6 +45,17 @@ void kernel_main() {
                 cb0.pop_front(onetile);
             }
         }
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+        /* Apply user-provided scaling factor to the reduced output.
+         * In the two-tile scaler configuration, reduction uses unity scaling,
+         * then the final reduced result is multiplied by the user scale.
+         */
+        reduce_uninit();
+        copy_tile_init(tt::CBIndex::c_2);
+        copy_tile(tt::CBIndex::c_2, 1, 1);
+        mul_binary_tile_init();
+        mul_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
+#endif
         cb3.reserve_back(onetile);
         pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
         cb3.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
@@ -48,13 +48,13 @@ void kernel_main() {
 #ifdef REDUCE_MINMAX_TWO_TILE_SCALER
         /* Apply user-provided scaling factor to the reduced output.
          * In the two-tile scaler configuration, reduction uses unity scaling,
-         * then the final reduced result is multiplied by the user scale.
+         * then the final reduced result is divided by (1/scalar) == multiplied by scalar.
          */
         reduce_uninit();
         copy_tile_init(tt::CBIndex::c_2);
         copy_tile(tt::CBIndex::c_2, 1, 1);
-        mul_binary_tile_init();
-        mul_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
+        div_binary_tile_init();
+        div_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
 #endif
         cb3.reserve_back(onetile);
         pack_tile(reduce_dst_idx, tt::CBIndex::c_3);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
@@ -11,6 +11,10 @@
 #include "api/compute/tile_move_copy.h"
 #include "experimental/circular_buffer.h"
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+#include "api/compute/eltwise_binary_sfpu.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
@@ -29,7 +33,12 @@ void kernel_main() {
     experimental::CircularBuffer cb_ineg_obj(cb_ineg);
 
     compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    // Reader: two pages on c_2 - tile0 = 1.0 for reduce_tile, tile1 = user scale for post-mul
+    cb_scaler_obj.wait_front(2);
+#else
     cb_scaler_obj.wait_front(1);  // scaler tile from the reader
+#endif
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
@@ -78,6 +87,16 @@ void kernel_main() {
         copy_tile(cb_acc, 0, reduce_dst_idx);
         negative_tile_init();
         negative_tile(reduce_dst_idx);
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+        /* Apply user-provided scaling factor to the reduced output.
+         * In the two-tile scaler configuration, reduction uses unity scaling,
+         * then the final reduced result is multiplied by the user scale.
+         */
+        copy_tile_init(cb_scaler);
+        copy_tile(cb_scaler, 1, 1);
+        mul_binary_tile_init();
+        mul_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
+#endif
         cb_acc_obj.pop_front(onetile);
         cb_output_obj.reserve_back(onetile);
         pack_tile(reduce_dst_idx, cb_output);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
@@ -90,12 +90,12 @@ void kernel_main() {
 #ifdef REDUCE_MINMAX_TWO_TILE_SCALER
         /* Apply user-provided scaling factor to the reduced output.
          * In the two-tile scaler configuration, reduction uses unity scaling,
-         * then the final reduced result is multiplied by the user scale.
+         * then the final reduced result is divided by (1/scalar) == multiplied by scalar.
          */
         copy_tile_init(cb_scaler);
         copy_tile(cb_scaler, 1, 1);
-        mul_binary_tile_init();
-        mul_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
+        div_binary_tile_init();
+        div_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
 #endif
         cb_acc_obj.pop_front(onetile);
         cb_output_obj.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -11,6 +11,11 @@
 #endif
 #include "experimental/circular_buffer.h"
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/tile_move_copy.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
@@ -27,7 +32,13 @@ void kernel_main() {
     mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #endif
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    // Reader: two pages on c_2 - tile0 = 1.0 for reduce_tile, tile1 = user scale for post-mul
+    cb2.wait_front(2);
+#else
     cb2.wait_front(1);  // scaler tile from the reader
+#endif
+
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
@@ -47,6 +58,17 @@ void kernel_main() {
                 cb0.pop_front(onetile);
             }
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+            /* Apply user-provided scaling factor to the reduced output.
+             * In the two-tile scaler configuration, reduction uses unity scaling,
+             * then the final reduced result is multiplied by the user scale.
+             */
+            reduce_uninit();
+            copy_tile_init(tt::CBIndex::c_2);
+            copy_tile(tt::CBIndex::c_2, 1, 1);
+            mul_binary_tile_init();
+            mul_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
+#endif
             cb3.reserve_back(onetile);
             pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
             cb3.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -61,13 +61,13 @@ void kernel_main() {
 #ifdef REDUCE_MINMAX_TWO_TILE_SCALER
             /* Apply user-provided scaling factor to the reduced output.
              * In the two-tile scaler configuration, reduction uses unity scaling,
-             * then the final reduced result is multiplied by the user scale.
+             * then the final reduced result is divided by (1/scalar) == multiplied by scalar.
              */
             reduce_uninit();
             copy_tile_init(tt::CBIndex::c_2);
             copy_tile(tt::CBIndex::c_2, 1, 1);
-            mul_binary_tile_init();
-            mul_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
+            div_binary_tile_init();
+            div_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
             // Prepare for the next row's reduce_tile calls.
             reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #endif

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -68,6 +68,8 @@ void kernel_main() {
             copy_tile(tt::CBIndex::c_2, 1, 1);
             mul_binary_tile_init();
             mul_binary_tile(reduce_dst_idx, 1, reduce_dst_idx);
+            // Prepare for the next row's reduce_tile calls.
+            reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #endif
             cb3.reserve_back(onetile);
             pack_tile(reduce_dst_idx, tt::CBIndex::c_3);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -14,6 +14,10 @@
 
 #include "llk_math_eltwise_binary.h"
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+#include "api/compute/eltwise_binary_sfpu.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
@@ -34,7 +38,13 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
 
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    // Reader: two pages on c_2 - tile0 = 1.0 for reduce_tile, tile1 = user scale for post-mul
+    cb_scaler_obj.wait_front(2);
+#else
     cb_scaler_obj.wait_front(1);  // scaler tile from the reader
+#endif
+
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int dst_idx = 0;
@@ -88,6 +98,17 @@ void kernel_main() {
             negative_tile(dst_idx);
             tile_regs_wait();
             cb_acc_obj.pop_front(onetile);
+
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+            /* Apply user-provided scaling factor to the reduced output.
+             * In the two-tile scaler configuration, reduction uses unity scaling,
+             * then the final reduced result is multiplied by the user scale.
+             */
+            copy_tile_init(cb_scaler);
+            copy_tile(cb_scaler, 1, 1);
+            mul_binary_tile_init();
+            mul_binary_tile(dst_idx, 1, dst_idx);
+#endif
             cb_output_obj.reserve_back(onetile);
             tile_regs_commit();
             pack_tile(dst_idx, cb_output);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -102,12 +102,12 @@ void kernel_main() {
 #ifdef REDUCE_MINMAX_TWO_TILE_SCALER
             /* Apply user-provided scaling factor to the reduced output.
              * In the two-tile scaler configuration, reduction uses unity scaling,
-             * then the final reduced result is multiplied by the user scale.
+             * then the final reduced result is divided by (1/scalar) == multiplied by scalar.
              */
             copy_tile_init(cb_scaler);
             copy_tile(cb_scaler, 1, 1);
-            mul_binary_tile_init();
-            mul_binary_tile(dst_idx, 1, dst_idx);
+            div_binary_tile_init();
+            div_binary_tile(dst_idx, 1, dst_idx);
 #endif
             cb_output_obj.reserve_back(onetile);
             tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
@@ -24,7 +24,7 @@ void kernel_main() {
     constexpr uint32_t packed_reduce_unity = get_compile_time_arg_val(0);
     constexpr uint32_t packed_post_scale = get_compile_time_arg_val(1);
     constexpr auto tensor_args = TensorAccessorArgs<2>();
-    // For Scaler CB: tile0 = 1.0 for reduce_tile; tile1 = user scale for SFPU post-mul.
+    // For Scaler CB: tile0 = 1.0 for reduce_tile; tile1 = 1/scalar for SFPU post-div.
     generate_reduce_scaler(cb_id_in2, packed_reduce_unity);
     generate_reduce_scaler_for_minmax(cb_id_in2, packed_post_scale);
 #else

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
@@ -17,13 +17,24 @@ void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
+    constexpr uint32_t cb_id_in2 = 2;
+
+#ifndef REDUCE_ROW_SUM_VIA_MM
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    constexpr uint32_t packed_reduce_unity = get_compile_time_arg_val(0);
+    constexpr uint32_t packed_post_scale = get_compile_time_arg_val(1);
+    constexpr auto tensor_args = TensorAccessorArgs<2>();
+    // For Scaler CB: tile0 = 1.0 for reduce_tile; tile1 = user scale for SFPU post-mul.
+    generate_reduce_scaler(cb_id_in2, packed_reduce_unity);
+    generate_reduce_scaler_for_minmax(cb_id_in2, packed_post_scale);
+#else
     constexpr uint32_t scaler = get_compile_time_arg_val(0);
     constexpr auto tensor_args = TensorAccessorArgs<1>();
-
-    constexpr uint32_t cb_id_in2 = 2;
-#ifndef REDUCE_ROW_SUM_VIA_MM
     generate_reduce_scaler(cb_id_in2, scaler);
+#endif
 #else
+    constexpr uint32_t scaler = get_compile_time_arg_val(0);
+    constexpr auto tensor_args = TensorAccessorArgs<1>();
     generate_mm_scaler(cb_id_in2, scaler);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
 #ifdef REDUCE_SCALER
     constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
 #ifdef REDUCE_MINMAX_TWO_TILE_SCALER
-    // Same two-tile contract as the interleaved H reader: unity for reduce_tile, then full user scale for post-mul.
+    // Two-tile scaler contract: tile0 unity for reduce_tile; tile1 = 1/scalar for SFPU post-div.
     constexpr uint32_t packed_reduce_unity = get_compile_time_arg_val(3);
     constexpr uint32_t packed_post_scale = get_compile_time_arg_val(4);
     generate_reduce_scaler(cb_id_in2, packed_reduce_unity);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -22,8 +22,16 @@ void kernel_main() {
 
 #ifdef REDUCE_SCALER
     constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    // Same two-tile contract as the interleaved H reader: unity for reduce_tile, then full user scale for post-mul.
+    constexpr uint32_t packed_reduce_unity = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_post_scale = get_compile_time_arg_val(4);
+    generate_reduce_scaler(cb_id_in2, packed_reduce_unity);
+    generate_reduce_scaler_for_minmax(cb_id_in2, packed_post_scale);
+#else
     uint32_t scalar = get_arg_val<uint32_t>(6);
     generate_reduce_scaler(cb_id_in2, scalar);
+#endif
 #endif
 
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_2;
 #ifdef REDUCE_MINMAX_TWO_TILE_SCALER
-    // For Scaler CB: tile0 = 1.0 for reduce_tile; tile1 = user scale for SFPU post-mul.
+    // For Scaler CB: tile0 = 1.0 for reduce_tile; tile1 = 1/scalar for SFPU post-div.
     constexpr uint32_t packed_reduce_unity = get_compile_time_arg_val(4);
     constexpr uint32_t packed_post_scale = get_compile_time_arg_val(5);
     generate_reduce_scaler(cb_id_in2, packed_reduce_unity);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -27,10 +27,19 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_2;
+#ifdef REDUCE_MINMAX_TWO_TILE_SCALER
+    // For Scaler CB: tile0 = 1.0 for reduce_tile; tile1 = user scale for SFPU post-mul.
+    constexpr uint32_t packed_reduce_unity = get_compile_time_arg_val(4);
+    constexpr uint32_t packed_post_scale = get_compile_time_arg_val(5);
+    generate_reduce_scaler(cb_id_in2, packed_reduce_unity);
+    generate_reduce_scaler_for_minmax(cb_id_in2, packed_post_scale);
+    constexpr auto tensor_args = TensorAccessorArgs<6>();
+#else
     constexpr uint32_t scalar = get_compile_time_arg_val(4);
     generate_reduce_scaler(cb_id_in2, scalar);
 
     constexpr auto tensor_args = TensorAccessorArgs<5>();
+#endif
     auto tensor_accessor = TensorAccessor(tensor_args, src_addr);
 
     experimental::Noc noc;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -28,13 +28,20 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     uint32_t Ht = H / tile_height;
     uint32_t HtWt = Ht * Wt;
 
-    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, user scale for post-mul)
+    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, 1/scalar for post-div).
     bfloat16 bfloat_scaler_value = bfloat16::truncate(operation_attributes.scaler);
     bfloat16 bfloat_one = bfloat16::truncate(1.0f);
     const bool is_min_or_max = (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MIN) ||
                                (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MAX);
     const bool min_max_scaler_cb = is_min_or_max && (bfloat_scaler_value != bfloat_one);
-    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    uint32_t packed_scaler_value;
+    if (min_max_scaler_cb) {
+        TT_FATAL(operation_attributes.scaler != 0.0f, "Scalar must be non-zero for post-div scaling");
+        const bfloat16 bfloat_recip = bfloat16::truncate(1.0f / operation_attributes.scaler);
+        packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_recip, bfloat_recip});
+    } else {
+        packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    }
     uint32_t packed_reduce_unity = pack_two_bfloat16_into_uint32({bfloat_one, bfloat_one});
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -28,6 +28,15 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     uint32_t Ht = H / tile_height;
     uint32_t HtWt = Ht * Wt;
 
+    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, user scale for post-mul)
+    bfloat16 bfloat_scaler_value = bfloat16::truncate(operation_attributes.scaler);
+    bfloat16 bfloat_one = bfloat16::truncate(1.0f);
+    const bool is_min_or_max = (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MIN) ||
+                               (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MAX);
+    const bool min_max_scaler_cb = is_min_or_max && (bfloat_scaler_value != bfloat_one);
+    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    uint32_t packed_reduce_unity = pack_two_bfloat16_into_uint32({bfloat_one, bfloat_one});
+
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
 
@@ -100,8 +109,12 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     }
 
     uint32_t scaler_cb_index = CBIndex::c_2;
+    // CB Scaler: two pages when min/max and scalar != 1.0 - tile0 = 1.0 for reduce_tile, tile1 = user scale for
+    // post-mul
+    const uint32_t scaler_cb_pages = min_max_scaler_cb ? 2u : 1u;
     tt_metal::CircularBufferConfig cb_scaler_config =
-        tt_metal::CircularBufferConfig(1 * scaler_single_tile_size, {{scaler_cb_index, scaler_cb_data_format}})
+        tt_metal::CircularBufferConfig(
+            scaler_cb_pages * scaler_single_tile_size, {{scaler_cb_index, scaler_cb_data_format}})
             .set_page_size(scaler_cb_index, scaler_single_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
 
@@ -125,8 +138,6 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     }
     tt_metal::Buffer* src0_buffer = a.buffer();
     tt_metal::KernelHandle reader_kernel_id;
-    bfloat16 bfloat_scaler_value = bfloat16::truncate(operation_attributes.scaler);
-    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
 
     if (operation_attributes.negate) {
         // The reduce_h_neg kernel pushes ntiles tiles per inner-loop iteration
@@ -180,6 +191,11 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
         std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, src1_cb_index, scaler_cb_index};
         std::map<std::string, std::string> reader_defines;
         reader_defines["REDUCE_SCALER"] = "1";
+        if (min_max_scaler_cb) {
+            reader_compile_time_args.push_back(packed_reduce_unity);
+            reader_compile_time_args.push_back(packed_scaler_value);
+            reader_defines["REDUCE_MINMAX_TWO_TILE_SCALER"] = "1";
+        }
         reader_kernel_id = tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
@@ -187,7 +203,15 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
             all_cores,
             tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
     } else {
-        std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, chunk_size, packed_scaler_value};
+        std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, chunk_size};
+        std::map<std::string, std::string> reader_defines;
+        if (min_max_scaler_cb) {
+            reader_compile_time_args.push_back(packed_reduce_unity);
+            reader_compile_time_args.push_back(packed_scaler_value);
+            reader_defines["REDUCE_MINMAX_TWO_TILE_SCALER"] = "1";
+        } else {
+            reader_compile_time_args.push_back(packed_scaler_value);
+        }
         TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
         reader_kernel_id = tt_metal::CreateKernel(
@@ -195,7 +219,7 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "reader_unary_transpose_wh_universal_input_cols_partitioned.cpp",
             all_cores,
-            tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+            tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
     }
 
     tt_metal::Buffer* dst_buffer = output.buffer();
@@ -222,6 +246,9 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     }
     std::map<std::string, std::string> reduce_defines =
         reduce_op_utils::get_defines(operation_attributes.math_op, tt::tt_metal::ReduceOpDim::H);
+    if (min_max_scaler_cb) {
+        reduce_defines["REDUCE_MINMAX_TWO_TILE_SCALER"] = "1";
+    }
     std::vector<uint32_t> compute_kernel_args_group_1 = {
         Ht,                         // Ht
         num_cols_per_core_group_1,  // Wt

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -55,6 +55,11 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
                               output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
     uint32_t chunk_size = use_width_sharding ? 1 : ttnn::get_dest_reg_count(operation_attributes.compute_kernel_config);
+    // REDUCE_MINMAX_TWO_TILE_SCALER stages the post-mul scaler into dst[ntiles] in `reduce_h*.cpp`.
+    // Reserve one dst reg so ntiles < dest_reg_count, preventing an out-of-bounds write (dst[dest_reg_count]).
+    if (min_max_scaler_cb && !use_width_sharding) {
+        chunk_size = std::max<uint32_t>(1u, chunk_size - 1u);
+    }
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto num_cols = NC * Wt;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -25,13 +25,20 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
 
-    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, user scale for post-mul)
+    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, 1/scalar for post-div).
     bfloat16 bfloat_scaler_value = bfloat16::truncate(operation_attributes.scaler);
     bfloat16 bfloat_one = bfloat16::truncate(1.0f);
     const bool is_min_or_max = (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MIN) ||
                                (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MAX);
     const bool min_max_scaler_cb = is_min_or_max && (bfloat_scaler_value != bfloat_one);
-    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    uint32_t packed_scaler_value;
+    if (min_max_scaler_cb) {
+        TT_FATAL(operation_attributes.scaler != 0.0f, "Scalar must be non-zero for post-div scaling");
+        const bfloat16 bfloat_recip = bfloat16::truncate(1.0f / operation_attributes.scaler);
+        packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_recip, bfloat_recip});
+    } else {
+        packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    }
     uint32_t packed_reduce_unity = pack_two_bfloat16_into_uint32({bfloat_one, bfloat_one});
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -25,6 +25,15 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
 
+    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, user scale for post-mul)
+    bfloat16 bfloat_scaler_value = bfloat16::truncate(operation_attributes.scaler);
+    bfloat16 bfloat_one = bfloat16::truncate(1.0f);
+    const bool is_min_or_max = (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MIN) ||
+                               (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MAX);
+    const bool min_max_scaler_cb = is_min_or_max && (bfloat_scaler_value != bfloat_one);
+    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    uint32_t packed_reduce_unity = pack_two_bfloat16_into_uint32({bfloat_one, bfloat_one});
+
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
 
@@ -63,8 +72,12 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
             .set_page_size(src0_cb_index, src0_single_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
+    // CB Scaler: two pages when min/max and scalar != 1.0 - tile0 = 1.0 for reduce_tile, tile1 = user scale for
+    // post-mul
+    const uint32_t scaler_cb_pages = min_max_scaler_cb ? 2u : 1u;
     tt_metal::CircularBufferConfig cb_scaler_config =
-        tt_metal::CircularBufferConfig(scaler_single_tile_size, {{CBIndex::c_2, scaler_cb_data_format}})
+        tt_metal::CircularBufferConfig(
+            scaler_cb_pages * scaler_single_tile_size, {{CBIndex::c_2, scaler_cb_data_format}})
             .set_page_size(CBIndex::c_2, scaler_single_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
 
@@ -75,10 +88,13 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
             .set_page_size(output_cb_index, dst_single_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
-    bfloat16 bfloat_scaler_value = bfloat16::truncate(operation_attributes.scaler);
-    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
     tt_metal::Buffer* src_buffer = a.buffer();
-    std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
+    std::vector<uint32_t> reader_compile_time_args;
+    if (min_max_scaler_cb) {
+        reader_compile_time_args = {packed_reduce_unity, packed_scaler_value};
+    } else {
+        reader_compile_time_args = {packed_scaler_value};
+    }
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
     tt_metal::Buffer* dst_buffer = output.buffer();
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
@@ -102,6 +118,9 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
 
     std::map<std::string, std::string> reduce_defines =
         reduce_op_utils::get_defines(operation_attributes.math_op, ReduceOpDim::W);
+    if (min_max_scaler_cb) {
+        reduce_defines["REDUCE_MINMAX_TWO_TILE_SCALER"] = "1";
+    }
 
     tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -34,8 +34,23 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     // sqrt(scaler). However, sqrt of a negative number is NaN, so negative scalers
     // must not reach this code path. Instead negative scalers are handled via the two-step
     // W-then-H path where the scaler is applied once (see the reduce function in reduce_op.cpp).
-    TT_FATAL(operation_attributes.scaler >= 0, "Scalar must be non-negative");
-    float scaler = std::sqrt(operation_attributes.scaler);
+
+    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, user scale for post-mul)
+    const bfloat16 bfloat_scaler_user = bfloat16::truncate(operation_attributes.scaler);
+    const bfloat16 bfloat_one = bfloat16::truncate(1.0f);
+    const bool is_min_or_max = (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MIN) ||
+                               (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MAX);
+    const bool min_max_scaler_cb = is_min_or_max && (bfloat_scaler_user != bfloat_one);
+    const uint32_t packed_reduce_unity = pack_two_bfloat16_into_uint32({bfloat_one, bfloat_one});
+    uint32_t packed_scaler_value = 0;
+    if (min_max_scaler_cb) {
+        packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_user, bfloat_scaler_user});
+    } else {
+        TT_FATAL(operation_attributes.scaler >= 0, "Scalar must be non-negative");
+        float scaler = std::sqrt(operation_attributes.scaler);
+        bfloat16 bfloat_scaler_value = bfloat16::truncate(scaler);
+        packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    }
 
     uint32_t num_tensor_tiles = NC * H * W / tile_hw;
 
@@ -70,8 +85,12 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
             .set_page_size(src0_cb_index, src0_single_tile_size);
     tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
+    // CB Scaler: two pages when min/max and scalar != 1.0 - tile0 = 1.0 for reduce_tile, tile1 = user scale for
+    // post-mul
+    const uint32_t scaler_cb_pages = min_max_scaler_cb ? 2u : 1u;
     tt_metal::CircularBufferConfig cb_scaler_config =
-        tt_metal::CircularBufferConfig(scaler_single_tile_size, {{CBIndex::c_2, scaler_cb_data_format}})
+        tt_metal::CircularBufferConfig(
+            scaler_cb_pages * scaler_single_tile_size, {{CBIndex::c_2, scaler_cb_data_format}})
             .set_page_size(CBIndex::c_2, scaler_single_tile_size);
     tt_metal::CreateCircularBuffer(program, core, cb_scaler_config);
 
@@ -82,9 +101,12 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
             .set_page_size(output_cb_index, dst_single_tile_size);
     tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
-    bfloat16 bfloat_scaler_value = bfloat16::truncate(scaler);
-    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
-    std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
+    std::vector<uint32_t> reader_compile_time_args;
+    if (min_max_scaler_cb) {
+        reader_compile_time_args = {packed_reduce_unity, packed_scaler_value};
+    } else {
+        reader_compile_time_args = {packed_scaler_value};
+    }
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     if (operation_attributes.negate) {
@@ -106,12 +128,16 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
+    std::map<std::string, std::string> reader_defines;
+    if (min_max_scaler_cb) {
+        reader_defines["REDUCE_MINMAX_TWO_TILE_SCALER"] = "1";
+    }
     tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
         "reader_unary_reduce_universal_start_id.cpp",
         core,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
 
     tt_metal::KernelHandle writer_kernel_id = tt_metal::CreateKernel(
         program,
@@ -129,6 +155,11 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
         std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw") +
         (operation_attributes.negate ? "_neg" : "") + ".cpp";
 
+    std::map<std::string, std::string> reduce_defines =
+        reduce_op_utils::get_defines(operation_attributes.math_op, tt::tt_metal::ReduceOpDim::HW);
+    if (min_max_scaler_cb) {
+        reduce_defines["REDUCE_MINMAX_TWO_TILE_SCALER"] = "1";
+    }
     tt_metal::CreateKernel(
         program,
         compute_kernel,
@@ -137,7 +168,7 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .compile_args = compute_kernel_args,
-            .defines = reduce_op_utils::get_defines(operation_attributes.math_op, tt::tt_metal::ReduceOpDim::HW)});
+            .defines = reduce_defines});
 
     tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, {a.buffer()->address(), num_tensor_tiles, 0});
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -35,7 +35,7 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     // must not reach this code path. Instead negative scalers are handled via the two-step
     // W-then-H path where the scaler is applied once (see the reduce function in reduce_op.cpp).
 
-    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, user scale for post-mul)
+    // Min/max, scalar != 1.0: two packed tiles for scaler CB (unity for reduce_tile, 1/scalar for post-div).
     const bfloat16 bfloat_scaler_user = bfloat16::truncate(operation_attributes.scaler);
     const bfloat16 bfloat_one = bfloat16::truncate(1.0f);
     const bool is_min_or_max = (operation_attributes.math_op == tt::tt_metal::ReduceOpMath::MIN) ||
@@ -44,7 +44,9 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     const uint32_t packed_reduce_unity = pack_two_bfloat16_into_uint32({bfloat_one, bfloat_one});
     uint32_t packed_scaler_value = 0;
     if (min_max_scaler_cb) {
-        packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_user, bfloat_scaler_user});
+        TT_FATAL(operation_attributes.scaler != 0.0f, "Scalar must be non-zero for post-div scaling");
+        const bfloat16 bfloat_recip = bfloat16::truncate(1.0f / operation_attributes.scaler);
+        packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_recip, bfloat_recip});
     } else {
         TT_FATAL(operation_attributes.scaler >= 0, "Scalar must be non-negative");
         float scaler = std::sqrt(operation_attributes.scaler);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -651,6 +651,19 @@ Tensor max(
     float scalar,
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    /* Scaling is applied after reduction, so flip the op for negative scalars:
+     *  max(x * (-s)) = min(x) * (-s), and vice versa. */
+    if (scalar < 0.0f) {
+        return operations::reduction::reduce<reduction_common::ReduceType::Min>(
+            input_tensor_arg,
+            dim_arg,
+            keepdim,
+            memory_config_arg,
+            compute_kernel_config,
+            scalar,
+            correction,
+            sub_core_grids);
+    }
     return operations::reduction::reduce<reduction_common::ReduceType::Max>(
         input_tensor_arg,
         dim_arg,
@@ -671,6 +684,19 @@ Tensor min(
     float scalar,
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    /* Scaling is applied after reduction, so flip the op for negative scalars:
+     * max(x * (-s)) = min(x) * (-s), and vice versa. */
+    if (scalar < 0.0f) {
+        return operations::reduction::reduce<reduction_common::ReduceType::Max>(
+            input_tensor_arg,
+            dim_arg,
+            keepdim,
+            memory_config_arg,
+            compute_kernel_config,
+            scalar,
+            correction,
+            sub_core_grids);
+    }
     return operations::reduction::reduce<reduction_common::ReduceType::Min>(
         input_tensor_arg,
         dim_arg,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -20,6 +20,7 @@
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <numeric>
 
@@ -138,12 +139,20 @@ static Tensor reduce_impl(
         auto reduce_nd_loop = [&](const bool use_reduce_type, float scalar) -> Tensor {
             Tensor output_tensor = input_tensor_arg;
             bool first = true;
+            const int min_reduce_axis = *std::min_element(dim.begin(), dim.end());
             for (int i_dim = rank - 1; i_dim >= 0; i_dim--) {
                 bool found = std::find(dim.begin(), dim.end(), i_dim) != dim.end();
                 if (found) {
                     // Only apply the scalar once when reducing dim-by-dim,
                     // otherwise the result will be scaled multiple times.
                     float effective_scalar = first ? scalar : 1.0;
+                    if constexpr (
+                        reduce_type == reduction_common::ReduceType::Max ||
+                        reduce_type == reduction_common::ReduceType::Min) {
+                        // Sum/Mean: scale once on the first partial reduction. Min/Max: only on last
+                        // partial step (min_reduce_axis) so the result is scalar * global op(x).
+                        effective_scalar = (i_dim == min_reduce_axis) ? scalar : 1.0;
+                    }
                     first = false;
 
                     bool transpose = i_dim < rank - 2;


### PR DESCRIPTION
## Summary

- Closes #40498

### Problem description
The scalar parameter in ttnn.max/min reductions is eventually passed to the Tensix GMPOOL hardware instruction as the SrcB scalar. However, per the [GMPOOL ISA documentation](https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/TensixTile/TensixCoprocessor/GMPOOL.md), this instruction only uses the exponent of the scalar value (applying exp2 ∘ floor ∘ log2), discarding both the sign bit and the mantissa.

This means:
- Negative scalars are treated as positive (sign is ignored)
- Non-power-of-two scalars are rounded down to the nearest power of two (mantissa is ignored)

For example, scalars -2.43, -2.0, 2.0, and 2.43 all produce the same result: scaling by 2.0

In fact, even the value 2.0 doesn't work for all cases. For example, `shape=(3, 4) dim=(-2, -1) scalar=2.0 op=max` also fails. This is because it chooses a code path where the scalar is applied twice, so the code passes square root of the scalar (sqrt(2.0) = 1.414) to be applied twice. However, only the exponent is used from 1.41, so it ends applying scalar of 1 twice, yielding no scaling.

The only scalar values that work correctly are positive powers of two. However, ttnn.max/min are supposed to match PyTorch behavior and thus should accept and correctly apply any scalar.

---
### What's changed

To ensure `ttnn.max` / `ttnn.min` correctly support arbitrary scalar values and match PyTorch behavior, the `min/max` reduction path now avoids relying on GMPOOL scalar scaling when `scalar != 1.0`.

Instead, reduction is performed with unity scaling, and the full user scalar is applied after reduction.

To support this flow, a dedicated **two-tile scaler configuration** is introduced on the scalar Circular Buffer when required. This path is enabled through `min_max_scaler_cb` in host-side program setup, which allocates two scaler tiles instead of one, and the compute kernels use the `REDUCE_MINMAX_TWO_TILE_SCALER` define to switch to the new behavior.

Scaler CB layout in this mode:

- tile 0 → unity scalar used during reduction
- tile 1 → `1 / (user scalar)` used for post-reduction division

#### Files changed:

**1) Added full-tile scaler generation for min/max post-division**
    File: `ttnn/cpp/ttnn/kernel/dataflow/generate_reduce_scaler.hpp`
    Added: `generate_reduce_scaler_for_minmax()`
The second scaler tile used for post-reduction division is filled uniformly across the tile so SFPU `div_binary_tile` applies the exact scalar value correctly. The existing face-oriented scaler layout is retained for the unity tile consumed by `reduce_tile` during reduction.

**2. Updated reduction program factories**
         Files: `ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_*_core_*_program_factory.cpp`
Updated all three reduction program factory files to:
- pass both `packed_reduce_unity` and `packed_scaler_value` as reader compile-time args
- enable the two-tile scaler CB path for min/max when `scalar != 1.0`
- define `REDUCE_MINMAX_TWO_TILE_SCALER` for compute kernels when this mode is active

**3. Updated compute kernels**
        Files: `ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_*.cpp` (6 files)
Added support for the two-tile scaler configuration. For min/max scalar reductions:
- reduction runs using unity scaling
- final reduced output is divided by the reciprocal of user scalar after reduction
This avoids incorrect GMPOOL scalar handling while preserving existing reduction behavior.

**4. Updated reader kernels**
         Files: `ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_*.cpp` (3 files)
Updated reader kernels to populate the scaler CB using compile-time arguments from the program factory.
In two-tile mode:
- tile 0 is generated as unity scaler for reduce_tile
- tile 1 is generated as `1/(user scalar)` for post-reduction division

**5. Added min/max operation flipping for negative scalars**
        File: ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
For negative scalars, the reduction operation is flipped before execution so results match PyTorch semantics:
`max(x * -s) = min(x) / -(1/s)`
`min(x * -s) = max(x) / -(1/s)`
This ensures correct ordering when scaling is applied after reduction.

**6. Added unit test coverage**
        File: tests/ttnn/unit_tests/operations/reduce/test_reduction.py
Added:
- test_min_max_scalar
- test_min_max_scalar_width_sharded

---

## Notes for Reviewers
The two-tile scaler path is only enabled for `ttnn.min` / `ttnn.max` when the user scalar is not 1.0. All other reductions continue using the existing scaler path.

Start with `min_max_scaler_cb` / `REDUCE_MINMAX_TWO_TILE_SCALER` in the H, W, and single-core HW program factories, then review the reader kernels that populate two scaler tiles, followed by the `reduce_*.cpp` post-reduction division path guarded by that define. Documentation in `reduce.h` has been updated to reflect GMPOOL scalar limitations and the post-reduction scaling behavior for MAX/MIN.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-ttnn-min-max-scaler)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-ttnn-min-max-scaler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-ttnn-min-max-scaler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-ttnn-min-max-scaler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-ttnn-min-max-scaler)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-ttnn-min-max-scaler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-ttnn-min-max-scaler)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-ttnn-min-max-scaler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-ttnn-min-max-scaler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-ttnn-min-max-scaler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-ttnn-min-max-scaler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-ttnn-min-max-scaler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-ttnn-min-max-scaler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-ttnn-min-max-scaler)