### PR TITLE
fix(llk): fix pack_reads_per_xy_plane default and reduce ownership

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp
@@ -133,7 +133,8 @@ struct RMSNorm {
                 add_rsqrt_tile_init();
                 cb_wait_front(CTArgs::input_cb, num_tiles);
                 tile_regs_acquire();
-                mul_reduce_scalar_tile<PoolType::SUM>(CTArgs::input_cb, CTArgs::input_cb, num_tiles, args.scalar);
+                mul_reduce_scalar_tile<PoolType::SUM>(
+                    CTArgs::input_cb, CTArgs::input_cb, CTArgs::output_cb, num_tiles, args.scalar);
                 mul_reduce_scalar_uninit();
             }
             {

--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -169,7 +169,7 @@ ALWI void sampling_reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, 
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, math_fidelity>(icb)));
 #endif
-    PACK((llk_pack_reduce_mask_config<reduce_dim, ckernel::PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<reduce_dim, ckernel::PackMode::Default>(ocb)));
 }
 
 template <PoolType reduce_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation, MathFidelity math_fidelity>
@@ -223,6 +223,9 @@ template <
     uint32_t cols>
 void softmax_reduce_c() {
     reconfig_data_format(in0_cb, scale_cb);
+    // Reconfigure packer for out_cb BEFORE the reduce mask is programmed by
+    // sampling_reduce_init.
+    pack_reconfig_data_format(out_cb);
     sampling_reduce_init<pool_type, reduce_dim, false, MathFidelity::HiFi4>(in0_cb, scale_cb, out_cb);
     const uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);
@@ -235,7 +238,6 @@ void softmax_reduce_c() {
                 in0_cb, scale_cb, i * cols + j, 0, reduce_dst_idx);
         }
         cb_reserve_back(out_cb, 1);
-        pack_reconfig_data_format(out_cb);
         pack_tile(reduce_dst_idx, out_cb);
         cb_push_back(out_cb, 1);
         release_dst();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/compute_kernel_sentinel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/compute_kernel_sentinel.cpp
@@ -83,6 +83,7 @@ void kernel_main() {
 
     reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_in1, cb_in0, cb_out0);
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_SRCB | RECONFIG_CHANGED_PACK));
+    reduce_uninit();
 
     tilize_init(cb_in0, 1, cb_out1);
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_PACK));

--- a/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
     tile_regs_acquire();
 
     // Perform fused multiply + reduce scalar
-    ckernel::mul_reduce_scalar_tile<REDUCE_OP>(tt::CBIndex::c_0, tt::CBIndex::c_1, num_tiles);
+    ckernel::mul_reduce_scalar_tile<REDUCE_OP>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16, num_tiles);
 
     tile_regs_commit();
     tile_regs_wait();

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
@@ -46,7 +46,7 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < rows; i++) {
         acquire_dst();
-        reduce_block_max_row_init<cols>();
+        reduce_block_max_row_init<cols>(out_max_cb);
         reduce_block_max_row<cols>(qk_im_cb, scale_cb, i * cols, reduce_dst_idx);
         reduce_block_max_row_uninit(qk_im_cb);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
@@ -147,7 +147,6 @@ inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output 
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
 
@@ -155,7 +154,6 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
-        face_r_dim,
         tile_c_dim,
         num_faces,
         false /* partial_face */);
@@ -184,7 +182,6 @@ llk_pack_reconfig_data_format_disaggregated(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
-        face_r_dim,
         tile_c_dim,
         num_faces,
         false /* partial_face */);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_reduce_api.h
@@ -9,9 +9,12 @@
  * LLK PACK REDUCE
  *************************************************************************/
 
+// Use the runtime face_r_dim of the output CB. Required for narrow tiles
+// (e.g. tile_dimensions=[1,32]) where face_r_dim differs from FACE_R_DIM.
 template <ReduceDim dim, PackMode pack_mode = PackMode::Default>
-inline void llk_pack_reduce_mask_config() {
-    _llk_pack_reduce_mask_config_<dim, pack_mode>();
+inline void llk_pack_reduce_mask_config(uint32_t ocb) {
+    const std::uint32_t output_id = get_output_id(ocb);
+    _llk_pack_reduce_mask_config_<dim, pack_mode>(get_output_face_r_dim(output_id));
 }
 
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_rows_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_rows_api.h
@@ -42,10 +42,7 @@ inline void llk_pack_rows(
         (dst_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
-    // Pack rows uses pack_reads_per_xy_plane=1 (set in _llk_pack_rows_init_) for row packing,
-    // which differs from standard tile face_r_dim. Use ProgramByTile to skip face_r_dim check.
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByTile>(
-        pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_rows_(dst_index, pack_addr);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
@@ -23,8 +23,7 @@ inline void llk_pack_init(
     const std::uint32_t num_faces = get_output_num_faces(output_id);
 
     if constexpr (!skip_addrmod_config) {
-        LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-            pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+        LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
     }
 
     // For pack with tilize enabled, check if the original input format is 8-bit.
@@ -45,8 +44,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
     std::uint32_t pack_tile_addr =
         get_output_tile_address<out_of_order_output, pack_mode>(output_id, output_tile_index);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output)));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     LLK_ASSERT(
         (tile_index < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
@@ -61,8 +59,7 @@ inline void llk_matmul_pack(
 
     static_assert(
         !((pack_mode == PackMode::Untilize) && out_of_order_output), "untilize out of order packing is not supported!");
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output)));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
     LLK_ASSERT(
         ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -179,8 +179,7 @@ llk_pack_untilize_init(std::uint32_t output, const std::uint32_t face_r_dim, con
     static_assert(diagonal == false, "Diagonal is only supported on WH");
     const std::uint32_t output_id = get_output_id(output);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, num_faces);
@@ -298,8 +297,7 @@ llk_pack_untilize(
             (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
             16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -143,8 +143,7 @@ inline void llk_pack_untilize_init(std::uint32_t output) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, num_faces);
@@ -239,8 +238,7 @@ inline void llk_pack_untilize(
             (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
             16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
@@ -12,12 +12,14 @@
 /**
  * @brief Configures PACKER0 edge mask programming to support reduce operations (Quasar native API).
  *
- * @tparam untilize Unused on Quasar
+ * ocb is unused on Quasar (different packer architecture); accepted to keep
+ * the API arch-agnostic with Blackhole/Wormhole B0 callers that thread the output CB through.
+ *
  * @tparam reduce_dim The reduce op dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
  * @tparam pack_mode Unused on Quasar
  */
 template <ReduceDim reduce_dim, [[maybe_unused]] PackMode pack_mode = PackMode::Default>
-inline void llk_pack_reduce_mask_config() {
+inline void llk_pack_reduce_mask_config([[maybe_unused]] uint32_t ocb) {
     static_assert(pack_mode == PackMode::Default, "Quasar pack reduce mask does not support pack_mode != Default");
     _llk_pack_reduce_mask_config_<reduce_dim>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_fast_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_fast_tilize_api.h
@@ -19,8 +19,7 @@ inline void llk_pack_fast_tilize_init(
     const uint32_t use_32bit_dest =
         pack_src_format[input_id] == (uint)DataFormat::Float32 || pack_src_format[input_id] == (uint)DataFormat::Tf32;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByTile>(
-        pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_fast_tilize_init_<DST_SYNC_MODE>(use_32bit_dest, pack_dst_format[output_id], unit_dim, num_faces);
 }
@@ -52,8 +51,7 @@ inline void llk_pack_fast_tilize_block(
 
     const std::uint32_t pack_tile_addr = get_output_tile_address<true, PackMode::Default>(output_id, output_tile_index);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByTile>(
-        pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_fast_tilize_block_(tile_index, pack_tile_addr, unit_dim, num_units, num_faces);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_reduce_api.h
@@ -9,9 +9,12 @@
  * LLK PACK REDUCE
  *************************************************************************/
 
+// Use the runtime face_r_dim of the output CB. Required for narrow tiles
+// (e.g. tile_dimensions=[1,32]) where face_r_dim differs from FACE_R_DIM.
 template <ReduceDim dim, PackMode pack_mode = PackMode::Default>
-inline void llk_pack_reduce_mask_config() {
-    _llk_pack_reduce_mask_config_<dim, pack_mode>();
+inline void llk_pack_reduce_mask_config(uint32_t ocb) {
+    const std::uint32_t output_id = get_output_id(ocb);
+    _llk_pack_reduce_mask_config_<dim, pack_mode>(get_output_face_r_dim(output_id));
 }
 
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_rows_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_rows_api.h
@@ -43,10 +43,7 @@ inline void llk_pack_rows(
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t pack_addr = get_output_tile_address<true, PackMode::Default>(output_id, output_index);
 
-    // Pack rows uses pack_reads_per_xy_plane=1 (set in _llk_pack_rows_init_) for row packing,
-    // which differs from standard tile face_r_dim. Use ProgramByTile to skip face_r_dim check.
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByTile>(
-        pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_rows_(dst_index, pack_addr);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
@@ -25,8 +25,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
     if constexpr (!skip_addrmod_config) {
-        LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-            pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+        LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
     }
 
     _llk_pack_init_<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
@@ -47,8 +46,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
     std::uint32_t pack_tile_addr =
         get_output_tile_address<out_of_order_output, pack_mode>(output_id, output_tile_index);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output)));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, pack_mode>(tile_index, pack_tile_addr);
 }
@@ -60,8 +58,7 @@ inline void llk_matmul_pack(
 
     static_assert(
         !((pack_mode == PackMode::Untilize) && out_of_order_output), "untilize out of order packing is not supported!");
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output)));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
     LLK_ASSERT(
         ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
@@ -143,8 +143,7 @@ inline void llk_pack_untilize_init(std::uint32_t output) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         pack_dst_format[output_id], face_r_dim, num_faces);
@@ -228,8 +227,7 @@ inline void llk_pack_untilize(
             (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
             16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
@@ -179,8 +179,7 @@ llk_pack_untilize_init(std::uint32_t output, const std::uint32_t face_r_dim, con
     static_assert(dense == false, "Dense is only supported on BH");
     const std::uint32_t output_id = get_output_id(output);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         pack_dst_format[output_id], face_r_dim, num_faces);
@@ -287,8 +286,7 @@ llk_pack_untilize(
             (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
             16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(

--- a/tt_metal/hw/inc/api/compute/experimental/mul_reduce_scalar.h
+++ b/tt_metal/hw/inc/api/compute/experimental/mul_reduce_scalar.h
@@ -56,6 +56,7 @@ ALWI void mul_reduce_scalar_init(uint32_t icb0, uint32_t icb1) {
  * |----------------|---------------------------------------------------------------|----------|-------------|----------|
  * | icb0           | Input circular buffer 0 (tensor A)                            | uint32_t | 0 to 31     | True     |
  * | icb1           | Input circular buffer 1 (tensor B)                            | uint32_t | 0 to 31     | True     |
+ * | ocb            | Output circular buffer (used to program packer face_r_dim)    | uint32_t | 0 to 31     | True     |
  * | num_tiles      | Number of tiles to process                                    | uint32_t | 1 to 8      | True     |
  * | scalar         | Scalar multiplier for reduction (default: 1.0)                | float    | Any float   | False    |
  *
@@ -63,7 +64,7 @@ ALWI void mul_reduce_scalar_init(uint32_t icb0, uint32_t icb1) {
  */
 // clang-format on
 template <PoolType reduce_type = PoolType::SUM>
-ALWI void mul_reduce_scalar_tile(uint32_t icb0, uint32_t icb1, uint32_t num_tiles, float scaler = 1.0f) {
+ALWI void mul_reduce_scalar_tile(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint32_t num_tiles, float scaler = 1.0f) {
     // Step 1: Unpack input tiles from both circular buffers and perform multiplication
     for (uint32_t i = 0; i < num_tiles; i++) {
         UNPACK((llk_unpack_AB(icb0, icb1, i, i)));
@@ -90,7 +91,7 @@ ALWI void mul_reduce_scalar_tile(uint32_t icb0, uint32_t icb1, uint32_t num_tile
         _calculate_fill_, RC_custom, APPROX, 2 /*ITERATIONS*/, 0 /*dst_index*/, 0.0f));
 
     // Step 5: Configure packer for scalar reduction
-    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_SCALAR, PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_SCALAR, PackMode::Default>(ocb)));
 
     // Step 6: Perform column reduction for each tile, accumulating into dest[0]
     // First iteration (i=0) - no move needed

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -75,7 +75,7 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, uint32_t 
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>(icb)));
 #endif
-    PACK((llk_pack_reduce_mask_config<reduce_dim, PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<reduce_dim, PackMode::Default>(ocb)));
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/reduce_custom.h
+++ b/tt_metal/hw/inc/api/compute/reduce_custom.h
@@ -53,13 +53,14 @@ namespace ckernel {
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | block_ct_dim              | The number of tiles in the width dimension to process as a block                        | uint32_t  | 1 to 2^32-1                                   | True     |
  * | Template   | respect_trigger           | Triggers MOP split optimization                                                         | bool      | {true, false}                                  | False    |
+ * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
 template <uint32_t block_ct_dim, bool respect_trigger = false>
-ALWI void reduce_block_max_row_init() {
+ALWI void reduce_block_max_row_init(uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
     MATH((llk_math_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE>()));
-    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
 // clang-format off
@@ -126,13 +127,14 @@ ALWI void reduce_block_max_row(uint32_t icb, uint32_t icb_scaler, uint32_t row_s
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|
  * | Template   | block_ct_dim              | The number of tiles in the width dimension to process as a block                        | uint32_t  | 1 to 2^32-1                                   | True     |
  * | Template   | respect_trigger           | Triggers MOP split optimization                                                         | bool      | {true, false}                                  | False    |
+ * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
 template <uint32_t block_ct_dim, bool respect_trigger = false>
-ALWI void reduce_block_max_row_reinit_short() {
+ALWI void reduce_block_max_row_reinit_short(uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
     MATH((llk_math_reduce_block_max_row_reinit_with_mop<block_ct_dim>()));
-    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 #endif
 
@@ -142,10 +144,10 @@ ALWI void reduce_block_max_row_reinit_short() {
  * (which uses ADDR_MOD_4) so ADDR_MOD_3 is preserved from the previous reduce.
  */
 template <uint32_t block_ct_dim, bool respect_trigger = false>
-ALWI void reduce_block_max_row_reinit_minimal() {
+ALWI void reduce_block_max_row_reinit_minimal(uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
     MATH((llk_math_reduce_block_max_row_reinit_minimal()));
-    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
 /**
@@ -153,20 +155,21 @@ ALWI void reduce_block_max_row_reinit_minimal() {
  * Requires copy_tile_custom (which uses ADDR_MOD_4) so ADDR_MOD_3 is preserved
  * from the previous reduce.
  */
-ALWI void reduce_block_max_row_reinit_minimal_runtime(uint32_t block_ct_dim, bool respect_trigger = false) {
+ALWI void reduce_block_max_row_reinit_minimal_runtime(
+    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
     MATH((llk_math_reduce_block_max_row_reinit_minimal_runtime()));
-    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
 /**
  * Short reinit (runtime variant): Reprograms reduce MOP and restores addrmods.
  * Used when reduce follows custom SDPA sub path with runtime block_ct_dim.
  */
-ALWI void reduce_block_max_row_reinit_short_runtime(uint32_t block_ct_dim, bool respect_trigger = false) {
+ALWI void reduce_block_max_row_reinit_short_runtime(uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
     MATH((llk_math_reduce_block_max_row_reinit_short_runtime<DST_ACCUM_MODE>(block_ct_dim)));
-    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 #endif
 
@@ -218,10 +221,10 @@ ALWI void reduce_block_max_row_uninit(uint32_t icb) {
 }
 
 // Runtime variants - block_ct_dim and respect_trigger are runtime parameters.
-ALWI void reduce_block_max_row_init_runtime(uint32_t block_ct_dim, bool respect_trigger = false) {
+ALWI void reduce_block_max_row_init_runtime(uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
     MATH((llk_math_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim)));
-    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>()));
+    PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
 ALWI void reduce_block_max_row_runtime(

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -184,14 +184,14 @@ inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim                 = FACE_R_DIM,
-    const std::uint32_t tile_c_dim                 = TILE_C_DIM,
-    const std::uint32_t num_faces                  = 4,
-    const bool partial_face                        = false,
-    [[maybe_unused]] const bool narrow_tile        = false,
-    [[maybe_unused]] const std::uint32_t num_tiles = 1)
+    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t tile_c_dim                  = TILE_C_DIM,
+    const std::uint32_t num_faces                   = 4,
+    const bool partial_face                         = false,
+    [[maybe_unused]] const bool narrow_tile         = false,
+    [[maybe_unused]] const std::uint32_t num_tiles  = 1)
 {
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face);
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, tile_c_dim, num_faces, partial_face);
 }
 
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false>

--- a/tt_metal/tt-llk/tests/sources/reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_test.cpp
@@ -133,7 +133,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
         formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
 
-    _llk_pack_reduce_mask_config_<REDUCE_DIM>();
+    _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape.face_r_dim);
 
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -484,7 +484,7 @@ inline void set_packer_config(
 __attribute__((noinline)) bool is_pack_reads_per_xy_plane(const std::uint32_t expected, const std::uint32_t nop_count = 10);
 
 template <bool is_fp32_dest_acc_en>
-inline void reconfig_packer_data_format(
+__attribute__((noinline)) inline void reconfig_packer_data_format(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -478,12 +478,16 @@ inline void set_packer_config(
     sync_regfile_write(p_gpr_pack::EXP0_SEC_SIZE_BFP);
 }
 
+// Forward declaration: defined later in this file. Needed here so that the non-dependent call
+// inside `reconfig_packer_data_format`'s LLK_ASSERT is found via unqualified lookup at
+// the template's first-phase name lookup (ADL cannot find it from a std::uint32_t argument).
+__attribute__((noinline)) bool is_pack_reads_per_xy_plane(const std::uint32_t expected, const std::uint32_t nop_count = 10);
+
 template <bool is_fp32_dest_acc_en>
 inline void reconfig_packer_data_format(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim,
     const std::uint32_t tile_c_dim,
     const std::uint32_t num_faces,
     const bool partial_face)
@@ -510,18 +514,11 @@ inline void reconfig_packer_data_format(
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);
     TTI_WRCFG(p_gpr_pack::TMP_LO, p_cfg::WRCFG_32b, THCON_SEC0_REG1_Row_start_section_size_ADDR32 + 2);
 
-    // Some initialization methods modify this configuration register, so need to set it again
-    // Number of reads per face used for resetting tile position generator for edge masks
-    pack_counters_u pack_counters;
-    pack_counters.val                       = 0;
-    pack_counters.f.pack_reads_per_xy_plane = face_r_dim;
-    TT_SETDMAREG(0, LOWER_HALFWORD(pack_counters.val), 0, LO_16(p_gpr_pack::TMP0));
-    TT_SETDMAREG(0, UPPER_HALFWORD(pack_counters.val), 0, HI_16(p_gpr_pack::TMP0));
-
-    for (std::uint32_t i = 0; i < NUM_PACKERS; i++)
-    {
-        TT_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i); // disable auto last generation
-    }
+    LLK_ASSERT(
+        is_pack_reads_per_xy_plane(1),
+        "reconfig_packer_data_format: pack_reads_per_xy_plane counter must be 1 before packer reconfig "
+        "(invariant violated; reduce mask should have been cleared via _llk_pack_reduce_mask_clear_). Please uncomment "
+        "DEVICE_PRINT #2111 for debugging.");
 
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val = 0;
@@ -580,11 +577,11 @@ inline void configure_pack(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
-    const std::uint32_t tile_c_dim  = TILE_C_DIM,
-    const std::uint32_t num_faces   = 4,
-    const bool partial_face         = false,
-    const std::uint32_t relu_config = 0)
+    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t tile_c_dim                  = TILE_C_DIM,
+    const std::uint32_t num_faces                   = 4,
+    const bool partial_face                         = false,
+    const std::uint32_t relu_config                 = 0)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     LLK_ASSERT(
@@ -618,18 +615,7 @@ inline void configure_pack(
 
     set_packer_config<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, num_faces, partial_face);
 
-    // PACK_COUNTERS_SEC0_pack_per_xy_plane = cfg_reg_array[3][0 +: 8];
-    // PACK_COUNTERS_SEC0_pack_reads_per_xy_plane = cfg_reg_array[3][8 +: 8];
-    // PACK_COUNTERS_SEC0_pack_xys_per_tile = cfg_reg_array[3][16 +: 7];
-    // PACK_COUNTERS_SEC0_pack_yz_transposed = cfg_reg_array[3][23 +: 1];
-    pack_counters_u pack_counters;
-    pack_counters.val                       = 0;
-    pack_counters.f.pack_reads_per_xy_plane = face_r_dim; // Number of reads per face
-                                                          // Used for resetting tile position generator for edge masks
-    for (std::uint32_t i = 0; i < NUM_PACKERS; i++)
-    {
-        cfg[PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i] = pack_counters.val; // disable auto last generation
-    }
+    // LLK_ASSERT to verify pack_reads_per_xy_plane is 1?
 
     pck_edge_offset_u pck_edge_offset;
     pck_edge_offset.val    = 0;
@@ -828,25 +814,21 @@ __attribute__((noinline)) std::array<pack_counters_t, NUM_PACKERS> read_pack_cou
     return config_vec;
 }
 
-enum class PackerProgramType
-{
-    ProgramByTile,
-    ProgramByFace,
-};
-
 /**
- * Validates that all packers' config and counters match the expected formats and face dimension.
+ * Validates that all packers' config matches the expected formats.
  * On mismatch, issues DEVICE_PRINT (when enabled) and LLK_ASSERT. Typically invoked via
- * `LLK_ASSERT_BLOCK(are_packers_configured_correctly<...>(...))` in llk_pack_tile_api.h.
+ * `LLK_ASSERT_BLOCK(are_packers_configured_correctly(...))` in llk_pack_tile_api.h.
+ *
+ * The pack_reads_per_xy_plane counter is validated separately via is_pack_reads_per_xy_plane
+ * (invoked at reconfig time), since its expected value depends on whether a reduce mask is
+ * currently programmed, not on the per-pack call site.
  *
  * @param pack_src_format   Expected input data format for all packers
  * @param pack_dst_format   Expected output data format for all packers
- * @param face_r_dim        Expected face row dimension (pack_reads_per_xy_plane) (default FACE_R_DIM)
  * @param nop_count         Number of nop operations to ensure configuration writes complete (default 10)
  */
-template <PackerProgramType program_type = PackerProgramType::ProgramByTile>
 __attribute__((noinline)) void are_packers_configured_correctly(
-    const std::uint32_t pack_src_format, const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t nop_count = 10)
+    const std::uint32_t pack_src_format, const std::uint32_t pack_dst_format, const std::uint32_t nop_count = 10)
 {
     // Ensure configuration writes complete before subsequent operations
     tensix_sync();
@@ -856,8 +838,7 @@ __attribute__((noinline)) void are_packers_configured_correctly(
     }
 
     static_assert(NUM_PACKERS == 1, "NUM_PACKERS must be 1");
-    const pack_config_t config     = read_pack_config()[0];
-    const pack_counters_t counters = read_pack_counters()[0];
+    const pack_config_t config = read_pack_config()[0];
     // Must match set_packer_config / reconfig_packer_data_format: gasket feeds Float16 into the packer for Fp8_e4m3 L1 output.
     const std::uint32_t pack_output_src_format = masked_data_format(pack_src_format);
     const std::uint32_t pack_output_dst_format = masked_data_format(pack_dst_format);
@@ -884,20 +865,39 @@ __attribute__((noinline)) void are_packers_configured_correctly(
             "are_packers_configured_correctly: pack_dst_format mismatch. Uncomment DEVICE_PRINT #1102 to inspect "
             "expected/actual.");
     }
+}
 
-    if constexpr (program_type == PackerProgramType::ProgramByFace)
+/**
+ * Validates that the packer pack_reads_per_xy_plane counter matches the expected value.
+ * Intended to be called from reconfig paths to assert the invariant: between non-reduce
+ * operations the counter is 1; the reduce layer owns transitions to FACE_R_DIM via
+ * `_llk_pack_reduce_mask_config_` and back to 1 via `_llk_pack_reduce_mask_clear_`.
+ *
+ * @param expected   Expected value of pack_reads_per_xy_plane
+ * @param nop_count  Number of nop operations to ensure configuration writes complete (default 10)
+ * @return true if the packer counter matches expected, false otherwise.
+ */
+__attribute__((noinline)) bool is_pack_reads_per_xy_plane(const std::uint32_t expected, const std::uint32_t nop_count)
+{
+    // Ensure configuration writes complete before reading back
+    tensix_sync();
+    for (std::uint32_t i = 0; i < nop_count; i++)
     {
-        if (counters.pack_reads_per_xy_plane != face_r_dim)
-        {
-            // DEVICE_PRINT(
-            // "#1103 are_packers_configured_correctly: pack_reads_per_xy_plane mismatch. expected: {}, actual: {}\n", face_r_dim,
-            // counters.pack_reads_per_xy_plane);
-            LLK_ASSERT(
-                (counters.pack_reads_per_xy_plane == face_r_dim),
-                "are_packers_configured_correctly: pack_reads_per_xy_plane / face_r_dim mismatch. Uncomment "
-                "DEVICE_PRINT #1103 to inspect expected/actual.");
-        }
+        asm volatile("nop");
     }
+
+    static_assert(NUM_PACKERS == 1, "NUM_PACKERS must be 1");
+    const pack_counters_t counters = read_pack_counters()[0];
+    if (counters.pack_reads_per_xy_plane != expected)
+    {
+        // Debug: print the mismatched packer counter value.
+        // DEVICE_PRINT(
+        //     "#2111 is_pack_reads_per_xy_plane: mismatch on packer 0 (expected={}) actual [P0={}]\n",
+        //     expected,
+        //     counters.pack_reads_per_xy_plane);
+        return false;
+    }
+    return true;
 }
 
 } // namespace ckernel::packer

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -615,7 +615,18 @@ inline void configure_pack(
 
     set_packer_config<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, num_faces, partial_face);
 
-    // LLK_ASSERT to verify pack_reads_per_xy_plane is 1?
+    // PACK_COUNTERS_SEC0_pack_per_xy_plane = cfg_reg_array[3][0 +: 8];
+    // PACK_COUNTERS_SEC0_pack_reads_per_xy_plane = cfg_reg_array[3][8 +: 8];
+    // PACK_COUNTERS_SEC0_pack_xys_per_tile = cfg_reg_array[3][16 +: 7];
+    // PACK_COUNTERS_SEC0_pack_yz_transposed = cfg_reg_array[3][23 +: 1];
+    pack_counters_u pack_counters;
+    pack_counters.val = 0;
+    // Number of reads per face used for resetting tile position generator for edge masks.
+    pack_counters.f.pack_reads_per_xy_plane = 1;
+    for (std::uint32_t i = 0; i < NUM_PACKERS; i++)
+    {
+        cfg[PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i] = pack_counters.val; // disable auto last generation
+    }
 
     pck_edge_offset_u pck_edge_offset;
     pck_edge_offset.val    = 0;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_tilize.h
@@ -155,7 +155,7 @@ __attribute__((noinline)) void _llk_pack_fast_tilize_init_(
         // is_fp32_dest_acc_en). Uninit mirrors by restoring caller's pack_src.
         constexpr std::uint32_t compat_src = ckernel::to_underlying(DataFormat::Float16_b);
         const std::uint32_t tile_size      = SCALE_DATUM_SIZE(pack_dst_format, TILE_C_DIM * TILE_R_DIM);
-        reconfig_packer_data_format<is_fp32_dest_acc_en>(compat_src, pack_dst_format, tile_size, FACE_R_DIM, TILE_C_DIM, num_faces, /*partial_face=*/false);
+        reconfig_packer_data_format<is_fp32_dest_acc_en>(compat_src, pack_dst_format, tile_size, TILE_C_DIM, num_faces, /*partial_face=*/false);
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
         cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(0);
     }
@@ -277,8 +277,7 @@ inline void _llk_pack_fast_tilize_uninit_(
         // Mirror of init: restore caller's pack_src_format via reconfig, which also
         // sets Read_32b correctly (=1 for fp32/dest_acc per cpack_common logic).
         const std::uint32_t tile_size = SCALE_DATUM_SIZE(pack_dst_format, TILE_C_DIM * TILE_R_DIM);
-        reconfig_packer_data_format<is_fp32_dest_acc_en>(
-            pack_src_format, pack_dst_format, tile_size, FACE_R_DIM, TILE_C_DIM, num_faces, /*partial_face=*/false);
+        reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, TILE_C_DIM, num_faces, /*partial_face=*/false);
     }
     // DEST remap is NOT cleared here — set/owned by the math thread (see init comment).
     // BH-specific: restore strides modified by fast-tilize init (WH doesn't modify them).

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -341,13 +341,12 @@ inline void _llk_pack_reconfig_data_format_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
     const std::uint32_t tile_c_dim = TILE_C_DIM,
     const std::uint32_t num_faces  = 4,
     const bool partial_face        = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face);
+    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, tile_c_dim, num_faces, partial_face);
 }
 
 inline void _llk_pack_set_fp32_dest_acc_(bool enable)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -102,7 +102,7 @@ inline void _llk_pack_reconfig_l1_acc_(const std::uint32_t enable)
 }
 
 template <ReduceDim dim, PackMode pack_mode = PackMode::Default>
-inline void _llk_pack_reduce_mask_config_()
+inline void _llk_pack_reduce_mask_config_(const std::uint32_t face_r_dim = FACE_R_DIM)
 {
     ckernel::packer::pck_edge_offset_u pack_edge_offset = {.val = 0};
 
@@ -174,6 +174,8 @@ inline void _llk_pack_reduce_mask_config_()
     // Wait for packer to finish to avoid breaking its current configuration
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
 
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(face_r_dim);
+
     // Configure packer
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);
     TTI_WRCFG(p_gpr_pack::TMP_LO, p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC1_mask_ADDR32);
@@ -196,6 +198,8 @@ inline void _llk_pack_reduce_mask_clear_()
 
     // Wait for packer to finish to avoid breaking its current configuration
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
+
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(1);
 
     // Clear out packer configuration for reduce
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -558,6 +558,11 @@ inline void reconfigure_exp_threshold(const std::uint32_t pack_dst_format)
     cfg_reg_rmw_tensix<THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 3, 0, THRESHOLD_RMW_MASK>(threshold_rmw_data);
 }
 
+// Forward declaration: defined later in this file. Needed here so that the non-dependent call
+// inside `reconfig_packer_data_format`'s LLK_ASSERT is found via unqualified lookup at
+// the template's first-phase name lookup (ADL cannot find it from a std::uint32_t argument).
+__attribute__((noinline)) bool is_pack_reads_per_xy_plane(const std::uint32_t expected, const std::uint32_t nop_count = 10);
+
 template <bool is_fp32_dest_acc_en>
 inline void reconfig_packer_data_format(
     const std::uint32_t pack_src_format,
@@ -588,18 +593,10 @@ inline void reconfig_packer_data_format(
     TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC1_REG1_Row_start_section_size_ADDR32 + 2 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
     TTI_REG2FLOP(2, 0, 0, 0, THCON_SEC1_REG8_Row_start_section_size_ADDR32 + 2 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::TMP_LO);
 
-    // Some initialization methods modify this configuration register, so need to set it again
-    // Number of reads per face used for resetting tile position generator for edge masks
-    pack_counters_u pack_counters;
-    pack_counters.val                       = 0;
-    pack_counters.f.pack_reads_per_xy_plane = face_r_dim;
-    TT_SETDMAREG(0, LOWER_HALFWORD(pack_counters.val), 0, LO_16(p_gpr_pack::TMP0));
-    TT_SETDMAREG(0, UPPER_HALFWORD(pack_counters.val), 0, HI_16(p_gpr_pack::TMP0));
-
-    for (std::uint32_t i = 0; i < NUM_PACKERS; i++)
-    {
-        TT_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i); // disable auto last generation
-    }
+    LLK_ASSERT(
+        is_pack_reads_per_xy_plane(1),
+        "reconfig_packer_data_format: pack_reads_per_xy_plane counter must be 1 before packer reconfig (invariant violated; reduce mask should have been "
+        "cleared via _llk_pack_reduce_mask_clear_). Please uncomment DEVICE_PRINT #2111 for debugging.");
 
     dest_rd_ctrl_u dest_rd_ctrl;
     dest_rd_ctrl.val = 0;
@@ -730,8 +727,8 @@ inline void configure_pack(
     // PACK_COUNTERS_SEC0_pack_yz_transposed = cfg_reg_array[3][23 +: 1];
     pack_counters_u pack_counters;
     pack_counters.val                       = 0;
-    pack_counters.f.pack_reads_per_xy_plane = face_r_dim; // Number of reads per face
-                                                          // Used for resetting tile position generator for edge masks
+    pack_counters.f.pack_reads_per_xy_plane =
+        1; // Default 1 — makes non-reduce operations agnostic to this counter; reduce sets it via _llk_pack_reduce_mask_config_
     for (std::uint32_t i = 0; i < NUM_PACKERS; i++)
     {
         cfg[PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i] = pack_counters.val; // disable auto last generation
@@ -1000,25 +997,21 @@ inline std::array<pack_counters_t, NUM_PACKERS> read_pack_counters()
     return counters_vec;
 }
 
-enum class PackerProgramType
-{
-    ProgramByTile,
-    ProgramByFace,
-};
-
 /**
- * Validates that all packers' config and counters match the expected formats and face dimension.
+ * Validates that all packers' config matches the expected formats.
  * On mismatch, issues DEVICE_PRINT (when enabled) and LLK_ASSERT. Typically invoked via
- * `LLK_ASSERT_BLOCK(are_packers_configured_correctly<...>(...))` in llk_pack_tile_api.h.
+ * `LLK_ASSERT_BLOCK(are_packers_configured_correctly(...))` in llk_pack_tile_api.h.
+ *
+ * The pack_reads_per_xy_plane counter is validated separately via is_pack_reads_per_xy_plane
+ * (invoked at reconfig time), since its expected value depends on whether a reduce mask is
+ * currently programmed, not on the per-pack call site.
  *
  * @param pack_src_format   Expected input data format for all packers
  * @param pack_dst_format   Expected output data format for all packers
- * @param face_r_dim        Expected face row dimension (pack_reads_per_xy_plane) (default FACE_R_DIM)
  * @param nop_count         Number of nop operations to ensure configuration writes complete (default 10)
  */
-template <PackerProgramType program_type = PackerProgramType::ProgramByTile>
 __attribute__((noinline)) void are_packers_configured_correctly(
-    const std::uint32_t pack_src_format, const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t nop_count = 10)
+    const std::uint32_t pack_src_format, const std::uint32_t pack_dst_format, const std::uint32_t nop_count = 10)
 {
     // Ensure configuration writes complete before subsequent operations
     tensix_sync();
@@ -1065,25 +1058,46 @@ __attribute__((noinline)) void are_packers_configured_correctly(
                 "are_packers_configured_correctly: pack_dst_format mismatch. Uncomment DEVICE_PRINT #2102 to inspect "
                 "packer index and expected/actual.");
         }
+    }
+}
 
-        if constexpr (program_type == PackerProgramType::ProgramByFace)
+/**
+ * Validates that all packers' pack_reads_per_xy_plane counter matches the expected value.
+ * Intended to be called from reconfig paths to assert the invariant: between non-reduce
+ * operations the counter is 1; the reduce layer owns transitions to FACE_R_DIM via
+ * `_llk_pack_reduce_mask_config_` and back to 1 via `_llk_pack_reduce_mask_clear_`.
+ *
+ * @param expected   Expected value of pack_reads_per_xy_plane
+ * @param nop_count  Number of nop operations to ensure configuration writes complete (default 10)
+ * @return true if all packers' counters match expected, false otherwise.
+ */
+__attribute__((noinline)) bool is_pack_reads_per_xy_plane(const std::uint32_t expected, const std::uint32_t nop_count)
+{
+    // Ensure configuration writes complete before reading back
+    tensix_sync();
+    for (std::uint32_t i = 0; i < nop_count; i++)
+    {
+        asm volatile("nop");
+    }
+
+    const std::array<pack_counters_t, NUM_PACKERS> counters_vec = read_pack_counters();
+    for (std::uint32_t i = 0; i < NUM_PACKERS; i++)
+    {
+        if (counters_vec[i].pack_reads_per_xy_plane != expected)
         {
-            pack_counters_u counters = {.val = 0};
-            counters.val             = cfg[PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i];
-            if (counters.f.pack_reads_per_xy_plane != face_r_dim)
-            {
-                // DEVICE_PRINT(
-                // "#2103 are_packers_configured_correctly: packer {} pack_reads_per_xy_plane mismatch. expected: {}, actual: {}\n",
-                // i,
-                // face_r_dim,
-                // counters.f.pack_reads_per_xy_plane);
-                LLK_ASSERT(
-                    (counters.f.pack_reads_per_xy_plane == face_r_dim),
-                    "are_packers_configured_correctly: pack_reads_per_xy_plane / face_r_dim mismatch. Uncomment "
-                    "DEVICE_PRINT #2103 to inspect packer index and expected/actual.");
-            }
+            // Debug: print which packer mismatched and dump all per-packer counter values.
+            // DEVICE_PRINT(
+            //     "#2111 is_pack_reads_per_xy_plane: mismatch on packer {} (expected={}) actual [P0={} P1={} P2={} P3={}]\n",
+            //     i,
+            //     expected,
+            //     counters_vec[0].pack_reads_per_xy_plane,
+            //     counters_vec[1].pack_reads_per_xy_plane,
+            //     counters_vec[2].pack_reads_per_xy_plane,
+            //     counters_vec[3].pack_reads_per_xy_plane);
+            return false;
         }
     }
+    return true;
 }
 
 } // namespace ckernel::packer

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -564,7 +564,7 @@ inline void reconfigure_exp_threshold(const std::uint32_t pack_dst_format)
 __attribute__((noinline)) bool is_pack_reads_per_xy_plane(const std::uint32_t expected, const std::uint32_t nop_count = 10);
 
 template <bool is_fp32_dest_acc_en>
-inline void reconfig_packer_data_format(
+__attribute__((noinline)) inline void reconfig_packer_data_format(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size  = 0,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -153,7 +153,7 @@ inline void _llk_pack_reconfig_l1_acc_(const std::uint32_t enable)
 }
 
 template <ReduceDim dim, PackMode pack_mode = PackMode::Default>
-inline void _llk_pack_reduce_mask_config_()
+inline void _llk_pack_reduce_mask_config_(const std::uint32_t face_r_dim = FACE_R_DIM)
 {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize,
@@ -229,6 +229,11 @@ inline void _llk_pack_reduce_mask_config_()
     // Wait for packer to finish to avoid breaking its current configuration
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
 
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(face_r_dim);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC1_pack_reads_per_xy_plane_RMW>(face_r_dim);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC2_pack_reads_per_xy_plane_RMW>(face_r_dim);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC3_pack_reads_per_xy_plane_RMW>(face_r_dim);
+
     // Configure packer
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);
     TTI_WRCFG(p_gpr_pack::TMP_LO, p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC1_mask_ADDR32);
@@ -251,6 +256,11 @@ inline void _llk_pack_reduce_mask_clear_()
 
     // Wait for packer to finish to avoid breaking its current configuration
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
+
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(1);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC1_pack_reads_per_xy_plane_RMW>(1);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC2_pack_reads_per_xy_plane_RMW>(1);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC3_pack_reads_per_xy_plane_RMW>(1);
 
     // Clear out packer configuration for reduce
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -188,8 +188,8 @@ void kernel_main() {
         cb_scaler_global_obj.wait_front(1);
         reconfig_data_format_srca(cb_x2, cb_ex_external2);
         reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
-        reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_ex_external2, cb_scaler_global, cb_reduction_out);
         pack_reconfig_data_format(cb_reduction_out);
+        reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_ex_external2, cb_scaler_global, cb_reduction_out);
         CircularBuffer(cb_reduction_out)
             .reserve_back(num_tiles_per_partial_result * num_tiles_per_allgather_worker);
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -104,8 +104,8 @@ void kernel_main() {
                         copy_tile(cb_acc, i, i);
                     }
                 }
-                reduce_init<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, cb_acc);
                 pack_reconfig_data_format(cb_acc);
+                reduce_init<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, cb_acc);
                 for (uint32_t i = 0; i < ntiles; ++i) {
                     reduce_tile<REDUCE_OP, REDUCE_DIM>(cb_ineg, cb_scaler, i, 0, i);
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -152,7 +152,7 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, bool do_eltwise_max = false) {
         /**
          * For `dst_tiles` number of rows, compute the max into the even indices of the DST register.
          */
-        reduce_block_max_row_init<cols>();
+        reduce_block_max_row_init<cols>(out_cb);
         for (uint32_t i = 0; i < dst_tiles; i++) {
             const uint32_t reduce_dst_idx = i;
             reduce_block_max_row<cols>(in0_cb, scale_cb, (row_start_idx + i) * cols, reduce_dst_idx);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -297,7 +297,7 @@ void reduce_c_row_group(
         cb_wait_front(in0_cb, cumulative_input_tiles);
     }
 
-    reduce_block_max_row_init_runtime(reduce_cols, respect_trigger);
+    reduce_block_max_row_init_runtime(out_cb, reduce_cols, respect_trigger);
     for (uint32_t i = 0; i < group_size; i++) {
         const uint32_t input_tile_start = (row_start + i) * row_stride;
         reduce_block_max_row_runtime(in0_cb, scale_cb, input_tile_start, i, respect_trigger);


### PR DESCRIPTION
### Summary

`pack_reads_per_xy_plane` is a hardware packer counter that controls when the
Y-position counter resets for edge-mask purposes. It was incorrectly initialised
to `face_r_dim` (16) in `configure_pack()` and `reconfig_packer_data_format()`
in both Blackhole and Wormhole B0.

The correct default is **1** — when set to 1, the counter resets on every read,
making all non-reduce packer operations agnostic to this setting. Only reduce
operations (row/col/scalar) require a non-1 value.

This PR:
- Changes `configure_pack()` and `reconfig_packer_data_format()` to initialise
  `pack_reads_per_xy_plane = 1` in both BH and WH B0.
- Adds `cfg_reg_rmw_tensix<PACK_COUNTERS_SEC*_pack_reads_per_xy_plane_RMW>(face_r_dim)`
  at the start of `_llk_pack_reduce_mask_config_()` (after the existing STALL) to
  set the field when entering reduce mode.
- Adds the symmetric reset to 1 in `_llk_pack_reduce_mask_clear_()`.

Root cause of past bug: [tt-metal#17132](https://github.com/tenstorrent/tt-metal/issues/17132)
was patched at the compute API layer (PR#17486) rather than at the LLK layer where
the incorrect default lives. This PR is the correct fix.

Resolves [tt-llk#989](https://github.com/tenstorrent/tt-llk/issues/989)

Please check https://github.com/tenstorrent/tt-metal/issues/46105 for understanding the fix to make https://github.com/tenstorrent/tt-metal/issues/46105 as noinline

---

### Notes for reviewers

The PR has grown beyond the original 4-file LLK fix. The expansions below are
all consequences of pushing counter ownership down to the reduce layer end-to-end.
Please skim this section before reviewing.

#### 1. Compute-API signature changes (source-breaking for out-of-tree callers)

Because the reduce path now requires the **runtime** `face_r_dim` of the output CB
(narrow tiles can have `face_r_dim != FACE_R_DIM`, e.g. `tile_dimensions=[1, 32]`),
every reduce-init API now threads the output CB through to the packer LLK:

| Before | After |
|---|---|
| `llk_pack_reduce_mask_config<...>()` | `llk_pack_reduce_mask_config<...>(ocb)` |
| `reduce_block_max_row_init<...>()` | `reduce_block_max_row_init<...>(ocb)` |
| `reduce_block_max_row_reinit_short<...>()` | `reduce_block_max_row_reinit_short<...>(ocb)` |
| `reduce_block_max_row_reinit_minimal<...>()` | `reduce_block_max_row_reinit_minimal<...>(ocb)` |
| `reduce_block_max_row_reinit_minimal_runtime(block_ct_dim, ...)` | `reduce_block_max_row_reinit_minimal_runtime(ocb, block_ct_dim, ...)` |
| `reduce_block_max_row_reinit_short_runtime(block_ct_dim, ...)` | `reduce_block_max_row_reinit_short_runtime(ocb, block_ct_dim, ...)` |
| `reduce_block_max_row_init_runtime(block_ct_dim, ...)` | `reduce_block_max_row_init_runtime(ocb, block_ct_dim, ...)` |
| `mul_reduce_scalar_tile<...>(icb0, icb1, num_tiles, scaler)` | `mul_reduce_scalar_tile<...>(icb0, icb1, ocb, num_tiles, scaler)` |

`reduce_init(icb, icb_scaler, ocb, ...)` already had `ocb`; only the internal
threading to the packer mask config changed.

All in-tree callers have been updated in this PR (see file list below).
Out-of-tree compute kernels that call these APIs will need a one-line update.

#### 2. `pack_reconfig_data_format` must precede `*_reduce_init` (ordering)

The new invariant assertion in `reconfig_packer_data_format` (see §3) fires if the
packer-format reconfig runs *after* the reduce mask is programmed, because reduce
moves `pack_reads_per_xy_plane` from `1` to `face_r_dim`. Three consumer kernels
were re-ordered to call `pack_reconfig_data_format(out_cb)` **before**
`reduce_init` / `sampling_reduce_init` instead of after:

- `ttnn/.../reduction/generic/device/kernels/compute/reduce_h_neg.cpp`
- `ttnn/.../normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp`
- `models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp` (hoisted out of the inner pack loop)

If you maintain other reduce-using compute kernels, please verify the same
ordering. Symptom of getting it wrong: assert fires with
`reconfig_packer_data_format: pack_reads_per_xy_plane counter must be 1 ...`

#### 3. New invariant assertion at reconfig boundary

Added `is_pack_reads_per_xy_plane(expected)` (BH/WH `cpack_common.h`) and call
`LLK_ASSERT(is_pack_reads_per_xy_plane(1), ...)` at the start of
`reconfig_packer_data_format`. This catches any caller that leaves the reduce
mask programmed across a packer reconfig (the original class of bug).

To debug a fired assert, uncomment `DEVICE_PRINT #2111` in the source.

#### 4. `PackerProgramType` enum removed

The `ProgramByTile` / `ProgramByFace` template parameter on
`are_packers_configured_correctly` was a band-aid that let
`_llk_pack_rows_` skip the `pack_reads_per_xy_plane == face_r_dim` check.
Now that reduce owns the counter end-to-end, the enum and the templated check
are no longer needed: every `LLK_ASSERT_BLOCK(are_packers_configured_correctly<...>(...))`
call site in `llk_pack_{rows,tile,untilize,fast_tilize}_api.h` (both arches)
simplified to the un-templated form.

#### 5. BH `face_r_dim` parameter pruning

On BH, `reconfig_packer_data_format` never consumed `face_r_dim` (unlike WH, which
uses it in `set_packer_l1_offset`). After this PR, BH stops consuming it for the
counter write too, so the parameter is now genuinely dead. Removed from:
- BH `reconfig_packer_data_format` (cpack_common.h)
- BH `_llk_pack_reconfig_data_format_` (llk_pack.h)
- BH `llk_pack_reconfig_data_format(new_output)` (llk_pack_common_api.h)
- BH `_llk_pack_reconfig_data_format_wrapper_` (test helper) and 2 internal call sites

`llk_pack_reconfig_data_format_disaggregated` keeps the parameter in its signature
on BH for cross-arch API symmetry (it's used arch-agnostically by `pack_untilize.h`
/ `compute_pool_2d.cpp`) — marked `[[maybe_unused]]`.

#### 6. Quasar API stub and `icb_out` → `ocb` rename

To keep `llk_pack_reduce_mask_config` callable identically across arches, the
Quasar variant accepts the new `ocb` parameter as `[[maybe_unused]]` (Quasar's
packer architecture doesn't use this counter). At the same time, the original
parameter name `icb_out` was renamed to `ocb` on all three arches — it always
referred to the *output* CB (it's fed into `get_output_id` / `get_output_face_r_dim`),
and every caller already passes a variable literally named `ocb`.

---

### What's changed

**LLK core (Blackhole — `tt_metal/tt-llk/tt_llk_blackhole/`)**
- `common/inc/cpack_common.h` — `configure_pack()` and `reconfig_packer_data_format()`:
  `pack_reads_per_xy_plane = face_r_dim` → `= 1`; added invariant assert + helper
  `is_pack_reads_per_xy_plane()`; removed `PackerProgramType` enum and the
  templated `face_r_dim` check from `are_packers_configured_correctly()`;
  dropped unused `face_r_dim` param from `reconfig_packer_data_format`.
- `llk_lib/llk_pack_common.h` — `_llk_pack_reduce_mask_config_(face_r_dim = FACE_R_DIM)`
  writes the counter via `cfg_reg_rmw_tensix<...SEC0_pack_reads_per_xy_plane_RMW>`;
  `_llk_pack_reduce_mask_clear_()` resets it to `1`.
- `llk_lib/llk_pack.h`, `llk_lib/experimental/llk_pack_fast_tilize.h` — propagated
  `face_r_dim` removal at the wrapper / internal call sites.

**LLK core (Wormhole B0 — `tt_metal/tt-llk/tt_llk_wormhole_b0/`)**
- Identical changes to `cpack_common.h` / `llk_pack_common.h`. WH writes all
  four packer sections (SEC0–SEC3) in the reduce mask config/clear.

**LLK API shims (`tt_metal/hw/ckernels/{blackhole,wormhole_b0,quasar}/metal/llk_api/`)**
- `llk_pack_reduce_api.h` — `llk_pack_reduce_mask_config` gains `ocb` parameter
  and threads `get_output_face_r_dim(...)` into the LLK; `icb_out` renamed to `ocb`.
- `llk_pack_{rows,tile,untilize,fast_tilize}_api.h` — `are_packers_configured_correctly`
  call sites de-templated (PackerProgramType removed).
- BH `llk_pack_common_api.h` — dropped dead `face_r_dim` plumbing in
  `llk_pack_reconfig_data_format(new_output)`; `[[maybe_unused]]` on
  `llk_pack_reconfig_data_format_disaggregated`'s `face_r_dim`.

**Compute API (`tt_metal/hw/inc/api/compute/`)**
- `reduce.h` — `reduce_init` threads `ocb` into the new packer mask config.
- `reduce_custom.h` — added `ocb` parameter to 7 `reduce_block_max_row_*` functions.
- `experimental/mul_reduce_scalar.h` — added `ocb` parameter to `mul_reduce_scalar_tile`.

**Tests**
- `tt_metal/tt-llk/tests/sources/reduce_test.cpp` — passes the runtime
  `face_r_dim` into `_llk_pack_reduce_mask_config_` (fixes the narrow-tile
  regression that originally surfaced this).
- `tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h` — BH wrapper
  drops `face_r_dim` forwarding.
- `tests/tt_metal/.../compute/mul_reduce_scalar.cpp`,
  `tests/tt_metal/.../sdpa/reduce_block_max_row/compute.cpp` — updated to new
  API signatures.

**Models / ttnn consumer kernels** (updated to new API signatures + reorder pack-reconfig where needed):
- `models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp`
- `models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp` *(reordered pack-reconfig)*
- `ttnn/.../transformer/sdpa/device/kernels/compute/compute_common.hpp`
- `ttnn/.../transformer/sdpa/device/kernels/compute/compute_streaming.hpp`
- `ttnn/.../reduction/generic/device/kernels/compute/reduce_h_neg.cpp` *(reordered pack-reconfig)*
- `ttnn/.../normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp` *(reordered pack-reconfig)*

### What's intentionally unchanged

- **Quasar packer core** — Different packer architecture; does not use
  `pack_reads_per_xy_plane` in this register layout. Only the API shim was
  updated to accept the new `ocb` parameter (marked `[[maybe_unused]]`).
- **`_llk_pack_rows_init_`** — Already sets `pack_reads_per_xy_plane = 1`
  correctly; no change needed.
- **Compute API layer band-aid** — The existing workaround in tt-metal PR#17486
  is left in place; its removal is tracked separately under
  [tt-metal#17641](https://github.com/tenstorrent/tt-metal/issues/17641).

### Invariant after this change

```bash
# No wrong defaults remain:
grep -rn "pack_reads_per_xy_plane = face_r_dim" \
    tt_metal/tt-llk/tt_llk_blackhole/ tt_metal/tt-llk/tt_llk_wormhole_b0/
# Expected: empty

# Reduce functions own the field (cfg-RMW programming):
grep -n "pack_reads_per_xy_plane_RMW" \
    tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h \
    tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
# Expected: 2 hits in BH (config + clear), 8 hits in WH (4 sections × {config, clear})

# Invariant is asserted at every packer reconfig:
grep -n "is_pack_reads_per_xy_plane(1)" \
    tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h \
    tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
# Expected: 1 hit each (inside reconfig_packer_data_format)
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (compute-API signature changes — see Notes for reviewers §1; all in-tree callers updated)
- [ ] Documentation update
- [x] Refactoring (PackerProgramType removal, BH `face_r_dim` pruning, `icb_out`→`ocb`)

### Checklist

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/989-pack-reads-per-xy-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/989-pack-reads-per-xy-plane)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/989-pack-reads-per-xy-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/989-pack-reads-per-xy-plane)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/989-pack-reads-per-xy-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/989-pack-reads-per-xy-plane)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/989-pack-reads-per-xy-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/989-pack-reads-per-xy-plane)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/989-pack-reads-per-xy-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/989-pack-reads-per-xy-plane)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/989-pack-reads-per-xy-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/989-pack-reads-per-xy-plane)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/989-pack-reads-per-xy-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/989-pack-reads-per-xy-plane)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/989-pack-reads-per-xy-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/989-pack-reads-per-xy-plane)
