### PR TITLE
ds_prefill(Add LM head and sampling to DeepSeek prefill transformer)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/cache/test_lm_head_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_lm_head_cache.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import shutil
+from pathlib import Path
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
+from tests.ttnn.utils_for_testing import comp_pcc
+
+CACHE_DIR = Path("/tmp/DS_PREFILL_lm_head")
+
+
+@pytest.fixture(autouse=True)
+def cleanup_cache():
+    if CACHE_DIR.exists():
+        shutil.rmtree(CACHE_DIR)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    yield
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (2, 2),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
+            id="linear-2x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_lm_head_weights_cold_warm_cache(mesh_device, device_params):
+    """Test: weights → cold cache → warm cache produce identical outputs."""
+    vocab_size = DeepSeekV3Config.VOCAB_SIZE
+    emb_dim = DeepSeekV3Config.EMB_SIZE
+    seq_len = 256
+
+    # Create random weight (single tensor, not dict)
+    torch.manual_seed(42)
+    torch_weight = torch.randn(vocab_size, emb_dim, dtype=torch.float32)
+
+    # Create input
+    dispatch_group_size = mesh_device.shape[0]  # SP factor
+    torch_input = torch.randn(dispatch_group_size, seq_len, emb_dim, dtype=torch.bfloat16)
+    input_tt = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+    )
+    global_token_id = seq_len * dispatch_group_size - 1
+
+    # Helper to convert output to torch
+    def to_torch_concat(tt_tensor):
+        return ttnn.to_torch(
+            tt_tensor,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        )
+
+    # === Path 1: From Weights ===
+    lm_head_from_weights = TtLMHead(
+        mesh_device,
+        emb_dim=emb_dim,
+        vocab_size=vocab_size,
+        torch_weight=torch_weight,
+        weight_cache_path=None,
+    )
+    output1, _ = lm_head_from_weights(input_tt, global_token_id)
+    output1 = to_torch_concat(output1)
+
+    # === Path 2: Cold Cache ===
+    from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
+
+    init_checker(CACHE_DIR)
+    assert not TtLMHead.check_cache_complete(CACHE_DIR), "Cache should be empty before build"
+
+    profiler.clear()
+    profiler.start("build_cache")
+    TtLMHead.build_ttnn_cache(torch_weight, vocab_size, emb_dim, mesh_device, CACHE_DIR)
+    profiler.end("build_cache")
+
+    init_checker(CACHE_DIR)  # Re-init checker after cache build
+    assert TtLMHead.check_cache_complete(CACHE_DIR), "Cache should be complete after build"
+
+    profiler.start("cold_load")
+    lm_head_cold = TtLMHead(
+        mesh_device,
+        emb_dim=emb_dim,
+        vocab_size=vocab_size,
+        torch_weight=None,
+        weight_cache_path=CACHE_DIR,
+    )
+    profiler.end("cold_load")
+    output2, _ = lm_head_cold(input_tt, global_token_id)
+    output2 = to_torch_concat(output2)
+
+    # === Path 3: Warm Cache ===
+    profiler.start("warm_load")
+    lm_head_warm = TtLMHead(
+        mesh_device,
+        emb_dim=emb_dim,
+        vocab_size=vocab_size,
+        torch_weight=None,
+        weight_cache_path=CACHE_DIR,
+    )
+    profiler.end("warm_load")
+    output3, _ = lm_head_warm(input_tt, global_token_id)
+    output3 = to_torch_concat(output3)
+
+    # === Validation ===
+    passed_cold, pcc_cold = comp_pcc(output1, output2)
+    passed_warm, pcc_warm = comp_pcc(output1, output3)
+
+    logger.info(f"LM Head Cache Test:")
+    logger.info(f"  Weights vs Cold Cache PCC: {pcc_cold}")
+    logger.info(f"  Weights vs Warm Cache PCC: {pcc_warm}")
+
+    logger.info(f"  build_cache: {profiler.get('build_cache')*1000:.1f} ms")
+    logger.info(f"  cold_load:   {profiler.get('cold_load')*1000:.1f} ms")
+    logger.info(f"  warm_load:   {profiler.get('warm_load')*1000:.1f} ms")
+
+    assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
+    assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_lm_head_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_lm_head_cache.py
@@ -12,6 +12,7 @@ import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CACHE_DIR = Path("/tmp/DS_PREFILL_lm_head")
@@ -23,6 +24,7 @@ def cleanup_cache():
         shutil.rmtree(CACHE_DIR)
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     yield
+    report_and_clear()
 
 
 @pytest.mark.parametrize(
@@ -31,8 +33,8 @@ def cleanup_cache():
         pytest.param(
             (2, 2),
             {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -50,6 +50,7 @@ def random_weights(config, emb_dim: int, vocab_size: int, dtype: torch.dtype):
     return config, weights
 
 
+@pytest.mark.parametrize("is_balanced", [False, True], ids=["sequential", "balanced"])
 @pytest.mark.parametrize(
     "batch_seq_len, emb_dim, vocab_size, run_full_pcc_check",
     [
@@ -99,6 +100,7 @@ def test_lm_head(
     run_full_pcc_check: bool,
     num_links: int,
     topology: ttnn.Topology,
+    is_balanced: bool,
 ):
     """
     Test TtLMHead PCC against torch.nn.Linear reference.
@@ -146,11 +148,12 @@ def test_lm_head(
         mesh_device=mesh_device,
         emb_dim=emb_dim,
         vocab_size=vocab_size,
-        torch_weights=weights,
+        torch_weight=weights["lm_head.weight"] if weights else None,
         num_links=num_links,
         topology=topology,
         activations_dtype=ttnn_activations_dtype,
         weights_dtype=ttnn_weights_dtype,
+        is_balanced=is_balanced,
     )
 
     tt_input = ttnn.from_torch(
@@ -193,3 +196,50 @@ def test_lm_head(
     assert pcc_passed, f"PCC test failed: {pcc_message}"
 
     logger.debug("PCC test passed!")
+
+
+def test_global_to_local_token_id():
+    """Verify token mapping for both balanced and sequential modes."""
+    from models.demos.deepseek_v3_d_p.tt.mla.utils import global_to_local_token_id
+
+    sp_factor = 4
+    seq_len = 1024
+    chunk_size_balanced = seq_len // (2 * sp_factor)  # 128
+    chunk_size_sequential = seq_len // sp_factor  # 256
+
+    # === is_balanced=True (zigzag) ===
+    # Token 0 -> device 0, offset 0
+    device_id, local_id = global_to_local_token_id(0, sp_factor, seq_len, is_balanced=True)
+    assert device_id == 0 and local_id == 0, f"Expected (0, 0), got ({device_id}, {local_id})"
+
+    # Token at start of chunk 1 -> device 1, offset 0
+    device_id, local_id = global_to_local_token_id(chunk_size_balanced, sp_factor, seq_len, is_balanced=True)
+    assert device_id == 1 and local_id == 0, f"Expected (1, 0), got ({device_id}, {local_id})"
+
+    # Token at start of chunk 7 (last chunk) -> device 0, with offset chunk_size
+    # Chunk 7 maps to device: num_chunks - 1 - chunk_id = 8 - 1 - 7 = 0
+    device_id, local_id = global_to_local_token_id(7 * chunk_size_balanced, sp_factor, seq_len, is_balanced=True)
+    assert (
+        device_id == 0 and local_id == chunk_size_balanced
+    ), f"Expected (0, {chunk_size_balanced}), got ({device_id}, {local_id})"
+
+    # === is_balanced=False (sequential) ===
+    # Token 0 -> device 0, offset 0
+    device_id, local_id = global_to_local_token_id(0, sp_factor, seq_len, is_balanced=False)
+    assert device_id == 0 and local_id == 0, f"Expected (0, 0), got ({device_id}, {local_id})"
+
+    # Token 256 -> device 1, offset 0
+    device_id, local_id = global_to_local_token_id(chunk_size_sequential, sp_factor, seq_len, is_balanced=False)
+    assert device_id == 1 and local_id == 0, f"Expected (1, 0), got ({device_id}, {local_id})"
+
+    # Token 512 -> device 2, offset 0
+    device_id, local_id = global_to_local_token_id(2 * chunk_size_sequential, sp_factor, seq_len, is_balanced=False)
+    assert device_id == 2 and local_id == 0, f"Expected (2, 0), got ({device_id}, {local_id})"
+
+    # Last token (1023) -> device 3, offset 255
+    device_id, local_id = global_to_local_token_id(seq_len - 1, sp_factor, seq_len, is_balanced=False)
+    assert (
+        device_id == 3 and local_id == chunk_size_sequential - 1
+    ), f"Expected (3, {chunk_size_sequential - 1}), got ({device_id}, {local_id})"
+
+    logger.info("test_global_to_local_token_id passed!")

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -32,7 +32,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_route
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
-from models.demos.deepseek_v3_d_p.utils.test_utils import save_norm_output
+from models.demos.deepseek_v3_d_p.utils.test_utils import save_intermediate_output
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     ABC_1K_PATH,
     PROMPTS_PATH,
@@ -57,6 +57,7 @@ SEQ_LEN_25K = 25 * 1024
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="Requires Blackhole.")
+@pytest.mark.parametrize("temperature", [[0.5]], ids=["temp_sweep"])
 @pytest.mark.parametrize("return_kv_cache", [True], ids=["kv_cache"])
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize(
@@ -127,6 +128,7 @@ def test_prefill_transformer(
     input_source,
     use_pretrained,
     return_kv_cache,
+    temperature,
     weight_cache_path,
     is_ci_env,
     is_ci_v2_env,
@@ -355,49 +357,50 @@ def test_prefill_transformer(
     do_return_kv = pcc_validation and return_kv_cache
     for i in range(num_iterations):
         logger.info(f"Starting iteration: {i}")
-        result = transformer(tt_tokens, tt_kvpe_cache, return_intermediates=pcc_validation, read_profiler=True)
+        first_token_id, first_token_prob, tt_intermediates = transformer(
+            tt_tokens,
+            tt_kvpe_cache,
+            return_intermediates=pcc_validation,
+            read_profiler=True,
+            temperature=temperature,
+        )
         logger.info(f"Starting completion sync on iteration: {i}")
         ttnn.synchronize_device(mesh_device)
-
     profiler.end("tt_forward")
-    logger.info("Forward pass completed successfully")
+    logger.info(f"Forward pass completed. First token: ID={first_token_id}, prob={first_token_prob:.4f}")
 
+    # --- Save intermediate outputs ---
     if pcc_validation:
-        tt_output, tt_snapshots = result
-    else:
-        tt_output = result
+        assert tt_intermediates is not None, "Expected intermediates dict"
+        test_params = {
+            "mesh_shape": mesh_shape,
+            "isl_total": isl_total,
+            "isl_per_chip": isl_per_chip,
+            "num_layers": num_layers,
+            "n_routed_experts": n_routed_experts,
+            "capacity_factor": capacity_factor,
+            "gate_fallback_mode": gate_fallback_mode,
+            "use_pretrained": use_pretrained,
+            "input_source": input_source,
+            "topology": str(topology),
+            "num_links": num_links,
+            "emb_dim": emb_dim,
+            "sp_factor": sp_factor,
+            "tp_factor": tp_factor,
+        }
 
-    # --- Validate output shape ---
-    expected_per_device_shape = [1, 1, isl_per_chip, emb_dim // tp_factor]
-    output_shape = list(tt_output.shape)
-    assert (
-        output_shape == expected_per_device_shape
-    ), f"Output shape mismatch: got {output_shape}, expected {expected_per_device_shape}"
-    logger.info(f"Output shape: {output_shape} (matches expected)")
+        assert "norm" in tt_intermediates, "Expected 'norm' in intermediates"
+        save_intermediate_output(
+            tensor=tt_intermediates["norm"],
+            name="norm",
+            test_params=test_params,
+        )
 
-    # --- Save final norm output ---
-    if pcc_validation:
-        final_norm_label, final_norm_tensor = tt_snapshots[-1]
-        assert final_norm_label == "norm", f"Expected last snapshot to be 'norm', got '{final_norm_label}'"
-
-        save_norm_output(
-            norm_tensor=final_norm_tensor,
-            test_params={
-                "mesh_shape": mesh_shape,
-                "isl_total": isl_total,
-                "isl_per_chip": isl_per_chip,
-                "num_layers": num_layers,
-                "n_routed_experts": n_routed_experts,
-                "capacity_factor": capacity_factor,
-                "gate_fallback_mode": gate_fallback_mode,
-                "use_pretrained": use_pretrained,
-                "input_source": input_source,
-                "topology": str(topology),
-                "num_links": num_links,
-                "emb_dim": emb_dim,
-                "sp_factor": sp_factor,
-                "tp_factor": tp_factor,
-            },
+        assert "lm_head" in tt_intermediates, "Expected 'lm_head' in intermediates"
+        save_intermediate_output(
+            tensor=tt_intermediates["lm_head"],
+            name="lm_head",
+            test_params=test_params,
         )
 
     # --- PCC check ---
@@ -420,8 +423,16 @@ def test_prefill_transformer(
         # else: already computed by load_and_compute_layer_by_layer()
 
         # Per-stage PCC comparison
+        # ref_snapshots is a list of tensors: [embed, layer_0, ..., layer_N, norm, lm_head]
+        # tt_intermediates is a dict with keys: "embed", "layer_0", ..., "layer_N", "norm", "lm_head", "first_token"
         pcc_results = []
-        for (label, tt_host), ref_host in zip(tt_snapshots, ref_snapshots):
+        ref_labels = ["embed"] + [f"layer_{i}" for i in range(num_layers)] + ["norm", "lm_head"]
+        for label, ref_host in zip(ref_labels, ref_snapshots):
+            if label not in tt_intermediates:
+                logger.error(f"{label:<20s}  Missing from TT intermediates")
+                pcc_results.append((label, -1.0))
+                continue
+            tt_host = tt_intermediates[label]
             try:
                 _, pcc = comp_pcc(ref_host.float(), tt_host.float())
                 logger.debug(f"{label:<20s}  PCC = {pcc:.6f}")
@@ -471,6 +482,35 @@ def test_prefill_transformer(
             if pcc <= threshold:
                 failures.append((label, pcc))
         logger.info(f"{'='*50}")
+
+        # Log first token info (returned value is for first temperature in list)
+        try:
+            tok = request.getfixturevalue("tokenizer")
+        except Exception:
+            tok = None
+
+        # Decode token to string
+        token_text = tok.decode([first_token_id]) if tok else "N/A"
+        first_temp = temperature[0] if isinstance(temperature, list) else temperature
+        logger.info(
+            f"First Token: ID={first_token_id} [{repr(token_text)}] prob={first_token_prob*100:.1f}% temp={first_temp}"
+        )
+
+        # Log all temperature results from intermediates
+        if tt_intermediates and "first_token" in tt_intermediates:
+            for result in tt_intermediates["first_token"]:
+                tid = result["token_id"]
+                tprob = result["probability"]
+                ttemp = result["temperature"]
+                ttext = tok.decode([tid]) if tok else "N/A"
+                logger.debug(f"First Token: ID={tid} [{repr(ttext)}] prob={tprob*100:.1f}% temp={ttemp}")
+                # Print top5
+                if "top5" in result:
+                    for i, t5 in enumerate(result["top5"]):
+                        t5_id = t5["token_id"]
+                        t5_prob = t5["probability"]
+                        t5_text = tok.decode([t5_id]) if tok else "N/A"
+                        logger.debug(f"  top{i+1}: ID={t5_id} [{repr(t5_text)}] prob={t5_prob*100:.1f}%")
 
         # Store failures for deferred check (after timing report)
         has_pcc_failures = len(failures) > 0

--- a/models/demos/deepseek_v3_d_p/tests/test_tokenizer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_tokenizer.py
@@ -58,18 +58,24 @@ def test_tokenize_prompt_to_chat_template(tokenizer):
 @pytest.mark.parametrize(
     "input_path",
     [
-        Path("/tmp/r1/pretrained_abc_1k_isl1024_layers61_experts256.pt"),
+        # Path("/tmp/r1/pretrained_abc_1k_isl1024_layers61_experts256.pt"),
         Path(
             "/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Reference-prefill/pretrained_abc_1k_isl1024_layers61_experts256.pt"
         ),
         Path(
             "/workspace/ds_output_all_sources_new_/norm_20260415_114721_mesh8x4_isl1024_L61_e256_cf32_gatehost_all_pretrained_abc_1k.pt"
         ),
+        Path(
+            "/tmp/ds_output_all_sources_new_ndshard/norm_20260421_061041_mesh8x4_isl1024_L61_e256_cf32_gatehost_all_pretrained_abc_1k.pt"
+        ),
+        Path(
+            "/tmp/ds_output_all_sources_new_ndshard/norm_20260421_150333_mesh8x4_isl1024_L61_e256_cf32_gatehost_all_pretrained_abc_1k.pt"
+        ),
     ],
 )
 def test_first_token_from_reference(input_path, model_path, config_only, tokenizer):
     # Use weights_only=False since this is a trusted local file with custom objects
-    logger.info(f"{input_path=}")
+    logger.warning(f"{input_path=}")
     if not input_path.exists():
         pytest.skip(f"Reference artifact not found: {input_path}")
     data = torch.load(input_path, weights_only=False)
@@ -133,21 +139,22 @@ def test_first_token_from_reference(input_path, model_path, config_only, tokeniz
         return probs.div_(torch.empty_like(probs).exponential_(1)).argmax(dim=-1)
 
     index = -1  # Last token
-    for temperature in [0.0, 0.5, 1]:
-        first_token = sample(logits=logits[index].clone(), temperature=temperature)
-        token_text = tokenizer.decode([first_token.item()])
-        logger.info(f"{index} First token (temperature={temperature}): {first_token.item()} -> {repr(token_text)}")
-
-    last_logit = logits[-1, :].clone()
+    last_logit = logits[index, :].clone()
     top_k = 5
-    top_logits, top_indices = torch.topk(last_logit, top_k, dim=-1)
-    probs = torch.softmax(last_logit, dim=-1)
 
-    for i, (token_id, logit_value) in enumerate(zip(top_indices.tolist(), top_logits.tolist())):
-        token_text = tokenizer.decode([token_id])
-        prob = probs[token_id].item()
+    for temperature in [0.0, 0.5, 1.0]:
+        # Sample token
+        first_token = sample(logits=last_logit.clone(), temperature=temperature)
+        token_text = tokenizer.decode([first_token.item()])
+        logger.info(f"First token (temp={temperature}): ID={first_token.item()} [{repr(token_text)}]")
 
-        logger.info(
-            f"{i+1}. Token ID: {token_id:6d} | Logit: {logit_value:8.4f} | "
-            f"Prob: {prob:8.6f} | Text: {repr(token_text)}"
-        )
+        # Compute temperature-scaled probabilities
+        scaled_logits = last_logit / max(temperature, 1e-5)
+        probs = torch.softmax(scaled_logits, dim=-1)
+
+        # Get top-5 by probability (after temperature scaling)
+        top_probs, top_indices = torch.topk(probs, top_k, dim=-1)
+
+        for i, (token_id, prob) in enumerate(zip(top_indices.tolist(), top_probs.tolist())):
+            token_text = tokenizer.decode([token_id])
+            logger.info(f"  top{i+1}: ID={token_id:6d} | Prob: {prob*100:6.2f}% | Text: {repr(token_text)}")

--- a/models/demos/deepseek_v3_d_p/tt/mla/utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/utils.py
@@ -64,31 +64,47 @@ def reverse_reorder_tensor_chunks(tensor: torch.Tensor, chunk_order: list[int], 
     return reorder_tensor_chunks(tensor, inverse_order, seq_dim)
 
 
-def global_to_local_token_id(global_token_id: int, sp_factor: int, seq_len: int) -> tuple[int, int]:
-    """Convert a global token ID to a device ID and local token ID under zigzag (striped) attention.
-
-    In zigzag attention, the sequence is split into 2*sp_factor chunks. Device k holds
-    chunks k and (2*sp_factor - 1 - k), balancing causal attention workload across devices.
+def global_to_local_token_id(
+    global_token_id: int,
+    sp_factor: int,
+    seq_len: int,
+    is_balanced: bool = True,
+) -> tuple[int, int]:
+    """Convert a global token ID to a device ID and local token ID.
 
     Args:
         global_token_id: The global token position across the full sequence.
         sp_factor: Number of devices in the sequence parallel group.
         seq_len: Total sequence length across all devices.
+        is_balanced: If True (default), uses zigzag (striped) attention where the sequence
+            is split into 2*sp_factor chunks and device k holds chunks k and (2*sp_factor - 1 - k),
+            balancing causal attention workload. If False, uses sequential distribution where
+            the sequence is split into sp_factor chunks and device k holds chunk k.
 
     Returns:
         A tuple of (device_id, local_token_id).
     """
-    num_chunks = 2 * sp_factor
-    chunk_size = seq_len // num_chunks
-    chunk_id = global_token_id // chunk_size
-    offset_in_chunk = global_token_id % chunk_size
+    if is_balanced:
+        # Zigzag/balanced: num_chunks = 2 * sp_factor
+        num_chunks = 2 * sp_factor
+        chunk_size = seq_len // num_chunks
+        chunk_id = global_token_id // chunk_size
+        offset_in_chunk = global_token_id % chunk_size
 
-    if chunk_id < sp_factor:
+        if chunk_id < sp_factor:
+            device_id = chunk_id
+            local_token_id = offset_in_chunk
+        else:
+            device_id = num_chunks - 1 - chunk_id
+            local_token_id = chunk_size + offset_in_chunk
+    else:
+        # Sequential: num_chunks = sp_factor
+        num_chunks = sp_factor
+        chunk_size = seq_len // num_chunks
+        chunk_id = global_token_id // chunk_size
+        offset_in_chunk = global_token_id % chunk_size
         device_id = chunk_id
         local_token_id = offset_in_chunk
-    else:
-        device_id = num_chunks - 1 - chunk_id
-        local_token_id = chunk_size + offset_in_chunk
 
     return device_id, local_token_id
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py
@@ -28,6 +28,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
+from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 
@@ -88,6 +89,10 @@ class TtPrefillTransformer(LightweightModule):
 
         # Final norm
         if not TtDistributedRmsNorm.check_cache_complete(cache_path, "norm"):
+            return False
+
+        # LM head
+        if not TtLMHead.check_cache_complete(cache_path):
             return False
 
         logger.info(f"TTNN cache complete at {cache_path} ({num_layers} layers)")
@@ -192,6 +197,18 @@ class TtPrefillTransformer(LightweightModule):
         # --- RoPE (computed once, reused across all layers) ---
         self.rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
 
+        # --- LM Head ---
+        self.lm_head = TtLMHead(
+            mesh_device=mesh_device,
+            emb_dim=config.hidden_size,
+            vocab_size=config.vocab_size,
+            torch_weight=state_dict.get("lm_head_weight"),  # None if cache exists
+            num_links=num_links,
+            topology=topology,
+            is_balanced=is_balanced,
+            weight_cache_path=weight_cache_path,
+        )
+
         logger.info(f"TtPrefillTransformer construction complete ({num_layers} layers)")
 
     def _to_host(self, tt_tensor):
@@ -210,9 +227,10 @@ class TtPrefillTransformer(LightweightModule):
         kvpe_cache: ttnn.Tensor,
         return_intermediates: bool = False,
         read_profiler: bool = False,
+        temperature: float | list[float] = 0.0,
     ):
         """
-        Forward pass: embed -> [block x N] -> norm.
+        Forward pass: embed -> [block x N] -> norm -> lm_head.
 
         Args:
             token_ids: [1, 1, seq_len_per_chip] uint32, SP-sharded
@@ -220,22 +238,26 @@ class TtPrefillTransformer(LightweightModule):
                         each layer writes to its own slot via cache_layer_idx
             return_intermediates: if True, sync + snapshot to host after each stage
             read_profiler: if True, read TTNN profiler after each layer to avoid profiler buffer overflows
+            temperature: Temperature for sampling. Can be a single float or list of floats.
+                        If list, returns first temperature result but stores all in intermediates.
 
         Returns:
-            If return_intermediates=False:
-                tt_output: [1, 1, seq_per_chip, emb_dim/tp] TILE_LAYOUT
-            If return_intermediates=True:
-                (tt_output, intermediates)
+            Tuple of (first_token_id, first_token_prob, intermediates_dict or None)
+            - first_token_id: sampled token ID (for first temperature if list provided)
+            - first_token_prob: probability of sampled token (for first temperature if list provided)
+            - intermediates: dict with keys like "embed", "layer_0", "norm", "lm_head", "first_token"
+                            where "first_token" is a list of results for each temperature
+                            (None if return_intermediates=False)
         """
         rope_tensors = self.rope_setup.get_rope_tensors(self.seq_len)
-        intermediates = [] if return_intermediates else None
+        intermediates = {} if return_intermediates else None
 
         h = self.embed(token_ids)  # [1, seq_per_chip, emb_dim/tp]
         h = ttnn.unsqueeze_to_4D(h)  # [1, 1, seq_per_chip, emb_dim/tp]
 
         if return_intermediates:
             ttnn.synchronize_device(self.mesh_device)
-            intermediates.append(("embed", self._to_host(h)))
+            intermediates["embed"] = self._to_host(h)
 
         for i, layer in enumerate(self.layers):
             signpost(f"forward_layer_{i}_start")
@@ -243,7 +265,7 @@ class TtPrefillTransformer(LightweightModule):
             signpost(f"forward_layer_{i}_end")
             if return_intermediates:
                 ttnn.synchronize_device(self.mesh_device)
-                intermediates.append((f"layer_{i}", self._to_host(h)))
+                intermediates[f"layer_{i}"] = self._to_host(h)
             if read_profiler:
                 ttnn.ReadDeviceProfiler(self.mesh_device)
 
@@ -251,6 +273,74 @@ class TtPrefillTransformer(LightweightModule):
 
         if return_intermediates:
             ttnn.synchronize_device(self.mesh_device)
-            intermediates.append(("norm", self._to_host(h)))
-            return h, intermediates
-        return h
+            intermediates["norm"] = self._to_host(h)
+
+        # LM Head: compute logits and sample first token
+        global_token_id = self.seq_len - 1  # Last token; assuming padding front/left
+        logits, (device_id, token_offset) = self.lm_head(h, global_token_id)
+
+        logits_host = self.lm_head.logit_to_host(logits)
+        first_token_logits = self.lm_head.select_first_token(logits_host, device_id, token_offset)
+
+        # Handle temperature as float or list
+        temperatures = temperature if isinstance(temperature, list) else [temperature]
+
+        # Sample for all temperatures
+        sweep_results = []
+        for temp in temperatures:
+            token_id, token_prob, top5 = self._sample_token(first_token_logits.clone(), temp)
+            sweep_results.append(
+                {
+                    "token_id": token_id,
+                    "probability": token_prob,
+                    "temperature": temp,
+                    "device_id": device_id,
+                    "token_offset": token_offset,
+                    "top5": top5,
+                }
+            )
+
+        # Return values are for first temperature
+        first_token_id = sweep_results[0]["token_id"]
+        first_token_prob = sweep_results[0]["probability"]
+
+        logger.debug(f"[TtPrefillTransformer.forward] {logits.shape}")
+        logger.debug(f"[TtPrefillTransformer.forward] {logits_host.shape}")
+        logger.debug(f"[TtPrefillTransformer.forward] {first_token_logits.shape}")
+        logger.debug(
+            f"[TtPrefillTransformer.forward] {first_token_id=}, {first_token_prob=:.4f} {device_id=}, {token_offset=}"
+        )
+
+        if return_intermediates:
+            intermediates["lm_head"] = logits_host
+            intermediates["first_token"] = sweep_results
+
+        return first_token_id, first_token_prob, intermediates
+
+    def _sample_token(self, logits: torch.Tensor, temperature: float = 1.0) -> tuple[int, float, list]:
+        """
+        Sample token from logits with temperature scaling.
+
+        Uses Gumbel-softmax trick for sampling (same as DeepSeek reference).
+        https://github.com/deepseek-ai/DeepSeek-V3/blob/main/inference/generate.py
+
+        Args:
+            logits: Logits tensor for a single token position
+            temperature: Temperature for scaling (0.0 = argmax)
+
+        Returns:
+            Tuple of (sampled_token_id, probability, top5_list)
+            where top5_list is [{token_id, probability}, ...]
+        """
+        logits = logits / max(temperature, 1e-5)
+        probs = torch.softmax(logits.float(), dim=-1)
+
+        # Get top-5 tokens
+        top5_probs, top5_ids = torch.topk(probs.flatten(), k=5)
+        top5 = [{"token_id": tid.item(), "probability": tprob.item()} for tid, tprob in zip(top5_ids, top5_probs)]
+
+        # Gumbel-softmax trick for sampling (use non-in-place to preserve probs)
+        gumbel = probs / torch.empty_like(probs).exponential_(1)
+        sampled_id = gumbel.argmax(dim=-1)
+        prob = probs.flatten()[sampled_id.item()].item()
+        return sampled_id.item(), prob, top5

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_prefill_transformer.py
@@ -5,12 +5,10 @@
 """
 TtPrefillTransformer — multi-layer prefill model for DeepSeek V3.
 
-Composes: embed -> [block x N] -> norm
+Composes: embed -> [block x N] -> norm -> lm_head -> sample
 
 Equivalent to the reference Transformer class (models/demos/deepseek_v3/reference/deepseek/model.py:419)
 but targeting the TT prefill path with SP+TP parallelism.
-
-No LM head — returns hidden states after final norm.
 """
 
 import os
@@ -37,15 +35,12 @@ class TtPrefillTransformer(LightweightModule):
     """
     Multi-layer prefill transformer for DeepSeek V3.
 
-    Architecture: embed -> [TtPrefillBlock x num_layers] -> norm
+    Architecture: embed -> [TtPrefillBlock x num_layers] -> norm -> lm_head -> sample
 
     State dict keys:
         embed_weight:   torch.Tensor [vocab_size, emb_dim]
         norm_weight:    torch.Tensor [emb_dim]
         layers:         list[dict] — per-layer state dicts for TtPrefillBlock
-
-    Note: LM head (ColumnParallelLinear output projection) is not implemented yet.
-    TODO: Add LM head after https://github.com/tenstorrent/tt-metal/pull/41275 lands.
     """
 
     @staticmethod
@@ -280,6 +275,9 @@ class TtPrefillTransformer(LightweightModule):
         logits, (device_id, token_offset) = self.lm_head(h, global_token_id)
 
         logits_host = self.lm_head.logit_to_host(logits)
+        assert (
+            logits_host.shape[-1] == self.lm_head.vocab_size
+        ), f"Expected full vocab {self.lm_head.vocab_size}, got {logits_host.shape[-1]} — TP concat may be broken"
         first_token_logits = self.lm_head.select_first_token(logits_host, device_id, token_offset)
 
         # Handle temperature as float or list
@@ -332,10 +330,22 @@ class TtPrefillTransformer(LightweightModule):
             Tuple of (sampled_token_id, probability, top5_list)
             where top5_list is [{token_id, probability}, ...]
         """
-        logits = logits / max(temperature, 1e-5)
         probs = torch.softmax(logits.float(), dim=-1)
 
-        # Get top-5 tokens
+        # Get top-5 tokens (unscaled)
+        top5_probs, top5_ids = torch.topk(probs.flatten(), k=5)
+        top5 = [{"token_id": tid.item(), "probability": tprob.item()} for tid, tprob in zip(top5_ids, top5_probs)]
+
+        if temperature <= 0:
+            # Deterministic argmax — no Gumbel noise
+            sampled_id = probs.argmax(dim=-1)
+            prob = probs.flatten()[sampled_id.item()].item()
+            return sampled_id.item(), prob, top5
+
+        logits = logits / temperature
+        probs = torch.softmax(logits.float(), dim=-1)
+
+        # Recompute top-5 with temperature-scaled probs
         top5_probs, top5_ids = torch.topk(probs.flatten(), k=5)
         top5 = [{"token_id": tid.item(), "probability": tprob.item()} for tid, tprob in zip(top5_ids, top5_probs)]
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -279,7 +279,7 @@ class TtLMHead(LightweightModule):
         logger.debug(f"Created sharded LM head weight: {tt_weight.shape}")
         return tt_weight
 
-    def forward(self, x: ttnn.Tensor, global_token_id: int) -> tuple[ttnn.Tensor, int]:
+    def forward(self, x: ttnn.Tensor, global_token_id: int) -> tuple[ttnn.Tensor, tuple[int, int]]:
         """
         Forward pass: project hidden states to vocabulary logits.
 
@@ -288,9 +288,10 @@ class TtLMHead(LightweightModule):
             global_token_id: The global token position whose logits we need.
 
         Returns:
-            A tuple of:
-                - Logits tensor [dispatch_group_size, TILE_SIZE, vocab_size]
-                - Token offset within the output tile (index in dim 1 for the target token)
+            tuple[ttnn.Tensor, tuple[int, int]]:
+                - Logits tensor [dispatch_group_size, TILE_SIZE, vocab_size/tp]
+                - (device_id, token_offset): which SP device holds the target token
+                  and the index within the tile
         """
         logger.debug(f"[TtLMHead.forward] INPUT SHAPES:")
         logger.debug(f"  x.shape={x.shape}")
@@ -338,8 +339,8 @@ class TtLMHead(LightweightModule):
         output = ttnn.matmul(x_full, self.weight, compute_kernel_config=self.compute_kernel_config)
         logger.debug(f"[TtLMHead.forward] output (after matmul) shape: {output.shape}")
 
-        # output is logits [1,1, TILE_SIZE, vocab_size]
-        # fractured over SP; replicated over TP
+        # output is logits [1,1, TILE_SIZE, vocab_size/tp]
+        # fractured over SP; TP-sharded on vocab dim
         # the last logit/token is on device_id at token_offset within the tile
         return output, (device_id, token_offset)
 
@@ -350,14 +351,12 @@ class TtLMHead(LightweightModule):
             mesh_composer=ttnn.create_mesh_composer(
                 self.mesh_device,
                 config=ttnn.MeshComposerConfig(
-                    dims=(0, 1),
-                    mesh_shape_override=ttnn.MeshShape(
-                        self.mesh_device.shape[0], 1  # SP fractured
-                    ),  # Replicated across TP axis
+                    dims=(0, -1),  # SP fractured on dim 0, TP concat on vocab dim
+                    mesh_shape_override=ttnn.MeshShape(self.mesh_device.shape[0], self.mesh_device.shape[1]),
                 ),
             ),
         ).to(torch.bfloat16)
         return tt_logit_host
 
-    def select_first_token(self, tt_logit_host: ttnn.Tensor, device_id: int, token_offset: int) -> torch.Tensor:
-        return tt_logit_host[device_id, 0, token_offset, :].unsqueeze(0).unsqueeze(0)
+    def select_first_token(self, logit_host: torch.Tensor, device_id: int, token_offset: int) -> torch.Tensor:
+        return logit_host[device_id, 0, token_offset, :].unsqueeze(0).unsqueeze(0)

--- a/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_lm_head.py
@@ -15,6 +15,9 @@ Weight Sharding (across mesh columns):
       mesh_mapper dims=(None, -1)
 """
 
+from pathlib import Path
+from typing import Optional
+
 import torch
 from loguru import logger
 
@@ -42,17 +45,107 @@ class TtLMHead(LightweightModule):
         3. All-gather output across mesh columns → [dispatch_group_size, TILE_SIZE, vocab_size]
     """
 
+    @staticmethod
+    def check_cache_complete(cache_path: Path) -> bool:
+        """Check if LM head weight cache files exist."""
+        from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
+
+        if not pattern_exists("lm_head_weight*.tensorbin", "LMHead"):
+            logger.debug("TTNN cache missing: lm_head_weight")
+            return False
+        return True
+
+    @staticmethod
+    def _convert_and_cache_weight(
+        torch_weight: torch.Tensor | None,
+        emb_dim: int,
+        vocab_size: int,
+        mesh_device: ttnn.MeshDevice,
+        dtype: ttnn.DataType,
+        cache_path: Path | None,
+        device: ttnn.MeshDevice | None = None,
+    ) -> ttnn.Tensor | None:
+        """
+        Shared logic for converting LM head weight to ttnn with caching.
+
+        Args:
+            torch_weight: Weight tensor [vocab_size, emb_dim] in HF format.
+                          If None, creates empty tensor for cache-loading.
+            emb_dim: Embedding dimension
+            vocab_size: Vocabulary size
+            mesh_device: Mesh device (for mesh_mapper)
+            dtype: Data type
+            cache_path: Cache directory path
+            device: None for cache-only, mesh_device for cache+load
+
+        Returns:
+            ttnn.Tensor if device is not None, else None
+        """
+        if torch_weight is not None:
+            assert torch_weight.shape == (
+                vocab_size,
+                emb_dim,
+            ), f"Weight shape mismatch: got {torch_weight.shape}, expected ({vocab_size}, {emb_dim})"
+            # Transpose HF [vocab_size, emb_dim] to TTNN [emb_dim, vocab_size]
+            torch_weight = torch_weight.T.contiguous()
+        else:
+            # Empty tensor for cache loading
+            torch_weight = torch.empty(emb_dim, vocab_size)
+
+        mesh_mapper = ttnn.ShardTensor2dMesh(
+            mesh_device,
+            mesh_shape=mesh_device.shape,
+            dims=(None, -1),  # Shard vocab_size across TP axis (columns)
+        )
+
+        cache_file_name = str(cache_path / "lm_head_weight") if cache_path else None
+
+        tt_weight = ttnn.as_tensor(
+            torch_weight,
+            mesh_mapper=mesh_mapper,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            dtype=dtype,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG if device else None,
+            cache_file_name=cache_file_name,
+        )
+
+        if device is not None:
+            ttnn.synchronize_device(device)
+
+        if device is None:
+            del tt_weight
+            return None
+        else:
+            return tt_weight
+
+    @staticmethod
+    def build_ttnn_cache(
+        torch_weight: torch.Tensor,
+        vocab_size: int,
+        emb_dim: int,
+        mesh_device: ttnn.MeshDevice,
+        cache_path: Path,
+        dtype: ttnn.DataType = ttnn.bfloat16,
+    ):
+        """Build TTNN cache for LM head weight without device copy."""
+        TtLMHead._convert_and_cache_weight(
+            torch_weight, emb_dim, vocab_size, mesh_device, dtype, cache_path, device=None
+        )
+
     def __init__(
         self,
         mesh_device,
         emb_dim: int = DeepSeekV3Config.EMB_SIZE,
         vocab_size: int = DeepSeekV3Config.VOCAB_SIZE,
-        torch_weights: dict = None,
+        torch_weight: torch.Tensor = None,
         num_links: int = 1,
         topology: ttnn.Topology = ttnn.Topology.Ring,
         activations_dtype=ttnn.bfloat16,
         weights_dtype=ttnn.bfloat16,
         compute_kernel_config: ttnn.WormholeComputeKernelConfig = COMPUTE_KERNEL_CONFIG_HIFI2,
+        is_balanced: bool = False,
+        weight_cache_path: Optional[Path] = None,
     ):
         """
         Initialize TtLMHead module.
@@ -61,12 +154,16 @@ class TtLMHead(LightweightModule):
             mesh_device: TTNN mesh device
             emb_dim: Embedding dimension (default: 7168)
             vocab_size: Vocabulary size (default: 129280)
-            torch_weights: Optional dict with key 'weight' containing torch tensor [vocab_size, emb_dim]
+            torch_weight: Optional weight tensor [vocab_size, emb_dim].
+                          If None, loads from cache or creates random weight.
             num_links: Number of ethernet links to use for CCL (default: 1)
             topology: CCL topology - Linear or Ring (default: Ring)
             activations_dtype: Data type for activations (default: bfloat16)
             weights_dtype: Data type for weights (default: bfloat16)
             compute_kernel_config: Compute kernel configuration
+            is_balanced: If True, uses zigzag token mapping. If False (default),
+                         uses sequential mapping. Should match TtMLA's is_balanced.
+            weight_cache_path: Optional path to weight cache directory
         """
         super().__init__()
         self.mesh_device = mesh_device
@@ -79,15 +176,27 @@ class TtLMHead(LightweightModule):
         self.activations_dtype = activations_dtype
         self.weights_dtype = weights_dtype
         self.compute_kernel_config = compute_kernel_config
+        self.is_balanced = is_balanced
+        self.weight_cache_path = weight_cache_path
 
         logger.debug(f"Initializing TtLMHead with emb_dim={emb_dim}, vocab_size={vocab_size}")
         logger.debug(f"Mesh shape: {mesh_device.shape}, num_devices={self.num_devices}")
         logger.debug(f"CCL config: num_links={num_links}, topology={topology}")
+        logger.debug(f"is_balanced={is_balanced}, weight_cache_path={weight_cache_path}")
 
-        if torch_weights is not None:
+        if torch_weight is not None:
             logger.debug("Creating weight from provided torch tensor")
-            self.weight = self._create_sharded_weight_from_torch(
-                torch_weights["lm_head.weight"], dims=(None, -1), name="lm_head_weight", dtype=self.weights_dtype
+            self.weight = self._create_weight_from_torch(torch_weight)
+        elif weight_cache_path is not None:
+            logger.debug("Loading weight from cache")
+            self.weight = self._convert_and_cache_weight(
+                None,
+                self.emb_dim,
+                self.vocab_size,
+                self.mesh_device,
+                self.weights_dtype,
+                self.weight_cache_path,
+                device=self.mesh_device,
             )
         else:
             logger.debug("Creating random sharded weight")
@@ -146,6 +255,30 @@ class TtLMHead(LightweightModule):
         torch_weight = torch.randn(*shape, dtype=torch.float32)
         return self._to_sharded_ttnn(torch_weight, dims, name, dtype)
 
+    def _create_weight_from_torch(self, torch_weight: torch.Tensor) -> ttnn.Tensor:
+        """
+        Convert torch LM head weight to TP-sharded ttnn tensor.
+
+        Uses shared static method for conversion with caching.
+
+        Args:
+            torch_weight: [vocab_size, emb_dim] in HF format
+
+        Returns:
+            Sharded ttnn tensor: each TP device gets [emb_dim, vocab_size / tp_factor]
+        """
+        tt_weight = self._convert_and_cache_weight(
+            torch_weight,
+            self.emb_dim,
+            self.vocab_size,
+            self.mesh_device,
+            self.weights_dtype,
+            self.weight_cache_path,
+            device=self.mesh_device,
+        )
+        logger.debug(f"Created sharded LM head weight: {tt_weight.shape}")
+        return tt_weight
+
     def forward(self, x: ttnn.Tensor, global_token_id: int) -> tuple[ttnn.Tensor, int]:
         """
         Forward pass: project hidden states to vocabulary logits.
@@ -165,16 +298,21 @@ class TtLMHead(LightweightModule):
         # ========================================
         # Step 0: Extract the tile containing the target token
         # ========================================
-        # Convert global token ID to local token ID on this device using zigzag mapping.
-        seq_len_per_device = x.shape[1]
+        # Use negative indexing: seq_len is at dim -2, emb_dim at dim -1
+        seq_len_per_device = x.shape[-2]
         seq_len = seq_len_per_device * self.sp_factor
-        _, local_token_id = global_to_local_token_id(global_token_id, self.sp_factor, seq_len)
+
+        # Convert global token ID to local token ID on this device.
+        device_id, local_token_id = global_to_local_token_id(
+            global_token_id, self.sp_factor, seq_len, is_balanced=self.is_balanced
+        )
 
         # We only need logits for a single token, but matmul operates on tiles.
         # Find the tile-aligned start position that contains local_token_id.
         tile_start = (local_token_id // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
-        x = ttnn.narrow(x, dim=1, start=tile_start, length=ttnn.TILE_SIZE)
-        logger.debug(f"[TtLMHead.forward] After narrow (tile_start={tile_start}): x.shape={x.shape}")
+        token_offset = local_token_id % ttnn.TILE_SIZE
+        x = ttnn.narrow(x, dim=-2, start=tile_start, length=ttnn.TILE_SIZE)
+        logger.debug(f"[TtLMHead.forward] After narrow ({local_token_id=} {tile_start=}): {x.shape=} {token_offset=}")
 
         # ========================================
         # Step 1: All-gather x to get full emb_dim (replicated across TP axis)
@@ -200,5 +338,26 @@ class TtLMHead(LightweightModule):
         output = ttnn.matmul(x_full, self.weight, compute_kernel_config=self.compute_kernel_config)
         logger.debug(f"[TtLMHead.forward] output (after matmul) shape: {output.shape}")
 
-        token_offset = local_token_id % ttnn.TILE_SIZE
-        return output, token_offset
+        # output is logits [1,1, TILE_SIZE, vocab_size]
+        # fractured over SP; replicated over TP
+        # the last logit/token is on device_id at token_offset within the tile
+        return output, (device_id, token_offset)
+
+    def logit_to_host(self, tt_logit: ttnn.Tensor) -> torch.Tensor:
+        ttnn.synchronize_device(self.mesh_device)  # ensure all computation is done before copying to host
+        tt_logit_host = ttnn.to_torch(
+            tt_logit,
+            mesh_composer=ttnn.create_mesh_composer(
+                self.mesh_device,
+                config=ttnn.MeshComposerConfig(
+                    dims=(0, 1),
+                    mesh_shape_override=ttnn.MeshShape(
+                        self.mesh_device.shape[0], 1  # SP fractured
+                    ),  # Replicated across TP axis
+                ),
+            ),
+        ).to(torch.bfloat16)
+        return tt_logit_host
+
+    def select_first_token(self, tt_logit_host: ttnn.Tensor, device_id: int, token_offset: int) -> torch.Tensor:
+        return tt_logit_host[device_id, 0, token_offset, :].unsqueeze(0).unsqueeze(0)

--- a/models/demos/deepseek_v3_d_p/utils/test_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/test_utils.py
@@ -50,22 +50,26 @@ def get_input_mem_config(config, mesh_shape):
     )
 
 
-def save_norm_output(
-    norm_tensor: torch.Tensor,
+def save_intermediate_output(
+    tensor: torch.Tensor,
+    name: str,
     test_params: dict,
     output_dir: Optional[Union[str, Path]] = None,
 ):
     """
-    Save final norm output to timestamped .pt file.
+    Save intermediate output tensor to timestamped .pt file.
 
     Args:
-        norm_tensor: Final norm output tensor
+        tensor: Output tensor to save
+        name: Name/type of output (e.g., "norm", "lm_head")
         test_params: Dict with all test parameters (mesh_shape, isl_total, num_layers, etc.)
-        output_dir: Output directory (default: /tmp/norm_outputs or NORM_OUTPUT_DIR env var)
+        output_dir: Output directory (default: /tmp/{name}_outputs or {NAME}_OUTPUT_DIR env var)
     """
     # Get output directory
     if output_dir is None:
-        output_dir = Path(os.getenv("NORM_OUTPUT_DIR", "/tmp/norm_outputs"))
+        env_var = f"{name.upper()}_OUTPUT_DIR"
+        default_dir = f"/tmp/{name}_outputs"
+        output_dir = Path(os.getenv(env_var, default_dir))
     else:
         output_dir = Path(output_dir)
 
@@ -82,7 +86,7 @@ def save_norm_output(
     # Build filename
     mesh_shape = test_params["mesh_shape"]
     filename = (
-        f"norm_{timestamp}_"
+        f"{name}_{timestamp}_"
         f"mesh{mesh_shape[0]}x{mesh_shape[1]}_"
         f"isl{test_params['isl_total']}_"
         f"L{test_params['num_layers']}_"
@@ -98,13 +102,13 @@ def save_norm_output(
     # Save tensor with metadata
     torch.save(
         {
-            "norm_output": norm_tensor,
+            f"{name}_output": tensor,
             "metadata": test_params,
         },
         save_path,
     )
 
-    logger.info(f"✓ Saved final norm output to: {save_path}")
-    logger.info(f"  Shape: {norm_tensor.shape}, Mean: {norm_tensor.mean():.6f}, Std: {norm_tensor.std():.6f}")
+    logger.info(f"✓ Saved {name} output to: {save_path}")
+    logger.info(f"  Shape: {tensor.shape}, Mean: {tensor.mean():.6f}, Std: {tensor.std():.6f}")
 
     return save_path

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -543,6 +543,7 @@ def load_and_compute_layer_by_layer(
     if compute_reference:
         norm_with_prefix = {f"norm.{k}": v for k, v in norm_dequant.items()}
         hf_model.load_state_dict(norm_with_prefix, strict=False)
+        logger.debug(f"[norm] h_ref {h_ref.dtype=}, norm_weight dtype={norm_dequant['weight'].dtype}")
         with torch.no_grad():
             h_ref = hf_model.norm(h_ref)
         ref_snapshots.append(h_ref)
@@ -570,9 +571,10 @@ def load_and_compute_layer_by_layer(
 
     if compute_reference:
         # Apply lm_head projection: logits = h_ref @ lm_head_weight.T
+        logger.debug(f"[lm_head] h_ref {h_ref.dtype=}, lm_head_weight.dtype={lm_head_dequant['weight'].dtype}")
         lm_head_weight = lm_head_dequant["weight"].to(torch.bfloat16)
         with torch.no_grad():
-            h_ref_lm = torch.nn.functional.linear(h_ref, lm_head_weight)
+            h_ref_lm = torch.nn.functional.linear(h_ref.to(torch.bfloat16), lm_head_weight)
         ref_snapshots.append(h_ref_lm)
         del lm_head_weight
 

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -344,6 +344,7 @@ def load_and_compute_layer_by_layer(
     from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
     from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_block import TtPrefillBlock
     from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
+    from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
     from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 
     if gate_fallback_mode is None:
@@ -561,6 +562,34 @@ def load_and_compute_layer_by_layer(
         lazy_sd.evict(k)
     del norm_sd, norm_dequant
     gc.collect()
+
+    # --- Process LM Head ---
+    logger.info("Processing lm_head...")
+    lm_head_sd = sub_state_dict(lazy_sd, "lm_head.")
+    lm_head_dequant = dequantize_state_dict(lm_head_sd, config)
+
+    if compute_reference:
+        # Apply lm_head projection: logits = h_ref @ lm_head_weight.T
+        lm_head_weight = lm_head_dequant["weight"].to(torch.bfloat16)
+        with torch.no_grad():
+            h_ref_lm = torch.nn.functional.linear(h_ref, lm_head_weight)
+        ref_snapshots.append(h_ref_lm)
+        del lm_head_weight
+
+    if build_ttnn_cache:
+        TtLMHead.build_ttnn_cache(
+            torch_weight=lm_head_dequant["weight"],
+            vocab_size=config.vocab_size,
+            emb_dim=config.hidden_size,
+            mesh_device=mesh_device,
+            cache_path=weight_cache_path,
+        )
+
+    for k in lm_head_sd.keys():
+        lazy_sd.evict(k)
+    del lm_head_sd, lm_head_dequant
+    gc.collect()
+    _log_memory("After lm_head processed and cleared")
 
     # Cleanup
     lazy_sd.close()


### PR DESCRIPTION
### Summary

Integrates LM head projection and token sampling into `TtPrefillTransformer`, so the forward pass now returns a sampled token ID and probability instead of raw hidden states.

**Key changes:**
- `TtPrefillTransformer.forward()` now runs the full pipeline: embed → layers → norm → lm_head → sample, returning `(first_token_id, first_token_prob, intermediates)`
- `TtLMHead` enhanced with weight caching (`build_ttnn_cache` / `check_cache_complete`), balanced vs sequential token mapping (`is_balanced`), and host-side logit extraction (`logit_to_host`, `select_first_token`)
- `global_to_local_token_id` extended with `is_balanced` parameter for sequential (non-zigzag) token distribution
- Temperature sweep support: pass a list of temperatures to get sampling results for each
- `save_norm_output` generalized to `save_intermediate_output` (supports norm, lm_head, etc.)
- Reference path (`load_and_compute_layer_by_layer`) updated to compute and cache LM head reference outputs
- New `test_lm_head_cache.py` for cold/warm cache validation; existing tests updated to match new APIs

### Notes for reviewers

- The `TtPrefillTransformer.forward()` return type changed from `tt_output` / `(tt_output, intermediates)` to `(token_id, prob, intermediates_or_None)` — callers need updating
- `TtLMHead.__init__` parameter renamed from `torch_weights` (dict) to `torch_weight` (single tensor)
- Intermediates changed from list of tuples to dict keyed by stage name

**DeepSeek Prefill CI:**
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-lm-head-and-sampling-rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-lm-head-and-sampling-rebase)