### PR TITLE
LLK tests: support ttsim functional simulator

### DIFF
--- a/tools/triage/requirements.txt
+++ b/tools/triage/requirements.txt
@@ -1,3 +1,6 @@
 pycapnp==2.0.0
 mpi4py>=4.1.1
-tt-exalens==0.3.15; platform_machine == "x86_64"
+# tt-exalens 0.3.17 pins tt-umd==0.9.5.dev260424 (a prerelease); listing tt-umd explicitly is what
+# tells uv to allow the prerelease for the transitive resolution.
+tt-umd==0.9.5.dev260424; platform_machine == "x86_64"
+tt-exalens==0.3.17; platform_machine == "x86_64"

--- a/tt_metal/tt-llk/tests/README.md
+++ b/tt_metal/tt-llk/tests/README.md
@@ -51,6 +51,11 @@ Replace <test_file_name> with the specific test script you want to execute, e.g.
 pytest
 ```
 
+### Running on the ttsim functional simulator
+
+See [TTSIM.md](TTSIM.md) for running the LLK suite on
+[ttsim](https://github.com/tenstorrent/ttsim) — no silicon required.
+
 ---
 
 ## Logging

--- a/tt_metal/tt-llk/tests/TTSIM.md
+++ b/tt_metal/tt-llk/tests/TTSIM.md
@@ -1,0 +1,107 @@
+# Running LLK Tests on ttsim
+
+[ttsim](https://github.com/tenstorrent/ttsim) is Tenstorrent's functional
+simulator. It models a Wormhole or Blackhole chip end-to-end on a plain
+x86_64 Linux host — no silicon required. The LLK test suite can target
+ttsim with the same pytest invocations used for silicon, modulo a couple
+of environment variables.
+
+## Prerequisites
+
+- `libttsim_{wh,bh}.so` downloaded from
+  [ttsim releases](https://github.com/tenstorrent/ttsim/releases).
+- A SoC descriptor YAML for the target arch, placed next to the `.so`
+  and named `soc_descriptor.yaml` (ttsim derives its path from the `.so`
+  path).
+- `tt-umd` with TTSim fixes for arch / noc-translation / chip-info and
+  clock advance on host writes (check `pip show tt-umd`; required
+  version depends on when these land).
+- `tt-exalens` with the `send_tensix_risc_reset` positional-API fix
+  (0.3.16+).
+- SFPI compiler set up per the main `README.md` (SFPI is required for
+  kernel compilation regardless of backend).
+
+## Setup
+
+```bash
+# One-time: assemble the simulator directory
+mkdir -p ~/sim
+cd ~/sim
+# Pick the arch that matches the tests you want to run:
+wget https://github.com/tenstorrent/ttsim/releases/latest/download/libttsim_bh.so
+# Copy the arch-appropriate SOC descriptor from tt-metal:
+cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml \
+   ~/sim/soc_descriptor.yaml
+```
+
+## Running tests
+
+```bash
+export TT_METAL_SIMULATOR=~/sim/libttsim_bh.so
+
+# ttsim does not currently support SFPLOADMACRO — disable it if your
+# tests hit the SFPU:
+export TT_METAL_DISABLE_SFPLOADMACRO=1
+
+cd $TT_METAL_HOME/tt_metal/tt-llk/tests/python_tests
+pytest -v --run-simulator --timeout=600 test_eltwise_unary_datacopy.py
+```
+
+`TT_METAL_SIMULATOR` is the canonical env var — the same one tt-metal
+runtime and the ttsim project docs use. `TT_UMD_SIMULATOR_PATH` is
+accepted as an alias for back-compat with the RTL-simulator flow; when
+both are set, `TT_METAL_SIMULATOR` wins.
+
+### Canonical smoke test
+
+The simplest end-to-end check that the stack is wired up:
+
+```bash
+pytest -v --run-simulator --timeout=300 \
+  test_eltwise_unary_datacopy.py -k "Float16_b and not tilize"
+```
+
+This exercises unpack → math (datacopy) → pack on a single tile with
+the most common format and no SFPU/tilize paths.
+
+## Supported architectures
+
+| Arch | LLK tests on ttsim |
+|---|---|
+| Blackhole | Working (validated against ttsim v1.5.4). |
+| Wormhole B0 | Working (validated against ttsim v1.5.4). |
+| Quasar | Not validated. |
+
+## Limitations
+
+- **Slow dispatch only.** ttsim does not yet implement fast dispatch.
+  LLK tests go through the direct exalens path and are unaffected, but
+  any programming example invoked alongside needs
+  `TT_METAL_SLOW_DISPATCH_MODE=1`.
+- **SFPLOADMACRO** is not implemented. Set
+  `TT_METAL_DISABLE_SFPLOADMACRO=1` if your test hits the SFPU.
+- **Not all ISA is modeled.** Unimplemented opcodes surface as
+  `UnimplementedFunctionality` errors from the simulator. See the
+  [ttsim README](https://github.com/tenstorrent/ttsim) for the error
+  taxonomy, and file a bug against the ttsim repo with a minimal repro
+  if you hit one.
+- **Performance.** ttsim is substantially slower than silicon for
+  individual tests. Use it for correctness and CI coverage, not
+  performance measurements.
+
+## Troubleshooting
+
+- `Getting NOC translation status is not supported in TTSim simulation device` —
+  old tt-umd; upgrade to a release that contains the TTSimTTDevice fixes.
+- `Exactly 2 or 14 ETH cores should be harvested on full Blackhole` —
+  same cause; upgrade tt-umd.
+- `SOFT_RESET_0=0x6F` warnings flooding the log — old tt-exalens;
+  upgrade to 0.3.16+ (the reset sequence is skipped on ttsim).
+- `UnimplementedFunctionality: <opcode>` from ttsim — ISA gap, not a
+  test or harness issue. File against
+  [tenstorrent/ttsim](https://github.com/tenstorrent/ttsim/issues) with
+  a minimal repro.
+- `Polling brisc command timed out` on WH — you're running an old
+  tt-umd. The fix that advances the sim clock on host writes
+  (TTSimTTDevice::write_to_device) is required; upgrade to a release
+  that contains it.

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -7,9 +7,33 @@ import json
 import logging
 import os
 import signal
+import sys
 from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
+
+# ttsim runs in-process (no ExalensServer). Its init must complete before any helpers.* import,
+# because helpers.chip_architecture.get_chip_architecture() reaches check_context() and this
+# conftest calls it at module-load time via the skip_for_* markers defined further down.
+# TT_METAL_SIMULATOR is the canonical env var (matches tt-metal runtime and the ttsim README);
+# TT_UMD_SIMULATOR_PATH is kept as an alias for the existing RTL-simulator workflow.
+# Gate on --run-simulator so the env var being set doesn't force a ttsim init on silicon runs,
+# and skip --compile-producer (it only compiles ELFs and never talks to a device). xdist workers
+# inherit env vars but not the controller's argv, so trust the env var when PYTEST_XDIST_WORKER
+# is set.
+_SIMULATOR_PATH = os.environ.get("TT_METAL_SIMULATOR") or os.environ.get(
+    "TT_UMD_SIMULATOR_PATH"
+)
+_IS_XDIST_WORKER = "PYTEST_XDIST_WORKER" in os.environ
+_SHOULD_RUN_SIMULATOR = _IS_XDIST_WORKER or (
+    "--run-simulator" in sys.argv and "--compile-producer" not in sys.argv
+)
+if _SHOULD_RUN_SIMULATOR and _SIMULATOR_PATH and _SIMULATOR_PATH.endswith(".so"):
+    from ttexalens import tt_exalens_init as _tt_exalens_init
+
+    _tt_exalens_init.init_ttexalens(
+        simulation_directory=_SIMULATOR_PATH, use_4B_mode=False
+    )
 
 import helpers.order_processing as order_processing
 import helpers.utils as utils_module
@@ -276,21 +300,29 @@ def pytest_configure(config):
 
     if TestConfig.BUILD_MODE != BuildMode.PRODUCE:
         if test_target.run_simulator:
-            simulator_path = os.environ.get("TT_UMD_SIMULATOR_PATH")
-
-            if simulator_path is None:
+            if _SIMULATOR_PATH is None:
                 pytest.exit(
-                    "ERROR: --run-simulator requires TT_UMD_SIMULATOR_PATH "
-                    "environment variable to be set.",
+                    "ERROR: --run-simulator requires TT_METAL_SIMULATOR "
+                    "(or TT_UMD_SIMULATOR_PATH) environment variable to be set.",
                     returncode=1,
                 )
 
-            # Only the controller process manages the server; xdist workers
-            # just connect to the already-running instance.
-            if not hasattr(config, "workerinput"):
+            if _SIMULATOR_PATH.endswith(".so"):
+                # ttsim: already initialized at module import above; runs in-process, no server.
+                # --reset-simulator-per-test restarts the ExalensServer, which ttsim doesn't use,
+                # so it would be a silent no-op. Fail fast to avoid confusing false-green runs.
+                if test_target.reset_simulator_per_test:
+                    pytest.exit(
+                        "ERROR: --reset-simulator-per-test is not supported with ttsim. "
+                        "Re-run without it.",
+                        returncode=1,
+                    )
+            elif not hasattr(config, "workerinput"):
+                # RTL simulator: only the controller process manages the server; xdist workers
+                # just connect to the already-running instance.
                 global _exalens_server
                 _exalens_server = ExalensServer(
-                    simulator_path=simulator_path,
+                    simulator_path=_SIMULATOR_PATH,
                     port=test_target.simulator_port,
                 )
         else:

--- a/tt_metal/tt-llk/tests/requirements.txt
+++ b/tt_metal/tt-llk/tests/requirements.txt
@@ -3,8 +3,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 # tt packages from test.pypi.org
-tt-exalens==0.3.16
-tt-umd==0.9.5.dev260402
+tt-exalens==0.3.17
+tt-umd==0.9.5.dev260424
 
 # tt-smi from pypi
 tt-smi==3.1.1


### PR DESCRIPTION
## Summary

Sets up the LLK test harness to target [ttsim](https://github.com/tenstorrent/ttsim) (Tenstorrent's functional simulator, \`libttsim.so\`) via the \`TT_METAL_SIMULATOR\` environment variable — the same variable tt-metal runtime and the ttsim project README already use.

### Code change (\`tt_metal/tt-llk/tests/python_tests/conftest.py\`)

- Resolve the simulator path from \`TT_METAL_SIMULATOR\`, with \`TT_UMD_SIMULATOR_PATH\` accepted as an alias for the existing RTL-simulator workflow.
- When the path is a \`.so\`, initialize tt-exalens in-process at module import (\`helpers.device\` calls \`check_context()\` at load time, so this has to happen before any \`helpers.*\` import) and skip the \`ExalensServer\` spawn in \`pytest_configure\` (ttsim is in-process, no server socket).

### Docs (\`tt_metal/tt-llk/tests/TTSIM.md\`)

New user-facing guide (sibling of \`LOGGING.md\`) covering setup, canonical invocation, supported architectures, limitations, and troubleshooting. \`tests/README.md\` gets one pointer to it.

### Companion PRs

- tenstorrent/tt-umd#2515 — \`TTSimTTDevice: make it a complete TTDevice for LLK test use\`
- tenstorrent/tt-exalens#1001 — \`umd_api: fix send_tensix_risc_reset kwarg for current UMD bindings\`

Both required; tt-metal side alone does not work without them.

## Test plan

- [x] \`test_eltwise_unary_datacopy\` (Float16_b, 3 parametrizations) passes on vanilla ttsim v1.5.4 (\`libttsim_{bh,wh}.so\` straight from the public release page)
  - Blackhole: 3/3 pass
  - Wormhole B0: 3/3 pass
- [ ] \`--run-simulator\` path on RTL simulator unchanged (still works via \`TT_UMD_SIMULATOR_PATH\`)
- [ ] Silicon path unchanged

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/llk-tests-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/llk-tests-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/llk-tests-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/llk-tests-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/llk-tests-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/llk-tests-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/llk-tests-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/llk-tests-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/llk-tests-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/llk-tests-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/llk-tests-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/llk-tests-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/llk-tests-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/llk-tests-ttsim)