### PR TITLE
fix(slice): align RM CB sizing with kernel's num_read_per_barrier to avoid deadlock (#39947)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1503,3 +1503,34 @@ def test_issue_42753_regression(device, input_shape, begins, ends, step):
     tt_output_torch = ttnn.to_torch(tt_output)
 
     assert_with_pcc(torch_output, tt_output_torch, 0.99)
+
+
+@pytest.mark.parametrize(
+    "shape, slice_start, slice_end",
+    [
+        ((8, 16, 300, 6, 2), (0, 0, 0, 0, 1), (8, 16, 300, 6, 2)),
+    ],
+)
+def test_slice_rm_nd_misaligned_last_dim(device, shape, slice_start, slice_end):
+    """Regression test for issue #39947: RM slice deadlocks when num_read_per_barrier diverges
+    between compute_cb_size and get_slice_runtime_args_rm (triggered by 5D + non-zero last-dim
+    offset on a non-tile-aligned last dim, where the CB was sized too small for the kernel's
+    reserve_back)."""
+    torch.manual_seed(0)
+
+    dram_interleaved = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None)
+    torch_input = torch.randn(shape, dtype=torch.float32)
+
+    tt_input = ttnn.from_torch(
+        torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_interleaved
+    )
+    tt_output = ttnn.slice(tt_input, slice_start, slice_end, [1] * len(shape), memory_config=dram_interleaved)
+
+    torch_expected = torch_input[
+        slice_start[0] : slice_end[0],
+        slice_start[1] : slice_end[1],
+        slice_start[2] : slice_end[2],
+        slice_start[3] : slice_end[3],
+        slice_start[4] : slice_end[4],
+    ]
+    assert_with_pcc(torch_expected, ttnn.to_torch(tt_output), 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -161,7 +161,8 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
     auto dst_buffer_alignment = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
                                     ? ::hal::get_dram_alignment()
                                     : ::hal::get_l1_alignment();
-    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+    const auto single_alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+    auto alignment = single_alignment;
 
     // if begins is not aligned then we need to pad the cb size, so that we can read from the nearest aligned address
     uint32_t begins_bytes = output_tensor_start[-1] * input.element_size();
@@ -173,6 +174,10 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
     const ttnn::Shape& output_shape = output.padded_shape();
     const uint32_t unpadded_row_size_bytes = output_shape[-1] * input.element_size();
     const uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, alignment);
+    // Kernel runtime args use the single-aligned stick stride (see get_slice_runtime_args_rm); CB sizing must
+    // compute num_read_per_barrier against the same stride, otherwise the CB pages vs the kernel's reserve_back(N)
+    // can diverge and the reader deadlocks on cb_reserve_back.
+    const uint32_t stick_stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
     const uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2
                                          ? num_sticks_per_core_group_1
                                          : num_sticks_per_core_group_2;
@@ -180,7 +185,7 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
     if (num_input_pages != 0) {
         auto num_sticks_per_core_pad32 = num_input_pages + ((32 - num_input_pages % 32) % 32);
         num_sticks_per_core_read =
-            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, cb_page_size, MAX_READ_SIZE);
+            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, stick_stride_for_merge, MAX_READ_SIZE);
         num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
     }
 


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-metal/issues/39947

### Problem description

`ttnn.slice` hangs on shape `(8, 16, 300, 6, 2)` with a last-dim slice at a non-zero offset (e.g. `[..., 1:2]`). Test reports PASSED (ttnn dispatch is async), then `close_mesh_device` hangs forever at teardown waiting for the stuck kernel to drain.

**Root cause:** `SliceRmProgramFactory` computes `num_read_per_barrier` in two places — `compute_cb_size` (used to size the CB) and `get_slice_runtime_args_rm` (passed to the reader kernel as a runtime arg). Both call `merge_num_sticks_to_read`, but with different `stick_size_bytes` arguments: `compute_cb_size` passes `cb_page_size` (doubled alignment, 64), while `get_slice_runtime_args_rm` passes `unpadded_row_size_bytes_offset` (single alignment, 32). When the per-core stick count is aligned to the single alignment but not the doubled one, the two calls return different `num_read_per_barrier` values. For the repro the CB ends up sized for 32 reserves while the reader is told to reserve 113 → `cb_reserve_back` blocks forever on the first iteration → deadlock.

### What's changed

Fix (`slice_program_factory_rm.cpp`) — in `compute_cb_size`, compute the `merge_num_sticks_to_read` stride using the single alignment (same as the kernel's runtime arg), instead of `cb_page_size`:
```diff
+ const uint32_t stick_stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
  num_sticks_per_core_read =
-     tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, cb_page_size, MAX_READ_SIZE);
+     tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, stick_stride_for_merge, MAX_READ_SIZE);
```

### Checklist

- [x] Nightly tt-metal L2 tests - https://github.com/tenstorrent/tt-metal/actions/runs/24980774471
- [x] Sanity tests - https://github.com/tenstorrent/tt-metal/actions/runs/24922863073

Note: Nightly failures on my branch also occur in main ([run](https://github.com/tenstorrent/tt-metal/actions/runs/24980603689)), confirming this change introduces no regression.