### PR TITLE
fix(softmax): pass cur_cb_length_t to pad_input to avoid last-cb_pass deadlock (#42555)

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -731,3 +731,43 @@ def test_softmax_4096x4096_fp32(device):
         atol=0.001,
         frobenius_threshold=0.019,
     )
+
+
+@pytest.mark.parametrize(
+    "shape, dim",
+    [
+        ((1, 100, 6800), -1),
+    ],
+)
+def test_softmax_large_kernel_mask_padded(device, shape, dim):
+    """Regression test for issue #42555: softmax deadlocks in the large-kernel path when a
+    non-tile-aligned H combines with a Wt not divisible by the capped CB length."""
+    torch.manual_seed(0)
+
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output = F.softmax(torch_input, dim=dim, dtype=torch.bfloat16)
+
+    compute_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=True,
+    )
+
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_output = ttnn.softmax(
+        ttnn_input,
+        dim=dim,
+        compute_kernel_config=compute_config,
+        numeric_stable=True,
+    )
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_numeric_metrics(
+        torch_output,
+        ttnn_output,
+        pcc_threshold=0.999,
+        rtol=0.03,
+        atol=0.001,
+        frobenius_threshold=0.02,
+        ulp_threshold=15,
+        check_ulp=True,
+    )

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -392,7 +392,7 @@ void kernel_main() {
 #else
             if (do_mask && cur_pass == num_cb_passes - 1) {
                 // pad
-                pad_input(cb_in0, cb_x, cb_length_t, blk);
+                pad_input(cb_in0, cb_x, cur_cb_length_t, blk);
                 cb_processed_input = cb_x;
             } else {
                 // no Pad
@@ -433,7 +433,7 @@ void kernel_main() {
             // a part of the tensor
             if (do_mask && cur_pass == num_cb_passes - 1) {
                 // pad
-                pad_input(cb_in0, cb_x, cb_length_t, blk);
+                pad_input(cb_in0, cb_x, cur_cb_length_t, blk);
                 cb_processed_input = cb_x;
             } else {
                 // no Pad
@@ -500,7 +500,7 @@ void kernel_main() {
 #else
             if (do_mask && cur_pass == num_cb_passes - 1) {
                 // pad
-                pad_input(cb_in0, cb_x, cb_length_t, blk);
+                pad_input(cb_in0, cb_x, cur_cb_length_t, blk);
                 cb_processed_input = cb_x;
             } else {
                 // no Pad


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-metal/issues/42555

### Problem description

`ttnn.softmax` hangs on shape `(1, 100, 6800)` with `numeric_stable=True` + `fp32_dest_acc_en=True`. Test reports PASSED (ttnn dispatch is async), then `close_mesh_device` hangs forever at teardown waiting for the stuck kernel to drain. 

**Root cause:** For large tensors, softmax routes to `softmax_large_tensor.cpp` which chunks the row into `num_cb_passes` passes of `cb_length_t` tiles each (78 + 78 + 57 = 213 for our repro). When `H` isn't tile-aligned, `pad_input` is called on the last chunk to mask the padded rows — but it was passed `cb_length_t` (78) as its length instead of `cur_cb_length_t` (57, the actual tiles remaining). It tried to consume 78 tiles from `cb_in0` when the reader only produced 57 → producer/consumer deadlock.

### What's changed

Fix (`softmax_large_tensor.cpp`) — three call sites:
```diff
- pad_input(cb_in0, cb_x, cb_length_t, blk);
+ pad_input(cb_in0, cb_x, cur_cb_length_t, blk);
```

### Checklist

- [x] Nightly tt-metal L2 tests - https://github.com/tenstorrent/tt-metal/actions/runs/24882223294
- [x] Sanity tests - https://github.com/tenstorrent/tt-metal/actions/runs/24881999341
