### PR TITLE
Semaphore support for Metal 2.0 host APIs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -461,28 +461,93 @@ TEST_F(ProgramSpecTestQuasar, DFBAliasingFails) {
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-// Remove once implemented
-TEST_F(ProgramSpecTestQuasar, SemaphoresFail) {
-    // Semaphores are not yet implemented for Quasar
+TEST_F(ProgramSpecTestQuasar, SemaphoresSucceed) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     SemaphoreSpec sem;
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
+    spec.workers.value()[0].semaphores = {"sem_0"};
 
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
 
-// Remove once implemented
-TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsFail) {
-    // Semaphore bindings are not yet implemented
+TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsSucceed) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    SemaphoreSpec sem;
+    sem.unique_id = "sem_0";
+    sem.target_nodes = NodeCoord{0, 0};
+    spec.semaphores = {sem};
+    spec.workers.value()[0].semaphores = {"sem_0"};
 
     KernelSpec::SemaphoreBinding binding;
     binding.semaphore_spec_name = "sem_0";
     binding.accessor_name = "my_sem";
     spec.kernels[0].semaphore_bindings = {binding};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    KernelSpec::SemaphoreBinding binding;
+    binding.semaphore_spec_name = "missing_sem";
+    binding.accessor_name = "my_sem";
+    spec.kernels[0].semaphore_bindings = {binding};
+
+    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingInvalidAccessorFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    SemaphoreSpec sem;
+    sem.unique_id = "sem_0";
+    sem.target_nodes = NodeCoord{0, 0};
+    spec.semaphores = {sem};
+    spec.workers.value()[0].semaphores = {"sem_0"};
+
+    KernelSpec::SemaphoreBinding binding;
+    binding.semaphore_spec_name = "sem_0";
+    binding.accessor_name = "has-dash";
+    spec.kernels[0].semaphore_bindings = {binding};
+
+    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    SemaphoreSpec sem0;
+    sem0.unique_id = "sem_0";
+    sem0.target_nodes = NodeCoord{0, 0};
+
+    SemaphoreSpec sem1;
+    sem1.unique_id = "sem_1";
+    sem1.target_nodes = NodeCoord{0, 0};
+
+    spec.semaphores = {sem0, sem1};
+    spec.workers.value()[0].semaphores = {"sem_0", "sem_1"};
+
+    spec.kernels[0].semaphore_bindings = {
+        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "same"},
+        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_1", .accessor_name = "same"}};
+
+    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    SemaphoreSpec sem;
+    sem.unique_id = "sem_0";
+    sem.target_nodes = NodeCoord{0, 0};
+    sem.initial_value = 1;
+    spec.semaphores = {sem};
+    spec.workers.value()[0].semaphores = {"sem_0"};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -1478,12 +1543,11 @@ TEST(AggregateSpecTypes, SemaphoreSpecDesignatedInitializers) {
     SemaphoreSpec sem{
         .unique_id = "my_semaphore",
         .target_nodes = NodeCoord{0, 0},
-        .initial_value = 0,
-        .memory_type = SemaphoreSpec::SemaphoreMemoryType::Register,
+        .initial_value = 7,
     };
 
     EXPECT_EQ(sem.unique_id, "my_semaphore");
-    EXPECT_EQ(sem.memory_type, SemaphoreSpec::SemaphoreMemoryType::Register);
+    EXPECT_EQ(sem.initial_value, 7u);
 }
 
 TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
@@ -1777,6 +1841,23 @@ TEST_F(ProgramSpecTestGen1, DFBTargetsOutOfBoundsNodeFails) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("out of bounds")));
+}
+
+TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
+    // Gen1 accepts non-zero initial values (only Quasar rejects them).
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    SemaphoreSpec sem;
+    sem.unique_id = "sem_0";
+    sem.target_nodes = NodeCoord{0, 0};
+    sem.initial_value = 3;
+    spec.semaphores = {sem};
+    spec.workers.value()[0].semaphores = {"sem_0"};
+
+    spec.kernels[0].semaphore_bindings = {
+        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
 
 TEST_F(ProgramSpecTestGen1, DuplicateKernelNameFails) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -498,7 +498,10 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
     binding.accessor_name = "my_sem";
     spec.kernels[0].semaphore_bindings = {binding};
 
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("references unknown semaphore 'missing_sem'")));
 }
 
 TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingInvalidAccessorFails) {
@@ -515,7 +518,10 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingInvalidAccessorFails) {
     binding.accessor_name = "has-dash";
     spec.kernels[0].semaphore_bindings = {binding};
 
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("semaphore accessor_name 'has-dash' must be a valid C++ identifier")));
 }
 
 TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
@@ -536,7 +542,9 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "same"},
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_1", .accessor_name = "same"}};
 
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("duplicate semaphore accessor_name 'same'")));
 }
 
 TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
@@ -549,7 +557,10 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
     spec.semaphores = {sem};
     spec.workers.value()[0].semaphores = {"sem_0"};
 
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("has initial_value=1 but only zero is supported on Quasar")));
 }
 
 // ---- Named RTA / CRTA / CTA schema validation ----

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1892,8 +1892,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("is a compute kernel with 1 semaphore binding(s). "
-                                 "On WH/BH, semaphores can only be bound to data movement kernels.")));
+            ::testing::HasSubstr("has semaphore bindings, but it is a compute kernel.")));
 }
 
 TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -490,6 +490,25 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsSucceed) {
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
 
+TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelSucceedsOnQuasar) {
+    // Quasar permits compute kernels to participate in semaphore signalling.
+    // (The corresponding Gen1 test asserts this is rejected on WH/BH.)
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    SemaphoreSpec sem;
+    sem.unique_id = "sem_0";
+    sem.target_nodes = NodeCoord{0, 0};
+    spec.semaphores = {sem};
+    spec.workers.value()[0].semaphores = {"sem_0"};
+
+    // kernels[1] is the compute kernel in MakeMinimalValidProgramSpec
+    ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
+    spec.kernels[1].semaphore_bindings = {
+        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
 TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
@@ -1852,6 +1871,47 @@ TEST_F(ProgramSpecTestGen1, DFBTargetsOutOfBoundsNodeFails) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("out of bounds")));
+}
+
+TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
+    // On WH/BH, compute kernels cannot participate in semaphore signalling.
+    // (The corresponding Quasar test asserts this is allowed there.)
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    SemaphoreSpec sem;
+    sem.unique_id = "sem_0";
+    sem.target_nodes = NodeCoord{0, 0};
+    spec.semaphores = {sem};
+    spec.workers.value()[0].semaphores = {"sem_0"};
+
+    // kernels[1] is the compute kernel in MakeMinimalGen1ValidProgramSpec
+    ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
+    spec.kernels[1].semaphore_bindings = {
+        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("is a compute kernel with 1 semaphore binding(s). "
+                                 "On WH/BH, semaphores can only be bound to data movement kernels.")));
+}
+
+TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {
+    // Sanity check: binding a semaphore to a DM kernel on WH/BH is allowed.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    SemaphoreSpec sem;
+    sem.unique_id = "sem_0";
+    sem.target_nodes = NodeCoord{0, 0};
+    spec.semaphores = {sem};
+    spec.workers.value()[0].semaphores = {"sem_0"};
+
+    // kernels[0] is the DM kernel in MakeMinimalGen1ValidProgramSpec
+    ASSERT_TRUE(spec.kernels[0].is_dm_kernel());
+    spec.kernels[0].semaphore_bindings = {
+        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
 
 TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -334,32 +334,66 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
 
     const NodeCoord node{0, 0};
 
-    auto producer = MakeMinimalGen1DMKernel("producer", node, DataMovementProcessor::RISCV_0);
-    producer.source = KernelSpec::SourceFilePath{
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp"};
-    producer.semaphore_bindings = {
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "only_sem", .accessor_name = "signal"}};
+    // A SemaphoreSpec describes a Program-scope semaphore: it identifies the sem by name and
+    // declares which nodes will see it. Initial value defaults to 0.
+    SemaphoreSpec sem{
+        .unique_id = "only_sem",
+        .target_nodes = node,
+    };
 
-    auto consumer = MakeMinimalGen1DMKernel("consumer", node, DataMovementProcessor::RISCV_1);
-    consumer.source = KernelSpec::SourceFilePath{
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp"};
-    consumer.semaphore_bindings = {
-        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "only_sem", .accessor_name = "waiter"}};
+    // A KernelSpec binds the semaphore by its `unique_id` and gives it a kernel-local
+    // `accessor_name` — the name the kernel source uses to refer to it. The runtime emits
+    // `sem::<accessor_name>` constants in `kernel_bindings_generated.h` for the kernel to
+    // consume. The producer and consumer below choose different accessor names for the same
+    // semaphore.
+    KernelSpec producer{
+        .unique_id = "producer",
+        .source =
+            KernelSpec::SourceFilePath{
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp"},
+        .target_nodes = node,
+        .num_threads = 1,
+        .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "signal"}},
+        .config_spec =
+            DataMovementConfiguration{
+                .gen1_data_movement_config =
+                    DataMovementConfiguration::Gen1DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0,
+                    },
+            },
+    };
+    KernelSpec consumer{
+        .unique_id = "consumer",
+        .source =
+            KernelSpec::SourceFilePath{
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp"},
+        .target_nodes = node,
+        .num_threads = 1,
+        .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "waiter"}},
+        .config_spec =
+            DataMovementConfiguration{
+                .gen1_data_movement_config =
+                    DataMovementConfiguration::Gen1DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_1,
+                    },
+            },
+    };
 
-    SemaphoreSpec sem;
-    sem.unique_id = "only_sem";
-    sem.target_nodes = node;
-
-    ProgramSpec spec;
-    spec.program_id = "semaphore_accessor_loopback";
-    spec.kernels = {producer, consumer};
-    spec.semaphores = {sem};
-    spec.workers = std::vector<WorkerSpec>{WorkerSpec{
+    // A WorkerSpec ties together the kernels, DFBs, and semaphores that share a node.
+    WorkerSpec worker{
         .unique_id = "worker_0",
         .kernels = {"producer", "consumer"},
         .semaphores = {"only_sem"},
         .target_nodes = node,
-    }};
+    };
+
+    // The ProgramSpec aggregates everything and is consumed by `MakeProgramFromSpec`.
+    ProgramSpec spec{
+        .program_id = "semaphore_accessor_loopback",
+        .kernels = {producer, consumer},
+        .semaphores = {sem},
+        .workers = std::vector<WorkerSpec>{worker},
+    };
 
     Program program = MakeProgramFromSpec(spec);
     detail::LaunchProgram(device, program);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -309,5 +309,62 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     EXPECT_EQ(output_data, input_data);
 }
 
+// ============================================================================
+// Semaphore Accessor Name Loopback Test
+// ============================================================================
+//
+// Targeted test for the semaphore accessor name plumbing.
+// Very minimal: just one semaphore and two kernels that sync on it via
+// different local accessor names.
+//
+//   - Producer (BRISC) and consumer (NCRISC) each resolve their accessor name
+//     to a sem ID. Test only completes if both land on the same underlying ID.
+//   - If producer's sem::signal ID != consumer's sem::waiter ID, consumer hangs
+//     forever on wait(1).
+//
+// Proves: kernel_bindings_generated.h emits the sem:: namespace correctly, both
+// kernels' views agree on the sem ID, Metal 2.0 allocates the sem (on Gen1).
+//
+// A failure will (unfortunately) manifest as a hang.
+// Any outcome other than "test completes" indicates the name resolution is wrong:
+
+TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+
+    const NodeCoord node{0, 0};
+
+    auto producer = MakeMinimalGen1DMKernel("producer", node, DataMovementProcessor::RISCV_0);
+    producer.source = KernelSpec::SourceFilePath{
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp"};
+    producer.semaphore_bindings = {
+        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "only_sem", .accessor_name = "signal"}};
+
+    auto consumer = MakeMinimalGen1DMKernel("consumer", node, DataMovementProcessor::RISCV_1);
+    consumer.source = KernelSpec::SourceFilePath{
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp"};
+    consumer.semaphore_bindings = {
+        KernelSpec::SemaphoreBinding{.semaphore_spec_name = "only_sem", .accessor_name = "waiter"}};
+
+    SemaphoreSpec sem;
+    sem.unique_id = "only_sem";
+    sem.target_nodes = node;
+
+    ProgramSpec spec;
+    spec.program_id = "semaphore_accessor_loopback";
+    spec.kernels = {producer, consumer};
+    spec.semaphores = {sem};
+    spec.workers = std::vector<WorkerSpec>{WorkerSpec{
+        .unique_id = "worker_0",
+        .kernels = {"producer", "consumer"},
+        .semaphores = {"only_sem"},
+        .target_nodes = node,
+    }};
+
+    Program program = MakeProgramFromSpec(spec);
+    detail::LaunchProgram(device, program);
+    // If we got here, both kernels resolved their sem accessors to the same ID.
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -324,9 +324,6 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
 //
 // Proves: kernel_bindings_generated.h emits the sem:: namespace correctly, both
 // kernels' views agree on the sem ID, Metal 2.0 allocates the sem (on Gen1).
-//
-// A failure will (unfortunately) manifest as a hang.
-// Any outcome other than "test completes" indicates the name resolution is wrong:
 
 TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     auto mesh_device = devices_.at(0);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal test kernel: waits on a semaphore via its sem:: accessor name.
+// The consumer's accessor name differs from the producer's to prove both kernels
+// independently resolve their names to the same underlying sem ID.
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc_semaphore.h"
+
+void kernel_main() {
+    experimental::Semaphore s(sem::waiter);
+    s.wait(1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal test kernel: increments a semaphore via its sem:: accessor name.
+// The sole purpose is to exercise the sem-accessor-name → ID resolution machinery
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc_semaphore.h"
+
+void kernel_main() {
+    experimental::Semaphore s(sem::signal);
+    s.up(1);
+}

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -36,11 +36,13 @@ struct SemaphoreSpec {
 
     // Initial value
     // NOTE: Setting a non-zero initial value is not supported on Gen2 architectures.
-    // Runtime wants to deprecate this feature for ALL architectures
+    // NOTE: Runtime wants to deprecate this feature for ALL architectures.
+    //       When remote DFB becomes available, non-zero initial values will be removed.
     uint32_t initial_value = 0;
 
     // Backing memory
-    // NOTE: Register-backed semaphores are only supported on Gen2 architectures.
+    // NOTE: Register-backed semaphores are a Gen2-only hardware feature.
+    //       They are not yet supported; TBD whether we will ever support them.
     enum class SemaphoreMemoryType { L1, Register };
     SemaphoreMemoryType memory_type = SemaphoreMemoryType::L1;
 };

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -107,6 +107,7 @@ Kernel::Kernel(
     const std::unordered_map<std::string, uint32_t>& named_compile_args,
     bool is_metal2_kernel,
     const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles,
+    const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles,
     const std::vector<std::string>& named_runtime_args,
     const std::vector<std::string>& named_common_runtime_args) :
     programmable_core_type_(programmable_core_type),
@@ -117,6 +118,7 @@ Kernel::Kernel(
     named_compile_time_args_(named_compile_args),
     is_metal2_kernel_(is_metal2_kernel),
     dataflow_buffer_local_accessor_handles_(dataflow_buffer_local_accessor_handles),
+    semaphore_local_accessor_handles_(semaphore_local_accessor_handles),
     named_runtime_args_(named_runtime_args),
     named_common_runtime_args_(named_common_runtime_args),
 
@@ -281,6 +283,13 @@ void Kernel::process_dataflow_buffer_local_accessor_handles(
     const std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)> callback) const {
     for (const auto& [accessor_name, logical_dfb_id] : this->dataflow_buffer_local_accessor_handles_) {
         callback(accessor_name, logical_dfb_id);
+    }
+}
+
+void Kernel::process_semaphore_local_accessor_handles(
+    const std::function<void(const std::string& accessor_name, uint16_t semaphore_id)> callback) const {
+    for (const auto& [accessor_name, semaphore_id] : this->semaphore_local_accessor_handles_) {
+        callback(accessor_name, semaphore_id);
     }
 }
 
@@ -453,6 +462,10 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(static_cast<uint64_t>(it->second));
     }
     for (const auto& it : sorted_iters(this->dataflow_buffer_local_accessor_handles_)) {
+        hasher.update(it->first);
+        hasher.update(static_cast<uint64_t>(it->second));
+    }
+    for (const auto& it : sorted_iters(this->semaphore_local_accessor_handles_)) {
         hasher.update(it->first);
         hasher.update(static_cast<uint64_t>(it->second));
     }

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -90,6 +90,8 @@ KernelHandle CreateKernelFromString(
 
 // Metal 2.0: local DFB accessor names -> logical DFB ids
 using DataflowBufferLocalAccessorHandleMap = std::unordered_map<std::string, uint16_t>;
+// Metal 2.0: local semaphore accessor names -> semaphore ids
+using SemaphoreLocalAccessorHandleMap = std::unordered_map<std::string, uint16_t>;
 
 class Kernel : public JitBuildSettings {
 public:
@@ -149,6 +151,8 @@ public:
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const override;
     void process_dataflow_buffer_local_accessor_handles(
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const override;
+    void process_semaphore_local_accessor_handles(
+        std::function<void(const std::string& accessor_name, uint16_t semaphore_id)>) const override;
     const std::vector<std::string>& get_named_runtime_args() const override { return named_runtime_args_; }
     const std::vector<std::string>& get_named_common_runtime_args() const override {
         return named_common_runtime_args_;
@@ -214,6 +218,7 @@ protected:
         // boundary is obvious at a glance; the others are ignored when it is false.
         bool is_metal2_kernel = false,
         const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {});
 
@@ -231,6 +236,7 @@ protected:
     // named_common_runtime_args_ determines byte-offset layout in the dispatch buffer.
     const bool is_metal2_kernel_;
     const DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
+    const SemaphoreLocalAccessorHandleMap semaphore_local_accessor_handles_;
     const std::vector<std::string> named_runtime_args_;
     const std::vector<std::string> named_common_runtime_args_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
@@ -268,6 +274,7 @@ public:
         // Metal 2.0-only parameters below.
         bool is_metal2_kernel = false,
         const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {}) :
         Kernel(
@@ -280,6 +287,7 @@ public:
             config.named_compile_args,
             is_metal2_kernel,
             dataflow_buffer_local_accessor_handles,
+            semaphore_local_accessor_handles,
             named_runtime_args,
             named_common_runtime_args),
         config_(config) {
@@ -398,6 +406,7 @@ public:
         // Metal 2.0-only parameters below.
         bool is_metal2_kernel = false,
         const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {}) :
         Kernel(
@@ -410,6 +419,7 @@ public:
             config.named_compile_args,
             is_metal2_kernel,
             dataflow_buffer_local_accessor_handles,
+            semaphore_local_accessor_handles,
             named_runtime_args,
             named_common_runtime_args),
         config_(config) {
@@ -477,6 +487,7 @@ public:
         // Metal 2.0-only parameters below.
         bool is_metal2_kernel = false,
         const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {}) :
         Kernel(
@@ -489,6 +500,7 @@ public:
             config.named_compile_args,
             is_metal2_kernel,
             dataflow_buffer_local_accessor_handles,
+            semaphore_local_accessor_handles,
             named_runtime_args,
             named_common_runtime_args),
         config_(config),
@@ -542,6 +554,7 @@ public:
         // Metal 2.0-only parameters below.
         bool is_metal2_kernel = false,
         const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
+        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
         const std::vector<std::string>& named_runtime_args = {},
         const std::vector<std::string>& named_common_runtime_args = {}) :
         Kernel(
@@ -554,6 +567,7 @@ public:
             config.named_compile_args,
             is_metal2_kernel,
             dataflow_buffer_local_accessor_handles,
+            semaphore_local_accessor_handles,
             named_runtime_args,
             named_common_runtime_args),
         config_(config),

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -102,6 +102,7 @@ using KernelRiscMaskMap = std::unordered_map<const KernelSpec*, uint16_t>;
 
 // DFB name -> DFB ID map (for unpack_to_dest_mode indexing)
 using DFBNameToIdMap = std::unordered_map<DFBSpecName, uint32_t>;
+using SemaphoreNameToIdMap = std::unordered_map<SemaphoreSpecName, uint32_t>;
 
 // ============================================================================
 // Basic Utility Helpers
@@ -324,6 +325,29 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
     for (const auto& semaphore : spec.semaphores) {
         auto [it, inserted] = collected.semaphore_by_name.try_emplace(semaphore.unique_id, &semaphore);
         TT_FATAL(inserted, "Duplicate SemaphoreSpec name '{}'", semaphore.unique_id);
+    }
+
+    // Validate semaphore bindings
+    for (const auto& kernel : spec.kernels) {
+        std::unordered_set<std::string> accessor_names;
+        for (const auto& binding : kernel.semaphore_bindings) {
+            auto [it, inserted] = accessor_names.insert(binding.accessor_name);
+            TT_FATAL(
+                inserted,
+                "Kernel '{}' has duplicate semaphore accessor_name '{}'",
+                kernel.unique_id,
+                binding.accessor_name);
+            TT_FATAL(
+                IsValidCppIdentifier(binding.accessor_name),
+                "Kernel '{}' semaphore accessor_name '{}' must be a valid C++ identifier",
+                kernel.unique_id,
+                binding.accessor_name);
+            TT_FATAL(
+                collected.semaphore_by_name.contains(binding.semaphore_spec_name),
+                "Kernel '{}' references unknown semaphore '{}'",
+                kernel.unique_id,
+                binding.semaphore_spec_name);
+        }
     }
 
     // Check for duplicate WorkerSpec unique_ids (not collected)
@@ -651,15 +675,18 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate SemaphoreSpecs
     //////////////////////////////////
 
-    // Semaphores aren't supported yet for Quasar
-    TT_FATAL(spec.semaphores.empty(), "Semaphores are not supported yet");
-
-    // Validate no semaphore bindings are used (semaphores not yet implemented)
-    for (const auto& kernel : spec.kernels) {
+    for (const auto& sem : spec.semaphores) {
         TT_FATAL(
-            kernel.semaphore_bindings.empty(),
-            "KernelSpec '{}' has semaphore bindings, but semaphores are not yet implemented",
-            kernel.unique_id);
+            sem.memory_type == SemaphoreSpec::SemaphoreMemoryType::L1,
+            "SemaphoreSpec '{}' uses non-L1 memory type, which is not yet supported",
+            sem.unique_id);
+        if (is_gen2_arch()) {
+            TT_FATAL(
+                sem.initial_value == 0,
+                "SemaphoreSpec '{}' has initial_value={} but only zero is supported on Quasar",
+                sem.unique_id,
+                sem.initial_value);
+        }
     }
 
     //////////////////////////////
@@ -1145,6 +1172,24 @@ tt::tt_metal::DataflowBufferLocalAccessorHandleMap MakeDataflowBufferLocalAccess
     return out;
 }
 
+// Create map of local accessor name -> logical Semaphore id
+tt::tt_metal::SemaphoreLocalAccessorHandleMap MakeSemaphoreLocalAccessorHandles(
+    const KernelSpec& kernel_spec, const SemaphoreNameToIdMap& semaphore_name_to_id) {
+    tt::tt_metal::SemaphoreLocalAccessorHandleMap out;
+    out.reserve(kernel_spec.semaphore_bindings.size());
+    for (const auto& semaphore_binding : kernel_spec.semaphore_bindings) {
+        const uint32_t id = semaphore_name_to_id.at(semaphore_binding.semaphore_spec_name);
+        TT_FATAL(
+            id <= std::numeric_limits<uint16_t>::max(),
+            "Kernel '{}' semaphore '{}' id {} does not fit uint16_t",
+            kernel_spec.unique_id,
+            semaphore_binding.semaphore_spec_name,
+            id);
+        out.emplace(semaphore_binding.accessor_name, static_cast<uint16_t>(id));
+    }
+    return out;
+}
+
 // Create a DataflowBufferConfig from a DataflowBufferSpec and endpoint info.
 experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     const DataflowBufferSpec* dfb_spec,
@@ -1403,6 +1448,17 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
         dfb_name_to_id[dfb_name] = dfb_id;
     }
 
+    // Create Semaphores and build name -> ID map.
+    // NOTE: Iterate over spec.semaphores to preserve user-provided deterministic ordering.
+    SemaphoreNameToIdMap semaphore_name_to_id;
+    for (const auto& semaphore_spec : spec.semaphores) {
+        const SemaphoreSpecName& semaphore_name = semaphore_spec.unique_id;
+        uint32_t sem_id = program_impl->create_semaphore(
+            to_node_range_set(semaphore_spec.target_nodes), semaphore_spec.initial_value, CoreType::WORKER);
+        program_impl->register_semaphore_spec_name(semaphore_name, sem_id);
+        semaphore_name_to_id[semaphore_name] = sem_id;
+    }
+
     // Create Kernels (arch-specific)
     for (const KernelSpec& kernel_spec : spec.kernels) {
         KernelSource kernel_src = MakeKernelSource(kernel_spec);
@@ -1411,6 +1467,8 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
         // Make the local accessor name -> DFB ID map for this kernel
         const tt::tt_metal::DataflowBufferLocalAccessorHandleMap dfb_handles =
             MakeDataflowBufferLocalAccessorHandles(kernel_spec, dfb_name_to_id);
+        const tt::tt_metal::SemaphoreLocalAccessorHandleMap semaphore_handles =
+            MakeSemaphoreLocalAccessorHandles(kernel_spec, semaphore_name_to_id);
 
         // Named-args schema fields passed to the Kernel ctor. The names are used at JIT time
         // to emit kernel_args_generated.h and factor into the kernel cache key.
@@ -1435,6 +1493,7 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
                     processors,
                     is_metal2_kernel,
                     dfb_handles,
+                    semaphore_handles,
                     named_rtas,
                     named_crtas);
             } else {
@@ -1447,6 +1506,7 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
                     processors,
                     is_metal2_kernel,
                     dfb_handles,
+                    semaphore_handles,
                     named_rtas,
                     named_crtas);
             }
@@ -1454,11 +1514,25 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
             if (kernel_spec.is_dm_kernel()) {
                 auto config = MakeGen1DataMovementConfig(kernel_spec);
                 kernel = std::make_shared<DataMovementKernel>(
-                    kernel_src, node_ranges, config, is_metal2_kernel, dfb_handles, named_rtas, named_crtas);
+                    kernel_src,
+                    node_ranges,
+                    config,
+                    is_metal2_kernel,
+                    dfb_handles,
+                    semaphore_handles,
+                    named_rtas,
+                    named_crtas);
             } else {
                 auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_id);
                 kernel = std::make_shared<ComputeKernel>(
-                    kernel_src, node_ranges, config, is_metal2_kernel, dfb_handles, named_rtas, named_crtas);
+                    kernel_src,
+                    node_ranges,
+                    config,
+                    is_metal2_kernel,
+                    dfb_handles,
+                    semaphore_handles,
+                    named_rtas,
+                    named_crtas);
             }
         }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -694,11 +694,10 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     if (is_gen1_arch()) {
         for (const auto& kernel : spec.kernels) {
             if (kernel.is_compute_kernel() && !kernel.semaphore_bindings.empty()) {
-                TT_FATAL(
-                    false,
+                TT_THROW(
                     "KernelSpec '{}' has semaphore bindings, but it is a compute kernel. "
                     "On WH/BH, semaphores can only be bound to data movement kernels.",
-                    kernel.unique_id;
+                    kernel.unique_id);
             }
         }
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -689,6 +689,20 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
+    // On Gen1 (WH/BH), semaphores can only be bound to DM kernels, not compute kernels.
+    // Compute-kernel semaphore access is a Quasar-only feature.
+    if (is_gen1_arch()) {
+        for (const auto& kernel : spec.kernels) {
+            if (kernel.is_compute_kernel() && !kernel.semaphore_bindings.empty()) {
+                TT_FATAL(
+                    false,
+                    "KernelSpec '{}' has semaphore bindings, but it is a compute kernel. "
+                    "On WH/BH, semaphores can only be bound to data movement kernels.",
+                    kernel.unique_id;
+            }
+        }
+    }
+
     //////////////////////////////
     // Validate WorkerSpecs
     //////////////////////////////

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1397,6 +1397,48 @@ void detail::ProgramImpl::add_semaphore(
     semaphores_.emplace_back(Semaphore(crs, semaphore_id, init_value, core_type));
 }
 
+uint32_t detail::ProgramImpl::create_semaphore(const CoreRangeSet& crs, uint32_t initial_value, CoreType core_type) {
+    TT_FATAL(!crs.ranges().empty(), "Expecting a non-empty CoreRangeSet!");
+    TT_FATAL(
+        MetalContext::instance().is_coord_in_range(crs.ranges().back().end_coord, core_type),
+        "Coordinates out of range");
+
+    // The allocated ID must be free on every core in crs. Find the max ID that's free on each
+    // range (they each return the smallest free ID on their cores) and use that everywhere.
+    std::optional<uint32_t> semaphore_id;
+    for (const auto& core_range : crs.ranges()) {
+        std::vector<uint32_t> semaphore_histogram(NUM_SEMAPHORES, 0);
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                CoreCoord logical_core(x, y);
+                auto existing = this->semaphores_on_core(logical_core, core_type);
+                if (existing.size() == NUM_SEMAPHORES) {
+                    TT_THROW(
+                        "Cannot add semaphore on core {}. Max number of semaphores ({}) reached!",
+                        logical_core.str(),
+                        NUM_SEMAPHORES);
+                }
+                for (const auto& semaphore : existing) {
+                    semaphore_histogram[semaphore.get().id()]++;
+                }
+            }
+        }
+        std::optional<uint32_t> candidate;
+        for (uint32_t sem_id = 0; sem_id < semaphore_histogram.size(); sem_id++) {
+            if (semaphore_histogram[sem_id] == 0) {
+                candidate = sem_id;
+                break;
+            }
+        }
+        TT_FATAL(candidate.has_value(), "Unable to initialize semaphores on core range {}", core_range.str());
+        semaphore_id = semaphore_id.has_value() ? std::max(*semaphore_id, *candidate) : candidate;
+    }
+    TT_FATAL(semaphore_id.has_value(), "Unable to initialize Semaphore!");
+
+    this->add_semaphore(crs, *semaphore_id, initial_value, core_type);
+    return *semaphore_id;
+}
+
 std::vector<std::vector<CoreCoord>> detail::ProgramImpl::logical_cores() const {
     std::vector<std::vector<CoreCoord>> cores_in_program;
     std::vector<std::set<CoreCoord>> unique_cores;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -309,6 +309,14 @@ public:
 
     KernelHandle add_kernel(const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType& core_type);
 
+    // Allocate the next free semaphore ID on the given cores and insert the semaphore.
+    // Returns the allocated ID; TT_FATALs if no slot can be found.
+    uint32_t create_semaphore(const CoreRangeSet& crs, uint32_t initial_value, CoreType core_type);
+
+    // Insert a semaphore at the caller-specified ID. Used by:
+    //   - Construction paths where the ID is already decided upstream (ProgramDescriptor ctor path).
+    //   - create_semaphore above
+    // The ProgramDescriptor path is something of a hack; it will eventually be deprecated in favor of Metal 2.0.
     void add_semaphore(const CoreRangeSet& crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type);
 
     // Validates that a semaphore ID is within bounds and not already in use on overlapping cores

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -113,7 +113,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     // NOTE: Both accessor types are emitted as constexpr variables, i.e. as implicit CTAs.
     //       This is a design decision; we could alternatively emit them as implicit CRTAs.
     //       (Or, we could give the user the choice via the Metal 2.0 host API, on a per-kernel or per-accessor basis.)
-    //       Implicit CTA is simplier and cheaper, but could theoretically cause unnecessary kernel cache hit misses.
+    //       Implicit CTA is simpler and cheaper, but could theoretically cause unnecessary kernel cache hit misses.
     //       We are starting simple and can adjust later if problems arise.
     //       Legacy kernels passed semaphores both ways, kernel folks think this was more random than intentional.
     ostringstream content;

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -87,30 +87,64 @@ void write_file(const string& path, const string& content) {
 }
 
 // METAL 2.0 only:
-// NOTE: This is only invoked for Metal 2.0 kernels created via the new host API.
-//       Legacy kernels do not get kernel_bindings_generated.h.
+// This is only invoked for Metal 2.0 kernels created via the new ProgramSpec host APIs.
+// Legacy kernels (created via CreateKernel) do not get kernel_bindings_generated.h.
 void write_kernel_bindings_generated_header(const string& out_dir, const JitBuildSettings& settings) {
     const string path = out_dir + "kernel_bindings_generated.h";
-    vector<pair<string, uint16_t>> entries;
-    settings.process_dataflow_buffer_local_accessor_handles(
-        [&entries](const string& name, uint16_t id) { entries.emplace_back(name, id); });
-    sort(entries.begin(), entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
+    // Get the DFB bindings from the settings callback
+    // Sort them to ensure the file output is deterministic (note: this is strictly unnecessary, could remove)
+    vector<pair<string, uint16_t>> dfb_entries;
+    settings.process_dataflow_buffer_local_accessor_handles(
+        [&dfb_entries](const string& name, uint16_t id) { dfb_entries.emplace_back(name, id); });
+    sort(dfb_entries.begin(), dfb_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    // Get the semaphore bindings from the settings callback
+    // Sort them to ensure the file output is deterministic (note: this is strictly unnecessary, could remove)
+    vector<pair<string, uint16_t>> sem_entries;
+    settings.process_semaphore_local_accessor_handles(
+        [&sem_entries](const string& name, uint16_t id) { sem_entries.emplace_back(name, id); });
+    sort(sem_entries.begin(), sem_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    // Emit the header content:
+    //  - DFB accessors are emitted into the dfb namespace
+    //  - Semaphore accessors are emitted into the sem namespace
+    //
+    // NOTE: Both accessor types are emitted as constexpr variables, i.e. as implicit CTAs.
+    //       This is a design decision; we could alternatively emit them as implicit CRTAs.
+    //       (Or, we could give the user the choice via the Metal 2.0 host API, on a per-kernel or per-accessor basis.)
+    //       Implicit CTA is simplier and cheaper, but could theoretically cause unnecessary kernel cache hit misses.
+    //       We are starting simple and can adjust later if problems arise.
+    //       Legacy kernels passed semaphores both ways, kernel folks think this was more random than intentional.
     ostringstream content;
-    content << "// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.\n"
-               "//\n"
-               "// SPDX-License-Identifier: Apache-2.0\n\n"
-               "// AUTO-GENERATED — do not edit.\n\n"
+    content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n";
-    if (entries.empty()) {
+    if (dfb_entries.empty() && sem_entries.empty()) {
         content << "// No bindings for this kernel.\n";
     } else {
-        content << "#include \"experimental/dataflow_buffer.h\"\n\n"
-                   "namespace dfb {\n";
-        for (const auto& [name, id] : entries) {
-            content << "constexpr experimental::DFBAccessor " << name << "{" << id << "};\n";
+        if (!dfb_entries.empty()) {
+            content << "#include \"experimental/dataflow_buffer.h\"\n";
         }
-        content << "}  // namespace dfb\n";
+        if (!sem_entries.empty()) {
+            content << "#include <cstdint>\n";
+        }
+        content << "\n";
+
+        if (!dfb_entries.empty()) {
+            content << "namespace dfb {\n";
+            for (const auto& [name, id] : dfb_entries) {
+                content << "constexpr experimental::DFBAccessor " << name << "{" << id << "};\n";
+            }
+            content << "}  // namespace dfb\n";
+        }
+
+        if (!sem_entries.empty()) {
+            content << "namespace sem {\n";
+            for (const auto& [name, id] : sem_entries) {
+                content << "constexpr std::uint32_t " << name << " = " << id << "u;\n";
+            }
+            content << "}  // namespace sem\n";
+        }
     }
     write_file(path, content.str());
 }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -93,14 +93,16 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     const string path = out_dir + "kernel_bindings_generated.h";
 
     // Get the DFB bindings from the settings callback
-    // Sort them to ensure the file output is deterministic (note: this is strictly unnecessary, could remove)
+    // Sort them to ensure the file output is deterministic for the JIT build cache
+    // (aka the on-disk per-object dephash cache)
     vector<pair<string, uint16_t>> dfb_entries;
     settings.process_dataflow_buffer_local_accessor_handles(
         [&dfb_entries](const string& name, uint16_t id) { dfb_entries.emplace_back(name, id); });
     sort(dfb_entries.begin(), dfb_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
     // Get the semaphore bindings from the settings callback
-    // Sort them to ensure the file output is deterministic (note: this is strictly unnecessary, could remove)
+    // Sort them to ensure the file output is deterministic for the JIT build cache
+    // (aka the on-disk per-object dephash cache)
     vector<pair<string, uint16_t>> sem_entries;
     settings.process_semaphore_local_accessor_handles(
         [&sem_entries](const string& name, uint16_t id) { sem_entries.emplace_back(name, id); });

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -32,10 +32,15 @@ public:
     // Called to process the user named compile time args
     virtual void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const = 0;
+
     // Called to process the user kernel resource bindings (Metal 2.0 APIs)
-    // (Initially just DFB local accessor names, but will be extended and refactored as needed.)
+    //  - DFB accessors
+    //  - Semaphore accessors
+    //  - Tensor accessors (TODO)
     virtual void process_dataflow_buffer_local_accessor_handles(
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const {}
+    virtual void process_semaphore_local_accessor_handles(
+        std::function<void(const std::string& accessor_name, uint16_t semaphore_id)>) const {}
 
     // Named RTA/CRTA schema (Metal 2.0 APIs).
     // The order of names determines the byte offset of each arg within the named-args

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -183,43 +183,6 @@ void ConfigureKernelGroup(
     }
 }
 
-std::optional<uint32_t> get_semaphore_id(const Program& program, const CoreRange& core_range, CoreType core_type) {
-    std::optional<uint32_t> semaphore_id = std::nullopt;
-    std::vector<uint32_t> semaphore_histogram(NUM_SEMAPHORES, 0);
-    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-            CoreCoord logical_core(x, y);
-            auto semaphores = program.impl().semaphores_on_core(logical_core, core_type);
-            if (semaphores.size() == NUM_SEMAPHORES) {
-                TT_THROW(
-                    "Cannot add semaphore on core {}. Max number of semaphores ({}) reached!",
-                    logical_core.str(),
-                    NUM_SEMAPHORES);
-            }
-
-            for (const auto& semaphore : semaphores) {
-                semaphore_histogram[semaphore.get().id()]++;
-            }
-        }
-    }
-
-    std::optional<uint32_t> uninitialized_sem_id = std::nullopt;
-    for (int sem_id = 0; sem_id < semaphore_histogram.size(); sem_id++) {
-        if (semaphore_histogram.at(sem_id) == 0) {
-            uninitialized_sem_id = sem_id;
-            break;
-        }
-    }
-
-    if (uninitialized_sem_id.has_value()) {
-        semaphore_id = uninitialized_sem_id;
-    } else {
-        TT_THROW("Unable to initialize semaphores on core range {}", core_range.str());
-    }
-
-    return semaphore_id;
-}
-
 inline void SetRuntimeArgsImpl(
     const Program& program, KernelHandle kernel_id, const CoreCoord& c, stl::Span<const uint32_t> runtime_args) {
     if (!runtime_args.empty()) {
@@ -1593,24 +1556,7 @@ uint32_t CreateSemaphore(
             },
         },
         core_spec);
-    std::optional<uint32_t> semaphore_id;
-    TT_FATAL(!crs.ranges().empty(), "Expecting a non-empty CoreRangeSet!");
-    TT_FATAL(
-        MetalContext::instance().is_coord_in_range((crs.ranges().back()).end_coord, core_type),
-        "Coordinates out of range");
-    for (const auto& core_range : crs.ranges()) {
-        std::optional<uint32_t> semaphore_id_candidate = get_semaphore_id(program, core_range, core_type);
-        if (!semaphore_id.has_value()) {
-            semaphore_id = semaphore_id_candidate;
-        } else {
-            semaphore_id = std::max(semaphore_id.value(), semaphore_id_candidate.value());
-        }
-    }
-    TT_FATAL(semaphore_id.has_value(), "Unable to initialize Semaphore!");
-
-    program.impl().add_semaphore(crs, semaphore_id.value(), initial_value, core_type);
-
-    return semaphore_id.value();
+    return program.impl().create_semaphore(crs, initial_value, core_type);
 }
 
 GlobalSemaphore CreateGlobalSemaphore(


### PR DESCRIPTION
### PR Type
New feature

### Problem description
In Metal 2.0, the user "binds" a semaphore to a kernel and assigns it a local accessor name in their host code. On the device side, they create a `Semaphore` object from that accessor. 

e.g.

```C++
using namespace tt::tt_metal::experimental::metal2_host_api;

SemaphoreSpec done_sem{
    .unique_id = "done",
    .target_nodes = NodeCoord{0, 0} 
};

KernelSpec consumer = /* ... */;
consumer.semaphore_bindings = {
    {.semaphore_spec_name = "done", .accessor_name = "done_flag"},
};
```
```
#include "experimental/noc_semaphore.h"

void kernel_main() {
    experimental::Semaphore done(sem::done_flag); 
    done.wait(1);
    // ...
}
```

**Design decision**: The semaphore accessor binding could either be baked into the kernel binary (implicit CTA), or passed as an implicit CRTA. Legacy kernels use both mechanisms. 

The choice here (after consulting with kernel team) is to bake the semaphore ID (and DFB accessor ID) into the kernel binary. This is the simplest solution; it reduces dispatch overhead but could theoretically reduce kernel cache hits. The decision and the why are documented in code comments. This is easy to change later if we want to.

### What's changed
 - **Host API**: Semaphore declaration and binding APIs were already in place; this just tweaks comments in the public header. Small notes:
        - Non-zero semaphore initial value is disallowed on Quasar. I'm allowing it on WH/BH for now.
        - `SemaphoreMemoryType` is kept in the API, with a note that we might get rid of it if we give up on `Register`.
 - **Device API**: Add semaphore bindings to the auto-gen `kernel_bindings_generated.h`, hardcoded as constexprs (`codegen.cpp`).
 - **Validation**: Added semaphore legality checks to `program_spec.cpp`
 - **Plumbing**: 
       - Modified `Kernel`, `ProgramImpl` and ` JitBuildSettings` to get the semaphore accessor names from host API down to the header generator.
       - Modified `program_spec.cpp` to set them.
       - Moved the `create_semaphore` implementation function over to `ProgramImpl`. Unlike the Quasar-specific DFB creation logic, this code is reached from both the legacy APIs and Metal 2.0; this move made the code paths cleaner.
 - **Testing**: Add some unit tests (on mock device) and a trivial HW test to prove the semaphore names work as expected.
 
This change follows the same pattern as DFB local accessors ([#42009](https://github.com/tenstorrent/tt-metal/pull/42009).

### Notes to reviewers
 - Are we happy with the namespace choices for the emitted accessor names? I wanted to double check, as kernel authors won't be able to use these identifies as local variable names without colliding with the namespace.
       - `dfb::accessor_name` for DFBs
       - `sem::accessor_name` for semaphores?
 - Opinion... should we disable non-zero initialization for WH/BH from the start?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/semaphore-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/semaphore-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/semaphore-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/semaphore-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/semaphore-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/semaphore-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/semaphore-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/semaphore-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/semaphore-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/semaphore-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/semaphore-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/semaphore-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/semaphore-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/semaphore-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/semaphore-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/semaphore-support)