### PR TITLE
Add persistent kernel termination to DeepSeekV3 B1 pipeline stages

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -226,7 +226,9 @@ def run_demo(
                 logger.info("Shutting down launch-only pipeline after interrupt.")
 
         model_pipeline.barrier()
-        logger.info("Pod pipeline complete")
+
+        logger.info("Pod pipeline complete - terminating now...")
+        model_pipeline.terminate()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -30,6 +30,7 @@ from models.demos.deepseek_v3_b1.metadata.metadata import DeepseekMetadata, crea
 from models.demos.deepseek_v3_b1.micro_ops.dram_zero_fill.op import DRAMZeroFill
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
+from models.demos.deepseek_v3_b1.micro_ops.persistent_loop.op import PersistentLoop
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import HostIoPlacement, LoopbackConfig, PipelineBlock
 from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert, SharedExpert
@@ -879,6 +880,7 @@ class DecoderStage(StageKind):
             downstream_sockets=self._state["downstream_sockets"],
             persistent_next_iter_semaphore=self._state.get("persistent_next_iter_semaphore"),
             persistent_mode=self._persistent_mode,
+            termination_semaphore=self._state.get("termination_semaphore"),
             is_torus=self._is_torus,
             forward_metadata=self._forward_metadata,
         )
@@ -901,9 +903,7 @@ class DecoderStage(StageKind):
         )
         moe_semaphores = MoeOp.create_semaphores(mesh_device)
         reduce_semaphores = [ttnn.create_global_semaphore(mesh_device, available_cores, 0) for _ in range(4)]
-        persistent_next_iter_semaphore = (
-            ttnn.create_global_semaphore(mesh_device, available_cores, 1) if self._persistent_mode else None
-        )
+        self._persistent_loop = PersistentLoop(mesh_device, available_cores, self._persistent_mode)
 
         if self._is_moe:
             d = create_decoder_block_tensors(
@@ -951,8 +951,9 @@ class DecoderStage(StageKind):
             "downstream_sockets": downstream_sockets,
         }
 
-        if persistent_next_iter_semaphore is not None:
-            self._state["persistent_next_iter_semaphore"] = persistent_next_iter_semaphore
+        if self._persistent_mode:
+            self._state["persistent_next_iter_semaphore"] = self._persistent_loop.next_iter_semaphore
+            self._state["termination_semaphore"] = self._persistent_loop.termination_semaphore
 
         self._state["decoder_program_context"] = self._build_decoder_program_context()
 
@@ -960,6 +961,9 @@ class DecoderStage(StageKind):
 
     def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
         DecoderBlock.execute(*self._state["decoder_program_context"])
+
+    def terminate(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        self._persistent_loop.terminate()
 
 
 class MoEDecoderStage(DecoderStage):

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -30,7 +30,7 @@ from models.demos.deepseek_v3_b1.demo.stage import (
     StageKind,
 )
 from models.demos.deepseek_v3_b1.demo.weight_provider import WeightProvider
-from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock, StageMetadata
+from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlockKind, StageMetadata
 
 
 def create_fabric_router_config(max_payload_size: int) -> Any:
@@ -108,39 +108,6 @@ def create_single_galaxy_pipeline_configuration(
             1: stage_1,
             2: lambda d: PassthroughStage(fwd_payload),
             3: lambda d: PassthroughStage(fwd_payload),
-        }
-    )
-
-
-def create_single_galaxy_pipeline_spec_stage_only_configuration(
-    weight_provider: WeightProvider,
-    *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
-) -> PipelineConfiguration:
-    """4-stage single-galaxy: Embed -> LMHead -> Token fwd -> Token fwd."""
-    fwd_payload = PassthroughPayload.ACTIVATION_W_TOKEN_META
-
-    def stage_0(device: ttnn.MeshDevice) -> StageKind:
-        return EmbeddingStage(
-            weight_provider.load_embedding(device),
-            d2h_page_size=ACTIVATION_W_TOKEN_META_PAGE_SIZE_BYTES,
-            forward_metadata=True,
-        )
-
-    def stage_1(device: ttnn.MeshDevice) -> StageKind:
-        return SpecLMHeadStage(
-            weights=weight_provider.load_lm_head(device),
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
-        )
-
-    return PipelineConfiguration(
-        {
-            0: stage_0,
-            1: lambda d: PassthroughStage(fwd_payload),
-            2: lambda d: PassthroughStage(fwd_payload),
-            3: stage_1,
         }
     )
 
@@ -299,9 +266,6 @@ def create_single_galaxy_deepseek_pipeline_configuration(
     )
 
 
-create_single_galaxy_deepseek_pipeline = create_single_galaxy_deepseek_pipeline_configuration
-
-
 def create_single_pod_pipeline_configuration(
     weight_provider: WeightProvider,
     *,
@@ -356,7 +320,7 @@ def create_single_pod_pipeline_configuration(
         )
 
     dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
-    moe_layer_id = moe_layer_id_override if moe_layer_id_override is not None else None
+    moe_layer_id = moe_layer_id_override
 
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
@@ -438,7 +402,7 @@ def create_sp4_pipeline_configuration(
         )
 
     dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
-    moe_layer_id = moe_layer_id_override if moe_layer_id_override is not None else None
+    moe_layer_id = moe_layer_id_override
 
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
@@ -575,7 +539,7 @@ class Pipeline:
             my_stage_idx=self._my_stage_idx,
             stages_metadata=stages_metadata,
         )
-        self._pipeline_block: PipelineBlock | None = None
+        self._pipeline_block: PipelineBlockKind | None = None
 
     @property
     def my_mesh_id(self) -> int:
@@ -585,6 +549,13 @@ class Pipeline:
     @property
     def my_stage_idx(self) -> int:
         return self._my_stage_idx
+
+    @property
+    def _block(self) -> PipelineBlockKind:
+        """Non-null view of ``_pipeline_block``; raises if :meth:`configure_block` hasn't run."""
+        if self._pipeline_block is None:
+            raise RuntimeError("Pipeline.configure_block() must be called first")
+        return self._pipeline_block
 
     def configure_block(self) -> None:
         """Phase 1: Create the PipelineBlock (socket wiring)."""
@@ -596,22 +567,16 @@ class Pipeline:
         Decoder/dense stages also build :meth:`DecoderBlock.get_program_context` here so
         program construction finishes before :meth:`start_pipeline`.
         """
-        if self._pipeline_block is None:
-            raise RuntimeError("Pipeline.configure_block() must be called before setup()")
-        self._stage_kind.setup(self._ctx, self._pipeline_block)
+        self._stage_kind.setup(self._ctx, self._block)
 
     def start_pipeline(self) -> None:
         """Phase 3: Start pipeline block kernels (socket interfaces + auxiliary bypass sockets)."""
-        if self._pipeline_block is None:
-            raise RuntimeError("Pipeline.configure_block() must be called before start_pipeline()")
-        self._pipeline_block.run()
+        self._block.run()
         self._stage_kind.run_auxiliary_sockets()
 
     def start_compute(self) -> None:
         """Phase 4: Launch stage compute (e.g. ``LMHeadSampling.op``, ``DecoderBlock.execute``)."""
-        if self._pipeline_block is None:
-            raise RuntimeError("Pipeline.configure_block() must be called before start_compute()")
-        self._stage_kind.launch_compute(self._ctx, self._pipeline_block)
+        self._stage_kind.launch_compute(self._ctx, self._block)
 
     def setup_and_run(self) -> None:
         """Run all four phases in order."""
@@ -636,28 +601,62 @@ class Pipeline:
         self.barrier()
 
     def write_token(self, token_tensor: ttnn.Tensor) -> None:
-        if self._pipeline_block is None:
-            raise RuntimeError("Pipeline.setup_and_run() or configure_block() must be called first")
-        self._pipeline_block.write_token(token_tensor)
+        self._block.write_token(token_tensor)
 
-    def read_output(self, output_tensor: ttnn.Tensor):
-        if self._pipeline_block is None:
-            raise RuntimeError("Pipeline.setup_and_run() or configure_block() must be called first")
-        return self._pipeline_block.read_output(output_tensor)
+    def read_output(self, output_tensor: ttnn.Tensor) -> None:
+        self._block.read_output(output_tensor)
 
     def export_host_socket_descriptors(self, prefix: str) -> None:
-        if self._pipeline_block is None:
-            raise RuntimeError("Pipeline.setup_and_run() must complete before exporting host socket descriptors")
-        self._pipeline_block.export_host_socket_descriptors(prefix)
+        self._block.export_host_socket_descriptors(prefix)
 
     def barrier(self) -> None:
         ttnn.distributed_context_barrier()
 
     def terminate(self) -> None:
-        """Terminate the pipeline block and any auxiliary sockets."""
+        """Terminate the pipeline block.
+
+        Compute kernels and the d2d_exchange / host_io kernels are independent
+        persistent programs that communicate over sockets; each has its own
+        termination semaphore.
+
+        The shutdown sequence is:
+
+          1. Barrier — all ranks start teardown together.
+          2. Set the compute-kernel termination semaphore.  The flag is written
+             to L1 but no core observes it yet: they are all blocked at the
+             iteration gate (``persistent_next_iter_sem``) or mid-iteration.
+          3. Barrier — all ranks have written their termination flags.
+          4. Stage 0 pushes a dummy token and drains the round-trip result.
+             The token naturally triggers ``persistent_next_iter_sem`` via the
+             pipeline's socket/d2d flow, providing both the gate release AND
+             the data payload.  All cores complete this final iteration
+             together, loop back to the top-of-loop termination check, see the
+             flag, and break.
+          5. Barrier — non-stage-0 ranks wait for the dummy round-trip.
+             (No ``synchronize_device`` here: d2d/host_io kernels are still
+             running and would block.)
+          6. Tear down d2d_exchange / host_io via ``PipelineBlock.terminate``
+             (sets socket termination semaphores + ``synchronize_device``).
+          7. Final ``synchronize_device``.
+        """
+        if self._pipeline_block is None:
+            return
+
+        ttnn.distributed_context_barrier()
+
+        self._stage_kind.terminate(self._ctx, self._pipeline_block)
         self._stage_kind.terminate_auxiliary()
-        if self._pipeline_block is not None:
-            self._pipeline_block.terminate()
+
+        ttnn.distributed_context_barrier()
+
+        if self._pipeline_block.is_first_pipeline_stage():
+            self._pipeline_block.push_dummy_token()
+            self._pipeline_block.drain_dummy_output()
+
+        ttnn.distributed_context_barrier()
+
+        self._pipeline_block.terminate()
+        ttnn.synchronize_device(self._mesh_device)
 
 
 def create_single_pod_spec_decode_pipeline_configuration(
@@ -723,7 +722,7 @@ def create_single_pod_spec_decode_pipeline_configuration(
         )
 
     dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
-    moe_layer_id = moe_layer_id_override if moe_layer_id_override is not None else None
+    moe_layer_id = moe_layer_id_override
 
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
@@ -760,7 +759,7 @@ def create_single_pod_combined_spec_decode_pipeline_configuration(
             embedding_weights=weight_provider.load_embedding(device),
             fp32_dest_acc_en=fp32_dest_acc_en,
             persistent_mode=persistent_mode,
-            shared_head_norm=weight_provider.load_shared_head_norm(device),
+            spec_weights=weight_provider.load_spec(device),
         )
 
     def passthrough_stage(device: ttnn.MeshDevice) -> StageKind:

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -20,10 +20,12 @@ import ttnn
 from models.demos.deepseek_v3_b1.fused_ops.lm_head_sampling.op import LMHeadSampling
 from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import MeshWrapper, SocketInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
+from models.demos.deepseek_v3_b1.micro_ops.persistent_loop.op import PersistentLoop
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import (
     HostIoPlacement,
     LoopbackConfig,
     PipelineBlock,
+    PipelineBlockKind,
     StageMetadata,
 )
 from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions
@@ -56,17 +58,13 @@ ACTIVATION_FIFO_SIZE = activation_fifo_size_bytes(ACTIVATION_PAGE_SIZE_BYTES)
 PIPELINE_CORE_COORD = ttnn.CoreCoord(12, 8)
 SECOND_PIPELINE_CORE_COORD = ttnn.CoreCoord(12, 7)
 
-# Embedding core coords for the combined SpecLMHead+Embedding stage (column 12, outside mcast grid)
-EMBEDDING_H2D_CORE_COORD = ttnn.CoreCoord(12, 0)
+# Embedding D2H core coord for the combined SpecLMHead+Embedding stage (column 12, outside mcast grid)
 EMBEDDING_D2H_CORE_COORD = ttnn.CoreCoord(12, 1)
-ARGMAX_RELAY_CORE = ttnn.CoreCoord(12, 2)
 
 # MTP constants
-embedding_dim = 7168
-mtp_output_dim = 7168
 num_dram_banks = 8
 METADATA_NUM_ELEMS = 32
-mtp_n_per_core = mtp_output_dim // num_dram_banks
+mtp_n_per_core = ACTIVATION_DIM // num_dram_banks
 mtp_padded_dim = num_dram_banks * mtp_n_per_core
 
 # Token metadata payload: just token info (id, type, pos) — same physical size as TOKEN.
@@ -96,10 +94,10 @@ class StageKind(ABC):
     """Abstract stage kind: controls PipelineBlock creation, setup, and compute launch."""
 
     @abstractmethod
-    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
-        """Create and return the PipelineBlock for this stage."""
+    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlockKind:
+        """Create and return the pipeline block for this stage."""
 
-    def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+    def setup(self, ctx: StageContext, pipeline_block: PipelineBlockKind) -> None:
         """Post-creation setup (tensor allocation, etc).
 
         Decoder stages may also compile/build device programs here so ``launch_compute`` only
@@ -112,8 +110,17 @@ class StageKind(ABC):
     def terminate_auxiliary(self) -> None:
         """Terminate auxiliary sockets. Default: no-op."""
 
-    def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+    def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlockKind) -> None:
         """Run stage compute after ``pipeline_block.run()`` (execute pre-built programs where applicable). Default: no-op."""
+
+    def terminate(self, ctx: StageContext, pipeline_block: PipelineBlockKind) -> None:
+        """Signal the stage's persistent compute kernels to exit on the next iteration.
+
+        Concrete stages that launch persistent compute kernels (e.g. LMHead, Decoder)
+        override this to set a termination semaphore. The pipeline orchestrator then
+        pushes a dummy token through the pipeline so each stage can complete its final
+        iteration and break naturally at the top-of-loop termination check. Default: no-op.
+        """
 
 
 class PassthroughPayload(Enum):
@@ -304,7 +311,6 @@ class SpecLMHeadStage(StageKind):
     N_PER_CORE = 160
     N_TOTAL = NUM_MATMUL_CORES * N_PER_CORE
     A_TILE = ttnn.Tile([1, 32])
-    B_TILE = ttnn.Tile([32, 32])
     OUT_TILE = ttnn.Tile([1, 32])
     ARGMAX_FINAL_CORE = ttnn.CoreCoord(0, 0)
     LMHEAD_INPUT_CORE = ttnn.CoreCoord(10, 9)
@@ -380,11 +386,6 @@ class SpecLMHeadStage(StageKind):
         )
         argmax_final_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(cls.ARGMAX_FINAL_CORE, cls.ARGMAX_FINAL_CORE)])
 
-        input_a_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.BufferType.L1,
-            ttnn.ShardSpec(mcast_core_grid, (cls.M, cls.K + METADATA_NUM_ELEMS), ttnn.ShardOrientation.ROW_MAJOR),
-        )
         output_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.L1,
@@ -511,8 +512,10 @@ class SpecLMHeadStage(StageKind):
             "global_semaphore": ttnn.create_global_semaphore(mesh_device, argmax_final_core_grid, 0),
             "global_stage2_semaphore": ttnn.create_global_semaphore(mesh_device, argmax_final_core_grid, 0),
         }
+        self._persistent_loop = PersistentLoop(mesh_device, worker_crs, self._persistent_mode)
         if self._persistent_mode:
-            self._state["persistent_next_iter_semaphore"] = ttnn.create_global_semaphore(mesh_device, worker_crs, 1)
+            self._state["persistent_next_iter_semaphore"] = self._persistent_loop.next_iter_semaphore
+            self._state["termination_semaphore"] = self._persistent_loop.termination_semaphore
 
     def run_auxiliary_sockets(self) -> None:
         pass
@@ -543,10 +546,14 @@ class SpecLMHeadStage(StageKind):
             socket_output=d["lmhead_output_socket"],
             persistent_mode=self._persistent_mode,
             persistent_next_iter_semaphore=d.get("persistent_next_iter_semaphore"),
+            termination_semaphore=d.get("termination_semaphore"),
             is_mtp_base_stage=False,
             is_mtp_verify_stage=True,
             metadata_tensor=d["metadata_tensor"],
         )
+
+    def terminate(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        self._persistent_loop.terminate()
 
 
 class BaseLMHeadStage(StageKind):
@@ -559,9 +566,8 @@ class BaseLMHeadStage(StageKind):
     N_PER_CORE = 160
     N_TOTAL = NUM_MATMUL_CORES * N_PER_CORE
     A_TILE = ttnn.Tile([1, 32])
-    B_TILE = ttnn.Tile([32, 32])
     OUT_TILE = ttnn.Tile([1, 32])
-    ARGMAX_FINAL_CORE = ttnn.CoreCoord(0, 1)  # Changed from (0, 1) to (0, 0)
+    ARGMAX_FINAL_CORE = ttnn.CoreCoord(0, 1)
     LMHEAD_INPUT_CORE = ttnn.CoreCoord(10, 9)
 
     def __init__(
@@ -644,11 +650,6 @@ class BaseLMHeadStage(StageKind):
         )
         argmax_final_core_grid = ttnn.CoreRangeSet(
             [ttnn.CoreRange(BaseLMHeadStage.ARGMAX_FINAL_CORE, BaseLMHeadStage.ARGMAX_FINAL_CORE)]
-        )
-        input_a_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.BufferType.L1,
-            ttnn.ShardSpec(mcast_core_grid, (BaseLMHeadStage.M, BaseLMHeadStage.K), ttnn.ShardOrientation.ROW_MAJOR),
         )
         output_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
@@ -818,28 +819,6 @@ class BaseLMHeadStage(StageKind):
             )
             reduce_semaphores = [ttnn.create_global_semaphore(mesh_device, reduce_sem_crs, 0) for _ in range(4)]
 
-        sender = BaseLMHeadStage.LMHEAD_INPUT_CORE
-        matmul_bbox = matmul_core_grid.bounding_box()
-        mcast_end_x = max(matmul_bbox.end.x, sender.x)
-        mcast_end_y = max(matmul_bbox.end.y, sender.y)
-        mcast_receiver_ranges = []
-        if sender.y > 0:
-            mcast_receiver_ranges.append(
-                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(mcast_end_x, sender.y - 1))
-            )
-        if sender.x > 0:
-            mcast_receiver_ranges.append(
-                ttnn.CoreRange(ttnn.CoreCoord(0, sender.y), ttnn.CoreCoord(sender.x - 1, sender.y))
-            )
-        if sender.x < mcast_end_x:
-            mcast_receiver_ranges.append(
-                ttnn.CoreRange(ttnn.CoreCoord(sender.x + 1, sender.y), ttnn.CoreCoord(mcast_end_x, sender.y))
-            )
-        if sender.y < mcast_end_y:
-            mcast_receiver_ranges.append(
-                ttnn.CoreRange(ttnn.CoreCoord(0, sender.y + 1), ttnn.CoreCoord(mcast_end_x, mcast_end_y))
-            )
-
         eh_gather_output_buf = None
 
         if self._enable_mtp:
@@ -912,9 +891,10 @@ class BaseLMHeadStage(StageKind):
             num_cores = compute_grid_size.x * compute_grid_size.y
             available_cores = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, row_wise=True)
             self._lmhead_state["mtp_bcast_semaphores"] = [ttnn.create_global_semaphore(mesh_device, available_cores, 0)]
+        self._persistent_loop = PersistentLoop(mesh_device, worker_crs, self._persistent_mode)
         if self._persistent_mode:
-            persistent_next_iter_semaphore = ttnn.create_global_semaphore(mesh_device, worker_crs, 1)
-            self._lmhead_state["persistent_next_iter_semaphore"] = persistent_next_iter_semaphore
+            self._lmhead_state["persistent_next_iter_semaphore"] = self._persistent_loop.next_iter_semaphore
+            self._lmhead_state["termination_semaphore"] = self._persistent_loop.termination_semaphore
 
     def run_auxiliary_sockets(self) -> None:
         pass
@@ -952,6 +932,7 @@ class BaseLMHeadStage(StageKind):
             socket_output=d["lmhead_output_socket"],
             persistent_mode=self._persistent_mode,
             persistent_next_iter_semaphore=d.get("persistent_next_iter_semaphore"),
+            termination_semaphore=d.get("termination_semaphore"),
             is_mtp_base_stage=True,
             eh_gather_output_buf_tensor=d.get("eh_gather_output_buf"),
             metadata_tensor=d.get("metadata_tensor"),
@@ -961,6 +942,9 @@ class BaseLMHeadStage(StageKind):
             mtp_bcast_semaphores=d.get("mtp_bcast_semaphores"),
             base_token_buffer=d.get("base_token_buffer"),
         )
+
+    def terminate(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        self._persistent_loop.terminate()
 
 
 class _CombinedPipelineBlock:
@@ -1115,6 +1099,26 @@ class _CombinedPipelineBlock:
     def read_output(self, output_tensor) -> None:
         self.d2h_socket.read_tensor(output_tensor)
 
+    def push_dummy_token(self) -> None:
+        """Push a single zeroed token through the H2D socket. See :meth:`PipelineBlock.push_dummy_token`."""
+        page_words = TOKEN_PAGE_SIZE_BYTES // 4
+        dummy = ttnn.from_torch(
+            torch.zeros(1, page_words, dtype=torch.uint32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        self.h2d_socket.write_tensor(dummy)
+
+    def drain_dummy_output(self) -> None:
+        """Drain one page from the D2H socket. See :meth:`PipelineBlock.drain_dummy_output`."""
+        page_words = TOKEN_META_PAGE_SIZE_BYTES // 4
+        sink = ttnn.from_torch(
+            torch.zeros(1, page_words, dtype=torch.uint32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        self.d2h_socket.read_tensor(sink)
+
     def get_downstream_socket(self):
         """SpecLMHead reads activation+metadata from this socket (loopback entry downstream)."""
         return self.entry_socket_interface.get_downstream_socket()
@@ -1128,7 +1132,7 @@ class SpecLMHeadWithEmbeddingStage(SpecLMHeadStage):
     """Combined SpecLMHead + Embedding on the same mesh.
 
     SpecLMHead occupies (0,0)-(10,9).  Embedding I/O uses column 12:
-      H2D at EMBEDDING_H2D_CORE_COORD, D2H at EMBEDDING_D2H_CORE_COORD,
+      H2D at PIPELINE_CORE_COORD, D2H at EMBEDDING_D2H_CORE_COORD,
       argmax final at ARGMAX_FINAL_CORE.  Exit D2D relay uses PIPELINE_CORE_COORD.
 
     Pipeline topology:

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -56,6 +56,7 @@
 #include "../../../unified_kernels/eltwise_add.hpp"
 #include "../../../unified_kernels/gated_reduce.hpp"
 #include "../../../unified_kernels/residual_add.hpp"
+#include "../../../unified_kernels/persistent_loop.hpp"
 #ifdef ENABLE_REDUCE_TO_ONE
 #include "../../../unified_kernels/reduce_to_one_b1.hpp"
 #endif
@@ -3033,8 +3034,12 @@ void kernel_main() {
     }
 #endif
 #endif
-    uint32_t iteration = 0;
-    while (true) {
+
+    constexpr uint32_t persistent_mode = get_named_compile_time_arg_val("persistent_mode");
+    constexpr uint32_t persistent_next_iter_sem_addr = get_named_compile_time_arg_val("persistent_next_iter_sem_addr");
+    constexpr uint32_t termination_semaphore_addr = get_named_compile_time_arg_val("termination_semaphore_addr");
+    deepseek_b1_ops::PersistentLoop<persistent_mode == 1> loop(termination_semaphore_addr, num_iterations);
+    while (loop.next()) {
         {
             DeviceZoneScopedN("MLA_CB_RECONFIG");
             unified_kernels::reconfig_cb_interfaces(mla_cb_config);
@@ -3075,12 +3080,6 @@ void kernel_main() {
         {
             DeviceZoneScopedN("MOE");
             moe_body();
-        }
-        iteration++;
-        if constexpr (!persistent_mode) {
-            if (iteration >= num_iterations) {
-                break;
-            }
         }
     }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -200,6 +200,7 @@ class DecoderBlock:
         broadcast_topology_override=None,
         persistent_next_iter_semaphore=None,
         persistent_mode=False,
+        termination_semaphore=None,
         is_torus=True,
         forward_metadata=False,
     ):
@@ -292,6 +293,7 @@ class DecoderBlock:
             downstream_sockets=downstream_sockets,
             persistent_next_iter_semaphore=persistent_next_iter_semaphore,
             persistent_mode=persistent_mode,
+            termination_semaphore=termination_semaphore,
             bcast_sender_coord=sender_coord,
             is_torus=is_torus,
             forward_metadata_size_bytes=DeepseekMetadata.aligned_size_bytes() if forward_metadata else 0,

--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
@@ -60,6 +60,7 @@
 #include "../../../unified_kernels/rmsnorm.hpp"
 #include "../../../unified_kernels/dram_streaming_matmul.hpp"
 #include "../../../unified_kernels/reduce_to_one_b1.hpp"
+#include "../../../unified_kernels/persistent_loop.hpp"
 #include "../../../metadata/metadata.hpp"
 
 // ============================================================================
@@ -639,7 +640,9 @@ void kernel_main() {
         Op<McastCTArgs, Core::is_input_core, Core::is_mcast_receiver_core, Core::is_matmul_core, true>
             mcast;
 
-    uint32_t iteration_count = 0;
+    constexpr uint32_t termination_semaphore_addr = get_named_compile_time_arg_val("termination_semaphore_addr");
+    deepseek_b1_ops::PersistentLoop<Core::persistent_mode> loop(termination_semaphore_addr);
+
     constexpr uint32_t TOKEN_TYPE_BASE = 0;
     constexpr uint32_t TOKEN_TYPE_SPEC = 1;
 
@@ -1111,9 +1114,7 @@ void kernel_main() {
     mcast.init(mcast_args);
 
     // Persistent loop
-    while (true) {
-        iteration_count++;
-
+    while (loop.next()) {
         // Base Stage: run LM head sampling and MTP ops
         if constexpr (Core::is_base_stage) {
             lm_head_sampling();
@@ -1173,10 +1174,6 @@ void kernel_main() {
             noc_async_atomic_barrier();
         }
 #endif
-
-        if constexpr (!Core::persistent_mode) {
-            break;
-        }
     }
     mcast.teardown(mcast_args);
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/op.py
@@ -453,6 +453,11 @@ class LMHeadSampling:
                 "persistent_next_iter_semaphore is required when persistent_mode=True "
                 "(must be a global semaphore on the full device grid)"
             )
+        if persistent_mode and termination_semaphore is None:
+            raise ValueError(
+                "termination_semaphore is required when persistent_mode=True "
+                "(must be a global semaphore on the full device grid)"
+            )
         global_sem_addr = (
             int(ttnn.get_global_semaphore_address(global_semaphore)) if (enable_argmax and not skip_ccl) else 0
         )
@@ -461,6 +466,9 @@ class LMHeadSampling:
         )
         persistent_next_iter_global_sem_addr = (
             int(ttnn.get_global_semaphore_address(persistent_next_iter_semaphore)) if persistent_mode else 0
+        )
+        termination_global_sem_addr = (
+            int(ttnn.get_global_semaphore_address(termination_semaphore)) if persistent_mode else 0
         )
         # Calculate packet size and page info for CCL broadcast
 
@@ -1140,6 +1148,7 @@ class LMHeadSampling:
                     ("argmax_socket_cb", argmax_socket_cb if enable_socket_output else 0),
                     ("argmax_socket_page_size_bytes", socket_page_size_bytes if enable_socket_output else 0),
                     ("persistent_mode", 1 if persistent_mode else 0),
+                    ("termination_semaphore_addr", termination_global_sem_addr),
                     ("fabric_gate_bcast_turn_semaphore_id", fabric_gate_bcast_turn_semaphore_id),
                     ("fabric_gate_argmax_turn_semaphore_id", fabric_gate_argmax_turn_semaphore_id),
                     ("fabric_gate_bcast_noc_x", int(bcast_worker_core_phys.x)),
@@ -1261,6 +1270,7 @@ class LMHeadSampling:
                     ("argmax_socket_cb", argmax_socket_cb if enable_socket_output else 0),
                     ("argmax_socket_page_size_bytes", socket_page_size_bytes if enable_socket_output else 0),
                     ("persistent_mode", 1 if persistent_mode else 0),
+                    ("termination_semaphore_addr", termination_global_sem_addr),
                     ("fabric_gate_bcast_turn_semaphore_id", fabric_gate_bcast_turn_semaphore_id),
                     ("fabric_gate_argmax_turn_semaphore_id", fabric_gate_argmax_turn_semaphore_id),
                     ("fabric_gate_bcast_noc_x", int(bcast_worker_core_phys.x)),
@@ -1362,6 +1372,7 @@ class LMHeadSampling:
                     ("matmul_k_num_tiles", num_tiles_k),
                     ("matmul_out_w", out_w_per_core),
                     ("persistent_mode", 1 if persistent_mode else 0),
+                    ("termination_semaphore_addr", termination_global_sem_addr),
                     ("fabric_gate_bcast_turn_semaphore_id", fabric_gate_bcast_turn_semaphore_id),
                     ("fabric_gate_argmax_turn_semaphore_id", fabric_gate_argmax_turn_semaphore_id),
                     ("fabric_gate_bcast_noc_x", int(bcast_worker_core_phys.x)),

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -4445,6 +4445,7 @@ class MoeOp:
         downstream_sockets=None,
         persistent_next_iter_semaphore=None,
         persistent_mode=False,
+        termination_semaphore=None,
         forward_metadata_size_bytes=0,
         metadata_l1_addr=0,
     ):
@@ -4463,6 +4464,9 @@ class MoeOp:
             int(ttnn.get_global_semaphore_address(persistent_next_iter_semaphore))
             if persistent_next_iter_semaphore is not None
             else 0
+        )
+        self.termination_sem_addr = (
+            int(ttnn.get_global_semaphore_address(termination_semaphore)) if termination_semaphore is not None else 0
         )
 
         if cb_id_context is None:
@@ -4682,6 +4686,9 @@ class MoeOp:
         ncrisc_args += [("persistent_next_iter_sem_addr", self.persistent_next_iter_sem_addr)]
         brisc_args += [("persistent_next_iter_sem_addr", self.persistent_next_iter_sem_addr)]
         trisc_args += [("persistent_next_iter_sem_addr", self.persistent_next_iter_sem_addr)]
+        ncrisc_args += [("termination_semaphore_addr", self.termination_sem_addr)]
+        brisc_args += [("termination_semaphore_addr", self.termination_sem_addr)]
+        trisc_args += [("termination_semaphore_addr", self.termination_sem_addr)]
 
     def _build_semaphore_descriptors(self):
         """Build semaphore descriptors — empty, global semaphores are used instead."""
@@ -4836,6 +4843,7 @@ class MoeOp:
         num_iterations=1,
         persistent_mode=False,
         persistent_next_iter_semaphore=None,
+        termination_semaphore=None,
         # ReduceToOne parameters
         reduce_intermediate_tensors: Optional[list] = None,
         reduce_output_tensor: Optional[ttnn.Tensor] = None,
@@ -4935,6 +4943,7 @@ class MoeOp:
             cb_id_context=cb_id_context,
             persistent_next_iter_semaphore=persistent_next_iter_semaphore,
             persistent_mode=persistent_mode,
+            termination_semaphore=termination_semaphore,
         )
 
         # ==================================================================

--- a/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange.cpp
@@ -7,7 +7,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/socket_api.h"
-#include "api/debug/dprint.h"
+#include "../../../unified_kernels/termination.hpp"
 
 constexpr uint32_t sender_socket_config_addr = get_compile_time_arg_val(0);
 constexpr uint32_t receiver_socket_config_addr = get_compile_time_arg_val(1);
@@ -19,18 +19,6 @@ constexpr uint32_t partial_packet_size = get_compile_time_arg_val(6);
 constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(7);
 constexpr bool use_fabric_on_receiver = get_compile_time_arg_val(8);
 constexpr bool use_fabric_on_sender = get_compile_time_arg_val(9);
-
-FORCE_INLINE bool socket_wait_for_pages_with_termination(
-    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
-    constexpr uint32_t termination_value = 1;
-    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == termination_value) {
-            return false;
-        }
-    }
-    return true;
-}
 
 FORCE_INLINE void write_data_to_local_core_with_ack(
     SocketSenderInterface& sender_socket, uint32_t l1_read_addr, uint64_t dst_addr, uint32_t page_size) {
@@ -147,9 +135,6 @@ void kernel_main() {
     set_receiver_socket_page_size(receiver_socket, page_size);
     sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, 0);
 
-    DPRINT << "Starting d2d exchange kernel" << ENDL();
-    DEVICE_PRINT("Starting d2d exchange kernel\n");
-
     uint64_t downstream_bytes_sent_noc_addr = get_noc_addr(
         downstream_enc.d2d.downstream_noc_x,
         downstream_enc.d2d.downstream_noc_y,
@@ -191,7 +176,7 @@ void kernel_main() {
 
     while (true) {
         socket_reserve_pages(sender_socket, 1);
-        if (!socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
+        if (!deepseek_b1_ops::socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
             break;
         }
 

--- a/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange_multiple_upstreams.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange_multiple_upstreams.cpp
@@ -129,11 +129,11 @@ FORCE_INLINE bool process_upstream_sockets(
     uint32_t remaining = num_sockets_this_risc;
     uint32_t worker_idx = 0;
     uint32_t processed_mask = 0;
-    invalidate_l1_cache();
-    if (termination_semaphore[0] == 1) {
-        return true;
-    }
     while (remaining > 0) {
+        invalidate_l1_cache();
+        if (termination_semaphore[0] == 1) {
+            return true;
+        }
         if (!(processed_mask & (1 << worker_idx)) && socket_wait_for_pages(receiver_sockets[worker_idx], 1, 1)) {
             uint32_t l1_read_addr = receiver_sockets[worker_idx].read_ptr;
             uint64_t dst_addr = dst_addr_base + (socket_start_idx + worker_idx) * upstream_page_size;

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_multicore_receiver.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_multicore_receiver.cpp
@@ -7,20 +7,9 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "../../../unified_kernels/termination.hpp"
 #include "api/socket_api.h"
 #include "pcie_noc_utils.h"
-
-FORCE_INLINE bool socket_wait_for_pages_with_termination(
-    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
-    constexpr uint32_t termination_value = 1;
-    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == termination_value) {
-            return false;
-        }
-    }
-    return true;
-}
 
 void kernel_main() {
     constexpr uint32_t send_socket_config_addr = get_compile_time_arg_val(0);
@@ -72,7 +61,8 @@ void kernel_main() {
     // Collect data from all upstream sockets into a single 14KB page
     while (true) {
         // Wait for pages in current upstream socket with termination checks
-        if (!socket_wait_for_pages_with_termination(receiver_sockets[current_socket_idx], 1, termination_semaphore)) {
+        if (!deepseek_b1_ops::socket_wait_for_pages_with_termination(
+                receiver_sockets[current_socket_idx], 1, termination_semaphore)) {
             break;
         }
 

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp
@@ -6,30 +6,7 @@
 #include "api/socket_api.h"
 #include "pcie_noc_utils.h"
 #include "api/debug/dprint.h"
-
-FORCE_INLINE bool socket_wait_for_pages_with_termination(
-    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
-    constexpr uint32_t termination_value = 1;
-    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == termination_value) {
-            return false;
-        }
-    }
-    return true;
-}
-
-FORCE_INLINE bool cb_wait_for_pages_with_termination(
-    uint32_t cb_index, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
-    constexpr uint32_t termination_value = 1;
-    while (!cb_pages_available_at_front(cb_index, num_pages)) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == termination_value) {
-            return false;
-        }
-    }
-    return true;
-}
+#include "../../../unified_kernels/termination.hpp"
 
 void kernel_main() {
     DPRINT << "Starting d2h sender kernel" << ENDL();
@@ -89,7 +66,8 @@ void kernel_main() {
         socket_reserve_pages(sender_socket, 1);
         if constexpr (loopback_mode) {
             // Wait for data in CB with termination checks
-            if (!cb_wait_for_pages_with_termination(upstream_interface_index, 1, termination_semaphore)) {
+            if (!deepseek_b1_ops::cb_wait_for_pages_with_termination(
+                    upstream_interface_index, 1, termination_semaphore)) {
                 break;
             }
             uint32_t read_addr = get_read_ptr(upstream_interface_index);
@@ -104,7 +82,7 @@ void kernel_main() {
             cb_pop_front(upstream_interface_index, 1);
         } else {
             // Wait for pages in receiver socket with timeout and termination checks
-            if (!socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
+            if (!deepseek_b1_ops::socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
                 break;
             }
             uint32_t read_addr = receiver_socket.read_ptr;

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <cstdint>
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
 #include "pcie_noc_utils.h"
 #include "../../../metadata/metadata.hpp"
+
+#include "../../../unified_kernels/termination.hpp"
 
 // Get this value from MeshSocket struct on host
 constexpr uint32_t recv_socket_config_addr = get_compile_time_arg_val(0);
@@ -26,18 +29,6 @@ constexpr uint32_t embedding_page_size = get_compile_time_arg_val(13);
 constexpr uint32_t embedding_addr = get_compile_time_arg_val(14);
 // TensorAccessorArgs for embedding tensor at CT arg index 15
 constexpr auto embedding_args = TensorAccessorArgs<15>();
-
-FORCE_INLINE bool socket_wait_for_pages_with_termination(
-    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
-    constexpr uint32_t termination_value = 1;
-    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == termination_value) {
-            return false;
-        }
-    }
-    return true;
-}
 
 FORCE_INLINE void write_data_to_local_core_with_ack(
     SocketSenderInterface& sender_socket, uint32_t l1_read_addr, uint64_t dst_addr, uint32_t page_size) {
@@ -200,8 +191,7 @@ void kernel_main() {
 
     while (true) {
         // Wait for pages in H2D socket
-        // DPRINT << "H2D Waiting For Pages" << ENDL();
-        if (!socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
+        if (!deepseek_b1_ops::socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
             break;
         }
         // DPRINT << "H2D Waiting For Pages Done" << ENDL();

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp
@@ -6,6 +6,7 @@
 #include "api/socket_api.h"
 #include "pcie_noc_utils.h"
 #include "api/debug/dprint.h"
+#include "../../../unified_kernels/termination.hpp"
 
 // Get this value from MeshSocket struct on host
 constexpr uint32_t recv_socket_config_addr = get_compile_time_arg_val(0);
@@ -19,18 +20,6 @@ constexpr uint32_t whole_packet_size = get_compile_time_arg_val(7);
 constexpr uint32_t num_whole_fabric_packets_per_link = get_compile_time_arg_val(8);
 constexpr uint32_t partial_packet_size = get_compile_time_arg_val(9);
 constexpr bool use_fabric = get_compile_time_arg_val(10);
-
-FORCE_INLINE bool socket_wait_for_pages_with_termination(
-    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
-    constexpr uint32_t termination_value = 1;
-    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
-        invalidate_l1_cache();
-        if (termination_semaphore[0] == termination_value) {
-            return false;
-        }
-    }
-    return true;
-}
 
 FORCE_INLINE void write_data_to_local_core_with_ack(
     SocketSenderInterface& sender_socket, uint32_t l1_read_addr, uint64_t dst_addr, uint32_t page_size) {
@@ -192,7 +181,7 @@ void kernel_main() {
 
     while (true) {
         // Wait for pages in H2D socket
-        if (!socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
+        if (!deepseek_b1_ops::socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
             break;
         }
         if constexpr (pull_from_host) {

--- a/models/demos/deepseek_v3_b1/micro_ops/persistent_loop/kernels/persistent_loop_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/persistent_loop/kernels/persistent_loop_kernel.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/persistent_loop.hpp"
+
+void kernel_main() {
+    constexpr uint32_t persistent_mode = get_named_compile_time_arg_val("persistent_mode");
+    constexpr uint32_t termination_semaphore_addr = get_named_compile_time_arg_val("termination_semaphore_addr");
+    constexpr uint32_t max_iterations = get_named_compile_time_arg_val("max_iterations");
+    constexpr uint32_t iteration_count_addr = get_named_compile_time_arg_val("iteration_count_addr");
+
+    deepseek_b1_ops::PersistentLoop<persistent_mode == 1> loop(termination_semaphore_addr, max_iterations);
+    while (loop.next()) {
+#if defined(COMPILE_FOR_BRISC)
+        volatile tt_l1_ptr uint32_t* count_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iteration_count_addr);
+        *count_ptr = loop.iteration();
+#endif
+    }
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/persistent_loop/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/persistent_loop/op.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import UnifiedKernelDescriptor
+
+
+class PersistentLoop:
+    """Manages persistent loop state for compute kernels.
+
+    Encapsulates termination and next-iteration semaphore creation,
+    compile-time arg generation, and termination signaling.  Used by
+    LMHeadStage, DecoderStage, and unit tests.
+    """
+
+    def __init__(self, mesh_device, core_range_set, persistent_mode=True):
+        self.persistent_mode = persistent_mode
+        self.termination_semaphore = None
+        self.next_iter_semaphore = None
+        if persistent_mode:
+            self.termination_semaphore = ttnn.create_global_semaphore(mesh_device, core_range_set, 0)
+            self.next_iter_semaphore = ttnn.create_global_semaphore(mesh_device, core_range_set, 1)
+
+    @property
+    def termination_semaphore_address(self):
+        if self.termination_semaphore is not None:
+            return int(ttnn.get_global_semaphore_address(self.termination_semaphore))
+        return 0
+
+    @property
+    def next_iter_semaphore_address(self):
+        if self.next_iter_semaphore is not None:
+            return int(ttnn.get_global_semaphore_address(self.next_iter_semaphore))
+        return 0
+
+    def get_compile_time_args(self):
+        """Named CT args common to all persistent compute kernels."""
+        return [
+            ("persistent_mode", 1 if self.persistent_mode else 0),
+            ("termination_semaphore_addr", self.termination_semaphore_address),
+        ]
+
+    def terminate(self):
+        """Signal the persistent kernel to exit. No-op when not in persistent mode."""
+        if self.termination_semaphore is not None:
+            ttnn.reset_global_semaphore_value(self.termination_semaphore, 1)
+
+    def reset(self):
+        """Reset termination semaphore for a new launch cycle."""
+        if self.termination_semaphore is not None:
+            ttnn.reset_global_semaphore_value(self.termination_semaphore, 0)
+
+    KERNEL_PATH = "models/demos/deepseek_v3_b1/micro_ops/persistent_loop/kernels/persistent_loop_kernel.cpp"
+
+    def op(self, mesh_device, core_coord, iteration_count_semaphore, max_iterations=1):
+        """Dispatch a minimal test kernel that exercises PersistentLoop."""
+        iteration_count_addr = int(ttnn.get_global_semaphore_address(iteration_count_semaphore))
+        core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core_coord, core_coord)])
+
+        named_ct_args = self.get_compile_time_args() + [
+            ("max_iterations", max_iterations),
+            ("iteration_count_addr", iteration_count_addr),
+        ]
+
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source=self.KERNEL_PATH,
+            core_ranges=core_range_set,
+            ncrisc_named_compile_time_args=named_ct_args,
+            brisc_named_compile_time_args=named_ct_args,
+            trisc_named_compile_time_args=named_ct_args,
+        )
+
+        kernel_result = unified_kernel.get_kernel_descriptors()
+
+        program = ttnn.ProgramDescriptor(
+            kernels=kernel_result.kernels,
+            semaphores=[],
+            cbs=[],
+        )
+
+        mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+        coord = ttnn.MeshCoordinate(0, 0)
+        mesh_program_descriptor[ttnn.MeshCoordinateRange(coord, coord)] = program
+
+        dummy_tensor = ttnn.allocate_tensor_on_device(
+            ttnn.Shape([0, 0, 0, 0]), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, mesh_device
+        )
+        ttnn.generic_op([dummy_tensor, dummy_tensor], mesh_program_descriptor)

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
@@ -50,6 +50,9 @@ entry_socket_interface / exit_socket_interface can be any of:
 """
 
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+import torch
 
 import ttnn
 from models.demos.deepseek_v3_b1.metadata.metadata import DeepseekMetadata
@@ -131,6 +134,48 @@ class LoopbackConfig:
         return self._mode == "fabric"
 
 
+@runtime_checkable
+class PipelineBlockKind(Protocol):
+    """Structural interface for any pipeline-block-like object that ``Pipeline`` can drive.
+
+    Both :class:`PipelineBlock` and the combined-stage block in
+    ``demo/stage.py`` implement this. Methods listed here are the ones consumed by
+    :class:`Pipeline` and by stage ``setup`` / ``launch_compute`` / ``terminate``;
+    parallel-mode-only methods (``get_upstream_sockets`` etc.) are intentionally
+    omitted because they're stage-specific and the caller knows the concrete type.
+    """
+
+    def run(self) -> None:
+        ...
+
+    def terminate(self) -> None:
+        ...
+
+    def is_first_pipeline_stage(self) -> bool:
+        ...
+
+    def write_token(self, token_tensor: ttnn.Tensor) -> None:
+        ...
+
+    def read_output(self, output_tensor: ttnn.Tensor) -> None:
+        ...
+
+    def push_dummy_token(self) -> None:
+        ...
+
+    def drain_dummy_output(self) -> None:
+        ...
+
+    def get_upstream_socket(self):
+        ...
+
+    def get_downstream_socket(self):
+        ...
+
+    def export_host_socket_descriptors(self, io_socket_descriptor_prefix: str) -> None:
+        ...
+
+
 class PipelineBlock:
     def __init__(
         self,
@@ -200,6 +245,8 @@ class PipelineBlock:
         self.d2h_socket = None
         self.entry_socket_interface = None
         self.exit_socket_interface = None
+        self._h2d_page_size_bytes = None
+        self._d2h_page_size_bytes = None
 
         token_size_bytes = 64
         if self.is_pipeline_start:
@@ -311,12 +358,14 @@ class PipelineBlock:
             h2d_socket_fifo_size,
             ttnn.H2DMode.HOST_PUSH,
         )
+        self._h2d_page_size_bytes = token_size_bytes
 
         if self.initialize_loopback:
             d2h_device_coord = pipeline_config[self.num_procs].exit_node_coord
             self.d2h_socket = ttnn.D2HSocket(
                 mesh_device, ttnn.MeshCoreCoord(d2h_device_coord, host_io_placement.d2h_core), d2h_socket_fifo_size
             )
+            self._d2h_page_size_bytes = d2h_socket_page_size
 
         self.host_io = HostInterface(
             self.h2d_socket,
@@ -327,11 +376,11 @@ class PipelineBlock:
             h2d_downstream_core=ttnn.MeshCoreCoord(
                 pipeline_config[self.my_stage_idx].exit_node_coord, host_io_placement.fwd_d2d_core
             ),
-            d2h_upstream_core=ttnn.MeshCoreCoord(
-                pipeline_config[self.num_procs].entry_node_coord, host_io_placement.lb_d2d_core
-            )
-            if self.initialize_loopback
-            else None,
+            d2h_upstream_core=(
+                ttnn.MeshCoreCoord(pipeline_config[self.num_procs].entry_node_coord, host_io_placement.lb_d2d_core)
+                if self.initialize_loopback
+                else None
+            ),
             embedding_tensor=embedding_tensor,
             metadata_size_bytes=downstream_d2d_socket_page_size - embedding_size_bytes,
         )
@@ -396,6 +445,7 @@ class PipelineBlock:
         self.d2h_socket = ttnn.D2HSocket(
             mesh_device, ttnn.MeshCoreCoord(d2h_device_coord, d2h_core), d2h_socket_fifo_size
         )
+        self._d2h_page_size_bytes = d2h_socket_page_size
 
         # HostInterface creates an upstream_socket_pair (entry_core → exit_core) for its D2H
         # kernel. We then wire the entry_socket_interface's downstream to the same pair so that
@@ -459,9 +509,11 @@ class PipelineBlock:
             upstream_d2d_socket_page_size,
             ttnn.MeshCoreCoord(pipeline_config[prev_stage].exit_node_coord, pipeline_core_coord),
             ttnn.MeshCoreCoord(pipeline_config[self.my_stage_idx].entry_node_coord, pipeline_core_coord),
-            downstream_core_coord=entry_node_downstream
-            if entry_node_downstream
-            else ttnn.MeshCoreCoord(pipeline_config[self.my_stage_idx].exit_node_coord, pipeline_core_coord),
+            downstream_core_coord=(
+                entry_node_downstream
+                if entry_node_downstream
+                else ttnn.MeshCoreCoord(pipeline_config[self.my_stage_idx].exit_node_coord, pipeline_core_coord)
+            ),
             sender_mesh=MeshWrapper(rank=ps.rank, mesh_id=ps.mesh_id),
             receiver_mesh=MeshWrapper(mesh_device),
         )
@@ -647,7 +699,8 @@ class PipelineBlock:
             for si in self.entry_socket_interface:
                 si.terminate(False)
             for i, si in enumerate(self.exit_socket_interface):
-                si.terminate(i == len(self.exit_socket_interface) - 1)
+                last = i == len(self.exit_socket_interface) - 1
+                si.terminate(last)
         elif self.is_pipeline_start:
             self.host_io.terminate(False)
             if self.initialize_loopback:
@@ -656,7 +709,8 @@ class PipelineBlock:
         else:
             self.entry_socket_interface.terminate(False)
             if self.has_exit:
-                self.exit_socket_interface.terminate(not self.has_d2h)
+                sync = not self.has_d2h
+                self.exit_socket_interface.terminate(sync)
             if self.host_io is not None:
                 self.host_io.terminate(True)
 
@@ -694,6 +748,35 @@ class PipelineBlock:
             self.d2h_socket.read_tensor(output_tensor)
             result = ttnn.to_torch(output_tensor).reshape(-1).contiguous()
             send_bytes(result.view(torch.uint8).numpy().tobytes(), 0)
+
+    def push_dummy_token(self):
+        """Push a single zeroed token through the H2D socket.
+
+        Used during pipeline teardown to wake every stage's compute loop one last
+        iteration so each persistent kernel returns to its top-of-loop termination
+        check and breaks cleanly.
+        """
+        assert self.is_first_pipeline_stage(), "push_dummy_token() requires the first pipeline stage"
+        assert self.h2d_socket is not None and self._h2d_page_size_bytes is not None
+        page_words = self._h2d_page_size_bytes // 4
+        dummy = ttnn.from_torch(
+            torch.zeros(1, page_words, dtype=torch.uint32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        self.h2d_socket.write_tensor(dummy)
+
+    def drain_dummy_output(self):
+        """Drain one page from the D2H socket — pairs with :meth:`push_dummy_token` during teardown."""
+        if self.d2h_socket is None or self._d2h_page_size_bytes is None:
+            return
+        page_words = self._d2h_page_size_bytes // 4
+        sink = ttnn.from_torch(
+            torch.zeros(1, page_words, dtype=torch.uint32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        self.d2h_socket.read_tensor(sink)
 
     def get_upstream_socket(self):
         """Return a single upstream socket (non-parallel mode only)."""

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py
@@ -13,7 +13,6 @@ Output stays width-sharded across matmul cores.
 
 In single-device mode (skip_ccl=True): CCL is skipped and the input is used directly.
 """
-
 import os
 import re
 import statistics
@@ -4495,31 +4494,38 @@ def test_persistent_mode(mesh_device, use_fp32, device_params):
         stages_metadata=stages_metadata,
         pipeline_config=pipeline_config,
     )
-    pipeline.setup_and_run()
+    try:
+        pipeline.setup_and_run()
 
-    if pipeline.my_mesh_id == 0:
-        for iteration in range(iterations):
-            logger.info(f"Writing token for iteration {iteration}")
-            torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = iteration
-            token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
-            output_tensor = ttnn.from_torch(
-                torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
-                dtype=ttnn.uint32,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-            )
-            pipeline.write_token(token_tensor)
-            pipeline.read_output(output_tensor)
-            got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
-            expected_idx = torch_expected_indices[iteration]
-            logger.info(f"Iteration {iteration} output token: {got}, expected: {expected_idx}")
-            assert torch.equal(
-                got, expected_idx
-            ), f"PipelineBlock 4-stage token mismatch. expected={int(expected_idx.item())}, got={int(got.item())}"
+        if pipeline.my_mesh_id == 0:
+            for iteration in range(iterations):
+                logger.info(f"Writing token for iteration {iteration}")
+                torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
+                torch_token[0, 0] = iteration
+                token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+                output_tensor = ttnn.from_torch(
+                    torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
+                    dtype=ttnn.uint32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                )
+                pipeline.write_token(token_tensor)
+                pipeline.read_output(output_tensor)
+                got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
+                expected_idx = torch_expected_indices[iteration]
+                logger.info(f"Iteration {iteration} output token: {got}, expected: {expected_idx}")
+                assert torch.equal(
+                    got, expected_idx
+                ), f"PipelineBlock 4-stage token mismatch. expected={int(expected_idx.item())}, got={int(got.item())}"
 
-    logger.info(f"Barrier for P{pipeline.my_mesh_id}")
-    pipeline.barrier()
-    logger.info(f"Barrier completed for P{pipeline.my_mesh_id}")
+        logger.info(f"Barrier for P{pipeline.my_mesh_id}")
+        pipeline.barrier()
+        logger.info(f"Barrier completed for P{pipeline.my_mesh_id}")
+    finally:
+        logger.info(f"Terminating P{pipeline.my_mesh_id}")
+        pipeline.terminate()
+        logger.info(f"Terminated P{pipeline.my_mesh_id}")
+
+    logger.info("TEST COMPLETE!")
 
 
 @pytest.mark.parametrize("use_fp32", [True])
@@ -4709,59 +4715,61 @@ def test_persistent_mode_real_weights(mesh_device, use_fp32, hf_model_path, hf_s
         pipeline_config=pipeline_config,
     )
     pipeline.setup_and_run()
-
-    if pipeline.my_mesh_id == 0:
-        got_tokens = []
-        for iteration in range(iterations):
-            in_tok = int(input_token_ids[iteration].item())
-            logger.info(f"Writing token for iteration {iteration} (in_tok={in_tok})")
-            torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = in_tok
-            token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
-            output_tensor = ttnn.from_torch(
-                torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
-                dtype=ttnn.uint32,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-            )
-            pipeline.write_token(token_tensor)
-            pipeline.read_output(output_tensor)
-            got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
-            got_tokens.append(got)
-        got_all = torch.stack(got_tokens, dim=0)
-        got_flat = got_all.squeeze(-1).squeeze(-1)
-        logger.info(f"Random input token ids (in_tok per iter): {input_token_ids.tolist()}")
-        logger.info(f"All output tokens (real weights): {got_flat.tolist()}")
-        logger.info(f"Reference top-{topk} per iteration (first row): {ref_topk[0].tolist()}")
-        mismatches = []
-        for i in range(iterations):
-            in_tok = int(input_token_ids[i].item())
-            g = int(got_flat[i].item())
-            top_ids = [int(x) for x in ref_topk[i].tolist()]
-            if g not in top_ids:
-                mismatches.append((i, in_tok, g, top_ids))
-        results_table = _format_real_weights_topk_results_table(
-            hf_state_dict,
-            input_token_ids,
-            got_flat,
-            ref_topk,
-            topk=topk,
-        )
-        logger.info(results_table)
-        if mismatches:
-            report = _format_real_weights_topk_mismatch_report(
+    try:
+        if pipeline.my_mesh_id == 0:
+            got_tokens = []
+            for iteration in range(iterations):
+                in_tok = int(input_token_ids[iteration].item())
+                logger.info(f"Writing token for iteration {iteration} (in_tok={in_tok})")
+                torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
+                torch_token[0, 0] = in_tok
+                token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+                output_tensor = ttnn.from_torch(
+                    torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
+                    dtype=ttnn.uint32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                )
+                pipeline.write_token(token_tensor)
+                pipeline.read_output(output_tensor)
+                got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
+                got_tokens.append(got)
+            got_all = torch.stack(got_tokens, dim=0)
+            got_flat = got_all.squeeze(-1).squeeze(-1)
+            logger.info(f"Random input token ids (in_tok per iter): {input_token_ids.tolist()}")
+            logger.info(f"All output tokens (real weights): {got_flat.tolist()}")
+            logger.info(f"Reference top-{topk} per iteration (first row): {ref_topk[0].tolist()}")
+            mismatches = []
+            for i in range(iterations):
+                in_tok = int(input_token_ids[i].item())
+                g = int(got_flat[i].item())
+                top_ids = [int(x) for x in ref_topk[i].tolist()]
+                if g not in top_ids:
+                    mismatches.append((i, in_tok, g, top_ids))
+            results_table = _format_real_weights_topk_results_table(
                 hf_state_dict,
-                mismatches,
+                input_token_ids,
+                got_flat,
+                ref_topk,
                 topk=topk,
-                total_iters=iterations,
             )
-            logger.error(report)
-            pytest.fail(
-                f"PipelineBlock (real weights): {len(mismatches)} output(s) not in HF functional top-{topk}.\n{report}"
-            )
+            logger.info(results_table)
+            if mismatches:
+                report = _format_real_weights_topk_mismatch_report(
+                    hf_state_dict,
+                    mismatches,
+                    topk=topk,
+                    total_iters=iterations,
+                )
+                logger.error(report)
+                pytest.fail(
+                    f"PipelineBlock (real weights): {len(mismatches)} output(s) not in HF functional top-{topk}.\n{report}"
+                )
 
-    logger.info(f"Barrier for P{pipeline.my_mesh_id} (real weights)")
-    pipeline.barrier()
-    logger.info(f"Barrier completed for P{pipeline.my_mesh_id} (real weights)")
+        logger.info(f"Barrier for P{pipeline.my_mesh_id} (real weights)")
+        pipeline.barrier()
+        logger.info(f"Barrier completed for P{pipeline.my_mesh_id} (real weights)")
+    finally:
+        pipeline.terminate()
 
 
 @pytest.mark.skipif(
@@ -4811,31 +4819,33 @@ def test_persistent_mode_pod(mesh_device, use_fp32, device_params):
         pipeline_config=pipeline_config,
     )
     pipeline.setup_and_run()
+    try:
+        if pipeline.my_mesh_id == 0:
+            for iteration in range(iterations):
+                torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
+                torch_token[0, 0] = iteration
+                token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+                output_tensor = ttnn.from_torch(
+                    torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
+                    dtype=ttnn.uint32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                )
+                logger.info(f"Writing token for iteration {iteration}")
+                pipeline.write_token(token_tensor)
+                logger.info(f"Reading output for iteration {iteration}")
+                pipeline.read_output(output_tensor)
+                got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
+                expected_idx = torch_expected_indices[iteration]
+                logger.info(f"Iteration {iteration} output token: {got}, expected: {expected_idx}")
+                assert torch.equal(
+                    got, expected_idx
+                ), f"Pod 16-stage token mismatch at iter {iteration}. expected={int(expected_idx.item())}, got={int(got.item())}"
 
-    if pipeline.my_mesh_id == 0:
-        for iteration in range(iterations):
-            torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = iteration
-            token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
-            output_tensor = ttnn.from_torch(
-                torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
-                dtype=ttnn.uint32,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-            )
-            logger.info(f"Writing token for iteration {iteration}")
-            pipeline.write_token(token_tensor)
-            logger.info(f"Reading output for iteration {iteration}")
-            pipeline.read_output(output_tensor)
-            got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
-            expected_idx = torch_expected_indices[iteration]
-            logger.info(f"Iteration {iteration} output token: {got}, expected: {expected_idx}")
-            assert torch.equal(
-                got, expected_idx
-            ), f"Pod 16-stage token mismatch at iter {iteration}. expected={int(expected_idx.item())}, got={int(got.item())}"
-
-    logger.info(f"Barrier for stage {pipeline.my_mesh_id + 1}")
-    pipeline.barrier()
-    logger.info(f"Barrier completed for stage {pipeline.my_mesh_id + 1}")
+        logger.info(f"Barrier for stage {pipeline.my_mesh_id + 1}")
+        pipeline.barrier()
+        logger.info(f"Barrier completed for stage {pipeline.my_mesh_id + 1}")
+    finally:
+        pipeline.terminate()
 
 
 @pytest.mark.parametrize("use_fp32", [True])
@@ -4875,20 +4885,20 @@ def test_persistent_mode_spec_decode(mesh_device, use_fp32):
 
     iterations = 50
     run_golden = False
-    run_on = "pod"  # "pod" or "glx"
 
-    if run_on == "pod":
+    num_procs = int(ttnn.distributed_context_get_size())
+    if num_procs == 4:
         config = create_single_pod_combined_spec_decode_pipeline_configuration(
             SyntheticWeightProvider(),
             fp32_dest_acc_en=use_fp32,
         )
-    elif run_on == "glx":
+    elif num_procs == 16:
         config = create_single_galaxy_combined_spec_decode_pipeline_configuration(
             SyntheticWeightProvider(),
             fp32_dest_acc_en=use_fp32,
         )
     else:
-        raise ValueError(f"Invalid run_on value: {run_on}")
+        raise ValueError(f"Test does not support {num_procs} distributed processes")
 
     print(f"[TEST] config created, building pipeline", flush=True)
     pipeline_config = ttnn._ttnn.multi_device.experimental.generate_blitz_decode_pipeline()
@@ -4904,74 +4914,71 @@ def test_persistent_mode_spec_decode(mesh_device, use_fp32):
     pos_id = 0
     slot_id = 23
 
-    try:
-        pipeline.setup_and_run()
-        logger.debug(f"[TEST P{pid}] setup_and_run complete")
+    pipeline.setup_and_run()
+    logger.debug(f"[TEST P{pid}] setup_and_run complete")
 
-        token_meta_words = TOKEN_META_PAGE_SIZE_BYTES // 4
+    token_meta_words = TOKEN_META_PAGE_SIZE_BYTES // 4
 
-        if pipeline.my_mesh_id == 0:
+    if pipeline.my_mesh_id == 0:
+        if run_golden:
+            logger.debug(f"[TEST] computing golden...")
+            golden, golden_debug = _compute_expected_spec_decode_tokens_synthetic(iterations)
+            logger.debug(f"[TEST] golden computed, creating config")
+        else:
+            logger.debug(f"[TEST] skipping golden computation")
+
+        tok0_id = 0
+        tok0_type = 0
+        tok0_pos = 0
+        tok1_id = 0
+        tok1_type = 0
+        tok1_pos = 0
+
+        for iteration in range(iterations):
+            logger.debug(f"[TEST P{pid}] iter {iteration} write_token")
+            torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
+            torch_token[0, 6] = slot_id
+            torch_token[0, 7] = iteration
+            torch_token[0, 8] = iteration
+            torch_token[0, 9] = iteration
+            token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+            output_tensor = ttnn.from_torch(
+                torch.zeros(1, token_meta_words, dtype=torch.uint32),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+            pipeline.write_token(token_tensor)
+            logger.debug(f"[TEST P{pid}] iter {iteration} read_output")
+            pipeline.read_output(output_tensor)
+            logger.debug(f"[TEST P{pid}] iter {iteration} to_torch")
+            raw = ttnn.to_torch(output_tensor).to(torch.uint32).flatten()
+
+            tok0_id = raw[0].item()
+            tok0_type = raw[1].item()
+            tok0_pos = raw[2].item()
+            tok1_id = raw[3].item()
+            tok1_type = raw[4].item()
+            tok1_pos = raw[5].item()
+
             if run_golden:
-                logger.debug(f"[TEST] computing golden...")
-                golden, golden_debug = _compute_expected_spec_decode_tokens_synthetic(iterations)
-                logger.debug(f"[TEST] golden computed, creating config")
+                expected_base, expected_spec = golden[iteration]
             else:
-                logger.debug(f"[TEST] skipping golden computation")
+                expected_base = None
+                expected_spec = None
 
-            tok0_id = 0
-            tok0_type = 0
-            tok0_pos = 0
-            tok1_id = 0
-            tok1_type = 0
-            tok1_pos = 0
+            type_name = {0: "BASE", 1: "SPEC"}
+            logger.debug(
+                f"[TEST P{pid}] iter {iteration} "
+                f"t0={tok0_id}/{type_name.get(tok0_type,'?')} "
+                f"t1={tok1_id}/{type_name.get(tok1_type,'?')} ",
+                f"t0 pos={tok0_pos} t1 pos={tok1_pos} ",
+                f"golden base token={expected_base} golden spec token={expected_spec}",
+            )
 
-            for iteration in range(iterations):
-                logger.debug(f"[TEST P{pid}] iter {iteration} write_token")
-                torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-                torch_token[0, 6] = slot_id
-                torch_token[0, 7] = iteration
-                torch_token[0, 8] = iteration
-                torch_token[0, 9] = iteration
-                token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
-                output_tensor = ttnn.from_torch(
-                    torch.zeros(1, token_meta_words, dtype=torch.uint32),
-                    dtype=ttnn.uint32,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                )
-                pipeline.write_token(token_tensor)
-                logger.debug(f"[TEST P{pid}] iter {iteration} read_output")
-                pipeline.read_output(output_tensor)
-                logger.debug(f"[TEST P{pid}] iter {iteration} to_torch")
-                raw = ttnn.to_torch(output_tensor).to(torch.uint32).flatten()
-
-                tok0_id = raw[0].item()
-                tok0_type = raw[1].item()
-                tok0_pos = raw[2].item()
-                tok1_id = raw[3].item()
-                tok1_type = raw[4].item()
-                tok1_pos = raw[5].item()
-
-                if run_golden:
-                    expected_base, expected_spec = golden[iteration]
-                else:
-                    expected_base = None
-                    expected_spec = None
-
-                type_name = {0: "BASE", 1: "SPEC"}
-                logger.debug(
-                    f"[TEST P{pid}] iter {iteration} "
-                    f"t0={tok0_id}/{type_name.get(tok0_type,'?')} "
-                    f"t1={tok1_id}/{type_name.get(tok1_type,'?')} ",
-                    f"t0 pos={tok0_pos} t1 pos={tok1_pos} ",
-                    f"golden base token={expected_base} golden spec token={expected_spec}",
-                )
-
-        logger.debug(f"[TEST P{pid}] all iterations done, barrier")
-        pipeline.barrier()
-        logger.debug(f"[TEST P{pid}] barrier done, terminate")
-        pipeline.terminate()
-        logger.debug(f"[TEST P{pid}] terminate done, final barrier")
-        pipeline.barrier()
-        logger.debug(f"[TEST P{pid}] final barrier done")
-    finally:
-        pass
+    logger.debug(f"[TEST P{pid}] all iterations done, barrier")
+    pipeline.barrier()
+    logger.debug(f"[TEST P{pid}] barrier done, terminate")
+    pipeline.terminate()
+    logger.debug(f"[TEST P{pid}] terminate done, final barrier")
+    pipeline.barrier()
+    logger.debug(f"[TEST P{pid}] final barrier done")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_persistent_loop.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_persistent_loop.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for PersistentLoop micro-op (unified_kernels/persistent_loop.hpp).
+
+Tests the setup/teardown cycle for both persistent and non-persistent modes.
+"""
+
+import pytest
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch, skip_for_wormhole_b0
+from models.demos.deepseek_v3_b1.micro_ops.persistent_loop.op import PersistentLoop
+
+CORE_COORD = ttnn.CoreCoord(0, 0)
+CORE_RANGE_SET = ttnn.CoreRangeSet([ttnn.CoreRange(CORE_COORD, CORE_COORD)])
+
+
+@skip_for_wormhole_b0("PersistentLoop test is for Blackhole only")
+@pytest.mark.parametrize("num_cycles", [5])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(1, 1)],
+    indirect=True,
+)
+def test_persistent_loop_teardown_cycle(mesh_device, num_cycles):
+    """Launch a persistent kernel, terminate it, and repeat N times.
+
+    Validates that PersistentLoop correctly observes the termination semaphore
+    and that the kernel can be cleanly re-launched after each teardown.
+    """
+    if not is_slow_dispatch():
+        pytest.skip("Persistent mode requires TT_METAL_SLOW_DISPATCH_MODE=1")
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    loop = PersistentLoop(mesh_device, CORE_RANGE_SET)
+    iteration_count_sem = ttnn.create_global_semaphore(mesh_device, CORE_RANGE_SET, 0)
+
+    for cycle in range(num_cycles):
+        logger.info(f"Cycle {cycle + 1}/{num_cycles}: launching persistent kernel")
+
+        loop.reset()
+        ttnn.reset_global_semaphore_value(iteration_count_sem, 0)
+
+        loop.op(
+            mesh_device=mesh_device,
+            core_coord=CORE_COORD,
+            iteration_count_semaphore=iteration_count_sem,
+        )
+
+        logger.info(f"Cycle {cycle + 1}/{num_cycles}: terminating")
+        loop.terminate()
+        ttnn.synchronize_device(mesh_device)
+        logger.info(f"Cycle {cycle + 1}/{num_cycles}: teardown complete")
+
+    logger.info(f"All {num_cycles} teardown cycles completed successfully")
+
+
+@skip_for_wormhole_b0("PersistentLoop test is for Blackhole only")
+@pytest.mark.parametrize("max_iterations", [1, 10])
+@pytest.mark.parametrize("num_cycles", [3])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(1, 1)],
+    indirect=True,
+)
+def test_persistent_loop_non_persistent(mesh_device, max_iterations, num_cycles):
+    """Launch a non-persistent kernel that runs a fixed number of iterations.
+
+    Validates that PersistentLoop correctly counts iterations in non-persistent
+    mode and that the kernel can be re-dispatched multiple times.
+    """
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    loop = PersistentLoop(mesh_device, CORE_RANGE_SET, persistent_mode=False)
+    iteration_count_sem = ttnn.create_global_semaphore(mesh_device, CORE_RANGE_SET, 0)
+
+    for cycle in range(num_cycles):
+        logger.info(
+            f"Cycle {cycle + 1}/{num_cycles}: launching non-persistent kernel (max_iterations={max_iterations})"
+        )
+
+        ttnn.reset_global_semaphore_value(iteration_count_sem, 0)
+
+        loop.op(
+            mesh_device=mesh_device,
+            core_coord=CORE_COORD,
+            iteration_count_semaphore=iteration_count_sem,
+            max_iterations=max_iterations,
+        )
+
+        ttnn.synchronize_device(mesh_device)
+        logger.info(f"Cycle {cycle + 1}/{num_cycles}: kernel completed")
+
+    logger.info(f"All {num_cycles} non-persistent cycles completed successfully")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_persistent_loop.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_persistent_loop.py
@@ -74,6 +74,9 @@ def test_persistent_loop_non_persistent(mesh_device, max_iterations, num_cycles)
     Validates that PersistentLoop correctly counts iterations in non-persistent
     mode and that the kernel can be re-dispatched multiple times.
     """
+    if not is_slow_dispatch():
+        pytest.skip("Persistent mode requires TT_METAL_SLOW_DISPATCH_MODE=1")
+
     ttnn.enable_asynchronous_slow_dispatch(mesh_device)
 
     loop = PersistentLoop(mesh_device, CORE_RANGE_SET, persistent_mode=False)

--- a/models/demos/deepseek_v3_b1/unified_kernels/persistent_loop.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/persistent_loop.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "kernel_op_api.hpp"
+
+namespace deepseek_b1_ops {
+
+// ============================================================================
+// PersistentLoop — reusable loop controller for persistent-mode fused ops.
+//
+// Persistent mode: checks a host-written termination semaphore each iteration.
+// On TRISC, drains the PACK coprocessor (tensix_sync) before checking so the
+// coprocessor pipeline is clean if the kernel exits.
+//
+// Non-persistent mode: runs up to max_iterations then exits.
+//
+// Usage:
+//   PersistentLoop<persistent_mode> loop(termination_semaphore_addr);
+//   while (loop.next()) {
+//       // ... iteration body ...
+//   }
+// ============================================================================
+template <bool persistent_mode>
+class PersistentLoop {
+public:
+    PersistentLoop(uint32_t termination_semaphore_addr, uint32_t max_iterations = 1) :
+        termination_semaphore_(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_semaphore_addr)),
+        max_iterations_(max_iterations),
+        iteration_(0) {}
+
+    bool next() {
+        if constexpr (persistent_mode) {
+#if defined(COMPILE_FOR_TRISC)
+            tensix_sync();
+#endif
+            invalidate_l1_cache();
+            if (termination_semaphore_[0] == 1) {
+                return false;
+            }
+        } else {
+            if (iteration_ >= max_iterations_) {
+                return false;
+            }
+        }
+        iteration_++;
+        return true;
+    }
+
+    uint32_t iteration() const { return iteration_; }
+
+private:
+    volatile tt_l1_ptr uint32_t* termination_semaphore_;
+    uint32_t max_iterations_;
+    uint32_t iteration_;
+};
+
+}  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/termination.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/termination.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/socket_api.h"
+
+namespace deepseek_b1_ops {
+
+FORCE_INLINE bool socket_wait_for_pages_with_termination(
+    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
+    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
+        invalidate_l1_cache();
+        if (termination_semaphore[0] == 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
+FORCE_INLINE bool cb_wait_for_pages_with_termination(
+    uint32_t cb_index, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
+    while (!cb_pages_available_at_front(cb_index, num_pages)) {
+        invalidate_l1_cache();
+        if (termination_semaphore[0] == 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace deepseek_b1_ops


### PR DESCRIPTION
### Summary

This pull request adds support for pipeline termination to the existing DeepSeek v3 B1 pipeline stages. 

The main changes include introducing a new shutdown sequence for persistent compute kernels, refactoring pipeline and stage abstractions to use a more generic `PipelineBlockKind`, and refactoring persistent loop management.

Before this change, we required developers to reset the entire cluster between all workloads because kernels were not correctly shutdown. This will no longer be required.

## What's changed

### 1) Add shared device-sidel termination primitives
- Adds `models/demos/deepseek_v3_b1/unified_kernels/persistent_loop.hpp`
- Adds `models/demos/deepseek_v3_b1/unified_kernels/termination.hpp`

These headers define common loop and wait semantics so persistent kernels and socket/cb waits use a single termination contract.

### 2) Introduces a dedicated persistent-loop micro-op
- Adds `models/demos/deepseek_v3_b1/micro_ops/persistent_loop/op.py`
- Adds `models/demos/deepseek_v3_b1/micro_ops/persistent_loop/kernels/persistent_loop_kernel.cpp`

This micro-op implements the semaphore lifecycle/plumbing and centralizes persistent-loop control, which is used for unit testing setup/teardown.

### 3) Wire up termination semaphore support in ops/kernels
Termination-related args/plumbing were propagated through:
- Decoder block (`fused_ops/decoder_block/*`)
- LM head sampling (`fused_ops/lm_head_sampling/*`)
- MoE op (`fused_ops/moe/op.py`)
- D2D exchange kernels (`micro_ops/d2d_exchange/kernels/*`)
- Host I/O kernels (`micro_ops/host_io/kernels/*`)
- Pipeline block op (`micro_ops/pipeline_block/op.py`)

### 4) Updates stage and pipeline teardown orchestration
- Stage implementations now trigger persistent-loop termination in their teardown flow.
- Pipeline teardown is made explicit and ordered (termination signaling + synchronization/barrier expectations).
- CLI now invokes pipeline termination via `model_pipeline.terminate()` to guarantee graceful shutdown on exit path.

### 5) Adds and updates tests
- Adds `models/demos/deepseek_v3_b1/tests/unit_tests/test_persistent_loop.py`
- Updates `models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py`
These tests validate persistent loop teardown behavior and improve regression coverage for termination semantics in persistent mode.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/stage-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/stage-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmal/stage-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmal/stage-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/stage-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/stage-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/stage-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/stage-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmal/stage-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmal/stage-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/stage-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/stage-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/stage-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/stage-teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/stage-teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/stage-teardown)