### PR TITLE
Pool CB Fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -331,8 +331,17 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
 
-    // Compute CB sizes centrally - used for both CB creation and L1 validation
+    // Compute CB sizes centrally - used for both CB creation and L1 validation.
+    // When the DRAM config-tensor path is active, the reader indices tensor is already built on
+    // host so we pass its real per-core page size. Auto-shard evaluation in pool_utils.cpp still
+    // falls back to the worst case because the buffers do not exist yet there. The scalar config
+    // tensor (only created for avg pool without one_scalar_per_core) is not yet known at this
+    // point, so its prediction remains the worst case; that matches how the CB is created below.
     auto output_shard_shape = outputs[0].shard_spec().value().shape;
+    std::optional<uint32_t> reader_indices_actual_page_size;
+    if (config_tensor_in_dram) {
+        reader_indices_actual_page_size = reader_indices_storage.get_buffer()->page_size();
+    }
     PoolCBSizes cb_sizes = calculate_pool_cb_sizes(
         params,
         one_scalar_per_core,
@@ -340,7 +349,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         output_layout,
         outputs[0].dtype(),
         {output_shard_shape[0], output_shard_shape[1]},
-        config_tensor_in_dram);
+        config_tensor_in_dram,
+        reader_indices_actual_page_size);
 
     const auto& input_shape = input.padded_shape();
     const uint32_t shard_width = input.shard_spec()->shape[1];
@@ -403,17 +413,18 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     const uint32_t max_reader_indices_size =
         (max_out_nhw_per_core * 3 * sizeof(uint16_t)) + 2;  // worst case of 3 indices per output element
+    const uint32_t actual_reader_indices_buffer_page_size = reader_indices_storage.get_buffer()->page_size();
     TT_FATAL(
-        reader_indices_storage.get_buffer()->page_size() <= max_reader_indices_size,
+        actual_reader_indices_buffer_page_size <= max_reader_indices_size,
         "Reader indices buffer page size {} exceeds max expected size {}",
-        reader_indices_storage.get_buffer()->page_size(),
+        actual_reader_indices_buffer_page_size,
         max_reader_indices_size);
 
     tt::tt_metal::create_cb(
         in_reader_indices_cb_id,
         program,
         all_cores,
-        config_tensor_in_dram ? max_reader_indices_size : in_reader_indices_cb_pagesize,
+        config_tensor_in_dram ? actual_reader_indices_buffer_page_size : in_reader_indices_cb_pagesize,
         in_reader_indices_cb_npages,
         tt::DataFormat::UInt16,
         config_tensor_in_dram ? nullptr : reader_indices_storage.get_buffer());

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -222,7 +222,9 @@ PoolCBSizes calculate_pool_cb_sizes(
     const Layout& output_layout,
     const DataType& output_dtype,
     const std::array<uint32_t, 2>& output_shard_shape,
-    bool config_tensor_in_dram) {
+    bool config_tensor_in_dram,
+    std::optional<uint32_t> reader_indices_actual_page_size,
+    std::optional<uint32_t> scalar_config_actual_page_size) {
     PoolCBSizes sizes;
     const bool is_output_tiled = output_layout == Layout::TILE;
 
@@ -295,13 +297,16 @@ PoolCBSizes calculate_pool_cb_sizes(
     }
 
     // Config tensor L1 CB (for DRAM-based config tensors)
+    // When the factory has the real DRAM buffers it can pass their actual page sizes so that the
+    // predicted CB footprint matches the CB the factory creates. For auto-shard estimation we fall
+    // back to the worst case (3 uint16 indices per output element + 2-byte segment count).
     sizes.config_tensor_l1_size = 0;
     if (config_tensor_in_dram) {
-        sizes.config_tensor_l1_size =
-            (output_shard_shape[0] * 6) + 2;  // Worst case of 6 Bytes per output elem for reader indices
+        const uint32_t reader_indices_worst_case = (output_shard_shape[0] * 6) + 2;
+        sizes.config_tensor_l1_size += reader_indices_actual_page_size.value_or(reader_indices_worst_case);
         if (!one_scalar_per_core) {
-            sizes.config_tensor_l1_size +=
-                output_shard_shape[0] * 6;  // Additional 6 Bytes per output elem for avg pool scalar config tensor
+            const uint32_t scalar_config_worst_case = output_shard_shape[0] * 6;
+            sizes.config_tensor_l1_size += scalar_config_actual_page_size.value_or(scalar_config_worst_case);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -111,7 +111,9 @@ PoolCBSizes calculate_pool_cb_sizes(
     const Layout& output_layout,
     const DataType& output_dtype,
     const std::array<uint32_t, 2>& output_shard_shape,
-    bool config_tensor_in_dram);
+    bool config_tensor_in_dram,
+    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt,
+    std::optional<uint32_t> scalar_config_actual_page_size = std::nullopt);
 
 // Separate L1 usage for local CBs vs globally-allocated tensor buffers.
 // Tracking these separately prevents two errors from cancelling out in validation


### PR DESCRIPTION
When config_tensor_in_dram is set, the pool program factory was creating the in_reader_indices CB with the worst-case pagesize (3 uint16 indices per output element + segment count). The reader kernel actually loads exactly `reader_indices_storage.get_buffer()->page_size()` bytes per core (passed to it as the reader_page_size compile-time arg), so the remaining bytes of the CB were always unused.

On Wormhole that headroom was absorbing tight-L1 pool configs. After #41021 raised MEM_BRISC_FIRMWARE_SIZE from 6 KiB to 6 KiB + 2560 B to make room for the perf-counter firmware, the static-CB region shifted up by 2560 B. That pushed test_mpwi_32_bit_index
[BFLOAT16, [3, 32, 300, 300, 7, 7, 1, 1, 3, 3, 1, 1, False]] (and similar N300 MPWI cases with large kernels) past the top of the L1 buffer region with a ~2.4 KB overlap, tripping
`validate_circular_buffer_region`.

Size the CB to the actual reader indices buffer page size (which for that test is ~68 B vs. the 25316 B worst case) and thread the same value into `calculate_pool_cb_sizes` so the factory's actual-vs-predicted CB validation still matches. Auto-shard L1 estimation in `calculate_L1_usage` keeps the worst-case assumption since it runs before the config tensor is built.

Also added an optional scalar_config_actual_page_size parameter for symmetry; it currently isn't used (the scalar config tensor is constructed after the CB-size prediction, so we still predict its worst case), but the scaffolding is in place if we want to trim that CB next.

Verified on N300 (wormhole_b0):
- tests/ttnn/unit_tests/operations/pool/test_mpwi.py: 67 passed, 4 skipped (the 4 are pre-existing OOM skips).
- tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py: pytest exit code 0.
- tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py: 248 passed, 144 skipped, 0 failed.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)