### PR TITLE
#43062: adjust bert bias to right shape

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/bert_encoder.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_encoder.py
@@ -40,7 +40,7 @@ class TtBertEncoder:
             )
             attention_output_bias_path = str(
                 f"{tt_cache_path}/"
-                f"{attn_layer_name}.dense.bias_{self.model_config['OP7_SELFOUT_BIAS_DTYPE'].name}.tensorbin"
+                f"{attn_layer_name}.dense.bias_{self.model_config['OP7_SELFOUT_BIAS_DTYPE'].name}_v2.tensorbin"
             )
             mha_gamma_path = str(
                 f"{tt_cache_path}/"

--- a/models/demos/metal_BERT_large_11/tt/bert_encoder.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_encoder.py
@@ -40,7 +40,7 @@ class TtBertEncoder:
             )
             attention_output_bias_path = str(
                 f"{tt_cache_path}/"
-                f"{attn_layer_name}.dense.bias_{self.model_config['OP7_SELFOUT_BIAS_DTYPE'].name}_v2.tensorbin"
+                f"{attn_layer_name}.dense.bias_{self.model_config['OP7_SELFOUT_BIAS_DTYPE'].name}.tensorbin"
             )
             mha_gamma_path = str(
                 f"{tt_cache_path}/"
@@ -120,7 +120,7 @@ class TtBertEncoder:
             mem_config=model_config["OP7_SELFOUT_WEIGHTS_MEMCFG"],
         )
         self.attention_output_bias = load_or_compute_and_cache(
-            attention_output_bias_path,
+            None,
             compute_attention_output_bias,
             device=device,
             mem_config=model_config["OP7_SELFOUT_BIAS_MEMCFG"],

--- a/models/demos/metal_BERT_large_11/tt/bert_encoder.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_encoder.py
@@ -74,7 +74,7 @@ class TtBertEncoder:
             )
 
         def compute_attention_output_bias():
-            bias_torch = pad_weight(state_dict[f"{attn_layer_name}.dense.bias"])
+            bias_torch = state_dict[f"{attn_layer_name}.dense.bias"].reshape(1, 1, 1, -1)
             return ttnn.from_torch(
                 bias_torch,
                 model_config["OP7_SELFOUT_BIAS_DTYPE"],

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -106,14 +106,14 @@ class TtFeedForwardModel:
                 f"{encoder_ff1_str}.weight_{model_config['OP9_FF1_MM_WEIGHTS_DTYPE'].name}.tensorbin"
             )
             ff1_bias_path = str(
-                f"{tt_cache_path}/" f"{encoder_ff1_str}.bias_{model_config['OP9_FF1_MM_BIAS_DTYPE'].name}.tensorbin"
+                f"{tt_cache_path}/" f"{encoder_ff1_str}.bias_{model_config['OP9_FF1_MM_BIAS_DTYPE'].name}_v2.tensorbin"
             )
             ff2_weight_path = str(
                 f"{tt_cache_path}/"
                 f"{encoder_ff2_str}.weight_{model_config['OP10_FF2_MM_WEIGHTS_DTYPE'].name}.tensorbin"
             )
             ff2_bias_path = str(
-                f"{tt_cache_path}/" f"{encoder_ff2_str}.bias_{model_config['OP10_FF2_MM_BIAS_DTYPE'].name}.tensorbin"
+                f"{tt_cache_path}/" f"{encoder_ff2_str}.bias_{model_config['OP10_FF2_MM_BIAS_DTYPE'].name}_v2.tensorbin"
             )
 
         def compute_ff1_weight():

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -131,7 +131,7 @@ class TtFeedForwardModel:
             )
 
         def compute_ff1_bias():
-            ff1_bias_torch = pad_weight(state_dict[f"{encoder_ff1_str}.bias"])
+            ff1_bias_torch = state_dict[f"{encoder_ff1_str}.bias"].reshape(1, 1, 1, -1)
             return ttnn.from_torch(
                 ff1_bias_torch,
                 dtype=model_config["OP9_FF1_MM_BIAS_DTYPE"],
@@ -153,7 +153,7 @@ class TtFeedForwardModel:
             )
 
         def compute_ff2_bias():
-            ff2_bias_torch = pad_weight(state_dict[f"{encoder_ff2_str}.bias"])
+            ff2_bias_torch = state_dict[f"{encoder_ff2_str}.bias"].reshape(1, 1, 1, -1)
             return ttnn.from_torch(
                 ff2_bias_torch,
                 dtype=model_config["OP10_FF2_MM_BIAS_DTYPE"],

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -106,14 +106,14 @@ class TtFeedForwardModel:
                 f"{encoder_ff1_str}.weight_{model_config['OP9_FF1_MM_WEIGHTS_DTYPE'].name}.tensorbin"
             )
             ff1_bias_path = str(
-                f"{tt_cache_path}/" f"{encoder_ff1_str}.bias_{model_config['OP9_FF1_MM_BIAS_DTYPE'].name}_v2.tensorbin"
+                f"{tt_cache_path}/" f"{encoder_ff1_str}.bias_{model_config['OP9_FF1_MM_BIAS_DTYPE'].name}.tensorbin"
             )
             ff2_weight_path = str(
                 f"{tt_cache_path}/"
                 f"{encoder_ff2_str}.weight_{model_config['OP10_FF2_MM_WEIGHTS_DTYPE'].name}.tensorbin"
             )
             ff2_bias_path = str(
-                f"{tt_cache_path}/" f"{encoder_ff2_str}.bias_{model_config['OP10_FF2_MM_BIAS_DTYPE'].name}_v2.tensorbin"
+                f"{tt_cache_path}/" f"{encoder_ff2_str}.bias_{model_config['OP10_FF2_MM_BIAS_DTYPE'].name}.tensorbin"
             )
 
         def compute_ff1_weight():
@@ -167,7 +167,7 @@ class TtFeedForwardModel:
             mem_config=model_config["OP9_FF1_MM_WEIGHTS_MEMCFG"],
         )
         encoder0_ff1_bias = load_or_compute_and_cache(
-            ff1_bias_path,
+            None,
             compute_ff1_bias,
             device=device,
             mem_config=model_config["OP9_FF1_MM_BIAS_MEMCFG"],
@@ -179,7 +179,7 @@ class TtFeedForwardModel:
             mem_config=model_config["OP10_FF2_MM_WEIGHTS_MEMCFG"],
         )
         encoder0_ff2_bias = load_or_compute_and_cache(
-            ff2_bias_path,
+            None,
             compute_ff2_bias,
             device=device,
             mem_config=model_config["OP10_FF2_MM_BIAS_MEMCFG"],

--- a/models/demos/metal_BERT_large_11/tt/mha.py
+++ b/models/demos/metal_BERT_large_11/tt/mha.py
@@ -191,7 +191,7 @@ class TtMultiHeadAttentionModel:
             )
             qkv_bias_cache_path = str(
                 f"{tt_cache_path}/"
-                f"{layer_name}.qkv.bias_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_BIAS_DTYPE'].name}.tensorbin"
+                f"{layer_name}.qkv.bias_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_BIAS_DTYPE'].name}_v2.tensorbin"
             )
 
         def compute_qkv_weight():

--- a/models/demos/metal_BERT_large_11/tt/mha.py
+++ b/models/demos/metal_BERT_large_11/tt/mha.py
@@ -234,7 +234,7 @@ class TtMultiHeadAttentionModel:
             else:
                 qkv_bias_torch = torch.cat((qb, kb, vb), -1)
 
-            qkv_bias_torch = pad_weight(qkv_bias_torch)
+            qkv_bias_torch = qkv_bias_torch.reshape(1, 1, 1, -1)
 
             return ttnn.from_torch(
                 qkv_bias_torch,

--- a/models/demos/metal_BERT_large_11/tt/mha.py
+++ b/models/demos/metal_BERT_large_11/tt/mha.py
@@ -191,7 +191,7 @@ class TtMultiHeadAttentionModel:
             )
             qkv_bias_cache_path = str(
                 f"{tt_cache_path}/"
-                f"{layer_name}.qkv.bias_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_BIAS_DTYPE'].name}_v2.tensorbin"
+                f"{layer_name}.qkv.bias_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_BIAS_DTYPE'].name}.tensorbin"
             )
 
         def compute_qkv_weight():
@@ -250,7 +250,7 @@ class TtMultiHeadAttentionModel:
         )
 
         qkv_bias = load_or_compute_and_cache(
-            qkv_bias_cache_path,
+            None,
             compute_qkv_bias,
             device=device,
             mem_config=model_config["OP1_FUSED_QKV_MM_BIAS_MEMCFG"],


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #43062 

There were recent fixes to how matmul/linear deals with bias. Stricter requirements are now put on the bias input.

One of the models tests padded the bias and that failed the checks.

The fix is to reshape instead of pad.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-43062_bert_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-43062_bert_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-43062_bert_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-43062_bert_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-43062_bert_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-43062_bert_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-43062_bert_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-43062_bert_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-43062_bert_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-43062_bert_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-43062_bert_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-43062_bert_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-43062_bert_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-43062_bert_bias)