### PR TITLE
#42840: fixed data leak in reshape & added regression test

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -108,6 +108,42 @@ def test_reshape_block_shard(
     assert torch.allclose(expected_output, actual_output)
 
 
+def test_issue_42840_regression_buffer_leak(device):
+    """Regression test for issue #42840: with block-sharded tiled tensors corrupts the output's tile-padding
+    rows with real input data. The padding rows must be zero but contain values from earlier input tiles."""
+    PROBE = {float(t + 1) for t in range((1576 + 31) // 32)}  # {1.0 … 50.0}
+
+    x = torch.zeros(1576, 2304, dtype=torch.bfloat16)
+    for t in range(50):
+        x[t * 32 : min((t + 1) * 32, 1576), :] = float(t + 1)
+
+    block_sharded_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))]),
+            [224, 288],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+
+    tt = ttnn.from_torch(
+        x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=block_sharded_config
+    )
+    tt_r = ttnn.reshape(tt, [8, 197, 2304], memory_config=block_sharded_config)
+    tt_il = ttnn.to_memory_config(tt_r, ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1))
+
+    padded = tt_il.to_torch_with_padded_shape().to(torch.float32)
+    padding = padded[:, 197:, :]
+
+    leaks = {}
+    for b in range(8):
+        hits = [v for v in torch.unique(padding[b][padding[b] != 0]).tolist() if v in PROBE]
+        if hits:
+            leaks[b] = [int(v) - 1 for v in hits]
+    assert not leaks, f"Leaked input tile-rows into output padding: {leaks}"
+
+
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 def test_reshape_height_shard(device, layout):
     input_shape = [1, 1, 256, 32]

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -109,8 +109,12 @@ def test_reshape_block_shard(
 
 
 def test_issue_42840_regression_buffer_leak(device):
-    """Regression test for issue #42840: with block-sharded tiled tensors corrupts the output's tile-padding
-    rows with real input data. The padding rows must be zero but contain values from earlier input tiles."""
+    """Regression test for issue #42840: reshaping block-sharded tiled tensors corrupted the output's
+    tile-padding rows with real input data. The padding rows must be zero but contained values from earlier
+    input tiles."""
+    if device.core_grid.y < 8:
+        pytest.skip("Requires 8x8 core grid")
+
     PROBE = {float(t + 1) for t in range((1576 + 31) // 32)}  # {1.0 … 50.0}
 
     x = torch.zeros(1576, 2304, dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -31,7 +31,15 @@ void kernel_main() {
     bool first = true;
     cb_reserve_back(cb_id_working, 1);
     const uint32_t working_write_addr = get_write_ptr(cb_id_working);
+    const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     for (uint32_t output_page_idx = start_output_page; output_page_idx < end_output_page; ++output_page_idx) {
+        for (uint32_t offset = 0; offset < Tile_size_bytes; offset += MEM_ZEROS_SIZE) {
+            uint32_t size = (offset + MEM_ZEROS_SIZE <= Tile_size_bytes) ? MEM_ZEROS_SIZE : (Tile_size_bytes - offset);
+            noc_async_read(zeros_noc_addr, working_write_addr + offset, size);
+        }
+
+        noc_async_read_barrier();
+
         cb_wait_front(cb_id_mapping, 1);
         const uint32_t map_addr = get_read_ptr(cb_id_mapping);
         auto map_ptr = reinterpret_cast<volatile tt_l1_ptr SegmentMapData*>(map_addr);


### PR DESCRIPTION
### Summary

[Link to Issue](https://github.com/tenstorrent/tt-metal/issues/42840)

Reshape op previously corrupted output padding for block sharded tensors. This was caused by the buffer being reused without being cleared. It now gets cleared per output page write so the data does not leak into padded tiles.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/reshape-buffer-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smeydanshahiTT/reshape-buffer-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=smeydanshahiTT/reshape-buffer-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:smeydanshahiTT/reshape-buffer-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smeydanshahiTT/reshape-buffer-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smeydanshahiTT/reshape-buffer-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smeydanshahiTT/reshape-buffer-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smeydanshahiTT/reshape-buffer-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smeydanshahiTT/reshape-buffer-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smeydanshahiTT/reshape-buffer-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smeydanshahiTT/reshape-buffer-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smeydanshahiTT/reshape-buffer-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smeydanshahiTT/reshape-buffer-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smeydanshahiTT/reshape-buffer-leak)