### PR TITLE
Deepseek l1 worker size for auto-mapper

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -34,21 +34,28 @@ def _fabric_config_for_num_procs(num_procs: int):
     raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4, 16, or 64)")
 
 
+def _needs_extended_worker_l1(num_procs: int) -> bool:
+    """True for the one host that required extra L1 (``TT_MESH_ID`` from tt-run, or legacy global rank).
+
+    For 4×16 pod layouts, tt-run sets ``TT_MESH_ID=3`` on the mesh that replaced global rank 62.
+    With only mesh id, single-mesh 16-proc cannot be identified via env (all ranks share the same id),
+    so the rank fallback is used for 16 procs.
+    """
+    mid = os.environ.get("TT_MESH_ID")
+    if num_procs == 64:
+        return int(mid) == 62
+    if num_procs == 16:
+        return int(mid) == 14
+    return False
+
+
 @contextlib.contextmanager
 def open_mesh_device():
-    my_rank = int(ttnn.distributed_context_get_rank())
-    num_procs = int(ttnn.distributed_context_get_size())
-    worker_l1_size = 1431568
-    if num_procs == 64:
-        if my_rank == 62:
-            worker_l1_size = 1499000
-    elif num_procs == 16:
-        if my_rank == 14:
-            worker_l1_size = 1499000
     """Open mesh device using bh_2d_mesh_device_context (pod pipeline settings)."""
+    num_procs = int(ttnn.distributed_context_get_size())
+    worker_l1_size = 1499000 if _needs_extended_worker_l1(num_procs) else 1431568
     if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
         os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
-    num_procs = int(ttnn.distributed_context_get_size())
     device_params = {
         "fabric_config": _fabric_config_for_num_procs(num_procs),
         "fabric_router_config": create_fabric_router_config(15232),


### PR DESCRIPTION
Fixing so L1 Size is determined by Mesh ID instead of Rank to avoid this error:

```
[1,22]<stderr>: Statically allocated circular buffers in program 12 clash with L1 buffers on core range [(x=0,y=0) - (x=10,y=9)]. L1 buffer allocated at 215104 and static circular buffer region ends at 260160[1,22]<stderr>: Statically allocated circular buffers in program 12 clash with L1 buffers on core range [(x=0,y=0) - (x=10,y=9)]. L1 buffer allocated at 215104 and static circular buffer region ends at 260160
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/fix-cli-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/fix-cli-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ridvan/fix-cli-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ridvan/fix-cli-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/fix-cli-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/fix-cli-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/fix-cli-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/fix-cli-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ridvan/fix-cli-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ridvan/fix-cli-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/fix-cli-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/fix-cli-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/fix-cli-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/fix-cli-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/fix-cli-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/fix-cli-rank)