### PR TITLE
Update R2 of sdpa worker to handle block by block

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sdpa_reduce_row.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sdpa_reduce_row.h
@@ -79,7 +79,7 @@ inline void _init_sdpa_reduce_sum_row_8x32_replay_buffers_() {
     // Record replay buffer
     // LREG0 will contain the first 4 rows, LREG2 will contain the second 4 rows
     // Max will be the first 16 instructions, SUM will be the last 16 instructions
-    load_replay_buf<NoExec>(0, 16, [] {
+    load_replay_buf<NoExec>(16, 16, [] {
         // Sum instructions
         reduce_row_8x32_instrs<PoolType::SUM>();
     });

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -168,7 +168,8 @@ inline void init_fast_approx_exp_constants() {
 
 inline void fast_approx_exp(uint32_t dst_index) {
     TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, dst_index + get_dest_buffer_base());
-    ckernel::sfpu::calculate_exponential<true, DST_ACCUM_MODE, true, 4, true>();
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+    ckernel::sfpu::calculate_exponential<true, DST_ACCUM_MODE, true, 8, true>();
 }
 
 // TODO: Currently hardcodes the lregs used by red max
@@ -295,6 +296,7 @@ void compute_sdpa_chunk(
     for (uint32_t i = 0; i < chunk_size; i++) {
         // Wait for FPU that tile is ready (sem is non-zero)
         PACK((t6_semaphore_wait_on_zero<p_stall::STALL_SFPU>(semaphore::FPU_SFPU)));
+        // Each tile is 2 densely packed faces of 8x16, making it the same as a full 16x16 face
         PACK((fast_approx_exp(mm1_dst_offset + i * packed_tile_size)));
         PACK((t6_semaphore_get<p_stall::WAIT_SFPU>(semaphore::FPU_SFPU)));
         // No stall since we waited on sfpu already

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -225,36 +225,32 @@ ALWI void sdpa_tail_streaming(
     uint32_t cb_l1,
     uint32_t cb_l2,
     uint32_t cb_l_out) {
-    constexpr bool dense = untilize;
+    constexpr bool dense = false;
     constexpr uint32_t total_size = num_l_chunks * block_size;
-    ckernel::sdpa_tail_ms_reduce<
-        SDPA_EXP_APPROX_MODE,
-        normalize,
-        untilize ? total_size : block_size,
-        scale_fp32,
-        vector_mode,
-        false,
-        dense>(cb_worker_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l1);
+    ckernel::sdpa_tail_ms_reduce<SDPA_EXP_APPROX_MODE, normalize, block_size, scale_fp32, vector_mode, false, dense>(
+        cb_worker_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l1);
 
-    // TODO: Unit test perf seemed better if we operated on all chunks
-    // Retest in streaming context since unit test doesn't need to wait for input
+    bool acquire_regs = !normalize;
     if constexpr (untilize) {
-        custom_pack_untilize_dest_init<total_size, total_size, false, TILE_C_DIM, dense>(cb_l_out, 8, dense ? 2 : 4);
-        cb_wait_front(cb_l1, total_size);
-        cb_wait_front(cb_l2, total_size);
+        custom_pack_untilize_dest_init<block_size, total_size, false, TILE_C_DIM, dense>(cb_l_out, 8, dense ? 2 : 4);
         cb_reserve_back(cb_l_out, total_size);
-        ckernel::sdpa_tail_l_block<total_size, 1, untilize, dense, false>(cb_l1, cb_l2, cb_l_out, 0, 0, false);
+        for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
+            cb_wait_front(cb_l1, (chunk + 1) * block_size);
+            cb_wait_front(cb_l2, (chunk + 1) * block_size);
+            ckernel::sdpa_tail_l_block<block_size, num_l_chunks, untilize, dense, false>(
+                cb_l1, cb_l2, cb_l_out, chunk * block_size, chunk, acquire_regs);
+            acquire_regs = true;
+        }
         cb_push_back(cb_l_out, total_size);
         pack_untilize_uninit(cb_l_out);
     } else {
-        bool acquire_regs = !normalize;
         pack_block_contiguous_init(cb_l_out);
         for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
             cb_wait_front(cb_l1, (chunk + 1) * block_size);
             cb_wait_front(cb_l2, (chunk + 1) * block_size);
             cb_reserve_back(cb_l_out, block_size);
             uint32_t tile_index = chunk * block_size;
-            ckernel::sdpa_tail_l_block<block_size, 1, untilize, dense, false>(
+            ckernel::sdpa_tail_l_block<block_size, num_l_chunks, untilize, dense, false>(
                 cb_l1, cb_l2, cb_l_out, tile_index, 0, acquire_regs);
             acquire_regs = true;
             cb_push_back(cb_l_out, block_size);


### PR DESCRIPTION
### Summary
The normalization/untilize was originally set up to wait for all l blocks before doing a one-shot computation. Change to compute block by block.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/sdpa-worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/sdpa-worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aho/sdpa-worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aho/sdpa-worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/sdpa-worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/sdpa-worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/sdpa-worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/sdpa-worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/sdpa-worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/sdpa-worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/sdpa-worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/sdpa-worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/sdpa-worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/sdpa-worker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/sdpa-worker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/sdpa-worker)