### PR TITLE
[DCAMP-247] Support removing hosts from cabling and deployment descriptors

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1472,6 +1472,90 @@ void CablingGenerator::merge(
     merge_other(other, new_file_path, existing_sources);
 }
 
+bool CablingGenerator::remove_host_from_resolved_graph(
+    ResolvedGraphInstance& graph, const std::string& hostname) {
+    // Leaf case: the target lives directly in this graph.
+    auto node_it = graph.nodes.find(hostname);
+    if (node_it != graph.nodes.end()) {
+        const HostId removed_id = node_it->second.host_id;
+        graph.nodes.erase(node_it);
+        std::erase_if(
+            graph.children_order,
+            [&](const std::pair<std::string, bool>& entry) { return entry.second && entry.first == hostname; });
+
+        // Drop every internal connection touching the removed host_id and rebuild lookups.
+        for (auto& [port_type, conns] : graph.internal_connections) {
+            std::erase_if(conns, [&](const PortConnection& conn) {
+                return std::get<0>(conn.first) == removed_id || std::get<0>(conn.second) == removed_id;
+            });
+        }
+        std::erase_if(graph.internal_connections, [](const auto& kv) { return kv.second.empty(); });
+        graph.endpoint_to_dest.clear();
+        graph.connection_pairs.clear();
+        for (const auto& [port_type, conns] : graph.internal_connections) {
+            for (const auto& conn : conns) {
+                graph.endpoint_to_dest[conn.first] = conn.second;
+                graph.endpoint_to_dest[conn.second] = conn.first;
+                graph.connection_pairs.insert(normalize_graph_connection(conn));
+            }
+        }
+        return true;
+    }
+
+    // Recursive case: find in a subgraph, then collapse the subgraph if it went empty.
+    for (auto& [sub_name, subgraph] : graph.subgraphs) {
+        if (!remove_host_from_resolved_graph(*subgraph, hostname)) {
+            continue;
+        }
+        if (subgraph->nodes.empty() && subgraph->subgraphs.empty()) {
+            const std::string collapsed_name = sub_name;
+            graph.subgraphs.erase(collapsed_name);
+            std::erase_if(graph.children_order, [&](const std::pair<std::string, bool>& entry) {
+                return !entry.second && entry.first == collapsed_name;
+            });
+        }
+        return true;
+    }
+    return false;
+}
+
+void CablingGenerator::remove_host(const std::string& hostname) {
+    if (!root_instance_ || !remove_host_from_resolved_graph(*root_instance_, hostname)) {
+        log_warning(tt::LogDistributed, "remove_host: hostname '{}' not found; no-op", hostname);
+        return;
+    }
+
+    std::erase_if(deployment_hosts_, [&](const Host& h) { return h.hostname == hostname; });
+
+    // Renumbers host_ids to 0..N-1, remaps connections, and refreshes host_id_to_node_.
+    reassign_host_ids_dfs();
+
+    // Reorder deployment_hosts_ to match the new DFS host_id order.
+    std::unordered_map<std::string, Host> all_hosts;
+    for (const auto& h : deployment_hosts_) {
+        all_hosts[h.hostname] = h;
+    }
+    const auto saved_hosts = deployment_hosts_;
+    rebuild_deployment_hosts_in_dfs_order(all_hosts);
+    if (deployment_hosts_.size() != saved_hosts.size()) {
+        // Reordering needs every node to have a matching hostname entry; if that isn't the
+        // case (e.g. synthetic test fixtures), keep the pre-reorder list intact.
+        deployment_hosts_ = saved_hosts;
+    }
+
+    // Reset port availability on all surviving nodes before re-deriving chip connections;
+    // otherwise ports already marked during the original load would conflict when the
+    // remaining internal_connections are re-applied.
+    recreate_nodes_from_templates(*root_instance_);
+    generate_logical_chip_connections();
+}
+
+void CablingGenerator::remove_hosts(const std::vector<std::string>& hostnames) {
+    for (const auto& hostname : hostnames) {
+        remove_host(hostname);
+    }
+}
+
 // Getters for all data
 const std::vector<Host>& CablingGenerator::get_deployment_hosts() const { return deployment_hosts_; }
 

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1472,21 +1472,58 @@ void CablingGenerator::merge(
     merge_other(other, new_file_path, existing_sources);
 }
 
-bool CablingGenerator::remove_host_from_resolved_graph(
-    ResolvedGraphInstance& graph, const std::string& hostname) {
-    // Leaf case: the target lives directly in this graph.
-    auto node_it = graph.nodes.find(hostname);
-    if (node_it != graph.nodes.end()) {
-        const HostId removed_id = node_it->second.host_id;
-        graph.nodes.erase(node_it);
-        std::erase_if(
-            graph.children_order,
-            [&](const std::pair<std::string, bool>& entry) { return entry.second && entry.first == hostname; });
+// Graph that directly owns the node with `host_id`, or nullptr.
+static ResolvedGraphInstance* find_graph_containing_host_id(ResolvedGraphInstance& graph, HostId host_id) {
+    for (const auto& [node_name, node] : graph.nodes) {
+        if (node.host_id == host_id) {
+            return &graph;
+        }
+    }
+    for (auto& [sub_name, subgraph] : graph.subgraphs) {
+        if (auto* found = find_graph_containing_host_id(*subgraph, host_id)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
 
-        // Drop every internal connection touching the removed host_id and rebuild lookups.
+// True if `host_id` is referenced by a connection in any graph other than `owner` (i.e. at an
+// ancestor level), which removal can't scrub and renumber would leave dangling.
+static bool host_id_referenced_outside_graph(
+    ResolvedGraphInstance& graph, const ResolvedGraphInstance* owner, HostId host_id) {
+    if (&graph != owner) {
+        for (const auto& [port_type, conns] : graph.internal_connections) {
+            for (const auto& conn : conns) {
+                if (std::get<0>(conn.first) == host_id || std::get<0>(conn.second) == host_id) {
+                    return true;
+                }
+            }
+        }
+    }
+    for (auto& [sub_name, subgraph] : graph.subgraphs) {
+        if (host_id_referenced_outside_graph(*subgraph, owner, host_id)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CablingGenerator::remove_host_id_from_resolved_graph(ResolvedGraphInstance& graph, HostId host_id) {
+    // Leaf case: the node with this host_id lives directly in this graph.
+    for (auto it = graph.nodes.begin(); it != graph.nodes.end(); ++it) {
+        if (it->second.host_id != host_id) {
+            continue;
+        }
+        const std::string node_name = it->first;
+        graph.nodes.erase(it);
+        std::erase_if(graph.children_order, [&](const std::pair<std::string, bool>& entry) {
+            return entry.second && entry.first == node_name;
+        });
+
+        // Drop connections touching the removed host_id and rebuild lookups.
         for (auto& [port_type, conns] : graph.internal_connections) {
             std::erase_if(conns, [&](const PortConnection& conn) {
-                return std::get<0>(conn.first) == removed_id || std::get<0>(conn.second) == removed_id;
+                return std::get<0>(conn.first) == host_id || std::get<0>(conn.second) == host_id;
             });
         }
         std::erase_if(graph.internal_connections, [](const auto& kv) { return kv.second.empty(); });
@@ -1504,7 +1541,7 @@ bool CablingGenerator::remove_host_from_resolved_graph(
 
     // Recursive case: find in a subgraph, then collapse the subgraph if it went empty.
     for (auto& [sub_name, subgraph] : graph.subgraphs) {
-        if (!remove_host_from_resolved_graph(*subgraph, hostname)) {
+        if (!remove_host_id_from_resolved_graph(*subgraph, host_id)) {
             continue;
         }
         if (subgraph->nodes.empty() && subgraph->subgraphs.empty()) {
@@ -1519,41 +1556,85 @@ bool CablingGenerator::remove_host_from_resolved_graph(
     return false;
 }
 
-void CablingGenerator::remove_host(const std::string& hostname) {
-    if (!root_instance_ || !remove_host_from_resolved_graph(*root_instance_, hostname)) {
-        log_warning(tt::LogDistributed, "remove_host: hostname '{}' not found; no-op", hostname);
-        return;
-    }
-
-    std::erase_if(deployment_hosts_, [&](const Host& h) { return h.hostname == hostname; });
-
-    // Renumbers host_ids to 0..N-1, remaps connections, and refreshes host_id_to_node_.
+void CablingGenerator::finalize_after_removal() {
+    // Renumber host_ids to 0..N-1 and remap connections.
     reassign_host_ids_dfs();
 
-    // Reorder deployment_hosts_ to match the new DFS host_id order.
+    // Reorder deployment_hosts_ to match the DFS host_id order (rebuild handles the
+    // name-mismatch fallback itself).
     std::unordered_map<std::string, Host> all_hosts;
     for (const auto& h : deployment_hosts_) {
         all_hosts[h.hostname] = h;
     }
-    const auto saved_hosts = deployment_hosts_;
     rebuild_deployment_hosts_in_dfs_order(all_hosts);
-    if (deployment_hosts_.size() != saved_hosts.size()) {
-        // Reordering needs every node to have a matching hostname entry; if that isn't the
-        // case (e.g. synthetic test fixtures), keep the pre-reorder list intact.
-        deployment_hosts_ = saved_hosts;
-    }
 
-    // Reset port availability on all surviving nodes before re-deriving chip connections;
-    // otherwise ports already marked during the original load would conflict when the
-    // remaining internal_connections are re-applied.
+    // Reset port availability before re-deriving chip connections so surviving internal
+    // connections don't conflict with ports marked during the original load.
     recreate_nodes_from_templates(*root_instance_);
     generate_logical_chip_connections();
 }
 
+void CablingGenerator::remove_host(const std::string& hostname) { remove_hosts({hostname}); }
+
 void CablingGenerator::remove_hosts(const std::vector<std::string>& hostnames) {
-    for (const auto& hostname : hostnames) {
-        remove_host(hostname);
+    if (!root_instance_) {
+        for (const auto& hostname : hostnames) {
+            log_warning(tt::LogDistributed, "remove_host: hostname '{}' not found; no-op", hostname);
+        }
+        return;
     }
+
+    // A user names a deployment host, but the cabling's child/node names are independent labels.
+    // deployment_hosts_ is indexed by host_id, so resolve every hostname -> host_id against the
+    // current (pre-mutation) state up front. Resolving after a removal would be wrong: removals
+    // don't renumber until finalize, so deployment_hosts_ indices would drift from graph host_ids.
+    struct Pending {
+        std::string hostname;
+        HostId host_id;
+    };
+    std::vector<Pending> pending;
+    for (const auto& hostname : hostnames) {
+        HostId host_id{0};
+        bool found = false;
+        for (size_t i = 0; i < deployment_hosts_.size(); ++i) {
+            if (deployment_hosts_[i].hostname == hostname) {
+                host_id = HostId(static_cast<uint32_t>(i));
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            log_warning(tt::LogDistributed, "remove_host: hostname '{}' not found; no-op", hostname);
+            continue;
+        }
+
+        ResolvedGraphInstance* owner = find_graph_containing_host_id(*root_instance_, host_id);
+        if (owner == nullptr) {
+            log_warning(
+                tt::LogDistributed, "remove_host: no node for host '{}' (host_id {}); no-op", hostname, *host_id);
+            continue;
+        }
+
+        // Cross-level (hierarchical) removal isn't supported: an ancestor-level connection can't be
+        // scrubbed here and would be left dangling after renumber. Check every requested host before
+        // mutating so the batch is all-or-nothing on this error.
+        if (host_id_referenced_outside_graph(*root_instance_, owner, host_id)) {
+            throw std::runtime_error(fmt::format(
+                "remove_host: host '{}' participates in connections declared outside its containing graph; "
+                "cross-level (hierarchical) host removal is not supported",
+                hostname));
+        }
+        pending.push_back({hostname, host_id});
+    }
+
+    if (pending.empty()) {
+        return;
+    }
+    for (const auto& p : pending) {
+        remove_host_id_from_resolved_graph(*root_instance_, p.host_id);
+        std::erase_if(deployment_hosts_, [&](const Host& h) { return h.hostname == p.hostname; });
+    }
+    finalize_after_removal();
 }
 
 // Getters for all data

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -174,10 +174,10 @@ public:
     const std::vector<Host>& get_deployment_hosts() const;
     const std::vector<LogicalChannelConnection>& get_chip_connections() const;
 
-    // Remove a host (by hostname) from the resolved cluster + deployment.
-    // Drops the host's node, any internal connections touching it, and empty subgraphs
-    // left behind; renumbers remaining host_ids to stay contiguous 0..N-1.
-    // Emits a warning and no-ops if `hostname` isn't present. Safe to call repeatedly.
+    // Remove host(s) by hostname: drops the node, its connections, and empty subgraphs, then
+    // renumbers remaining host_ids to 0..N-1. Warns and no-ops on unknown hostnames (safe to
+    // repeat). Throws if a host is wired outside its containing graph (cross-level/hierarchical
+    // removal is unsupported).
     void remove_host(const std::string& hostname);
     void remove_hosts(const std::vector<std::string>& hostnames);
 
@@ -260,10 +260,13 @@ private:
         const std::string& path_prefix,
         std::unordered_map<HostId, std::string>& host_to_node_path);
 
-    // Recursive helper for remove_host(). Drops the node, scrubs connections in the
-    // containing graph, and collapses any sub_instance left empty. Returns true if the
-    // hostname was found and removed (in this subtree), false otherwise.
-    bool remove_host_from_resolved_graph(ResolvedGraphInstance& graph, const std::string& hostname);
+    // Recursive helper for remove_hosts(): drops the node with `host_id`, scrubs its connections,
+    // and collapses any emptied sub_instance. Returns true if the host_id was found and removed.
+    bool remove_host_id_from_resolved_graph(ResolvedGraphInstance& graph, HostId host_id);
+
+    // Renumber host_ids, rebuild deployment order, and regenerate chip connections. Run once per
+    // remove_hosts() call after the structural removals.
+    void finalize_after_removal();
 
     // Utility function to generate logical chip connections from cluster hierarchy
     void generate_logical_chip_connections();

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -174,6 +174,13 @@ public:
     const std::vector<Host>& get_deployment_hosts() const;
     const std::vector<LogicalChannelConnection>& get_chip_connections() const;
 
+    // Remove a host (by hostname) from the resolved cluster + deployment.
+    // Drops the host's node, any internal connections touching it, and empty subgraphs
+    // left behind; renumbers remaining host_ids to stay contiguous 0..N-1.
+    // Emits a warning and no-ops if `hostname` isn't present. Safe to call repeatedly.
+    void remove_host(const std::string& hostname);
+    void remove_hosts(const std::vector<std::string>& hostnames);
+
     // Method to emit factory system descriptor
     void emit_factory_system_descriptor(const std::string& output_path) const;
 
@@ -252,6 +259,11 @@ private:
         const std::unique_ptr<ResolvedGraphInstance>& graph,
         const std::string& path_prefix,
         std::unordered_map<HostId, std::string>& host_to_node_path);
+
+    // Recursive helper for remove_host(). Drops the node, scrubs connections in the
+    // containing graph, and collapses any sub_instance left empty. Returns true if the
+    // hostname was found and removed (in this subtree), false otherwise.
+    bool remove_host_from_resolved_graph(ResolvedGraphInstance& graph, const std::string& hostname);
 
     // Utility function to generate logical chip connections from cluster hierarchy
     void generate_logical_chip_connections();

--- a/tools/scaleout/cabling_generator/remove_hosts.py
+++ b/tools/scaleout/cabling_generator/remove_hosts.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Remove one or more hosts from a cabling + deployment descriptor pair.
+
+The host's node, any internal connections touching it, and any subgraph left empty
+are dropped. Remaining host_ids are renumbered to stay contiguous 0..N-1. Unknown
+hostnames produce a warning and no mutation.
+
+Usage:
+    ./remove_hosts.py \
+        --cabling <path-or-dir> \
+        --deployment <path> \
+        --remove <hostname> [--remove <hostname> ...] \
+        --output-dir <path> \
+        [--build-dir <name>]
+
+Generates in output-dir:
+    - updated_fsd.textproto
+    - updated_cabling_descriptor.textproto
+    - updated_deployment_descriptor.textproto
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def validate_paths(paths):
+    for name, path in paths.items():
+        if not os.path.exists(path):
+            print(f"Error: {name} not found: {path}", file=sys.stderr)
+            sys.exit(1)
+
+
+def find_cabling_generator(repo_root, build_dir=None):
+    """Find run_cabling_generator binary, checking multiple build directories."""
+    binary_subpath = Path("tools") / "scaleout" / "run_cabling_generator"
+
+    if build_dir:
+        candidate = repo_root / build_dir / binary_subpath
+        if candidate.exists():
+            return candidate
+        print(f"Error: run_cabling_generator not found at {candidate}", file=sys.stderr)
+        sys.exit(1)
+
+    for bd in ("build_Release", "build_Debug", "build"):
+        candidate = repo_root / bd / binary_subpath
+        if candidate.exists():
+            return candidate
+
+    print("Error: run_cabling_generator not found in any build directory", file=sys.stderr)
+    print("Searched: build_Release, build_Debug, build", file=sys.stderr)
+    print("Build with: ./build_metal.sh --build-tests", file=sys.stderr)
+    sys.exit(1)
+
+
+def count_hosts(deployment_path):
+    """Count host entries in a deployment descriptor (regex-based for robustness)."""
+    with open(deployment_path, "r") as f:
+        content = f.read()
+    return len(re.findall(r"^\s*hosts\s*\{", content, re.MULTILINE))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Remove hosts from a cabling + deployment descriptor pair.",
+    )
+    parser.add_argument(
+        "--cabling",
+        required=True,
+        help="Cabling descriptor .textproto file, or a directory of them to be merged first",
+    )
+    parser.add_argument("--deployment", required=True, help="Deployment descriptor .textproto file")
+    parser.add_argument(
+        "--remove",
+        action="append",
+        required=True,
+        metavar="HOSTNAME",
+        help="Hostname to remove; pass multiple times to remove several hosts",
+    )
+    parser.add_argument("--output-dir", "-o", required=True, help="Output directory")
+    parser.add_argument(
+        "--build-dir",
+        default=None,
+        help="Build directory name (e.g. build_Release). Auto-detected if not specified.",
+    )
+
+    args = parser.parse_args()
+
+    validate_paths({"cabling": args.cabling, "deployment": args.deployment})
+
+    # Drop accidental empty --remove values; preserve user-given order otherwise.
+    remove_list = [h.strip() for h in args.remove if h and h.strip()]
+    if not remove_list:
+        print("Error: --remove must specify at least one non-empty hostname", file=sys.stderr)
+        sys.exit(1)
+
+    script_dir = Path(__file__).resolve().parent
+    # tools/scaleout/cabling_generator/remove_hosts.py -> repo root is 3 levels up
+    repo_root = script_dir.parent.parent.parent
+    cabling_gen = find_cabling_generator(repo_root, args.build_dir)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # The C++ tool runs with cwd=repo_root, so convert input paths to absolute to ensure
+    # they resolve regardless of the user's working directory.
+    cabling_path = str(Path(args.cabling).resolve())
+    deployment_path = str(Path(args.deployment).resolve())
+
+    cmd = [
+        str(cabling_gen),
+        "--cabling", cabling_path,
+        "--deployment", deployment_path,
+        "--remove-hosts", ",".join(remove_list),
+        "--output", "updated",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(repo_root))
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    # Surface warnings (e.g. unknown-hostname no-ops) regardless of exit code.
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        print("run_cabling_generator failed", file=sys.stderr)
+        sys.exit(1)
+
+    generated_fsd = repo_root / "out" / "scaleout" / "factory_system_descriptor_updated.textproto"
+    generated_cabling = repo_root / "out" / "scaleout" / "cabling_descriptor_updated.textproto"
+    generated_deployment = repo_root / "out" / "scaleout" / "deployment_descriptor_updated.textproto"
+
+    if not generated_fsd.exists():
+        print(f"Error: Output file not found: {generated_fsd}", file=sys.stderr)
+        sys.exit(1)
+
+    shutil.copy(generated_fsd, output_dir / "updated_fsd.textproto")
+    if generated_cabling.exists():
+        shutil.copy(generated_cabling, output_dir / "updated_cabling_descriptor.textproto")
+    if generated_deployment.exists():
+        shutil.copy(generated_deployment, output_dir / "updated_deployment_descriptor.textproto")
+
+    final_deployment = output_dir / "updated_deployment_descriptor.textproto"
+    if final_deployment.exists():
+        print(f"Requested removal of {len(remove_list)} host(s); {count_hosts(str(final_deployment))} remain")
+    print(f"Output: {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/scaleout/cabling_generator/remove_hosts.py
+++ b/tools/scaleout/cabling_generator/remove_hosts.py
@@ -33,11 +33,51 @@ import sys
 from pathlib import Path
 
 
-def validate_paths(paths):
-    for name, path in paths.items():
-        if not os.path.exists(path):
-            print(f"Error: {name} not found: {path}", file=sys.stderr)
-            sys.exit(1)
+# RFC 1123 host/label characters only. Anchored, no path separators, no leading
+# dash. This is an allowlist: any input that does not match is rejected outright,
+# which prevents both argument injection (e.g. a value starting with "-") and any
+# attempt to smuggle shell/path metacharacters into the downstream binary call.
+HOSTNAME_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,253}[A-Za-z0-9])?$")
+
+
+def validate_hostname(hostname):
+    """Reject any hostname that is not a plain RFC 1123-style name."""
+    if not HOSTNAME_RE.match(hostname):
+        print(f"Error: invalid hostname: {hostname!r}", file=sys.stderr)
+        sys.exit(1)
+    return hostname
+
+
+def validate_build_dir(build_dir):
+    """Constrain --build-dir to a single, simple directory name.
+
+    Rejecting path separators and traversal keeps the binary-discovery path
+    rooted under repo_root and prevents user input from escaping it.
+    """
+    if (
+        build_dir in (".", "..")
+        or "/" in build_dir
+        or "\\" in build_dir
+        or os.sep in build_dir
+        or (os.altsep and os.altsep in build_dir)
+    ):
+        print(f"Error: invalid --build-dir (must be a simple directory name): {build_dir!r}", file=sys.stderr)
+        sys.exit(1)
+    return build_dir
+
+
+def resolve_input_file(name, raw_path):
+    """Resolve a user-supplied input path to an absolute, existing regular file.
+
+    Resolving normalizes any '..' traversal to a concrete absolute path, and the
+    absolute form guarantees the value cannot be misread as a CLI flag by the
+    downstream binary (it always begins with the filesystem root).
+    """
+    resolved = Path(raw_path).resolve()
+    if not resolved.is_file():
+        print(f"Error: {name} not found or not a regular file: {raw_path}", file=sys.stderr)
+        sys.exit(1)
+    return str(resolved)
 
 
 def find_cabling_generator(repo_root, build_dir=None):
@@ -95,26 +135,29 @@ def main():
 
     args = parser.parse_args()
 
-    validate_paths({"cabling": args.cabling, "deployment": args.deployment})
-
     # Drop accidental empty --remove values; preserve user-given order otherwise.
-    remove_list = [h.strip() for h in args.remove if h and h.strip()]
+    # Every retained hostname is validated against a strict allowlist before it is
+    # ever placed on the downstream command line.
+    remove_list = [validate_hostname(h.strip()) for h in args.remove if h and h.strip()]
     if not remove_list:
         print("Error: --remove must specify at least one non-empty hostname", file=sys.stderr)
         sys.exit(1)
 
+    build_dir = validate_build_dir(args.build_dir) if args.build_dir else None
+
     script_dir = Path(__file__).resolve().parent
     # tools/scaleout/cabling_generator/remove_hosts.py -> repo root is 3 levels up
     repo_root = script_dir.parent.parent.parent
-    cabling_gen = find_cabling_generator(repo_root, args.build_dir)
+    cabling_gen = find_cabling_generator(repo_root, build_dir)
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # The C++ tool runs with cwd=repo_root, so convert input paths to absolute to ensure
-    # they resolve regardless of the user's working directory.
-    cabling_path = str(Path(args.cabling).resolve())
-    deployment_path = str(Path(args.deployment).resolve())
+    # they resolve regardless of the user's working directory. resolve_input_file also
+    # normalizes traversal and verifies the target is an existing regular file.
+    cabling_path = resolve_input_file("cabling", args.cabling)
+    deployment_path = resolve_input_file("deployment", args.deployment)
 
     cmd = [
         str(cabling_gen),

--- a/tools/scaleout/cabling_generator/remove_hosts.py
+++ b/tools/scaleout/cabling_generator/remove_hosts.py
@@ -33,15 +33,12 @@ import sys
 from pathlib import Path
 
 
-# RFC 1123 host/label characters only. Anchored, no path separators, no leading
-# dash. This is an allowlist: any input that does not match is rejected outright,
-# which prevents both argument injection (e.g. a value starting with "-") and any
-# attempt to smuggle shell/path metacharacters into the downstream binary call.
+# RFC 1123 allowlist: rejects anything with a leading dash, path separators, or shell
+# metacharacters, blocking argument/path injection into the downstream binary call.
 HOSTNAME_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,253}[A-Za-z0-9])?$")
 
 
 def validate_hostname(hostname):
-    """Reject any hostname that is not a plain RFC 1123-style name."""
     if not HOSTNAME_RE.match(hostname):
         print(f"Error: invalid hostname: {hostname!r}", file=sys.stderr)
         sys.exit(1)
@@ -49,11 +46,7 @@ def validate_hostname(hostname):
 
 
 def validate_build_dir(build_dir):
-    """Constrain --build-dir to a single, simple directory name.
-
-    Rejecting path separators and traversal keeps the binary-discovery path
-    rooted under repo_root and prevents user input from escaping it.
-    """
+    """Constrain --build-dir to a simple directory name (no separators/traversal)."""
     if (
         build_dir in (".", "..")
         or "/" in build_dir
@@ -67,12 +60,7 @@ def validate_build_dir(build_dir):
 
 
 def resolve_input_file(name, raw_path):
-    """Resolve a user-supplied input path to an absolute, existing regular file.
-
-    Resolving normalizes any '..' traversal to a concrete absolute path, and the
-    absolute form guarantees the value cannot be misread as a CLI flag by the
-    downstream binary (it always begins with the filesystem root).
-    """
+    """Resolve an input path to an absolute, existing regular file (normalizes traversal)."""
     resolved = Path(raw_path).resolve()
     if not resolved.is_file():
         print(f"Error: {name} not found or not a regular file: {raw_path}", file=sys.stderr)
@@ -135,9 +123,7 @@ def main():
 
     args = parser.parse_args()
 
-    # Drop accidental empty --remove values; preserve user-given order otherwise.
-    # Every retained hostname is validated against a strict allowlist before it is
-    # ever placed on the downstream command line.
+    # Validate against the allowlist and drop empties, preserving order.
     remove_list = [validate_hostname(h.strip()) for h in args.remove if h and h.strip()]
     if not remove_list:
         print("Error: --remove must specify at least one non-empty hostname", file=sys.stderr)
@@ -153,18 +139,20 @@ def main():
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # The C++ tool runs with cwd=repo_root, so convert input paths to absolute to ensure
-    # they resolve regardless of the user's working directory. resolve_input_file also
-    # normalizes traversal and verifies the target is an existing regular file.
+    # The C++ tool runs with cwd=repo_root, so pass absolute (resolved, existing) input paths.
     cabling_path = resolve_input_file("cabling", args.cabling)
     deployment_path = resolve_input_file("deployment", args.deployment)
 
     cmd = [
         str(cabling_gen),
-        "--cabling", cabling_path,
-        "--deployment", deployment_path,
-        "--remove-hosts", ",".join(remove_list),
-        "--output", "updated",
+        "--cabling",
+        cabling_path,
+        "--deployment",
+        deployment_path,
+        "--remove-hosts",
+        ",".join(remove_list),
+        "--output",
+        "updated",
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(repo_root))

--- a/tools/scaleout/cabling_generator/remove_hosts.py
+++ b/tools/scaleout/cabling_generator/remove_hosts.py
@@ -59,11 +59,12 @@ def validate_build_dir(build_dir):
     return build_dir
 
 
-def resolve_input_file(name, raw_path):
-    """Resolve an input path to an absolute, existing regular file (normalizes traversal)."""
+def resolve_input_path(name, raw_path, *, allow_dir=False):
+    """Resolve an input path to an absolute, existing file (or dir) (normalizes traversal)."""
     resolved = Path(raw_path).resolve()
-    if not resolved.is_file():
-        print(f"Error: {name} not found or not a regular file: {raw_path}", file=sys.stderr)
+    if not (resolved.is_file() or (allow_dir and resolved.is_dir())):
+        expected = "a regular file or directory" if allow_dir else "a regular file"
+        print(f"Error: {name} not found or not {expected}: {raw_path}", file=sys.stderr)
         sys.exit(1)
     return str(resolved)
 
@@ -140,8 +141,9 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # The C++ tool runs with cwd=repo_root, so pass absolute (resolved, existing) input paths.
-    cabling_path = resolve_input_file("cabling", args.cabling)
-    deployment_path = resolve_input_file("deployment", args.deployment)
+    # --cabling may be a file or a directory of descriptors to merge; --deployment is file-only.
+    cabling_path = resolve_input_path("cabling", args.cabling, allow_dir=True)
+    deployment_path = resolve_input_path("deployment", args.deployment)
 
     cmd = [
         str(cabling_gen),

--- a/tools/scaleout/src/run_cabling_generator.cpp
+++ b/tools/scaleout/src/run_cabling_generator.cpp
@@ -23,7 +23,31 @@ struct InputConfig {
     std::string output_name;
     bool loc_info = true;  // Default to detailed location info
     bool is_cabling_directory = false;
+    std::vector<std::string> remove_hosts;  // Hostnames to drop after load, before emission
 };
+
+// Parse a comma-separated list of hostnames. Trims whitespace and drops empty entries.
+static std::vector<std::string> parse_csv_hostnames(const std::string& csv) {
+    std::vector<std::string> out;
+    std::string current;
+    auto flush = [&]() {
+        size_t start = current.find_first_not_of(" \t");
+        size_t end = current.find_last_not_of(" \t");
+        if (start != std::string::npos) {
+            out.push_back(current.substr(start, end - start + 1));
+        }
+        current.clear();
+    };
+    for (char c : csv) {
+        if (c == ',') {
+            flush();
+        } else {
+            current.push_back(c);
+        }
+    }
+    flush();
+    return out;
+}
 
 bool file_exists(const std::string& path) {
     return std::filesystem::exists(path) && std::filesystem::is_regular_file(path);
@@ -50,7 +74,11 @@ InputConfig parse_arguments(int argc, char** argv) {
         cxxopts::value<std::string>()->default_value(""))(
         "s,simple",
         "Generate simple CSV output (hostname-based) instead of detailed location information (rack, shelf, etc.)",
-        cxxopts::value<bool>()->default_value("false")->implicit_value("true"))("h,help", "Print usage information");
+        cxxopts::value<bool>()->default_value("false")->implicit_value("true"))(
+        "remove-hosts",
+        "Comma-separated list of hostnames to remove from the loaded cluster before emission. "
+        "Dangling references and empty subgraphs are cleaned up; remaining host_ids are renumbered.",
+        cxxopts::value<std::string>()->default_value(""))("h,help", "Print usage information");
 
     try {
         auto result = options.parse(argc, argv);
@@ -74,6 +102,13 @@ InputConfig parse_arguments(int argc, char** argv) {
                       << " --cabling cabling.textproto --deployment deployment.textproto --output test --simple"
                       << std::endl;
             std::cout << "  # Generates simple CSV with hostname information only" << std::endl;
+            std::cout << std::endl;
+            std::cout << "  " << argv[0]
+                      << " --cabling cabling.textproto --deployment deployment.textproto"
+                         " --remove-hosts host-a,host-b --output trimmed"
+                      << std::endl;
+            std::cout << "  # Removes the named hosts from the loaded cluster before generating outputs"
+                      << std::endl;
             exit(0);
         }
 
@@ -90,6 +125,7 @@ InputConfig parse_arguments(int argc, char** argv) {
         config.deployment_descriptor_path = result["deployment"].as<std::string>();
         config.output_name = result["output"].as<std::string>();
         config.loc_info = !result["simple"].as<bool>();
+        config.remove_hosts = parse_csv_hostnames(result["remove-hosts"].as<std::string>());
 
         // Check if cabling descriptor is a directory or file
         if (directory_exists(config.cabling_descriptor_path)) {
@@ -157,6 +193,14 @@ int main(int argc, char** argv) {
 
         std::cout << "Loading descriptors and initializing generator..." << std::endl;
         CablingGenerator cabling_generator(config.cabling_descriptor_path, config.deployment_descriptor_path);
+
+        if (!config.remove_hosts.empty()) {
+            std::cout << "Removing " << config.remove_hosts.size() << " host(s) from loaded cluster:" << std::endl;
+            for (const auto& h : config.remove_hosts) {
+                std::cout << "  - " << h << std::endl;
+            }
+            cabling_generator.remove_hosts(config.remove_hosts);
+        }
 
         std::string factory_output = "out/scaleout/factory_system_descriptor" + config.output_name + ".textproto";
         std::string cabling_output = "out/scaleout/cabling_guide" + config.output_name + ".csv";

--- a/tools/scaleout/src/run_cabling_generator.cpp
+++ b/tools/scaleout/src/run_cabling_generator.cpp
@@ -23,10 +23,10 @@ struct InputConfig {
     std::string output_name;
     bool loc_info = true;  // Default to detailed location info
     bool is_cabling_directory = false;
-    std::vector<std::string> remove_hosts;  // Hostnames to drop after load, before emission
+    std::vector<std::string> remove_hosts;
 };
 
-// Parse a comma-separated list of hostnames. Trims whitespace and drops empty entries.
+// Split a comma-separated list, trimming surrounding whitespace and dropping empty entries.
 static std::vector<std::string> parse_csv_hostnames(const std::string& csv) {
     std::vector<std::string> out;
     std::string current;

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -35,6 +35,29 @@ target_link_libraries(
 # Make sure protobuf files are generated before compiling descriptor merger tests
 add_dependencies(test_descriptor_merger scaleout_generated_protos)
 
+# Test for host removal functionality
+add_executable(test_host_removal test_host_removal.cpp)
+
+set_target_properties(
+    test_host_removal
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tools/scaleout
+)
+
+target_include_directories(test_host_removal SYSTEM PRIVATE ${Metalium_BINARY_DIR}/tools/scaleout)
+
+target_link_libraries(
+    test_host_removal
+    PRIVATE
+        TT::ScaleoutTools
+        gmock_main
+        enchantum::enchantum
+        protobuf::libprotobuf
+)
+
+add_dependencies(test_host_removal scaleout_generated_protos)
+
 # Test for link retraining validation
 add_executable(
     test_link_retraining

--- a/tools/tests/scaleout/test_host_removal.cpp
+++ b/tools/tests/scaleout/test_host_removal.cpp
@@ -1,0 +1,546 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <google/protobuf/text_format.h>
+
+#include <cabling_generator/cabling_generator.hpp>
+#include "protobuf/cluster_config.pb.h"
+#include "protobuf/deployment.pb.h"
+
+namespace tt::scaleout_tools {
+
+class HostRemovalTest : public ::testing::Test {
+protected:
+    static std::string create_test_dir(const std::string& test_name) {
+        const std::string dir = "generated/tests/" + test_name + "/";
+        if (std::filesystem::exists(dir)) {
+            std::filesystem::remove_all(dir);
+        }
+        std::filesystem::create_directories(dir);
+        return dir;
+    }
+
+    static void write_textproto(const std::string& path, const std::string& content) {
+        std::ofstream ofs(path);
+        ofs << content;
+    }
+
+    // Builds a flat single-template cabling descriptor where the hostnames are used as both
+    // the graph `children.name` and the deployment `host:` field. `connections` is a list of
+    // (from_name, to_name, tray_a, port_a, tray_b, port_b) tuples expressed as
+    // `internal_connections` of type QSFP_DD.
+    struct Conn {
+        std::string from;
+        std::string to;
+        uint32_t tray_a = 1;
+        uint32_t port_a = 1;
+        uint32_t tray_b = 1;
+        uint32_t port_b = 1;
+    };
+    static void write_flat_cabling(
+        const std::string& path,
+        const std::string& template_name,
+        const std::vector<std::string>& hostnames,
+        const std::string& node_descriptor,
+        const std::vector<Conn>& connections = {}) {
+        std::string content = "graph_templates {\n  key: \"" + template_name + "\"\n  value {\n";
+        for (const auto& h : hostnames) {
+            content +=
+                "    children { name: \"" + h + "\" node_ref { node_descriptor: \"" + node_descriptor + "\" } }\n";
+        }
+        if (!connections.empty()) {
+            content += "    internal_connections {\n      key: \"QSFP_DD\"\n      value {\n";
+            for (const auto& c : connections) {
+                content += "        connections {\n";
+                content += "          port_a { path: [\"" + c.from + "\"] tray_id: " + std::to_string(c.tray_a) +
+                           " port_id: " + std::to_string(c.port_a) + " }\n";
+                content += "          port_b { path: [\"" + c.to + "\"] tray_id: " + std::to_string(c.tray_b) +
+                           " port_id: " + std::to_string(c.port_b) + " }\n";
+                content += "        }\n";
+            }
+            content += "      }\n    }\n";
+        }
+        content += "  }\n}\n";
+        content += "root_instance {\n  template_name: \"" + template_name + "\"\n";
+        for (size_t i = 0; i < hostnames.size(); ++i) {
+            content +=
+                "  child_mappings { key: \"" + hostnames[i] + "\" value { host_id: " + std::to_string(i) + " } }\n";
+        }
+        content += "}\n";
+        write_textproto(path, content);
+    }
+
+    static void write_simple_deployment(
+        const std::string& path, const std::vector<std::string>& hostnames, const std::string& node_type) {
+        std::string content;
+        for (const auto& h : hostnames) {
+            content += "hosts {\n";
+            content += "  host: \"" + h + "\"\n";
+            content += "  node_type: \"" + node_type + "\"\n";
+            content += "}\n";
+        }
+        write_textproto(path, content);
+    }
+
+    static cabling_generator::proto::ClusterDescriptor load_cluster(const std::string& path) {
+        std::ifstream f(path);
+        EXPECT_TRUE(f.is_open()) << path;
+        std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+        cabling_generator::proto::ClusterDescriptor desc;
+        EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc)) << path;
+        return desc;
+    }
+
+    static deployment::proto::DeploymentDescriptor load_deployment(const std::string& path) {
+        std::ifstream f(path);
+        EXPECT_TRUE(f.is_open()) << path;
+        std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+        deployment::proto::DeploymentDescriptor desc;
+        EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc)) << path;
+        return desc;
+    }
+
+    // Writes the generator out to cabling + deployment textprotos in `dir` and returns their paths.
+    static std::pair<std::string, std::string> emit_pair(const CablingGenerator& gen, const std::string& dir) {
+        const std::string cabling_out = dir + "emitted_cabling.textproto";
+        const std::string deployment_out = dir + "emitted_deployment.textproto";
+        gen.emit_cabling_descriptor(cabling_out);
+        gen.emit_deployment_descriptor(deployment_out);
+        return {cabling_out, deployment_out};
+    }
+
+    // Collects all host_ids referenced in the root_instance child_mappings (single level only).
+    static std::vector<uint32_t> collect_root_host_ids(const cabling_generator::proto::ClusterDescriptor& desc) {
+        std::vector<uint32_t> ids;
+        for (const auto& [_, mapping] : desc.root_instance().child_mappings()) {
+            if (mapping.mapping_case() == cabling_generator::proto::ChildMapping::kHostId) {
+                ids.push_back(mapping.host_id());
+            }
+        }
+        std::sort(ids.begin(), ids.end());
+        return ids;
+    }
+
+    static std::vector<std::string> hostnames_in_deployment(const deployment::proto::DeploymentDescriptor& d) {
+        std::vector<std::string> names;
+        for (const auto& h : d.hosts()) {
+            names.push_back(h.host());
+        }
+        return names;
+    }
+};
+
+// Core case: drop a single leaf. Graph shrinks, deployment shrinks, host_ids stay contiguous 0..N-1.
+TEST_F(HostRemovalTest, RemoveLeafHostRenumbersRemaining) {
+    const std::string dir = create_test_dir("remove_leaf_host");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c", "node_d"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_b");
+
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto cabling_desc = load_cluster(cabling_out);
+    auto deployment_desc = load_deployment(deployment_out);
+
+    // 3 hosts survive in both descriptors; "node_b" is gone; host_ids are contiguous 0..2.
+    EXPECT_EQ(cabling_desc.root_instance().child_mappings().size(), 3u);
+    EXPECT_FALSE(cabling_desc.root_instance().child_mappings().contains("node_b"));
+    EXPECT_EQ(collect_root_host_ids(cabling_desc), (std::vector<uint32_t>{0, 1, 2}));
+
+    const auto names = hostnames_in_deployment(deployment_desc);
+    EXPECT_EQ(names.size(), 3u);
+    EXPECT_EQ(std::count(names.begin(), names.end(), "node_b"), 0);
+}
+
+// Connection touching the removed host must be dropped from the emitted descriptor.
+TEST_F(HostRemovalTest, RemoveHostDropsTouchingConnections) {
+    const std::string dir = create_test_dir("remove_host_drops_connections");
+    const std::vector<std::string> hosts = {"node_a", "node_b"};
+    write_flat_cabling(
+        dir + "cabling.textproto",
+        "cluster",
+        hosts,
+        "WH_GALAXY",
+        {Conn{"node_a", "node_b", 1, 1, 1, 1}});
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_b");
+
+    auto [cabling_out, _] = emit_pair(gen, dir);
+    auto desc = load_cluster(cabling_out);
+
+    // After removal, no internal_connections should reference node_b (or survive at all,
+    // since the only connection we declared touches it).
+    const auto& templates = desc.graph_templates();
+    ASSERT_TRUE(templates.contains("cluster"));
+    size_t total_conns = 0;
+    for (const auto& [port_type, conns] : templates.at("cluster").internal_connections()) {
+        total_conns += conns.connections_size();
+        for (const auto& conn : conns.connections()) {
+            for (const auto& seg : conn.port_a().path()) {
+                EXPECT_NE(seg, "node_b") << "connection still references node_b";
+            }
+            for (const auto& seg : conn.port_b().path()) {
+                EXPECT_NE(seg, "node_b") << "connection still references node_b";
+            }
+        }
+    }
+    EXPECT_EQ(total_conns, 0u);
+}
+
+// remove_hosts drops several in one call.
+TEST_F(HostRemovalTest, RemoveMultipleHostsInOneCall) {
+    const std::string dir = create_test_dir("remove_multiple_hosts");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c", "node_d"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_hosts({"node_b", "node_d"});
+
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto cabling_desc = load_cluster(cabling_out);
+    auto deployment_desc = load_deployment(deployment_out);
+
+    EXPECT_EQ(cabling_desc.root_instance().child_mappings().size(), 2u);
+    EXPECT_FALSE(cabling_desc.root_instance().child_mappings().contains("node_b"));
+    EXPECT_FALSE(cabling_desc.root_instance().child_mappings().contains("node_d"));
+    EXPECT_EQ(collect_root_host_ids(cabling_desc), (std::vector<uint32_t>{0, 1}));
+    EXPECT_EQ(deployment_desc.hosts_size(), 2);
+}
+
+// Unknown hostname produces no mutation and no throw.
+TEST_F(HostRemovalTest, RemoveUnknownHostIsNoOp) {
+    const std::string dir = create_test_dir("remove_unknown_host");
+    const std::vector<std::string> hosts = {"node_a", "node_b"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    EXPECT_NO_THROW(gen.remove_host("does-not-exist"));
+
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto cabling_desc = load_cluster(cabling_out);
+    auto deployment_desc = load_deployment(deployment_out);
+
+    EXPECT_EQ(cabling_desc.root_instance().child_mappings().size(), 2u);
+    EXPECT_EQ(deployment_desc.hosts_size(), 2);
+}
+
+// After removal, emit + reload must produce a valid generator with the reduced cluster.
+TEST_F(HostRemovalTest, RemovedClusterRoundTripsThroughEmit) {
+    const std::string dir = create_test_dir("remove_round_trip");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c"};
+    write_flat_cabling(
+        dir + "cabling.textproto",
+        "cluster",
+        hosts,
+        "WH_GALAXY",
+        {Conn{"node_a", "node_b", 1, 1, 1, 1}, Conn{"node_b", "node_c", 1, 2, 1, 2}});
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_b");
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+
+    // Reload with a fresh generator — must not error and must describe 2 hosts.
+    EXPECT_NO_THROW({
+        CablingGenerator reloaded(cabling_out, deployment_out);
+        EXPECT_EQ(reloaded.get_deployment_hosts().size(), 2u);
+    });
+}
+
+// Removing the very first host (host_id 0) — the renumbering must shift everyone down.
+TEST_F(HostRemovalTest, RemoveFirstHostShiftsRemaining) {
+    const std::string dir = create_test_dir("remove_first_host");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_a");
+
+    // In-memory state: 2 hosts, contiguous host_ids 0..1.
+    EXPECT_EQ(gen.get_deployment_hosts().size(), 2u);
+
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto cabling_desc = load_cluster(cabling_out);
+    auto deployment_desc = load_deployment(deployment_out);
+
+    EXPECT_EQ(cabling_desc.root_instance().child_mappings().size(), 2u);
+    EXPECT_FALSE(cabling_desc.root_instance().child_mappings().contains("node_a"));
+    EXPECT_EQ(collect_root_host_ids(cabling_desc), (std::vector<uint32_t>{0, 1}));
+    EXPECT_EQ(deployment_desc.hosts_size(), 2);
+    EXPECT_EQ(deployment_desc.hosts(0).host(), "node_b");
+    EXPECT_EQ(deployment_desc.hosts(1).host(), "node_c");
+}
+
+// Removing the last host (highest host_id) — boundary case for renumbering.
+TEST_F(HostRemovalTest, RemoveLastHostLeavesContiguousIds) {
+    const std::string dir = create_test_dir("remove_last_host");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_c");
+
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto cabling_desc = load_cluster(cabling_out);
+    auto deployment_desc = load_deployment(deployment_out);
+
+    EXPECT_EQ(cabling_desc.root_instance().child_mappings().size(), 2u);
+    EXPECT_FALSE(cabling_desc.root_instance().child_mappings().contains("node_c"));
+    EXPECT_EQ(collect_root_host_ids(cabling_desc), (std::vector<uint32_t>{0, 1}));
+    EXPECT_EQ(deployment_desc.hosts_size(), 2);
+}
+
+// Surviving connections must reference the renumbered host_ids of the surviving hosts,
+// AND their hostnames in the emitted descriptor's path must match the survivors.
+TEST_F(HostRemovalTest, SurvivingConnectionsUseRenumberedIds) {
+    const std::string dir = create_test_dir("surviving_connections_renumber");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c", "node_d"};
+    // Build connections: a-b (drop), b-c (drop), a-c (keep), a-d (keep), c-d (keep).
+    write_flat_cabling(
+        dir + "cabling.textproto",
+        "cluster",
+        hosts,
+        "WH_GALAXY",
+        {
+            Conn{"node_a", "node_b", 1, 1, 1, 1},
+            Conn{"node_b", "node_c", 1, 2, 1, 2},
+            Conn{"node_a", "node_c", 2, 1, 2, 1},
+            Conn{"node_a", "node_d", 3, 1, 3, 1},
+            Conn{"node_c", "node_d", 4, 1, 4, 1},
+        });
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_b");
+
+    auto [cabling_out, _] = emit_pair(gen, dir);
+    auto desc = load_cluster(cabling_out);
+
+    // Surviving connections: a-c, a-d, c-d (three).
+    ASSERT_TRUE(desc.graph_templates().contains("cluster"));
+    size_t total_conns = 0;
+    std::set<std::pair<std::string, std::string>> survivors;
+    for (const auto& [port_type, conns] : desc.graph_templates().at("cluster").internal_connections()) {
+        for (const auto& c : conns.connections()) {
+            ASSERT_EQ(c.port_a().path_size(), 1);
+            ASSERT_EQ(c.port_b().path_size(), 1);
+            const std::string a = c.port_a().path(0);
+            const std::string b = c.port_b().path(0);
+            EXPECT_NE(a, "node_b");
+            EXPECT_NE(b, "node_b");
+            // Normalize as a sorted pair for set membership.
+            survivors.insert(a < b ? std::make_pair(a, b) : std::make_pair(b, a));
+            ++total_conns;
+        }
+    }
+    EXPECT_EQ(total_conns, 3u);
+    EXPECT_TRUE(survivors.count({"node_a", "node_c"}));
+    EXPECT_TRUE(survivors.count({"node_a", "node_d"}));
+    EXPECT_TRUE(survivors.count({"node_c", "node_d"}));
+}
+
+// Calling remove_host twice on the same hostname must be safe — the second call no-ops.
+TEST_F(HostRemovalTest, IdempotentDoubleRemove) {
+    const std::string dir = create_test_dir("idempotent_double_remove");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_b");
+    EXPECT_EQ(gen.get_deployment_hosts().size(), 2u);
+    EXPECT_NO_THROW(gen.remove_host("node_b"));  // already gone -> warn + no-op
+    EXPECT_EQ(gen.get_deployment_hosts().size(), 2u);
+}
+
+// chip_connections_ must be regenerated (not stale) after removal. We can't easily assert
+// an exact post-removal count because chip_connections includes intra-node inter-board
+// connections too, but we can verify (a) it shrinks and (b) no surviving entry references
+// the removed host_id.
+TEST_F(HostRemovalTest, ChipConnectionsShrinkAfterRemoval) {
+    const std::string dir = create_test_dir("chip_connections_shrink");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c"};
+    write_flat_cabling(
+        dir + "cabling.textproto",
+        "cluster",
+        hosts,
+        "WH_GALAXY",
+        {Conn{"node_a", "node_b", 1, 1, 1, 1}, Conn{"node_b", "node_c", 1, 2, 1, 2}});
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    const size_t before = gen.get_chip_connections().size();
+    ASSERT_GT(before, 0u);
+
+    // The host_id of node_b before removal — chip_connections referencing it must be gone afterwards.
+    HostId removed_id{0};
+    for (const auto& h : gen.get_deployment_hosts()) {
+        if (h.hostname == "node_b") {
+            // deployment_hosts_ is in DFS host_id order; index gives the host_id.
+            removed_id = HostId(static_cast<uint32_t>(&h - &gen.get_deployment_hosts().front()));
+        }
+    }
+
+    gen.remove_host("node_b");
+    const size_t after = gen.get_chip_connections().size();
+    EXPECT_LT(after, before) << "removing a connected host must shrink chip_connections";
+
+    // After renumber, host_ids 0..N-2. We can't compare to the pre-renumber removed_id directly,
+    // but we can assert that no surviving entry points at any host that's no longer in the cluster.
+    std::set<HostId> live_ids;
+    for (const auto& h : gen.get_deployment_hosts()) {
+        live_ids.insert(HostId(static_cast<uint32_t>(&h - &gen.get_deployment_hosts().front())));
+    }
+    for (const auto& [a, b] : gen.get_chip_connections()) {
+        EXPECT_TRUE(live_ids.contains(a.host_id)) << "stale endpoint host_id " << *a.host_id;
+        EXPECT_TRUE(live_ids.contains(b.host_id)) << "stale endpoint host_id " << *b.host_id;
+    }
+    (void)removed_id;
+}
+
+// Sequential remove + remove must keep state consistent (no stale connections, contiguous ids).
+TEST_F(HostRemovalTest, SequentialRemovalsKeepStateConsistent) {
+    const std::string dir = create_test_dir("sequential_removals");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c", "node_d"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_a");
+    gen.remove_host("node_d");
+
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto cabling_desc = load_cluster(cabling_out);
+    auto deployment_desc = load_deployment(deployment_out);
+
+    EXPECT_EQ(cabling_desc.root_instance().child_mappings().size(), 2u);
+    EXPECT_EQ(collect_root_host_ids(cabling_desc), (std::vector<uint32_t>{0, 1}));
+    EXPECT_EQ(deployment_desc.hosts_size(), 2);
+
+    // Both surviving descriptors must round-trip cleanly through a fresh generator.
+    EXPECT_NO_THROW({
+        CablingGenerator reloaded(cabling_out, deployment_out);
+        EXPECT_EQ(reloaded.get_deployment_hosts().size(), 2u);
+    });
+}
+
+// remove_host with an empty hostname must not match anything (i.e. behave as a no-op).
+TEST_F(HostRemovalTest, RemoveEmptyHostnameIsNoOp) {
+    const std::string dir = create_test_dir("remove_empty_hostname");
+    const std::vector<std::string> hosts = {"node_a", "node_b"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    EXPECT_NO_THROW(gen.remove_host(""));
+    EXPECT_EQ(gen.get_deployment_hosts().size(), 2u);
+}
+
+// Invariant: deployment_hosts_ ordering matches DFS host_id order after removal.
+// (We construct a fresh generator on the emitted output and verify deployment.hosts(i).host()
+// matches the cabling's child whose host_id == i.)
+TEST_F(HostRemovalTest, DeploymentOrderingMatchesDfsHostIds) {
+    const std::string dir = create_test_dir("deployment_ordering_dfs");
+    const std::vector<std::string> hosts = {"node_a", "node_b", "node_c", "node_d", "node_e"};
+    write_flat_cabling(dir + "cabling.textproto", "cluster", hosts, "WH_GALAXY");
+    write_simple_deployment(dir + "deployment.textproto", hosts, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_c");  // remove a middle node
+
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto cabling_desc = load_cluster(cabling_out);
+    auto deployment_desc = load_deployment(deployment_out);
+
+    // Build hostname -> host_id from the cabling root_instance child_mappings.
+    std::unordered_map<std::string, uint32_t> hostname_to_id;
+    for (const auto& [name, mapping] : cabling_desc.root_instance().child_mappings()) {
+        ASSERT_EQ(mapping.mapping_case(), cabling_generator::proto::ChildMapping::kHostId);
+        hostname_to_id[name] = mapping.host_id();
+    }
+
+    // For each entry in deployment.hosts(i), the cabling's child with hostname == hosts(i).host()
+    // must have host_id == i. (i.e. the deployment is positionally indexed by host_id.)
+    ASSERT_EQ(deployment_desc.hosts_size(), 4);
+    for (int i = 0; i < deployment_desc.hosts_size(); ++i) {
+        const std::string& hostname = deployment_desc.hosts(i).host();
+        ASSERT_TRUE(hostname_to_id.contains(hostname)) << "deployment host '" << hostname << "' has no cabling entry";
+        EXPECT_EQ(hostname_to_id[hostname], static_cast<uint32_t>(i))
+            << "deployment[" << i << "].host = '" << hostname << "' but cabling host_id = " << hostname_to_id[hostname];
+    }
+}
+
+// Nested case: removing the only leaf of a sub_instance collapses it out of the parent.
+TEST_F(HostRemovalTest, RemoveLastNodeInSubgraphCollapsesIt) {
+    const std::string dir = create_test_dir("remove_last_node_collapses_subgraph");
+    // Two templates: `outer` has child `group` (graph_ref) + sibling leaf `node_top`,
+    // and `group` has one leaf `node_inner`. Removing `node_inner` should collapse `group`.
+    write_textproto(
+        dir + "cabling.textproto",
+        R"(
+graph_templates {
+  key: "outer"
+  value {
+    children { name: "node_top" node_ref { node_descriptor: "WH_GALAXY" } }
+    children { name: "group" graph_ref { graph_template: "group" } }
+  }
+}
+graph_templates {
+  key: "group"
+  value {
+    children { name: "node_inner" node_ref { node_descriptor: "WH_GALAXY" } }
+  }
+}
+root_instance {
+  template_name: "outer"
+  child_mappings {
+    key: "node_top"
+    value { host_id: 0 }
+  }
+  child_mappings {
+    key: "group"
+    value {
+      sub_instance {
+        template_name: "group"
+        child_mappings {
+          key: "node_inner"
+          value { host_id: 1 }
+        }
+      }
+    }
+  }
+}
+)");
+    write_simple_deployment(dir + "deployment.textproto", {"node_top", "node_inner"}, "WH_GALAXY");
+
+    CablingGenerator gen(dir + "cabling.textproto", dir + "deployment.textproto");
+    gen.remove_host("node_inner");
+
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto desc = load_cluster(cabling_out);
+
+    // `group` should no longer appear as a child mapping of the root instance; only node_top remains.
+    EXPECT_EQ(desc.root_instance().child_mappings().size(), 1u);
+    EXPECT_TRUE(desc.root_instance().child_mappings().contains("node_top"));
+    EXPECT_FALSE(desc.root_instance().child_mappings().contains("group"));
+
+    // And the surviving host is at host_id 0.
+    EXPECT_EQ(collect_root_host_ids(desc), (std::vector<uint32_t>{0}));
+
+    // Round-trip the reduced descriptor — must still load cleanly.
+    EXPECT_NO_THROW({ CablingGenerator reloaded(cabling_out, deployment_out); });
+}
+
+}  // namespace tt::scaleout_tools

--- a/tools/tests/scaleout/test_host_removal.cpp
+++ b/tools/tests/scaleout/test_host_removal.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <filesystem>
 #include <fstream>
+#include <stdexcept>
 #include <google/protobuf/text_format.h>
 
 #include <cabling_generator/cabling_generator.hpp>
@@ -29,10 +30,8 @@ protected:
         ofs << content;
     }
 
-    // Builds a flat single-template cabling descriptor where the hostnames are used as both
-    // the graph `children.name` and the deployment `host:` field. `connections` is a list of
-    // (from_name, to_name, tray_a, port_a, tray_b, port_b) tuples expressed as
-    // `internal_connections` of type QSFP_DD.
+    // Builds a flat single-template cabling descriptor using hostnames as both the graph
+    // `children.name` and the deployment `host:` field, with optional QSFP_DD connections.
     struct Conn {
         std::string from;
         std::string to;
@@ -365,10 +364,8 @@ TEST_F(HostRemovalTest, IdempotentDoubleRemove) {
     EXPECT_EQ(gen.get_deployment_hosts().size(), 2u);
 }
 
-// chip_connections_ must be regenerated (not stale) after removal. We can't easily assert
-// an exact post-removal count because chip_connections includes intra-node inter-board
-// connections too, but we can verify (a) it shrinks and (b) no surviving entry references
-// the removed host_id.
+// chip_connections_ must be regenerated after removal: it should shrink and no surviving entry
+// may reference a host_id that's no longer in the cluster.
 TEST_F(HostRemovalTest, ChipConnectionsShrinkAfterRemoval) {
     const std::string dir = create_test_dir("chip_connections_shrink");
     const std::vector<std::string> hosts = {"node_a", "node_b", "node_c"};
@@ -448,9 +445,8 @@ TEST_F(HostRemovalTest, RemoveEmptyHostnameIsNoOp) {
     EXPECT_EQ(gen.get_deployment_hosts().size(), 2u);
 }
 
-// Invariant: deployment_hosts_ ordering matches DFS host_id order after removal.
-// (We construct a fresh generator on the emitted output and verify deployment.hosts(i).host()
-// matches the cabling's child whose host_id == i.)
+// deployment_hosts_ ordering must match DFS host_id order after removal (deployment.hosts(i)
+// corresponds to the cabling child with host_id == i).
 TEST_F(HostRemovalTest, DeploymentOrderingMatchesDfsHostIds) {
     const std::string dir = create_test_dir("deployment_ordering_dfs");
     const std::vector<std::string> hosts = {"node_a", "node_b", "node_c", "node_d", "node_e"};
@@ -482,11 +478,11 @@ TEST_F(HostRemovalTest, DeploymentOrderingMatchesDfsHostIds) {
     }
 }
 
-// Nested case: removing the only leaf of a sub_instance collapses it out of the parent.
+// Removing the only leaf of a sub_instance collapses it out of the parent.
 TEST_F(HostRemovalTest, RemoveLastNodeInSubgraphCollapsesIt) {
     const std::string dir = create_test_dir("remove_last_node_collapses_subgraph");
-    // Two templates: `outer` has child `group` (graph_ref) + sibling leaf `node_top`,
-    // and `group` has one leaf `node_inner`. Removing `node_inner` should collapse `group`.
+    // `outer` holds leaf `node_top` + subgraph `group`; `group` holds one leaf `node_inner`.
+    // Removing `node_inner` should collapse `group`.
     write_textproto(
         dir + "cabling.textproto",
         R"(
@@ -541,6 +537,55 @@ root_instance {
 
     // Round-trip the reduced descriptor — must still load cleanly.
     EXPECT_NO_THROW({ CablingGenerator reloaded(cabling_out, deployment_out); });
+}
+
+// In 16_n300_lb_cluster, nodes inside sub-instances are wired at the cluster level, so removing
+// one is the unsupported cross-level case and must throw rather than corrupt cabling on renumber.
+// host_id 0 (deployment host "metal-wh-18") maps to superpod1/node1, which is wired to
+// superpod3/node1 at the cluster level.
+TEST_F(HostRemovalTest, RemoveHostWithCrossLevelConnectionThrows) {
+    CablingGenerator gen(
+        "tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto",
+        "tools/tests/scaleout/deployment_descriptors/16_lb_deployment.textproto");
+
+    ASSERT_EQ(gen.get_deployment_hosts().size(), 16u);
+    const std::string cross_level_host = gen.get_deployment_hosts().front().hostname;  // host_id 0
+    EXPECT_THROW(gen.remove_host(cross_level_host), std::runtime_error);
+    // Throw happens before any mutation, so the cluster is unchanged.
+    EXPECT_EQ(gen.get_deployment_hosts().size(), 16u);
+}
+
+// Real-descriptor path: 4x_bh_quietbox uses child names ("qb-0N") that differ from deployment
+// hostnames ("sjc1-tt-qb-0N"). Removing by hostname must resolve to the host_id the tool
+// associates with that deployment slot and drop the node + deployment entry together, keeping
+// cabling and deployment consistent (the pre-fix bug left the deployment untrimmed / mismatched).
+TEST_F(HostRemovalTest, RemoveByHostnameWhenNamesDifferFromHostnames) {
+    CablingGenerator gen(
+        "tests/scale_out/4x_bh_quietbox/cabling_descriptors/4x_bh_quietbox.textproto",
+        "tests/scale_out/4x_bh_quietbox/deployment_descriptors/4x_bh_qb_p150_deployment.textproto");
+    ASSERT_EQ(gen.get_deployment_hosts().size(), 4u);
+
+    gen.remove_host("sjc1-tt-qb-02");
+
+    const std::string dir = create_test_dir("remove_by_real_hostname");
+    auto [cabling_out, deployment_out] = emit_pair(gen, dir);
+    auto cabling_desc = load_cluster(cabling_out);
+    auto deployment_desc = load_deployment(deployment_out);
+
+    // Cabling and deployment must both shrink to 3 in lockstep and stay contiguous 0..2. (Before
+    // the fix, removing by hostname left the cabling at 3 nodes but the deployment at 4 hosts.)
+    EXPECT_EQ(cabling_desc.root_instance().child_mappings().size(), 3u);
+    EXPECT_EQ(collect_root_host_ids(cabling_desc), (std::vector<uint32_t>{0, 1, 2}));
+
+    const auto names = hostnames_in_deployment(deployment_desc);
+    EXPECT_EQ(names.size(), 3u);
+    EXPECT_EQ(std::count(names.begin(), names.end(), "sjc1-tt-qb-02"), 0);
+
+    // Emitted pair must reload cleanly with 3 hosts.
+    EXPECT_NO_THROW({
+        CablingGenerator reloaded(cabling_out, deployment_out);
+        EXPECT_EQ(reloaded.get_deployment_hosts().size(), 3u);
+    });
 }
 
 }  // namespace tt::scaleout_tools


### PR DESCRIPTION
### Summary
- Adds `CablingGenerator::remove_host` / `remove_hosts`, a `--remove-hosts <csv>` flag on `run_cabling_generator`, and a `remove_hosts.py` wrapper, so a decommissioned/relocated host can be dropped from a cabling + deployment pair without hand-editing the textprotos.
- A hostname is resolved to its `host_id` via the deployment (cabling child names are independent labels), then removal drops the node, scrubs every `internal_connection` touching that `host_id`, collapses any emptied sub-instance, renumbers remaining `host_id`s to `0..N-1`, resets port marks, and regenerates `chip_connections_`. Unknown hostnames warn-and-no-op.
- Cross-level (hierarchical) removal is unsupported and throws before mutating, rather than leaving stale endpoints. Closes #<issue-number>.

### Notes for reviewers
- Core logic is `remove_host_id_from_resolved_graph` (recursive scrub + subgraph collapse) + `finalize_after_removal`; `remove_hosts` resolves all hostnames and checks the guard up front, then mutates and finalizes once (batch is single-pass, all-or-nothing). Existing helpers (`reassign_host_ids_dfs`, `rebuild_deployment_hosts_in_dfs_order`, `recreate_nodes_from_templates`, `generate_logical_chip_connections`) do the heavy lifting.
- 16 tests in `test_host_removal.cpp` cover leaf/multi/first/last removal, dropped connections, renumbering, idempotent + sequential removes, chip-connection refresh, deployment ↔ host_id ordering, empty/unknown hostnames, subgraph collapse, emit→reload round-trip, the cross-level guard (`16_n300_lb_cluster`), and removal by real hostname when names differ (`4x_bh_quietbox`). Scaleout suites pass: 16 + 29 merger + 11 host_id + 12 fsd = 68.
- Out of scope: identifying hosts by `host_id`/physical location, and hierarchical removal — both build on the hostname-resolution path.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/descs_remove_hosts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/descs_remove_hosts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/descs_remove_hosts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/descs_remove_hosts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/descs_remove_hosts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/descs_remove_hosts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/descs_remove_hosts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/descs_remove_hosts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/descs_remove_hosts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/descs_remove_hosts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/descs_remove_hosts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/descs_remove_hosts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/descs_remove_hosts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/descs_remove_hosts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/descs_remove_hosts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/descs_remove_hosts)