### PR TITLE
Add wan2.2 solver on device

### DIFF
--- a/models/tt_dit/encoders/t5/model_t5.py
+++ b/models/tt_dit/encoders/t5/model_t5.py
@@ -108,7 +108,7 @@ class T5Encoder(Module):
     @traced_function(device=lambda self: self.mesh_device, clone_prep_inputs=False, prep_run=False)
     def forward(
         self, prompt: ttnn.Tensor, *, attention_mask: ttnn.Tensor | None = None, zero_masking: bool = False
-    ) -> ttnn.Tensor:
+    ) -> list[ttnn.Tensor]:
         embeddings = self.token_embeddings(prompt)
         hidden_states = self.encoder(embeddings, attention_mask=attention_mask)
         output = self.final_layer_norm(hidden_states[-1])

--- a/models/tt_dit/encoders/t5/model_t5.py
+++ b/models/tt_dit/encoders/t5/model_t5.py
@@ -15,6 +15,7 @@ from ...layers.normalization import RMSNorm
 from ...parallel.config import EncoderParallelConfig
 from ...parallel.manager import CCLManager
 from ...utils.substate import pop_substate, rename_substate
+from ...utils.tracing import traced_function
 
 
 # Make this a dataclass. Also consider using HF config directly.
@@ -104,10 +105,15 @@ class T5Encoder(Module):
         rename_substate(state, "encoder.final_layer_norm", "final_layer_norm")
         pop_substate(state, "shared")
 
-    def forward(self, prompt: ttnn.Tensor, *, attention_mask: ttnn.Tensor | None = None) -> ttnn.Tensor:
+    @traced_function(device=lambda self: self.mesh_device, clone_prep_inputs=False, prep_run=False)
+    def forward(
+        self, prompt: ttnn.Tensor, *, attention_mask: ttnn.Tensor | None = None, zero_masking: bool = False
+    ) -> ttnn.Tensor:
         embeddings = self.token_embeddings(prompt)
         hidden_states = self.encoder(embeddings, attention_mask=attention_mask)
         output = self.final_layer_norm(hidden_states[-1])
+        if zero_masking and attention_mask is not None:
+            output = output * ttnn.unsqueeze(attention_mask, -1)
         hidden_states.append(output)
         return hidden_states
 

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -266,7 +266,7 @@ class WanTransformer3DModel(Module):
         parallel_config: DiTParallelConfig,
         is_fsdp: bool = True,
         model_type: str = "t2v",
-        output_dtype: torch.dtype = ttnn.float32,
+        output_dtype: ttnn.DataType = ttnn.float32,
     ) -> None:
         super().__init__()
 
@@ -675,7 +675,14 @@ class WanTransformer3DModel(Module):
             return cond
 
         uncond = self.inner_step(
-            spatial_1BNI, negative_prompt_1BLP, rope_cos_1HND, rope_sin_1HND, trans_mat, N, timestep
+            spatial_1BNI,
+            negative_prompt_1BLP,
+            rope_cos_1HND,
+            rope_sin_1HND,
+            trans_mat,
+            N,
+            timestep,
+            gather_output=gather_output,
         )
 
         combined = ttnn.lerp(uncond, cond, guidance_scale)

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -266,6 +266,7 @@ class WanTransformer3DModel(Module):
         parallel_config: DiTParallelConfig,
         is_fsdp: bool = True,
         model_type: str = "t2v",
+        output_dtype: torch.dtype = ttnn.float32,
     ) -> None:
         super().__init__()
 
@@ -276,6 +277,7 @@ class WanTransformer3DModel(Module):
         self.fsdp_mesh_axis = self.parallel_config.sequence_parallel.mesh_axis if is_fsdp else None
         self.model_type = model_type
         self.cached_rope_features = {}
+        self.output_dtype = output_dtype
 
         assert model_type in ["t2v", "i2v"], "model_type must be either t2v or i2v"
         if model_type == "i2v":
@@ -591,7 +593,9 @@ class WanTransformer3DModel(Module):
 
         return spatial_out
 
-    def inner_step(self, spatial_1BNI, prompt_1BLP, rope_cos_1HND, rope_sin_1HND, trans_mat, N, timestep):
+    def inner_step(
+        self, spatial_1BNI, prompt_1BLP, rope_cos_1HND, rope_sin_1HND, trans_mat, N, timestep, gather_output=False
+    ):
         """
         Reduced forward function which assumes outer loop has cached certain inputs that are step independent:
             - prompt_1BLP
@@ -629,14 +633,15 @@ class WanTransformer3DModel(Module):
                 spatial_norm_1BND, dim=3, mesh_axis=self.parallel_config.tensor_parallel.mesh_axis
             )
 
-        proj_out_1BNI = self.proj_out(
-            spatial_norm_1BND, compute_kernel_config=self.hifi4_compute_kernel_config, dtype=ttnn.float32
+        spatial_1BNI = self.proj_out(
+            spatial_norm_1BND, compute_kernel_config=self.hifi4_compute_kernel_config, dtype=self.output_dtype
         )
 
         # Gather fp32 spatial output across sequence parallel devices (remains on device)
-        spatial_1BNI = self.ccl_manager.all_gather_persistent_buffer(
-            proj_out_1BNI, dim=2, mesh_axis=self.parallel_config.sequence_parallel.mesh_axis
-        )
+        if gather_output:
+            spatial_1BNI = self.ccl_manager.all_gather_persistent_buffer(
+                spatial_1BNI, dim=2, mesh_axis=self.parallel_config.sequence_parallel.mesh_axis
+            )
 
         return spatial_1BNI
 
@@ -654,6 +659,7 @@ class WanTransformer3DModel(Module):
         trans_mat: ttnn.Tensor,
         timestep: ttnn.Tensor,
         guidance_scale: float,
+        gather_output: bool = False,
     ) -> ttnn.Tensor:
         cond = self.inner_step(
             spatial_1BNI,
@@ -663,6 +669,7 @@ class WanTransformer3DModel(Module):
             trans_mat,
             N,
             timestep,
+            gather_output=gather_output,
         )
         if not do_classifier_free_guidance:
             return cond

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -124,7 +124,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             Number of links to use for CCL operations.
         checkpoint_name (`str`, *optional*, defaults to `"Wan-AI/Wan2.2-T2V-A14B-Diffusers"`):
             HuggingFace Hub repo ID to load model weights from.
-        scheduler (`FlowMatchEulerDiscreteScheduler`, *optional*):
+        scheduler (`UniPCMultistepScheduler`, *optional*):
             Scheduler to use for denoising. Defaults to `UniPCMultistepScheduler` loaded from the checkpoint.
         boundary_ratio (`float`, *optional*, defaults to `0.875`):
             Ratio of total timesteps used as the boundary for switching between the two transformers in two-stage
@@ -769,7 +769,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         latents: Optional[torch.Tensor] = None,
         prompt_embeds: Optional[torch.Tensor] = None,
         negative_prompt_embeds: Optional[torch.Tensor] = None,
-        output_type: Optional[str] = "np",
+        output_type: Optional[str] = "uint8",
         return_dict: bool = True,
         max_sequence_length: int = 512,
         traced: bool = False,

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -170,6 +170,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         target_height: int = 0,
         target_width: int = 0,
         t_chunk_size: int = 0,
+        run_warmup: bool = True,
     ):
         super().__init__()
 
@@ -333,8 +334,13 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             1, self.vae.config.z_dim, 1, 1, 1
         )
 
+        # persistent latent buffers to enable safe tracing.
+        self.latent_buffer = None
+        self.condition_buffer = None
+
         # TODO: Reset buffers for change in resolution. Also reinitialize trace
-        self.warmup_buffers(height=target_height, width=target_width)
+        if run_warmup:
+            self.warmup_buffers(height=target_height, width=target_width)
 
     def prepare_text_conditioning(self, tt_model, prompt_embeds, buffer, traced=False):
         prompt_1BLP = tt_model.prepare_text_conditioning(prompt_embeds)
@@ -344,9 +350,10 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             ttnn.copy(prompt_1BLP, buffer)
         return buffer
 
-    def warmup_buffers(self, height, width):
+    def warmup_buffers(self, height, width, image_prompt=None):
         self.run_single_prompt(
             prompt="warmup",
+            image_prompt=image_prompt,
             height=height,
             width=width,
             num_frames=81,
@@ -704,6 +711,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         """
         Adapter function to enable I2V. For base T2V, just return the latents.
         """
+        if latents.dtype == ttnn.float32:
+            latents = ttnn.typecast(latents, ttnn.bfloat16)
         return latents
 
     def prepare_latents(
@@ -911,6 +920,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         latent_frames, latent_height, latent_width = latents.shape[2], latents.shape[3], latents.shape[4]
         prepared_prompts = [False, False]
 
+        sp_axis = self.transformer_states[0].model.parallel_config.sequence_parallel.mesh_axis
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 warmup_t2 = i == 1 and len(timesteps) == 2  # Ensure transformer_2 is also warmed up
@@ -933,6 +943,16 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
                     if cond_latents is not None:
                         cond_latents, _ = ts.model.preprocess_spatial_input_host(cond_latents)
+                        cond_latents = tensor.from_torch(
+                            cond_latents,
+                            device=self.mesh_device,
+                            mesh_axes=[None, None, sp_axis, None],
+                            dtype=ttnn.bfloat16,
+                        )
+                        if self.condition_buffer is None:
+                            self.condition_buffer = cond_latents
+                        else:
+                            ttnn.copy(cond_latents, self.condition_buffer)
 
                     rope_cos_1HND, rope_sin_1HND, trans_mat = ts.model.get_rope_features(latents)
                     rope_args = {
@@ -941,13 +961,18 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                         "trans_mat": trans_mat,
                     }
 
-                    sp_axis = ts.model.parallel_config.sequence_parallel.mesh_axis
                     permuted_latent_tt = tensor.from_torch(
                         permuted_latent,
                         device=self.mesh_device,
                         mesh_axes=[None, None, sp_axis, None],
-                        dtype=ttnn.float32,
+                        dtype=ts.model.output_dtype,
                     )
+
+                # setup/update latent and condition buffers
+                if self.latent_buffer is None:
+                    self.latent_buffer = permuted_latent_tt
+                else:
+                    ttnn.copy(permuted_latent_tt, self.latent_buffer)
 
                 if self.config.expand_timesteps:
                     # seq_len: num_latent_frames * latent_height//2 * latent_width//2
@@ -957,8 +982,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 else:
                     timestep = t.expand(latents.shape[0])
 
-                permuted_model_input = self.get_model_input(permuted_latent_tt, cond_latents)
-                permuted_model_input = ttnn.typecast(permuted_model_input, ttnn.bfloat16)
+                permuted_model_input = self.get_model_input(self.latent_buffer, self.condition_buffer)
 
                 assert timestep.ndim == 1, "Wan2.2-T2V/I2V requires a 1D timestep tensor"
                 timestep = float32_tensor(
@@ -967,7 +991,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
                 permuted_noise_pred_tt = ts.model.combined_step(
                     do_classifier_free_guidance=self.do_classifier_free_guidance,
-                    spatial_1BNI=permuted_model_input,
+                    spatial_1BNI=ttnn.typecast(permuted_model_input, ttnn.bfloat16),
                     prompt_1BLP=ts.prompt_buffer,
                     negative_prompt_1BLP=ts.negative_prompt_buffer,
                     N=patchified_seqlen,
@@ -980,7 +1004,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
                 permuted_latent_tt = self._solver.step(
                     step=i,
-                    latent=permuted_latent_tt,
+                    latent=self.latent_buffer,
                     velocity_pred=permuted_noise_pred_tt,
                 )
 
@@ -988,7 +1012,6 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         self._current_timestep = None
 
-        sp_axis = ts.model.parallel_config.sequence_parallel.mesh_axis
         permuted_latent_tt = ts.model.ccl_manager.all_gather_persistent_buffer(
             permuted_latent_tt, dim=2, mesh_axis=sp_axis
         )

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -18,7 +18,7 @@ from diffusers.models import AutoencoderKLWan
 from diffusers.models import WanTransformer3DModel as TorchWanTransformer3DModel
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from diffusers.pipelines.wan.pipeline_output import WanPipelineOutput
-from diffusers.schedulers import FlowMatchEulerDiscreteScheduler, UniPCMultistepScheduler
+from diffusers.schedulers import UniPCMultistepScheduler
 from diffusers.video_processor import VideoProcessor
 from loguru import logger
 from transformers import AutoTokenizer, UMT5EncoderModel
@@ -31,10 +31,10 @@ from ...models.transformers.wan2_2.transformer_wan import WanTransformer3DModel
 from ...models.vae.vae_wan2_1 import WanDecoder
 from ...parallel.config import DiTParallelConfig, EncoderParallelConfig, ParallelFactor, VaeHWParallelConfig
 from ...parallel.manager import CCLManager
-from ...utils import cache
+from ...solvers import UniPCSolver
+from ...utils import cache, tensor
 from ...utils.conv3d import conv3d_blocking_hash
 from ...utils.tensor import (
-    bf16_tensor,
     fast_device_to_host,
     float32_tensor,
     float_to_uint8,
@@ -157,7 +157,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         num_links,
         *,
         checkpoint_name: str = "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
-        scheduler: FlowMatchEulerDiscreteScheduler = None,
+        scheduler: UniPCMultistepScheduler = None,
         boundary_ratio: Optional[float] = 0.875,
         expand_timesteps: bool = False,  # Wan2.2 ti2v
         dynamic_load=False,
@@ -182,9 +182,6 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             checkpoint_name, subfolder="text_encoder", trust_remote_code=True
         )
         self.vae = AutoencoderKLWan.from_pretrained(checkpoint_name, subfolder="vae", trust_remote_code=True)
-        self.scheduler = scheduler or UniPCMultistepScheduler.from_pretrained(
-            checkpoint_name, subfolder="scheduler", flow_shift=12.0
-        )
         self.torch_transformer = TorchWanTransformer3DModel.from_pretrained(
             checkpoint_name, subfolder="transformer", trust_remote_code=True
         )
@@ -297,6 +294,11 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             TransformerState(self.transformer, "transformer", self.torch_transformer, guidance_scale=4.0),
             TransformerState(self.transformer_2, "transformer_2", self.torch_transformer_2, guidance_scale=3.0),
         ]
+
+        scheduler = scheduler or UniPCMultistepScheduler.from_pretrained(
+            checkpoint_name, subfolder="scheduler", flow_shift=12.0
+        )
+        self._solver = UniPCSolver(scheduler=scheduler)
 
         if self.dynamic_load:
             # setup models that cannot be loaded together with the corresponding model.
@@ -869,9 +871,9 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 max_sequence_length=max_sequence_length,
             )
 
-        # 4. Prepare timesteps
-        self.scheduler.set_timesteps(num_inference_steps, device=device)
-        timesteps = self.scheduler.timesteps
+        # 4. Prepare schedule
+        self._solver.set_schedule(num_inference_steps, device=device)
+        timesteps = self._solver.timesteps
 
         # 5. Prepare latent variables
         if seed is not None:
@@ -893,18 +895,17 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         mask = torch.ones(latents.shape, dtype=torch.float32, device=device)
 
         # 6. Denoising loop
-        num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         self._num_timesteps = len(timesteps)
 
         if self.config.boundary_ratio is not None:
-            boundary_timestep = self.config.boundary_ratio * self.scheduler.config.num_train_timesteps
+            boundary_timestep = self.config.boundary_ratio * self._solver.scheduler.config.num_train_timesteps
         else:
             boundary_timestep = -1  # Always use transformer (no transformer_2)
 
         if profiler:
             profiler.start("denoising", profiler_iteration)
 
-        permuted_latent = None
+        permuted_latent_tt = None
         rope_args = None
 
         latent_frames, latent_height, latent_width = latents.shape[2], latents.shape[3], latents.shape[4]
@@ -926,7 +927,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     )
                     prepared_prompts[transformer_idx] = True
 
-                if permuted_latent is None:
+                if permuted_latent_tt is None:
                     # First iteration, preprocess spatial input and prepare rope features
                     permuted_latent, patchified_seqlen = ts.model.preprocess_spatial_input_host(latents)
 
@@ -940,6 +941,14 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                         "trans_mat": trans_mat,
                     }
 
+                    sp_axis = ts.model.parallel_config.sequence_parallel.mesh_axis
+                    permuted_latent_tt = tensor.from_torch(
+                        permuted_latent,
+                        device=self.mesh_device,
+                        mesh_axes=[None, None, sp_axis, None],
+                        dtype=ttnn.float32,
+                    )
+
                 if self.config.expand_timesteps:
                     # seq_len: num_latent_frames * latent_height//2 * latent_width//2
                     temp_ts = (mask[0][0][:, ::2, ::2] * t).flatten()
@@ -948,14 +957,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 else:
                     timestep = t.expand(latents.shape[0])
 
-                permuted_model_input = self.get_model_input(permuted_latent, cond_latents)
-                permuted_model_input = bf16_tensor(
-                    permuted_model_input,
-                    device=self.mesh_device,
-                    mesh_axis=self.parallel_config.sequence_parallel.mesh_axis,
-                    shard_dim=-2,
-                    on_host=traced,
-                )
+                permuted_model_input = self.get_model_input(permuted_latent_tt, cond_latents)
+                permuted_model_input = ttnn.typecast(permuted_model_input, ttnn.bfloat16)
 
                 assert timestep.ndim == 1, "Wan2.2-T2V/I2V requires a 1D timestep tensor"
                 timestep = float32_tensor(
@@ -972,17 +975,24 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     **rope_args,
                     guidance_scale=ts.guidance_scale,
                     traced=traced,
+                    gather_output=False,
                 )
 
-                # Move result to host for scheduler step
-                permuted_noise_pred = local_device_to_torch(permuted_noise_pred_tt)
+                permuted_latent_tt = self._solver.step(
+                    step=i,
+                    latent=permuted_latent_tt,
+                    velocity_pred=permuted_noise_pred_tt,
+                )
 
-                # compute the previous noisy sample x_t -> x_t-1
-                permuted_latent = self.scheduler.step(permuted_noise_pred, t, permuted_latent, return_dict=False)[0]
+                progress_bar.update()
 
-                # call the callback, if provided
-                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
-                    progress_bar.update()
+        self._current_timestep = None
+
+        sp_axis = ts.model.parallel_config.sequence_parallel.mesh_axis
+        permuted_latent_tt = ts.model.ccl_manager.all_gather_persistent_buffer(
+            permuted_latent_tt, dim=2, mesh_axis=sp_axis
+        )
+        permuted_latent = local_device_to_torch(permuted_latent_tt)
 
         # Postprocess spatial output
         latents = ts.model.postprocess_spatial_output_host(

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -991,7 +991,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
                 permuted_noise_pred_tt = ts.model.combined_step(
                     do_classifier_free_guidance=self.do_classifier_free_guidance,
-                    spatial_1BNI=ttnn.typecast(permuted_model_input, ttnn.bfloat16),
+                    spatial_1BNI=permuted_model_input,
                     prompt_1BLP=ts.prompt_buffer,
                     negative_prompt_1BLP=ts.negative_prompt_buffer,
                     N=patchified_seqlen,

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -528,6 +528,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         prompt: Union[str, List[str]] = None,
         num_videos_per_prompt: int = 1,
         max_sequence_length: int = 512,
+        traced: bool = False,
     ):
         prompt = [prompt] if isinstance(prompt, str) else prompt
         prompt = [prompt_clean(u) for u in prompt]
@@ -555,7 +556,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         tt_prompt = ttnn.from_torch(
             text_input_ids,
             layout=ttnn.TILE_LAYOUT,
-            device=self.mesh_device,
+            device=self.mesh_device if not traced else None,
             mesh_mapper=mesh_mapper,
         )
 
@@ -563,14 +564,11 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             mask,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            device=self.mesh_device,
+            device=self.mesh_device if not traced else None,
             mesh_mapper=mesh_mapper,
         )
 
-        prompt_embeds = self.tt_umt5_encoder(tt_prompt, attention_mask=tt_mask)[-1]
-
-        # use the mask to zero out the padding tokens.
-        prompt_embeds = prompt_embeds * ttnn.unsqueeze(tt_mask, -1)
+        prompt_embeds = self.tt_umt5_encoder(tt_prompt, attention_mask=tt_mask, zero_masking=True, traced=traced)[-1]
 
         prompt_embeds = self.encoder_ccl_manager.all_gather(
             prompt_embeds, dim=0, mesh_axis=DP_axis, use_hyperparams=True
@@ -591,6 +589,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         prompt_embeds: Optional[torch.Tensor] = None,
         negative_prompt_embeds: Optional[torch.Tensor] = None,
         max_sequence_length: int = 512,
+        traced: bool = True,
     ):
         r"""
         Batch encodes the prompt and negative prompt into text encoder hidden states..
@@ -658,6 +657,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             prompt=all_input_prompts,
             num_videos_per_prompt=num_videos_per_prompt,
             max_sequence_length=max_sequence_length,
+            traced=traced,
         )
 
         # When CFG is enabled, we should be able to leave the shards on device.
@@ -878,6 +878,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 prompt_embeds=prompt_embeds,
                 negative_prompt_embeds=negative_prompt_embeds,
                 max_sequence_length=max_sequence_length,
+                traced=traced,
             )
 
         # 4. Prepare schedule

--- a/models/tt_dit/pipelines/wan/pipeline_wan_i2v.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_i2v.py
@@ -4,27 +4,29 @@
 
 # Adapted from https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/wan/pipeline_wan.py
 
+import os
 from typing import List, NamedTuple, Optional, Union
 
-import PIL
 import torch
 from diffusers.schedulers import UniPCMultistepScheduler
+from PIL import Image
 
 import ttnn
 
 from ...models.vae.vae_wan2_1 import WanEncoder
+from ...utils import cache
 from ...utils.conv3d import conv_pad_height, conv_pad_in_channels
-from ...utils.tensor import bf16_tensor_2dshard, fast_device_to_host
+from ...utils.tensor import bf16_tensor_2dshard, fast_device_to_host, unflatten
 from .pipeline_wan import WanPipeline
 
 
 class ImagePrompt(NamedTuple):
-    image: PIL.Image.Image
+    image: Image.Image
     frame_pos: int
 
 
 class WanPipelineI2V(WanPipeline):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, target_height: int = 0, target_width: int = 0, **kwargs):
         # Update I2V specific defaults
         if "checkpoint_name" not in kwargs:
             kwargs["checkpoint_name"] = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
@@ -33,9 +35,10 @@ class WanPipelineI2V(WanPipeline):
                 kwargs["checkpoint_name"], subfolder="scheduler", trust_remote_code=True
             )
 
-        super().__init__(*args, model_type="i2v", **kwargs)
+        # initialize without warmup
+        super().__init__(*args, model_type="i2v", run_warmup=False, **kwargs)
 
-        self.tt_encoder = WanEncoder(
+        self.tt_vae_encoder = WanEncoder(
             base_dim=self.vae.config.base_dim,
             in_channels=self.vae.config.in_channels,
             z_dim=self.vae.config.z_dim,
@@ -49,37 +52,44 @@ class WanPipelineI2V(WanPipeline):
             parallel_config=self.vae_parallel_config,
         )
 
-        self.tt_encoder.load_state_dict(self.vae.state_dict())
+        cache.load_model(
+            self.tt_vae_encoder,
+            model_name=os.path.basename(self.checkpoint_name),
+            subfolder="vae_encoder",
+            parallel_config=self.vae_parallel_config,
+            mesh_shape=tuple(self.mesh_device.shape),
+            get_torch_state_dict=lambda: self.vae.state_dict(),
+        )
+
+        # warmup buffers
+        self.warmup_buffers(
+            height=target_height, width=target_width, image_prompt=Image.new("RGB", (target_width, target_height))
+        )
 
     @staticmethod
     def create_pipeline(*args, **kwargs):
         # Update I2V specific defaults
         if "checkpoint_name" not in kwargs:
             kwargs["checkpoint_name"] = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
-        if "scheduler" not in kwargs:
-            kwargs["scheduler"] = UniPCMultistepScheduler.from_pretrained(
-                kwargs["checkpoint_name"], subfolder="scheduler", trust_remote_code=True
-            )
         return WanPipeline.create_pipeline(*args, pipeline_class=WanPipelineI2V, **kwargs)
 
     def get_model_input(self, latents, cond_latents):
         """
         Adapter function to enable I2V. For base T2V, just return the latents.
         """
-        # Reshape to make the channel last
-        U, B, NPad, T_size = latents.shape
-        # break out the channels for processing
-        latents = latents.reshape(U, B, NPad, T_size // self.vae.config.z_dim, -1)
-        cond_latents = cond_latents.reshape(U, B, NPad, T_size // self.vae.config.z_dim, -1)
-
-        # concatenate the latents and cond_latents
-        model_input = torch.cat([latents, cond_latents], dim=-1).reshape(U, B, NPad, -1)
-        return model_input
+        latents = super().get_model_input(latents, None)
+        z_dim = self.vae.config.z_dim
+        t_size = latents.shape[-1]
+        model_input = ttnn.concat(
+            [unflatten(latents, -1, (t_size // z_dim, -1)), unflatten(cond_latents, -1, (t_size // z_dim, -1))],
+            dim=-1,
+        )
+        return ttnn.reshape(model_input, (*tuple(latents.shape)[:-1], -1))
 
     def prepare_latents(
         self,
         batch_size: int,
-        image_prompt: Union[ImagePrompt, PIL.Image.Image, List[ImagePrompt]],
+        image_prompt: Union[ImagePrompt, Image.Image, List[ImagePrompt]],
         num_channels_latents: int = 16,
         height: int = 480,
         width: int = 832,
@@ -92,7 +102,7 @@ class WanPipelineI2V(WanPipeline):
 
         if isinstance(image_prompt, ImagePrompt):
             image_prompt = [image_prompt]
-        elif isinstance(image_prompt, PIL.Image.Image):
+        elif isinstance(image_prompt, Image.Image):
             image_prompt = [ImagePrompt(image=image_prompt, frame_pos=0)]
 
         latents, _ = super().prepare_latents(
@@ -147,7 +157,7 @@ class WanPipelineI2V(WanPipeline):
             },
         )
 
-        encoded_video_BCTHW, new_logical_h = self.tt_encoder(tt_video_condition_BTHWC, logical_h)
+        encoded_video_BCTHW, new_logical_h = self.tt_vae_encoder(tt_video_condition_BTHWC, logical_h)
 
         # convert to torch
         concat_dims = [None, None]

--- a/models/tt_dit/solvers/__init__.py
+++ b/models/tt_dit/solvers/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from .base import Solver
+from .euler import EulerSolver
+from .unipc import UniPCSolver, UniPCVariant
+
+__all__ = ["EulerSolver", "Solver", "UniPCSolver", "UniPCVariant"]

--- a/models/tt_dit/solvers/base.py
+++ b/models/tt_dit/solvers/base.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import torch
+from diffusers.schedulers.scheduling_utils import SchedulerMixin
+
+import ttnn
+
+
+class Solver(ABC):
+    def __init__(self, scheduler: SchedulerMixin) -> None:
+        if not isinstance(scheduler, SchedulerMixin):
+            msg = f"scheduler must be a diffusers SchedulerMixin, got {type(scheduler).__name__}"
+            raise ValueError(msg)
+        self._scheduler = scheduler
+        self._sigmas = None
+        self._alphas = None
+        self._timesteps = None
+
+    @property
+    def scheduler(self) -> SchedulerMixin:
+        return self._scheduler
+
+    @property
+    def sigmas(self) -> list[float] | None:
+        """Returns the active sigma schedule, or None when no schedule has been provided."""
+        return self._sigmas
+
+    @property
+    def alphas(self) -> list[float] | None:
+        """Returns the active alpha schedule, or None when no schedule has been provided."""
+        return self._alphas
+
+    @property
+    def timesteps(self) -> torch.Tensor | None:
+        """Returns the active timesteps, or None when no timesteps have been provided."""
+        return self._timesteps
+
+    def set_schedule(self, num_inference_steps: int | None = None, *, device: object = None, **kwargs: object) -> None:
+        """Forward to ``scheduler.set_timesteps`` and cache sigmas/alphas for device stepping."""
+        self._scheduler.set_timesteps(num_inference_steps, device=device, **kwargs)
+        sigmas = self._scheduler.sigmas
+        self._sigmas = sigmas.tolist()
+        self._alphas = (1.0 - sigmas).tolist()
+        self._timesteps = self._scheduler.timesteps
+
+    @abstractmethod
+    def step(self, *, step: int, latent: ttnn.Tensor, velocity_pred: ttnn.Tensor) -> ttnn.Tensor:
+        """Advance the latent one step toward the clean data.
+
+        Args:
+            step: Current step index into the sigmas/alphas schedule.
+            latent: Noisy latent at the current step.
+            velocity_pred: Predicted velocity at the current step.
+
+        Returns:
+            The predicted latent at the next step.
+        """
+
+    def _assert_schedule(self) -> None:
+        if self._sigmas is None or self._alphas is None:
+            msg = "schedule must be set before stepping"
+            raise ValueError(msg)

--- a/models/tt_dit/solvers/euler.py
+++ b/models/tt_dit/solvers/euler.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+
+import ttnn
+
+from .base import Solver
+
+
+class EulerSolver(Solver):
+    def __init__(self, scheduler: FlowMatchEulerDiscreteScheduler | None = None) -> None:
+        super().__init__(scheduler if scheduler is not None else FlowMatchEulerDiscreteScheduler())
+
+    def step(self, *, step: int, latent: ttnn.Tensor, velocity_pred: ttnn.Tensor) -> ttnn.Tensor:
+        self._assert_schedule()
+
+        sigma_curr = self._sigmas[step]
+        sigma_next = self._sigmas[step + 1]
+
+        return latent + (sigma_next - sigma_curr) * velocity_pred

--- a/models/tt_dit/solvers/unipc.py
+++ b/models/tt_dit/solvers/unipc.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from diffusers.schedulers import UniPCMultistepScheduler
+
+import ttnn
+
+from .base import Solver
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+@dataclass(frozen=True)
+class _State:
+    clean_preds: tuple[ttnn.Tensor, ...]
+    corrected: ttnn.Tensor
+
+
+class UniPCVariant(Enum):
+    BH1 = "bh1"  # B(h) = h
+    BH2 = "bh2"  # B(h) = 1 - e^(-h)
+
+    def b(self, h: float) -> float:
+        if self is UniPCVariant.BH1:
+            return h
+        return -math.expm1(-h)
+
+
+class UniPCSolver(Solver):
+    def __init__(self, scheduler: UniPCMultistepScheduler | None = None) -> None:
+        """Wrap a diffusers scheduler for on-device UniPC stepping."""
+        if scheduler is None:
+            scheduler = UniPCMultistepScheduler(use_flow_sigmas=True, prediction_type="flow_prediction")
+
+        if not isinstance(scheduler, UniPCMultistepScheduler):
+            msg = f"scheduler must be a UniPCMultistepScheduler, got {type(scheduler).__name__}"
+            raise ValueError(msg)
+
+        if not scheduler.config.use_flow_sigmas:
+            msg = "Only UniPCMultistepScheduler configured with use_flow_sigmas=True is supported"
+            raise ValueError(msg)
+
+        order = scheduler.config.solver_order
+        if order not in (1, 2):
+            msg = f"only order 1 and 2 are supported, got {order}"
+            raise ValueError(msg)
+
+        super().__init__(scheduler)
+        self.order = order
+        self.variant = UniPCVariant(scheduler.config.solver_type)
+        self._state = None
+
+    def set_schedule(self, num_inference_steps: int | None = None, *, device: object = None, **kwargs: object) -> None:
+        super().set_schedule(num_inference_steps, device=device, **kwargs)
+        self._state = None
+
+    def step(self, *, step: int, latent: ttnn.Tensor, velocity_pred: ttnn.Tensor) -> ttnn.Tensor:
+        self._assert_schedule()
+
+        clean_pred = latent - self._sigmas[step] * velocity_pred
+
+        state = self._state or _State(
+            tuple(ttnn.empty_like(latent) for _ in range(self.order)),
+            ttnn.empty_like(latent),
+        )
+
+        if step != 0:
+            corrected = self._correct(
+                order=_taper(self.order, step - 1, len(self._sigmas) - 1),
+                latent=state.corrected,
+                step=step - 1,
+                clean_preds=(*state.clean_preds, clean_pred),
+            )
+        else:
+            corrected = latent
+
+        del latent
+
+        ttnn.copy(corrected, state.corrected)
+        del corrected
+
+        ttnn.copy(clean_pred, state.clean_preds[0])
+        clean_preds = (*state.clean_preds[1:], state.clean_preds[0])
+        del clean_pred
+
+        predicted = self._predict(
+            order=_taper(self.order, step, len(self._sigmas) - 1),
+            latent=state.corrected,
+            step=step,
+            clean_preds=clean_preds,
+        )
+
+        self._state = _State(clean_preds, state.corrected)
+        return predicted
+
+    def _predict(
+        self, *, order: int, latent: ttnn.Tensor, step: int, clean_preds: Sequence[ttnn.Tensor]
+    ) -> ttnn.Tensor:
+        sigma_curr, sigma_next = self._sigmas[step : step + 2]
+        alpha_curr, alpha_next = self._alphas[step : step + 2]
+
+        lam_curr = _log(alpha_curr) - _log(sigma_curr)
+        lam_next = _log(alpha_next) - _log(sigma_next)
+        h = lam_next - lam_curr
+
+        coeff_latent = sigma_next / sigma_curr
+        coeff_curr = -alpha_next * math.expm1(-h)
+
+        latent = coeff_latent * latent + coeff_curr * clean_preds[-1]
+
+        if order == 1:
+            return latent
+
+        lam_prev = _log(self._alphas[step - 1]) - _log(self._sigmas[step - 1])
+        r = (lam_curr - lam_prev) / h
+        w = alpha_next * self.variant.b(h) * 0.5 / r
+
+        return latent + w * (clean_preds[-1] - clean_preds[-2])
+
+    def _correct(
+        self, *, order: int, latent: ttnn.Tensor, step: int, clean_preds: Sequence[ttnn.Tensor]
+    ) -> ttnn.Tensor:
+        sigma_curr, sigma_next = self._sigmas[step : step + 2]
+        alpha_curr, alpha_next = self._alphas[step : step + 2]
+
+        lam_curr = _log(alpha_curr) - _log(sigma_curr)
+        lam_next = _log(alpha_next) - _log(sigma_next)
+        h = lam_next - lam_curr
+
+        coeff_latent = sigma_next / sigma_curr
+        coeff_clean = -alpha_next * math.expm1(-h)
+
+        latent = coeff_latent * latent + coeff_clean * clean_preds[-2]
+
+        if order == 1:
+            # UniC-1: c=0.5, r=1
+            w = alpha_next * self.variant.b(h) * 0.5
+            return latent + w * (clean_preds[-1] - clean_preds[-2])
+
+        # UniC-2: solve 2x2 system
+        exp_neg_h = math.expm1(-h)
+
+        lam_prev = _log(self._alphas[step - 1]) - _log(self._sigmas[step - 1])
+        r_1 = (lam_curr - lam_prev) / h
+
+        g1 = (h + exp_neg_h) / h**2
+        g2 = (h**2 - 2 * h - 2 * exp_neg_h) / h**2
+
+        if math.isinf(r_1):
+            w_prev = 0.0
+            w_pred = alpha_next * h * g1
+        else:
+            det = h * (1 + r_1)
+            c_1 = (h * g1 - g2) / det
+            c_2 = (g2 + r_1 * h * g1) / det
+
+            w_prev = alpha_next * h * c_1 / r_1
+            w_pred = alpha_next * h * c_2
+
+        return latent + w_prev * (clean_preds[-2] - clean_preds[-3]) + w_pred * (clean_preds[-1] - clean_preds[-2])
+
+
+def _taper(order: int, step: int, num_steps: int) -> int:
+    return min(order, step + 1, num_steps - step)
+
+
+def _log(x: float, /) -> float:
+    return math.log(x) if x != 0 else -math.inf

--- a/models/tt_dit/solvers/unipc.py
+++ b/models/tt_dit/solvers/unipc.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 class _State:
     clean_preds: tuple[ttnn.Tensor, ...]
     corrected: ttnn.Tensor
+    oldest_idx: int = 0
 
 
 class UniPCVariant(Enum):
@@ -61,7 +62,8 @@ class UniPCSolver(Solver):
 
     def set_schedule(self, num_inference_steps: int | None = None, *, device: object = None, **kwargs: object) -> None:
         super().set_schedule(num_inference_steps, device=device, **kwargs)
-        self._state = None
+        if self._state is not None:
+            self._state = _State(self._state.clean_preds, self._state.corrected, 0)
 
     def step(self, *, step: int, latent: ttnn.Tensor, velocity_pred: ttnn.Tensor) -> ttnn.Tensor:
         self._assert_schedule()
@@ -72,24 +74,24 @@ class UniPCSolver(Solver):
             tuple(ttnn.empty_like(latent) for _ in range(self.order)),
             ttnn.empty_like(latent),
         )
+        clean_preds = _ordered_clean_preds(state.clean_preds, state.oldest_idx)
 
         if step != 0:
             corrected = self._correct(
                 order=_taper(self.order, step - 1, len(self._sigmas) - 1),
                 latent=state.corrected,
                 step=step - 1,
-                clean_preds=(*state.clean_preds, clean_pred),
+                clean_preds=(*clean_preds, clean_pred),
             )
         else:
             corrected = latent
 
-        del latent
-
         ttnn.copy(corrected, state.corrected)
         del corrected
 
-        ttnn.copy(clean_pred, state.clean_preds[0])
-        clean_preds = (*state.clean_preds[1:], state.clean_preds[0])
+        ttnn.copy(clean_pred, state.clean_preds[state.oldest_idx])
+        oldest_idx = (state.oldest_idx + 1) % self.order
+        clean_preds = _ordered_clean_preds(state.clean_preds, oldest_idx)
         del clean_pred
 
         predicted = self._predict(
@@ -99,7 +101,7 @@ class UniPCSolver(Solver):
             clean_preds=clean_preds,
         )
 
-        self._state = _State(clean_preds, state.corrected)
+        self._state = _State(state.clean_preds, state.corrected, oldest_idx)
         return predicted
 
     def _predict(
@@ -171,6 +173,10 @@ class UniPCSolver(Solver):
 
 def _taper(order: int, step: int, num_steps: int) -> int:
     return min(order, step + 1, num_steps - step)
+
+
+def _ordered_clean_preds(clean_preds: tuple[ttnn.Tensor, ...], oldest_idx: int) -> tuple[ttnn.Tensor, ...]:
+    return clean_preds[oldest_idx:] + clean_preds[:oldest_idx]
 
 
 def _log(x: float, /) -> float:

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -44,7 +44,7 @@ def t2v_metrics(mesh_device, height):
     if tuple(mesh_device.shape) == (2, 4) and height == 480:
         if is_blackhole():
             expected_metrics = {
-                "encoder": 0.08,
+                "encoder": 0.1,
                 "denoising": 240.0,
                 "vae": 5.0,
                 "total": 255.0,

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -188,7 +188,7 @@ def test_pipeline_performance(
     """Performance test for Wan pipeline with detailed timing analysis."""
 
     benchmark_profiler = BenchmarkProfiler()
-    traced = True  # mesh_shape == (4, 32)  # trace only for quadx32
+    traced = mesh_shape == (4, 32)  # trace only for quadx32
 
     # Skip 4U.
     if galaxy_type == "4U":

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -29,6 +29,16 @@ def _scale_expected_metrics(expected_metrics: dict, factor: float) -> dict:
     return {k: v * factor for k, v in expected_metrics.items()}
 
 
+def create_fractal_image(width: int, height: int) -> Image.Image:
+    c = np.linspace(-2.0, 1.0, width)[None, :] + 1j * np.linspace(-1.5, 1.5, height)[:, None]
+    z = np.zeros_like(c)
+    img = np.zeros(c.shape, dtype=np.uint8)
+    for i in range(32):
+        z = z * z + c
+        img[(img == 0) & (np.abs(z) > 2)] = 255 - 8 * i
+    return Image.fromarray(np.dstack((img, np.roll(img, width // 10, 1), np.roll(img, height // 10, 0))), "RGB")
+
+
 def t2v_metrics(mesh_device, height):
     expected_metrics = {}
     if tuple(mesh_device.shape) == (2, 4) and height == 480:
@@ -104,7 +114,7 @@ def wan_pipeline_metrics_condimg(mesh_device, width, height, model_type, topolog
     else:
         pipeline_cls = WanPipelineI2V
         expected_metrics = i2v_metrics(mesh_device, height)
-        image_prompt = Image.fromarray(np.random.randint(0, 256, (height, width, 3), dtype=np.uint8), "RGB")
+        image_prompt = create_fractal_image(width, height)
 
     # Only WH 4x8 uses ring; BH 4x8 linear is the distinct Linear case at this mesh shape.
     if tuple(mesh_device.shape) == (4, 8) and topology == ttnn.Topology.Linear:

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -188,7 +188,7 @@ def test_pipeline_performance(
     """Performance test for Wan pipeline with detailed timing analysis."""
 
     benchmark_profiler = BenchmarkProfiler()
-    traced = mesh_shape == (4, 32)  # trace only for quadx32
+    traced = True  # mesh_shape == (4, 32)  # trace only for quadx32
 
     # Skip 4U.
     if galaxy_type == "4U":

--- a/models/tt_dit/tests/unit/test_solvers.py
+++ b/models/tt_dit/tests/unit/test_solvers.py
@@ -165,7 +165,7 @@ def test_unipc_constructor_validation() -> None:
 
 @pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
 def test_unipc_set_schedule_resets_state(mesh_device: ttnn.MeshDevice) -> None:
-    """set_schedule should clear cached trajectory state between runs."""
+    """set_schedule should reset logical history without reallocating state buffers."""
     solver = UniPCSolver(
         scheduler=UniPCMultistepScheduler(
             use_flow_sigmas=True,
@@ -181,10 +181,16 @@ def test_unipc_set_schedule_resets_state(mesh_device: ttnn.MeshDevice) -> None:
     solver.step(step=0, latent=latent, velocity_pred=velocity)
 
     assert solver._state is not None
+    clean_preds = solver._state.clean_preds
+    corrected = solver._state.corrected
+    assert solver._state.oldest_idx == 1
 
     solver.set_schedule(_NUM_STEPS)
 
-    assert solver._state is None
+    assert solver._state is not None
+    assert solver._state.clean_preds == clean_preds
+    assert solver._state.corrected is corrected
+    assert solver._state.oldest_idx == 0
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)

--- a/models/tt_dit/tests/unit/test_solvers.py
+++ b/models/tt_dit/tests/unit/test_solvers.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+from diffusers.pipelines.mochi.pipeline_mochi import linear_quadratic_schedule
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+from diffusers.schedulers.scheduling_unipc_multistep import UniPCMultistepScheduler
+
+import ttnn
+from models.tt_dit.solvers.euler import EulerSolver
+from models.tt_dit.solvers.unipc import UniPCSolver, UniPCVariant
+from models.tt_dit.utils import tensor
+from models.tt_dit.utils.check import assert_quality
+
+_NUM_STEPS = 17
+
+
+# Euler solver tests
+
+
+def _motif_sigmas(*, step_count: int, linear_quadratic_emulating_steps: int) -> torch.Tensor:
+    assert step_count % 2 == 0
+
+    s = step_count
+    n = linear_quadratic_emulating_steps
+    a = s // 2 / n - 1
+
+    sigmas1 = torch.linspace(1, 0, n + 1)[: s // 2]
+    sigmas2 = torch.linspace(0, 1, s // 2 + 1).pow(2) * a - a
+
+    return torch.concat([sigmas1, sigmas2])
+
+
+def _assert_euler_matches_scheduler(
+    mesh_device: ttnn.MeshDevice,
+    *,
+    schedule_kwargs: dict[str, object],
+    expected_timesteps: torch.Tensor | None = None,
+    expected_sigmas: torch.Tensor | None = None,
+) -> None:
+    solver = EulerSolver()
+    ref_scheduler = FlowMatchEulerDiscreteScheduler()
+
+    solver.set_schedule(**schedule_kwargs)
+    ref_scheduler.set_timesteps(**schedule_kwargs)
+
+    assert solver.timesteps is not None
+    assert torch.allclose(solver.timesteps, ref_scheduler.timesteps)
+    assert solver.sigmas == ref_scheduler.sigmas.tolist()
+    assert solver.alphas == (1.0 - ref_scheduler.sigmas).tolist()
+
+    if expected_timesteps is not None:
+        assert torch.allclose(solver.timesteps, expected_timesteps)
+
+    if expected_sigmas is not None:
+        assert solver.sigmas == expected_sigmas.tolist()
+
+    torch.manual_seed(0)
+    torch_latent = torch.randn(1, 1, 32, 32)
+    ref = torch_latent.clone()
+    latent = tensor.from_torch(torch_latent, device=mesh_device, dtype=ttnn.float32)
+
+    for step_idx in range(len(ref_scheduler.timesteps)):
+        torch_velocity = torch.randn_like(torch_latent)
+        ref = ref_scheduler.step(torch_velocity, ref_scheduler.timesteps[step_idx], ref, return_dict=False)[0]
+
+        velocity = tensor.from_torch(torch_velocity, device=mesh_device, dtype=ttnn.float32)
+        latent = solver.step(step=step_idx, latent=latent, velocity_pred=velocity)
+
+        result_ours = ttnn.to_torch(latent)
+        assert_quality(result_ours, ref, pcc=0.999_999, relative_rmse=1e-5)
+
+
+def test_solver_set_schedule_caches_scheduler_outputs() -> None:
+    """set_schedule should forward scheduler kwargs and cache schedule outputs."""
+    scheduler = FlowMatchEulerDiscreteScheduler()
+    solver = EulerSolver(scheduler=scheduler)
+
+    sigmas = torch.linspace(1.0, 1 / _NUM_STEPS, _NUM_STEPS)
+    mu = 0.75
+    solver.set_schedule(sigmas=sigmas, mu=mu)
+
+    assert solver.timesteps is scheduler.timesteps
+    assert solver.sigmas == scheduler.sigmas.tolist()
+    assert solver.alphas == (1.0 - scheduler.sigmas).tolist()
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_euler_set_schedule_with_sigmas_and_mu_matches_scheduler(mesh_device: ttnn.MeshDevice) -> None:
+    """EulerSolver should match scheduler outputs for the flux/qwen sigmas+mu path."""
+    sigmas = torch.linspace(1.0, 1 / _NUM_STEPS, _NUM_STEPS).tolist()
+    _assert_euler_matches_scheduler(mesh_device, schedule_kwargs={"sigmas": sigmas, "mu": 0.75})
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_euler_set_schedule_with_mochi_sigmas_matches_scheduler(mesh_device: ttnn.MeshDevice) -> None:
+    """EulerSolver should match scheduler outputs for the mochi custom sigma path."""
+    sigmas = linear_quadratic_schedule(_NUM_STEPS, 0.025)
+    _assert_euler_matches_scheduler(mesh_device, schedule_kwargs={"sigmas": sigmas})
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_euler_set_schedule_with_motif_sigmas_matches_main(mesh_device: ttnn.MeshDevice) -> None:
+    """EulerSolver should reproduce motif's main-branch timesteps and sigma schedule."""
+    step_count = 18
+    sigmas = _motif_sigmas(step_count=step_count, linear_quadratic_emulating_steps=1000)
+    _assert_euler_matches_scheduler(
+        mesh_device,
+        schedule_kwargs={"sigmas": sigmas[:-1].tolist()},
+        expected_timesteps=sigmas[:-1] * 1000,
+        expected_sigmas=sigmas,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_euler_matches_diffusers(mesh_device: ttnn.MeshDevice) -> None:
+    """EulerSolver should match FlowMatchEulerDiscreteScheduler at every step."""
+    torch.manual_seed(0)
+
+    torch_latent = torch.randn(1, 1, 32, 32)
+
+    solver = EulerSolver()
+    solver.set_schedule(_NUM_STEPS)
+    scheduler = solver.scheduler
+
+    ref = torch_latent.clone()
+    latent = tensor.from_torch(torch_latent, device=mesh_device, dtype=ttnn.float32)
+
+    for step_idx in range(_NUM_STEPS):
+        torch_velocity = torch.randn_like(torch_latent)
+
+        ref = scheduler.step(torch_velocity, scheduler.timesteps[step_idx], ref, return_dict=False)[0]
+
+        velocity = tensor.from_torch(torch_velocity, device=mesh_device, dtype=ttnn.float32)
+        latent = solver.step(step=step_idx, latent=latent, velocity_pred=velocity)
+
+        result_ours = ttnn.to_torch(latent)
+        assert_quality(result_ours, ref, pcc=0.999_999, relative_rmse=1e-5)
+
+
+# UniPC solver tests
+
+
+def test_unipc_constructor_validation() -> None:
+    """UniPCSolver should reject incompatible scheduler configurations."""
+    with pytest.raises(ValueError, match="UniPCMultistepScheduler"):
+        UniPCSolver(scheduler=FlowMatchEulerDiscreteScheduler())  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="use_flow_sigmas=True"):
+        UniPCSolver(scheduler=UniPCMultistepScheduler())
+
+    with pytest.raises(ValueError, match="only order 1 and 2 are supported"):
+        UniPCSolver(
+            scheduler=UniPCMultistepScheduler(
+                use_flow_sigmas=True,
+                prediction_type="flow_prediction",
+                solver_order=3,
+            )
+        )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_unipc_set_schedule_resets_state(mesh_device: ttnn.MeshDevice) -> None:
+    """set_schedule should clear cached trajectory state between runs."""
+    solver = UniPCSolver(
+        scheduler=UniPCMultistepScheduler(
+            use_flow_sigmas=True,
+            prediction_type="flow_prediction",
+            solver_order=2,
+            solver_type=UniPCVariant.BH2.value,
+        )
+    )
+    solver.set_schedule(_NUM_STEPS)
+
+    latent = tensor.from_torch(torch.randn(1, 1, 32, 32), device=mesh_device, dtype=ttnn.float32)
+    velocity = tensor.from_torch(torch.randn(1, 1, 32, 32), device=mesh_device, dtype=ttnn.float32)
+    solver.step(step=0, latent=latent, velocity_pred=velocity)
+
+    assert solver._state is not None
+
+    solver.set_schedule(_NUM_STEPS)
+
+    assert solver._state is None
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("variant", [UniPCVariant.BH1, UniPCVariant.BH2])
+@pytest.mark.parametrize("shift", [5.0, 12.0])
+def test_unipc_matches_diffusers(mesh_device: ttnn.MeshDevice, variant: UniPCVariant, shift: float) -> None:
+    """UniPCSolver should match UniPCMultistepScheduler at every step."""
+    torch.manual_seed(0)
+
+    torch_latent = torch.randn(1, 1, 32, 32)
+
+    scheduler = UniPCMultistepScheduler(
+        use_flow_sigmas=True,
+        flow_shift=shift,
+        prediction_type="flow_prediction",
+        solver_order=2,
+        solver_type=variant.value,
+    )
+    solver = UniPCSolver(scheduler=scheduler)
+    solver.set_schedule(_NUM_STEPS)
+
+    ref = torch_latent.clone()
+    latent = tensor.from_torch(torch_latent, device=mesh_device, dtype=ttnn.float32)
+
+    for step_idx in range(_NUM_STEPS):
+        if step_idx == _NUM_STEPS - 1 and variant is UniPCVariant.BH1:
+            # Diffusers bh1 produces NaN on the final step; skip.
+            break
+
+        torch_velocity = torch.randn_like(torch_latent)
+
+        ref = scheduler.step(torch_velocity, scheduler.timesteps[step_idx], ref, return_dict=False)[0]
+
+        velocity = tensor.from_torch(torch_velocity, device=mesh_device, dtype=ttnn.float32)
+        latent = solver.step(step=step_idx, latent=latent, velocity_pred=velocity)
+
+        result_ours = ttnn.to_torch(latent)
+        assert_quality(result_ours, ref, pcc=1 - 3e-10, relative_rmse=3e-7)

--- a/models/tt_dit/utils/tracing.py
+++ b/models/tt_dit/utils/tracing.py
@@ -242,6 +242,9 @@ class Tracer:
 
 _TRACER_VALID_INPUT_TYPES = (ttnn.Tensor, int, float, str, bool, NoneType)
 
+_MESH_DEVICE_PARAM_NAMES: tuple[str, ...] = ("mesh_device", "device")
+"""Parameter names that ``traced_function`` recognises as the Tracer's mesh device, in priority order."""
+
 
 def _verify_value(value: Any, *, path_label: str) -> Any:
     if not isinstance(value, _TRACER_VALID_INPUT_TYPES):
@@ -249,6 +252,23 @@ def _verify_value(value: Any, *, path_label: str) -> Any:
         raise TypeError(msg)
 
     return value
+
+
+def _is_tracer_valid_value(value: Any) -> bool:
+    """Return True if ``value`` can be passed through to a ``Tracer`` as an input.
+
+    Matches ``_TRACER_VALID_INPUT_TYPES`` plus any nesting of those inside ``tuple``,
+    ``list``, or ``dict`` (the containers supported by ``Tracer._tree_map``). Used at
+    call time by ``traced_function`` to classify each argument as either a tracer input
+    or a bindable config value.
+    """
+    if isinstance(value, _TRACER_VALID_INPUT_TYPES):
+        return True
+    if isinstance(value, (tuple, list)):
+        return all(_is_tracer_valid_value(v) for v in value)
+    if isinstance(value, dict):
+        return all(isinstance(k, _TRACER_VALID_INPUT_TYPES) and _is_tracer_valid_value(v) for k, v in value.items())
+    return False
 
 
 def _clone_tensor(value: Any, *, path_label: str) -> Any:  # noqa: ARG001
@@ -324,6 +344,7 @@ def traced_function(
     _fn: Callable[..., Any] | None = None,
     *,
     device: ttnn.MeshDevice | Callable[..., ttnn.MeshDevice] | None = None,
+    inject_mesh_device: bool = False,
     prep_run: bool = True,
     clone_prep_inputs: bool = True,
 ) -> Any:
@@ -331,38 +352,70 @@ def traced_function(
 
     Can be applied with or without arguments::
 
-        # Standalone function — device provided directly at decoration time:
-        @traced_function(device=mesh_device, clone_prep_inputs=False)
-        def my_function(x: ttnn.Tensor, scale: float) -> ttnn.Tensor: ...
-
-        # Method — device resolved lazily via lambda from the bound context (self):
+        # Method — device resolved lazily via callable from the bound context (self):
         @traced_function(device=lambda self: self.mesh_device, clone_prep_inputs=False)
         def my_method(self, x: ttnn.Tensor, scale: float) -> ttnn.Tensor: ...
 
+        # Standalone function — device and other non-tracer-valid args are classified
+        # dynamically on the first traced call. The parameter must be named `mesh_device`:
+        @traced_function(clone_prep_inputs=False)
+        def my_function(x, mesh_device, ccl_manager=None, pre_transfer_fn=None): ...
+
+        # Standalone function — `mesh_device` is auto-injected as a wrapper-only kwarg
+        # (like `traced`) and never forwarded to the wrapped function:
+        @traced_function(inject_mesh_device=True, clone_prep_inputs=False)
+        def my_pure_function(x: ttnn.Tensor, scale: float) -> ttnn.Tensor: ...
+
         # Call without tracing (original function, no overhead):
-        result = my_function(x, scale=1.0)
+        result = my_function(x, mesh_device=md)
+        result = my_pure_function(x, scale=1.0)
         result = model.my_method(x, scale=1.0)
 
         # Call with tracing (captures on first call, replays on subsequent calls):
-        result = my_function(x, scale=1.0, traced=True)
+        result = my_function(x, mesh_device=md, traced=True)
+        result = my_pure_function(x, scale=1.0, mesh_device=md, traced=True)
         result = model.my_method(x, scale=1.0, traced=True)
 
         # With optional Tracer call-time kwargs:
-        result = my_function(x, scale=1.0, traced=True, tracer_cq_id=1, tracer_blocking_execution=False)
+        result = my_function(x, mesh_device=md, traced=True, tracer_cq_id=1, tracer_blocking_execution=False)
 
     The decorated callable gains a ``traced`` keyword argument at call time. When
     ``traced=False`` (the default) the original function is called directly. When
     ``traced=True`` a ``Tracer`` is lazily created on the first call and subsequent
     calls execute the captured trace.
 
-    If the first positional argument is not a valid ``Tracer`` input type
-    (i.e. not a ``ttnn.Tensor``, scalar, or ``None``) it is treated as a
-    bindable context (e.g. ``self``) and bound away before the ``Tracer`` sees
-    any inputs.     When ``device`` is a callable it is called with that context to
-    resolve the device. One ``Tracer`` per unique first argument is maintained in a
-    ``WeakKeyDictionary``, giving per-instance tracing for methods. For plain
-    functions whose first argument is a valid tracer type, a single shared
-    ``Tracer`` is used instead.
+    Three modes for supplying the Tracer's device:
+
+    1. **Context-bound** — ``device=<callable>`` (or literal). The first
+       positional argument is treated as a bindable context (typical for
+       methods: ``self``), bound away via ``functools.partial``, and — when
+       ``device`` is callable — passed through it to resolve the device. One
+       ``Tracer`` per unique context in a ``WeakKeyDictionary``.
+    2. **Auto-discovered** — ``device=None`` (omitted). The function must
+       declare a parameter literally named ``mesh_device`` or ``device``
+       (first match in that priority order). On the first traced call,
+       each argument is classified at runtime: any value that isn't a
+       ``Tracer``-valid input (``ttnn.Tensor``, scalar, ``None``, or a
+       nested ``tuple``/``list``/``dict`` of those) is bound into a
+       ``functools.partial``. The bind set is frozen after the first call
+       and reused. The matched mesh parameter drives the ``Tracer``'s
+       device. One ``Tracer`` is cached per unique tuple of bound-value
+       identities.
+    3. **Injected** — ``inject_mesh_device=True``. The wrapper accepts
+       either ``mesh_device=`` or ``device=`` as an auto-added kwarg
+       (analogous to ``traced=``), consumes it, and never forwards it to
+       the wrapped function. Exactly one of the two may be supplied per
+       call. The function itself must *not* declare a ``mesh_device`` or
+       ``device`` parameter. Other non-tracer-valid args from the wrapped
+       function's signature are still classified and bound on the first
+       traced call, exactly as in mode (2).
+
+    Decoration-time validation:
+      - ``device=`` and ``inject_mesh_device=True`` are mutually exclusive.
+      - ``inject_mesh_device=True`` requires the wrapped function *not* to
+        declare a ``mesh_device`` or ``device`` parameter (to avoid ambiguity).
+      - Omitting ``device=`` with ``inject_mesh_device=False`` on a function
+        that declares neither ``mesh_device`` nor ``device`` raises ``ValueError``.
 
     Tracer call-time kwargs (``tracer_cq_id``, ``tracer_blocking_execution``,
     ``tracer_execute_on_capture``) are forwarded to the ``Tracer`` when tracing
@@ -370,9 +423,13 @@ def traced_function(
 
     Args:
         _fn: The function to wrap when used without parentheses (``@traced_function``).
-        device: Device for tracing. Pass a ``ttnn.MeshDevice`` directly for plain
-            functions, or a callable (e.g. ``lambda self: self.mesh_device``) for
-            methods so it can be resolved lazily from the bound context.
+        device: Device for tracing. For methods, pass a callable
+            (e.g. ``lambda self: self.mesh_device``) so it can be resolved lazily
+            from the bound context. Omit entirely for standalone functions that
+            declare a ``mesh_device`` parameter or set ``inject_mesh_device=True``.
+        inject_mesh_device: If ``True``, the wrapper accepts ``mesh_device=`` as an
+            auto-added kwarg and consumes it without forwarding to the wrapped
+            function. Mutually exclusive with ``device=``.
         prep_run: Forwarded to ``Tracer.__init__``.
         clone_prep_inputs: Forwarded to ``Tracer.__init__``.
     """
@@ -387,24 +444,115 @@ def traced_function(
             raise ValueError(msg)
         return device(context) if callable(device) else device
 
+    if inject_mesh_device and device is not None:
+        msg = "@traced_function: inject_mesh_device=True is mutually exclusive with device="
+        raise ValueError(msg)
+
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        sig = inspect.signature(fn)
+
+        # First matching parameter name (in priority order) is what we'll look up at call time.
+        sig_mesh_param = next((n for n in _MESH_DEVICE_PARAM_NAMES if n in sig.parameters), None)
+
+        if inject_mesh_device and sig_mesh_param is not None:
+            msg = (
+                f"@traced_function: {fn.__qualname__} declares a {sig_mesh_param!r} parameter but "
+                "inject_mesh_device=True would also add one. Rename the parameter, or drop "
+                "inject_mesh_device=True to use signature-based auto-discovery instead."
+            )
+            raise ValueError(msg)
+
+        if device is None and not inject_mesh_device and sig_mesh_param is None:
+            msg = (
+                f"@traced_function: {fn.__qualname__} was decorated without device= and has no "
+                f"parameter named any of {_MESH_DEVICE_PARAM_NAMES}. Provide "
+                "device=<callable returning a ttnn.MeshDevice> (e.g. lambda self: self.mesh_device) "
+                "for methods, declare a 'mesh_device' (or 'device') parameter on the function for "
+                "auto-discovery, or pass inject_mesh_device=True to have the wrapper accept one as "
+                "an auto-added kwarg."
+            )
+            raise ValueError(msg)
+
         _tracers: weakref.WeakKeyDictionary[Any, Tracer] = weakref.WeakKeyDictionary()
-        _tracer_shared: Tracer | None = None
+        _tracers_auto: dict[tuple[int, ...], Tracer] = {}
+        _auto_bind_names: tuple[str, ...] | None = None  # frozen on the first traced call
 
         def _needs_new_tracer(tracer: Tracer | None) -> bool:
             return tracer is None or (not tracer.trace_captured and tracer._function is None)
 
         @functools.wraps(fn)
         def wrapper(*args: Any, traced: bool = False, **kwargs: Any) -> Any:
-            nonlocal _tracer_shared
+            nonlocal _auto_bind_names
+
+            # When injecting, accept either name but only one at a time. The kwarg is consumed
+            # by the wrapper in every path — it is never forwarded to the wrapped function.
+            injected_mesh_device: Any = _OMITTED
+            if inject_mesh_device:
+                supplied = [(n, kwargs.pop(n)) for n in _MESH_DEVICE_PARAM_NAMES if n in kwargs]
+                if len(supplied) > 1:
+                    msg = (
+                        f"@traced_function: pass only one of {_MESH_DEVICE_PARAM_NAMES} as the "
+                        f"injected mesh-device kwarg; got "
+                        f"{ {n: v for n, v in supplied} !r}"
+                    )
+                    raise TypeError(msg)
+                if supplied:
+                    injected_mesh_device = supplied[0][1]
 
             if not traced:
                 for k in _TRACER_CALL_KWARGS:
                     kwargs.pop(k, None)
                 return fn(*args, **kwargs)
 
-            # If the first argument is not a valid Tracer input type, treat it as a
-            # bindable context (e.g. self) — bind it away and track a Tracer per instance.
+            # Auto-discovery path: classify args at runtime on the first traced call.
+            # Everything that isn't a Tracer-valid value is bound into the partial.
+            if device is None:
+                tracer_call_kwargs = {k: kwargs.pop(k) for k in list(kwargs) if k in _TRACER_CALL_KWARGS}
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+
+                if _auto_bind_names is None:
+                    _auto_bind_names = tuple(
+                        name
+                        for name in sig.parameters
+                        if name in bound.arguments and not _is_tracer_valid_value(bound.arguments[name])
+                    )
+                    if not inject_mesh_device and sig_mesh_param not in _auto_bind_names:
+                        md = bound.arguments.get(sig_mesh_param, None) if sig_mesh_param else None
+                        msg = (
+                            f"@traced_function: {fn.__qualname__} expected {sig_mesh_param!r} to "
+                            f"be a non-tracer-valid value (e.g. ttnn.MeshDevice), got "
+                            f"{type(md).__name__}={md!r}"
+                        )
+                        raise TypeError(msg)
+
+                bind_values = {n: bound.arguments.pop(n) for n in _auto_bind_names}
+                if inject_mesh_device:
+                    if injected_mesh_device is _OMITTED:
+                        msg = (
+                            f"@traced_function: {fn.__qualname__} was called with traced=True "
+                            f"but none of {_MESH_DEVICE_PARAM_NAMES} were supplied as kwargs "
+                            "(required when inject_mesh_device=True)."
+                        )
+                        raise TypeError(msg)
+                    mesh_device_val = injected_mesh_device
+                    key = (id(mesh_device_val), *(id(v) for v in bind_values.values()))
+                else:
+                    mesh_device_val = bind_values[sig_mesh_param]
+                    key = tuple(id(v) for v in bind_values.values())
+
+                t = _tracers_auto.get(key)
+                if _needs_new_tracer(t):
+                    _tracers_auto[key] = Tracer(
+                        functools.partial(fn, **bind_values),
+                        device=mesh_device_val,
+                        prep_run=prep_run,
+                        clone_prep_inputs=clone_prep_inputs,
+                    )
+                return _tracers_auto[key](*bound.args, **bound.kwargs, **tracer_call_kwargs)
+
+            # Context-bound path: first arg is a non-tracer-valid context (e.g. self);
+            # bind it away and track one Tracer per instance.
             if args and not isinstance(args[0], _TRACER_VALID_INPUT_TYPES):
                 context, rest = args[0], args[1:]
                 if _needs_new_tracer(_tracers.get(context)):
@@ -416,17 +564,20 @@ def traced_function(
                     )
                 return _tracers[context](*rest, **kwargs)
 
-            # Plain function — single shared Tracer.
-            if _needs_new_tracer(_tracer_shared):
-                _tracer_shared = Tracer(
-                    fn,
-                    device=_resolve_device(None),
-                    prep_run=prep_run,
-                    clone_prep_inputs=clone_prep_inputs,
-                )
-            return _tracer_shared(*args, **kwargs)
+            # device= was supplied but the first positional argument is a valid Tracer input
+            # (or absent), so there's no context to bind. Standalone functions should omit
+            # device= and declare a 'mesh_device' parameter for auto-discovery instead.
+            msg = (
+                f"@traced_function: {fn.__qualname__} was called with traced=True, but device= "
+                "was provided at decoration time and the first positional argument is not a "
+                "bindable context (it is a tracer-valid type). For standalone functions, omit "
+                "device= and declare a 'mesh_device' parameter to use auto-discovery; for "
+                "methods, ensure self is passed positionally."
+            )
+            raise TypeError(msg)
 
         wrapper._tracers = _tracers  # type: ignore[attr-defined]
+        wrapper._tracers_auto = _tracers_auto  # type: ignore[attr-defined]
         return wrapper
 
     if _fn is not None:

--- a/models/tt_dit/utils/tracing.py
+++ b/models/tt_dit/utils/tracing.py
@@ -142,6 +142,8 @@ class Tracer:
                 # Trace capture records commands but does not execute them. Execute the trace to
                 # actually compute outputs.
                 ttnn.execute_trace(self._device, trace_id, cq_id=tracer_cq_id, blocking=tracer_blocking_execution)
+                ttnn.synchronize_device(self._device)
+                ttnn.distributed_context_barrier()
 
             # Allow resources referenced by the function to be freed, which might be used to offload
             # weights.
@@ -172,6 +174,8 @@ class Tracer:
                     _tree_map(self._update_input, self._kwargs[name], new, path_label=f'kwargs["{name}"]')
 
             ttnn.execute_trace(self._device, self._trace_id, cq_id=tracer_cq_id, blocking=tracer_blocking_execution)
+            ttnn.synchronize_device(self._device)
+            ttnn.distributed_context_barrier()
 
         return self._outputs
 


### PR DESCRIPTION
## Summary

This PR pulls:
- Pulls in solver on device implementation from [friedrich/solver-on-device](https://github.com/tenstorrent/tt-metal/pull/40624) , fixes tracing, update schedules,  and updates solver on device for tt_dit wan models. Followup PR for other models
  -Updates Wan I2V as well
- Updates the current tracing decorator to support arbitrary functions.
- Add tracing to T5 text encoder

## Quad blackhole galaxy results
### On host
```
[1,3]<stdout>: --------------------------------------------------------------------------------
[1,3]<stdout>: Text Encoding             | Mean:   0.1968s | Std:   0.0000s | Min:   0.1968s | Max:   0.1968s
[1,3]<stdout>: Denoising                 | Mean:  32.9149s | Std:   0.0000s | Min:  32.9149s | Max:  32.9149s
[1,3]<stdout>: VAE Decoding              | Mean:   0.4918s | Std:   0.0000s | Min:   0.4918s | Max:   0.4918s
[1,3]<stdout>: Total Pipeline            | Mean:  33.7820s | Std:   0.0000s | Min:  33.7820s | Max:  33.7820s
[1,3]<stdout>: --------------------------------------------------------------------------------
```
### On device
```
3]<stdout>: --------------------------------------------------------------------------------
[1,3]<stdout>: Text Encoding             | Mean:   0.0570s | Std:   0.0000s | Min:   0.0570s | Max:   0.0570s
[1,3]<stdout>: Denoising                 | Mean:  30.5159s | Std:   0.0000s | Min:  30.5159s | Max:  30.5159s
[1,3]<stdout>: VAE Decoding              | Mean:   0.5109s | Std:   0.0000s | Min:   0.5109s | Max:   0.5109s
[1,3]<stdout>: Total Pipeline            | Mean:  31.1187s | Std:   0.0000s | Min:  31.1187s | Max:  31.1187s
[1,3]<stdout>: --------------------------------------------------------------------------------
```

## Single blackhole galaxy results
### On host
```
--------------------------------------------------------------------------------
Text Encoding             | Mean:   0.1179s | Std:   0.0000s | Min:   0.1179s | Max:   0.1179s
Denoising                 | Mean: 136.2678s | Std:   0.0000s | Min: 136.2678s | Max: 136.2678s
VAE Decoding              | Mean:   1.7523s | Std:   0.0000s | Min:   1.7523s | Max:   1.7523s
Total Pipeline            | Mean: 138.1606s | Std:   0.0000s | Min: 138.1606s | Max: 138.1606s
```

### On device
```
--------------------------------------------------------------------------------
Text Encoding             | Mean:   0.1314s | Std:   0.0000s | Min:   0.1314s | Max:   0.1314s
Denoising                 | Mean: 134.5019s | Std:   0.0000s | Min: 134.5019s | Max: 134.5019s
VAE Decoding              | Mean:   1.0409s | Std:   0.0000s | Min:   1.0409s | Max:   1.0409s
Total Pipeline            | Mean: 135.7001s | Std:   0.0000s | Min: 135.7001s | Max: 135.7001s
```

### Tests
- [![T3K performance](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-perf-tests.yaml/badge.svg?branch=sadesoye%2Fscheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-perf-tests.yaml?query=branch%3Asadesoye%2Fscheduler_on_device)
- [![T3K unit](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=sadesoye%2Fscheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml?query=branch%3Asadesoye%2Fscheduler_on_device)
- [![T3K integration](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=sadesoye%2Fscheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml?query=branch%3Asadesoye%2Fscheduler_on_device)
- [![Galaxy Sanity check](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml/badge.svg?branch=sadesoye%2Fscheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-sanity.yaml?query=branch%3Asadesoye%2Fscheduler_on_device)
- [![Galaxy integration](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-integration-tests.yaml/badge.svg?branch=sadesoye%2Fscheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-integration-tests.yaml?query=branch%3Asadesoye%2Fscheduler_on_device)
- [![Galaxy performance](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml/badge.svg?branch=sadesoye%2Fscheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml?query=branch%3Asadesoye%2Fscheduler_on_device)
- [![Blackhole demo](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml/badge.svg?branch=sadesoye%2Fscheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml?query=branch%3Asadesoye%2Fscheduler_on_device)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/scheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/scheduler_on_device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sadesoye/scheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sadesoye/scheduler_on_device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/scheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/scheduler_on_device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/scheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/scheduler_on_device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/scheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/scheduler_on_device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/scheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/scheduler_on_device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/scheduler_on_device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/scheduler_on_device)