### PR TITLE
ds_prefill: decouple untilize-send path from zero_init kernel (#42999)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -271,7 +271,7 @@ class TtMoe(LightweightModule):
             cluster_axis=0,
             num_links=self.row_num_links,
             topology=self.row_topology,
-            init_zeros=True,
+            init_zeros=False,
         )
 
         # Initialize routed expert

--- a/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_moe_post_combine_reduce.py
+++ b/tests/ttnn/unit_tests/operations/deepseek/test_deepseek_moe_post_combine_reduce.py
@@ -263,3 +263,104 @@ def test_output_layout(device):
     )
     assert result_tt.layout == ttnn.TILE_LAYOUT, f"Expected TILE_LAYOUT, got {result_tt.layout}"
     assert list(result_tt.shape) == [1, NUM_TOKENS, EMB_DIM], f"Wrong shape: {result_tt.shape}"
+
+
+# ============================================================================
+# Garbage-in-nonlocal-slots tests (repro for issue #42999)
+# ============================================================================
+#
+# In real MoE prefill, when combine runs with init_zeros=False, DRAM slots for
+# non-local experts are left uninitialized. Those bytes can decode to NaN/Inf
+# in bfloat16. The post_combine_reduce kernel is supposed to skip non-local
+# experts, but when a token has *all* non-local experts, the writer forces the
+# last expert's weight to 0 and compute takes the `must_zero_init` path — it
+# multiplies the uninitialized combine_input tile by 0. In IEEE-754,
+# NaN*0 = NaN and Inf*0 = NaN, so garbage leaks through and poisons the sum.
+
+
+@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
+@pytest.mark.parametrize("garbage", ["nan", "inf"], ids=["nan", "inf"])
+def test_all_nonlocal_garbage_in_combine(device, garbage):
+    """All experts non-local + garbage (NaN/Inf) in combine_input.
+
+    Every token hits the `must_zero_init` path. Expected output: all zeros.
+    If the kernel does mul(garbage, 0) the IEEE-754 result is NaN and the
+    output is polluted — reproducing the test_prefill_block PCC collapse.
+    """
+    torch.manual_seed(42)
+    fill = float("nan") if garbage == "nan" else float("inf")
+    combine = torch.full((1, NUM_TOKENS, NUM_EXPERTS, EMB_DIM), fill, dtype=torch.bfloat16)
+    weights = torch.randn(1, NUM_TOKENS, NUM_EXPERTS, 1, dtype=torch.bfloat16)
+
+    # Dispatch table: all -1 → every expert is non-local for this chip.
+    table = torch.full((NUM_ROUTED_EXPERTS,), -1, dtype=torch.int32)
+    dispatch_table_tt = ttnn.from_torch(
+        table, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    _, indices_tt = make_indices(NUM_TOKENS, NUM_EXPERTS, device)
+
+    result = ttnn.to_torch(
+        new_implementation(to_device(combine, device), to_device(weights, device), indices_tt, dispatch_table_tt)
+    )
+
+    nan_count = torch.isnan(result).sum().item()
+    inf_count = torch.isinf(result).sum().item()
+    max_abs = result.abs().max().item() if result.numel() > 0 else 0.0
+    logger.info(f"  all_nonlocal_{garbage}: NaN={nan_count} Inf={inf_count} max|x|={max_abs}")
+    assert nan_count == 0, f"got {nan_count} NaN in output (NaN*0=NaN leaked through must_zero_init)"
+    assert inf_count == 0, f"got {inf_count} Inf in output"
+    assert max_abs == 0.0, f"expected all-zero output, got max|x|={max_abs}"
+
+
+@run_for_blackhole(reason_str="DeepSeek-V3 dimensions require 100 cores (3200 tokens / 32 per core); WH has only 72")
+@pytest.mark.parametrize("garbage", ["nan", "inf"], ids=["nan", "inf"])
+def test_mixed_nonlocal_garbage_in_combine(device, garbage):
+    """Partial non-local (TP4-like) + garbage only in non-local slots.
+
+    Mimics real combine behaviour: local slots hold valid data, non-local
+    slots hold uninitialised DRAM (simulated as NaN/Inf). With topk=8 and
+    75% non-local, ~10% of tokens fall through the `must_zero_init` path
+    and are the ones that can poison the output.
+    """
+    torch.manual_seed(42)
+    fill = float("nan") if garbage == "nan" else float("inf")
+    local_expert_end = 64  # TP4: 64/256 experts local per chip
+    combine = torch.randn(1, NUM_TOKENS, NUM_EXPERTS, EMB_DIM, dtype=torch.bfloat16)
+    weights = torch.randn(1, NUM_TOKENS, NUM_EXPERTS, 1, dtype=torch.bfloat16)
+
+    table = torch.full((NUM_ROUTED_EXPERTS,), -1, dtype=torch.int32)
+    for i in range(local_expert_end):
+        table[i] = i // 8
+    dispatch_table_tt = ttnn.from_torch(
+        table, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    indices_torch, indices_tt = make_indices(NUM_TOKENS, NUM_EXPERTS, device)
+
+    # Poison non-local slots in combine + reference: only local experts contribute.
+    ref_combine = combine.clone()
+    all_nonlocal_tokens = 0
+    for t in range(NUM_TOKENS):
+        any_local = False
+        for k in range(NUM_EXPERTS):
+            expert_id = indices_torch[0, t, k].item()
+            if expert_id >= local_expert_end:
+                combine[0, t, k, :] = fill
+                ref_combine[0, t, k, :] = 0.0
+            else:
+                any_local = True
+        if not any_local:
+            all_nonlocal_tokens += 1
+    ref = pytorch_reference(ref_combine, weights)
+    logger.info(f"  mixed_{garbage}: {all_nonlocal_tokens}/{NUM_TOKENS} tokens hit must_zero_init")
+
+    result = ttnn.to_torch(
+        new_implementation(to_device(combine, device), to_device(weights, device), indices_tt, dispatch_table_tt)
+    )
+
+    nan_count = torch.isnan(result).sum().item()
+    inf_count = torch.isinf(result).sum().item()
+    logger.info(f"  mixed_{garbage}: NaN={nan_count} Inf={inf_count} in output")
+    assert nan_count == 0, f"got {nan_count} NaN in output"
+    assert inf_count == 0, f"got {inf_count} Inf in output"
+    assert_pcc(result, ref, label=f"mixed_nonlocal_{garbage}")

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -684,7 +684,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
     std::map<std::string, std::string> writer_defines = fabric_defines;
 
-    if (init_zeros) {
+    // Launch zero_init_writer whenever we need either the zero-init prelude (init_zeros)
+    // or the TILE_LAYOUT untilize-send path. With INIT_ZEROS=0 the kernel skips the
+    // prelude and runs only the send loop — needed so cb_untilize_id / cb_stop_signal_id
+    // always have a drainer, even when init_zeros=False.
+    const bool need_zero_init_kernel = init_zeros || is_tile_layout;
+    if (need_zero_init_kernel) {
         uint32_t noc_max_burst_size;
         const auto arch = mesh_device->arch();
         if (arch == tt::ARCH::BLACKHOLE) {
@@ -700,10 +705,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
                 .set_page_size(tt::CBIndex::c_7, noc_max_burst_size);
         tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, zi_inline_cb_config);
 
-        uint32_t total_zero_init_cores = num_cores + num_idle_cores;
-        uint32_t total_output_pages = detail::get_num_pages(output_tensor);
-        pages_per_core = total_output_pages / total_zero_init_cores;
-        remainder_pages = total_output_pages % total_zero_init_cores;
+        if (init_zeros) {
+            uint32_t total_zero_init_cores = num_cores + num_idle_cores;
+            uint32_t total_output_pages = detail::get_num_pages(output_tensor);
+            pages_per_core = total_output_pages / total_zero_init_cores;
+            remainder_pages = total_output_pages % total_zero_init_cores;
+        }
 
         tt::tt_metal::CircularBufferConfig zi_idle_cb_config =
             tt::tt_metal::CircularBufferConfig(noc_max_burst_size, {{tt::CBIndex::c_6, tt::DataFormat::UInt8}})
@@ -737,6 +744,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
 
         std::map<std::string, std::string> zi_defines;
         zi_defines["IS_TILE_LAYOUT"] = is_tile_layout ? "1" : "0";
+        zi_defines["INIT_ZEROS"] = init_zeros ? "1" : "0";
 
         zero_init_kernel_id = tt::tt_metal::CreateKernel(
             program,
@@ -831,23 +839,27 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
     }
 
-    // Set runtime args for hybrid idle row cores
-    if (init_zeros) {
+    // Set runtime args for hybrid idle row cores. When !init_zeros the zero-init-prelude
+    // args (page_start, page_end, zi_done_sem, sender NOC coords) are skipped — the kernel
+    // compiled with INIT_ZEROS=0 does not read them.
+    if (need_zero_init_kernel) {
         for (uint32_t idle_idx = 0; idle_idx < num_idle_cores; idle_idx++) {
-            uint32_t row_idx = num_cores + idle_idx;
-            uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
-            uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
-
-            // Each idle core signals all sender cores
             std::vector<uint32_t> zi_runtime_args = {
                 output_tensor.buffer()->address(),
-                page_start,
-                page_end,
-                zi_done_semaphore_id,
             };
-            for (const auto& [noc_x, noc_y] : sender_noc_coords) {
-                zi_runtime_args.push_back(noc_x);
-                zi_runtime_args.push_back(noc_y);
+
+            if (init_zeros) {
+                uint32_t row_idx = num_cores + idle_idx;
+                uint32_t page_start = (row_idx * pages_per_core) + std::min(row_idx, remainder_pages);
+                uint32_t page_end = page_start + pages_per_core + (row_idx < remainder_pages ? 1 : 0);
+                zi_runtime_args.push_back(page_start);
+                zi_runtime_args.push_back(page_end);
+                zi_runtime_args.push_back(zi_done_semaphore_id);
+                // Each idle core signals all sender cores when its zero-init range is done
+                for (const auto& [noc_x, noc_y] : sender_noc_coords) {
+                    zi_runtime_args.push_back(noc_x);
+                    zi_runtime_args.push_back(noc_y);
+                }
             }
 
             // TILE_LAYOUT: append owning-sender info so zero_init_writer can run its send loop

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
@@ -13,6 +13,10 @@
 // the untilized rows to the sender's receive buffer, and signals the sender that data has
 // landed. The loop exits when compute pushes ROUTE_INFO_SENTINEL onto cb_stop_signal_id.
 //
+// INIT_ZEROS=0: skip the zero-init prelude (buffer fill, zero_pages, sender-sem signalling)
+// and run only the IS_TILE_LAYOUT send path. Launched unconditionally for TILE_LAYOUT so the
+// send path always has a drainer for cb_untilize_id / cb_stop_signal_id.
+//
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
@@ -33,6 +37,8 @@ void kernel_main() {
     // ===== Runtime args =====
     uint32_t rt_args_idx = 0;
     uint32_t output_addr = get_arg_val<uint32_t>(rt_args_idx++);
+
+#if INIT_ZEROS
     uint32_t page_start = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t page_end = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t zi_done_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
@@ -48,9 +54,11 @@ void kernel_main() {
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args_idx++);
         sender_sem_noc_addrs[c] = get_noc_addr(noc_x, noc_y, zi_done_sem_l1_offset);
     }
+#endif
 
     const auto output_addr_gen = TensorAccessor(output_args, output_addr);
 
+#if INIT_ZEROS
     fill_zero_buffer(cb_zero_buffer_id);
     uint32_t zero_buffer_addr = get_write_ptr(cb_zero_buffer_id);
 
@@ -62,6 +70,7 @@ void kernel_main() {
     }
 
     noc_async_atomic_barrier();
+#endif
 
 #if IS_TILE_LAYOUT
     // ===== Untilized-data send path (moved from reader_untilize.cpp steps 3-7) =====


### PR DESCRIPTION
Commit 3ce30d3238a (#42571) moved the combine untilize-send flow (steps 3-7) from reader_untilize.cpp into zero_init_writer.cpp but kept that kernel gated on init_zeros=True. With init_zeros=False, the kernel was never launched, so nothing drained cb_untilize_id / cb_stop_signal_id -- combine's output DRAM was never written and PCC collapsed to ~0.0001 in test_prefill_block.

Fix: gate only the zero-init prelude (fill_zero_buffer / zero_pages / sender-sem signal) in zero_init_writer.cpp on a new INIT_ZEROS define, and launch the kernel whenever init_zeros || is_tile_layout. Flipping init_zeros back to False in tt_moe.py recovers the ~12% combine perf from #42087 without the PCC regression that prompted #43001.

Also adds two post_combine_reduce unit tests that inject NaN/Inf in non-local slots to confirm TT FPU mul-by-zero shortcut keeps the skip path safe.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/issue-42999-init-zeros-untilize-decouple)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/issue-42999-init-zeros-untilize-decouple)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/issue-42999-init-zeros-untilize-decouple)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/issue-42999-init-zeros-untilize-decouple)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/issue-42999-init-zeros-untilize-decouple)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/issue-42999-init-zeros-untilize-decouple)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/issue-42999-init-zeros-untilize-decouple)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/issue-42999-init-zeros-untilize-decouple)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/issue-42999-init-zeros-untilize-decouple)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/issue-42999-init-zeros-untilize-decouple)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/issue-42999-init-zeros-untilize-decouple)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/issue-42999-init-zeros-untilize-decouple)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/issue-42999-init-zeros-untilize-decouple)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/issue-42999-init-zeros-untilize-decouple)