### PR TITLE
Fix assert_numeric_metrics to print all applicable stats when any one of them fails

### DIFF
--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -667,6 +667,7 @@ def assert_numeric_metrics(
     check_frobenius=True,
     check_pcc=True,
     check_ulp=False,
+    assert_on_fail=True,
 ):
     """
     Run one or more numeric similarity checks between a golden tensor and an actual tensor.
@@ -674,6 +675,9 @@ def assert_numeric_metrics(
     Intended for TTNN tests that compare PyTorch reference output against device or CPU
     round-trip results. Individual checks can be disabled when a metric does not apply
     (for example, skip Frobenius for degenerate or non-finite cases).
+
+    This enhanced version evaluates ALL enabled metrics before asserting, providing
+    comprehensive debugging information even when multiple metrics fail.
 
     Args:
         expected_result (Union[ttnn.Tensor, torch.Tensor]): Reference (golden) tensor.
@@ -688,34 +692,107 @@ def assert_numeric_metrics(
         check_frobenius (bool, optional): If True, run relative Frobenius check. Defaults to True.
         check_pcc (bool, optional): If True, run PCC when the tensor has more than one element. Defaults to True.
         check_ulp (bool, optional): If True, run ULP comparison (non-finite mismatches fail). Defaults to False.
+        assert_on_fail (bool, optional): If True, assert when any check fails. If False, return (passed, message) tuple.
+            Defaults to True for backward compatibility.
 
     Returns:
-        None
+        None if assert_on_fail=True (default behavior)
+        (bool, str) tuple if assert_on_fail=False: (all_checks_passed, detailed_message)
 
     Raises:
-        AssertionError: If any enabled check fails (shape mismatch, tolerance exceeded, or PCC/ULP below threshold).
+        AssertionError: If assert_on_fail=True and any enabled check fails (shape mismatch, tolerance exceeded, or PCC/ULP below threshold).
 
     Notes:
         - PCC is skipped when ``torch.numel(expected_result) == 1`` because correlation is undefined for a scalar.
         - Allclose and Frobenius use helpers that normalize ``ttnn.Tensor`` inputs to PyTorch tensors.
+        - All enabled metrics are evaluated before asserting, allowing comprehensive debugging.
     """
+    # Normalize tensors
+    expected_result = _normalize_tensor(expected_result)
+    actual_result = _normalize_tensor(actual_result)
+
+    # Validate shapes
+    assert list(expected_result.shape) == list(
+        actual_result.shape
+    ), f"Shape mismatch: expected {list(expected_result.shape)} vs actual {list(actual_result.shape)}"
+
     # Align dtypes first so all downstream numeric checks compare values in the same precision.
     if expected_result.dtype != actual_result.dtype:
         actual_result = actual_result.type(expected_result.dtype)
 
-    # Element-wise tolerance check (absolute + relative).
+    # Collect all metric results
+    overall_passed = True
+    messages = []
+    num_checks_enabled = 0
+    num_checks_passed = 0
+
+    # Check 1: Element-wise tolerance check (absolute + relative).
     if check_allclose:
-        assert_allclose(expected_result, actual_result, rtol=rtol, atol=atol)
+        num_checks_enabled += 1
+        passed, message = comp_allclose(expected_result, actual_result, rtol, atol)
+        if passed:
+            num_checks_passed += 1
+            messages.append(f"[ALLCLOSE PASSED] {message}")
+        else:
+            messages.append(f"[ALLCLOSE FAILED] {message}")
+        overall_passed &= passed
 
-    # Global error-magnitude check using relative Frobenius norm.
+    # Check 2: Global error-magnitude check using relative Frobenius norm.
     if check_frobenius:
-        assert_relative_frobenius(expected_result, actual_result, threshold=frobenius_threshold)
+        num_checks_enabled += 1
+        rel_frob, is_zero = comp_relative_frobenius(expected_result, actual_result)
+        passed = rel_frob <= frobenius_threshold
+        if passed:
+            num_checks_passed += 1
+            prefix = "[FROBENIUS PASSED]"
+        else:
+            prefix = "[FROBENIUS FAILED]"
 
-    # PCC is undefined/degenerate for scalars, so only run it for tensors with more than one element.
-    if check_pcc and torch.numel(expected_result) != 1:
-        passing_pcc, pcc_message = comp_pcc(expected_result, actual_result, pcc_threshold)
-        assert passing_pcc, f"pcc={pcc_message}"
+        if is_zero:
+            message = f"Expected norm is 0. Absolute error {rel_frob:.6e} {'<=' if passed else '>'} threshold {frobenius_threshold}"
+        else:
+            message = (
+                f"Relative Frobenius norm {rel_frob:.6e} {'<=' if passed else '>'} threshold {frobenius_threshold}"
+            )
+        messages.append(f"{prefix} {message}")
+        overall_passed &= passed
 
-    # ULP-based comparison is stricter for floating-point representation differences.
+    # Check 3: PCC is undefined/degenerate for scalars, so only run it for tensors with more than one element.
+    if check_pcc:
+        if torch.numel(expected_result) == 1:
+            messages.append("[PCC SKIPPED] PCC undefined for scalar tensors")
+        else:
+            num_checks_enabled += 1
+            passed, pcc_value = comp_pcc(expected_result, actual_result, pcc_threshold)
+            if passed:
+                num_checks_passed += 1
+                messages.append(f"[PCC PASSED] PCC={pcc_value:.6f} >= threshold {pcc_threshold}")
+            else:
+                messages.append(f"[PCC FAILED] PCC={pcc_value:.6f} < threshold {pcc_threshold}")
+            overall_passed &= passed
+
+    # Check 4: ULP-based comparison is stricter for floating-point representation differences.
     if check_ulp:
-        assert_with_ulp(expected_result, actual_result, ulp_threshold=ulp_threshold, allow_nonfinite=False)
+        num_checks_enabled += 1
+        passed, message = comp_ulp(expected_result, actual_result, ulp_threshold, allow_nonfinite=False)
+        if passed:
+            num_checks_passed += 1
+            messages.append(f"[ULP PASSED] {message}")
+        else:
+            messages.append(f"[ULP FAILED] {message}")
+        overall_passed &= passed
+
+    # Build final message
+    if num_checks_enabled == 0:
+        full_message = "No checks enabled"
+    else:
+        header = f"Numeric metrics: {num_checks_passed}/{num_checks_enabled} checks passed"
+        if not overall_passed:
+            header = f"Numeric metrics comparison failed: {num_checks_passed}/{num_checks_enabled} checks passed"
+        full_message = header + "\n" + "\n".join(messages)
+
+    # Return or assert based on flag
+    if assert_on_fail:
+        assert overall_passed, full_message
+    else:
+        return overall_passed, full_message

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -734,12 +734,14 @@ def assert_numeric_metrics(
     if check_allclose:
         num_checks_enabled += 1
         passed, message = comp_allclose(expected_result, actual_result, rtol, atol)
+        # Convert to Python boolean if it's a tensor
+        passed = bool(passed.item() if hasattr(passed, "item") else passed)
         if passed:
             num_checks_passed += 1
             messages.append(f"[ALLCLOSE PASSED] {message}")
         else:
             messages.append(f"[ALLCLOSE FAILED] {message}")
-        overall_passed &= passed
+        overall_passed = overall_passed and passed
 
     # Check 2: Global error-magnitude check using relative Frobenius norm.
     if check_frobenius:
@@ -759,7 +761,7 @@ def assert_numeric_metrics(
                 f"Relative Frobenius norm {rel_frob:.6e} {'<=' if passed else '>'} threshold {frobenius_threshold}"
             )
         messages.append(f"{prefix} {message}")
-        overall_passed &= passed
+        overall_passed = overall_passed and passed
 
     # Check 3: PCC is undefined/degenerate for scalars, so only run it for tensors with more than one element.
     if check_pcc:
@@ -768,23 +770,27 @@ def assert_numeric_metrics(
         else:
             num_checks_enabled += 1
             passed, pcc_value = comp_pcc(expected_result, actual_result, pcc_threshold)
+            # Convert to Python boolean if it's a tensor
+            passed = bool(passed.item() if hasattr(passed, "item") else passed)
             if passed:
                 num_checks_passed += 1
                 messages.append(f"[PCC PASSED] PCC={pcc_value:.6f} >= threshold {pcc_threshold}")
             else:
                 messages.append(f"[PCC FAILED] PCC={pcc_value:.6f} < threshold {pcc_threshold}")
-            overall_passed &= passed
+            overall_passed = overall_passed and passed
 
     # Check 4: ULP-based comparison is stricter for floating-point representation differences.
     if check_ulp:
         num_checks_enabled += 1
         passed, message = comp_ulp(expected_result, actual_result, ulp_threshold, allow_nonfinite=False)
+        # Convert to Python boolean if it's a tensor
+        passed = bool(passed.item() if hasattr(passed, "item") else passed)
         if passed:
             num_checks_passed += 1
             messages.append(f"[ULP PASSED] {message}")
         else:
             messages.append(f"[ULP FAILED] {message}")
-        overall_passed &= passed
+        overall_passed = overall_passed and passed
 
     # Build final message
     if num_checks_enabled == 0:

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -788,13 +788,14 @@ def assert_numeric_metrics(
 
     # Build final message
     if num_checks_enabled == 0:
-        full_message = "No checks enabled"
+        header = "No checks enabled"
     else:
         header = f"Numeric metrics: {num_checks_passed}/{num_checks_enabled} checks passed"
         if not overall_passed:
             header = f"Numeric metrics comparison failed: {num_checks_passed}/{num_checks_enabled} checks passed"
-        full_message = header + "\n" + "\n".join(messages)
 
+    details = "\n".join(messages)
+    full_message = header if not details else header + "\n" + details
     # Return or assert based on flag
     if assert_on_fail:
         assert overall_passed, full_message

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -693,7 +693,7 @@ def assert_numeric_metrics(
         check_pcc (bool, optional): If True, run PCC when the tensor has more than one element. Defaults to True.
         check_ulp (bool, optional): If True, run ULP comparison (non-finite mismatches fail). Defaults to False.
         assert_on_fail (bool, optional): If True, assert when any check fails. If False, return (passed, message) tuple.
-            Defaults to True for backward compatibility.
+            Defaults to True.
 
     Returns:
         None if assert_on_fail=True (default behavior)

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -712,9 +712,13 @@ def assert_numeric_metrics(
     actual_result = _normalize_tensor(actual_result)
 
     # Validate shapes
-    assert list(expected_result.shape) == list(
-        actual_result.shape
-    ), f"Shape mismatch: expected {list(expected_result.shape)} vs actual {list(actual_result.shape)}"
+    expected_shape = list(expected_result.shape)
+    actual_shape = list(actual_result.shape)
+    if expected_shape != actual_shape:
+        message = f"Shape mismatch: expected {expected_shape} vs actual {actual_shape}"
+        if assert_on_fail:
+            raise AssertionError(message)
+        return False, message
 
     # Align dtypes first so all downstream numeric checks compare values in the same precision.
     if expected_result.dtype != actual_result.dtype:


### PR DESCRIPTION
## Summary
- Fixes #42975 by improving `assert_numeric_metrics` to evaluate and report ALL applicable metrics before asserting
- Previously, the function would fail on the first assertion, leaving developers without visibility into other potentially failing metrics
- Added optional `assert_on_fail` parameter to support non-asserting mode

## Problem
`assert_numeric_metrics` in `tests/ttnn/utils_for_testing.py` was failing on the first assert and not evaluating/printing other metrics. This made analyzing failures difficult, especially for AI-assisted debugging, as only the first failing metric was visible.

## Solution  
Refactored the function following the pattern of `comp_allclose_and_pcc` to:
1. Collect all metric results before asserting
2. Build a comprehensive error message showing ALL metrics with their pass/fail status
3. Add optional `assert_on_fail` parameter (defaults to `True` for backward compatibility)

## Key Changes
- All enabled metrics are now evaluated before asserting
- Clear `[PASSED/FAILED/SKIPPED]` status for each metric  
- Added `assert_on_fail` parameter to optionally return `(bool, message)` tuple instead of asserting
- Comprehensive error messages show all metric results with thresholds
- PCC properly skipped for scalar tensors with clear message

## Example Output
```
Numeric metrics comparison failed: 2/4 checks passed
[ALLCLOSE FAILED] Max ATOL Delta: 1.234e-03, Max RTOL Delta: 2.345e-02
[FROBENIUS PASSED] Relative Frobenius norm 8.765e-03 <= threshold 0.01
[PCC FAILED] PCC=0.997234 < threshold 0.999
[ULP PASSED] Max ULP Delta: 8.5
```

## Backward Compatibility
✅ Fully backward compatible - the default `assert_on_fail=True` ensures all 457+ existing calls across 59 test files continue to work unchanged.

## Testing
Created comprehensive test suite verifying:
- All metrics are evaluated even when some fail
- Non-asserting mode returns proper tuple
- PCC is properly skipped for scalar tensors
- Mixed pass/fail results are correctly reported
- Backward compatibility is maintained

## Benefits
- **Better debugging**: See all failing metrics at once instead of one at a time
- **AI-friendly**: Provides complete context for automated analysis
- **Flexible**: New non-asserting mode allows custom error handling
- **No breaking changes**: Existing tests continue to work unchanged

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/assert-numeric-metrics-all-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/assert-numeric-metrics-all-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/assert-numeric-metrics-all-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/assert-numeric-metrics-all-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/assert-numeric-metrics-all-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/assert-numeric-metrics-all-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/assert-numeric-metrics-all-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/assert-numeric-metrics-all-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/assert-numeric-metrics-all-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/assert-numeric-metrics-all-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/assert-numeric-metrics-all-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/assert-numeric-metrics-all-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/assert-numeric-metrics-all-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/assert-numeric-metrics-all-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/assert-numeric-metrics-all-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/assert-numeric-metrics-all-stats)