### PR TITLE
Implement warmup flow in demo

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -27,11 +27,17 @@ from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import (
     DEFAULT_MAX_SEQ_LEN,
+    DEFAULT_PREFILL_WARMUP_MODE_DEMO,
+    DEFAULT_PREFILL_WARMUP_MODE_VLLM,
     DEFAULT_SAMPLING_TEMPERATURE,
     DEFAULT_SAMPLING_TOP_K,
     DEFAULT_SAMPLING_TOP_P,
+    PREFILL_WARMUP_MODE_LINEAR_ADDITIVE,
+    PREFILL_WARMUP_MODE_LINEAR_MULTIPLES,
     USERS_PER_ROW,
+    align_up,
     even_int_div,
+    get_min_alignment_value_for_prefill,
     make_deepseek_sampling_args,
 )
 from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
@@ -171,7 +177,9 @@ class DeepseekGenerator(WarmupForwardMixin):
         sample_on_device: bool = False,
         enable_mtp: bool = False,
         sampling_params: SamplingParams | None = None,
+        vllm_context: bool = False,
     ) -> None:
+        self.vllm_context = vllm_context  # track if Generator is initialized in vLLM context
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
         self.cache_dir = cache_dir
@@ -199,6 +207,10 @@ class DeepseekGenerator(WarmupForwardMixin):
                 model_max_seq_len,
             )
         self.hf_config.max_seq_len = requested_max_seq_len
+        assert (
+            self.hf_config.max_seq_len % ttnn.TILE_SIZE == 0
+        ), f"hf_config.max_seq_len {self.hf_config.max_seq_len} must be TILE_SIZE={ttnn.TILE_SIZE} aligned"
+
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
             try:
@@ -301,6 +313,114 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         self._prepare_weight_configs(cache_dir)
         self._assert_mtp_available()
+
+    def warmup_model(self, min_token_len: int, max_token_len: int):
+        if not self.vllm_context:
+            # Phase 1: Warmup (i) prefill and (ii) decode without trace
+            logger.debug(f"Phase 1: (i) Warmup prefill without trace for demo")
+            self.warmup_model_prefill(
+                kv_cache=None,
+                enable_trace=False,
+                can_sample_on_device=False,
+                non_greedy_decoding_on_device=False,
+                min_token_len=min_token_len,
+                max_token_len=max_token_len,
+                sample_on_device=self.sample_on_device,
+            )
+            logger.debug(f"Phase 1: (ii) Warmup decode without trace for demo")
+            self._warmup_model_decode_demo(enable_trace=False, sample_on_device=self.sample_on_device)
+
+            if self.enable_trace:
+                # Phase 2: Warmup decode with trace (deepseek does not support prefill with trace)
+                logger.debug(f"Phase 2: Warmup decode with trace for demo")
+                self._warmup_model_decode_demo(enable_trace=True, sample_on_device=self.sample_on_device)
+            else:
+                logger.debug("Demo was initiated without trace, skipping Phase 2: Warmup decode with trace")
+            logger.info("Warmup completed for demo mode")
+
+        else:
+            logger.info("vLLM runs its own warmup, no need to warmup explicitly for vLLM context")
+
+    def _warmup_model_decode_demo(self, enable_trace: bool, sample_on_device: bool):
+        warmup_tokens = torch.zeros(self.batch_size, dtype=torch.int32)
+        warmup_start_pos = torch.zeros(self.batch_size, dtype=torch.int32)
+        decode_logits = self.decode_forward(
+            tokens=warmup_tokens,
+            start_pos=warmup_start_pos,
+            enable_trace=enable_trace,
+            page_table=None,
+            sample_on_device=sample_on_device,
+        )
+
+        if sample_on_device:
+            self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
+        else:
+            self._sample_on_host(decode_logits)
+
+    def _get_default_prefill_warmup_mode(self) -> str:
+        return DEFAULT_PREFILL_WARMUP_MODE_VLLM if self.vllm_context else DEFAULT_PREFILL_WARMUP_MODE_DEMO
+
+    def _get_prefill_warmup_token_lens(self, min_prompt_len: int = 0, max_prompt_len: int = 0) -> list[int]:
+        """Build and cache supported prefill warmup lengths.
+
+        Args:
+            min_prompt_len: Minimum prompt length to consider (inclusive). Rounded
+                up to the prefill alignment value for warmup generation.
+            max_prompt_len: Maximum prompt length to consider. If ``<= 0``, uses
+                ``self.hf_config.max_seq_len`` and rounds up to the same alignment.
+
+        Supported modes:
+            - ``LINEAR_ADDITIVE``: ``tile, 2*tile, 3*tile, ...``
+              Dense warmup coverage with more warmup compile/runtime cost.
+            - ``LINEAR_MULTIPLES``: ``tile, 2*tile, 4*tile, 8*tile, ...``
+              Geometric warmup coverage with fewer warmup points and more runtime padding.
+
+        Returns:
+            A unique, ascending list of prompt lengths aligned to the prefill
+            boundary. The list always includes the effective upper bound.
+        """
+        mode = self._get_default_prefill_warmup_mode()
+        alignment_value = get_min_alignment_value_for_prefill(self.mesh_device.shape[0])
+        upper_bound = max_prompt_len if max_prompt_len > 0 else self.hf_config.max_seq_len
+
+        upper_bound = align_up(upper_bound, alignment_value)
+        lower_bound = align_up(min_prompt_len, alignment_value)
+
+        assert (
+            upper_bound <= self.hf_config.max_seq_len
+        ), f"Upper bound {upper_bound} can not exceed model max seq len {self.hf_config.max_seq_len}"
+        assert (
+            lower_bound <= self.hf_config.max_seq_len
+        ), f"Lower bound {lower_bound} can not exceed model max seq len {self.hf_config.max_seq_len}"
+        cache_key = (lower_bound, upper_bound, mode)
+        cache = getattr(self, "_prefill_warmup_prompt_lens_cache", {})
+        if cache_key in cache:
+            return cache[cache_key]
+
+        prompt_lens_set: set[int] = set()
+        if mode == PREFILL_WARMUP_MODE_LINEAR_ADDITIVE:
+            prompt_len = lower_bound
+            while prompt_len <= upper_bound:
+                prompt_lens_set.add(prompt_len)
+                prompt_len += alignment_value
+        elif mode == PREFILL_WARMUP_MODE_LINEAR_MULTIPLES:
+            multiple = 1
+            while alignment_value * multiple < lower_bound:
+                multiple *= 2
+            while alignment_value * multiple <= upper_bound:
+                prompt_lens_set.add(alignment_value * multiple)
+                multiple *= 2
+        else:
+            raise ValueError(
+                f"Unsupported warmup prompt_len mode '{mode}'. "
+                "Expected one of ['LINEAR_ADDITIVE', 'LINEAR_MULTIPLES']."
+            )
+
+        prompt_lens_set.add(upper_bound)
+        prompt_lens = sorted(prompt_lens_set)
+        cache[cache_key] = prompt_lens
+        self._prefill_warmup_prompt_lens_cache = cache
+        return prompt_lens
 
     def _validate_and_initialize_sampling(
         self,
@@ -1765,6 +1885,24 @@ class DeepseekGenerator(WarmupForwardMixin):
         profiler.end("tokenizing")
 
         logger.info(f"Lengths of {lengths.shape} (encoded) prompts: {lengths}")
+        padded_seq_len = int(tokens_batched.shape[-1])
+        # For demo the entire batch of prompts are padded to the same max length,
+        # so we warmup the model with only one prefill length i.e. min and max are the same.
+        # Once https://github.com/tenstorrent/tt-metal/issues/43099 is fixed, we can use the actual min lengths of the prompts
+        min_token_len = padded_seq_len
+        max_token_len = padded_seq_len
+        assert (
+            max_token_len <= self.hf_config.max_seq_len
+        ), f"Max prompt length {max_token_len} exceeds model max seq len {self.hf_config.max_seq_len}"
+
+        if self.signpost:
+            signpost(header="warmup_model")
+        profiler.start("warmup_model")
+        self.warmup_model(min_token_len, max_token_len)
+        profiler.end("warmup_model")
+        if self.signpost:
+            signpost(header="warmup_model")
+
         decode_steps_for_stats = 0
         decode_forward_passes = 0
         decode_step_active_masks_for_stats: List[List[bool]] = []
@@ -2219,6 +2357,20 @@ class DeepseekGenerator(WarmupForwardMixin):
             out.append(1)
         return out
 
+    def _pad_seq_len_to_warmup_prompt_lens(self, seq_len: int) -> int:
+        """Return the smallest supported prefill length >= seq_len.
+
+        Raises:
+            ValueError: If seq_len exceeds every value returned by
+                _get_prefill_warmup_token_lens().
+        """
+        warmup_token_lens = self._get_prefill_warmup_token_lens()
+        for supported_len in warmup_token_lens:
+            if seq_len <= supported_len:
+                return supported_len
+
+        raise ValueError(f"seq_len {seq_len} is greater than all supported prefill lengths {warmup_token_lens}")
+
     def _prefill(
         self,
         tokens: torch.Tensor,
@@ -2242,6 +2394,28 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         tokens = tokens.view(1, 1, -1)
         seq_len = tokens.shape[-1]
+        if self.vllm_context:
+            # In vLLM context, we perform warmup for prefill and decode.
+            # prefill warmup is performed for all supported prompt lengths in the list returned by _get_prefill_warmup_prompt_lens()
+            # We need to pad the seq_len to the closest supported warmup prompt length, otherwise memory corruption can happen.
+            # The memory corruption happens when any new device memory is allocated when trace is active.
+            max_supported_seq_len = max(self._get_prefill_warmup_token_lens())
+            if seq_len > max_supported_seq_len:
+                raise ValueError(
+                    f"seq_len {seq_len} is greater than {max_supported_seq_len}. "
+                    "Crash here early rather than wait for memory corruption to happen and crash later."
+                )
+            padded_seq_len = self._pad_seq_len_to_warmup_prompt_lens(seq_len)
+            if padded_seq_len > seq_len:
+                pad_token_id = getattr(self, "pad_token_id", 0)
+                pad_tokens = torch.full(
+                    (tokens.shape[0], tokens.shape[1], padded_seq_len - seq_len),
+                    pad_token_id,
+                    dtype=tokens.dtype,
+                    device=tokens.device,
+                )
+                tokens = torch.cat((tokens, pad_tokens), dim=-1)
+                seq_len = padded_seq_len
 
         # Prepare TT inputs for prefill - reshape to [1, 1, actual_seq_len]
         tt_tokens = ttnn.from_torch(
@@ -2679,16 +2853,11 @@ class DeepseekGenerator(WarmupForwardMixin):
         """Allocate persistent inputs, capture trace for one decode iteration, and store trace state."""
         assert self._trace_id is None, "Trace already captured"
 
-        # 1) Warm-up compile run (no trace) to keep compilation out of capture
-        logger.info("Running warm-up decode step (no trace)...")
-        if self.signpost:
-            signpost(header="decode_warmup")
-        _ = self._decode_step(init_tokens, positions, page_tables=page_tables, sample_on_device=False)
-        ttnn.synchronize_device(self.mesh_device)
-        if self.signpost:
-            signpost(header="decode_warmup")
+        # vLLM handles warmup calls internally, so we don't need to do anything here.
+        # For demo mode, we need to do warmup explicitly.
+        # So, overall it's expected that the warmup is done before capturing the trace.
 
-        # 2) Allocate persistent device inputs
+        # 1) Allocate persistent device inputs
         self._trace_tokens = self._tt_from_tokens_step(init_tokens)
         self._trace_positions = ttnn.from_torch(
             positions,
@@ -2707,7 +2876,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             self._trace_page_tables_to_use = self._get_page_tables()
         ttnn.synchronize_device(self.mesh_device)
 
-        # 3) Capture decode graph
+        # 2) Capture decode graph
         self.ccl.reset_sem_counters()
         logger.info("Begin capturing decode trace...")
         if self.signpost:
@@ -2743,7 +2912,8 @@ class DeepseekGenerator(WarmupForwardMixin):
     ) -> ttnn.Tensor | torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
-        self.enable_trace = enable_trace
+        if self.vllm_context:
+            self.enable_trace = enable_trace
 
         if not enable_trace:
             return self._decode_step(tokens, start_pos, page_table, sample_on_device)
@@ -2844,9 +3014,82 @@ class DeepseekGenerator(WarmupForwardMixin):
                 ttnn.ReadDeviceProfiler(self.mesh_device)
             return logits.squeeze(0).squeeze(0)
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device) -> None:
-        logger.warning("Warmup model prefill not implemented for DeepseekGenerator")
-        logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator")
+    def _get_warmup_page_size(self) -> int:
+        for attr_name in ("page_size", "block_size", "kv_cache_page_size"):
+            value = getattr(self, attr_name, None)
+            if isinstance(value, int) and value > 0:
+                return value
+        for container_name in ("model_args", "model_config", "config"):
+            container = getattr(self, container_name, None)
+            if container is None:
+                continue
+            for attr_name in ("page_size", "block_size", "kv_cache_page_size"):
+                value = getattr(container, attr_name, None)
+                if isinstance(value, int) and value > 0:
+                    return value
+        return 1
+
+    def _build_warmup_page_table(self, prompt_len: int) -> torch.Tensor:
+        page_size = self._get_warmup_page_size()
+        num_pages = max(1, (prompt_len + page_size - 1) // page_size)
+        return torch.arange(num_pages, dtype=torch.int32).unsqueeze(0)
+
+    def warmup_model_prefill(
+        self,
+        kv_cache,
+        enable_trace,
+        can_sample_on_device,
+        non_greedy_decoding_on_device,
+        min_token_len: int = 0,
+        max_token_len: int = 0,
+        sample_on_device: bool | None = None,
+    ) -> None:
+        if enable_trace:
+            logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator; skipping warmup.")
+            return
+
+        user_id = 0
+        if sample_on_device is None or self.vllm_context:
+            sample_on_device_list = [False, True]
+        else:
+            sample_on_device_list = [sample_on_device]
+
+        for sample_on_device in sample_on_device_list:
+            for token_len in self._get_prefill_warmup_token_lens(min_token_len, max_token_len):
+                vocab = int(getattr(self.hf_config, "vocab_size", 129280))
+                tokens = torch.randint(vocab, (1, token_len), dtype=torch.int32)
+                tokens, _ = self._pad_batch(tokens, 1)
+                # TODO: MTP path warmup needed?
+                prefill_logits = self._prefill(
+                    tokens=tokens,
+                    user_id=user_id,
+                    sample_on_device=sample_on_device,
+                    return_last_hidden=False,
+                )
+                if sample_on_device:
+                    self._validate_and_initialize_sampling(
+                        None,
+                        sample_on_device,
+                        enable_trace=enable_trace,
+                    )
+
+                    prefill_logits = self._slice_last_token_logits(prefill_logits, token_len, expand_to_batch=True)
+                    self._sample_tokens_device(prefill_logits, user_slots=[user_id])
+
+        # Warmup creates temporary page tables; clean them up to free memory.
+        try:
+            if self.page_tables_tt is not None:
+                for i, page_table in enumerate(self.page_tables_tt):
+                    try:
+                        ttnn.deallocate(page_table)
+                    except Exception as e:
+                        logger.warning(f"Failed to deallocate warmup page table {i}: {e}")
+                self.page_tables_tt = None
+            self.base_page_table_host = None
+        except Exception as e:
+            logger.warning(f"Failed to cleanup warmup page tables: {e}")
+
+        logger.info("Prefill warmup completed.")
 
     def get_kv_cache(self):
         assert self.model_state is not None, "Model state is not initialized"

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -207,9 +207,6 @@ class DeepseekGenerator(WarmupForwardMixin):
                 model_max_seq_len,
             )
         self.hf_config.max_seq_len = requested_max_seq_len
-        assert (
-            self.hf_config.max_seq_len % ttnn.TILE_SIZE == 0
-        ), f"hf_config.max_seq_len {self.hf_config.max_seq_len} must be TILE_SIZE={ttnn.TILE_SIZE} aligned"
 
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
@@ -302,6 +299,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.prefill_max_tokens = prefill_max_tokens
         self.force_recalculate = force_recalculate
         self.profile_decode = profile_decode  # Profile decode: skip prefill, run only 1st dense + 1st MoE layer
+        self._warmup_completed_configs: set[tuple[bool, bool, int, int, int]] = set()
         logger.info(f"Enable trace: {self.enable_trace}")
         if self.profile_decode:
             logger.info("profile_decode=True: Prefill skipped, decode runs only 1st dense layer + 1st MoE layer")
@@ -386,12 +384,11 @@ class DeepseekGenerator(WarmupForwardMixin):
         upper_bound = align_up(upper_bound, alignment_value)
         lower_bound = align_up(min_prompt_len, alignment_value)
 
-        assert (
-            upper_bound <= self.hf_config.max_seq_len
-        ), f"Upper bound {upper_bound} can not exceed model max seq len {self.hf_config.max_seq_len}"
-        assert (
-            lower_bound <= self.hf_config.max_seq_len
-        ), f"Lower bound {lower_bound} can not exceed model max seq len {self.hf_config.max_seq_len}"
+        if upper_bound > self.hf_config.max_seq_len:
+            raise ValueError(f"Upper bound {upper_bound} can not exceed model max seq len {self.hf_config.max_seq_len}")
+        if lower_bound > self.hf_config.max_seq_len:
+            raise ValueError(f"Lower bound {lower_bound} can not exceed model max seq len {self.hf_config.max_seq_len}")
+
         cache_key = (lower_bound, upper_bound, mode)
         cache = getattr(self, "_prefill_warmup_prompt_lens_cache", {})
         if cache_key in cache:
@@ -1891,17 +1888,31 @@ class DeepseekGenerator(WarmupForwardMixin):
         # Once https://github.com/tenstorrent/tt-metal/issues/43099 is fixed, we can use the actual min lengths of the prompts
         min_token_len = padded_seq_len
         max_token_len = padded_seq_len
-        assert (
-            max_token_len <= self.hf_config.max_seq_len
-        ), f"Max prompt length {max_token_len} exceeds model max seq len {self.hf_config.max_seq_len}"
-
-        if self.signpost:
-            signpost(header="warmup_model")
+        if max_token_len > self.hf_config.max_seq_len:
+            raise ValueError(
+                f"Max prompt length {max_token_len} exceeds model max seq len {self.hf_config.max_seq_len}"
+            )
+        # Warmup is expensive and only depends on runtime mode + prefill length bounds.
+        # Cache completed warmups per configuration so repeated generate() calls can skip it.
+        warmup_cache_key = (
+            bool(self.enable_trace),
+            bool(self.sample_on_device),
+            int(self.hf_config.max_seq_len),
+            int(min_token_len),
+            int(max_token_len),
+        )
         profiler.start("warmup_model")
-        self.warmup_model(min_token_len, max_token_len)
+        if warmup_cache_key not in self._warmup_completed_configs:
+            if self.signpost:
+                signpost(header="warmup_model")
+            self.warmup_model(min_token_len, max_token_len)
+            self._warmup_completed_configs.add(warmup_cache_key)
+            if self.signpost:
+                signpost(header="warmup_model")
+        else:
+            # Keep profiler timing for "warmup_model" even when warmup is skipped.
+            logger.info(f"Skipping warmup_model; warmup already completed for cache key={warmup_cache_key}.")
         profiler.end("warmup_model")
-        if self.signpost:
-            signpost(header="warmup_model")
 
         decode_steps_for_stats = 0
         decode_forward_passes = 0
@@ -2396,7 +2407,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         seq_len = tokens.shape[-1]
         if self.vllm_context:
             # In vLLM context, we perform warmup for prefill and decode.
-            # prefill warmup is performed for all supported prompt lengths in the list returned by _get_prefill_warmup_prompt_lens()
+            # prefill warmup is performed for all supported prompt lengths in the list returned by _get_prefill_warmup_token_lens()
             # We need to pad the seq_len to the closest supported warmup prompt length, otherwise memory corruption can happen.
             # The memory corruption happens when any new device memory is allocated when trace is active.
             max_supported_seq_len = max(self._get_prefill_warmup_token_lens())
@@ -2407,7 +2418,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                 )
             padded_seq_len = self._pad_seq_len_to_warmup_prompt_lens(seq_len)
             if padded_seq_len > seq_len:
-                pad_token_id = getattr(self, "pad_token_id", 0)
+                pad_token_id = self._get_pad_id()
                 pad_tokens = torch.full(
                     (tokens.shape[0], tokens.shape[1], padded_seq_len - seq_len),
                     pad_token_id,
@@ -3014,26 +3025,6 @@ class DeepseekGenerator(WarmupForwardMixin):
                 ttnn.ReadDeviceProfiler(self.mesh_device)
             return logits.squeeze(0).squeeze(0)
 
-    def _get_warmup_page_size(self) -> int:
-        for attr_name in ("page_size", "block_size", "kv_cache_page_size"):
-            value = getattr(self, attr_name, None)
-            if isinstance(value, int) and value > 0:
-                return value
-        for container_name in ("model_args", "model_config", "config"):
-            container = getattr(self, container_name, None)
-            if container is None:
-                continue
-            for attr_name in ("page_size", "block_size", "kv_cache_page_size"):
-                value = getattr(container, attr_name, None)
-                if isinstance(value, int) and value > 0:
-                    return value
-        return 1
-
-    def _build_warmup_page_table(self, prompt_len: int) -> torch.Tensor:
-        page_size = self._get_warmup_page_size()
-        num_pages = max(1, (prompt_len + page_size - 1) // page_size)
-        return torch.arange(num_pages, dtype=torch.int32).unsqueeze(0)
-
     def warmup_model_prefill(
         self,
         kv_cache,
@@ -3057,8 +3048,8 @@ class DeepseekGenerator(WarmupForwardMixin):
         for sample_on_device in sample_on_device_list:
             for token_len in self._get_prefill_warmup_token_lens(min_token_len, max_token_len):
                 vocab = int(getattr(self.hf_config, "vocab_size", 129280))
-                tokens = torch.randint(vocab, (1, token_len), dtype=torch.int32)
-                tokens, _ = self._pad_batch(tokens, 1)
+                warmup_token_ids = [torch.randint(vocab, (token_len,), dtype=torch.int32).tolist()]
+                tokens, _ = self._pad_batch(warmup_token_ids, 1)
                 # TODO: MTP path warmup needed?
                 prefill_logits = self._prefill(
                     tokens=tokens,
@@ -3072,9 +3063,25 @@ class DeepseekGenerator(WarmupForwardMixin):
                         sample_on_device,
                         enable_trace=enable_trace,
                     )
-
-                    prefill_logits = self._slice_last_token_logits(prefill_logits, token_len, expand_to_batch=True)
-                    self._sample_tokens_device(prefill_logits, user_slots=[user_id])
+                    sliced_prefill_logits = self._slice_last_token_logits(
+                        prefill_logits, token_len, expand_to_batch=True
+                    )
+                    sampled_tokens = self._sample_tokens_device(sliced_prefill_logits, user_slots=[user_id])
+                    try:
+                        if sampled_tokens is not None:
+                            ttnn.deallocate(sampled_tokens)
+                    except Exception as e:
+                        logger.warning(f"Failed to deallocate sampled tokens: {e}")
+                    try:
+                        if sliced_prefill_logits is not None:
+                            ttnn.deallocate(sliced_prefill_logits)
+                    except Exception as e:
+                        logger.warning(f"Failed to deallocate sliced prefill logits: {e}")
+                    try:
+                        if prefill_logits is not None:
+                            ttnn.deallocate(prefill_logits)
+                    except Exception as e:
+                        logger.warning(f"Failed to deallocate prefill logits: {e}")
 
         # Warmup creates temporary page tables; clean them up to free memory.
         try:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -1901,18 +1901,20 @@ class DeepseekGenerator(WarmupForwardMixin):
             int(min_token_len),
             int(max_token_len),
         )
-        profiler.start("warmup_model")
+        
         if warmup_cache_key not in self._warmup_completed_configs:
             if self.signpost:
                 signpost(header="warmup_model")
+            profiler.start("warmup_model")
             self.warmup_model(min_token_len, max_token_len)
-            self._warmup_completed_configs.add(warmup_cache_key)
+            profiler.end("warmup_model")
             if self.signpost:
                 signpost(header="warmup_model")
+            
+            self._warmup_completed_configs.add(warmup_cache_key)
         else:
             # Keep profiler timing for "warmup_model" even when warmup is skipped.
             logger.info(f"Skipping warmup_model; warmup already completed for cache key={warmup_cache_key}.")
-        profiler.end("warmup_model")
 
         decode_steps_for_stats = 0
         decode_forward_passes = 0

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -3042,8 +3042,9 @@ class DeepseekGenerator(WarmupForwardMixin):
             return
 
         user_id = 0
+        original_sample_on_device = getattr(self, "sample_on_device", False)
         if sample_on_device is None or self.vllm_context:
-            sample_on_device_list = [False, True]
+            sample_on_device_list = [False, True] if can_sample_on_device else [False]
         else:
             sample_on_device_list = [sample_on_device]
 
@@ -3084,6 +3085,14 @@ class DeepseekGenerator(WarmupForwardMixin):
                             ttnn.deallocate(prefill_logits)
                     except Exception as e:
                         logger.warning(f"Failed to deallocate prefill logits: {e}")
+
+        if getattr(self, "sample_on_device", False) != original_sample_on_device:
+            # Warmup may initialize sampling internals; restore the caller's expected mode.
+            self._validate_and_initialize_sampling(
+                None,
+                original_sample_on_device,
+                enable_trace=enable_trace,
+            )
 
         # Warmup creates temporary page tables; clean them up to free memory.
         try:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -1901,7 +1901,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             int(min_token_len),
             int(max_token_len),
         )
-        
+
         if warmup_cache_key not in self._warmup_completed_configs:
             if self.signpost:
                 signpost(header="warmup_model")
@@ -1910,7 +1910,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             profiler.end("warmup_model")
             if self.signpost:
                 signpost(header="warmup_model")
-            
+
             self._warmup_completed_configs.add(warmup_cache_key)
         else:
             # Keep profiler timing for "warmup_model" even when warmup is skipped.

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import torch
 from loguru import logger
 
+import ttnn
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
@@ -65,6 +66,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             cache_dir=Path(cache_dir) if cache_dir else None,
             tokenizer=tokenizer,
             max_seq_len=max_seq_len,
+            vllm_context=True,
         )
 
         return model
@@ -216,6 +218,22 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         # - sample_on_device=True  -> sampled token ids
         # - sample_on_device=False -> logits [B, 1, V] for host sampling
         return decode_output
+
+    def read_decode_output(self, tt_out, async_read=False):
+        # If decode already returned host tensors, pass through.
+        if isinstance(tt_out, torch.Tensor):
+            return (tt_out, []) if async_read else tt_out
+
+        # Device-sampling decode output: TT tensor -> host torch token ids.
+        if isinstance(tt_out, ttnn.Tensor):
+            host_tokens = self._tokens_from_device(
+                tt_out,
+                self.mesh_device,
+                batch_size_per_row=self.batch_size_per_row,
+            )
+            return (host_tokens, []) if async_read else host_tokens
+
+        raise TypeError(f"Unsupported decode output type from DeepseekV3ForCausalLM: {type(tt_out)}")
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
         assert (

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -54,6 +54,45 @@ def get_fabric_config():
     )
 
 
+# We cann't warmup prefill for all possible prompt lengths, only warmup for the selective prompt lengths.
+# LINEAR_ADDITIVE: tile, 2*tile, 3*tile, ... hf_config.max_seq_len
+# LINEAR_MULTIPLES: tile, 2*tile, 4*tile, 8*tile, ... hf_config.max_seq_len
+PREFILL_WARMUP_MODE_LINEAR_ADDITIVE = "LINEAR_ADDITIVE"
+PREFILL_WARMUP_MODE_LINEAR_MULTIPLES = "LINEAR_MULTIPLES"
+DEFAULT_PREFILL_WARMUP_MODE_VLLM = PREFILL_WARMUP_MODE_LINEAR_MULTIPLES
+DEFAULT_PREFILL_WARMUP_MODE_DEMO = PREFILL_WARMUP_MODE_LINEAR_ADDITIVE
+
+
+def is_quad_mesh(mesh_device: ttnn.MeshDevice) -> bool:
+    """Check whether the mesh device has a QUAD configuration (16x8)."""
+    return mesh_device.shape[0] == 16 and mesh_device.shape[1] == 8
+
+
+def align_up(value: int, align_value: int) -> int:
+    """Round value up to the next multiple of align_value, with a minimum of align_value."""
+    return max(align_value, (value + align_value - 1) // align_value * align_value)
+
+
+def get_min_alignment_value_for_prefill(rows: int) -> int:
+    """for quad mesh, we need to align each seq_len chunk per row to the tile size
+    for other meshes, we align the entire seq_len to the tile size"""
+    return int(ttnn.TILE_SIZE) * rows if rows == 16 else int(ttnn.TILE_SIZE)
+
+
+def align_prefill_padded_seq_len(seq_len: int, num_mesh_rows: int) -> int:
+    """Round ``seq_len`` up to a multiple of ``TILE_SIZE * num_mesh_rows`` (mesh axis 0).
+
+    Used when padding prefill token batches so the workspace sequence length satisfies
+    dispatch / mesh-row alignment constraints.
+    """
+    seq_len_i = int(seq_len)
+    rows = int(num_mesh_rows)
+    if rows <= 0:
+        raise ValueError(f"num_mesh_rows must be > 0, got {num_mesh_rows!r}")
+    alignment = get_min_alignment_value_for_prefill(num_mesh_rows)
+    return align_up(seq_len_i, alignment)
+
+
 def make_deepseek_sampling_args(
     mesh_device,
     vocab_size: int,

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -54,7 +54,7 @@ def get_fabric_config():
     )
 
 
-# We cann't warmup prefill for all possible prompt lengths, only warmup for the selective prompt lengths.
+# We can't warmup prefill for all possible prompt lengths, only warmup for the selective prompt lengths.
 # LINEAR_ADDITIVE: tile, 2*tile, 3*tile, ... hf_config.max_seq_len
 # LINEAR_MULTIPLES: tile, 2*tile, 4*tile, 8*tile, ... hf_config.max_seq_len
 PREFILL_WARMUP_MODE_LINEAR_ADDITIVE = "LINEAR_ADDITIVE"
@@ -70,7 +70,7 @@ def is_quad_mesh(mesh_device: ttnn.MeshDevice) -> bool:
 
 def align_up(value: int, align_value: int) -> int:
     """Round value up to the next multiple of align_value, with a minimum of align_value."""
-    return max(align_value, (value + align_value - 1) // align_value * align_value)
+    return int(max(align_value, (value + align_value - 1) // align_value * align_value))
 
 
 def get_min_alignment_value_for_prefill(rows: int) -> int:
@@ -89,7 +89,7 @@ def align_prefill_padded_seq_len(seq_len: int, num_mesh_rows: int) -> int:
     rows = int(num_mesh_rows)
     if rows <= 0:
         raise ValueError(f"num_mesh_rows must be > 0, got {num_mesh_rows!r}")
-    alignment = get_min_alignment_value_for_prefill(num_mesh_rows)
+    alignment = get_min_alignment_value_for_prefill(rows)
     return align_up(seq_len_i, alignment)
 
 


### PR DESCRIPTION
### Summary
https://github.com/tenstorrent/tt-metal/issues/42791

Added a demo warmup flow that runs prefill and decode warmups and added a dedicated decode warmup helper in generator.py.
Introduced configurable prefill warmup token-length generation with alignment logic, additive/multiples modes, and caching; used it to align warmup and padding behavior.
Added alignment helpers and warmup mode constants in config_helpers.py, and tightened prefill alignment calculations.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapati/demo_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/demo_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pprajapati/demo_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pprajapati/demo_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/demo_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/demo_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/demo_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/demo_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pprajapati/demo_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pprajapati/demo_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/demo_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/demo_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/demo_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/demo_warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/demo_warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/demo_warmup)