### PR TITLE
Port causal support to v2 streaming SDPA + writer NOC race fix

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -209,31 +209,10 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
             is_balanced=True,
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat8_b,
-            q_chunk_sizes=[160],  # Tuned for each sequence length
-            k_chunk_sizes=[160],
-            seq_len=3200,
-        )
-    )
-
-    configs.append(
-        ModelConfig(
-            name="mla_100k_straddle",  # k_chunk doesn't divide seq_len
-            nhq=mla_nhq,
-            nhk=1,
-            nhv=mla_nhq,
-            d_q=576,
-            d_k=576,
-            d_v=128,
-            is_causal=True,
-            is_balanced=True,
-            q_dtype=ttnn.bfloat16,
-            kv_dtype=ttnn.bfloat8_b,
             q_chunk_sizes=[160],
-            k_chunk_sizes=[256],
+            # k=160 -> Sk_chunk_t=5; k=256 straddles (3200%256=128); k=320 -> Sk_chunk_t=10 with kt-sub=2.
+            k_chunk_sizes=[160, 256, 320],
             seq_len=3200,
-            # Sk_chunk_t=8 straddle-mask branch exceeds default kernel config buffer.
-            # Empirically tuned to give +5 KiB headroom on this shape.
-            worker_l1_size=1456640,
         )
     )
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -23,7 +23,7 @@ import math
 import torch
 from dataclasses import dataclass, field
 from itertools import product
-from typing import ClassVar, List, Tuple, Dict
+from typing import List, Dict
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -23,7 +23,7 @@ import math
 import torch
 from dataclasses import dataclass, field
 from itertools import product
-from typing import ClassVar, List, Tuple, Dict, Optional
+from typing import ClassVar, List, Tuple, Dict
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
@@ -75,10 +75,6 @@ class ModelConfig:
 
     # Can be hardware-dependent to keep per-core work balanced between Galaxy and Quiet Box
     seq_len: int
-
-    # Override worker L1 size for configs whose kernel binary exceeds the default buffer.
-    # None means use the device default.
-    worker_l1_size: Optional[int] = None
 
 
 def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
@@ -369,7 +365,6 @@ def generate_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, Mode
                     model.is_balanced,
                     model.q_dtype,
                     model.kv_dtype,
-                    model.worker_l1_size,
                 )
             )
             config_ids.append(get_test_case_id(model, q_chunk, k_chunk))
@@ -403,7 +398,6 @@ def run_ring_joint_sdpa(
     rmse_threshold=None,
     do_check=True,
     num_iterations=1,
-    worker_l1_size=None,
 ):
     """
     Run Ring Joint Attention SDPA using direct ttnn operations with auto-detected devices.
@@ -485,10 +479,7 @@ def run_ring_joint_sdpa(
 
     # Open mesh device based on calculated configuration
     mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
-    open_kwargs = {}
-    if worker_l1_size is not None:
-        open_kwargs["worker_l1_size"] = worker_l1_size
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **open_kwargs)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
     num_links = 2
 
     try:
@@ -807,7 +798,7 @@ TEST_CONFIG_MODELS = list(MODEL_CONFIGS.keys())
 # === TEST 1: PERFORMANCE SWEEP (skipped on CI) ===
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
 @pytest.mark.parametrize(
-    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype,worker_l1_size",
+    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
     TEST_CONFIGS,
     ids=TEST_CONFIG_IDS,
 )
@@ -826,7 +817,6 @@ def test_ring_joint_attention_sdpa_sweep_perf_impl(
     is_balanced,
     q_dtype,
     kv_dtype,
-    worker_l1_size,
 ):
     """
     Performance sweep test for ring joint attention SDPA.
@@ -852,13 +842,12 @@ def test_ring_joint_attention_sdpa_sweep_perf_impl(
         is_causal=is_causal,
         is_balanced=is_balanced,
         do_check=False,
-        worker_l1_size=worker_l1_size,
     )
 
 
 # === TEST 2: ACCURACY VERIFICATION ===
 @pytest.mark.parametrize(
-    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype,worker_l1_size",
+    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
     TEST_CONFIGS,
     ids=TEST_CONFIG_IDS,
 )
@@ -877,7 +866,6 @@ def test_ring_joint_attention_sdpa_accuracy(
     is_balanced,
     q_dtype,
     kv_dtype,
-    worker_l1_size,
 ):
     """
     Accuracy verification test for ring joint attention SDPA.
@@ -912,13 +900,12 @@ def test_ring_joint_attention_sdpa_accuracy(
         is_balanced=is_balanced,
         pcc_threshold=pcc_threshold,
         rmse_threshold=rmse_threshold,
-        worker_l1_size=worker_l1_size,
     )
 
 
 # === TEST 3: DETERMINISM VERIFICATION ===
 @pytest.mark.parametrize(
-    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype,worker_l1_size",
+    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
     TEST_CONFIGS,
     ids=TEST_CONFIG_IDS,
 )
@@ -937,7 +924,6 @@ def test_ring_joint_attention_sdpa_determinism(
     is_balanced,
     q_dtype,
     kv_dtype,
-    worker_l1_size,
 ):
     """
     Test ring joint attention SDPA determinism: run 10 times with same inputs and verify outputs match exactly.
@@ -962,7 +948,6 @@ def test_ring_joint_attention_sdpa_determinism(
         is_causal=is_causal,
         is_balanced=is_balanced,
         num_iterations=num_iterations,
-        worker_l1_size=worker_l1_size,
     )
 
 
@@ -1033,7 +1018,6 @@ def test_ring_joint_attention_create_perf_table(model_name):
             is_balanced,
             q_dtype,
             kv_dtype,
-            worker_l1_size,
         ) = config
 
         # Config now contains global (TP/SP-scaled) values

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -2495,7 +2495,7 @@ void sdpa_ring(
         out_num_blocks,
         global_q_start,  // iter_q_start
         global_q_end,    // iter_q_end
-        q_num_chunks,    // q_num_chunks (number of local q chunks)
+        q_num_chunks,    // q_num_chunks (total per-head chunks: local + joint)
         0,               // local_q_start (not used)
         0,               // chunked_q_chunk_offset (not used)
         0,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1412,23 +1412,23 @@ void apply_causal_mask_lightweight(
     PACK((llk_pack_reconfig_l1_acc(1)));
 
     for (uint32_t row = 0; row < num_rows; row++) {
-        int32_t diag_col = (int32_t)(q_start_tile + row) - (int32_t)k_start_tile;
+        int32_t diag_col = static_cast<int32_t>(q_start_tile + row) - static_cast<int32_t>(k_start_tile);
         uint32_t row_offset = row * num_cols;
 
         if (diag_col < 0) {
             // Entire row above diagonal -> stamp all neginf
             stamp_tile_range_l1_acc<dst_batch>(mask_cb, neginf_idx, out_cb, row_offset, num_cols);
-        } else if ((uint32_t)diag_col < num_cols) {
+        } else if (static_cast<uint32_t>(diag_col) < num_cols) {
             // Stamp the diagonal tile
             tile_regs_acquire();
             copy_tile(mask_cb, diag_idx, 0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile<true>(0, out_cb, row_offset + (uint32_t)diag_col);
+            pack_tile<true>(0, out_cb, row_offset + static_cast<uint32_t>(diag_col));
             tile_regs_release();
 
             // Stamp neginf tiles to the right of diagonal
-            uint32_t neginf_start = (uint32_t)diag_col + 1;
+            uint32_t neginf_start = static_cast<uint32_t>(diag_col) + 1;
             if (neginf_start < num_cols) {
                 stamp_tile_range_l1_acc<dst_batch>(
                     mask_cb, neginf_idx, out_cb, row_offset + neginf_start, num_cols - neginf_start);
@@ -1447,7 +1447,7 @@ void apply_causal_mask_lightweight(
  * template parameter(s), not by default-constructing this context.
  */
 struct LightweightMaskContext {
-    bool is_causal = false;                  // True only on ring_iter 0 for causal configs
+    bool is_causal = false;                  // Causal masking active for this context instance
     uint32_t neginf_tile_idx = 0;            // Index of -inf tile in the mask CB
     uint32_t causal_diag_tile_idx = 0;       // Index of causal diagonal tile in the mask CB
     uint32_t global_n_padded_tiles = 0;      // Fully padded K tile columns for global_n chunk

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -598,8 +598,9 @@ static SDPA_NOINLINE void apply_lightweight_mask_streaming(
     uint32_t q_start_tile = 0,
     uint32_t k_start_tile = 0,
     uint32_t active_Sk = num_cols) {
+    // Caller-owned contract (see function comment): pack state for mask_cb is initialized
+    // before entry via copy_tile_to_dst_init_short + llk_pack_reconfig_l1_acc(1).
     uint32_t boundary_col = num_cols - num_padded - (has_partial ? 1 : 0);
-    copy_tile_to_dst_init_short(mask_cb);
     for (uint32_t row = 0; row < sbh; row++) {
         uint32_t row_offset = (q_subblock * sbh + row) * num_cols;
 
@@ -1381,6 +1382,7 @@ void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
     const uint32_t num_kv_chunks,
+    const uint32_t num_q_chunks,
     const uint32_t ring_iter,
     const uint32_t ring_id,
     const uint32_t num_local_k_chunks,
@@ -1426,12 +1428,11 @@ void sdpa_ring_v2(
 
     uint32_t KV_chunks_processed_in_iter = 0;
 
-    // Q chunks per head for causal position and zigzag remapping
-    const uint32_t num_q_chunks_per_head = (local_padded_Nt + Sq_chunk_t - 1) / Sq_chunk_t;
-
     for (uint32_t q = global_q_start; q < global_q_end; q++) {
-        // Compute Q chunk index (with optional zigzag remapping for causal balancing)
-        uint32_t q_chunk = remap_q_index(q, num_q_chunks_per_head, use_zigzag_balancing) % num_q_chunks_per_head;
+        // Compute Q chunk index (with optional zigzag remapping for causal balancing).
+        // num_q_chunks is total per-head chunks (local + joint), matching the divisor the
+        // writer/reader use to flatten (batch, head, q_chunk) — see ring_joint_sdpa.cpp.
+        uint32_t q_chunk = remap_q_index(q, num_q_chunks, use_zigzag_balancing) % num_q_chunks;
 
         // Causal K-chunk limit and Q start tile for this Q chunk
         uint32_t causal_k_limit = num_kv_chunks;
@@ -1459,7 +1460,7 @@ void sdpa_ring_v2(
         // On non-last ring iters: full skip (reader/writer also skip).
         // On last ring iter: normalize-only path — accumulated state from prior iters needs
         // normalization. Reader sends Q (for pop) but no K/V. Writer restores + drains output.
-        if (skip_first_half_q && (q_chunk < num_q_chunks_per_head / 2)) {
+        if (skip_first_half_q && (q_chunk < num_q_chunks / 2)) {
             if (!is_last_ring_iter) {
                 // Pop staging — compute is the designated consumer of staging CBs.
                 // Writer pushed via complete_restore; writer's issue_restore_reads for the

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -695,8 +695,7 @@ static __attribute__((noinline, noclone)) void sdpa_inner_loop_step(
     const uint32_t causal_diag_idx = 0) {
     // Callers guarantee active_Sk is evenly divisible by actual_sbw (via largest_factor_le).
     const uint32_t kt_num_full_subblocks = active_Sk / actual_sbw;
-    // TODO: pick up the size of dest from dest_helper once it is merged to main.
-    constexpr uint32_t dst_size = 8;
+    constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
     constexpr uint32_t in0_block_w = DHt;
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / qkt_subblock_h;
     constexpr uint32_t q_subblock_num_tiles = qkt_subblock_h * in0_block_w;
@@ -1484,7 +1483,7 @@ void sdpa_ring_v2(
 
             // Normalize accumulated state → cb_normalized_out (= cb_out).
             // normalize_row_streaming consumes sum and out from staging CBs.
-            constexpr uint32_t norm_dst_size = 8;
+            constexpr uint32_t norm_dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
             normalize_row_streaming<false, vDHt, norm_dst_size>(
                 q_prev_norm.sum, q_prev_norm.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, Sq_chunk_t);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -410,7 +410,7 @@ SDPA_NOINLINE void sub_exp_first_col_blocks(
  * sum_q_subblock controls read offset for sum_in_cb (cumulative when not popped per-row).
  */
 template <uint32_t sbh_t, uint32_t sbw_t, uint32_t dst_size>
-__attribute__((noinline, noclone)) void salad_correct_fused(
+void salad_correct_fused(
     uint32_t out_in_cb,
     uint32_t sum_in_cb,
     uint32_t bcast_cb,
@@ -583,7 +583,7 @@ static inline void l1_acc_single_tile(uint32_t mask_cb, uint32_t tile_idx, uint3
  * Caller must set up copy_tile_to_dst_init_short and llk_pack_reconfig_l1_acc(1) before calling,
  * and llk_pack_reconfig_l1_acc(0) after calling.
  */
-template <uint32_t num_cols>
+template <uint32_t num_cols, bool is_causal_sdpa>
 static SDPA_NOINLINE void apply_lightweight_mask_streaming(
     uint32_t mask_cb,
     uint32_t out_cb,
@@ -592,12 +592,12 @@ static SDPA_NOINLINE void apply_lightweight_mask_streaming(
     bool has_partial,
     uint32_t partial_tile_idx,
     uint32_t sbh,
-    bool causal = false,
-    uint32_t causal_neginf_idx = 0,
-    uint32_t causal_diag_idx = 0,
-    uint32_t q_start_tile = 0,
-    uint32_t k_start_tile = 0,
-    uint32_t active_Sk = num_cols) {
+    bool apply_causal,
+    uint32_t neginf_idx,
+    uint32_t causal_diag_idx,
+    uint32_t q_start_tile,
+    uint32_t k_start_tile,
+    uint32_t active_Sk) {
     // Caller-owned contract (see function comment): pack state for mask_cb is initialized
     // before entry via copy_tile_to_dst_init_short + llk_pack_reconfig_l1_acc(1).
     uint32_t boundary_col = num_cols - num_padded - (has_partial ? 1 : 0);
@@ -605,16 +605,19 @@ static SDPA_NOINLINE void apply_lightweight_mask_streaming(
         uint32_t row_offset = (q_subblock * sbh + row) * num_cols;
 
         // Causal mask: per-row diagonal + trailing neginf
-        if (causal) {
-            int32_t diag_col = (int32_t)(q_start_tile + q_subblock * sbh + row) - (int32_t)k_start_tile;
-            if (diag_col < 0) {
-                for (uint32_t col = 0; col < active_Sk; col++) {
-                    l1_acc_single_tile(mask_cb, causal_neginf_idx, out_cb, row_offset + col);
-                }
-            } else if ((uint32_t)diag_col < active_Sk) {
-                l1_acc_single_tile(mask_cb, causal_diag_idx, out_cb, row_offset + (uint32_t)diag_col);
-                for (uint32_t col = (uint32_t)diag_col + 1; col < active_Sk; col++) {
-                    l1_acc_single_tile(mask_cb, causal_neginf_idx, out_cb, row_offset + col);
+        if constexpr (is_causal_sdpa) {
+            if (apply_causal) {
+                int32_t diag_col =
+                    static_cast<int32_t>(q_start_tile + q_subblock * sbh + row) - static_cast<int32_t>(k_start_tile);
+                if (diag_col < 0) {
+                    for (uint32_t col = 0; col < active_Sk; col++) {
+                        l1_acc_single_tile(mask_cb, neginf_idx, out_cb, row_offset + col);
+                    }
+                } else if (static_cast<uint32_t>(diag_col) < active_Sk) {
+                    l1_acc_single_tile(mask_cb, causal_diag_idx, out_cb, row_offset + static_cast<uint32_t>(diag_col));
+                    for (uint32_t col = static_cast<uint32_t>(diag_col) + 1; col < active_Sk; col++) {
+                        l1_acc_single_tile(mask_cb, neginf_idx, out_cb, row_offset + col);
+                    }
                 }
             }
         }
@@ -626,7 +629,7 @@ static SDPA_NOINLINE void apply_lightweight_mask_streaming(
 
         uint32_t start = num_cols - num_padded;
         for (uint32_t col = start; col < num_cols; col++) {
-            l1_acc_single_tile(mask_cb, 0, out_cb, row_offset + col);
+            l1_acc_single_tile(mask_cb, neginf_idx, out_cb, row_offset + col);
         }
     }
 }
@@ -664,7 +667,7 @@ template <
     uint32_t qktv_subblock_w,
     bool use_padded_mask,
     bool ring_mode = false,
-    bool use_ring_mask = false,
+    bool is_causal_sdpa = false,
     bool uniform_dataformat = false,
     uint32_t cb_q_in = 0,
     uint32_t cb_kt_in = 0,
@@ -677,7 +680,7 @@ template <
     uint32_t cb_normalized_out = 0,
     uint32_t cb_mask_in = 0,
     uint32_t KT_stride = Sk_chunk_t>
-static __attribute__((noinline, noclone)) void sdpa_inner_loop_step(
+static void sdpa_inner_loop_step(
     AccumulatorHalf& prev,
     AccumulatorHalf& cur,
     const bool is_last_iter,
@@ -692,7 +695,7 @@ static __attribute__((noinline, noclone)) void sdpa_inner_loop_step(
     const bool apply_causal = false,
     const uint32_t causal_q_start_tile = 0,
     const uint32_t causal_k_start_tile = 0,
-    const uint32_t causal_neginf_idx = 0,
+    const uint32_t neginf_idx = 0,
     const uint32_t causal_diag_idx = 0) {
     // Callers guarantee active_Sk is evenly divisible by actual_sbw (via largest_factor_le).
     const uint32_t kt_num_full_subblocks = active_Sk / actual_sbw;
@@ -702,7 +705,7 @@ static __attribute__((noinline, noclone)) void sdpa_inner_loop_step(
     constexpr uint32_t q_subblock_num_tiles = qkt_subblock_h * in0_block_w;
     constexpr uint32_t row_tiles = qkt_subblock_h * KT_stride;  // Use KT_stride for cb_qkt_im row width
 
-    static_assert(!(use_padded_mask && use_ring_mask), "use_padded_mask and use_ring_mask are mutually exclusive");
+    static_assert(!(use_padded_mask && ring_mode), "use_padded_mask and ring_mode are mutually exclusive");
 
     // When all CBs share the same data format (e.g. all Float16_b for bf16 models),
     // reconfig calls are no-ops — skip entirely to save code size.
@@ -802,13 +805,13 @@ static __attribute__((noinline, noclone)) void sdpa_inner_loop_step(
         }
 
         // Ring mask: L1-accumulate causal + padding masks onto cb_qkt_im for this row group.
-        if constexpr (use_ring_mask) {
-            if (apply_causal || (apply_mask && lw_partial_tile_idx > 0)) {
+        if constexpr (ring_mode) {
+            if ((is_causal_sdpa && apply_causal) || (apply_mask && lw_partial_tile_idx > 0)) {
                 // MOP is configured for actual_sbw tiles (blocked matmul); mask needs 1 tile per pack.
                 configure_single_tile_pack(cb_qkt_im);
                 copy_tile_to_dst_init_short(cb_mask_in);
                 PACK((llk_pack_reconfig_l1_acc(1)));
-                apply_lightweight_mask_streaming<KT_stride>(
+                apply_lightweight_mask_streaming<KT_stride, is_causal_sdpa>(
                     cb_mask_in,
                     cb_qkt_im,
                     q_subblock,
@@ -817,13 +820,12 @@ static __attribute__((noinline, noclone)) void sdpa_inner_loop_step(
                     lw_partial_tile_idx,
                     qkt_subblock_h,
                     apply_causal,
-                    causal_neginf_idx,
+                    neginf_idx,
                     causal_diag_idx,
                     causal_q_start_tile,
                     causal_k_start_tile,
                     active_Sk);
                 PACK((llk_pack_reconfig_l1_acc(0)));
-                configure_pack_width(cb_qkt_im, actual_sbw);
             }
         }
 
@@ -1260,8 +1262,7 @@ void sdpa_standard_v2(
                 qktv_subblock_w,
                 use_padded_mask,
                 false,  // ring_mode
-                false,  // use_ring_mask
-
+                false,  // is_causal_sdpa
                 uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
@@ -1377,7 +1378,10 @@ template <
     uint32_t cb_normalized_out = 0,
     uint32_t cb_sum_out = 0,
     uint32_t cb_sum_in = 0,
-    bool lightweight_mask_enabled = false>
+    uint32_t cb_signal = 0,
+    bool lightweight_mask_enabled = false,
+    bool is_causal_sdpa = false,
+    bool is_balanced_sdpa = false>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1402,6 +1406,7 @@ void sdpa_ring_v2(
     const bool use_zigzag_balancing = false) {
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     constexpr bool uniform_format = uniform_dataformat;
+    const bool is_causal_iter = is_causal_sdpa && (ring_iter == 0);
 
     // reduce_trigger enables early reduce start via semaphore signaling from packer to unpacker.
     // All conditions are compile-time except the active_Sk == Sk_chunk_t guard (padded chunks).
@@ -1428,6 +1433,64 @@ void sdpa_ring_v2(
 
     uint32_t KV_chunks_processed_in_iter = 0;
 
+    // ---- Q-loop helpers ---------------------------------------------------
+
+    // Non-last ring iter: drain restored staging CBs and skip this Q chunk.
+    auto try_balanced_skip = [&](uint32_t q_chunk) -> bool {
+        if constexpr (is_balanced_sdpa) {
+            if (skip_first_half_q && q_chunk < num_q_chunks / 2 && !is_last_ring_iter) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Last ring iter: normalize accumulated state and signal writer, then skip K-loop.
+    auto try_normalize_only = [&](uint32_t q_chunk) -> bool {
+        if constexpr (is_balanced_sdpa) {
+            if (skip_first_half_q && q_chunk < num_q_chunks / 2 && is_last_ring_iter) {
+                AccumulatorHalf q_prev_norm = acc_state.prev;
+                if (q_per_core > 1 && ring_iter > 0) {
+                    q_prev_norm = {cb_sum_in, cb_max_in, cb_prev_out};
+                }
+                constexpr uint32_t norm_dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
+                normalize_row_streaming<false, vDHt, norm_dst_size>(
+                    q_prev_norm.sum, q_prev_norm.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, Sq_chunk_t);
+                cb_pop_front(q_prev_norm.max, Sq_chunk_t);
+                if (q_per_core > 1) {
+                    cb_reserve_back(cb_signal, 1);
+                    cb_push_back(cb_signal, 1);
+                }
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // ---- K-loop helpers ---------------------------------------------------
+
+    // Skip KV chunks beyond the logical sequence length (padding tiles).
+    auto try_skip_oob_kv = [&](uint32_t k_chunk, bool kv_chunk_is_joint) -> bool {
+        return !kv_chunk_is_joint && (local_padded_Nt * ring_id + k_chunk * Sk_chunk_t >= logical_nt);
+    };
+
+    // Causal skip: K chunks fully above the diagonal — drain K/V from CBs and skip.
+    auto try_skip_causal_above_diag = [&](uint32_t k_chunk, uint32_t causal_k_limit) -> bool {
+        if constexpr (is_causal_sdpa) {
+            if (is_causal_iter && k_chunk >= causal_k_limit) {
+                cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+                cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
+                cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
+                cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
+                KV_chunks_processed_in_iter++;
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // -----------------------------------------------------------------------
+
     for (uint32_t q = global_q_start; q < global_q_end; q++) {
         // Compute Q chunk index (with optional zigzag remapping for causal balancing).
         // num_q_chunks is total per-head chunks (local + joint), matching the divisor the
@@ -1437,71 +1500,34 @@ void sdpa_ring_v2(
         // Causal K-chunk limit and Q start tile for this Q chunk
         uint32_t causal_k_limit = num_kv_chunks;
         uint32_t q_start_tile = 0;
-        if (lw_mask.is_causal) {
-            q_start_tile = q_chunk * Sq_chunk_t;
-            causal_k_limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
+        if constexpr (is_causal_sdpa) {
+            if (is_causal_iter) {
+                q_start_tile = q_chunk * Sq_chunk_t;
+                causal_k_limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
+            }
         }
 
-        // Per-Q pre-scan: count K chunks that will actually be processed
+        if (try_balanced_skip(q_chunk)) {
+            continue;
+        }
+        if (try_normalize_only(q_chunk)) {
+            continue;
+        }
+
+        // Per-Q pre-scan: count K chunks that will actually be processed.
+        // Placed after balanced-skip guards so skipped Q chunks don't pay for the scan.
         uint32_t per_q_valid_kv = 0;
         for (uint32_t k = 0; k < num_kv_chunks; ++k) {
             const bool is_joint = k >= num_local_k_chunks;
-            const uint32_t kv_start = local_padded_Nt * ring_id + k * Sk_chunk_t;
-            if (!is_joint && (kv_start >= logical_nt)) {
+            if (try_skip_oob_kv(k, is_joint)) {
                 continue;
             }
-            if (lw_mask.is_causal && k >= causal_k_limit) {
-                continue;
+            if constexpr (is_causal_sdpa) {
+                if (is_causal_iter && k >= causal_k_limit) {
+                    continue;
+                }
             }
             per_q_valid_kv++;
-        }
-
-        // Balanced causal skip: first-half Q chunks handled by paired device.
-        // On non-last ring iters: full skip (reader/writer also skip).
-        // On last ring iter: normalize-only path — accumulated state from prior iters needs
-        // normalization. Reader sends Q (for pop) but no K/V. Writer restores + drains output.
-        if (skip_first_half_q && (q_chunk < num_q_chunks / 2)) {
-            if (!is_last_ring_iter) {
-                // Pop staging — compute is the designated consumer of staging CBs.
-                // Writer pushed via complete_restore; writer's issue_restore_reads for the
-                // next Q blocks on cb_reserve_back(staging) until we free it here.
-                if (q_per_core > 1 && ring_iter > 0) {
-                    cb_wait_front(cb_prev_out, out_chunk_tiles);
-                    cb_pop_front(cb_prev_out, out_chunk_tiles);
-                    cb_wait_front(cb_max_in, Sq_chunk_t);
-                    cb_pop_front(cb_max_in, Sq_chunk_t);
-                    cb_wait_front(cb_sum_in, Sq_chunk_t);
-                    cb_pop_front(cb_sum_in, Sq_chunk_t);
-                }
-                continue;
-            }
-
-            // === Normalize-only path (last ring iter) ===
-            AccumulatorHalf q_prev_norm = acc_state.prev;
-            if (q_per_core > 1 && ring_iter > 0) {
-                q_prev_norm = {cb_sum_in, cb_max_in, cb_prev_out};
-            }
-
-            // Normalize accumulated state → cb_normalized_out (= cb_out).
-            // normalize_row_streaming consumes sum and out from staging CBs.
-            constexpr uint32_t norm_dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
-            normalize_row_streaming<false, vDHt, norm_dst_size>(
-                q_prev_norm.sum, q_prev_norm.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, Sq_chunk_t);
-
-            cb_pop_front(q_prev_norm.max, Sq_chunk_t);
-            // No cb_q_in pop: reader does not push Q for balanced-skipped chunks (no QKV
-            // needed for the normalize-only path — it consumes only restored sum/out).
-
-            // Signal writer AFTER all staging CBs are freed.
-            // Invariant: staging CBs are empty when signal fires, so the writer's
-            // prefetch (cb_reserve_back on staging) before signal wait won't block.
-            constexpr uint32_t cb_signal_norm = tt::CBIndex::c_12;
-            if (q_per_core > 1) {
-                cb_reserve_back(cb_signal_norm, 1);
-                cb_push_back(cb_signal_norm, 1);
-            }
-
-            continue;
         }
 
         // Use persistent accumulator state from caller (single Q-chunk)
@@ -1523,20 +1549,11 @@ void sdpa_ring_v2(
         uint32_t KV_chunks_processed = 0;
 
         for (uint32_t k_chunk = 0; k_chunk < num_kv_chunks; ++k_chunk) {
-            // Skip KV chunks beyond logical sequence length (non-joint only)
             const bool kv_chunk_is_joint = k_chunk >= num_local_k_chunks;
-            const uint32_t kv_global_start_tile = local_padded_Nt * ring_id + k_chunk * Sk_chunk_t;
-            if (!kv_chunk_is_joint && (kv_global_start_tile >= logical_nt)) {
+            if (try_skip_oob_kv(k_chunk, kv_chunk_is_joint)) {
                 continue;
             }
-
-            // Causal skip: K chunks fully above the diagonal. Reader sent them, so pop K/V.
-            if (lw_mask.is_causal && k_chunk >= causal_k_limit) {
-                cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
-                cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
-                cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
-                cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
-                KV_chunks_processed_in_iter++;
+            if (try_skip_causal_above_diag(k_chunk, causal_k_limit)) {
                 continue;
             }
 
@@ -1550,7 +1567,6 @@ void sdpa_ring_v2(
             const bool is_last_k_of_last_ring_iter = is_last_ring_iter && is_last_k;
 
             // Signal writer that last K-chunk is starting (for row-by-row DMA save/restore).
-            constexpr uint32_t cb_signal = tt::CBIndex::c_12;
             if (is_last_k && q_per_core > 1) {
                 cb_reserve_back(cb_signal, 1);
                 cb_push_back(cb_signal, 1);
@@ -1603,11 +1619,13 @@ void sdpa_ring_v2(
             // Causal narrowing on the diagonal-crossing K-chunk: cols past the last Q-row's
             // diag tile are -inf for every row in the Q-chunk, so skip matmul/sub_exp/V there.
             // Composes with any prior padding narrowing via min().
-            if (lw_mask.is_causal && k_chunk == causal_k_limit - 1) {
-                const uint32_t causal_active = q_start_tile + Sq_chunk_t - k_chunk * Sk_chunk_t;
-                if (causal_active < active_Sk_param) {
-                    active_Sk_param = causal_active;
-                    chunk_sbw = largest_factor_le(active_Sk_param, qkt_subblock_w);
+            if constexpr (is_causal_sdpa) {
+                if (is_causal_iter && k_chunk == causal_k_limit - 1) {
+                    const uint32_t causal_active = q_start_tile + Sq_chunk_t - k_chunk * Sk_chunk_t;
+                    if (causal_active < active_Sk_param) {
+                        active_Sk_param = causal_active;
+                        chunk_sbw = largest_factor_le(active_Sk_param, qkt_subblock_w);
+                    }
                 }
             }
 
@@ -1635,8 +1653,7 @@ void sdpa_ring_v2(
                 qktv_subblock_w,
                 false,  // use_padded_mask — ring uses ring mask instead
                 true,   // ring_mode
-                true,   // use_ring_mask
-
+                is_causal_sdpa,
                 uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
@@ -1659,7 +1676,7 @@ void sdpa_ring_v2(
                 chunk_sbw,
                 step_save_out_cb,
                 step_save_max_cb,
-                lw_mask.is_causal,
+                is_causal_iter,
                 q_start_tile,
                 k_chunk * Sk_chunk_t,
                 lw_mask.neginf_tile_idx,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -410,7 +410,7 @@ SDPA_NOINLINE void sub_exp_first_col_blocks(
  * sum_q_subblock controls read offset for sum_in_cb (cumulative when not popped per-row).
  */
 template <uint32_t sbh_t, uint32_t sbw_t, uint32_t dst_size>
-void salad_correct_fused(
+__attribute__((noinline, noclone)) void salad_correct_fused(
     uint32_t out_in_cb,
     uint32_t sum_in_cb,
     uint32_t bcast_cb,
@@ -491,7 +491,7 @@ void salad_correct_fused(
  * scratch_cb is a 1-tile CB reused for the reciprocal intermediate.
  */
 template <bool profiling_enabled, uint32_t head_dim_t_, uint32_t dst_size>
-void normalize_row_streaming(
+static __attribute__((noinline, noclone)) void normalize_row_streaming(
     uint32_t cur_sum_cb,
     uint32_t cur_out_cb,
     uint32_t col_identity_cb,
@@ -591,18 +591,41 @@ static SDPA_NOINLINE void apply_lightweight_mask_streaming(
     uint32_t num_padded,
     bool has_partial,
     uint32_t partial_tile_idx,
-    uint32_t sbh) {
+    uint32_t sbh,
+    bool causal = false,
+    uint32_t causal_neginf_idx = 0,
+    uint32_t causal_diag_idx = 0,
+    uint32_t q_start_tile = 0,
+    uint32_t k_start_tile = 0,
+    uint32_t active_Sk = num_cols) {
     uint32_t boundary_col = num_cols - num_padded - (has_partial ? 1 : 0);
+    copy_tile_to_dst_init_short(mask_cb);
     for (uint32_t row = 0; row < sbh; row++) {
         uint32_t row_offset = (q_subblock * sbh + row) * num_cols;
 
+        // Causal mask: per-row diagonal + trailing neginf
+        if (causal) {
+            int32_t diag_col = (int32_t)(q_start_tile + q_subblock * sbh + row) - (int32_t)k_start_tile;
+            if (diag_col < 0) {
+                for (uint32_t col = 0; col < active_Sk; col++) {
+                    l1_acc_single_tile(mask_cb, causal_neginf_idx, out_cb, row_offset + col);
+                }
+            } else if ((uint32_t)diag_col < active_Sk) {
+                l1_acc_single_tile(mask_cb, causal_diag_idx, out_cb, row_offset + (uint32_t)diag_col);
+                for (uint32_t col = (uint32_t)diag_col + 1; col < active_Sk; col++) {
+                    l1_acc_single_tile(mask_cb, causal_neginf_idx, out_cb, row_offset + col);
+                }
+            }
+        }
+
+        // Padding mask: partial tile + fully-padded columns (unchanged)
         if (has_partial) {
             l1_acc_single_tile(mask_cb, partial_tile_idx, out_cb, row_offset + boundary_col);
         }
 
         uint32_t start = num_cols - num_padded;
         for (uint32_t col = start; col < num_cols; col++) {
-            l1_acc_single_tile(mask_cb, 0, out_cb, row_offset + col);  // neginf is always tile 0
+            l1_acc_single_tile(mask_cb, 0, out_cb, row_offset + col);
         }
     }
 }
@@ -653,7 +676,7 @@ template <
     uint32_t cb_normalized_out = 0,
     uint32_t cb_mask_in = 0,
     uint32_t KT_stride = Sk_chunk_t>
-static void sdpa_inner_loop_step(
+static __attribute__((noinline, noclone)) void sdpa_inner_loop_step(
     AccumulatorHalf& prev,
     AccumulatorHalf& cur,
     const bool is_last_iter,
@@ -664,7 +687,12 @@ static void sdpa_inner_loop_step(
     const bool reduce_trigger = false,
     const uint32_t actual_sbw = qkt_subblock_w,
     const uint32_t save_out_cb = INVALID_CB,
-    const uint32_t save_max_cb = INVALID_CB) {
+    const uint32_t save_max_cb = INVALID_CB,
+    const bool apply_causal = false,
+    const uint32_t causal_q_start_tile = 0,
+    const uint32_t causal_k_start_tile = 0,
+    const uint32_t causal_neginf_idx = 0,
+    const uint32_t causal_diag_idx = 0) {
     // Callers guarantee active_Sk is evenly divisible by actual_sbw (via largest_factor_le).
     const uint32_t kt_num_full_subblocks = active_Sk / actual_sbw;
     // TODO: pick up the size of dest from dest_helper once it is merged to main.
@@ -773,12 +801,10 @@ static void sdpa_inner_loop_step(
             reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
         }
 
-        // Ring mask: L1-accumulate partial-tile mask onto cb_qkt_im for this row group.
-        // Full-tile padding handled by active_Sk narrowing (reduce/sub_exp/V skip padded tiles),
-        // but num_padded must still reflect the actual count so boundary_col places the partial
-        // mask at active_Sk-1 instead of Sk_chunk_t-1.
+        // Ring mask: L1-accumulate causal + padding masks onto cb_qkt_im for this row group.
         if constexpr (use_ring_mask) {
-            if (apply_mask && lw_partial_tile_idx > 0) {
+            if (apply_causal || (apply_mask && lw_partial_tile_idx > 0)) {
+                // MOP is configured for actual_sbw tiles (blocked matmul); mask needs 1 tile per pack.
                 configure_single_tile_pack(cb_qkt_im);
                 copy_tile_to_dst_init_short(cb_mask_in);
                 PACK((llk_pack_reconfig_l1_acc(1)));
@@ -786,11 +812,18 @@ static void sdpa_inner_loop_step(
                     cb_mask_in,
                     cb_qkt_im,
                     q_subblock,
-                    Sk_chunk_t - active_Sk,  // padded tile count for correct boundary_col
-                    true,                    // has_partial — guaranteed by outer guard (lw_partial_tile_idx > 0)
+                    Sk_chunk_t - active_Sk,
+                    (apply_mask && lw_partial_tile_idx > 0),
                     lw_partial_tile_idx,
-                    qkt_subblock_h);
+                    qkt_subblock_h,
+                    apply_causal,
+                    causal_neginf_idx,
+                    causal_diag_idx,
+                    causal_q_start_tile,
+                    causal_k_start_tile,
+                    active_Sk);
                 PACK((llk_pack_reconfig_l1_acc(0)));
+                configure_pack_width(cb_qkt_im, actual_sbw);
             }
         }
 
@@ -1363,7 +1396,9 @@ void sdpa_ring_v2(
     RingAccumulatorState& acc_state,
     const bool is_last_ring_iter = false,
     const uint32_t q_per_core = 1,
-    const LightweightMaskContext& lw_mask = {}) {
+    const LightweightMaskContext& lw_mask = {},
+    const bool skip_first_half_q = false,
+    const bool use_zigzag_balancing = false) {
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     constexpr bool uniform_format = uniform_dataformat;
 
@@ -1385,21 +1420,90 @@ void sdpa_ring_v2(
     const uint32_t joint_n_sbw = lw_mask.joint_n_padded_tiles
                                      ? largest_factor_le(Sk_chunk_t - lw_mask.joint_n_padded_tiles, qkt_subblock_w)
                                      : full_sbw;
+    const uint32_t straddle_sbw =
+        lw_mask.straddle_num_padded_tiles
+            ? largest_factor_le(Sk_chunk_t - lw_mask.straddle_num_padded_tiles, qkt_subblock_w)
+            : full_sbw;
 
     uint32_t KV_chunks_processed_in_iter = 0;
 
-    // Pre-scan to count valid K chunks (needed to find last K chunk for normalization)
-    uint32_t total_valid_kv = 0;
-    for (uint32_t k = 0; k < num_kv_chunks; ++k) {
-        const bool is_joint = k >= num_local_k_chunks;
-        const uint32_t kv_start = local_padded_Nt * ring_id + k * Sk_chunk_t;
-        if (!is_joint && (kv_start >= logical_nt)) {
-            continue;
-        }
-        total_valid_kv++;
-    }
+    // Q chunks per head for causal position and zigzag remapping
+    const uint32_t num_q_chunks_per_head = (local_padded_Nt + Sq_chunk_t - 1) / Sq_chunk_t;
 
     for (uint32_t q = global_q_start; q < global_q_end; q++) {
+        // Compute Q chunk index (with optional zigzag remapping for causal balancing)
+        uint32_t q_chunk = remap_q_index(q, num_q_chunks_per_head, use_zigzag_balancing) % num_q_chunks_per_head;
+
+        // Causal K-chunk limit and Q start tile for this Q chunk
+        uint32_t causal_k_limit = num_kv_chunks;
+        uint32_t q_start_tile = 0;
+        if (lw_mask.is_causal) {
+            q_start_tile = q_chunk * Sq_chunk_t;
+            causal_k_limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
+        }
+
+        // Per-Q pre-scan: count K chunks that will actually be processed
+        uint32_t per_q_valid_kv = 0;
+        for (uint32_t k = 0; k < num_kv_chunks; ++k) {
+            const bool is_joint = k >= num_local_k_chunks;
+            const uint32_t kv_start = local_padded_Nt * ring_id + k * Sk_chunk_t;
+            if (!is_joint && (kv_start >= logical_nt)) {
+                continue;
+            }
+            if (lw_mask.is_causal && k >= causal_k_limit) {
+                continue;
+            }
+            per_q_valid_kv++;
+        }
+
+        // Balanced causal skip: first-half Q chunks handled by paired device.
+        // On non-last ring iters: full skip (reader/writer also skip).
+        // On last ring iter: normalize-only path — accumulated state from prior iters needs
+        // normalization. Reader sends Q (for pop) but no K/V. Writer restores + drains output.
+        if (skip_first_half_q && (q_chunk < num_q_chunks_per_head / 2)) {
+            if (!is_last_ring_iter) {
+                // Pop staging — compute is the designated consumer of staging CBs.
+                // Writer pushed via complete_restore; writer's issue_restore_reads for the
+                // next Q blocks on cb_reserve_back(staging) until we free it here.
+                if (q_per_core > 1 && ring_iter > 0) {
+                    cb_wait_front(cb_prev_out, out_chunk_tiles);
+                    cb_pop_front(cb_prev_out, out_chunk_tiles);
+                    cb_wait_front(cb_max_in, Sq_chunk_t);
+                    cb_pop_front(cb_max_in, Sq_chunk_t);
+                    cb_wait_front(cb_sum_in, Sq_chunk_t);
+                    cb_pop_front(cb_sum_in, Sq_chunk_t);
+                }
+                continue;
+            }
+
+            // === Normalize-only path (last ring iter) ===
+            AccumulatorHalf q_prev_norm = acc_state.prev;
+            if (q_per_core > 1 && ring_iter > 0) {
+                q_prev_norm = {cb_sum_in, cb_max_in, cb_prev_out};
+            }
+
+            // Normalize accumulated state → cb_normalized_out (= cb_out).
+            // normalize_row_streaming consumes sum and out from staging CBs.
+            constexpr uint32_t norm_dst_size = 8;
+            normalize_row_streaming<false, vDHt, norm_dst_size>(
+                q_prev_norm.sum, q_prev_norm.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, Sq_chunk_t);
+
+            cb_pop_front(q_prev_norm.max, Sq_chunk_t);
+            // No cb_q_in pop: reader does not push Q for balanced-skipped chunks (no QKV
+            // needed for the normalize-only path — it consumes only restored sum/out).
+
+            // Signal writer AFTER all staging CBs are freed.
+            // Invariant: staging CBs are empty when signal fires, so the writer's
+            // prefetch (cb_reserve_back on staging) before signal wait won't block.
+            constexpr uint32_t cb_signal_norm = tt::CBIndex::c_12;
+            if (q_per_core > 1) {
+                cb_reserve_back(cb_signal_norm, 1);
+                cb_push_back(cb_signal_norm, 1);
+            }
+
+            continue;
+        }
+
         // Use persistent accumulator state from caller (single Q-chunk)
         // or restore from DRAM (multi Q-chunk).
         AccumulatorHalf q_prev = acc_state.prev, q_cur = acc_state.cur;
@@ -1426,11 +1530,21 @@ void sdpa_ring_v2(
                 continue;
             }
 
+            // Causal skip: K chunks fully above the diagonal. Reader sent them, so pop K/V.
+            if (lw_mask.is_causal && k_chunk >= causal_k_limit) {
+                cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+                cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
+                cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
+                cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
+                KV_chunks_processed_in_iter++;
+                continue;
+            }
+
             KV_chunks_processed++;
             KV_chunks_processed_in_iter++;
 
             const bool is_first = is_first_kv_for_this_q && (KV_chunks_processed == 1);
-            const bool is_last_k = (KV_chunks_processed == total_valid_kv);
+            const bool is_last_k = (KV_chunks_processed == per_q_valid_kv);
 
             // Last K chunk of last ring_iter triggers per-row normalization
             const bool is_last_k_of_last_ring_iter = is_last_ring_iter && is_last_k;
@@ -1447,6 +1561,11 @@ void sdpa_ring_v2(
             const bool is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
             const bool is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
                                                (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id;
+            // Straddle chunk (rix > rid balanced-causal with k_chunk_size ∤ coarse_chunk_size):
+            // only the early-half columns attend; late-half columns must be dropped. Narrow
+            // active_Sk like local_n; no partial-tile stamp needed for tile-aligned straddle.
+            const bool is_straddle_mask_chunk =
+                lw_mask.straddle_num_padded_tiles > 0 && k_chunk == lw_mask.straddle_mask_chunk_id;
 
             bool apply_mask = is_global_n_mask_chunk || is_joint_n_mask_chunk;
 
@@ -1476,6 +1595,20 @@ void sdpa_ring_v2(
             } else if (is_joint_n_mask_chunk) {
                 active_Sk_param = Sk_chunk_t - lw_mask.joint_n_padded_tiles;
                 chunk_sbw = joint_n_sbw;
+            } else if (is_straddle_mask_chunk) {
+                active_Sk_param = Sk_chunk_t - lw_mask.straddle_num_padded_tiles;
+                chunk_sbw = straddle_sbw;
+            }
+
+            // Causal narrowing on the diagonal-crossing K-chunk: cols past the last Q-row's
+            // diag tile are -inf for every row in the Q-chunk, so skip matmul/sub_exp/V there.
+            // Composes with any prior padding narrowing via min().
+            if (lw_mask.is_causal && k_chunk == causal_k_limit - 1) {
+                const uint32_t causal_active = q_start_tile + Sq_chunk_t - k_chunk * Sk_chunk_t;
+                if (causal_active < active_Sk_param) {
+                    active_Sk_param = causal_active;
+                    chunk_sbw = largest_factor_le(active_Sk_param, qkt_subblock_w);
+                }
             }
 
             // On last K-chunk of non-last ring iters (multi-Q), redirect output, sum, and max
@@ -1525,7 +1658,12 @@ void sdpa_ring_v2(
                 can_reduce_trigger && (active_Sk_param == Sk_chunk_t),
                 chunk_sbw,
                 step_save_out_cb,
-                step_save_max_cb);
+                step_save_max_cb,
+                lw_mask.is_causal,
+                q_start_tile,
+                k_chunk * Sk_chunk_t,
+                lw_mask.neginf_tile_idx,
+                lw_mask.causal_diag_tile_idx);
 
             // Post-iteration cleanup: pop previous values and swap aliases
             // prev.out and cb_exp_max_diff are already popped row-by-row inside salad_correct_row.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
@@ -103,6 +103,9 @@ void kernel_main() {
     // Deferred norm: sum save/restore CBs for multi Q-chunk DRAM round-trip.
     constexpr uint32_t cb_sum_out = tt::CBIndex::c_10;
     constexpr uint32_t cb_sum_in = tt::CBIndex::c_11;
+    constexpr uint32_t cb_signal = tt::CBIndex::c_12;
+
+    constexpr uint32_t num_q_chunks = local_padded_Nt / Sq_chunk_t + Lt / Sq_chunk_t;
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
@@ -208,10 +211,12 @@ void kernel_main() {
                 cb_out,  // cb_normalized_out — output goes directly to cb_out
                 cb_sum_out,
                 cb_sum_in,
+                cb_signal,
                 needs_lightweight_mask>(
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,
+                num_q_chunks,
                 ring_iter,
                 ring_id,
                 num_local_k_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -144,8 +144,8 @@ void kernel_main() {
         {cb_sum_B, cb_max_B, cb_out_im_B},  // cur
     };
 
-    const uint32_t last_active_ring_iter =
-        find_last_active_ring_iter(fused_op_indexer.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L);
+    const uint32_t last_active_ring_iter = find_last_active_ring_iter(
+        fused_op_indexer.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L, is_causal, is_balanced);
 
     uint32_t ring_index = fused_op_indexer.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
@@ -209,12 +209,22 @@ void kernel_main() {
         const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
 
         if constexpr (use_streaming_compute) {
+            uint32_t iter_num_kv_chunks_v2 = num_kv_chunks;
+            if (is_causal && is_balanced && ring_index > ring_id) {
+                iter_num_kv_chunks_v2 /= 2;
+                // Include the straddle chunk; its late-half columns are -inf-masked via lw_mask.
+                if constexpr (has_straddle) {
+                    iter_num_kv_chunks_v2 = straddle_chunk_id + 1;
+                }
+            }
+            bool skip_first_half_q_v2 = (ring_index >= ring_id ? false : is_balanced);
+
             sdpa_ring_v2<
                 Sq_chunk_t,
                 Sk_chunk_t,
                 0,  // Skt — not used for ring
                 DHt,
-                DHt,  // vDHt = DHt for ring
+                vDHt,
                 scale_fp32,
                 qk_subblock_h,
                 qk_subblock_w,
@@ -241,7 +251,7 @@ void kernel_main() {
                 needs_lightweight_mask>(
                 global_q_start,
                 global_q_end,
-                num_kv_chunks,
+                iter_num_kv_chunks_v2,
                 ring_iter,
                 ring_id,
                 num_local_k_chunks,
@@ -256,7 +266,9 @@ void kernel_main() {
                 acc_state,
                 is_last_ring_iter,
                 q_per_core,
-                lw_mask);
+                lw_mask,
+                skip_first_half_q_v2,
+                use_zigzag_balancing);
         } else {
             bool is_causal_ring_iter = (ring_iter == 0 ? is_causal : false);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -258,6 +258,7 @@ void kernel_main() {
                 global_q_start,
                 global_q_end,
                 iter_num_kv_chunks,
+                num_q_chunks,
                 ring_iter,
                 ring_id,
                 num_local_k_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -208,17 +208,23 @@ void kernel_main() {
 
         const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
 
-        if constexpr (use_streaming_compute) {
-            uint32_t iter_num_kv_chunks_v2 = num_kv_chunks;
-            if (is_causal && is_balanced && ring_index > ring_id) {
-                iter_num_kv_chunks_v2 /= 2;
-                // Include the straddle chunk; its late-half columns are -inf-masked via lw_mask.
-                if constexpr (has_straddle) {
-                    iter_num_kv_chunks_v2 = straddle_chunk_id + 1;
-                }
+        // Per-ring-iter K-chunk count and Q-skip flag — shared by v1 (sdpa_ring) and v2
+        // (sdpa_ring_v2) paths.
+        //   rix > rid (Case 3): only sender's L half is sent — halve KV count, or extend to
+        //     include the straddle chunk when it crosses the coarse-half boundary (its
+        //     late-half columns are -inf-masked via lw_mask.straddle_*).
+        //   rix < rid && balanced (Case 2): skip first-half (L) Q-chunks.
+        uint32_t iter_num_kv_chunks = num_kv_chunks;
+        if (is_causal && is_balanced && ring_index > ring_id) {
+            if constexpr (has_straddle) {
+                iter_num_kv_chunks = straddle_chunk_id + 1;
+            } else {
+                iter_num_kv_chunks /= 2;
             }
-            bool skip_first_half_q_v2 = (ring_index >= ring_id ? false : is_balanced);
+        }
+        const bool skip_first_half_q = (ring_index >= ring_id ? false : is_balanced);
 
+        if constexpr (use_streaming_compute) {
             sdpa_ring_v2<
                 Sq_chunk_t,
                 Sk_chunk_t,
@@ -251,7 +257,7 @@ void kernel_main() {
                 needs_lightweight_mask>(
                 global_q_start,
                 global_q_end,
-                iter_num_kv_chunks_v2,
+                iter_num_kv_chunks,
                 ring_iter,
                 ring_id,
                 num_local_k_chunks,
@@ -267,23 +273,9 @@ void kernel_main() {
                 is_last_ring_iter,
                 q_per_core,
                 lw_mask,
-                skip_first_half_q_v2,
+                skip_first_half_q,
                 use_zigzag_balancing);
         } else {
-            bool is_causal_ring_iter = (ring_iter == 0 ? is_causal : false);
-
-            uint32_t iter_num_kv_chunks = num_kv_chunks;
-            if (is_causal && is_balanced && ring_index > ring_id) {
-                if constexpr (has_straddle) {
-                    // Straddle chunk straddles the coarse-half boundary; extend to include it.
-                    // Its late-half columns are -inf-masked via lw_mask.straddle_* above.
-                    iter_num_kv_chunks = straddle_chunk_id + 1;
-                } else {
-                    iter_num_kv_chunks /= 2;
-                }
-            }
-            bool skip_first_half_q = (ring_index >= ring_id ? false : is_balanced);
-
             sdpa_ring<
                 cb_qk_im,
                 cb_identity_scale_in,
@@ -345,7 +337,7 @@ void kernel_main() {
                 cb_prev_out,
                 cb_out,
                 lw_mask,
-                is_causal_ring_iter,
+                lw_mask.is_causal,
                 skip_first_half_q,
                 is_last_ring_iter,
                 use_zigzag_balancing);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -56,7 +56,7 @@ void kernel_main() {
     constexpr bool is_balanced = get_compile_time_arg_val(38) == 1;
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(39) == 1;
 
-    // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
+    // Lightweight mask: all mask tiles live in cb_mask_in.
     // Layout: [neginf(0)] [causal_diag?(1)] [global_n_partial?] [joint_l_partial?]
     // Needed when any K/joint dimension has padding, or when causal masking is active.
     constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
@@ -87,16 +87,25 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
+    // TODO: CB indices below are hardcoded and duplicated from the program factory.
+    // They should be passed as compile-time args so the factory is the single source of truth.
     constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
     constexpr uint32_t cb_v_in = tt::CBIndex::c_2;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
     constexpr uint32_t cb_scale_in = tt::CBIndex::c_4;
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
-    constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
     constexpr uint32_t cb_max_in = tt::CBIndex::c_6;  // deferred norm: running max
     constexpr uint32_t cb_lse_in = tt::CBIndex::c_6;  // eager norm: LSE
     constexpr uint32_t cb_prev_out = tt::CBIndex::c_7;
+    constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
+    constexpr uint32_t cb_recip_scratch = tt::CBIndex::c_9;  // 1-tile scratch for normalize_row_streaming
+    constexpr uint32_t cb_sum_out = tt::CBIndex::c_10;
+    constexpr uint32_t cb_sum_in = tt::CBIndex::c_11;
+    constexpr uint32_t cb_signal = tt::CBIndex::c_12;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t cb_max_out = tt::CBIndex::c_17;  // deferred norm: running max
+    constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;  // eager norm: LSE
     constexpr uint32_t cb_qk_im = tt::CBIndex::c_24;
     constexpr uint32_t cb_out_im_A = tt::CBIndex::c_25;
     constexpr uint32_t cb_out_im_B = tt::CBIndex::c_26;
@@ -105,18 +114,6 @@ void kernel_main() {
     constexpr uint32_t cb_sum_A = tt::CBIndex::c_29;
     constexpr uint32_t cb_sum_B = tt::CBIndex::c_30;
     constexpr uint32_t cb_exp_max_diff = tt::CBIndex::c_31;
-
-    constexpr uint32_t cb_out = tt::CBIndex::c_16;
-    constexpr uint32_t cb_max_out = tt::CBIndex::c_17;  // deferred norm: running max
-    constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;  // eager norm: LSE
-
-    // Streaming compute uses c_9 as 1-tile recip scratch for normalize_row_streaming.
-    // (c_4 is used by cb_scale_in in ring joint SDPA, unlike regular SDPA.)
-    constexpr uint32_t cb_recip_scratch = tt::CBIndex::c_9;
-
-    // Deferred norm: sum save/restore CBs for multi Q-chunk DRAM round-trip.
-    constexpr uint32_t cb_sum_out = tt::CBIndex::c_10;
-    constexpr uint32_t cb_sum_in = tt::CBIndex::c_11;
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
@@ -254,7 +251,10 @@ void kernel_main() {
                 cb_out,  // cb_normalized_out — output goes directly to cb_out
                 cb_sum_out,
                 cb_sum_in,
-                needs_lightweight_mask>(
+                cb_signal,
+                needs_lightweight_mask,
+                is_causal,
+                is_balanced>(
                 global_q_start,
                 global_q_end,
                 iter_num_kv_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -32,8 +32,9 @@ void kernel_main() {
     constexpr uint32_t is_causal = get_compile_time_arg_val(21);
     constexpr uint32_t is_balanced = get_compile_time_arg_val(22);
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(23) == 1;
+    constexpr bool use_streaming_compute = get_compile_time_arg_val(24) == 1;
 
-    constexpr auto q_args = TensorAccessorArgs<24>();
+    constexpr auto q_args = TensorAccessorArgs<25>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -167,6 +168,9 @@ void kernel_main() {
      * On the first iteration, read from local K, V.
      * On subsequent iterations, read from gathered K, V. Sync with AllGather fused signaler.
      */
+    const uint32_t last_active_ring_iter = find_last_active_ring_iter(
+        fused_op_receiver.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L, is_causal, is_balanced);
+
     uint32_t ring_index = fused_op_receiver.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
@@ -223,7 +227,12 @@ void kernel_main() {
             const auto q_row_start_tile = q_chunk * Sq_chunk_t;
             const bool is_joint_q = q_chunk >= num_local_q_chunks;
 
-            if (q_chunk < half_sequence && is_balanced && ring_index < ring_id) {
+            const bool balanced_skip_q = q_chunk < half_sequence && is_balanced && ring_index < ring_id;
+
+            // Balanced causal skip: this Q chunk is handled by the paired device. Reader sends
+            // nothing (no Q, no K/V) — compute's normalize-only path on the last ring iter does
+            // not read Q (normalize uses only restored sum/out).
+            if (balanced_skip_q) {
                 continue;
             }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -168,9 +168,6 @@ void kernel_main() {
      * On the first iteration, read from local K, V.
      * On subsequent iterations, read from gathered K, V. Sync with AllGather fused signaler.
      */
-    const uint32_t last_active_ring_iter = find_last_active_ring_iter(
-        fused_op_receiver.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L, is_causal, is_balanced);
-
     uint32_t ring_index = fused_op_receiver.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -32,7 +32,6 @@ void kernel_main() {
     constexpr uint32_t is_causal = get_compile_time_arg_val(21);
     constexpr uint32_t is_balanced = get_compile_time_arg_val(22);
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(23) == 1;
-    constexpr bool use_streaming_compute = get_compile_time_arg_val(24) == 1;
 
     constexpr auto q_args = TensorAccessorArgs<25>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
@@ -120,6 +119,8 @@ void kernel_main() {
         receiver_semaphore_noc_addr = get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
     }
 
+    // TODO: CB indices below are hardcoded and duplicated from the program factory.
+    // They should be passed as compile-time args so the factory is the single source of truth.
     constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
     constexpr uint32_t cb_v_in = tt::CBIndex::c_2;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -137,8 +137,8 @@ void complete_restore(
 // Only 3 barriers fire per ring iteration (one per TRID):
 //   Q[0]: wB(TRID_INNER), Q[N-2]: wB(TRID_LAST), Q[N-1]: wB(TRID_FIRST).
 // Start from 1 — TRID 0 is the default for all NOC writes and must not be used
-// for per-TRID barriers, as unrelated writes (e.g. write_out_row_by_row on last
-// ring iter) would inflate the outstanding count and stall the barrier.
+// for per-TRID barriers, as unrelated writes (e.g. write_out_row_by_row_no_pop
+// on last ring iter) would inflate the outstanding count and stall the barrier.
 constexpr uint32_t TRID_FIRST = 1;
 constexpr uint32_t TRID_INNER = 2;
 constexpr uint32_t TRID_LAST = 3;
@@ -214,10 +214,14 @@ void save_accumulators_with_trid(
     }
 
     noc_async_write_flushed_with_trid(save_trid);
-    // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_out_row_by_row on last ring iter).
+    // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_out_row_by_row_no_pop on last ring iter).
     // Without this, subsequent noc_async_write calls would inflate save_trid's outstanding count,
     // causing noc_async_write_barrier_with_trid(save_trid) to wait for unrelated writes.
     noc_async_write_set_trid(0);
+    // Pop cb_out AFTER the trid-flush above: the flush guarantees NOC has
+    // finished reading this call's source L1 bytes, so compute can now
+    // safely reserve and reuse those slots.
+    cb_pop_front(cb_out, out_tiles_to_pop);
     cb_pop_front(cb_max_out, Sq_chunk_t);
     cb_pop_front(cb_sum_out, Sq_chunk_t);
 }
@@ -409,8 +413,8 @@ void kernel_main() {
         generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in, is_causal>();
     }
 
-    const uint32_t last_active_ring_iter =
-        find_last_active_ring_iter(fused_op_receiver.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L);
+    const uint32_t last_active_ring_iter = find_last_active_ring_iter(
+        fused_op_receiver.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L, is_causal, is_balanced);
 
     uint32_t ring_index = fused_op_receiver.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
@@ -504,11 +508,14 @@ void kernel_main() {
                 const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
 
+                const bool balanced_skip_q = q_chunk < half_sequence && is_balanced && ring_index < ring_id;
+
                 const auto qi =
                     get_q_chunk_info(q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
                 const uint32_t end_seq_tile = get_end_seq_tile(qi, ring_id, Lt, local_padded_Nt);
 
-                // 1. Complete restore (ring_iter > 0 only)
+                // 1. Complete restore + prefetch run for ALL Q chunks (including balanced-skipped)
+                // to keep the prefetch pipeline in sync across ring iters.
                 if (!single_q_chunk && ring_iter > 0) {
                     complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
                 }
@@ -552,7 +559,15 @@ void kernel_main() {
                 //   Q[0]: wB(TRID_INNER) — clears all prev-ring inner saves
                 //   Q[N-2]: wB(TRID_LAST) — clears prev-ring Q[N-1] save
                 //   Q[1..N-3]: skip — TRID_INNER already cleared at Q[0]
-                if (!single_q_chunk && ring_iter > 0) {
+                //
+                // Skip the prefetch when this Q is on the normalize-only path
+                // (balanced_skip_q + is_last_ring_iter): normalize produces cb_out incrementally
+                // and blocks on cb_out space; cb_out can't drain until this writer gets to
+                // write_out (below). A cb_reserve_back(cb_prev_out) here would block until
+                // normalize finishes, creating a cycle with cb_out. Deferred prefetch below
+                // runs after write_out to break the cycle.
+                const bool defer_prefetch = balanced_skip_q && is_last_ring_iter;
+                if (!single_q_chunk && ring_iter > 0 && !defer_prefetch) {
                     const uint32_t next_q_index = q_index + 1;
                     if (next_q_index < q_per_core) {
                         const uint32_t next_trid =
@@ -560,7 +575,8 @@ void kernel_main() {
                         if (next_trid != TRID_INNER || next_q_index == 1) {
                             noc_async_write_barrier_with_trid(next_trid);
                         }
-                        const uint32_t gq = global_q_chunk + 1;
+                        const uint32_t gq =
+                            remap_q_index(global_q_start + next_q_index, num_q_chunks, use_zigzag_balancing);
                         const uint32_t nb_pf = gq / (NH * num_q_chunks);
                         const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
                         const uint32_t qc_pf = gq % num_q_chunks;
@@ -585,9 +601,9 @@ void kernel_main() {
                     }
                 }
                 // Cross-ring: Q[N-1] → Q[0] of next ring iter.
-                if (!single_q_chunk && !is_last_ring_iter && (global_q_chunk + 1 >= global_q_end)) {
+                if (!single_q_chunk && !is_last_ring_iter && q_index == last_q_index) {
                     noc_async_write_barrier_with_trid(TRID_FIRST);
-                    const uint32_t gq = global_q_start;
+                    const uint32_t gq = remap_q_index(global_q_start, num_q_chunks, use_zigzag_balancing);
                     const uint32_t nb_pf = gq / (NH * num_q_chunks);
                     const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
                     const uint32_t qc_pf = gq % num_q_chunks;
@@ -637,9 +653,18 @@ void kernel_main() {
                     deferred.pending = false;
                 }
 
-                // === Compute runs K-loop for this Q chunk ===
+                // Balanced causal skip: on non-last ring iters, compute pops staging and
+                // doesn't push the K-loop signal. Writer skips signal wait + save + write.
+                // On the last ring iter, compute runs normalize-only and pushes the signal;
+                // fall through to signal wait + write (no save — no ping-pong state to save).
+                if (balanced_skip_q && !is_last_ring_iter) {
+                    continue;
+                }
+
+                // === Compute runs K-loop (or normalize-only on last iter) ===
 
                 // Wait for compute to signal last K-chunk start (multi-Q only).
+                // Normalize-only path also pushes this signal.
                 if (!single_q_chunk) {
                     cb_wait_front(cb_signal, 1);
                     cb_pop_front(cb_signal, 1);
@@ -664,6 +689,50 @@ void kernel_main() {
                     deferred.nq = nq;
                     deferred.qi = qi;
                 }
+
+                // Delayed intra-ring prefetch for normalize-only Qs: skipped earlier to avoid
+                // cycling cb_prev_out <-> cb_out with compute's normalize. Now cb_out has been
+                // drained by write_out above, and compute's normalize has fully freed cb_prev_out.
+                if (defer_prefetch && !single_q_chunk) {
+                    const uint32_t next_q_index = q_index + 1;
+                    if (next_q_index < q_per_core) {
+                        const uint32_t next_trid =
+                            next_q_index == 0 ? TRID_FIRST : (next_q_index == last_q_index ? TRID_LAST : TRID_INNER);
+                        if (next_trid != TRID_INNER || next_q_index == 1) {
+                            noc_async_write_barrier_with_trid(next_trid);
+                        }
+                        const uint32_t gq =
+                            remap_q_index(global_q_start + next_q_index, num_q_chunks, use_zigzag_balancing);
+                        const uint32_t nb_pf = gq / (NH * num_q_chunks);
+                        const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
+                        const uint32_t qc_pf = gq % num_q_chunks;
+                        const auto qi_pf = get_q_chunk_info(
+                            qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                        issue_restore_reads(
+                            qi_pf.is_joint_q ? joint_out_generator : out_generator,
+                            stats_writer,
+                            stats_tile_logical,
+                            nb_pf,
+                            nq_pf,
+                            Sq_chunk_t,
+                            qi_pf.out_slice,
+                            qi_pf.stats_seq_start_tile,
+                            qi_pf.stats_seq_end_tile,
+                            sum_offset,
+                            cb_prev_out,
+                            cb_max_in,
+                            cb_sum_in,
+                            tile_bytes,
+                            stats_tile_bytes);
+                    }
+                }
+            }
+            // Hoisted DRAM-arrival barrier: on the last ring iter, write_out_row_by_row_no_pop
+            // issued N untagged NOC writes (one per Q on this core). Wait once at the end of the
+            // Q loop for all of them to land in DRAM, before the outer ring-iter loop advances
+            // or the op teardown runs. Previously this was a per-Q barrier inside the loop.
+            if (is_last_ring_iter) {
+                noc_async_write_barrier();
             }
         } else {
             for (uint32_t q_iter = 0; q_iter + global_q_start < global_q_end; ++q_iter) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -10,7 +10,7 @@
 
 // Eager-path reader: reads the previous ring iteration's normalized output and LSE from DRAM.
 // Used by the non-streaming (old sdpa_ring) path for sigmoid-based inter-iteration merging.
-// Pushes output tiles into cb_prev_out (c_7) and LSE tiles into cb_lse_in (c_6).
+// Pushes output tiles into cb_prev_out and LSE tiles into cb_lse_in.
 //
 // @param cat_out_generator   Address generator for the output DRAM tensor (local or joint)
 // @param stats_writer        TensorAccessor for the stats DRAM tensor
@@ -22,8 +22,8 @@
 // @param end_seq_tile        Last valid sequence tile (for padding-aware reads)
 // @param stats_seq_start_tile  First tile row in the stats tensor for this Q chunk
 // @param stats_seq_end_tile    One-past-last tile row (clamped to avoid reading past padding)
-// @param cb_prev_out         CB to push previous output tiles into (c_7, read by compute)
-// @param cb_lse_in           CB to push previous LSE tiles into (c_6, read by compute)
+// @param cb_prev_out         CB to push previous output tiles into (read by compute)
+// @param cb_lse_in           CB to push previous LSE tiles into (read by compute)
 // @param tile_bytes          Output tile size in bytes
 // @param stats_tile_bytes    Stats tile size in bytes
 template <typename ReaderType, typename TensorAccessorType>
@@ -228,7 +228,7 @@ void save_accumulators_with_trid(
 
 // Eager-path writer: writes normalized output and LSE to DRAM every ring iteration.
 // Used by the non-streaming (old sdpa_ring) path.
-// Reads from: cb_out (c_16), cb_lse_out (c_17).
+// Reads from: cb_out and cb_lse_out.
 //
 // @param cat_out_generator   Address generator for the output DRAM tensor (local or joint)
 // @param stats_writer        TensorAccessor for the stats DRAM tensor
@@ -240,8 +240,8 @@ void save_accumulators_with_trid(
 // @param end_seq_tile        Last valid sequence tile
 // @param stats_seq_start_tile  First tile row in stats tensor for this Q chunk's LSE
 // @param stats_seq_end_tile    One-past-last tile row (clamped to sequence bounds)
-// @param cb_out              CB to drain output tiles from (c_16)
-// @param cb_lse_out          CB to drain LSE tiles from (c_17)
+// @param cb_out              CB to drain output tiles from
+// @param cb_lse_out          CB to drain LSE tiles from
 // @param tile_bytes          Output tile size in bytes
 // @param stats_tile_bytes    Stats tile size in bytes
 template <typename ReaderType, typename TensorAccessorType>
@@ -361,8 +361,9 @@ void kernel_main() {
         false, /* wait_for_op_signal */
         argidx);
 
-    // c_6/c_17 carry softmax statistics between compute and writer for DRAM round-trips.
-    // Aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm.
+    // TODO: CB indices below are hardcoded and duplicated from the program factory.
+    // They should be passed as compile-time args so the factory is the single source of truth.
+    // The stats CB is aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm.
     constexpr uint32_t cb_max_in = tt::CBIndex::c_6;  // deferred norm: DRAM → compute (running max)
     constexpr uint32_t cb_lse_in = tt::CBIndex::c_6;  // eager norm: DRAM → compute (LSE)
     constexpr uint32_t cb_prev_out = tt::CBIndex::c_7;
@@ -373,6 +374,10 @@ void kernel_main() {
     constexpr uint32_t cb_sum_out = tt::CBIndex::c_10;
     constexpr uint32_t cb_sum_in = tt::CBIndex::c_11;
     constexpr uint32_t cb_signal = tt::CBIndex::c_12;
+    constexpr uint32_t cb_scale_in = tt::CBIndex::c_4;
+    constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
+    constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
+
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     constexpr uint32_t stats_tile_bytes = get_tile_size(cb_max_in);
 
@@ -388,10 +393,6 @@ void kernel_main() {
 
     const auto out_generator = PaddedAddrGenerator(out_writer, output_tile_logical);
     const auto joint_out_generator = PaddedAddrGenerator(joint_out_writer, joint_tile_logical);
-
-    constexpr uint32_t cb_scale_in = tt::CBIndex::c_4;
-    constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
-    constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
 
     generate_bcast_unary_scalar(cb_scale_in, scale_val);
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
@@ -592,10 +593,15 @@ void kernel_main() {
                     get_q_chunk_info(q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
                 const uint32_t end_seq_tile = get_end_seq_tile(qi, ring_id, Lt, local_padded_Nt);
 
-                // 1. Complete restore + prefetch run for ALL Q chunks (including balanced-skipped)
-                // to keep the prefetch pipeline in sync across ring iters.
+                // 1. Complete restore for all Q chunks to keep the prefetch pipeline in sync.
+                // For balanced-skip non-last-ring-iter Q chunks, barrier without pushing —
+                // compute skips these Q chunks entirely and doesn't need staging data.
                 if (!single_q_chunk && ring_iter > 0) {
-                    complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
+                    if (balanced_skip_q && !is_last_ring_iter) {
+                        noc_async_read_barrier();
+                    } else {
+                        complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
+                    }
                 }
 
                 // 2. Early flush: drain staging before prefetch when needed.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -501,6 +501,84 @@ void kernel_main() {
             const uint32_t last_q_index = q_per_core - 1;
             const bool flush_before_prefetch = single_valid_kv_chunk || q_per_core == 2;
 
+            // TRID assignment by Q position: Q[0] -> TRID_FIRST, Q[N-1] -> TRID_LAST,
+            // Q[1..N-2] -> TRID_INNER. Used both for tagging the current Q's save and for
+            // selecting which TRID to barrier on for the next Q's prefetch.
+            auto trid_for_q = [&](uint32_t qi) {
+                return qi == 0 ? TRID_FIRST : qi == last_q_index ? TRID_LAST : TRID_INNER;
+            };
+
+            // Issue NOC reads to fill staging for Q[pf_q_index] of the current ring_iter (or
+            // ring_iter+1 for cross-ring at q==last_q_index, when the caller passes 0). Optionally
+            // barriers on pf_trid first to ensure the prior save with that TRID has landed.
+            auto prefetch_for = [&](uint32_t pf_q_index, uint32_t pf_trid, bool barrier_first) {
+                if (barrier_first) {
+                    noc_async_write_barrier_with_trid(pf_trid);
+                }
+                const uint32_t gq = remap_q_index(global_q_start + pf_q_index, num_q_chunks, use_zigzag_balancing);
+                const uint32_t nb_pf = gq / (NH * num_q_chunks);
+                const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
+                const uint32_t qc_pf = gq % num_q_chunks;
+                const auto qi_pf =
+                    get_q_chunk_info(qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                issue_restore_reads(
+                    qi_pf.is_joint_q ? joint_out_generator : out_generator,
+                    stats_writer,
+                    stats_tile_logical,
+                    nb_pf,
+                    nq_pf,
+                    Sq_chunk_t,
+                    qi_pf.out_slice,
+                    qi_pf.stats_seq_start_tile,
+                    qi_pf.stats_seq_end_tile,
+                    sum_offset,
+                    cb_prev_out,
+                    cb_max_in,
+                    cb_sum_in,
+                    tile_bytes,
+                    stats_tile_bytes);
+            };
+
+            // Intra-ring prefetch: bounds-check next_q_index, then dispatch with the per-TRID
+            // barrier rule. Only barrier when next Q's TRID hasn't been cleared yet this ring
+            // iter: Q[0] -> wB(TRID_INNER), Q[N-2] -> wB(TRID_LAST), Q[1..N-3] -> skip
+            // (TRID_INNER already cleared at Q[0]).
+            auto prefetch_intra_ring = [&](uint32_t next_q_index) {
+                if (next_q_index >= q_per_core) {
+                    return;
+                }
+                const uint32_t next_trid = trid_for_q(next_q_index);
+                const bool need_barrier = (next_trid != TRID_INNER || next_q_index == 1);
+                prefetch_for(next_q_index, next_trid, need_barrier);
+            };
+
+            // Drain pending deferred save (raw accumulators -> DRAM) for the prior Q. Called at
+            // the early-flush site (before prefetch when total_valid_kv<=1 or q_per_core==2) and
+            // the late-flush site (after prefetch in the K-loop window).
+            auto flush_deferred_save = [&]() {
+                constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
+                save_accumulators_with_trid(
+                    deferred.qi.is_joint_q ? joint_out_generator : out_generator,
+                    stats_writer,
+                    stats_tile_logical,
+                    deferred.nb,
+                    deferred.nq,
+                    Sq_chunk_t,
+                    deferred.qi.out_slice,
+                    all_tiles_valid,
+                    deferred.qi.stats_seq_start_tile,
+                    deferred.qi.stats_seq_end_tile,
+                    sum_offset,
+                    cb_out,
+                    cb_max_out,
+                    cb_sum_out,
+                    tile_bytes,
+                    stats_tile_bytes,
+                    out_subblock_h,
+                    deferred.trid);
+                deferred.pending = false;
+            };
+
             for (uint32_t q_index = 0; q_index + global_q_start < global_q_end; ++q_index) {
                 uint32_t global_q_chunk = remap_q_index(global_q_start + q_index, num_q_chunks, use_zigzag_balancing);
 
@@ -520,137 +598,38 @@ void kernel_main() {
                     complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
                 }
 
-                // 2. Early flush (flush_before_prefetch): drain staging CBs before prefetch.
-                // - total_valid_kv <= 1: compute's sole K chunk triggers save_to_staging on
-                //   K0, reserving staging CBs immediately — deadlock if they're still full.
+                // 2. Early flush: drain staging before prefetch when needed.
+                // - total_valid_kv <= 1: compute's sole K chunk triggers save_to_staging on K0,
+                //   reserving staging CBs immediately — deadlock if they're still full.
                 // - q_per_core == 2: next Q == last Q whose deferred data isn't in DRAM yet,
                 //   so prefetch would read stale data without flushing first.
-                //
                 // With >= 2 valid K chunks and q_per_core >= 3, K0 uses ping-pong accumulators
-                // (not staging CBs), so the writer prefetches first and flushes later during
-                // the K-loop window — spreading DRAM writes to reduce bank contention.
+                // (not staging CBs), so we prefetch first and flush later during the K-loop
+                // window — spreading DRAM writes to reduce bank contention.
                 if (deferred.pending && flush_before_prefetch) {
-                    constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
-                    save_accumulators_with_trid(
-                        deferred.qi.is_joint_q ? joint_out_generator : out_generator,
-                        stats_writer,
-                        stats_tile_logical,
-                        deferred.nb,
-                        deferred.nq,
-                        Sq_chunk_t,
-                        deferred.qi.out_slice,
-                        all_tiles_valid,
-                        deferred.qi.stats_seq_start_tile,
-                        deferred.qi.stats_seq_end_tile,
-                        sum_offset,
-                        cb_out,
-                        cb_max_out,
-                        cb_sum_out,
-                        tile_bytes,
-                        stats_tile_bytes,
-                        out_subblock_h,
-                        deferred.trid);
-                    deferred.pending = false;
+                    flush_deferred_save();
                 }
 
                 // 3. Prefetch next Q chunk's accumulators from DRAM.
-                // Intra-ring: issue reads for Q[q+1] during Q[q]'s K-loop.
-                // Only barrier when next Q's TRID hasn't been cleared yet this ring iter:
-                //   Q[0]: wB(TRID_INNER) — clears all prev-ring inner saves
-                //   Q[N-2]: wB(TRID_LAST) — clears prev-ring Q[N-1] save
-                //   Q[1..N-3]: skip — TRID_INNER already cleared at Q[0]
-                //
-                // Skip the prefetch when this Q is on the normalize-only path
+                // Skip the intra-ring prefetch when this Q is on the normalize-only path
                 // (balanced_skip_q + is_last_ring_iter): normalize produces cb_out incrementally
-                // and blocks on cb_out space; cb_out can't drain until this writer gets to
-                // write_out (below). A cb_reserve_back(cb_prev_out) here would block until
+                // and blocks on cb_out space; cb_out can't drain until the writer reaches
+                // write_out below. A cb_reserve_back(cb_prev_out) here would block until
                 // normalize finishes, creating a cycle with cb_out. Deferred prefetch below
                 // runs after write_out to break the cycle.
                 const bool defer_prefetch = balanced_skip_q && is_last_ring_iter;
                 if (!single_q_chunk && ring_iter > 0 && !defer_prefetch) {
-                    const uint32_t next_q_index = q_index + 1;
-                    if (next_q_index < q_per_core) {
-                        const uint32_t next_trid =
-                            next_q_index == 0 ? TRID_FIRST : (next_q_index == last_q_index ? TRID_LAST : TRID_INNER);
-                        if (next_trid != TRID_INNER || next_q_index == 1) {
-                            noc_async_write_barrier_with_trid(next_trid);
-                        }
-                        const uint32_t gq =
-                            remap_q_index(global_q_start + next_q_index, num_q_chunks, use_zigzag_balancing);
-                        const uint32_t nb_pf = gq / (NH * num_q_chunks);
-                        const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
-                        const uint32_t qc_pf = gq % num_q_chunks;
-                        const auto qi_pf = get_q_chunk_info(
-                            qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                        issue_restore_reads(
-                            qi_pf.is_joint_q ? joint_out_generator : out_generator,
-                            stats_writer,
-                            stats_tile_logical,
-                            nb_pf,
-                            nq_pf,
-                            Sq_chunk_t,
-                            qi_pf.out_slice,
-                            qi_pf.stats_seq_start_tile,
-                            qi_pf.stats_seq_end_tile,
-                            sum_offset,
-                            cb_prev_out,
-                            cb_max_in,
-                            cb_sum_in,
-                            tile_bytes,
-                            stats_tile_bytes);
-                    }
+                    prefetch_intra_ring(q_index + 1);
                 }
-                // Cross-ring: Q[N-1] → Q[0] of next ring iter.
+                // Cross-ring: Q[N-1] -> Q[0] of next ring iter.
                 if (!single_q_chunk && !is_last_ring_iter && q_index == last_q_index) {
-                    noc_async_write_barrier_with_trid(TRID_FIRST);
-                    const uint32_t gq = remap_q_index(global_q_start, num_q_chunks, use_zigzag_balancing);
-                    const uint32_t nb_pf = gq / (NH * num_q_chunks);
-                    const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
-                    const uint32_t qc_pf = gq % num_q_chunks;
-                    const auto qi_pf = get_q_chunk_info(
-                        qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                    issue_restore_reads(
-                        qi_pf.is_joint_q ? joint_out_generator : out_generator,
-                        stats_writer,
-                        stats_tile_logical,
-                        nb_pf,
-                        nq_pf,
-                        Sq_chunk_t,
-                        qi_pf.out_slice,
-                        qi_pf.stats_seq_start_tile,
-                        qi_pf.stats_seq_end_tile,
-                        sum_offset,
-                        cb_prev_out,
-                        cb_max_in,
-                        cb_sum_in,
-                        tile_bytes,
-                        stats_tile_bytes);
+                    prefetch_for(/*pf_q_index=*/0, TRID_FIRST, /*barrier_first=*/true);
                 }
 
-                // 4. Late flush (>= 2 valid K chunks, q_per_core >= 3): flush during K-loop
+                // 4. Late flush (>= 2 valid K chunks, q_per_core >= 3): drain during K-loop
                 // window after prefetch, spreading DRAM writes to reduce bank contention.
                 if (deferred.pending) {
-                    constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
-                    save_accumulators_with_trid(
-                        deferred.qi.is_joint_q ? joint_out_generator : out_generator,
-                        stats_writer,
-                        stats_tile_logical,
-                        deferred.nb,
-                        deferred.nq,
-                        Sq_chunk_t,
-                        deferred.qi.out_slice,
-                        all_tiles_valid,
-                        deferred.qi.stats_seq_start_tile,
-                        deferred.qi.stats_seq_end_tile,
-                        sum_offset,
-                        cb_out,
-                        cb_max_out,
-                        cb_sum_out,
-                        tile_bytes,
-                        stats_tile_bytes,
-                        out_subblock_h,
-                        deferred.trid);
-                    deferred.pending = false;
+                    flush_deferred_save();
                 }
 
                 // Balanced causal skip: on non-last ring iters, compute pops staging and
@@ -684,7 +663,7 @@ void kernel_main() {
                     noc_async_write_barrier();
                 } else if (!single_q_chunk) {
                     deferred.pending = true;
-                    deferred.trid = q_index == 0 ? TRID_FIRST : (q_index == last_q_index ? TRID_LAST : TRID_INNER);
+                    deferred.trid = trid_for_q(q_index);
                     deferred.nb = nb;
                     deferred.nq = nq;
                     deferred.qi = qi;
@@ -694,37 +673,7 @@ void kernel_main() {
                 // cycling cb_prev_out <-> cb_out with compute's normalize. Now cb_out has been
                 // drained by write_out above, and compute's normalize has fully freed cb_prev_out.
                 if (defer_prefetch && !single_q_chunk) {
-                    const uint32_t next_q_index = q_index + 1;
-                    if (next_q_index < q_per_core) {
-                        const uint32_t next_trid =
-                            next_q_index == 0 ? TRID_FIRST : (next_q_index == last_q_index ? TRID_LAST : TRID_INNER);
-                        if (next_trid != TRID_INNER || next_q_index == 1) {
-                            noc_async_write_barrier_with_trid(next_trid);
-                        }
-                        const uint32_t gq =
-                            remap_q_index(global_q_start + next_q_index, num_q_chunks, use_zigzag_balancing);
-                        const uint32_t nb_pf = gq / (NH * num_q_chunks);
-                        const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
-                        const uint32_t qc_pf = gq % num_q_chunks;
-                        const auto qi_pf = get_q_chunk_info(
-                            qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
-                        issue_restore_reads(
-                            qi_pf.is_joint_q ? joint_out_generator : out_generator,
-                            stats_writer,
-                            stats_tile_logical,
-                            nb_pf,
-                            nq_pf,
-                            Sq_chunk_t,
-                            qi_pf.out_slice,
-                            qi_pf.stats_seq_start_tile,
-                            qi_pf.stats_seq_end_tile,
-                            sum_offset,
-                            cb_prev_out,
-                            cb_max_in,
-                            cb_sum_in,
-                            tile_bytes,
-                            stats_tile_bytes);
-                    }
+                    prefetch_intra_ring(q_index + 1);
                 }
             }
             // Hoisted DRAM-arrival barrier: on the last ring iter, write_out_row_by_row_no_pop

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -137,7 +137,7 @@ void complete_restore(
 // Only 3 barriers fire per ring iteration (one per TRID):
 //   Q[0]: wB(TRID_INNER), Q[N-2]: wB(TRID_LAST), Q[N-1]: wB(TRID_FIRST).
 // Start from 1 — TRID 0 is the default for all NOC writes and must not be used
-// for per-TRID barriers, as unrelated writes (e.g. write_out_row_by_row_no_pop
+// for per-TRID barriers, as unrelated writes (e.g. write_out_row_by_row
 // on last ring iter) would inflate the outstanding count and stall the barrier.
 constexpr uint32_t TRID_FIRST = 1;
 constexpr uint32_t TRID_INNER = 2;
@@ -217,11 +217,8 @@ void save_accumulators_with_trid(
     // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_out_row_by_row_no_pop on last ring iter).
     // Without this, subsequent noc_async_write calls would inflate save_trid's outstanding count,
     // causing noc_async_write_barrier_with_trid(save_trid) to wait for unrelated writes.
+    // cb_out was already popped per-group inside write_out_row_by_row (via drain_cb_row_grouped).
     noc_async_write_set_trid(0);
-    // Pop cb_out AFTER the trid-flush above: the flush guarantees NOC has
-    // finished reading this call's source L1 bytes, so compute can now
-    // safely reserve and reuse those slots.
-    cb_pop_front(cb_out, out_tiles_to_pop);
     cb_pop_front(cb_max_out, Sq_chunk_t);
     cb_pop_front(cb_sum_out, Sq_chunk_t);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
@@ -98,9 +98,16 @@ struct RingIdSequencer {
  * @param local_padded_Nt   Per-device padded sequence length in tiles
  * @param global_n_tile_id  Logical (unpadded) sequence length in tiles (logical_n / TILE_HEIGHT)
  * @param L                 Joint sequence length in elements (0 if no joint attention)
+ * @param is_causal         Whether causal masking is enabled
+ * @param is_balanced       Whether balanced (zigzag) causal distribution is enabled
  */
 inline uint32_t find_last_active_ring_iter(
-    RingIdSequencer seq, uint32_t local_padded_Nt, uint32_t global_n_tile_id, uint32_t L) {
+    RingIdSequencer seq,
+    uint32_t local_padded_Nt,
+    uint32_t global_n_tile_id,
+    uint32_t L,
+    bool is_causal = false,
+    bool is_balanced = false) {
     uint32_t last_active = 0;
     auto no_sync = [](uint32_t, uint32_t) {};
 
@@ -108,7 +115,8 @@ inline uint32_t find_last_active_ring_iter(
         uint32_t ring_id = seq.get_next_ring_id(no_sync);
         bool does_joint = (ring_id == seq.ring_size - 1);
         uint32_t kv_start = ring_id * local_padded_Nt;
-        bool does_work = (kv_start <= global_n_tile_id) || (does_joint && L != 0);
+        bool does_work = ((kv_start <= global_n_tile_id) || (does_joint && L != 0)) &&
+                         !(is_causal && seq.ring_index < ring_id && !is_balanced);
         if (does_work) {
             last_active = t;
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -333,7 +333,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // guarantees it — but kept explicit for clarity of the subblock-tiling requirement.
     const bool use_streaming_compute =
         !fp32_dest_acc_en && qk_out_subblock_h <= 2 && Sk_chunk_t % qk_out_subblock_w == 0 && qk_in0_num_subblocks > 1;
-    log_info(
+    log_debug(
         tt::LogOp,
         "use_streaming_compute: {} (is_causal={}, Sq_chunk_t={}, Sk_chunk_t={}, sbh={}, sbw={})",
         use_streaming_compute,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -326,13 +326,22 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const uint32_t out_in0_block_w = Sk_chunk_t;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
-    // This is done only in the non-causal case:
     // Streaming compute v2: eliminates row buffers via cb_push_back_hold_wr_ptr.
     // Streaming v2 requires q_num_subblocks > 1 (Sq_chunk_t > subblock_h) because the Phase 2
     // pipeline assumes at least one q_subblock iteration for correct softmax drain + SALAD overlap.
-    const bool use_streaming_compute = !fp32_dest_acc_en && qk_out_subblock_h <= 2 &&
-                                       Sk_chunk_t % (dst_size / qk_out_subblock_h) == 0 && qk_in0_num_subblocks > 1 && !args.is_causal;
-    log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
+    // The `Sk_chunk_t % qk_out_subblock_w == 0` clause is tautological — the selector already
+    // guarantees it — but kept explicit for clarity of the subblock-tiling requirement.
+    const bool use_streaming_compute =
+        !fp32_dest_acc_en && qk_out_subblock_h <= 2 && Sk_chunk_t % qk_out_subblock_w == 0 && qk_in0_num_subblocks > 1;
+    log_info(
+        tt::LogOp,
+        "use_streaming_compute: {} (is_causal={}, Sq_chunk_t={}, Sk_chunk_t={}, sbh={}, sbw={})",
+        use_streaming_compute,
+        args.is_causal,
+        Sq_chunk_t,
+        Sk_chunk_t,
+        qk_out_subblock_h,
+        qk_out_subblock_w);
 
     auto [out_out_subblock_h, out_out_subblock_w] =
         detail::determine_largest_subblock_size(Sq_chunk_t, vDHt, dst_size, use_streaming_compute ? 2 : UINT32_MAX);
@@ -432,7 +441,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         qk_out_subblock_h,
         args.is_causal,
         args.is_balanced,
-        static_cast<uint32_t>(enable_zigzag_balancing)};
+        static_cast<uint32_t>(enable_zigzag_balancing),
+        static_cast<uint32_t>(use_streaming_compute)};
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);


### PR DESCRIPTION
## Summary

Enables `sdpa_ring_v2` (the streaming compute path) for `is_causal && is_balanced`
configs (DeepSeek MLA), fixes a writer NOC-read vs L1-reuse race that produced
run-to-run non-determinism on causal shapes, and adds a per-chunk causal
matmul-narrowing optimization.

## Documentation

- 📖 **[Kernel analysis](https://gist.github.com/djordjenTT/baa59fe2f4e1bad2c14d77c9d92ea6e0#file-sdpa_ring_v2_kernel_analysis-md)** — full kernel reference (phases, accumulator state, prefetch pipeline mechanics, mask handling, causal-attention details).
- 🧭 **[PR review guidelines](https://gist.github.com/djordjenTT/baa59fe2f4e1bad2c14d77c9d92ea6e0#file-causal_streaming_sdpa_pr_guidelines-md)** — review map, focus areas, what to verify.

(Two commits in this branch: the first is the functional change; the second is pure
structural cleanup with bitwise-identical PCC. Reviewable as one logical change or split.)

## What changed

**Causal port** — `sdpa_ring_v2` now runs for `is_causal + is_balanced` configs
(DeepSeek MLA). Previously the `use_streaming_compute` gate excluded causal entirely.
This required: zigzag q_chunk remapping + per-Q `causal_k_limit` pre-scan in the K-loop;
balanced-skip + a new "normalize-only" path for L Q-chunks on the last ring iter; per-row
diagonal causal mask stamping via L1-acc; reader/writer plumbing for the new compute
contract; deadlock fix in the writer (defer intra-ring prefetch until after
`write_out_row_by_row` when balanced-skip lands on the last ring iter).

**Writer NOC-read vs L1-reuse race fix** — `write_out_row_by_row` was calling
`cb_pop_front` per row group without flushing in-flight NOC writes first, releasing L1
source slots while the NOC controller was still reading them. Compute's next Q refilled
the slots and corrupted DRAM at the prior Q's output positions. Fix renames to
`write_out_row_by_row_no_pop`, returns the total tile count, and lets callers pop after
their existing synchronization (TRID-tagged flush on the save path; per-Q
`noc_async_writes_flushed` + a single hoisted `noc_async_write_barrier` at the end of the
Q loop on the final-output path). Eliminated 6.8% iter-fail rate on mla_5x10
(1296-iter sample); output drain still overlaps with compute via the per-Q flush.

**Causal narrowing optimization** — on the diagonal-crossing K-chunk, narrow `active_Sk`
to `q_start_tile + Sq_chunk_t - k_chunk*Sk_chunk_t` when smaller than the chunk's existing
active range. Cols past the last Q-row's diag tile are `-inf` for every Q row in the
chunk, so matmul / sub_exp / V matmul on those cols can be skipped entirely. Composes
with padding/straddle narrowing via `min()`. **+0.7 pp math util** on mla_5x10 ceiling.

**v2 streaming improvements** — fix vDHt hardcoded to DHt in `sdpa_ring_v2` template call
(allows `d_v != d_qk` for MLA); extend straddle-mask narrowing to the v2 path (handles
`k_chunk_size` not dividing seq_len cleanly); relax the `Sk_chunk_t % qk_out_subblock_w`
gate so non-max-width subblocks become eligible for v2; rebase fix replacing direct
`llk_pack_mop_config` under `ARCH_BLACKHOLE` with `configure_*` helpers; skip
`cb_pop_front(cb_q_in)` on normalize-only iterations (reader doesn't push Q for
balanced-skipped chunks); `__attribute__((noinline, noclone))` on three hot functions to
keep v2 compute under BH 70656-byte program-config buffer limit.

**Test consolidation** — fold three near-identical MLA configs (`mla_100k` 5×5 /
`mla_100k_straddle` 5×8 / `mla_5x10` 5×10) into a single `mla_100k` with
`k_chunk_sizes=[160, 256, 320]`. Cross-product produces three test IDs:
`mla_100k-q160-k{160,256,320}`. Removes the `worker_l1_size=1456640` override — v2 fits
the default L1 region for Sk=8 straddle.

## Verification (4×Blackhole Quiet Box)

### PCC (threshold 0.999 MLA, 0.994 WAN; CCLs enabled)

| Config                                | PCC      | RMSE     | Result   |
|---------------------------------------|----------|----------|----------|
| `mla_100k-q160-k160` (Sk_t=5)         | 0.999570 | 0.006639 | ✅ PASS |
| `mla_100k-q160-k256` (Sk_t=8 straddle)| 0.999571 | 0.006633 | ✅ PASS |
| `mla_100k-q160-k320` (Sk_t=10)        | 0.999572 | 0.006626 | ✅ PASS |
| `wan2_2_1xGLX-q288-k512`              | 0.999678 | 0.006376 | ✅ PASS |
| `wan2_2_4xGLX-q224-k512`              | 0.999805 | 0.004760 | ✅ PASS |

### Determinism (50 iterations, bitwise compare iter N vs iter 0)

| Config                  | Diverged | Result   |
|-------------------------|----------|----------|
| `mla_100k-q160-k160`    | 0/50     | ✅ PASS |
| `mla_100k-q160-k256`    | 0/50     | ✅ PASS |
| `mla_100k-q160-k320`    | 0/50     | ✅ PASS |
| `wan2_2_1xGLX-q288-k512`| 0/50     | ✅ PASS |
| `wan2_2_4xGLX-q288-k512`| 0/50     | ✅ PASS |

### Math utilization (Tracy-profiled, single Q/K combo per config)

| Config                              | Disabled to measure                                | Duration | Math util | Result |
|-------------------------------------|----------------------------------------------------|----------|-----------|--------|
| `mla_100k-q160-k320` (5×10 ceiling) | CCL + SDPA-side DRAM reads (chain forwarding off)  | 4.111 ms | 73.6%     | ✅     |
| `wan2_2_1xGLX-q288-k512`            | CCL only (DRAM reads on)                           | 7.845 ms | 68.9%     | ✅     |
| `wan2_2_4xGLX-q224-k512`            | CCL only (DRAM reads on)                           | 0.561 ms | 66.2%     | ✅     |

Causal-narrowing optimization gain on mla_5x10 ceiling: **+0.7 pp** (72.9% → 73.6%) —
matches predicted ~5/110 K-chunks of work saved on iter 0 (50% reduction on the boundary
K-chunk for half the q-chunks). WAN configs unchanged (gate `is_causal=false`, narrowing
is inert).

## Test plan

- [x] PCC ≥ 0.999 on all 3 MLA `mla_100k-q160-k{160,256,320}` configs
- [x] PCC ≥ 0.994 on both WAN `wan2_2_{1xGLX,4xGLX}` configs
- [x] 50-iter bitwise determinism on all 5 configs above
- [x] Math-util ceiling on mla_5x10 with CCL+DRAM disabled — meets 72.9% baseline (achieved 73.6%)
- [x] WAN math-util baseline parity with prior numbers (68.9% / 66.2%)
- [x] Auto-merge against #41637 (helpers refactor) on writer/factory verified clean
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/runs/25057778815)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/runs/25057838470)
- [ ] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/runs/25057932018)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dnijemcevic/causal_streaming_sdpa_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dnijemcevic/causal_streaming_sdpa_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dnijemcevic/causal_streaming_sdpa_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/causal_streaming_sdpa_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dnijemcevic/causal_streaming_sdpa_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dnijemcevic/causal_streaming_sdpa_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dnijemcevic/causal_streaming_sdpa_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dnijemcevic/causal_streaming_sdpa_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dnijemcevic/causal_streaming_sdpa_v3)