### PR TITLE
[tt-triage] Revert elf cache to use FDs and raise the FD limit upon triage run

### DIFF
--- a/tools/triage/elfs_cache.py
+++ b/tools/triage/elfs_cache.py
@@ -10,21 +10,18 @@ Usage:
 Description:
     Thread-safe data provider for caching ParsedElfFile objects.
     Provides an API for grabbing or caching ParsedElfFile objects by given elf path.
-    ELF files are accessed via mmap rather than held-open file descriptors.
 
 Owner:
     adjordjevic-TT
 """
 
-import mmap
 import os
 import threading
-
-from elftools.elf.elffile import ELFFile
 
 from triage import triage_singleton, ScriptConfig, run_script, TTTriageError
 from ttexalens.context import Context
 from ttexalens.hardware.risc_debug import ParsedElfFile
+from ttexalens.tt_exalens_lib import parse_elf
 from utils import INFO
 
 script_config = ScriptConfig(
@@ -34,9 +31,11 @@ script_config = ScriptConfig(
 
 class ElfsCache:
     """
-    Thread-safe cache for ParsedElfFile objects, backed by mmap.
+    Thread-safe cache for ParsedElfFile objects.
     When `enabled=False` the cache acts as a pass-through: every lookup
-    re-parses the ELF. Intended as a mitigation toggle via --disable-elf-cache
+    re-parses the ELF and returns it without storing a reference, so the
+    ParsedElfFile is released (and its file descriptor closed) once the
+    caller drops it. Intended as a mitigation toggle via --disable-elf-cache
     if the cache misbehaves.
     """
 
@@ -57,7 +56,12 @@ class ElfsCache:
             if self._enabled and elf_path in self._cache:
                 return self._cache[elf_path]
 
-            parsed_elf = self._parse(elf_path)
+            parsed_elf = parse_elf(elf_path, self.context)
+            if not parsed_elf:
+                raise TTTriageError(
+                    f"Failed to extract DWARF info from ELF file {elf_path}.\n"
+                    f"Run workload with TT_METAL_RISCV_DEBUG_INFO=1 to enable debug info."
+                )
 
             if elf_path not in self._distinct_paths:
                 self._distinct_paths.add(elf_path)
@@ -91,27 +95,6 @@ class ElfsCache:
                 f"distinct elf files={len(self._distinct_paths)}\n"
                 f"total size={self._total_bytes / 1e6:.1f}MB\n"
             )
-
-    @staticmethod
-    def _parse(elf_path: str) -> ParsedElfFile:
-        fd = os.open(elf_path, os.O_RDONLY)
-        try:
-            mm = mmap.mmap(fd, 0, prot=mmap.PROT_READ)
-        finally:
-            os.close(fd)
-
-        try:
-            elf = ELFFile(mm)
-            if not elf.has_dwarf_info():
-                raise TTTriageError(
-                    f"Failed to extract DWARF info from ELF file {elf_path}.\n"
-                    f"Run workload with TT_METAL_RISCV_DEBUG_INFO=1 to enable debug info."
-                )
-        except Exception:
-            mm.close()
-            raise
-
-        return ParsedElfFile(elf, elf_path)
 
 
 @triage_singleton

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -101,14 +101,10 @@ def _raise_open_file_limit(desired: int = 65536) -> None:
         if new_soft <= soft:
             return
         resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
-    except Exception as e:
+    except (ImportError, OSError, ValueError) as e:
         utils.WARN(
             f"Failed to raise open file limit: {e}. This may cause issues when processing many ELF files. Consider increasing the limit manually (ulimit -n {desired})."
         )
-        pass
-
-
-_raise_open_file_limit()
 
 
 class ScriptPriority(Enum):
@@ -449,6 +445,7 @@ def create_progress() -> Progress:
 
 def process_arguments(args: ScriptArguments) -> None:
     init_console_and_verbosity(args)
+    _raise_open_file_limit()
 
 
 def parse_arguments(

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -87,6 +87,25 @@ from typing import Any, Callable, Iterable, TypeVar
 from types import ModuleType
 
 
+def _raise_open_file_limit(desired: int = 65536) -> None:
+    try:
+        import resource
+
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        new_soft = desired if hard == resource.RLIM_INFINITY else min(desired, hard)
+        if new_soft <= soft:
+            return
+        resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
+    except Exception as e:
+        utils.WARN(
+            f"Failed to raise open file limit: {e}. This may cause issues when processing many ELF files. Consider increasing the limit manually (ulimit -n {desired})."
+        )
+        pass
+
+
+_raise_open_file_limit()
+
+
 class ScriptPriority(Enum):
     LOW = 0
     MEDIUM = 1

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -88,6 +88,11 @@ from types import ModuleType
 
 
 def _raise_open_file_limit(desired: int = 65536) -> None:
+    """
+    Raise the open file limit for the current process to the desired value if possible.
+    This is necessary to avoid hitting the open file limit when processing many ELF files with the elf cache enabled.
+    If the file limit is already at or above the desired value, this function does nothing.
+    """
     try:
         import resource
 


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Reverts elf cache from mmap to use FDs as mmap in python uses shadow FDs so they are almost equivalent. Adds a call that raises the open FD limit at the start of triage (or calling any triage script directly).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/elf-cache-revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/elf-cache-revert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/elf-cache-revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/elf-cache-revert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/elf-cache-revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/elf-cache-revert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/elf-cache-revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/elf-cache-revert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/elf-cache-revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/elf-cache-revert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/elf-cache-revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/elf-cache-revert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/elf-cache-revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/elf-cache-revert)