### PR TITLE
[skip ci] Fix wheels.yaml: use github.sha instead of github.ref for hermetic builds

### DIFF
--- a/.github/workflows/ttnn-run-model-trace.yaml
+++ b/.github/workflows/ttnn-run-model-trace.yaml
@@ -607,7 +607,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           submodules: recursive
           ref: ${{ inputs.ref || github.sha }}
-          fetch-depth: ${{ (startsWith(inputs.ref || github.sha, 'refs/tags/')) && 1 || 500 }}
+          fetch-depth: ${{ (startsWith(inputs.ref, 'refs/tags/') || startsWith(github.ref, 'refs/tags/')) && 1 || 500 }}
           fetch-tags: true # Need tags for `git describe`
 
       - name: 📦 Restore CPM source cache

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -72,8 +72,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: ${{ (startsWith(inputs.ref || github.ref, 'refs/tags/')) && 1 || 500 }}
+          ref: ${{ inputs.ref || github.sha }}
+          fetch-depth: ${{ (startsWith(inputs.ref || github.sha, 'refs/tags/')) && 1 || 500 }}
           fetch-tags: true # Need tags for `git describe`
 
       - name: 📦 Restore CPM source cache


### PR DESCRIPTION
The wheel build job checked out `github.ref` (refs/heads/main) rather than `github.sha`. For push-to-main runs, this is a moving branch pointer. If a second commit lands on main before the wheel build job starts, git resolves refs/heads/main to the newer commit's SHA, producing a wheel built from commit N+1 but uploaded under commit N's artifact name.

This caused two confirmed push-to-main failures where the installed wheel contained headers from a newer commit while test jobs checked out the original commit's source, causing hard JIT compilation errors:
- SPLIT_DISPATCH_PAGE_PREAMBLE_SIZE (runs 24806484937)
- reduce_tile_math template deduction failure (run 24882661426)

Fix: use `github.sha` (pinned) instead of `github.ref` (moving), matching the pattern already used correctly in build-artifact.yaml.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afuller/hermetic-pipelines)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afuller/hermetic-pipelines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=afuller/hermetic-pipelines)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:afuller/hermetic-pipelines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afuller/hermetic-pipelines)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afuller/hermetic-pipelines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afuller/hermetic-pipelines)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afuller/hermetic-pipelines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afuller/hermetic-pipelines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afuller/hermetic-pipelines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afuller/hermetic-pipelines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afuller/hermetic-pipelines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afuller/hermetic-pipelines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afuller/hermetic-pipelines)