### PR TITLE
Optimize bcast setup/syncs for improved back to back and single token decode

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -500,7 +500,9 @@ void kernel_main() {
         get_named_compile_time_arg_val("bcast_is_root"),
         get_named_compile_time_arg_val("bcast_chunk_size_bytes"),
         get_named_compile_time_arg_val("bcast_last_chunk_size_bytes"),
-        get_named_compile_time_arg_val("bcast_num_chunks")>;
+        get_named_compile_time_arg_val("bcast_num_chunks"),
+        get_named_compile_time_arg_val("rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("rmsnorm_num_tiles")>;
 
     deepseek_b1_ops::Broadcast::WriterArgs bcast_args{};
 
@@ -1382,12 +1384,13 @@ void kernel_main() {
             {
                 DeviceZoneScopedN("CCL_BROADCAST");
                 deepseek_b1_ops::Broadcast::Op<BcastCTArgs, Core::is_input_core> bcast;
-                bcast(bcast_args);
+                bcast.open_connections(bcast_args);
+                bcast.run(bcast_args);
             }
         }
 
 #if defined(COMPILE_FOR_NCRISC)
-        if constexpr (Core::is_input_core) {
+        if constexpr (Core::is_input_core && Core::skip_ccl) {
             // Gamma CBs are already set up by NCRISC via setup_sharded_buffer
             constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
             constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
@@ -1403,10 +1406,10 @@ void kernel_main() {
         }
 
         if constexpr (!Core::is_input_core) {
-            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
-            unified_kernels::sync_riscs_enter(ccl_sync_sem);
-            unified_kernels::sync_riscs_exit(ccl_sync_sem);
+            volatile tt_l1_ptr uint32_t* risc_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("risc_sync_semaphore_addr"));
+            unified_kernels::sync_riscs_enter<true, false>(risc_sync_sem);
+            unified_kernels::sync_riscs_exit<true>(risc_sync_sem);
         }
 
         // TODO: These can be moved into the skip_attention block below now that we have the metadata mcast.
@@ -1425,10 +1428,27 @@ void kernel_main() {
         }
 
         if constexpr (Core::is_input_core) {
-            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
-            unified_kernels::sync_riscs_enter(ccl_sync_sem);
-            unified_kernels::sync_riscs_exit(ccl_sync_sem);
+            volatile tt_l1_ptr uint32_t* risc_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("risc_sync_semaphore_addr"));
+            unified_kernels::sync_riscs_enter<true, false>(risc_sync_sem);
+            unified_kernels::sync_riscs_exit<true>(risc_sync_sem);
+#ifdef COMPILE_FOR_NCRISC
+            constexpr uint32_t sdpa_forwarder0_noc_x = get_named_compile_time_arg_val("sdpa_forwarder0_noc_x");
+            constexpr uint32_t sdpa_forwarder0_noc_y = get_named_compile_time_arg_val("sdpa_forwarder0_noc_y");
+            constexpr uint32_t sdpa_forwarder1_noc_x = get_named_compile_time_arg_val("sdpa_forwarder1_noc_x");
+            constexpr uint32_t sdpa_forwarder1_noc_y = get_named_compile_time_arg_val("sdpa_forwarder1_noc_y");
+            constexpr uint32_t ccl_sender_noc_x = get_named_compile_time_arg_val("ccl_sender_noc_x");
+            constexpr uint32_t ccl_sender_noc_y = get_named_compile_time_arg_val("ccl_sender_noc_y");
+            constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore_addr");
+            uint64_t ccl_sync_sem_noc_addr =
+                get_noc_addr(sdpa_forwarder0_noc_x, sdpa_forwarder0_noc_y, ccl_sync_sem_addr);
+            noc_semaphore_inc(ccl_sync_sem_noc_addr, 2);
+            ccl_sync_sem_noc_addr = get_noc_addr(sdpa_forwarder1_noc_x, sdpa_forwarder1_noc_y, ccl_sync_sem_addr);
+            noc_semaphore_inc(ccl_sync_sem_noc_addr, 2);
+            ccl_sync_sem_noc_addr = get_noc_addr(ccl_sender_noc_x, ccl_sender_noc_y, ccl_sync_sem_addr);
+            noc_semaphore_inc(ccl_sync_sem_noc_addr, 2);
+            noc_async_atomic_barrier();
+#endif
         }
 
         // SP position handling.
@@ -1639,6 +1659,12 @@ void kernel_main() {
             }
             if constexpr (Core::is_sdpa_forwarder_core) {
                 deepseek_b1_ops::SdpaReduceForwarder::Op<SdpaReduceForwarderCTArgs> sdpa_reduce_forwarder;
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+                volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+                noc_semaphore_wait_min(ccl_sync_sem, 1);
+                unified_kernels::semaphore_dec(ccl_sync_sem, 1);
+#endif
                 sdpa_reduce_forwarder(sdpa_reduce_forwarder_args);
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
                 constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore2_addr");
@@ -1733,10 +1759,14 @@ void kernel_main() {
             DeviceZoneScopedN("CCL_SENDER_WRITER");
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
             PacketHeaderPool::reset();
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+            noc_semaphore_wait_min(ccl_sync_sem, 1);
+            unified_kernels::semaphore_dec(ccl_sync_sem, 1);
             deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> ccl_writer;
             ccl_writer.open_connections(ccl_sender_args, false);
             deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
-            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+            ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                 get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
             noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("sdpa_fwd_num_cores"));
             allgather_sender.open_connections(allgather_transport_args, false);

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -189,10 +189,10 @@ class AttentionBlock:
 
     @staticmethod
     def get_num_semaphores(num_links_bcast=1, num_links_allreduce=1):
-        # Pipeline semaphores: mcast (4) + gather (2) + rope (1) + MLA (6) + post-SDPA fused (10) + SDPA (2) + ccl_sync (1) + ccl_sync2 (1) = 27
+        # Pipeline semaphores: mcast (4) + gather (2) + rope (1) + MLA (6) + post-SDPA fused (10) + SDPA (2) + ccl_sync (1) + ccl_sync2 (1) + risc_sync (1)= 28
         # Post-SDPA fused (10): gather2 noc0/noc1 (2) + mcast3 receiver (1) + gather3 noc0/noc1 (2)
         #                       + scatter_arrival (1) + sdpa fwd r1/r2 (2) + sdpa bwd r1/r2 (2)
-        pipeline_num_semaphores = 27
+        pipeline_num_semaphores = 28
         allreduce_num_semaphores = DeepseekMinimalAllReduce.get_num_semaphores(num_links=num_links_allreduce)
         bcast_num_semaphores = DeepseekMinimalBroadcast.get_num_semaphores(num_links=num_links_bcast)
         allgather_num_semaphores = 2  # handoff_sem + recv_sem
@@ -627,6 +627,8 @@ class AttentionBlock:
         sdpa_forwarder_grid = sdpa_forwarder_scratch_sample.memory_config().shard_spec.grid
         sdpa_forwarder_cores = list(ttnn.corerange_to_cores(sdpa_forwarder_grid, row_wise=True))
         num_sdpa_forwarder_cores = len(sdpa_forwarder_cores)
+        assert num_sdpa_forwarder_cores == 2, "num_sdpa_forwarder_cores must be 2"
+        sdpa_forwarder_noc_coords = [device.worker_core_from_logical_core(core) for core in sdpa_forwarder_cores]
 
         # Add SDPA cores to full grid (workers and forwarders both part of unified kernel)
         full_grid = full_grid.merge(sdpa_worker_grid).merge(sdpa_forwarder_grid)
@@ -737,6 +739,8 @@ class AttentionBlock:
         # ========================================================================
 
         # Semaphore IDs for mcast synchronization
+        risc_sync_semaphore_addr = ttnn.get_global_semaphore_address(attention_block_semaphores[semaphore_index])
+        semaphore_index += 1
         mcast_data_sender_semaphore_addr = ttnn.get_global_semaphore_address(
             attention_block_semaphores[semaphore_index]
         )
@@ -1861,9 +1865,14 @@ class AttentionBlock:
                 ("input_noc_coord_y", input_noc_coord.y),
                 ("ccl_sender_noc_x", ccl_sender_noc_core.x),
                 ("ccl_sender_noc_y", ccl_sender_noc_core.y),
+                ("sdpa_forwarder0_noc_x", sdpa_forwarder_noc_coords[0].x),
+                ("sdpa_forwarder0_noc_y", sdpa_forwarder_noc_coords[0].y),
+                ("sdpa_forwarder1_noc_x", sdpa_forwarder_noc_coords[1].x),
+                ("sdpa_forwarder1_noc_y", sdpa_forwarder_noc_coords[1].y),
                 # CCL sync semaphore
                 ("ccl_sync_semaphore_addr", ccl_sync_semaphore_addr),
                 ("ccl_sync_semaphore2_addr", ccl_sync_semaphore2_addr),
+                ("risc_sync_semaphore_addr", risc_sync_semaphore_addr),
             ]
         )
 
@@ -1900,6 +1909,7 @@ class AttentionBlock:
             # CCL sync semaphore
             ("ccl_sync_semaphore_addr", ccl_sync_semaphore_addr),
             ("ccl_sync_semaphore2_addr", ccl_sync_semaphore2_addr),
+            ("risc_sync_semaphore_addr", risc_sync_semaphore_addr),
         ]
 
         # Append AllReduceConfig BRISC CT args (writer on sender core)
@@ -1961,6 +1971,7 @@ class AttentionBlock:
             # CCL sync semaphore
             ("ccl_sync_semaphore_addr", ccl_sync_semaphore_addr),
             ("ccl_sync_semaphore2_addr", ccl_sync_semaphore2_addr),
+            ("risc_sync_semaphore_addr", risc_sync_semaphore_addr),
         ]
 
         # Append AllReduceConfig TRISC CT args (compute on receiver core)
@@ -2044,9 +2055,12 @@ class AttentionBlock:
         # contiguously. We pad the backing buffer to fit metadata after the activation
         # data, but the CB format (what RMSNorm reads) remains activation-only.
         activation_size = num_tiles * cb_page_size
-
         in_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            input_cb, ref_input_tensor, core_ranges=full_device_grid
+            input_cb,
+            ref_input_tensor,
+            address_offset=0,
+            total_size=activation_size,
+            core_ranges=full_device_grid,
         )
         in_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2056,7 +2070,6 @@ class AttentionBlock:
                 tile=tile_descriptor,
             )
         ]
-        in_cb_descriptor.total_size = activation_size
 
         # Keep broadcast writer backing address explicit for this fused path.
         input_cb_l1_addr = ttnn.get_cb_address(in_cb_descriptor)

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -139,6 +139,8 @@ void kernel_main() {
     // Named compile-time args: rmsnorm reader, mcast receiver, matmul reader, gather sender
     // Runtime args: []
     // ============================================================================
+    constexpr uint32_t persistent_mode = get_named_compile_time_arg_val("persistent_mode");
+    constexpr uint32_t persistent_next_iter_sem_addr = get_named_compile_time_arg_val("persistent_next_iter_sem_addr");
     constexpr uint32_t num_iterations = get_named_compile_time_arg_val("num_iterations");
     constexpr uint32_t mla_cb_config_l1_addr = get_named_compile_time_arg_val("mla_reconfig_cb_config_l1_addr");
     uint32_t tt_l1_ptr* mla_cb_config = reinterpret_cast<uint32_t tt_l1_ptr*>(mla_cb_config_l1_addr);
@@ -531,7 +533,9 @@ void kernel_main() {
         get_named_compile_time_arg_val("bcast_is_root"),
         get_named_compile_time_arg_val("bcast_chunk_size_bytes"),
         get_named_compile_time_arg_val("bcast_last_chunk_size_bytes"),
-        get_named_compile_time_arg_val("bcast_num_chunks")>;
+        get_named_compile_time_arg_val("bcast_num_chunks"),
+        get_named_compile_time_arg_val("rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("rmsnorm_num_tiles")>;
 
     deepseek_b1_ops::Broadcast::WriterArgs bcast_args{};
 
@@ -2233,12 +2237,24 @@ void kernel_main() {
             {
                 DeviceZoneScopedN("CCL_BROADCAST");
                 deepseek_b1_ops::Broadcast::Op<BcastCTArgs, Core::is_input_core> bcast;
-                bcast(bcast_args);
+                bcast.open_connections(bcast_args);
+#if defined(COMPILE_FOR_NCRISC)
+                if constexpr (persistent_mode) {
+                    constexpr bool is_bcast_root = get_named_compile_time_arg_val("bcast_is_root") == 1;
+                    if constexpr (is_bcast_root && Core::is_sender_core) {
+                        auto next_iter_sem =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(persistent_next_iter_sem_addr);
+                        noc_semaphore_wait(next_iter_sem, 1);
+                        noc_semaphore_set(next_iter_sem, 0);
+                    }
+                }
+#endif
+                bcast.run(bcast_args);
             }
         }
 
 #if defined(COMPILE_FOR_NCRISC)
-        if constexpr (Core::is_input_core) {
+        if constexpr (Core::is_input_core && Core::skip_ccl) {
             // Gamma CBs are already set up by NCRISC via setup_sharded_buffer
             constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
             constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
@@ -2255,10 +2271,28 @@ void kernel_main() {
         }
 
         if constexpr (!Core::is_input_core) {
-            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
-            unified_kernels::sync_riscs_enter(ccl_sync_sem);
-            unified_kernels::sync_riscs_exit(ccl_sync_sem);
+            volatile tt_l1_ptr uint32_t* risc_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("risc_sync_semaphore_addr"));
+            unified_kernels::sync_riscs_enter<true, false>(risc_sync_sem);
+            unified_kernels::sync_riscs_exit<true>(risc_sync_sem);
+        } else {
+#ifdef COMPILE_FOR_NCRISC
+            constexpr uint32_t sdpa_forwarder0_noc_x = get_named_compile_time_arg_val("sdpa_forwarder0_noc_x");
+            constexpr uint32_t sdpa_forwarder0_noc_y = get_named_compile_time_arg_val("sdpa_forwarder0_noc_y");
+            constexpr uint32_t sdpa_forwarder1_noc_x = get_named_compile_time_arg_val("sdpa_forwarder1_noc_x");
+            constexpr uint32_t sdpa_forwarder1_noc_y = get_named_compile_time_arg_val("sdpa_forwarder1_noc_y");
+            constexpr uint32_t ccl_sender_noc_x = get_named_compile_time_arg_val("ccl_sender_noc_x");
+            constexpr uint32_t ccl_sender_noc_y = get_named_compile_time_arg_val("ccl_sender_noc_y");
+            constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore_addr");
+            uint64_t ccl_sync_sem_noc_addr =
+                get_noc_addr(sdpa_forwarder0_noc_x, sdpa_forwarder0_noc_y, ccl_sync_sem_addr);
+            noc_semaphore_inc(ccl_sync_sem_noc_addr, 2);
+            ccl_sync_sem_noc_addr = get_noc_addr(sdpa_forwarder1_noc_x, sdpa_forwarder1_noc_y, ccl_sync_sem_addr);
+            noc_semaphore_inc(ccl_sync_sem_noc_addr, 2);
+            ccl_sync_sem_noc_addr = get_noc_addr(ccl_sender_noc_x, ccl_sender_noc_y, ccl_sync_sem_addr);
+            noc_semaphore_inc(ccl_sync_sem_noc_addr, 2);
+            noc_async_atomic_barrier();
+#endif
         }
         // ====================================================================
         // Input core: RMSNorm + Mcast send
@@ -2488,6 +2522,12 @@ void kernel_main() {
             }
             if constexpr (Core::is_sdpa_forwarder_core) {
                 deepseek_b1_ops::SdpaReduceForwarder::Op<SdpaReduceForwarderCTArgs> sdpa_reduce_forwarder;
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+                volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+                noc_semaphore_wait_min(ccl_sync_sem, 1);
+                unified_kernels::semaphore_dec(ccl_sync_sem, 1);
+#endif
                 sdpa_reduce_forwarder(sdpa_reduce_forwarder_args);
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
                 constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore2_addr");
@@ -2578,10 +2618,14 @@ void kernel_main() {
             DeviceZoneScopedN("CCL_SENDER_WRITER");
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
             PacketHeaderPool::reset();
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+            noc_semaphore_wait_min(ccl_sync_sem, 1);
+            unified_kernels::semaphore_dec(ccl_sync_sem, 1);
             deepseek_b1_ops::AllReduce::WriterSingleLink<AllReduceWriterCTArgs> ccl_writer;
             ccl_writer.open_connections(ccl_sender_args, false);
             deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
-            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+            ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                 get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
             noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("sdpa_fwd_num_cores"));
             allgather_sender.open_connections(allgather_transport_args, false);
@@ -2665,14 +2709,11 @@ void kernel_main() {
             DeviceZoneScopedN("RESIDUAL_MCAST");
             residual_mcast(moe.routed.residual_mcast_args);
         }
-        if constexpr (!Core::is_input_core) {
-            // TODO: This is probably a stricter sync than what we actually need
-            // MLA syncs all riscs since the ops depend on reading updated position id
-            // We can simplify the moe sync back to only DM riscs if we use a different semaphore for moe
+        if constexpr (Core::is_reduce_fabric_core) {
             volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
-            unified_kernels::sync_riscs_enter(ccl_sync_sem);
-            unified_kernels::sync_riscs_exit(ccl_sync_sem);
+                get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
+            unified_kernels::sync_riscs_enter<false, false>(ccl_sync_sem);
+            unified_kernels::sync_riscs_exit<false>(ccl_sync_sem);
         }
 
         // 0b. RMSNorm: normalize input on sender core (residual_mcast_src → rmsnorm_output)
@@ -2970,14 +3011,6 @@ void kernel_main() {
             uint64_t sync_sem_noc_addr = get_noc_addr(sync_noc_x, sync_noc_y, sync_sem_addr);
             noc_semaphore_inc(sync_sem_noc_addr, 1);
         }
-#elif defined(COMPILE_FOR_NCRISC)
-        if constexpr (Core::is_sender_core) {
-            constexpr uint32_t sync_sem_addr = get_named_compile_time_arg_val("reduce_sync_sem_addr");
-            constexpr uint32_t num_fabric_cores = get_named_compile_time_arg_val("reduce_sync_num_fabric_cores");
-            volatile tt_l1_ptr uint32_t* sync_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_sem_addr);
-            noc_semaphore_wait(sync_sem_ptr, num_fabric_cores);
-            noc_semaphore_set(sync_sem_ptr, 0);  // reset for next iteration
-        }
 #endif
 #endif
     };
@@ -2989,9 +3022,17 @@ void kernel_main() {
         DeviceZoneScopedN("MCAST_INIT");
         mcast.init(mcast_args);
     }
-
-    constexpr uint32_t persistent_mode = get_named_compile_time_arg_val("persistent_mode");
-    constexpr uint32_t persistent_next_iter_sem_addr = get_named_compile_time_arg_val("persistent_next_iter_sem_addr");
+#ifdef ENABLE_REDUCE_TO_ONE
+#if defined(COMPILE_FOR_NCRISC)
+    // Check is at the start of the loop, so simulate an increment before the loop starts
+    if constexpr (Core::is_sender_core) {
+        constexpr uint32_t sync_sem_addr = get_named_compile_time_arg_val("reduce_sync_sem_addr");
+        constexpr uint32_t num_fabric_cores = get_named_compile_time_arg_val("reduce_sync_num_fabric_cores");
+        volatile tt_l1_ptr uint32_t* sync_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_sem_addr);
+        unified_kernels::semaphore_inc(sync_sem_ptr, num_fabric_cores);
+    }
+#endif
+#endif
     uint32_t iteration = 0;
     while (true) {
         {
@@ -2999,15 +3040,16 @@ void kernel_main() {
             unified_kernels::reconfig_cb_interfaces(mla_cb_config);
             setup_mla_sharded_buffers();
         }
-#if defined(COMPILE_FOR_BRISC)
-        if constexpr (persistent_mode) {
-            constexpr bool is_bcast_root = get_named_compile_time_arg_val("bcast_is_root") == 1;
-            if constexpr (is_bcast_root && Core::is_sender_core) {
-                auto next_iter_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(persistent_next_iter_sem_addr);
-                noc_semaphore_wait(next_iter_sem, 1);
-                noc_semaphore_set(next_iter_sem, 0);
-            }
+#ifdef ENABLE_REDUCE_TO_ONE
+#if defined(COMPILE_FOR_NCRISC)
+        if constexpr (Core::is_sender_core) {
+            constexpr uint32_t sync_sem_addr = get_named_compile_time_arg_val("reduce_sync_sem_addr");
+            constexpr uint32_t num_fabric_cores = get_named_compile_time_arg_val("reduce_sync_num_fabric_cores");
+            volatile tt_l1_ptr uint32_t* sync_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_sem_addr);
+            noc_semaphore_wait(sync_sem_ptr, num_fabric_cores);
+            noc_semaphore_set(sync_sem_ptr, 0);  // reset for next iteration
         }
+#endif
 #endif
         {
             DeviceZoneScopedN("MLA");

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -3029,7 +3029,7 @@ void kernel_main() {
         constexpr uint32_t sync_sem_addr = get_named_compile_time_arg_val("reduce_sync_sem_addr");
         constexpr uint32_t num_fabric_cores = get_named_compile_time_arg_val("reduce_sync_num_fabric_cores");
         volatile tt_l1_ptr uint32_t* sync_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_sem_addr);
-        unified_kernels::semaphore_inc(sync_sem_ptr, num_fabric_cores);
+        noc_semaphore_set(sync_sem_ptr, num_fabric_cores);
     }
 #endif
 #endif

--- a/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
@@ -65,7 +65,9 @@ struct Broadcast {
         uint32_t isRoot,
         uint32_t chunkSizeBytes,
         uint32_t lastChunkSizeBytes,
-        uint32_t numChunks>
+        uint32_t numChunks,
+        uint32_t cbOutId = 0,
+        uint32_t outNumTiles = 0>
     struct WriterCTArgs {
         static constexpr uint32_t cb0_id = cb0Id;
         static constexpr uint32_t num_pages_to_read = NumPagesToRead;
@@ -77,6 +79,8 @@ struct Broadcast {
         static constexpr uint32_t chunk_size_bytes = chunkSizeBytes;
         static constexpr uint32_t last_chunk_size_bytes = lastChunkSizeBytes;
         static constexpr uint32_t num_chunks = numChunks;
+        static constexpr uint32_t cb_out_id = cbOutId;
+        static constexpr uint32_t out_num_tiles = outNumTiles;
         static_assert(num_links <= Broadcast::MAX_NUM_LINKS, "num_links exceeds MAX_NUM_LINKS");
         static_assert(num_chunks > 0, "num_chunks must be greater than 0");
     };
@@ -100,11 +104,65 @@ struct Broadcast {
     public:
         void operator()(const RTArgs& args) {
             if constexpr (IsWorkerCore) {
+                open_connections_impl(args, /*reset_header_pool=*/true);
+                impl(args);
+            }
+        }
+
+        void open_connections(const RTArgs& args, bool reset_header_pool = true) {
+            if constexpr (IsWorkerCore) {
+                open_connections_impl(args, reset_header_pool);
+            }
+        }
+
+        void run(const RTArgs& args) {
+            if constexpr (IsWorkerCore) {
                 impl(args);
             }
         }
 
     private:
+#if defined(COMPILE_FOR_NCRISC)
+        std::array<tt::tt_fabric::WorkerToFabricEdmSender, CTArgs::num_connections> connections;
+        std::array<volatile PACKET_HEADER_TYPE*, CTArgs::num_connections> headers;
+        uint64_t dst_noc_base = 0;
+        std::array<uint64_t, CTArgs::num_links> sem_nocs;
+        std::array<volatile tt_l1_ptr uint32_t*, CTArgs::num_links> sem_ptrs;
+#endif
+
+        void open_connections_impl([[maybe_unused]] const RTArgs& args, [[maybe_unused]] bool reset_header_pool) {
+#if defined(COMPILE_FOR_NCRISC)
+            if constexpr (IsWorkerCore) {
+                if (reset_header_pool) {
+                    PacketHeaderPool::reset();
+                }
+
+                size_t arg_idx = args.per_core_rta_arg_idx_offset;
+                for (uint32_t neighbor_idx = 0; neighbor_idx < CTArgs::num_neighbors; neighbor_idx++) {
+                    const uint32_t dst_mesh_id = get_arg_val<uint32_t>(arg_idx++);
+                    const uint32_t dst_chip_id = get_arg_val<uint32_t>(arg_idx++);
+                    for (uint32_t link_idx = 0; link_idx < CTArgs::num_links; link_idx++) {
+                        const uint32_t connection_idx = neighbor_idx * CTArgs::num_links + link_idx;
+                        connections[connection_idx] =
+                            tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(
+                                arg_idx);
+                        connections[connection_idx].open_start();
+                        headers[connection_idx] = PacketHeaderPool::allocate_header();
+                        fabric_set_unicast_route(headers[connection_idx], dst_chip_id, dst_mesh_id);
+                        connections[connection_idx].open_finish();
+                    }
+                }
+
+                dst_noc_base = get_noc_addr(args.my_noc_x, args.my_noc_y, args.tensor_address0, 0);
+                for (uint32_t link_idx = 0; link_idx < CTArgs::num_links; link_idx++) {
+                    sem_nocs[link_idx] =
+                        safe_get_noc_addr(args.my_noc_x, args.my_noc_y, args.sem_bank_addrs[link_idx], 0);
+                    sem_ptrs[link_idx] = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.sem_bank_addrs[link_idx]);
+                }
+            }
+#endif
+        }
+
         void impl([[maybe_unused]] const RTArgs& args) {
 #if defined(COMPILE_FOR_BRISC)
             // ================================================================
@@ -145,35 +203,6 @@ struct Broadcast {
             // NCRISC - bcast writer
             // ================================================================
             if constexpr (IsWorkerCore) {
-                PacketHeaderPool::reset();
-
-                std::array<tt::tt_fabric::WorkerToFabricEdmSender, CTArgs::num_connections> connections;
-                std::array<volatile PACKET_HEADER_TYPE*, CTArgs::num_connections> headers;
-                size_t arg_idx = args.per_core_rta_arg_idx_offset;
-                for (uint32_t neighbor_idx = 0; neighbor_idx < CTArgs::num_neighbors; neighbor_idx++) {
-                    const uint32_t dst_mesh_id = get_arg_val<uint32_t>(arg_idx++);
-                    const uint32_t dst_chip_id = get_arg_val<uint32_t>(arg_idx++);
-                    for (uint32_t link_idx = 0; link_idx < CTArgs::num_links; link_idx++) {
-                        const uint32_t connection_idx = neighbor_idx * CTArgs::num_links + link_idx;
-                        connections[connection_idx] =
-                            tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(
-                                arg_idx);
-                        connections[connection_idx].open_start();
-                        headers[connection_idx] = PacketHeaderPool::allocate_header();
-                        fabric_set_unicast_route(headers[connection_idx], dst_chip_id, dst_mesh_id);
-                        connections[connection_idx].open_finish();
-                    }
-                }
-
-                const uint64_t dst_noc_base = get_noc_addr(args.my_noc_x, args.my_noc_y, args.tensor_address0, 0);
-                std::array<uint64_t, CTArgs::num_links> sem_nocs;
-                std::array<volatile tt_l1_ptr uint32_t*, CTArgs::num_links> sem_ptrs;
-                for (uint32_t link_idx = 0; link_idx < CTArgs::num_links; link_idx++) {
-                    sem_nocs[link_idx] =
-                        safe_get_noc_addr(args.my_noc_x, args.my_noc_y, args.sem_bank_addrs[link_idx], 0);
-                    sem_ptrs[link_idx] = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.sem_bank_addrs[link_idx]);
-                }
-
                 auto send_chunk = [&](uint32_t connection_idx,
                                       uint32_t link_idx,
                                       uint32_t src_base_addr,
@@ -226,12 +255,20 @@ struct Broadcast {
                 //   * leaf node (num_neighbors == 0), where forwarding loops are no-ops.
                 // In the leaf case, num_links remains configured (> 0), wait/reset semantics are still
                 // preserved for non-root nodes, and no fabric send occurs due to zero neighbors.
-
+                if constexpr (CTArgs::out_num_tiles != 0) {
+                    cb_reserve_back(CTArgs::cb_out_id, CTArgs::out_num_tiles);
+                }
                 if constexpr (CTArgs::is_root) {
                     cb_wait_front(CTArgs::cb0_id, CTArgs::num_pages_to_read);
                     const uint32_t src = get_read_ptr(CTArgs::cb0_id);
-                    constexpr uint32_t tensor_size_bytes = CTArgs::tensor0_page_size * CTArgs::num_pages_to_read;
-                    noc_async_write(src, dst_noc_base, tensor_size_bytes);
+                    if (src != args.tensor_address0) {
+                        constexpr uint32_t tensor_size_bytes = CTArgs::tensor0_page_size * CTArgs::num_pages_to_read;
+                        noc_async_write(src, dst_noc_base, tensor_size_bytes);
+                    }
+                    if constexpr (CTArgs::out_num_tiles != 0) {
+                        ASSERT(src == args.tensor_address0);
+                        cb_push_back(CTArgs::cb_out_id, CTArgs::out_num_tiles);
+                    }
                     auto no_wait = [&](uint32_t, uint32_t) {};
                     forward_chunks(src, no_wait);
                     cb_pop_front(CTArgs::cb0_id, CTArgs::num_pages_to_read);
@@ -241,6 +278,9 @@ struct Broadcast {
                         noc_semaphore_wait_min(sem_ptrs[link_idx], link_threshold);
                     };
                     forward_chunks(src, sem_wait);
+                    if constexpr (CTArgs::out_num_tiles != 0) {
+                        cb_push_back(CTArgs::cb_out_id, CTArgs::out_num_tiles);
+                    }
                     for (uint32_t link_idx = 0; link_idx < CTArgs::num_links; link_idx++) {
                         if (link_counters[link_idx] > 0) {
                             unified_kernels::semaphore_dec(sem_ptrs[link_idx], link_counters[link_idx]);

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
@@ -71,6 +71,11 @@ FORCE_INLINE void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t 
     __atomic_fetch_sub(sem_addr, val, __ATOMIC_RELAXED);
 }
 
+// Atomic semaphore increment
+FORCE_INLINE void semaphore_inc(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val = 1) {
+    __atomic_fetch_add(sem_addr, val, __ATOMIC_RELAXED);
+}
+
 #endif
 
 // Atomic L1 semaphore primitives by address — callable from any RISC
@@ -108,7 +113,7 @@ FORCE_INLINE void sem_atomic_dec(uint32_t sem_addr, uint32_t v = 1) {
 // Phase 2 (exit):  NC adds N to high half → participants each spin until high != 0,
 //                  then subtract 1. The last one drains high to 0 for next iteration.
 
-template <bool sync_math_risc = true>
+template <bool sync_math_risc = true, bool sync_tensix = true>
 FORCE_INLINE void sync_riscs_enter(volatile uint32_t tt_l1_ptr* sem_addr) {
 #if defined(UCK_CHLKC_MATH)
     if constexpr (sync_math_risc)
@@ -116,7 +121,9 @@ FORCE_INLINE void sync_riscs_enter(volatile uint32_t tt_l1_ptr* sem_addr) {
     {
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_TRISC)
 #if defined(COMPILE_FOR_TRISC)
-        tensix_sync();
+        if constexpr (sync_tensix) {
+            tensix_sync();
+        }
 #endif
         __atomic_fetch_add(&sem_addr[0], 1, __ATOMIC_RELAXED);
 #elif defined(COMPILE_FOR_NCRISC)


### PR DESCRIPTION
### Summary
We unnecessarily stall the cb reconfigure at the start of MLA waiting for fabric core from reduce to one to signal completion. We can move the stall to before connecting to fabric.
We can also move the stall that signals the exit to start node to after we connect to fabric, but before sending data. This optimizes back to back tokens.
For optimizing single token, we can push the input to rmsnorm immediately after receiving all of the data, instead of waiting for sending data to fabric and disconnecting to finish.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aho/bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/bcast)