### PR TITLE
Fix dispatch_s noc1 barrier issue by getting values from dispatch_d

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -288,10 +288,13 @@ void DispatchKernel::GenerateDependentConfigs() {
             auto* dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(downstream_kernels_[0]);
             TT_ASSERT(dispatch_s_kernel);
             dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
+            dependent_config_.dispatch_d_shutdown_sem_id =
+                dispatch_s_kernel->GetStaticConfig().dispatch_d_shutdown_sem_id;
         } else {
             // If no dispatch_s, no downstream
             TT_ASSERT(downstream_kernels_.empty());
             dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
+            dependent_config_.dispatch_d_shutdown_sem_id = UNUSED_SEM_ID;
         }
         dependent_config_.downstream_logical_core = UNUSED_LOGICAL_CORE;  // Unused
         dependent_config_.downstream_cb_base = 0;                         // Unused
@@ -347,6 +350,7 @@ void DispatchKernel::GenerateDependentConfigs() {
 
         dependent_config_.downstream_logical_core = UNUSED_LOGICAL_CORE;
         dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
+        dependent_config_.dispatch_d_shutdown_sem_id = UNUSED_SEM_ID;
         dependent_config_.split_prefetch = true;
         dependent_config_.downstream_cb_base = 0;    // Unused
         dependent_config_.downstream_cb_size = 0;    // Unused
@@ -387,6 +391,8 @@ void DispatchKernel::GenerateDependentConfigs() {
             if (auto* dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(ds_kernel)) {
                 TT_ASSERT(!found_dispatch_s, "DISPATCH_D has multiple downstream DISPATCH_S kernels.");
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
+                dependent_config_.dispatch_d_shutdown_sem_id =
+                    dispatch_s_kernel->GetStaticConfig().dispatch_d_shutdown_sem_id;
                 found_dispatch_s = true;
             } else if (auto* dispatch_h_kernel = dynamic_cast<DispatchKernel*>(ds_kernel)) {
                 TT_ASSERT(!found_dispatch_h, "DISPATCH_D has multiple downstream DISPATCH_H kernels.");
@@ -419,6 +425,7 @@ void DispatchKernel::GenerateDependentConfigs() {
 
         if (!found_dispatch_s) {
             dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
+            dependent_config_.dispatch_d_shutdown_sem_id = UNUSED_SEM_ID;
         }
     } else {
         TT_FATAL(false, "DispatchKernel must be one of (or both) H and D variants");
@@ -479,6 +486,7 @@ void DispatchKernel::CreateKernel() {
         {"DISPATCH_CB_PAGES", std::to_string(static_config_.dispatch_cb_pages.value())},
         {"MY_DISPATCH_CB_SEM_ID", std::to_string(static_config_.my_dispatch_cb_sem_id.value())},
         {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dependent_config_.upstream_dispatch_cb_sem_id.value())},
+        {"DISPATCH_D_SHUTDOWN_SEM_ID", std::to_string(dependent_config_.dispatch_d_shutdown_sem_id.value())},
         {"DISPATCH_CB_BLOCKS", std::to_string(static_config_.dispatch_cb_blocks.value())},
         {"UPSTREAM_SYNC_SEM", std::to_string(dependent_config_.upstream_sync_sem.value())},
         {"IS_CQ_DRAM_BACKED", std::to_string(device_->sysmem_manager().is_dram_backed())},

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -68,6 +68,7 @@ struct dispatch_dependent_config_t {
     std::optional<uint32_t> upstream_dispatch_cb_sem_id;  // Dependent
 
     std::optional<uint32_t> upstream_sync_sem;  // Dependent
+    std::optional<uint32_t> dispatch_d_shutdown_sem_id;
 
     std::optional<uint32_t> downstream_cb_base;    // 10, dependent
     std::optional<uint32_t> downstream_cb_size;    // Dependent

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -83,6 +83,8 @@ void DispatchSKernel::GenerateStaticConfigs() {
     static_config_.cb_size = my_dispatch_constants.dispatch_s_buffer_size();
     // used by dispatch_s to sync with prefetch
     static_config_.my_dispatch_cb_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+    // used by dispatch_d to signal that its shutdown handoff is ready
+    static_config_.dispatch_d_shutdown_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
     static_config_.dispatch_s_sync_sem_base_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM);
     // used by dispatch_d to signal that dispatch_s can send go signal
@@ -162,6 +164,7 @@ void DispatchSKernel::CreateKernel() {
         {"CB_LOG_PAGE_SIZE", std::to_string(static_config_.cb_log_page_size.value())},
         {"CB_SIZE", std::to_string(static_config_.cb_size.value())},
         {"MY_DISPATCH_CB_SEM_ID", std::to_string(static_config_.my_dispatch_cb_sem_id.value())},
+        {"DISPATCH_D_SHUTDOWN_SEM_ID", std::to_string(static_config_.dispatch_d_shutdown_sem_id.value())},
         {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dependent_config_.upstream_dispatch_cb_sem_id.value())},
         {"DISPATCH_S_SYNC_SEM_BASE_ADDR", std::to_string(static_config_.dispatch_s_sync_sem_base_addr.value())},
         {"MCAST_GO_SIGNAL_ADDR", std::to_string(static_config_.mcast_go_signal_addr.value())},

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -16,6 +16,7 @@ struct dispatch_s_static_config_t {
     std::optional<uint32_t> cb_log_page_size;
     std::optional<uint32_t> cb_size;
     std::optional<uint32_t> my_dispatch_cb_sem_id;
+    std::optional<uint32_t> dispatch_d_shutdown_sem_id;
     std::optional<uint32_t> dispatch_s_sync_sem_base_addr;
 
     std::optional<uint32_t> mcast_go_signal_addr;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1400,14 +1400,14 @@ struct NocCounterSnapshot {
     uint32_t posted_writes_num_issued;
 };
 
-FORCE_INLINE
-NocCounterSnapshot snapshot_dispatch_d_noc_counters() {
+template <uint32_t noc_index>
+FORCE_INLINE NocCounterSnapshot snapshot_dispatch_d_noc_counters() {
     return {
-        .reads_num_issued = noc_reads_num_issued[upstream_noc_index],
-        .nonposted_writes_num_issued = noc_nonposted_writes_num_issued[upstream_noc_index],
-        .nonposted_writes_acked = noc_nonposted_writes_acked[upstream_noc_index],
-        .nonposted_atomics_acked = noc_nonposted_atomics_acked[upstream_noc_index],
-        .posted_writes_num_issued = noc_posted_writes_num_issued[upstream_noc_index]
+        .reads_num_issued = noc_reads_num_issued[noc_index],
+        .nonposted_writes_num_issued = noc_nonposted_writes_num_issued[noc_index],
+        .nonposted_writes_acked = noc_nonposted_writes_acked[noc_index],
+        .nonposted_atomics_acked = noc_nonposted_atomics_acked[noc_index],
+        .posted_writes_num_issued = noc_posted_writes_num_issued[noc_index]
     };
 }
 
@@ -1470,7 +1470,7 @@ void kernel_main() {
 
     [[maybe_unused]] NocCounterSnapshot dispatch_d_noc_counter_start = {};
     if constexpr (publish_noc_count) {
-        dispatch_d_noc_counter_start = snapshot_dispatch_d_noc_counters();
+        dispatch_d_noc_counter_start = snapshot_dispatch_d_noc_counters<upstream_noc_index>();
     }
 
     for (size_t i = 0; i < max_num_worker_sems; i++) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -121,6 +121,9 @@ constexpr uint32_t dispatch_cb_end = dispatch_cb_base + dispatch_cb_size;
 constexpr uint32_t downstream_cb_end = downstream_cb_base + downstream_cb_size;
 constexpr uint32_t fd_core_type_idx = static_cast<uint32_t>(fd_core_type);
 
+constexpr bool dispatch_s_enabled = dispatch_d_shutdown_sem_id != 0;
+constexpr bool publish_noc_count = !distributed_dispatcher && dispatch_s_enabled;
+
 // Break buffer into blocks, 1/n of the total (dividing equally)
 // Do bookkeeping (release, etc) based on blocks
 // Note: due to the current method of release pages, up to 1 block of pages
@@ -1389,7 +1392,7 @@ static inline bool process_cmd_h(uint32_t& cmd_ptr) {
     return done;
 }
 
-struct dispatch_d_noc_counter_snapshot {
+struct NocCounterSnapshot {
     uint32_t reads_num_issued;
     uint32_t nonposted_writes_num_issued;
     uint32_t nonposted_writes_acked;
@@ -1398,7 +1401,7 @@ struct dispatch_d_noc_counter_snapshot {
 };
 
 FORCE_INLINE
-dispatch_d_noc_counter_snapshot snapshot_dispatch_d_noc_counters() {
+NocCounterSnapshot snapshot_dispatch_d_noc_counters() {
     return {
         .reads_num_issued = noc_reads_num_issued[upstream_noc_index],
         .nonposted_writes_num_issued = noc_nonposted_writes_num_issued[upstream_noc_index],
@@ -1409,10 +1412,14 @@ dispatch_d_noc_counter_snapshot snapshot_dispatch_d_noc_counters() {
 }
 
 // dispatch_d writes to the NOC1 core, but dispatch_s holds dedicated noc status on it. L1 noc counters
-// are levaraged along with a shutdown semaphore to transfer dispatch_d's write count to dispatch_s.
+// are leveraged along with a shutdown semaphore to transfer dispatch_d's write count to dispatch_s.
 FORCE_INLINE
-void publish_dispatch_d_noc_count(const dispatch_d_noc_counter_snapshot& snapshot) {
-    static_assert(!distributed_dispatcher, "publish_dispatch_d_noc_count is only supported when dispatch_d runs on the same core");
+void publish_dispatch_d_noc_count(const NocCounterSnapshot& snapshot) {
+    if constexpr (!publish_noc_count) {
+        DEVICE_PRINT("publish_dispatch_d_noc_count is only supported when dispatch_s runs on the same core");
+        ASSERT(0);
+        return;
+    }
 
     const uint32_t reads_delta = noc_reads_num_issued[upstream_noc_index] - snapshot.reads_num_issued;
     const uint32_t nonposted_writes_delta =
@@ -1461,8 +1468,8 @@ void kernel_main() {
         noc_local_state_init(upstream_noc_index);
     }
 
-    [[maybe_unused]] dispatch_d_noc_counter_snapshot dispatch_d_noc_counter_start = {};
-    if constexpr (!distributed_dispatcher) {
+    [[maybe_unused]] NocCounterSnapshot dispatch_d_noc_counter_start = {};
+    if constexpr (publish_noc_count) {
         dispatch_d_noc_counter_start = snapshot_dispatch_d_noc_counters();
     }
 
@@ -1545,7 +1552,7 @@ void kernel_main() {
 
     noc_async_full_barrier();
 
-    if constexpr (!distributed_dispatcher) {
+    if constexpr (publish_noc_count) {
         publish_dispatch_d_noc_count(dispatch_d_noc_counter_start);
     }
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -28,6 +28,7 @@ constexpr uint32_t dispatch_cb_log_page_size = DISPATCH_CB_LOG_PAGE_SIZE;
 constexpr uint32_t dispatch_cb_pages = DISPATCH_CB_PAGES;
 constexpr uint32_t my_dispatch_cb_sem_id = MY_DISPATCH_CB_SEM_ID;
 constexpr uint32_t upstream_dispatch_cb_sem_id = UPSTREAM_DISPATCH_CB_SEM_ID;
+constexpr uint32_t dispatch_d_shutdown_sem_id = DISPATCH_D_SHUTDOWN_SEM_ID;
 constexpr uint32_t dispatch_cb_blocks = DISPATCH_CB_BLOCKS;
 constexpr uint32_t upstream_sync_sem = UPSTREAM_SYNC_SEM;
 constexpr uint32_t command_queue_base_addr = COMMAND_QUEUE_BASE_ADDR;
@@ -1388,6 +1389,57 @@ static inline bool process_cmd_h(uint32_t& cmd_ptr) {
     return done;
 }
 
+struct dispatch_d_noc_counter_snapshot {
+    uint32_t reads_num_issued;
+    uint32_t nonposted_writes_num_issued;
+    uint32_t nonposted_writes_acked;
+    uint32_t nonposted_atomics_acked;
+    uint32_t posted_writes_num_issued;
+};
+
+FORCE_INLINE
+dispatch_d_noc_counter_snapshot snapshot_dispatch_d_noc_counters() {
+    return {
+        .reads_num_issued = noc_reads_num_issued[upstream_noc_index],
+        .nonposted_writes_num_issued = noc_nonposted_writes_num_issued[upstream_noc_index],
+        .nonposted_writes_acked = noc_nonposted_writes_acked[upstream_noc_index],
+        .nonposted_atomics_acked = noc_nonposted_atomics_acked[upstream_noc_index],
+        .posted_writes_num_issued = noc_posted_writes_num_issued[upstream_noc_index]
+    };
+}
+
+// dispatch_d writes to the NOC1 core, but dispatch_s holds dedicated noc status on it. L1 noc counters
+// are levaraged along with a shutdown semaphore to transfer dispatch_d's write count to dispatch_s.
+FORCE_INLINE
+void publish_dispatch_d_noc_count(const dispatch_d_noc_counter_snapshot& snapshot) {
+    static_assert(!distributed_dispatcher, "publish_dispatch_d_noc_count is only supported when dispatch_d runs on the same core");
+
+    const uint32_t reads_delta = noc_reads_num_issued[upstream_noc_index] - snapshot.reads_num_issued;
+    const uint32_t nonposted_writes_delta =
+        noc_nonposted_writes_num_issued[upstream_noc_index] - snapshot.nonposted_writes_num_issued;
+    const uint32_t nonposted_writes_acked_delta =
+        noc_nonposted_writes_acked[upstream_noc_index] - snapshot.nonposted_writes_acked;
+    const uint32_t nonposted_atomics_acked_delta =
+        noc_nonposted_atomics_acked[upstream_noc_index] - snapshot.nonposted_atomics_acked;
+    const uint32_t posted_writes_delta =
+        noc_posted_writes_num_issued[upstream_noc_index] - snapshot.posted_writes_num_issued;
+
+    // Leverage noc counters to store deltas so that dispatch_s can read them directly.
+    set_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(upstream_noc_index, reads_delta);
+    set_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(
+        upstream_noc_index, nonposted_writes_delta);
+    set_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(
+        upstream_noc_index, nonposted_writes_acked_delta);
+    set_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(
+        upstream_noc_index, nonposted_atomics_acked_delta);
+    set_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(
+        upstream_noc_index, posted_writes_delta);
+
+    volatile tt_l1_ptr uint32_t* shutdown_sem_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(dispatch_d_shutdown_sem_id));
+    *shutdown_sem_addr = 1;
+}
+
 void kernel_main() {
     set_l1_data_cache<true>();
 #if defined(FABRIC_RELAY)
@@ -1407,6 +1459,11 @@ void kernel_main() {
     static_assert(my_noc_index != upstream_noc_index);
     if constexpr (my_noc_index != upstream_noc_index) {
         noc_local_state_init(upstream_noc_index);
+    }
+
+    [[maybe_unused]] dispatch_d_noc_counter_snapshot dispatch_d_noc_counter_start = {};
+    if constexpr (!distributed_dispatcher) {
+        dispatch_d_noc_counter_start = snapshot_dispatch_d_noc_counters();
     }
 
     for (size_t i = 0; i < max_num_worker_sems; i++) {
@@ -1487,6 +1544,10 @@ void kernel_main() {
     dispatch_cb_reader.wait_all_pages();
 
     noc_async_full_barrier();
+
+    if constexpr (!distributed_dispatcher) {
+        publish_dispatch_d_noc_count(dispatch_d_noc_counter_start);
+    }
 
     if (is_h_variant && !is_d_variant) {
         relay_client.template teardown<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>();

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -331,7 +331,11 @@ void set_go_signal_noc_data() {
 // normal counter slots, then merge any non-zero deltas into our local counters before the barrier.
 FORCE_INLINE
 void merge_dispatch_d_noc_counter_deltas() {
-    static_assert(!distributed_dispatcher, "merge_dispatch_d_noc_counter_deltas is only supported when dispatch_d runs on the same core");
+    if constexpr (distributed_dispatcher) {
+        DEVICE_PRINT("merge_dispatch_d_noc_counter_deltas is only supported when dispatch_d runs on the same core");
+        ASSERT(0);
+        return;
+    }
 
     constexpr auto dispatch_d_proc_type = static_cast<decltype(proc_type)>(TensixProcessorTypes::DM0);
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -29,6 +29,7 @@ constexpr uint32_t cb_log_page_size = CB_LOG_PAGE_SIZE;
 constexpr uint32_t cb_size = CB_SIZE;
 constexpr uint32_t my_dispatch_cb_sem_id = MY_DISPATCH_CB_SEM_ID;
 constexpr uint32_t upstream_dispatch_cb_sem_id = UPSTREAM_DISPATCH_CB_SEM_ID;
+constexpr uint32_t dispatch_d_shutdown_sem_id = DISPATCH_D_SHUTDOWN_SEM_ID;
 constexpr uint32_t dispatch_s_sync_sem_base_addr = DISPATCH_S_SYNC_SEM_BASE_ADDR;
 constexpr uint32_t mcast_go_signal_addr = MCAST_GO_SIGNAL_ADDR;
 constexpr uint32_t unicast_go_signal_addr = UNICAST_GO_SIGNAL_ADDR;
@@ -325,6 +326,48 @@ void set_go_signal_noc_data() {
     cmd_ptr = round_up_pow2((uint32_t)data_ptr, L1_ALIGNMENT);
 }
 
+// When dispatch_d runs on the same core, it issues transactions on dispatch_s's dedicated NOC
+// that we never count locally. This function will wait for dispatch_d to publish its NOC 1 deltas into dispatch_d's
+// normal counter slots, then merge any non-zero deltas into our local counters before the barrier.
+FORCE_INLINE
+void merge_dispatch_d_noc_counter_deltas() {
+    static_assert(!distributed_dispatcher, "merge_dispatch_d_noc_counter_deltas is only supported when dispatch_d runs on the same core");
+
+    constexpr auto dispatch_d_proc_type = static_cast<decltype(proc_type)>(TensixProcessorTypes::DM0);
+
+    volatile tt_l1_ptr uint32_t* shutdown_sem_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(dispatch_d_shutdown_sem_id));
+    noc_semaphore_wait(shutdown_sem_addr, 1);
+
+    invalidate_l1_cache();
+    const uint32_t reads_delta =
+        get_noc_counter_val<dispatch_d_proc_type, NocBarrierType::READS_NUM_ISSUED>(my_noc_index);
+    const uint32_t nonposted_writes_delta =
+        get_noc_counter_val<dispatch_d_proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(my_noc_index);
+    const uint32_t nonposted_writes_acked_delta =
+        get_noc_counter_val<dispatch_d_proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(my_noc_index);
+    const uint32_t nonposted_atomics_acked_delta =
+        get_noc_counter_val<dispatch_d_proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(my_noc_index);
+    const uint32_t posted_writes_delta =
+        get_noc_counter_val<dispatch_d_proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(my_noc_index);
+
+    if (reads_delta != 0) {
+        noc_reads_num_issued[my_noc_index] += reads_delta;
+    }
+    if (nonposted_writes_delta != 0) {
+        noc_nonposted_writes_num_issued[my_noc_index] += nonposted_writes_delta;
+    }
+    if (nonposted_writes_acked_delta != 0) {
+        noc_nonposted_writes_acked[my_noc_index] += nonposted_writes_acked_delta;
+    }
+    if (nonposted_atomics_acked_delta != 0) {
+        noc_nonposted_atomics_acked[my_noc_index] += nonposted_atomics_acked_delta;
+    }
+    if (posted_writes_delta != 0) {
+        noc_posted_writes_num_issued[my_noc_index] += posted_writes_delta;
+    }
+}
+
 void kernel_main() {
     set_l1_data_cache<true>();
     DPRINT << "dispatch_s : start" << ENDL();
@@ -377,15 +420,13 @@ void kernel_main() {
     }
     // Confirm expected number of pages, spinning here is a leak
     cb_wait_all_pages<my_dispatch_cb_sem_id>(total_pages_acquired);
-#ifdef COMPILE_FOR_IDLE_ERISC
-    // Wait for all transactions to complete, to avoid hitting the asserts in
-    // idle_erisck.cc if there are outstanding transactions. These barriers
-    // don't work on worker cores, because there cq_dispatch is on the same core
-    // and shares use of this noc, but doesn't update this risc's transaction
-    // counts. However, we don't have the barrier checks in brisck.cc, so we can
-    // skip this for now.
+
+    if constexpr (!distributed_dispatcher) {
+        merge_dispatch_d_noc_counter_deltas();
+    }
+
     noc_async_full_barrier();
-#endif
+
     DPRINT << "dispatch_s : done" << ENDL();
     DEVICE_PRINT("dispatch_s : done\n");
     set_l1_data_cache<false>();


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Closes #18881 

- Fixes issue 18881 by passing counter values for NOC1 within dispatch_d to dispatch_s when both kernels share the same core (when distributed_dispatcher is false)
- Snapshots dispatch_d’s NOC1 counters at startup, computes shutdown deltas for all barrier counter types, and publishes those deltas into dispatch_d’s normal NOC counter slots
- Updates dispatch_s to wait for the dispatch_d shutdown semaphore, read dispatch_d’s published counter deltas, and merge nonzero deltas into its local NOC1 counter state before noc_async_full_barrier()

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
This fix keeps the current structure of dispatch_s still having dedicated ownership over NOC1, it simply adjusts the counters in dispatch_s to be accurate and allows for `noc_async_full_barrier()` to return successfully.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/18881-dispatch-s-update-noc-counter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/18881-dispatch-s-update-noc-counter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/18881-dispatch-s-update-noc-counter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/18881-dispatch-s-update-noc-counter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anashTT/18881-dispatch-s-update-noc-counter)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anashTT/18881-dispatch-s-update-noc-counter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/18881-dispatch-s-update-noc-counter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/18881-dispatch-s-update-noc-counter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/18881-dispatch-s-update-noc-counter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/18881-dispatch-s-update-noc-counter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/18881-dispatch-s-update-noc-counter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/18881-dispatch-s-update-noc-counter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/18881-dispatch-s-update-noc-counter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/18881-dispatch-s-update-noc-counter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/18881-dispatch-s-update-noc-counter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/18881-dispatch-s-update-noc-counter)